### PR TITLE
module_utils - fix calculation of file mode change

### DIFF
--- a/changelogs/fragments/78640-fix-module-utils-mode-calculation.yml
+++ b/changelogs/fragments/78640-fix-module-utils-mode-calculation.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - file modules - don't add executable bit to files for +X (https://github.com/ansible/ansible/issues/78623).
+  - file modules - fix inconsistency determining the new mode when there is no change to be made with the '=' operator.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1012,6 +1012,10 @@ class AnsibleModule(object):
 
         new_mode = stat.S_IMODE(path_stat.st_mode)
 
+        if not stat.S_ISDIR(path_stat.st_mode):
+            # chmod -X removes executable bit from files, +X does not add it
+            symbolic_mode = symbolic_mode.replace('+X', '')
+
         # Now parse all symbolic modes
         for mode in symbolic_mode.split(','):
             # Per single mode. This always contains a '+', '-' or '='
@@ -1049,6 +1053,9 @@ class AnsibleModule(object):
 
     @staticmethod
     def _apply_operation_to_mode(user, operator, mode_to_apply, current_mode):
+        if mode_to_apply == 0:
+            return current_mode
+
         if operator == '=':
             if user == 'u':
                 mask = stat.S_IRWXU | stat.S_ISUID

--- a/test/units/modules/test_copy.py
+++ b/test/units/modules/test_copy.py
@@ -172,6 +172,13 @@ DATA = (  # Going from no permissions to setting all for user, group, and/or oth
     # Same as chmod but is it a bug?
     # chmod a-X statfile <== removes execute from statfile
     (0o100777, u'a-X', 0o0666),
+    # chmod a+X statfile <== does not add execute to statfile
+    (0o100777, u'a-x+X', 0o0666),
+    (0o100777, u'a=-x+X', 0o0666),
+
+    # +x and -X overwrite each other
+    (0o100777, u'a+x-X', 0o0666),
+    (0o100000, u'a-X+x', 0o0111),
 
     # Verify X uses computed not original mode
     (0o100777, u'a=,u=rX', 0o0400),


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/78623

* Fix inconsistency returning the current mode when intermediary mode to apply is 0

These should be equivalent:
```python
>>> import os
>>> from ansible.module_utils import basic
>>> basic.AnsibleModule._symbolic_mode_to_octal(os.stat(basic.__file__), 'u=-x+X')
52
>>> basic.AnsibleModule._symbolic_mode_to_octal(os.stat(basic.__file__), 'u-x,u+X')
436
```
The first is 52 due to `_apply_operation_to_mode('u', '=', 0, 436)` returning 52 instead of the current mode 436.

* Fix +X applying to files (don't) to mirror chmod behavior

`chmod -x+X filename` removes the executable bit
as does
`chmod -X+X filename`
whereas only +x can add the executable bit to files.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py
