### PR TITLE
Fix test docs

### DIFF
--- a/lib/ansible/plugins/test/abs.yml
+++ b/lib/ansible/plugins/test/abs.yml
@@ -13,7 +13,7 @@ DOCUMENTATION:
       description: A path.
       type: path
 
-EXAMPLES:
+EXAMPLES: |
     is_path_absolute: "{{ '/etc/hosts' is abs }}}"
     relative_paths: "{{ all_paths | reject('abs') }}"
 

--- a/lib/ansible/plugins/test/directory.yml
+++ b/lib/ansible/plugins/test/directory.yml
@@ -10,7 +10,7 @@ DOCUMENTATION:
       description: A path.
       type: path
 
-EXAMPLES:
+EXAMPLES: |
   vars:
     my_etc_hosts_not_a_dir: "{{ '/etc/hosts' is directory}}"
     list_of_files: "{{ list_of_paths | reject('directory') }}"

--- a/lib/ansible/plugins/test/exists.yml
+++ b/lib/ansible/plugins/test/exists.yml
@@ -11,7 +11,7 @@ DOCUMENTATION:
       description: a path
       type: path
 
-EXAMPLES:
+EXAMPLES: |
   vars:
     my_etc_hosts_exists: "{{ '/etc/hosts' is exist }}"
     list_of_local_files_to_copy_to_remote: "{{ list_of_all_possible_files | select('exists') }}"

--- a/lib/ansible/plugins/test/file.yml
+++ b/lib/ansible/plugins/test/file.yml
@@ -11,7 +11,7 @@ DOCUMENTATION:
       description: A path.
       type: path
 
-EXAMPLES:
+EXAMPLES: |
   vars:
     my_etc_hosts_is_a_file: "{{ '/etc/hosts' is file }}"
     list_of_files: "{{ list_of_paths | select('file') }}"

--- a/lib/ansible/plugins/test/link.yml
+++ b/lib/ansible/plugins/test/link.yml
@@ -11,7 +11,7 @@ DOCUMENTATION:
       description: A path.
       type: path
 
-EXAMPLES:
+EXAMPLES: |
     ismyhostsalink: "{{ '/etc/hosts' is link}}"
     list_of_symlinks: "{{ list_of_paths | select('link') }}"
 

--- a/lib/ansible/plugins/test/link_exists.yml
+++ b/lib/ansible/plugins/test/link_exists.yml
@@ -11,7 +11,7 @@ DOCUMENTATION:
       description: A path.
       type: path
 
-EXAMPLES:
+EXAMPLES: |
     ismyhostsalink: "{{ '/etc/hosts' is link_exists}}"
     list_of_symlinks: "{{ list_of_paths | select('link_exists') }}"
 

--- a/lib/ansible/plugins/test/match.yml
+++ b/lib/ansible/plugins/test/match.yml
@@ -16,7 +16,7 @@ DOCUMENTATION:
       required: True
     ignorecase:
       description: Use case insenstive matching.
-      type:
+      type: boolean
       default: False
     multiline:
       description: Match against mulitple lines in string.

--- a/lib/ansible/plugins/test/mount.yml
+++ b/lib/ansible/plugins/test/mount.yml
@@ -11,7 +11,7 @@ DOCUMENTATION:
       description: A path.
       type: path
 
-EXAMPLES:
+EXAMPLES: |
   vars:
     ihopefalse: "{{ '/etc/hosts' is mount }}"
     normallytrue: "{{ '/tmp' is mount }}"

--- a/lib/ansible/plugins/test/nan.yml
+++ b/lib/ansible/plugins/test/nan.yml
@@ -11,7 +11,7 @@ DOCUMENTATION:
       description: Possible number representation or string that can be converted into one.
       type: raw
       required: true
-EXAMPLES:
+EXAMPLES: |
     isnan: "{{ '42' is nan }}"
 
 RETURN:

--- a/lib/ansible/plugins/test/search.yml
+++ b/lib/ansible/plugins/test/search.yml
@@ -15,7 +15,7 @@ DOCUMENTATION:
       required: True
     ignorecase:
       description: Use case insenstive matching.
-      type:
+      type: boolean
       default: False
     multiline:
       description: Match against mulitple lines in string.


### PR DESCRIPTION
##### SUMMARY
I (resp antsibull-docs) found some problems with some of the test docs:
- Sometimes examples are not strings.
- Two option `type:` had no content (i.e. YAML none)

CC @samccann @bcoca

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
various test plugins
