### PR TITLE
Fixes broken links in docsite where default branch name of linked repo has changed

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -91,7 +91,7 @@ The clickable links will take you directly to the relevant Matrix room in your b
 - `Discussions on developer topics and code related to features or bugs <https://matrix.to/#/#devel:ansible.com>`_ - ``Matrix: #devel:ansible.com | IRC: #ansible-devel``
 - `Discussions on community and collections related topics <https://matrix.to:/#/#community:ansible.com>`_ - ``Matrix: #community:ansible.com | IRC: #ansible-community``
 - `For public community meetings <https://matrix.to/#/#meeting:ansible.im>`_ - ``Matrix: #meeting:ansible.im | IRC: #ansible-meeting``
-   - We will generally announce these on one or more of the above mailing lists. See the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_
+   - We will generally announce these on one or more of the above mailing lists. See the `meeting schedule and agenda page <https://github.com/ansible/community/blob/main/meetings/README.md>`_
 
 .. _working_group_list:
 
@@ -124,7 +124,7 @@ Many of our community `Working Groups <https://github.com/ansible/community/wiki
 - `Windows Working Group <https://github.com/ansible/community/wiki/Windows>`_ - Matrix: `#windows:ansible.com <https://matrix.to:/#/#windows:ansible.com>`_ | IRC: ``#ansible-windows``
 - `Ansible developer tools Group <https://github.com/ansible/community/wiki/Ansible-developer-tools>`_ - Matrix: `#devtools:ansible.com <https://matrix.to/#/#devtools:ansible.com>`_ | IRC: ``#ansible-devtools``
 
-Want to `form a new Working Group <https://github.com/ansible/community/blob/master/WORKING-GROUPS.md>`_?
+Want to `form a new Working Group <https://github.com/ansible/community/blob/main/WORKING-GROUPS.md>`_?
 
 Regional and Language-specific channels
 ---------------------------------------
@@ -137,7 +137,7 @@ Regional and Language-specific channels
 Meetings on chat
 ----------------
 
-The Ansible community holds regular meetings on various topics on Matrix/IRC, and anyone who is interested is invited to participate. For more information about Ansible meetings, consult the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
+The Ansible community holds regular meetings on various topics on Matrix/IRC, and anyone who is interested is invited to participate. For more information about Ansible meetings, consult the `meeting schedule and agenda page <https://github.com/ansible/community/blob/main/meetings/README.md>`_.
 
 Ansible Community Topics
 ========================

--- a/docs/docsite/rst/community/contributing_maintained_collections.rst
+++ b/docs/docsite/rst/community/contributing_maintained_collections.rst
@@ -66,7 +66,7 @@ The following table shows:
     <tr>
       <td><a href="https://galaxy.ansible.com/amazon/aws">amazon.aws</a></td>
       <td><a href="https://galaxy.ansible.com/community/aws">community.aws</a></td>
-      <td><a href="https://github.com/ansible/community/tree/master/group-aws">AWS</a></td>
+      <td><a href="https://github.com/ansible/community/tree/main/group-aws">AWS</a></td>
       <td>✓**</td>
       <td>**</td>
       <td>✓</td>

--- a/docs/docsite/rst/dev_guide/debugging.rst
+++ b/docs/docsite/rst/dev_guide/debugging.rst
@@ -83,7 +83,7 @@ The following steps use ``localhost`` as the target host, but you can use the sa
 
     * The ``args`` file contains a JSON string. The string is a dictionary containing the module arguments and other variables that Ansible passes into the module to change its behavior. Modify this file to change the parameters passed to the module.
 
-    * The ``ansible`` directory contains the module code in ``modules`` as well as code from :mod:`ansible.module_utils` that is used by the module. Ansible includes files for any :mod:`ansible.module_utils` imports in the module but not any files from any other module. If your module uses :mod:`ansible.module_utils.url` Ansible will include it for you. But if your module includes `requests <https://requests.readthedocs.io/en/master/api/>`_, then you'll have to make sure that the Python `requests library <https://pypi.org/project/requests/>`_ is installed on the system before running the module.
+    * The ``ansible`` directory contains the module code in ``modules`` as well as code from :mod:`ansible.module_utils` that is used by the module. Ansible includes files for any :mod:`ansible.module_utils` imports in the module but not any files from any other module. If your module uses :mod:`ansible.module_utils.url` Ansible will include it for you. But if your module includes `requests <https://requests.readthedocs.io/en/latest/api/>`_, then you'll have to make sure that the Python `requests library <https://pypi.org/project/requests/>`_ is installed on the system before running the module.
 
     You can modify files in this directory if you suspect that the module is having a problem in some of this boilerplate code rather than in the module code you have written.
 

--- a/docs/docsite/rst/dev_guide/developing_collections_testing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_testing.rst
@@ -33,7 +33,7 @@ See :ref:`testing_compile` and :ref:`testing_sanity` for more information. See t
 Adding unit tests
 -----------------
 
-You must place unit tests in the appropriate ``tests/unit/plugins/`` directory. For example, you would place tests for ``plugins/module_utils/foo/bar.py`` in ``tests/unit/plugins/module_utils/foo/test_bar.py`` or ``tests/unit/plugins/module_utils/foo/bar/test_bar.py``. For examples, see the `unit tests in community.general <https://github.com/ansible-collections/community.general/tree/master/tests/unit/>`_.
+You must place unit tests in the appropriate ``tests/unit/plugins/`` directory. For example, you would place tests for ``plugins/module_utils/foo/bar.py`` in ``tests/unit/plugins/module_utils/foo/test_bar.py`` or ``tests/unit/plugins/module_utils/foo/bar/test_bar.py``. For examples, see the `unit tests in community.general <https://github.com/ansible-collections/community.general/tree/main/tests/unit/>`_.
 
 To run all unit tests for all supported Python versions:
 
@@ -67,7 +67,7 @@ You can write two different kinds of integration tests:
 * Ansible role tests run with ``ansible-playbook`` and validate various aspects of the module. They can depend on other integration tests (usually named ``prepare_bar`` or ``setup_bar``, which prepare a service or install a requirement named ``bar`` in order to test module ``foo``) to set-up required resources, such as installing required libraries or setting up server services.
 * ``runme.sh`` tests run directly as scripts. They can set up inventory files, and execute ``ansible-playbook`` or ``ansible-inventory`` with various settings.
 
