### PR TITLE
Add password_hash filter and fix some nits

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -91,8 +91,7 @@ options:
             - To create an account with a locked/disabled password on Linux systems, set this to C('!') or C('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to C('*************').
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
-              for details on various ways to generate these password values. For instance, to get a sha512 password
-              hash you may use the password_hash('sha512') filter.
+              for details on various ways to generate these password values.
         type: str
     state:
         description:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -86,12 +86,13 @@ options:
         version_added: "2.0"
     password:
         description:
-            - Optionally set the user's password to this crypted value.
+            - Optionally set the user's password to this encrypted value.
             - On macOS systems, this value has to be cleartext. Beware of security issues.
-            - To create a an account with a locked/disabled password on Linux systems, set this to C('!') or C('*').
-            - To create a an account with a locked/disabled password on OpenBSD, set this to C('*************').
+            - To create an account with a locked/disabled password on Linux systems, set this to C('!') or C('*').
+            - To create an account with a locked/disabled password on OpenBSD, set this to C('*************').
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
-              for details on various ways to generate these password values.
+              for details on various ways to generate these password values. For instance, to get a sha512 password
+              hash you may use the password_hash('sha512') filter.
         type: str
     state:
         description:


### PR DESCRIPTION
Proposal to add the `password_hash` filter in the password doc description. In this way, `ansible-doc` users may easily find this sample, which is widely used to generate password hashes (e.g. `{{ 'passwordsaresecret' | password_hash('sha512') }}`) in Linux boxes without having to jump out to the browser for an example.

Cheers!