### PR TITLE
Fix bcrypt install for paramiko test on macOS.

### DIFF
--- a/test/integration/targets/setup_paramiko/install-Darwin-python-3.yml
+++ b/test/integration/targets/setup_paramiko/install-Darwin-python-3.yml
@@ -1,5 +1,9 @@
 - name: Setup remote constraints
   include_tasks: setup-remote-constraints.yml
+- name: Upgrade the virtual environment's pip to enable installation of bcrypt wheels
+  pip:
+    name: pip
+    state: latest
 - name: Install Paramiko for Python 3 on MacOS
   pip: # no homebrew package manager in core, just use pip
     name: paramiko


### PR DESCRIPTION
##### SUMMARY

Fix bcrypt install for paramiko test on macOS.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

paramiko integration test