### PR TITLE
ansible-doc consistent version info ignore

### DIFF
--- a/changelogs/fragments/doc_vac_ignore.yml
+++ b/changelogs/fragments/doc_vac_ignore.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-doc will now not display version_added_collection under same conditions it does not display version_added.

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -355,7 +355,7 @@ class DocCLI(CLI, RoleMixin):
     name = 'ansible-doc'
 
     # default ignore list for detailed views
-    IGNORE = ('module', 'docuri', 'version_added', 'short_description', 'now_date', 'plainexamples', 'returndocs', 'collection')
+    IGNORE = ('module', 'docuri', 'version_added', 'version_added_collection', 'short_description', 'now_date', 'plainexamples', 'returndocs', 'collection')
 
     # Warning: If you add more elements here, you also need to add it to the docsite build (in the
     # ansible-community/antsibull repo)


### PR DESCRIPTION
hide the uneeded version_added_collection on tty display as they show now:
```
- host_key_checking
        Determines if SSH should check host keys.
        [Default: True]
        set_via:
          env:
          - name: ANSIBLE_HOST_KEY_CHECKING
          - name: ANSIBLE_SSH_HOST_KEY_CHECKING
            version_added_collection: ansible.builtin
          ini:
          - key: host_key_checking
            section: defaults
          - key: host_key_checking
            section: ssh_connection
            version_added_collection: ansible.builtin
          vars:
          - name: ansible_host_key_checking
            version_added_collection: ansible.builtin
          - name: ansible_ssh_host_key_checking
            version_added_collection: ansible.builtin

        type: boolean
```
after
```
- host_key_checking
        Determines if SSH should check host keys.
        [Default: True]
        set_via:
          env:
          - name: ANSIBLE_HOST_KEY_CHECKING
          - name: ANSIBLE_SSH_HOST_KEY_CHECKING
          ini:
          - key: host_key_checking
            section: defaults
          - key: host_key_checking
            section: ssh_connection
          vars:
          - name: ansible_host_key_checking
          - name: ansible_ssh_host_key_checking
        type: boolean
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-doc
