### PR TITLE
Hold display lock when forking

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -388,7 +388,8 @@ class StrategyBase:
                     worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader, self._variable_manager, plugin_loader)
                     self._workers[self._cur_worker] = worker_prc
                     self._tqm.send_callback('v2_runner_on_start', host, task)
-                    worker_prc.start()
+                    with display._lock:
+                        worker_prc.start()
                     display.debug("worker is %d (out of %d available)" % (self._cur_worker + 1, len(self._workers)))
                     queued = True
 


### PR DESCRIPTION
##### SUMMARY
If any other threads are calling display methods while the main
thread forks, the forked process could inherit a python file object
for stdout/stderr that is locked by a thread that no longer exists.

To avoid that, aquire and hold the lock for display when forking.
After forking, both processes will release the lock and will continue
as expected.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
display
