### PR TITLE
[2.13] Disable `connection_paramiko_ssh` under FreeBSD 13.0

### DIFF
--- a/test/integration/targets/connection_paramiko_ssh/aliases
+++ b/test/integration/targets/connection_paramiko_ssh/aliases
@@ -2,4 +2,5 @@ needs/ssh
 shippable/posix/group3
 needs/target/setup_paramiko
 needs/target/connection
+skip/freebsd/13.0
 destructive  # potentially installs/uninstalls OS packages via setup_paramiko

--- a/test/integration/targets/connection_paramiko_ssh/aliases
+++ b/test/integration/targets/connection_paramiko_ssh/aliases
@@ -2,5 +2,5 @@ needs/ssh
 shippable/posix/group3
 needs/target/setup_paramiko
 needs/target/connection
-skip/freebsd/13.0
+skip/freebsd/13.0  # bcrypt 4+ requires a newer version of rust than is available
 destructive  # potentially installs/uninstalls OS packages via setup_paramiko

--- a/test/integration/targets/setup_paramiko/aliases
+++ b/test/integration/targets/setup_paramiko/aliases
@@ -1,1 +1,2 @@
 needs/target/setup_remote_tmp_dir
+skip/freebsd/13.0

--- a/test/integration/targets/setup_paramiko/aliases
+++ b/test/integration/targets/setup_paramiko/aliases
@@ -1,2 +1,1 @@
 needs/target/setup_remote_tmp_dir
-skip/freebsd/13.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/integration/targets/connection_paramiko_ssh

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
`bcrypt` 4 is not buildable under this VM.