### PR TITLE
Add sudo for writing bash completion to a global

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -250,9 +250,9 @@ Global completion requires bash 4.2.
 
 .. code-block:: console
 
-    $ sudo activate-global-python-argcomplete
+    $ activate-global-python-argcomplete --user
 
-This will write a bash completion file to a global location. Use ``--dest`` to change the location.
+This will write a bash completion file to a user location. Use ``--dest`` to change the location or ``sudo`` to set up the completion globally.
 
 Per command configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -250,7 +250,7 @@ Global completion requires bash 4.2.
 
 .. code-block:: console
 
-    $ activate-global-python-argcomplete
+    $ sudo activate-global-python-argcomplete
 
 This will write a bash completion file to a global location. Use ``--dest`` to change the location.
 


### PR DESCRIPTION
##### SUMMARY
Add `sudo` into `activate-global-python-argcomplete` command.
Already docsite shows that `activate-global-python-argcomplete` command writes bash completion to a global location.
It means that this command needs root privilege.

I ran it as non-root user, following error is occuered.
> activate-global-python-argcomplete: error: [Errno 13] Permission denied: '/etc/bash_completion.d/python-argcomplete'

My environment
OS: Fedora release 33
bash: GNU bash, version 5.0.17
python: Python 3.9.9



##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