-For examples, see the `integration tests in community.general <https://github.com/ansible-collections/community.general/tree/master/tests/integration/targets/>`_. See also :ref:`testing_integration` for more details.
+For examples, see the `integration tests in community.general <https://github.com/ansible-collections/community.general/tree/main/tests/integration/targets/>`_. See also :ref:`testing_integration` for more details.
 
 Since integration tests can install requirements, and set-up, start and stop services, we recommended running them in docker containers or otherwise restricted environments whenever possible. By default, ``ansible-test`` supports Docker images for several operating systems. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for all options. Use the ``default`` image mainly for platform-independent integration tests, such as those for cloud modules. The following examples use the ``fedora35`` image.
 

--- a/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
@@ -177,9 +177,9 @@ When creating a new module there are a few things to keep in mind:
 - Use the full cmdlet name instead of aliases, for example ``Remove-Item`` over ``rm``
 - Use named parameters with cmdlets, for example ``Remove-Item -Path C:\temp`` over ``Remove-Item C:\temp``
 
-A very basic Powershell module `win_environment <https://github.com/ansible-collections/ansible.windows/blob/master/plugins/modules/win_environment.ps1>`_ incorporates best practices for Powershell modules. It demonstrates how to implement check-mode and diff-support, and also shows a warning to the user when a specific condition is met.
+A very basic Powershell module `win_environment <https://github.com/ansible-collections/ansible.windows/blob/main/plugins/modules/win_environment.ps1>`_ incorporates best practices for Powershell modules. It demonstrates how to implement check-mode and diff-support, and also shows a warning to the user when a specific condition is met.
 
-A slightly more advanced module is `win_uri <https://github.com/ansible-collections/ansible.windows/blob/master/plugins/modules/win_uri.ps1>`_ which additionally shows how to use different parameter types (bool, str, int, list, dict, path) and a selection of choices for parameters, how to fail a module and how to handle exceptions.
+A slightly more advanced module is `win_uri <https://github.com/ansible-collections/ansible.windows/blob/main/plugins/modules/win_uri.ps1>`_ which additionally shows how to use different parameter types (bool, str, int, list, dict, path) and a selection of choices for parameters, how to fail a module and how to handle exceptions.
 
 As part of the new ``AnsibleModule`` wrapper, the input parameters are defined and validated based on an argument
 spec. The following options can be set at the root level of the argument spec:

--- a/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
@@ -21,7 +21,7 @@ This list of prerequisites is designed to help ensure that you develop high-qual
 * We encourage supporting :ref:`Python 2.6+ and Python 3.5+ <developing_python_3>`.
 * Look at Ansible Galaxy and review the naming conventions in your functional area (such as cloud, networking, databases).
 * With great power comes great responsibility: Ansible collection maintainers have a duty to help keep content up to date and release collections they are responsible for regularly. As with all successful community projects, collection maintainers should keep a watchful eye for reported issues and contributions.
-* We strongly recommend unit and/or integration tests. Unit tests are especially valuable when external resources (such as cloud or network devices) are required. For more information see :ref:`developing_testing` and the `Testing Working Group <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
+* We strongly recommend unit and/or integration tests. Unit tests are especially valuable when external resources (such as cloud or network devices) are required. For more information see :ref:`developing_testing` and the `Testing Working Group <https://github.com/ansible/community/blob/main/meetings/README.md>`_.
 
 
 Naming conventions
@@ -56,7 +56,7 @@ In the :ref:`ansible_community_guide` you can find how to:
 
 * Subscribe to the Mailing Lists - We suggest "Ansible Development List" and "Ansible Announce list"
 * ``#ansible-devel`` - We have found that communicating on the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_) works best for developers so we can have an interactive dialogue.
-* Working group and other chat channel meetings - Join the various weekly meetings `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_
+* Working group and other chat channel meetings - Join the various weekly meetings `meeting schedule and agenda page <https://github.com/ansible/community/blob/main/meetings/README.md>`_
 
 Required files
 ==============

--- a/docs/docsite/rst/dev_guide/testing.rst
+++ b/docs/docsite/rst/dev_guide/testing.rst
@@ -251,4 +251,4 @@ Want to know more about testing?
 ================================
 
 If you'd like to know more about the plans for improving testing Ansible then why not join the
-`Testing Working Group <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
+`Testing Working Group <https://github.com/ansible/community/blob/main/meetings/README.md>`_.

--- a/docs/docsite/rst/dev_guide/testing_compile.rst
+++ b/docs/docsite/rst/dev_guide/testing_compile.rst
@@ -73,4 +73,4 @@ The full list of requirements can be found at `test/lib/ansible_test/_data/requi
 Extending compile tests
 =======================
 
-If you believe changes are needed to the compile tests please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/master/meetings/README.md>`_ so it can be discussed.
+If you believe changes are needed to the compile tests please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/main/meetings/README.md>`_ so it can be discussed.

--- a/docs/docsite/rst/dev_guide/testing_httptester.rst
+++ b/docs/docsite/rst/dev_guide/testing_httptester.rst
@@ -25,4 +25,4 @@ Source files can be found in the `http-test-container <https://github.com/ansibl
 Extending httptester
 ====================
 
-If you have sometime to improve ``httptester`` please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/master/meetings/README.md>`_ to avoid duplicated effort.
+If you have sometime to improve ``httptester`` please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/main/meetings/README.md>`_ to avoid duplicated effort.

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -245,4 +245,4 @@ For guidance on writing network test see :ref:`testing_resource_modules`.
 Where to find out more
 ======================
 
-If you'd like to know more about the plans for improving testing Ansible, join the `Testing Working Group <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
+If you'd like to know more about the plans for improving testing Ansible, join the `Testing Working Group <https://github.com/ansible/community/blob/main/meetings/README.md>`_.

--- a/docs/docsite/rst/locales/ja/LC_MESSAGES/community.po
+++ b/docs/docsite/rst/locales/ja/LC_MESSAGES/community.po
@@ -831,8 +831,8 @@ msgid "``#ansible-devel`` - For discussions on developer topics and code related
 msgstr "``#ansible-devel`` - 開発者のトピックや機能やバグに関連するコードについて議論する場。"
 
 #: ../../rst/community/communication.rst:51
