### PR TITLE
check if there attributes to set

### DIFF
--- a/changelogs/fragments/76727-chattr-fix-for-backups-of-symlinks.yml
+++ b/changelogs/fragments/76727-chattr-fix-for-backups-of-symlinks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - check if there are attributes to set before attempting to set them (https://github.com/ansible/ansible/issues/76727)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -958,7 +958,7 @@ class AnsibleModule(object):
             attr_mod = attributes[0]
             attributes = attributes[1:]
 
-        if existing.get('attr_flags', '') != attributes or attr_mod == '-':
+        if attributes and (existing.get('attr_flags', '') != attributes or attr_mod == '-'):
             attrcmd = self.get_bin_path('chattr')
             if attrcmd:
                 attrcmd = [attrcmd, '%s%s' % (attr_mod, attributes), b_path]

--- a/test/integration/targets/lineinfile/tasks/main.yml
+++ b/test/integration/targets/lineinfile/tasks/main.yml
@@ -1418,3 +1418,30 @@
       - testend1 is changed
       - testend2 is changed
       - testend_file.stat.checksum == 'ef36116966836ce04f6b249fd1837706acae4e19'
+
+- name: Integration test for issue 76727
+  block:
+  - name: Create a symbolic link for the test file
+    file:
+      src: "{{ remote_tmp_dir }}/test.txt"
+      dest: "{{ remote_tmp_dir }}/test-76727.txt"
+      state: link
+
+  - name: Insert a line and back it up
+    lineinfile:
+      dest: "{{ remote_tmp_dir }}/test-76727.txt"
+      state: present
+      line: "#Line for issue 76727"
+      backup: yes
+    register: result1
+
+  - name: Stat the backup file
+    stat:
+      path: "{{ result1.backup }}"
+    register: result2
+
+  - name: Assert that the line was inserted and backup is created
+    assert:
+      that:
+        - result1 is changed
+        - result2.stat.exists


### PR DESCRIPTION
Add fix for issue 76727: check if there attributes to set before attempting to set them

##### SUMMARY
When there are no attributes to be set, the command 'chattr' will fail with 'Operation not supported' when setting the attributes of the backupfile.
Fixes #76727

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py b/lib/ansible/module_utils/basic.py

##### ADDITIONAL INFORMATION
```
Error before change:
_Error while setting attributes: ./test-76727.txt.3395762.2022-09-04@19:05:40~: Operation not supported_
```
