### PR TITLE
Make `pip install paramiko` in CI more stable

### DIFF
--- a/test/integration/targets/setup_paramiko/install-Alpine-3-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-Alpine-3-python-3.yml
@@ -1,9 +1,5 @@
 - name: Setup remote constraints
   include_tasks: setup-remote-constraints.yml
 - name: Install Paramiko for Python 3 on Alpine
-  pip: # no apk package manager in core, just use pip
-    name: paramiko
-    extra_args: "-c {{ remote_constraints }}"
-  environment:
-    # Not sure why this fixes the test, but it does.
-    SETUPTOOLS_USE_DISTUTILS: stdlib
+  # no apk package manager in core, just use pip
+  include_tasks: install-paramiko-via-pip-python-3.yml

--- a/test/integration/targets/setup_paramiko/install-Darwin-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-Darwin-python-3.yml
@@ -1,9 +1,5 @@
 - name: Setup remote constraints
   include_tasks: setup-remote-constraints.yml
 - name: Install Paramiko for Python 3 on MacOS
-  pip: # no homebrew package manager in core, just use pip
-    name: paramiko
-    extra_args: "-c {{ remote_constraints }}"
-  environment:
-    # Not sure why this fixes the test, but it does.
-    SETUPTOOLS_USE_DISTUTILS: stdlib
+  # no homebrew package manager in core, just use pip
+  include_tasks: install-paramiko-via-pip-python-3.yml

--- a/test/integration/targets/setup_paramiko/install-FreeBSD-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-FreeBSD-python-3.yml
@@ -1,8 +1,5 @@
 - name: Setup remote constraints
   include_tasks: setup-remote-constraints.yml
 - name: Install Paramiko for Python 3 on FreeBSD
-  pip: # no package in pkg, just use pip
-    name: paramiko
-    extra_args: "-c {{ remote_constraints }}"
-  environment:
-    SETUPTOOLS_USE_DISTUTILS: stdlib
+  # no package in pkg, just use pip
+  include_tasks: install-paramiko-via-pip-python-3.yml

--- a/test/integration/targets/setup_paramiko/install-RedHat-8-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-RedHat-8-python-3.yml
@@ -1,8 +1,5 @@
 - name: Setup remote constraints
   include_tasks: setup-remote-constraints.yml
 - name: Install Paramiko for Python 3 on RHEL 8
-  pip: # no python3-paramiko package exists for RHEL 8
-    name: paramiko
-    extra_args: "-c {{ remote_constraints }}"
-  environment:
-    SETUPTOOLS_USE_DISTUTILS: stdlib
+  # no python3-paramiko package exists for RHEL 8
+  include_tasks: install-paramiko-via-pip-python-3.yml

--- a/test/integration/targets/setup_paramiko/install-RedHat-9-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-RedHat-9-python-3.yml
@@ -1,9 +1,8 @@
 - name: Setup remote constraints
   include_tasks: setup-remote-constraints.yml
 - name: Install Paramiko for Python 3 on RHEL 9
-  pip: # no python3-paramiko package exists for RHEL 9
-    name: paramiko
-    extra_args: "-c {{ remote_constraints }}"
+  # no python3-paramiko package exists for RHEL 9
+  include_tasks: install-paramiko-via-pip-python-3.yml
 
 - name: Drop the crypto-policy to LEGACY for these tests
   command: update-crypto-policies --set LEGACY

--- a/test/integration/targets/setup_paramiko/install-paramiko-via-pip-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-paramiko-via-pip-python-3.yml
@@ -1,0 +1,7 @@
+- name: Install Paramiko for Python 3 using pip
+  pip:
+    name: paramiko
+    extra_args: "-c {{ remote_constraints }}"
+  environment:
+    # Not sure why this fixes the test, but it does.
+    SETUPTOOLS_USE_DISTUTILS: stdlib

--- a/test/integration/targets/setup_paramiko/install-paramiko-via-pip-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-paramiko-via-pip-python-3.yml
@@ -1,3 +1,25 @@
+- name: Ensure PyPI is accessible before trying to install from it
+  wait_for:
+    connect_timeout: 10
+    host: pypi.org
+    msg: >-
+      There is an issue connection to PyPI, it won't be possible to
+      run `pip install` successfully until the network connectivity is
+      resolved.
+    port: 443
+    sleep: 15
+    timeout: 300
+- name: Ensure the PyPI CDN is accessible before trying to get dists
+  wait_for:
+    connect_timeout: 10
+    host: files.pythonhosted.org
+    msg: >-
+      There is an issue connection to the PyPI's content delivery
+      network, it won't be possible to run `pip install` successfully
+      until the network connectivity is resolved.
+    port: 443
+    sleep: 15
+    timeout: 300
 - name: Install Paramiko for Python 3 using pip
   pip:
     name: paramiko

--- a/test/integration/targets/setup_paramiko/install-paramiko-via-pip-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-paramiko-via-pip-python-3.yml
@@ -5,3 +5,7 @@
   environment:
     # Not sure why this fixes the test, but it does.
     SETUPTOOLS_USE_DISTUTILS: stdlib
+  register: pip_install_result
+  delay: 15
+  retries: 10
+  until: pip_install_result is not failed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There have been a noticeable amount of network-related failures in the `setup_paramiko` integration tests helper role when it tried installing `paramiko` from PyPI. This was caused by the network instability and required a manual job restart each time.

This patch attempts to eliminate the need for those restarts, adding more self-healing. Waiting for the connectivity + retries should make it less flaky, provided that the network issues are of short duration.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/integration/targets/setup_paramiko/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Example failure: https://dev.azure.com/ansible/ansible/_build/results?buildId=52061&view=logs&j=96d98051-de5a-5846-d6c0-98e63dcdbfd9&t=c2476f69-8c1f-561a-4f25-a218e506c05f&l=2635