-msgid "``#ansible-meeting`` - For public community meetings. We will generally announce these on one or more of the above mailing lists. See the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_"
-msgstr "``#ansible-meeting`` - コミュニティーの公開ミーティング用。通常は、上記のメーリングリストで告知されます。「`ミーティングのスケジュールおよび議題のページ <https://github.com/ansible/community/blob/master/meetings/README.md>`_」を参照してください。"
+msgid "``#ansible-meeting`` - For public community meetings. We will generally announce these on one or more of the above mailing lists. See the `meeting schedule and agenda page <https://github.com/ansible/community/blob/main/meetings/README.md>`_"
+msgstr "``#ansible-meeting`` - コミュニティーの公開ミーティング用。通常は、上記のメーリングリストで告知されます。「`ミーティングのスケジュールおよび議題のページ <https://github.com/ansible/community/blob/main/meetings/README.md>`_」を参照してください。"
 
 #: ../../rst/community/communication.rst:56
 msgid "Working groups"
@@ -923,8 +923,8 @@ msgid "`Windows Working Group <https://github.com/ansible/community/wiki/Windows
 msgstr "`Windows Working Group <https://github.com/ansible/community/wiki/Windows>`_ - ``#ansible-windows``"
 
 #: ../../rst/community/communication.rst:81
-msgid "Want to `form a new Working Group <https://github.com/ansible/community/blob/master/WORKING-GROUPS.md>`_?"
-msgstr "`新しいワーキンググループを作りたい <https://github.com/ansible/community/blob/master/WORKING-GROUPS.md>`_ ですか?"
+msgid "Want to `form a new Working Group <https://github.com/ansible/community/blob/main/WORKING-GROUPS.md>`_?"
+msgstr "`新しいワーキンググループを作りたい <https://github.com/ansible/community/blob/main/WORKING-GROUPS.md>`_ ですか?"
 
 #: ../../rst/community/communication.rst:84
 msgid "Regional and Language-specific channels"
@@ -951,8 +951,8 @@ msgid "IRC meetings"
 msgstr "IRC ミーティング"
 
 #: ../../rst/community/communication.rst:94
-msgid "The Ansible community holds regular IRC meetings on various topics, and anyone who is interested is invited to participate. For more information about Ansible meetings, consult the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_."
-msgstr "Ansible コミュニティーは、さまざまなトピックに関する定期的な IRC ミーティングを開いており、興味のある人は誰でも参加することができます。Ansible ミーティングの詳細は、「`meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_」を参照してください。"
+msgid "The Ansible community holds regular IRC meetings on various topics, and anyone who is interested is invited to participate. For more information about Ansible meetings, consult the `meeting schedule and agenda page <https://github.com/ansible/community/blob/main/meetings/README.md>`_."
+msgstr "Ansible コミュニティーは、さまざまなトピックに関する定期的な IRC ミーティングを開いており、興味のある人は誰でも参加することができます。Ansible ミーティングの詳細は、「`meeting schedule and agenda page <https://github.com/ansible/community/blob/main/meetings/README.md>`_」を参照してください。"
 
 #: ../../rst/community/communication.rst:98
 msgid "Ansible Tower support questions"

--- a/docs/docsite/rst/locales/ja/LC_MESSAGES/dev_guide.po
+++ b/docs/docsite/rst/locales/ja/LC_MESSAGES/dev_guide.po
@@ -396,8 +396,8 @@ msgid "The ``args`` file contains a JSON string. The string is a dictionary cont
 msgstr "``args`` ファイルには JSON 文字列が含まれています。この文字列は、Ansible がモジュールに渡したモジュール引数とその他の変数を含むディクショナリーで、動作を変更します。このファイルを変更して、モジュールに渡されるパラメーターを変更します。"
 
 #: ../../rst/dev_guide/debugging.rst:86
-msgid "The ``ansible`` directory contains the module code in ``modules`` as well as code from :mod:`ansible.module_utils` that is used by the module. Ansible includes files for any :mod:`ansible.module_utils` imports in the module but not any files from any other module. If your module uses :mod:`ansible.module_utils.url` Ansible will include it for you. But if your module includes `requests <https://requests.readthedocs.io/en/master/api/>`_, then you'll have to make sure that the Python `requests library <https://pypi.org/project/requests/>`_ is installed on the system before running the module."
-msgstr "``ansible`` ディレクトリーには、``modules`` のモジュールコードと、モジュールによって使用される :mod:`ansible.module_utils` のコードが含まれています。 Ansible には、モジュール内の :mod:`ansible.module_utils` インポートのファイルが含まれますが、他のモジュールからのファイルは含まれません。モジュールで :mod:`ansible.module_utils.url` が使用される場合は、Ansible にそれが含まれます。ただし、モジュールに `requests <https://requests.readthedocs.io/en/master/api/>`_ が含まれる場合は、モジュールを実行する前に Python `requests library <https://pypi.org/project/requests/>`_ がシステムにインストールされていることを確認する必要があります。"
+msgid "The ``ansible`` directory contains the module code in ``modules`` as well as code from :mod:`ansible.module_utils` that is used by the module. Ansible includes files for any :mod:`ansible.module_utils` imports in the module but not any files from any other module. If your module uses :mod:`ansible.module_utils.url` Ansible will include it for you. But if your module includes `requests <https://requests.readthedocs.io/en/latest/api/>`_, then you'll have to make sure that the Python `requests library <https://pypi.org/project/requests/>`_ is installed on the system before running the module."
+msgstr "``ansible`` ディレクトリーには、``modules`` のモジュールコードと、モジュールによって使用される :mod:`ansible.module_utils` のコードが含まれています。 Ansible には、モジュール内の :mod:`ansible.module_utils` インポートのファイルが含まれますが、他のモジュールからのファイルは含まれません。モジュールで :mod:`ansible.module_utils.url` が使用される場合は、Ansible にそれが含まれます。ただし、モジュールに `requests <https://requests.readthedocs.io/en/latest/api/>`_ が含まれる場合は、モジュールを実行する前に Python `requests library <https://pypi.org/project/requests/>`_ がシステムにインストールされていることを確認する必要があります。"
 
 #: ../../rst/dev_guide/debugging.rst:88
 msgid "You can modify files in this directory if you suspect that the module is having a problem in some of this boilerplate code rather than in the module code you have written."
@@ -1360,8 +1360,8 @@ msgid "See :ref:`testing_compile` and :ref:`testing_sanity` for more information
 msgstr "詳細は、:ref:`testing_compile` および :ref:`testing_sanity` を参照してください。健全性テストと、特定された問題を修正する方法は、「:ref:`健全性テストの完全リスト <all_sanity_tests>`」を参照してください。"
 
 #: ../../rst/dev_guide/developing_collections.rst:670
