### PR TITLE
ansible-test - Upgrade pylint.

### DIFF
--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.in
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.in
@@ -1,2 +1,2 @@
-pylint == 2.14.5  # currently vetted version
+pylint == 2.15.2  # currently vetted version
 pyyaml  # needed for collection_detail.py

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
@@ -1,13 +1,13 @@
 # edit "sanity.pylint.in" and generate with: hacking/update-sanity-requirements.py --test pylint
-astroid==2.11.7
+astroid==2.12.9
 dill==0.3.5.1
 isort==5.10.1
 lazy-object-proxy==1.7.1
 mccabe==0.7.0
 platformdirs==2.5.2
-pylint==2.14.5
+pylint==2.15.2
 PyYAML==6.0
 tomli==2.0.1
-tomlkit==0.11.3
+tomlkit==0.11.4
 typing-extensions==4.3.0
 wrapt==1.14.1

--- a/test/lib/ansible_test/_internal/commands/sanity/pylint.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/pylint.py
@@ -18,10 +18,6 @@ from . import (
     SANITY_ROOT,
 )
 
-from ...constants import (
-    CONTROLLER_PYTHON_VERSIONS,
-)
-
 from ...test import (
     TestResult,
 )
@@ -34,7 +30,6 @@ from ...util import (
     SubprocessError,
     display,
     is_subdir,
-    str_to_version,
 )
 
 from ...util_common import (
@@ -69,11 +64,6 @@ class PylintTest(SanitySingleVersion):
             'ansible-deprecated-date',
             'too-complex',
         ])
-
-    @property
-    def supported_python_versions(self) -> t.Optional[tuple[str, ...]]:
-        """A tuple of supported Python versions or None if the test does not depend on specific Python versions."""
-        return tuple(version for version in CONTROLLER_PYTHON_VERSIONS if str_to_version(version) < (3, 11))
 
     @property
     def error_code(self) -> t.Optional[str]:

--- a/test/lib/ansible_test/_internal/host_configs.py
+++ b/test/lib/ansible_test/_internal/host_configs.py
@@ -337,6 +337,7 @@ class PosixRemoteConfig(RemoteConfig, ControllerHostConfig, PosixConfig):
 
     def get_defaults(self, context: HostContext) -> PosixRemoteCompletionConfig:
         """Return the default settings."""
+        # pylint: disable=unexpected-keyword-arg  # see: https://github.com/PyCQA/pylint/issues/7434
         return filter_completion(remote_completion()).get(self.name) or remote_completion().get(self.platform) or PosixRemoteCompletionConfig(
             name=self.name,
             placeholder=True,

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test-target.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test-target.cfg
@@ -3,6 +3,8 @@
 disable=
     consider-using-f-string,  # Python 2.x support still required
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
+    deprecated-method,  # results vary by Python version
+    deprecated-module,  # results vary by Python version
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files
     import-outside-toplevel,  # common pattern in ansible related code
     raise-missing-from,  # Python 2.x does not support raise from

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test.cfg
@@ -3,6 +3,8 @@
 disable=
     consider-using-f-string,  # many occurrences
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
+    deprecated-method,  # results vary by Python version
+    deprecated-module,  # results vary by Python version
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files
     import-outside-toplevel,  # common pattern in ansible related code
     raise-missing-from,  # Python 2.x does not support raise from
@@ -42,6 +44,10 @@ class-attribute-rgx=[A-Za-z_][A-Za-z0-9_]{1,40}$
 attr-rgx=[a-z_][a-z0-9_]{1,40}$
 method-rgx=[a-z_][a-z0-9_]{1,40}$
 function-rgx=[a-z_][a-z0-9_]{1,40}$
+
+# Use the regex from earlier versions of pylint.
+# See: https://github.com/PyCQA/pylint/pull/7322
+typevar-rgx=^_{0,2}(?:[^\W\da-z_]+|(?:[^\W\da-z_]+[^\WA-Z_]+)+T?(?<!Type))(?:_co(?:ntra)?)?$
 
 [IMPORTS]
 

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/code-smell.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/code-smell.cfg
@@ -3,6 +3,8 @@
 disable=
     consider-using-f-string,  # many occurrences
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
+    deprecated-method,  # results vary by Python version
+    deprecated-module,  # results vary by Python version
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files
     import-outside-toplevel,  # common pattern in ansible related code
     raise-missing-from,  # Python 2.x does not support raise from

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
@@ -29,8 +29,8 @@ disable=
     consider-using-max-builtin,
     consider-using-min-builtin,
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
-    deprecated-method,
-    deprecated-module,
+    deprecated-method,  # results vary by Python version
+    deprecated-module,  # results vary by Python version
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files
     eval-used,
     exec-used,

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
@@ -27,8 +27,8 @@ disable=
     consider-using-max-builtin,
     consider-using-min-builtin,
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
-    deprecated-method,
-    deprecated-module,
+    deprecated-method,  # results vary by Python version
+    deprecated-module,  # results vary by Python version
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files
     eval-used,
     exec-used,

--- a/test/lib/ansible_test/_util/target/injector/python.py
+++ b/test/lib/ansible_test/_util/target/injector/python.py
@@ -27,7 +27,7 @@ def main():
                 found = bool(importlib.util.find_spec('coverage'))
             else:
                 # noinspection PyDeprecation
-                import imp  # pylint: disable=deprecated-module
+                import imp
 
                 try:
                     # noinspection PyDeprecation


### PR DESCRIPTION
##### SUMMARY

This version of pylint now supports Python 3.11.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
