### PR TITLE
[stable-2.12] Filter AWS test AMI selection on any Fedora-Cloud-Base image (#78669)

### DIFF
--- a/test/integration/targets/incidental_inventory_aws_ec2/playbooks/setup.yml
+++ b/test/integration/targets/incidental_inventory_aws_ec2/playbooks/setup.yml
@@ -14,7 +14,7 @@
       owner-id: '125523088429'
       virtualization-type: hvm
       root-device-type: ebs
-      name: 'Fedora-Atomic-27*'
+      name: 'Fedora-Cloud-Base-*'
     <<: *aws_connection_info
   register: fedora_images
 


### PR DESCRIPTION
(cherry picked from commit 046c59d)


Co-authored-by: Matt Martz <matt@sivel.net>