-msgid "You must place unit tests in the appropriate``tests/unit/plugins/`` directory. For example, you would place tests for ``plugins/module_utils/foo/bar.py`` in ``tests/unit/plugins/module_utils/foo/test_bar.py`` or ``tests/unit/plugins/module_utils/foo/bar/test_bar.py``. For examples, see the `unit tests in community.general <https://github.com/ansible-collections/community.general/tree/master/tests/unit/>`_."
-msgstr "ユニットテストを適切な ``tests/unit/plugins/`` ディレクトリーに置く必要があります。たとえば、``tests/unit/plugins/module_utils/foo/test_bar.py`` または ``tests/unit/plugins/module_utils/foo/bar/test_bar.py`` の ``plugins/module_utils/foo/bar.py`` にテストを置きます。たとえば、`community.general のユニットテスト <https://github.com/ansible-collections/community.general/tree/master/tests/unit/>`_ を参照してください。"
+msgid "You must place unit tests in the appropriate``tests/unit/plugins/`` directory. For example, you would place tests for ``plugins/module_utils/foo/bar.py`` in ``tests/unit/plugins/module_utils/foo/test_bar.py`` or ``tests/unit/plugins/module_utils/foo/bar/test_bar.py``. For examples, see the `unit tests in community.general <https://github.com/ansible-collections/community.general/tree/main/tests/unit/>`_."
+msgstr "ユニットテストを適切な ``tests/unit/plugins/`` ディレクトリーに置く必要があります。たとえば、``tests/unit/plugins/module_utils/foo/test_bar.py`` または ``tests/unit/plugins/module_utils/foo/bar/test_bar.py`` の ``plugins/module_utils/foo/bar.py`` にテストを置きます。たとえば、`community.general のユニットテスト <https://github.com/ansible-collections/community.general/tree/main/tests/unit/>`_ を参照してください。"
 
 #: ../../rst/dev_guide/developing_collections.rst:672
 msgid "To run all unit tests for all supported Python versions::"
@@ -1396,8 +1396,8 @@ msgid "``runme.sh`` tests run directly as scripts. They can set up inventory fil
 msgstr "``runme.sh`` テストは、直接スクリプトとして実行されます。インベントリーファイルを設定し、さまざまな設定で ``ansible-playbook`` または ``ansible-inventory`` を実行できます。"
 
 #: ../../rst/dev_guide/developing_collections.rst:696
-msgid "For examples, see the `integration tests in community.general <https://github.com/ansible-collections/community.general/tree/master/tests/integration/targets/>`_. See also :ref:`testing_integration` for more details."
-msgstr "例については、「`community.general の統合テスト <https://github.com/ansible-collections/community.general/tree/master/tests/integration/targets/>`_」を参照してください。詳細は、「:ref:`testing_integration`」も参照してください。"
+msgid "For examples, see the `integration tests in community.general <https://github.com/ansible-collections/community.general/tree/main/tests/integration/targets/>`_. See also :ref:`testing_integration` for more details."
+msgstr "例については、「`community.general の統合テスト <https://github.com/ansible-collections/community.general/tree/main/tests/integration/targets/>`_」を参照してください。詳細は、「:ref:`testing_integration`」も参照してください。"
 
 #: ../../rst/dev_guide/developing_collections.rst:698
 msgid "Since integration tests can install requirements, and set-up, start and stop services, we recommended running them in docker containers or otherwise restricted environments whenever possible. By default, ``ansible-test`` supports Docker images for several operating systems. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_data/completion/docker.txt>`_ for all options. Use the ``default`` image mainly for platform-independent integration tests, such as those for cloud modules. The following examples use the ``centos8`` image."
@@ -4490,12 +4490,12 @@ msgid "Use named parameters with cmdlets, for example ``Remove-Item -Path C:\\te
 msgstr "コマンドレットで名前付きパラメーターを使用します (例： ``Remove-Item C:\\temp`` より ``Remove-Item -Path C:\\temp`` を使用)。"
 
 #: ../../rst/dev_guide/developing_modules_general_windows.rst:185
-msgid "A very basic Powershell module `win_environment <https://github.com/ansible-collections/ansible.windows/blob/master/plugins/modules/win_environment.ps1>`_ incorporates best practices for Powershell modules. It demonstrates how to implement check-mode and diff-support, and also shows a warning to the user when a specific condition is met."
-msgstr "非常に基本的な Powershell モジュール `win_environment <https://github.com/ansible-collections/ansible.windows/blob/master/plugins/modules/win_environment.ps1>`_ が、Powershell モジュールのベストプラクティスが組み込まれています。これは、check-mode および diff-support を実装する方法を示し、特定の条件が満たされるとユーザーに警告を表示します。"
+msgid "A very basic Powershell module `win_environment <https://github.com/ansible-collections/ansible.windows/blob/main/plugins/modules/win_environment.ps1>`_ incorporates best practices for Powershell modules. It demonstrates how to implement check-mode and diff-support, and also shows a warning to the user when a specific condition is met."
+msgstr "非常に基本的な Powershell モジュール `win_environment <https://github.com/ansible-collections/ansible.windows/blob/main/plugins/modules/win_environment.ps1>`_ が、Powershell モジュールのベストプラクティスが組み込まれています。これは、check-mode および diff-support を実装する方法を示し、特定の条件が満たされるとユーザーに警告を表示します。"
 
 #: ../../rst/dev_guide/developing_modules_general_windows.rst:187
-msgid "A slightly more advanced module is `win_uri <https://github.com/ansible-collections/ansible.windows/blob/master/plugins/modules/win_uri.ps1>`_ which additionally shows how to use different parameter types (bool, str, int, list, dict, path) and a selection of choices for parameters, how to fail a module and how to handle exceptions."
-msgstr "もう少し高度なモジュールとしては `win_uri <https://github.com/ansible-collections/ansible.windows/blob/master/plugins/modules/win_uri.ps1>`_ がありますが、ここで、さまざまなパラメーター型 (bool、str、int、list、dict、path) の使用方法やパラメーターの選択方法、モジュールを失敗させる方法、例外の処理方法などを紹介しています。"
+msgid "A slightly more advanced module is `win_uri <https://github.com/ansible-collections/ansible.windows/blob/main/plugins/modules/win_uri.ps1>`_ which additionally shows how to use different parameter types (bool, str, int, list, dict, path) and a selection of choices for parameters, how to fail a module and how to handle exceptions."
+msgstr "もう少し高度なモジュールとしては `win_uri <https://github.com/ansible-collections/ansible.windows/blob/main/plugins/modules/win_uri.ps1>`_ がありますが、ここで、さまざまなパラメーター型 (bool、str、int、list、dict、path) の使用方法やパラメーターの選択方法、モジュールを失敗させる方法、例外の処理方法などを紹介しています。"
 
 #: ../../rst/dev_guide/developing_modules_general_windows.rst:189
 msgid "As part of the new ``AnsibleModule`` wrapper, the input parameters are defined and validated based on an argument spec. The following options can be set at the root level of the argument spec:"
