### PR TITLE
apt - fix failure when package is not installed and only_upgrade=True

### DIFF
--- a/changelogs/fragments/78781-fix-apt-only_upgrade-behavior.yml
+++ b/changelogs/fragments/78781-fix-apt-only_upgrade-behavior.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt - fix module failure when a package is not installed and only_upgrade=True (https://github.com/ansible/ansible/issues/78762).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -712,7 +712,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         installed, installed_version, version_installable, has_files = package_status(m, name, version_cmp, version, default_release, cache, state='install')
 
         if (not installed_version and not version_installable) or (not installed and only_upgrade):
-            status = False
+            status = not installed and only_upgrade
             data = dict(msg="no available installation candidate for %s" % package)
             return (status, data)
 

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -54,7 +54,7 @@
 
 # https://github.com/ansible/ansible/issues/30638
 - block:
-  - name: Fail to install foo=1.0.1 since foo is not installed and only_upgrade is set
+  - name: Do nothing to install foo=1.0.1 since foo is not installed and only_upgrade is set
     apt:
       name: foo=1.0.1
       state: present
@@ -67,7 +67,7 @@
     assert:
       that:
         - "apt_result is not changed"
-        - "apt_result is failed"
+        - "apt_result is success"
 
   - apt:
       name: foo=1.0.0


### PR DESCRIPTION
##### SUMMARY
Fixes #78762

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
