### PR TITLE
Docs: Fixes issue #78760 missing indexes

### DIFF
--- a/docs/docsite/rst/ansible_index.rst
+++ b/docs/docsite/rst/ansible_index.rst
@@ -96,6 +96,8 @@ Ansible releases a new major release approximately twice a year. The core applic
    :maxdepth: 1
    :caption: Reference & Appendices
 
+   collections/index
+   collections/all_plugins
    reference_appendices/playbooks_keywords
    reference_appendices/common_return_values
    reference_appendices/config

--- a/docs/docsite/rst/collections_guide/collections_index.rst
+++ b/docs/docsite/rst/collections_guide/collections_index.rst
@@ -1,0 +1,6 @@
+.. _index_collections:
+
+Collections index
+=================
+
+You can find an index of collections at :ref:`list_of_collections`.

--- a/docs/docsite/rst/collections_guide/index.rst
+++ b/docs/docsite/rst/collections_guide/index.rst
@@ -24,4 +24,4 @@ You can install and use collections through a distribution server, such as Ansib
    collections_listing
    collections_verifying
    collections_using_playbooks
-   ../collections/index
+   collections_index

--- a/docs/docsite/rst/core_index.rst
+++ b/docs/docsite/rst/core_index.rst
@@ -78,6 +78,8 @@ This documentation covers the version of ``ansible-core`` noted in the upper lef
    :maxdepth: 1
    :caption: Reference & Appendices
 
+   collections/index
+   collections/all_plugins
    reference_appendices/playbooks_keywords
    reference_appendices/common_return_values
    reference_appendices/config

--- a/docs/docsite/rst/module_plugin_guide/index.rst
+++ b/docs/docsite/rst/module_plugin_guide/index.rst
@@ -27,4 +27,4 @@ Ansible ships with several plugins and lets you easily use your own plugins.
    modules_support
    plugin_filtering_config
    ../plugins/plugins
-   ../collections/all_plugins
+   modules_plugins_index

--- a/docs/docsite/rst/module_plugin_guide/modules_plugins_index.rst
+++ b/docs/docsite/rst/module_plugin_guide/modules_plugins_index.rst
@@ -1,0 +1,6 @@
+.. _index_modules_plugins:
+
+Modules and plugins index
+=========================
+
+You can find an index of modules and plugins at :ref:`all_modules_and_plugins`.


### PR DESCRIPTION
##### SUMMARY
Resolves the missing links to the collections index and the modules/plugins index from issue #78760 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Documentation for collections index and modules and plugins index.

##### ADDITIONAL INFORMATION
Follows up on changes introduced for the User Guide restructure with issue #78082 
