### PR TITLE
ansible-doc: show version_added for set_via

### DIFF
--- a/changelogs/fragments/78730-ansible-doc-version_added.yml
+++ b/changelogs/fragments/78730-ansible-doc-version_added.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ansible-doc - show ``version_added`` value for plugin configuration (``set_via``) as well (https://github.com/ansible/ansible/pull/78730)."

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1116,8 +1116,12 @@ class DocCLI(CLI, RoleMixin):
                 if config in opt and opt[config]:
                     # Create a copy so we don't modify the original (in case YAML anchors have been used)
                     conf[config] = [dict(item) for item in opt.pop(config)]
-                    for ignore in DocCLI.IGNORE:
-                        for item in conf[config]:
+                    for item in conf[config]:
+                        version_added = item.pop('version_added', None)
+                        version_added_collection = item.pop('version_added_collection', None)
+                        if version_added:
+                            item['added in'] = DocCLI._format_version_added(version_added, version_added_collection)
+                        for ignore in DocCLI.IGNORE:
                             if ignore in item:
                                 del item[ignore]
 

--- a/test/integration/targets/ansible-doc/randommodule-text.output
+++ b/test/integration/targets/ansible-doc/randommodule-text.output
@@ -25,7 +25,8 @@ OPTIONS (= is mandatory):
         You can use `TEST_ENV' to set this.
         set_via:
           env:
-          - deprecated:
+          - added in: version 1.0.0
+            deprecated:
               alternative: none
               removed_in: 2.0.0
               version: 2.0.0


### PR DESCRIPTION
##### SUMMARY
(Example part of `ansible-doc -t connection ssh`.)

Before:
```
- host_key_checking
        Determines if SSH should check host keys.
        [Default: True]
        set_via:
          env:
          - name: ANSIBLE_HOST_KEY_CHECKING
          - name: ANSIBLE_SSH_HOST_KEY_CHECKING
            version_added_collection: ansible.builtin
          ini:
          - key: host_key_checking
            section: defaults
          - key: host_key_checking
            section: ssh_connection
            version_added_collection: ansible.builtin
          vars:
          - name: ansible_host_key_checking
            version_added_collection: ansible.builtin
          - name: ansible_ssh_host_key_checking
            version_added_collection: ansible.builtin
        
        type: boolean
```
(Since `version_added` is part of `DocCLI.IGNORE`, while `version_added_collection` is not, we get the above output. #78725 will clean that up as well.)

After:
```
- host_key_checking
        Determines if SSH should check host keys.
        [Default: True]
        set_via:
          env:
          - name: ANSIBLE_HOST_KEY_CHECKING
          - added in: version 2.5 of ansible-core
            name: ANSIBLE_SSH_HOST_KEY_CHECKING
          ini:
          - key: host_key_checking
            section: defaults
          - added in: version 2.5 of ansible-core
            key: host_key_checking
            section: ssh_connection
          vars:
          - added in: version 2.5 of ansible-core
            name: ansible_host_key_checking
          - added in: version 2.5 of ansible-core
            name: ansible_ssh_host_key_checking
        
        type: boolean
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-doc
