### PR TITLE
[stable-2.13] Guard urllib3 imports against all exceptions. Fixes #78648 (#78667)

### DIFF
--- a/changelogs/fragments/78648-urllib3-import-exceptions.yml
+++ b/changelogs/fragments/78648-urllib3-import-exceptions.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- urls - Guard imports of ``urllib3`` by catching ``Exception`` instead of
+  ``ImportError`` to prevent exceptions in the import process of optional
+  dependencies from preventing use of ``urls.py``
+  (https://github.com/ansible/ansible/issues/78648)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -114,19 +114,19 @@ try:
     HAS_URLLIB3_SSL_WRAP_SOCKET = False
     try:
         from urllib3.contrib.pyopenssl import PyOpenSSLContext
-    except ImportError:
+    except Exception:
         from requests.packages.urllib3.contrib.pyopenssl import PyOpenSSLContext
     HAS_URLLIB3_PYOPENSSLCONTEXT = True
-except ImportError:
+except Exception:
     # urllib3<1.15,>=1.6
     HAS_URLLIB3_PYOPENSSLCONTEXT = False
     try:
         try:
             from urllib3.contrib.pyopenssl import ssl_wrap_socket
-        except ImportError:
+        except Exception:
             from requests.packages.urllib3.contrib.pyopenssl import ssl_wrap_socket
         HAS_URLLIB3_SSL_WRAP_SOCKET = True
-    except ImportError:
+    except Exception:
         pass
 
 # Select a protocol that includes all secure tls protocols


### PR DESCRIPTION
(cherry picked from commit f8e24e4)


Co-authored-by: Matt Martz <matt@sivel.net>