### PR TITLE
Skip paramiko test on failing platforms.

### DIFF
--- a/test/integration/targets/connection_paramiko_ssh/aliases
+++ b/test/integration/targets/connection_paramiko_ssh/aliases
@@ -3,3 +3,5 @@ shippable/posix/group3
 needs/target/setup_paramiko
 destructive  # potentially installs/uninstalls OS packages via setup_paramiko
 skip/aix
+skip/macos/11.1  # skipping due to issues installing paramiko
+skip/rhel/8.3  # skipping due to issues installing paramiko

--- a/test/integration/targets/connection_paramiko_ssh/runme.sh
+++ b/test/integration/targets/connection_paramiko_ssh/runme.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+source /etc/os-release
+
+if [ "${ID}" == "alpine" ]; then
+  echo "skipping due to issues installing paramiko"
+  exit 0
+fi
+
 set -eux
 
 source ../setup_paramiko/setup.sh


### PR DESCRIPTION
##### SUMMARY

The paramiko install fails due to the new bcrypt 4.0.0 release.

The test is being skipped on the affected platforms since ansible-core 2.11 will reach end-of-life in November.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

connection_paramiko_ssh integration test
