### PR TITLE
Add OSMC to Debian OS_FAMILY_MAP

### DIFF
--- a/changelogs/fragments/add-omsc-os-family.yml
+++ b/changelogs/fragments/add-omsc-os-family.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Add OSMC to Debian os_family mapping

--- a/changelogs/fragments/add-omsc-os-family.yml
+++ b/changelogs/fragments/add-omsc-os-family.yml
@@ -1,2 +1,2 @@
-bugfixes:
-  - Add OSMC to Debian os_family mapping
+minor_changes:
+  - facts - add OSMC to Debian os_family mapping

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -516,7 +516,7 @@ class Distribution(object):
                                 'EuroLinux', 'Kylin Linux Advanced Server'],
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
                                 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux',
-                                'Pop!_OS', 'Parrot', 'Pardus GNU/Linux', 'Uos', 'Deepin'],
+                                'Pop!_OS', 'Parrot', 'Pardus GNU/Linux', 'Uos', 'Deepin', 'OSMC'],
                      'Suse': ['SuSE', 'SLES', 'SLED', 'openSUSE', 'openSUSE Tumbleweed',
                               'SLES_SAP', 'SUSE_LINUX', 'openSUSE Leap'],
                      'Archlinux': ['Archlinux', 'Antergos', 'Manjaro'],

--- a/test/units/module_utils/facts/system/distribution/fixtures/osmc.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/osmc.json
@@ -1,0 +1,23 @@
+{
+    "name": "OSMC",
+    "input": {
+        "/etc/os-release": "PRETTY_NAME=\"Open Source Media Center\"\nNAME=\"OSMC\"\nVERSION=\"March 2022\"\nVERSION_ID=\"2022.03-1\"\nID=osmc\nID_LIKE=debian\nANSI_COLOR=\"1;31\"\nHOME_URL=\"https://www.osmc.tv\"\nSUPPORT_URL=\"https://www.osmc.tv\"\nBUG_REPORT_URL=\"https://www.osmc.tv\""
+    },
+    "platform.dist": ["", "", ""],
+    "distro": {
+        "codename": "",
+        "id": "osmc",
+        "name": "OSMC",
+        "version": "",
+        "version_best": "",
+        "os_release_info": {},
+        "lsb_release_info": {}
+    },
+    "result": {
+        "distribution": "OSMC",
+        "distribution_major_version": "NA",
+        "distribution_release": "NA",
+        "os_family": "Debian",
+        "distribution_version": "March 2022"
+    }
+}


### PR DESCRIPTION
##### SUMMARY

The `os_family` fact of the Debian-based OSMC distribution was not detected correctly, this PR adds the distribution to the OS_FAMILY_MAP.

##### ADDITIONAL INFORMATION

This was the output before the fix:

```
"ansible_facts['os_family']": "OSMC"
"ansible_facts['distribution']": "OSMC"
```

This is the output after the fix:

```
"ansible_facts['os_family']": "Debian"
"ansible_facts['distribution']": "OSMC"
```

Example of the os-release File:

```
cat /etc/os-release

PRETTY_NAME="Open Source Media Center"
NAME="OSMC"
VERSION="March 2022"
VERSION_ID="2022.03-1"
ID=osmc
ID_LIKE=debian

ANSI_COLOR="1;31"
HOME_URL="https://www.osmc.tv"
SUPPORT_URL="https://www.osmc.tv"
BUG_REPORT_URL="https://www.osmc.tv"
```

Please let me know if I need to adjust the PR in any way. 

Thanks
Markus