@@ -5074,8 +5074,8 @@ msgid "With great power comes great responsibility: Ansible collection maintaine
 msgstr "大きな力には大きな責任が伴います。Ansible コレクションのメンテナーには、コンテンツを最新の状態に保ち、定期的に責任のあるコレクションをリリースするのを支援する義務があります。成功しているすべてのコミュニティープロジェクトと同様に、コレクションのメンテナーは、報告された問題や貢献に注意を払う必要があります。"
 
 #: ../../rst/dev_guide/developing_modules_in_groups.rst:24
-msgid "We strongly recommend unit and/or integration tests. Unit tests are especially valuable when external resources (such as cloud or network devices) are required. For more information see :ref:`developing_testing` and the `Testing Working Group <https://github.com/ansible/community/blob/master/meetings/README.md>`_."
-msgstr "ユニットテストや統合テストが強く推奨されます。ユニットテストは、外部リソース (クラウドやネットワークデバイスなど) が必要な場合に特に役に立ちます。詳細については、「:ref:`developing_testing`」および「`ワーキンググループのテスト <https://github.com/ansible/community/blob/master/meetings/README.md>`_」を参照してください。"
+msgid "We strongly recommend unit and/or integration tests. Unit tests are especially valuable when external resources (such as cloud or network devices) are required. For more information see :ref:`developing_testing` and the `Testing Working Group <https://github.com/ansible/community/blob/main/meetings/README.md>`_."
+msgstr "ユニットテストや統合テストが強く推奨されます。ユニットテストは、外部リソース (クラウドやネットワークデバイスなど) が必要な場合に特に役に立ちます。詳細については、「:ref:`developing_testing`」および「`ワーキンググループのテスト <https://github.com/ansible/community/blob/main/meetings/README.md>`_」を参照してください。"
 
 #: ../../rst/dev_guide/developing_modules_in_groups.rst:28
 msgid "Naming conventions"
@@ -5146,7 +5146,7 @@ msgid "``#ansible-devel`` - We have found that IRC ``#ansible-devel`` on FreeNod
 msgstr "``#ansible-devel`` - FreeNode の IRC ネットワーク ``#ansible-devel`` では、インタラクティブな対話を行うことができるため、モジュール開発者に最適なものであることが分かっています。"
 
 #: ../../rst/dev_guide/developing_modules_in_groups.rst:57
-msgid "IRC meetings - Join the various weekly IRC meetings `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_"
+msgid "IRC meetings - Join the various weekly IRC meetings `meeting schedule and agenda page <https://github.com/ansible/community/blob/main/meetings/README.md>`_"
 msgstr "IRC ミーティング。様々な IRC ミーティング (毎週) に参加する。「_」を参照してください。"
 
 #: ../../rst/dev_guide/developing_modules_in_groups.rst:60
@@ -10795,8 +10795,8 @@ msgid "Want to know more about testing?"
 msgstr "テストに関する詳細情報"
 
 #: ../../rst/dev_guide/testing.rst:242
-msgid "If you'd like to know more about the plans for improving testing Ansible then why not join the `Testing Working Group <https://github.com/ansible/community/blob/master/meetings/README.md>`_."
-msgstr "Ansible テストを改善する詳細な計画を確認したい場合は、`テストワーキンググループ <https://github.com/ansible/community/blob/master/meetings/README.md>`_ にご参加ください。"
+msgid "If you'd like to know more about the plans for improving testing Ansible then why not join the `Testing Working Group <https://github.com/ansible/community/blob/main/meetings/README.md>`_."
+msgstr "Ansible テストを改善する詳細な計画を確認したい場合は、`テストワーキンググループ <https://github.com/ansible/community/blob/main/meetings/README.md>`_ にご参加ください。"
 
 #: ../../rst/dev_guide/testing/sanity/action-plugin-docs.rst:2
 msgid "action-plugin-docs"
@@ -12317,8 +12317,8 @@ msgid "Extending compile tests"
 msgstr "コンパイルテストの拡張"
 
 #: ../../rst/dev_guide/testing_compile.rst:76
-msgid "If you believe changes are needed to the compile tests please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/master/meetings/README.md>`_ so it can be discussed."
-msgstr "コンパイルテストに変更が必要な場合は、`ワーキンググループのテストの議題 <https://github.com/ansible/community/blob/master/meetings/README.md>`_ にコメントを追加してください。その内容について話し合うことができます。"
+msgid "If you believe changes are needed to the compile tests please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/main/meetings/README.md>`_ so it can be discussed."
+msgstr "コンパイルテストに変更が必要な場合は、`ワーキンググループのテストの議題 <https://github.com/ansible/community/blob/main/meetings/README.md>`_ にコメントを追加してください。その内容について話し合うことができます。"
 
 #: ../../rst/dev_guide/testing_documentation.rst:9
 msgid "Before you submit a module for inclusion in the main Ansible repo, you must test your module documentation for correct HTML rendering and to ensure that the argspec matches the documentation in your Python file. The community pages offer more information on :ref:`testing reStructuredText documentation <testing_documentation_locally>`."
@@ -12402,8 +12402,8 @@ msgid "Extending httptester"
 msgstr "httptester の拡張"
 
 #: ../../rst/dev_guide/testing_httptester.rst:28
-msgid "If you have sometime to improve ``httptester`` please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/master/meetings/README.md>`_ to avoid duplicated effort."
-msgstr "``httptester`` を改善するタイミングがある場合は、重複作業を回避するために、「`ワーキンググループのテストの議題 <https://github.com/ansible/community/blob/master/meetings/README.md>`_」にコメントを追加します。"
+msgid "If you have sometime to improve ``httptester`` please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/main/meetings/README.md>`_ to avoid duplicated effort."
+msgstr "``httptester`` を改善するタイミングがある場合は、重複作業を回避するために、「`ワーキンググループのテストの議題 <https://github.com/ansible/community/blob/main/meetings/README.md>`_」にコメントを追加します。"
 
 #: ../../rst/dev_guide/testing_integration.rst:11
 msgid "The Ansible integration Test system."
