### PR TITLE
Added the collection_requirements w/out .rst

### DIFF
--- a/docs/docsite/rst/dev_guide/ansible_index.rst
+++ b/docs/docsite/rst/dev_guide/ansible_index.rst
@@ -93,6 +93,7 @@ If you prefer to read the entire guide, here's a list of the pages in order.
    developing_rebasing
    developing_module_utilities
    developing_collections
+   collection_requirements
    migrating_roles
    collections_galaxy_meta
    overview_architecture

--- a/docs/docsite/sphinx_conf/core_conf.py
+++ b/docs/docsite/sphinx_conf/core_conf.py
@@ -122,6 +122,7 @@ exclude_patterns = [
     'community/steering/steering_committee_past_members.rst',
     'community/steering/steering_index.rst',
     'dev_guide/ansible_index.rst',
+    'dev_guide/collection_requirements.rst',
     'dev_guide/core_index.rst',
     'dev_guide/platforms/aws_guidelines.rst',
     'dev_guide/platforms/openstack_guidelines.rst',

--- a/docs/docsite/sphinx_conf/core_lang_conf.py
+++ b/docs/docsite/sphinx_conf/core_lang_conf.py
@@ -123,6 +123,7 @@ exclude_patterns = [
     'community/steering/steering_index.rst',
     'dev_guide/ansible_index.rst',
     'dev_guide/core_index.rst',
+    'dev_guide/collection_requirements.rst',
     'dev_guide/platforms/aws_guidelines.rst',
     'dev_guide/platforms/openstack_guidelines.rst',
     'dev_guide/platforms/ovirt_dev_guide.rst',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I fix the file that wasn't showing up yet in a toc. By adding `collection_requirements` and `collection_requirements.rst `respectively.  Here are they:

- [https://github.com/ansible/ansible/blame/devel/docs/docsite/rst/dev_guide/ansible_index.rst](https://github.com/ansible/ansible/blame/devel/docs/docsite/rst/dev_guide/ansible_index.rst) This adds the file to a toc.
- [https://github.com/ansible/ansible/blob/devel/docs/docsite/sphinx_](https://github.com/ansible/ansible/blob/devel/docs/docsite/sphinx_conf/core_conf.py)
- [https://github.com/ansible/ansible/blob/devel/docs/docsite/sphinx_conf/core_l](https://github.com/ansible/ansible/blob/devel/docs/docsite/sphinx_conf/core_lang_conf.py) 


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
collection_requirements.rst #78637

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
