### PR TITLE
unarchive module fix check_mode for uncompressed tar files

### DIFF
--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -123,7 +123,8 @@ attributes:
     bypass_host_loop:
       support: none
     check_mode:
-      support: full
+      support: partial
+      details: Not supported for gzipped tar files.
     diff_mode:
       support: partial
       details: Uses gtar's C(--diff) arg to calculate if changed or not. If this C(arg) is not supported, it will always unpack the archive.


### PR DESCRIPTION
##### SUMMARY
Changed check-mode from full to partial.
Added details:"Not supported for gzipped tar files.
Fixes #78564 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
\lib\ansible\modules\unarchive.py

