### PR TITLE
ansible-galaxy - add support for submodules when installing collection

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -498,6 +498,8 @@ class GalaxyCLI(CLI):
             install_parser.add_argument('--ignore-signature-status-code', dest='ignore_gpg_errors', type=str, action='append',
                                         help=ignore_gpg_status_help, default=C.GALAXY_IGNORE_INVALID_SIGNATURE_STATUS_CODES,
                                         choices=list(GPG_ERROR_MAP.keys()))
+            install_parser.add_argument('--init-submodules', dest='init_submodules', action='store_true',
+                                        default=False, help='Init collection submodules')
         else:
             install_parser.add_argument('-r', '--role-file', dest='requirements',
                                         help='A file containing a list of roles to be installed.')

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -498,8 +498,8 @@ class GalaxyCLI(CLI):
             install_parser.add_argument('--ignore-signature-status-code', dest='ignore_gpg_errors', type=str, action='append',
                                         help=ignore_gpg_status_help, default=C.GALAXY_IGNORE_INVALID_SIGNATURE_STATUS_CODES,
                                         choices=list(GPG_ERROR_MAP.keys()))
-            install_parser.add_argument('--init-submodules', dest='init_submodules', action='store_true',
-                                        default=False, help='Init collection submodules')
+            install_parser.add_argument('--git-init-submodules', dest='git_init_submodules', action='store_true',
+                                        default=False, help='Init git submodules when installing collection from Git SCM')
         else:
             install_parser.add_argument('-r', '--role-file', dest='requirements',
                                         help='A file containing a list of roles to be installed.')

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -8,6 +8,7 @@ __metaclass__ = type
 
 import json
 import os
+import pathlib
 import tarfile
 import subprocess
 import typing as t
@@ -453,7 +454,19 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
             proc_err,
         )
 
-    return (
+    if pathlib.Path(f"{b_checkout_path.decode('utf-8')}/.gitmodules").is_file():
+        git_submodule_cmd = git_executable, 'submodule', 'update', '--init', '--recursive'
+        try:
+            subprocess.check_call(git_submodule_cmd, cwd=b_checkout_path)
+        except subprocess.CalledProcessError as proc_err:
+            raise_from(
+                AnsibleError(
+                    'Failed to download submodules'
+                ),
+                proc_err,
+            )
+
+        return (
         os.path.join(b_checkout_path, to_bytes(fragment))
         if fragment else b_checkout_path
     )

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -462,7 +462,7 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
         try:
             subprocess.check_call(git_submodule_cmd, cwd=b_checkout_path)
         except subprocess.CalledProcessError as proc_err:
-            raise AnsibleError('Failed to download submodules') from proc_err
+            raise AnsibleError('Failed to download Git submodules') from proc_err
 
     return (
         os.path.join(b_checkout_path, to_bytes(fragment))

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -32,7 +32,6 @@ from ansible.galaxy.dependency_resolution.dataclasses import _GALAXY_YAML
 from ansible.galaxy.user_agent import user_agent
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.common.process import get_bin_path
-from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.module_utils.common.yaml import yaml_load
 from ansible.module_utils.six import raise_from
 from ansible.module_utils.urls import open_url
@@ -466,7 +465,7 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
                 proc_err,
             )
 
-        return (
+    return (
         os.path.join(b_checkout_path, to_bytes(fragment))
         if fragment else b_checkout_path
     )

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -456,7 +456,7 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
         )
 
     has_submodules = (pathlib.Path(to_native(b_checkout_path)) / '.gitmodules').is_file()
-    with_submodule_cli_request = context.CLIARGS['init_submodules']
+    with_submodule_cli_request = context.CLIARGS['git_init_submodules']
     if with_submodule_cli_request and has_submodules:
         git_submodule_cmd = git_executable, 'submodule', 'update', '--init', '--recursive'
         try:

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -463,7 +463,6 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
         except subprocess.CalledProcessError as proc_err:
             raise AnsibleError('Failed to download submodules') from proc_err
 
-
     return (
         os.path.join(b_checkout_path, to_bytes(fragment))
         if fragment else b_checkout_path

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -458,12 +458,8 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
         try:
             subprocess.check_call(git_submodule_cmd, cwd=b_checkout_path)
         except subprocess.CalledProcessError as proc_err:
-            raise_from(
-                AnsibleError(
-                    'Failed to download submodules'
-                ),
-                proc_err,
-            )
+            raise AnsibleError('Failed to download submodules') from proc_err
+
 
     return (
         os.path.join(b_checkout_path, to_bytes(fragment))

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -455,7 +455,7 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
             proc_err,
         )
 
-    has_submodules = (pathlib.Path(b_checkout_path.decode()) / '.gitmodules').is_file()
+    has_submodules = (pathlib.Path(to_native(b_checkout_path)) / '.gitmodules').is_file()
     with_submodule_cli_request = context.CLIARGS['init_submodules']
     if with_submodule_cli_request and has_submodules:
         git_submodule_cmd = git_executable, 'submodule', 'update', '--init', '--recursive'

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -454,6 +454,7 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
             ),
             proc_err,
         )