@@ -12701,8 +12701,8 @@ msgid "Where to find out more"
 msgstr "その他の詳細情報"
 
 #: ../../rst/dev_guide/testing_integration.rst:236
-msgid "If you'd like to know more about the plans for improving testing Ansible, join the `Testing Working Group <https://github.com/ansible/community/blob/master/meetings/README.md>`_."
-msgstr "Ansible テストを改善する詳細な計画を確認したい場合は、`テストのワーキンググループ <https://github.com/ansible/community/blob/master/meetings/README.md>`_ にご参加ください。"
+msgid "If you'd like to know more about the plans for improving testing Ansible, join the `Testing Working Group <https://github.com/ansible/community/blob/main/meetings/README.md>`_."
+msgstr "Ansible テストを改善する詳細な計画を確認したい場合は、`テストのワーキンググループ <https://github.com/ansible/community/blob/main/meetings/README.md>`_ にご参加ください。"
 
 #: ../../rst/dev_guide/testing_integration_legacy.rst:7
 msgid "Testing using the Legacy Integration system"

--- a/docs/docsite/rst/locales/ja/LC_MESSAGES/network.po
+++ b/docs/docsite/rst/locales/ja/LC_MESSAGES/network.po
@@ -778,8 +778,8 @@ msgid "The :file:`main.yaml` file should just reference the transport."
 msgstr ":file:`main.yaml` ファイルは、トランスポートを参照するだけです。"
 
 #: ../../rst/network/dev_guide/developing_resource_modules_network.rst:514
-msgid "The following example walks through the integration tests for the ``vyos.vyos.vyos_l3_interfaces`` module in the `vyos.vyos <https://github.com/ansible-collections/vyos.vyos/tree/master/tests/integration>`_ collection:"
-msgstr "以下の例では、`vyos.vyos <https://github.com/ansible-collections/vyos.vyos/tree/master/tests/integration>`_ コレクションの ``vyos.vyos.vyos_l3_interfaces`` モジュールの統合テストを行います。"
+msgid "The following example walks through the integration tests for the ``vyos.vyos.vyos_l3_interfaces`` module in the `vyos.vyos <https://github.com/ansible-collections/vyos.vyos/tree/main/tests/integration>`_ collection:"
+msgstr "以下の例では、`vyos.vyos <https://github.com/ansible-collections/vyos.vyos/tree/main/tests/integration>`_ コレクションの ``vyos.vyos.vyos_l3_interfaces`` モジュールの統合テストを行います。"
 
 #: ../../rst/network/dev_guide/developing_resource_modules_network.rst:516
 msgid "``test/integration/targets/vyos_l3_interfaces/tasks/main.yaml``"
@@ -813,8 +813,8 @@ msgid "For example:"
 msgstr "たとえば、以下のようになります。"
 
 #: ../../rst/network/dev_guide/developing_resource_modules_network.rst:648
-msgid "See the complete test example of this at https://github.com/ansible-collections/cisco.nxos/blob/master/tests/integration/targets/prepare_nxos_tests/tasks/main.yml."
-msgstr "https://github.com/ansible-collections/cisco.nxos/blob/master/tests/integration/targets/prepare_nxos_tests/tasks/main.yml. で、このテストの完全例を参照してください。"
+msgid "See the complete test example of this at https://github.com/ansible-collections/cisco.nxos/blob/main/tests/integration/targets/prepare_nxos_tests/tasks/main.yml."
+msgstr "https://github.com/ansible-collections/cisco.nxos/blob/main/tests/integration/targets/prepare_nxos_tests/tasks/main.yml. で、このテストの完全例を参照してください。"
 
 #: ../../rst/network/dev_guide/developing_resource_modules_network.rst:652
 msgid "Running network integration tests"
@@ -853,8 +853,8 @@ msgid "To run integration tests for a specific transport:"
 msgstr "特定のトランスポートで統合テストを実行するには、次を実行します。"
 
 #: ../../rst/network/dev_guide/developing_resource_modules_network.rst:706
-msgid "See `test/integration/targets/nxos_bgp/tasks/main.yaml <https://github.com/ansible-collections/cisco.nxos/blob/master/tests/integration/targets/nxos_bgp/tasks/main.yaml>`_ for how this is implemented in the tests."
-msgstr "テストに実装される方法は、「`test/integration/targets/nxos_bgp/tasks/main.yaml <https://github.com/ansible-collections/cisco.nxos/blob/master/tests/integration/targets/nxos_bgp/tasks/main.yaml>`_」を参照してください。"
+msgid "See `test/integration/targets/nxos_bgp/tasks/main.yaml <https://github.com/ansible-collections/cisco.nxos/blob/main/tests/integration/targets/nxos_bgp/tasks/main.yaml>`_ for how this is implemented in the tests."
+msgstr "テストに実装される方法は、「`test/integration/targets/nxos_bgp/tasks/main.yaml <https://github.com/ansible-collections/cisco.nxos/blob/main/tests/integration/targets/nxos_bgp/tasks/main.yaml>`_」を参照してください。"
 
 #: ../../rst/network/dev_guide/developing_resource_modules_network.rst:708
 msgid "For more options:"
@@ -929,16 +929,16 @@ msgid "Mocking device data"
 msgstr "デバイスデータの模倣"
 
 #: ../../rst/network/dev_guide/developing_resource_modules_network.rst:795
