### PR TITLE
Overriding AnsibleContext.resolve is not needed/allowed

### DIFF
--- a/changelogs/fragments/remove-ansiblecontext-resolve.yml
+++ b/changelogs/fragments/remove-ansiblecontext-resolve.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Remove the ``AnsibleContext.resolve`` method as its override is not necessary. Furthermore the ability to override the ``resolve`` method was deprecated in Jinja 3.0.0 and removed in Jinja 3.1.0.

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -327,7 +327,7 @@ class AnsibleUndefined(StrictUndefined):
 
 class AnsibleContext(Context):
     '''
-    A custom context, which intercepts resolve() calls and sets a flag
+    A custom context, which intercepts resolve_or_missing() calls and sets a flag
     internally if any variable lookup returns an AnsibleUnsafe value. This
     flag is checked post-templating, and (when set) will result in the
     final templated result being wrapped in AnsibleUnsafe.
@@ -358,15 +358,6 @@ class AnsibleContext(Context):
     def _update_unsafe(self, val):
         if val is not None and not self.unsafe and self._is_unsafe(val):
             self.unsafe = True
-
-    def resolve(self, key):
-        '''
-        The intercepted resolve(), which uses the helper above to set the
-        internal flag whenever an unsafe variable value is returned.
-        '''
-        val = super(AnsibleContext, self).resolve(key)
-        self._update_unsafe(val)
-        return val
 
     def resolve_or_missing(self, key):
         val = super(AnsibleContext, self).resolve_or_missing(key)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://github.com/pallets/jinja/pull/1393
https://github.com/pallets/jinja/pull/1544

ci_complete
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/template/__init__.py`
