### PR TITLE
Skip test if no there are no problematic chars for wcswidth

### DIFF
--- a/test/units/utils/test_display.py
+++ b/test/units/utils/test_display.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import ctypes.util
 import locale
 import sys
 import unicodedata

--- a/test/units/utils/test_display.py
+++ b/test/units/utils/test_display.py
@@ -5,13 +5,32 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+import ctypes.util
 import locale
+import sys
+import unicodedata
 from unittest.mock import MagicMock
 
 import pytest
 
-from ansible.utils.display import Display, get_text_width
+from ansible.utils.display import _LIBC, _MAX_INT, Display, get_text_width
 from ansible.utils.multiprocessing import context as multiprocessing_context
+
+
+@pytest.fixture
+def problematic_wcswidth_chars():
+    problematic = []
+    try:
+        locale.setlocale(locale.LC_ALL, 'C.UTF-8')
+    except Exception:
+        return problematic
+
+    candidates = set(chr(c) for c in range(sys.maxunicode) if unicodedata.category(chr(c)) == 'Cf')
+    for c in candidates:
+        if _LIBC.wcswidth(c, _MAX_INT) == -1:
+            problematic.append(c)
+
+    return problematic
 
 
 def test_get_text_width():
@@ -35,9 +54,11 @@ def test_get_text_width():
     pytest.raises(TypeError, get_text_width, b'four')
 
 
-def test_get_text_width_no_locale():
+def test_get_text_width_no_locale(problematic_wcswidth_chars):
+    if not problematic_wcswidth_chars:
+        pytest.skip("No problmatic wcswidth chars")
     locale.setlocale(locale.LC_ALL, 'C.UTF-8')
-    pytest.raises(EnvironmentError, get_text_width, '\U000110cd')
+    pytest.raises(EnvironmentError, get_text_width, problematic_wcswidth_chars[0])
 
 
 def test_Display_banner_get_text_width(monkeypatch):


### PR DESCRIPTION
##### SUMMARY
Skip test if no there are no problematic chars for wcswidth. Fixes #78639 

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/units/utils/test_display.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