-msgid "To mock fetching results from devices or provide other complex data structures that come from external libraries, you can use ``fixtures`` to read in pre-generated data. The text files for this pre-generated data live in ``test/units/modules/network/PLATFORM/fixtures/``. See for example the `eos_l2_interfaces.cfg file <https://github.com/ansible-collections/arista.eos/blob/master/tests/unit/modules/network/eos/fixtures/eos_l2_interfaces_config.cfg>`_."
-msgstr "デバイスからの結果の取得や、外部ライブラリーからの複雑なデータ構造の提供を模倣するために、``fixtures`` を使用して事前に生成されたデータを読み込むことができます。この事前に生成されたデータのテキストファイルは、``test/units/modules/network/PLATFORM/fixtures/`` にあります。たとえば、`eos_l2_interfaces.cfg file <https://github.com/ansible-collections/arista.eos/blob/master/tests/unit/modules/network/eos/fixtures/eos_l2_interfaces_config.cfg>`_ の例を参照してください。"
+msgid "To mock fetching results from devices or provide other complex data structures that come from external libraries, you can use ``fixtures`` to read in pre-generated data. The text files for this pre-generated data live in ``test/units/modules/network/PLATFORM/fixtures/``. See for example the `eos_l2_interfaces.cfg file <https://github.com/ansible-collections/arista.eos/blob/main/tests/unit/modules/network/eos/fixtures/eos_l2_interfaces_config.cfg>`_."
+msgstr "デバイスからの結果の取得や、外部ライブラリーからの複雑なデータ構造の提供を模倣するために、``fixtures`` を使用して事前に生成されたデータを読み込むことができます。この事前に生成されたデータのテキストファイルは、``test/units/modules/network/PLATFORM/fixtures/`` にあります。たとえば、`eos_l2_interfaces.cfg file <https://github.com/ansible-collections/arista.eos/blob/main/tests/unit/modules/network/eos/fixtures/eos_l2_interfaces_config.cfg>`_ の例を参照してください。"
 
 #: ../../rst/network/dev_guide/developing_resource_modules_network.rst:798
 msgid "Load data using the ``load_fixture`` method and set this data as the return value of the ``get_device_data`` method in the facts file:"
 msgstr "``load_fixture`` メソッドを使用してデータを読み込み、このデータをファクトファイルの ``get_device_data`` メソッドの戻り値として設定します。"
 
 #: ../../rst/network/dev_guide/developing_resource_modules_network.rst:808
-msgid "See the unit test file `test_eos_l2_interfaces <https://github.com/ansible-collections/arista.eos/blob/master/tests/unit/modules/network/eos/test_eos_l2_interfaces.py>`_ for a practical example."
-msgstr "実用的な例は、ユニットテストファイル `test_eos_l2_interfaces <https://github.com/ansible-collections/arista.eos/blob/master/tests/unit/modules/network/eos/test_eos_l2_interfaces.py>`_ を参照してください。"
+msgid "See the unit test file `test_eos_l2_interfaces <https://github.com/ansible-collections/arista.eos/blob/main/tests/unit/modules/network/eos/test_eos_l2_interfaces.py>`_ for a practical example."
+msgstr "実用的な例は、ユニットテストファイル `test_eos_l2_interfaces <https://github.com/ansible-collections/arista.eos/blob/main/tests/unit/modules/network/eos/test_eos_l2_interfaces.py>`_ を参照してください。"
 
 #: ../../rst/network/dev_guide/developing_resource_modules_network.rst:814
 msgid ":ref:`testing_units`"

--- a/docs/docsite/rst/locales/ja/LC_MESSAGES/roadmap.po
+++ b/docs/docsite/rst/locales/ja/LC_MESSAGES/roadmap.po
@@ -1285,8 +1285,8 @@ msgid "You can submit feedback on the current roadmap in multiple ways:"
 msgstr "現在のロードマップに関するフィードバックは、複数の方法で送信できます。"
 
 #: ../../rst/roadmap/ansible_base_roadmap_index.rst:20
-msgid "Edit the agenda of an IRC `Core Team Meeting <https://github.com/ansible/community/blob/master/meetings/README.md>`_ (preferred)"
-msgstr "IRC `Core Team Meeting <https://github.com/ansible/community/blob/master/meetings/README.md>`_ の議題を編集 (推奨)"
+msgid "Edit the agenda of an IRC `Core Team Meeting <https://github.com/ansible/community/blob/main/meetings/README.md>`_ (preferred)"
+msgstr "IRC `Core Team Meeting <https://github.com/ansible/community/blob/main/meetings/README.md>`_ の議題を編集 (推奨)"
 
 #: ../../rst/roadmap/ansible_base_roadmap_index.rst:21
 msgid "Post on the ``#ansible-devel`` Freenode IRC channel"

--- a/docs/docsite/rst/locales/ja/LC_MESSAGES/scenario_guides.po
+++ b/docs/docsite/rst/locales/ja/LC_MESSAGES/scenario_guides.po
@@ -806,8 +806,8 @@ msgid "A detailed guide on how to use Ansible for automating network infrastruct
 msgstr "ネットワークインフラストラクチャーの自動化に Ansible を使用する方法に関する詳細なガイドです。"
 
 #: ../../rst/scenario_guides/guide_aci.rst:656
-msgid "`Network Working Group <https://github.com/ansible/community/tree/master/group-network>`_"
-msgstr "`Network Working Group <https://github.com/ansible/community/tree/master/group-network>`_"
+msgid "`Network Working Group <https://github.com/ansible/community/tree/main/group-network>`_"
+msgstr "`Network Working Group <https://github.com/ansible/community/tree/main/group-network>`_"
 
 #: ../../rst/scenario_guides/guide_aci.rst:657
 msgid "The Ansible Network community page, includes contact information and meeting information."

--- a/docs/docsite/rst/network/dev_guide/developing_resource_modules_network.rst
+++ b/docs/docsite/rst/network/dev_guide/developing_resource_modules_network.rst
@@ -511,7 +511,7 @@ For platforms that support ``connection: local`` *and* ``connection: network_cli
 * Name the :file:`targets/` directories after the module name.
 * The :file:`main.yaml` file should just reference the transport.
 
-The following example walks through the integration tests for the ``vyos.vyos.vyos_l3_interfaces`` module in the `vyos.vyos <https://github.com/ansible-collections/vyos.vyos/tree/master/tests/integration>`_ collection:
+The following example walks through the integration tests for the ``vyos.vyos.vyos_l3_interfaces`` module in the `vyos.vyos <https://github.com/ansible-collections/vyos.vyos/tree/main/tests/integration>`_ collection:
 
 ``test/integration/targets/vyos_l3_interfaces/tasks/main.yaml``
 
@@ -652,7 +652,7 @@ For example:
       nxos_int3: '{{ intdataraw[3].interface }}'
 
 
-See the complete test example of this at https://github.com/ansible-collections/cisco.nxos/blob/master/tests/integration/targets/prepare_nxos_tests/tasks/main.yml.
+See the complete test example of this at https://github.com/ansible-collections/cisco.nxos/blob/main/tests/integration/targets/prepare_nxos_tests/tasks/main.yml.
 
 
 Running network integration tests
