### PR TITLE
add galaxy docs back to core'

### DIFF
--- a/docs/docsite/rst/core_index.rst
+++ b/docs/docsite/rst/core_index.rst
@@ -72,6 +72,12 @@ This documentation covers the version of ``ansible-core`` noted in the upper lef
 
    dev_guide/index
 
+.. toctree::
+   :maxdepth: 2
+   :caption: Ansible Galaxy
+
+   galaxy/user_guide.rst
+   galaxy/dev_guide.rst
 
 .. toctree::
    :maxdepth: 1

--- a/docs/docsite/sphinx_conf/core_conf.py
+++ b/docs/docsite/sphinx_conf/core_conf.py
@@ -94,7 +94,6 @@ exclude_patterns = [
     '2.10_index.rst',
     'ansible_index.rst',
     'core_index.rst',
-    'galaxy',
     'network',
     'scenario_guides',
     'community/collection_contributors/test_index.rst',

--- a/docs/docsite/sphinx_conf/core_lang_conf.py
+++ b/docs/docsite/sphinx_conf/core_lang_conf.py
@@ -94,7 +94,6 @@ exclude_patterns = [
     '2.10_index.rst',
     'ansible_index.rst',
     'core_index.rst',
-    'galaxy',
     'network',
     'scenario_guides',
     'community/collection_contributors/test_index.rst',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Core docsite was missing the galaxy user and dev guide. Add them back.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #78760
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/rst/core_index.rst
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
