### PR TITLE
Always create new role

### DIFF
--- a/changelogs/fragments/always-create-new-role.yml
+++ b/changelogs/fragments/always-create-new-role.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- role deduplication - Always create new role object, regardless of
+  deduplication. Deduplication will only affect whether a duplicate call to a
+  role will execute, as opposed to re-using the same object.
+  (https://github.com/ansible/ansible/pull/78661)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -109,8 +109,11 @@ class Play(Base, Taggable, CollectionSearch):
         """Backwards compat for custom strategies using ``play.ROLE_CACHE``
         """
         cache = {}
-        for name, roles in self.role_cache.items():
-            cache[name] = {hash_params(role._get_hash_dict()): role for role in roles}
+        for path, roles in self.role_cache.items():
+            for role in roles:
+                name = role.get_name()
+                hashed_params = hash_params(role._get_hash_dict())
+                cache.setdefault(name, {})[hashed_params] = role
         return cache
 
     def _validate_hosts(self, attribute, name, value):

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -108,6 +108,10 @@ class Play(Base, Taggable, CollectionSearch):
     def ROLE_CACHE(self):
         """Backwards compat for custom strategies using ``play.ROLE_CACHE``
         """
+        display.deprecated(
+            'Play.ROLE_CACHE is deprecated in favor of Play.role_cache, or StrategyBase._get_cached_role',
+            version='2.18',
+        )
         cache = {}
         for path, roles in self.role_cache.items():
             for role in roles:

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -30,7 +30,7 @@ from ansible.playbook.base import Base
 from ansible.playbook.block import Block
 from ansible.playbook.collectionsearch import CollectionSearch
 from ansible.playbook.helpers import load_list_of_blocks, load_list_of_roles
-from ansible.playbook.role import Role
+from ansible.playbook.role import Role, hash_params
 from ansible.playbook.task import Task
 from ansible.playbook.taggable import Taggable
 from ansible.vars.manager import preprocess_vars
@@ -93,7 +93,7 @@ class Play(Base, Taggable, CollectionSearch):
         self._included_conditional = None
         self._included_path = None
         self._removed_hosts = []
-        self.ROLE_CACHE = {}
+        self.role_cache = {}
 
         self.only_tags = set(context.CLIARGS.get('tags', [])) or frozenset(('all',))
         self.skip_tags = set(context.CLIARGS.get('skip_tags', []))
@@ -103,6 +103,15 @@ class Play(Base, Taggable, CollectionSearch):
 
     def __repr__(self):
         return self.get_name()
+
+    @property
+    def ROLE_CACHE(self):
+        """Backwards compat for custom strategies using ``play.ROLE_CACHE``
+        """
+        cache = {}
+        for name, roles in self.role_cache.items():
+            cache[name] = {hash_params(role._get_hash_dict()): role for role in roles}
+        return cache
 
     def _validate_hosts(self, attribute, name, value):
         # Only validate 'hosts' if a value was passed in to original data set.
@@ -393,7 +402,7 @@ class Play(Base, Taggable, CollectionSearch):
 
     def copy(self):
         new_me = super(Play, self).copy()
-        new_me.ROLE_CACHE = self.ROLE_CACHE.copy()
+        new_me.role_cache = self.role_cache.copy()
         new_me._included_conditional = self._included_conditional
         new_me._included_path = self._included_path
         new_me._action_groups = self._action_groups

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -141,10 +141,14 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
             return '.'.join(x for x in (self._role_collection, self._role_name) if x)
         return self._role_name
 
+    def get_role_path(self):
+        return self._role_path
+
     def _get_hash_dict(self):
         return MappingProxyType(
             {
                 'name': self.get_name(),
+                'path': self.get_role_path(),
                 'params': MappingProxyType(self.get_role_params()),
                 'when': self.when,
                 'tags': self.tags,
@@ -172,13 +176,14 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
             r = Role(play=play, from_files=from_files, from_include=from_include, validate=validate, public=public)
             r._load_role_data(role_include, parent_role=parent_role)
 
-            if role_include.get_name() not in play.role_cache:
-                play.role_cache[role_include.get_name()] = []
+            role_path = r.get_role_path()
+            if role_path not in play.role_cache:
+                play.role_cache[role_path] = []
 
             # Using the role name as a cache key is done to improve performance when a large number of roles
             # are in use in the play
-            if r not in play.role_cache[role_include.get_name()]:
-                play.role_cache[role_include.get_name()].append(r)
+            if r not in play.role_cache[role_path]:
+                play.role_cache.setdefault(role_path, []).append(r)
 
             return r
 

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -142,7 +142,8 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         return self._role_name
 
     def get_role_path(self):
-        return self._role_path
+        # Purposefully using realpath for canonical path
+        return os.path.realpath(self._role_path)
 
     def _get_hash_dict(self):
         return MappingProxyType(

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -131,6 +131,8 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         # Indicates whether this role was included via include/import_role
         self.from_include = from_include
 
+        self._hash = None
+
         super(Role, self).__init__()
 
     def __repr__(self):
@@ -146,7 +148,9 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         return os.path.realpath(self._role_path)
 
     def _get_hash_dict(self):
-        return MappingProxyType(
+        if self._hash:
+            return self._hash
+        self._hash = MappingProxyType(
             {
                 'name': self.get_name(),
                 'path': self.get_role_path(),
@@ -158,6 +162,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
                 'from_include': self.from_include,
             }
         )
+        return self._hash
 
     def __eq__(self, other):
         if not isinstance(other, Role):

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -494,14 +494,14 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         all_vars = self.get_inherited_vars(dep_chain, only_exports=only_exports)
 
         # get exported variables from meta/dependencies
-        seen = set()
+        seen = []
         for dep in self.get_all_dependencies():
             # Avoid reruning dupe deps since they can have vars from previous invocations and they accumulate in deps
             # TODO: re-examine dep loading to see if we are somehow improperly adding the same dep too many times
             if dep not in seen:
                 # only take 'exportable' vars from deps
                 all_vars = combine_vars(all_vars, dep.get_vars(include_params=False, only_exports=True))
-                seen.add(dep)
+                seen.append(dep)
 
         # role_vars come from vars/ in a role
         all_vars = combine_vars(all_vars, self._role_vars)

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -111,7 +111,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         self.public = public
         self.static = True
 
-        self._metadata = None
+        self._metadata = RoleMetadata()
         self._play = play
         self._parents = []
         self._dependencies = []
@@ -220,8 +220,6 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         if metadata:
             self._metadata = RoleMetadata.load(metadata, owner=self, variable_manager=self._variable_manager, loader=self._loader)
             self._dependencies = self._load_dependencies()
-        else:
-            self._metadata = RoleMetadata()
 
         # reset collections list; roles do not inherit collections from parents, just use the defaults
         # FUTURE: use a private config default for this so we can allow it to be overridden later
@@ -420,10 +418,9 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         '''
 
         deps = []
-        if self._metadata:
-            for role_include in self._metadata.dependencies:
-                r = Role.load(role_include, play=self._play, parent_role=self)
-                deps.append(r)
+        for role_include in self._metadata.dependencies:
+            r = Role.load(role_include, play=self._play, parent_role=self)
+            deps.append(r)
 
         return deps
 
@@ -632,8 +629,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
         res['_had_task_run'] = self._had_task_run.copy()
         res['_completed'] = self._completed.copy()
 
-        if self._metadata:
-            res['_metadata'] = self._metadata.serialize()
+        res['_metadata'] = self._metadata.serialize()
 
         if include_deps:
             deps = []

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -189,7 +189,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
             # Using the role path as a cache key is done to improve performance when a large number of roles
             # are in use in the play
             if r not in play.role_cache[role_path]:
-                play.role_cache.setdefault(role_path, []).append(r)
+                play.role_cache.append(r)
 
             return r
 

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -181,7 +181,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
             if role_path not in play.role_cache:
                 play.role_cache[role_path] = []
 
-            # Using the role name as a cache key is done to improve performance when a large number of roles
+            # Using the role path as a cache key is done to improve performance when a large number of roles
             # are in use in the play
             if r not in play.role_cache[role_path]:
                 play.role_cache.setdefault(role_path, []).append(r)

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -189,7 +189,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch):
             # Using the role path as a cache key is done to improve performance when a large number of roles
             # are in use in the play
             if r not in play.role_cache[role_path]:
-                play.role_cache.append(r)
+                play.role_cache[role_path].append(r)
 
             return r
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1067,7 +1067,7 @@ class StrategyBase:
             idx = role_cache.index(task._role)
             return role_cache[idx]
         except ValueError:
-            return None
+            raise AnsibleError(f'Cannot locate {task._role.get_name()} in role cache')
 
     def get_hosts_left(self, iterator):
         ''' returns list of available hosts for this iterator by filtering out unreachables '''

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1062,9 +1062,10 @@ class StrategyBase:
 
     def _get_cached_role(self, task, play):
         role_path = task._role.get_role_path()
+        role_cache = play.role_cache[role_path]
         try:
-            idx = play.role_cache[role_path].index(task._role)
-            return play.role_cache[role_path][idx]
+            idx = role_cache.index(task._role)
+            return role_cache[idx]
         except ValueError:
             return None
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1061,8 +1061,8 @@ class StrategyBase:
         return [res]
 
     def _get_cached_role(self, task, play):
-        role_name = task._role.get_name()
-        for role_obj in play.role_cache[role_name]:
+        role_path = task._role.get_role_path()
+        for role_obj in play.role_cache[role_path]:
             if role_obj == task._role:
                 return role_obj
         return None

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1062,10 +1062,11 @@ class StrategyBase:
 
     def _get_cached_role(self, task, play):
         role_path = task._role.get_role_path()
-        for role_obj in play.role_cache[role_path]:
-            if role_obj == task._role:
-                return role_obj
-        return None
+        try:
+            idx = play.role_cache[role_path].index(task._role)
+            return play.role_cache[role_path][idx]
+        except ValueError:
+            return None
 
     def get_hosts_left(self, iterator):
         ''' returns list of available hosts for this iterator by filtering out unreachables '''

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1061,9 +1061,11 @@ class StrategyBase:
         return [res]
 
     def _get_cached_role(self, task, play):
-        for role_obj in play.ROLE_CACHE[task._role.get_name()]:
+        role_name = task._role.get_name()
+        for role_obj in play.role_cache[role_name]:
             if role_obj == task._role:
                 return role_obj
+        return None
 
     def get_hosts_left(self, iterator):
         ''' returns list of available hosts for this iterator by filtering out unreachables '''

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -764,7 +764,7 @@ class StrategyBase:
             # If this is a role task, mark the parent role as being run (if
             # the task was ok or failed, but not skipped or unreachable)
             if original_task._role is not None and role_ran:  # TODO:  and original_task.action not in C._ACTION_INCLUDE_ROLE:?
-                # lookup the role in the ROLE_CACHE to make sure we're dealing
+                # lookup the role in the role cache to make sure we're dealing
                 # with the correct object and mark it as executed
                 role_obj = self._get_cached_role(original_task, iterator._play)
                 role_obj._had_task_run[original_host.name] = True

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -175,13 +175,10 @@ class StrategyModule(StrategyBase):
                         # role which has already run (and whether that role allows duplicate execution)
                         if not isinstance(task, Handler) and task._role:
                             role_obj = self._get_cached_role(task, iterator._play)
-                            if role_obj.has_run(host):
-                                # If there is no metadata, the default behavior is to not allow duplicates,
-                                # if there is metadata, check to see if the allow_duplicates flag was set to true
-                                if task._role._metadata is None or task._role._metadata and not task._role._metadata.allow_duplicates:
-                                    display.debug("'%s' skipped because role has already run" % task, host=host_name)
-                                    del self._blocked_hosts[host_name]
-                                    continue
+                            if role_obj.has_run(host) and role_obj._metadata.allow_duplicates is False:
+                                display.debug("'%s' skipped because role has already run" % task, host=host_name)
+                                del self._blocked_hosts[host_name]
+                                continue
 
                         if task.action in C._ACTION_META:
                             self._execute_meta(task, play_context, iterator, target_host=host)

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -173,13 +173,15 @@ class StrategyModule(StrategyBase):
 
                         # check to see if this task should be skipped, due to it being a member of a
                         # role which has already run (and whether that role allows duplicate execution)
-                        if not isinstance(task, Handler) and task._role and task._role.has_run(host):
-                            # If there is no metadata, the default behavior is to not allow duplicates,
-                            # if there is metadata, check to see if the allow_duplicates flag was set to true
-                            if task._role._metadata is None or task._role._metadata and not task._role._metadata.allow_duplicates:
-                                display.debug("'%s' skipped because role has already run" % task, host=host_name)
-                                del self._blocked_hosts[host_name]
-                                continue
+                        if not isinstance(task, Handler) and task._role:
+                            role_obj = self._get_cached_role(task, iterator._play)
+                            if role_obj.has_run(host):
+                                # If there is no metadata, the default behavior is to not allow duplicates,
+                                # if there is metadata, check to see if the allow_duplicates flag was set to true
+                                if task._role._metadata is None or task._role._metadata and not task._role._metadata.allow_duplicates:
+                                    display.debug("'%s' skipped because role has already run" % task, host=host_name)
+                                    del self._blocked_hosts[host_name]
+                                    continue
 
                         if task.action in C._ACTION_META:
                             self._execute_meta(task, play_context, iterator, target_host=host)

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -172,12 +172,9 @@ class StrategyModule(StrategyBase):
                     # role which has already run (and whether that role allows duplicate execution)
                     if not isinstance(task, Handler) and task._role:
                         role_obj = self._get_cached_role(task, iterator._play)
-                        if role_obj.has_run(host):
-                            # If there is no metadata, the default behavior is to not allow duplicates,
-                            # if there is metadata, check to see if the allow_duplicates flag was set to true
-                            if task._role._metadata is None or task._role._metadata and not task._role._metadata.allow_duplicates:
-                                display.debug("'%s' skipped because role has already run" % task)
-                                continue
+                        if role_obj.has_run(host) and role_obj._metadata.allow_duplicates is False:
+                            display.debug("'%s' skipped because role has already run" % task)
+                            continue
 
                     display.debug("getting variables")
                     task_vars = self._variable_manager.get_vars(play=iterator._play, host=host, task=task,

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -170,12 +170,14 @@ class StrategyModule(StrategyBase):
 
                     # check to see if this task should be skipped, due to it being a member of a
                     # role which has already run (and whether that role allows duplicate execution)
-                    if not isinstance(task, Handler) and task._role and task._role.has_run(host):
-                        # If there is no metadata, the default behavior is to not allow duplicates,
-                        # if there is metadata, check to see if the allow_duplicates flag was set to true
-                        if task._role._metadata is None or task._role._metadata and not task._role._metadata.allow_duplicates:
-                            display.debug("'%s' skipped because role has already run" % task)
-                            continue
+                    if not isinstance(task, Handler) and task._role:
+                        role_obj = self._get_cached_role(task, iterator._play)
+                        if role_obj.has_run(host):
+                            # If there is no metadata, the default behavior is to not allow duplicates,
+                            # if there is metadata, check to see if the allow_duplicates flag was set to true
+                            if task._role._metadata is None or task._role._metadata and not task._role._metadata.allow_duplicates:
+                                display.debug("'%s' skipped because role has already run" % task)
+                                continue
 
                     display.debug("getting variables")
                     task_vars = self._variable_manager.get_vars(play=iterator._play, host=host, task=task,

--- a/test/integration/targets/roles/dupe_inheritance.yml
+++ b/test/integration/targets/roles/dupe_inheritance.yml
@@ -1,8 +1,7 @@
 - name: Test
-  hosts: localhost
+  hosts: testhost
   gather_facts: false
   roles:
-
     - role: top
       info: First definition
       testvar: abc

--- a/test/integration/targets/roles/dupe_inheritance.yml
+++ b/test/integration/targets/roles/dupe_inheritance.yml
@@ -1,0 +1,11 @@
+- name: Test
+  hosts: localhost
+  gather_facts: false
+  roles:
+
+    - role: top
+      info: First definition
+      testvar: abc
+
+    - role: top
+      info: Second definition

--- a/test/integration/targets/roles/roles/bottom/tasks/main.yml
+++ b/test/integration/targets/roles/roles/bottom/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: "{{ info }} - {{ role_name }}: testvar content"
+  debug:
+    msg: '{{ testvar | default("Not specified") }}'

--- a/test/integration/targets/roles/roles/middle/tasks/main.yml
+++ b/test/integration/targets/roles/roles/middle/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: "{{ info }} - {{ role_name }}: testvar content"
+  debug:
+    msg: '{{ testvar | default("Not specified") }}'
+
+- include_role:
+    name: bottom

--- a/test/integration/targets/roles/roles/top/tasks/main.yml
+++ b/test/integration/targets/roles/roles/top/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: "{{ info }} - {{ role_name }}: testvar content"
+  debug:
+    msg: '{{ testvar | default("Not specified") }}'
+
+- include_role:
+    name: middle

--- a/test/integration/targets/roles/runme.sh
+++ b/test/integration/targets/roles/runme.sh
@@ -14,6 +14,7 @@ set -eux
 [ "$(ansible-playbook allowed_dupes.yml -i ../../inventory --tags importrole "$@" | grep -c '"msg": "A"')" = "2" ]
 [ "$(ansible-playbook allowed_dupes.yml -i ../../inventory --tags includerole "$@" | grep -c '"msg": "A"')" = "2" ]
 
+[ "$(ansible-playbook dupe_inheritance.yml -i ../../inventory "$@" | grep -c '"msg": "abc"')" = "3" ]
 
 # ensure role data is merged correctly
 ansible-playbook data_integrity.yml -i ../../inventory "$@"

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -177,7 +177,7 @@ class TestRole(unittest.TestCase):
         })
 
         mock_play = MagicMock()
-        mock_play.ROLE_CACHE = {}
+        mock_play.role_cache = {}
 
         i = RoleInclude.load('foo_tasks', play=mock_play, loader=fake_loader)
         r = Role.load(i, play=mock_play)
@@ -199,7 +199,7 @@ class TestRole(unittest.TestCase):
         })
 
         mock_play = MagicMock()
-        mock_play.ROLE_CACHE = {}
+        mock_play.role_cache = {}
 
         i = RoleInclude.load('foo_tasks', play=mock_play, loader=fake_loader)
         r = Role.load(i, play=mock_play, from_files=dict(tasks='custom_main'))
@@ -217,7 +217,7 @@ class TestRole(unittest.TestCase):
         })
 
         mock_play = MagicMock()
-        mock_play.ROLE_CACHE = {}
+        mock_play.role_cache = {}
 
         i = RoleInclude.load('foo_handlers', play=mock_play, loader=fake_loader)
         r = Role.load(i, play=mock_play)
@@ -238,7 +238,7 @@ class TestRole(unittest.TestCase):
         })
 
         mock_play = MagicMock()
-        mock_play.ROLE_CACHE = {}
+        mock_play.role_cache = {}
 
         i = RoleInclude.load('foo_vars', play=mock_play, loader=fake_loader)
         r = Role.load(i, play=mock_play)
@@ -259,7 +259,7 @@ class TestRole(unittest.TestCase):
         })
 
         mock_play = MagicMock()
-        mock_play.ROLE_CACHE = {}
+        mock_play.role_cache = {}
 
         i = RoleInclude.load('foo_vars', play=mock_play, loader=fake_loader)
         r = Role.load(i, play=mock_play)
@@ -280,7 +280,7 @@ class TestRole(unittest.TestCase):
         })
 
         mock_play = MagicMock()
-        mock_play.ROLE_CACHE = {}
+        mock_play.role_cache = {}
 
         i = RoleInclude.load('foo_vars', play=mock_play, loader=fake_loader)
         r = Role.load(i, play=mock_play)
@@ -303,7 +303,7 @@ class TestRole(unittest.TestCase):
         })
 
         mock_play = MagicMock()
-        mock_play.ROLE_CACHE = {}
+        mock_play.role_cache = {}
 
         i = RoleInclude.load('foo_vars', play=mock_play, loader=fake_loader)
         r = Role.load(i, play=mock_play)
@@ -323,7 +323,7 @@ class TestRole(unittest.TestCase):
         })
 
         mock_play = MagicMock()
-        mock_play.ROLE_CACHE = {}
+        mock_play.role_cache = {}
 
         i = RoleInclude.load('foo_vars', play=mock_play, loader=fake_loader)
         r = Role.load(i, play=mock_play)
@@ -370,7 +370,7 @@ class TestRole(unittest.TestCase):
 
         mock_play = MagicMock()
         mock_play.collections = None
-        mock_play.ROLE_CACHE = {}
+        mock_play.role_cache = {}
 
         i = RoleInclude.load('foo_metadata', play=mock_play, loader=fake_loader)
         r = Role.load(i, play=mock_play)
@@ -415,7 +415,7 @@ class TestRole(unittest.TestCase):
         })
 
         mock_play = MagicMock()
-        mock_play.ROLE_CACHE = {}
+        mock_play.role_cache = {}
 
         i = RoleInclude.load(dict(role='foo_complex'), play=mock_play, loader=fake_loader)
         r = Role.load(i, play=mock_play)


### PR DESCRIPTION
##### SUMMARY
Always create new role

Fixes #78608
Fixes #66694 
Fixes #39543

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
```
lib/ansible/playbook/role/__init__.py
```

##### ADDITIONAL INFORMATION
Currently the role deduplication code, primarily used for handling `allow_duplicates` always dedupes a role, preventing subsequent calls from instantiating a new instance of the role if the role uniqueness checks match.  This is fine when roles don't call other roles, but when roles do call other roles, we get some weird behaviors, with parenting and inheritance.

This PR should alleviate the "weird behaviors" while still offering a way to track role completion for `allow_duplicates` while always instantiating a new role for every use.