@@ -710,7 +710,7 @@ To run integration tests for a specific transport:
   # Skip any cli tests
    ansible-test network-integration --inventory  /path/to-collection-module/test/integration/inventory.networking  --skip-tags="cli" nxos_.*
 
-See `test/integration/targets/nxos_bgp/tasks/main.yaml <https://github.com/ansible-collections/cisco.nxos/blob/master/tests/integration/targets/nxos_bgp/tasks/main.yaml>`_ for how this is implemented in the tests.
+See `test/integration/targets/nxos_bgp/tasks/main.yaml <https://github.com/ansible-collections/cisco.nxos/blob/main/tests/integration/targets/nxos_bgp/tasks/main.yaml>`_ for how this is implemented in the tests.
 
 For more options:
 
@@ -800,7 +800,7 @@ Mocking device data
 -----------------------
 
 To mock fetching results from devices or provide other complex data structures that
-come from external libraries, you can use ``fixtures`` to read in pre-generated data. The text files for this pre-generated data live in ``test/units/modules/network/PLATFORM/fixtures/``. See for example the `eos_l2_interfaces.cfg file <https://github.com/ansible-collections/arista.eos/blob/master/tests/unit/modules/network/eos/fixtures/eos_l2_interfaces_config.cfg>`_.
+come from external libraries, you can use ``fixtures`` to read in pre-generated data. The text files for this pre-generated data live in ``test/units/modules/network/PLATFORM/fixtures/``. See for example the `eos_l2_interfaces.cfg file <https://github.com/ansible-collections/arista.eos/blob/main/tests/unit/modules/network/eos/fixtures/eos_l2_interfaces_config.cfg>`_.
 
 Load data using the ``load_fixture`` method and set this data as the return value of the
 ``get_device_data`` method in the facts file:
@@ -812,7 +812,7 @@ Load data using the ``load_fixture`` method and set this data as the return valu
             return load_fixture('eos_l2_interfaces_config.cfg')
         self.execute_show_command.side_effect = load_from_file
 
-See the unit test file `test_eos_l2_interfaces <https://github.com/ansible-collections/arista.eos/blob/master/tests/unit/modules/network/eos/test_eos_l2_interfaces.py>`_
+See the unit test file `test_eos_l2_interfaces <https://github.com/ansible-collections/arista.eos/blob/main/tests/unit/modules/network/eos/test_eos_l2_interfaces.py>`_
 for a practical example.
 
 

--- a/docs/docsite/rst/os_guide/index.rst
+++ b/docs/docsite/rst/os_guide/index.rst
@@ -12,12 +12,12 @@ Using Ansible on Windows and BSD
 
 Welcome to the Ansible guide for Microsoft Windows and BSD.
 Because Windows is not a POSIX-compliant operating system, Ansible interacts with Windows hosts differently to Linux/Unix hosts.
-Likewise managing hosts that run BSD is different to managing other Unix-like host operating systems. 
+Likewise managing hosts that run BSD is different to managing other Unix-like host operating systems.
 Find out everything you need to know about using Ansible on Windows and with BSD hosts.
 
 .. toctree::
    :maxdepth: 2
-   
+
    windows_setup
    windows_usage
    windows_winrm

--- a/docs/docsite/rst/playbook_guide/index.rst
+++ b/docs/docsite/rst/playbook_guide/index.rst
@@ -12,7 +12,7 @@ Using Ansible playbooks
 
 Welcome to the Ansible playbooks guide.
 Playbooks are automation blueprints, in ``YAML`` format, that Ansible uses to deploy and configure nodes in an inventory.
-This guide introduces you to playbooks and then covers different use cases for tasks and plays, such as: 
+This guide introduces you to playbooks and then covers different use cases for tasks and plays, such as:
 
 * Executing tasks with elevated privileges or as a different user.
 * Using loops to repeat tasks for items in a list.

--- a/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
+++ b/docs/docsite/rst/roadmap/ansible_core_roadmap_index.rst
@@ -14,7 +14,7 @@ Each roadmap is published both as an idea of what is upcoming in ``ansible-core`
 
 You can submit feedback on the current roadmap in multiple ways:
 
-- Edit the agenda of an `Core Team Meeting <https://github.com/ansible/community/blob/master/meetings/README.md>`_ (preferred)
+- Edit the agenda of an `Core Team Meeting <https://github.com/ansible/community/blob/main/meetings/README.md>`_ (preferred)
 - Post on the ``#ansible-devel`` chat channel (using Matrix at ansible.im or using IRC at `irc.libera.chat <https://libera.chat/>`_)
 - Email the ansible-devel list
 

--- a/docs/docsite/rst/scenario_guides/guide_aci.rst
+++ b/docs/docsite/rst/scenario_guides/guide_aci.rst
@@ -653,7 +653,7 @@ You will find our roadmap, an overview of open ACI issues and pull-requests, and
        The Ansible ACI community wiki page, includes roadmap, ideas and development documentation.
    :ref:`network_guide`
        A detailed guide on how to use Ansible for automating network infrastructure.
-   `Network Working Group <https://github.com/ansible/community/tree/master/group-network>`_
+   `Network Working Group <https://github.com/ansible/community/tree/main/group-network>`_
        The Ansible Network community page, includes contact information and meeting information.
    `User Mailing List <https://groups.google.com/group/ansible-project>`_
        Have a question?  Stop by the google group!


### PR DESCRIPTION
##### SUMMARY

- Fixes broken links. For the github links this was where references to `master` in the URL are stale due to the default branch in the linked repository now being `main`. While github does have the functionality of dropping you on the default branch (via an HTTP 302 redirect) when it does not recognize the branch you are trying to reach, the fact that most of these links work is more of a coincidence than reliance on a github feature.
- Also removes unnecessary whitespace where found.

NB - None of these changes were through a mass search-and-replace. I followed each link and verified that it performed a 302 redirect.

<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Docs Pull Request

<!--- Pick one below and delete the rest
- Bugfix Pull Request
- Feature Pull Request
- Test Pull Request
-->

<!---
##### COMPONENT NAME

I'm not sure this section is relevant, but I'd be happy to update this with any additional needed info.
-->

<!---
Write the short name of the module, plugin, task or feature below
-->

<!---
##### ADDITIONAL INFORMATION

I'm not sure this section is relevant, but I'd be happy to update this with any additional needed info.
 -->

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change
```paste below

```
 -->