+
     has_submodules = (pathlib.Path(b_checkout_path.decode()) / '.gitmodules').is_file()
     with_submodule_cli_request = context.CLIARGS['init_submodules']
     if with_submodule_cli_request and has_submodules:

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -20,6 +20,8 @@ from urllib.parse import urldefrag
 from shutil import rmtree
 from tempfile import mkdtemp
 
+from ansible import context
+
 if t.TYPE_CHECKING:
     from ansible.galaxy.dependency_resolution.dataclasses import (
         Candidate, Requirement,
@@ -452,8 +454,9 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
             ),
             proc_err,
         )
-
-    if pathlib.Path(str(b_checkout_path) + "/.gitmodules").is_file():
+    has_submodules = (pathlib.Path(b_checkout_path.decode()) / '.gitmodules').is_file()
+    with_submodule_cli_request = context.CLIARGS['init_submodules']
+    if with_submodule_cli_request and has_submodules:
         git_submodule_cmd = git_executable, 'submodule', 'update', '--init', '--recursive'
         try:
             subprocess.check_call(git_submodule_cmd, cwd=b_checkout_path)

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -454,7 +454,7 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
             proc_err,
         )
 
-    if pathlib.Path(f"{b_checkout_path.decode('utf-8')}/.gitmodules").is_file():
+    if pathlib.Path(str(b_checkout_path) + "/.gitmodules").is_file():
         git_submodule_cmd = git_executable, 'submodule', 'update', '--init', '--recursive'
         try:
             subprocess.check_call(git_submodule_cmd, cwd=b_checkout_path)


### PR DESCRIPTION
##### SUMMARY

if a collection has git submodules eg. roles/<submodule1>, ... , install from source code does not initialize git submodules.

this patch check for `<collection_tmp_path>/.gitmodules` presence and then execute `git submodule update --init --recursive`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

ansible-galaxy collection install git+https://path/to/repo

##### ADDITIONAL INFORMATION

this is an example execution with a collection that contains submodules

```paste below
(.venv) ➜  ansible git:(devel) ✗ bin/ansible-galaxy collection install 'git+https://***gitlab***/******/ansible-collections/abc.xyz.git,master' --force
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing
source of code and can become unstable at any point.
Cloning into '/Users/xyz/.ansible/tmp/ansible-local-8633mqv7xdfr/tmpk1qitvel/abc.xyz'...
remote: Enumerating objects: 102, done.
remote: Counting objects: 100% (102/102), done.
remote: Compressing objects: 100% (67/67), done.
remote: Total 778 (delta 46), reused 79 (delta 33), pack-reused 676
Receiving objects: 100% (778/778), 123.61 KiB | 126.00 KiB/s, done.
Resolving deltas: 100% (416/416), done.
Already on 'master'
Your branch is up to date with 'origin/master'.

Submodule 'roles/submodule3' (https://***/****/ansible/ansible-roles/***.git) registered for path 'roles/submodule3'
Submodule path 'roles/submodule3': checked out 'b72e41408991c5ae709f83e67f44e9d4b01e7aeb'
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Installing 'abc.xyz:1.0.3' to '/Users/xyz/.ansible/collections/ansible_collections/abc/xyz'
Created collection for abc.xyz:1.0.3 at /Users/xyz/.ansible/collections/ansible_collections/abc/xyz
abc.xyz:1.0.3 was installed successfully
(.venv) ➜  ansible git:(devel) ✗ 

```
