### PR TITLE
apt - fix short-circuiting when package is not installed and only_upgrade=True

### DIFF
--- a/changelogs/fragments/78781-fix-apt-only_upgrade-behavior.yml
+++ b/changelogs/fragments/78781-fix-apt-only_upgrade-behavior.yml
@@ -1,2 +1,4 @@
 bugfixes:
-  - apt - fix module failure when a package is not installed and only_upgrade=True (https://github.com/ansible/ansible/issues/78762).
+- >-
+  apt - Fix module failure when a package is not installed and only_upgrade=True.
+  Skip that package and check the remaining requested packages for upgrades. (https://github.com/ansible/ansible/issues/78762)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -711,8 +711,13 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         package_names.append(name)
         installed, installed_version, version_installable, has_files = package_status(m, name, version_cmp, version, default_release, cache, state='install')
 
-        if (not installed_version and not version_installable) or (not installed and only_upgrade):
-            status = not installed and only_upgrade
+        if not installed and only_upgrade:
+            # only_upgrade upgrades packages that are already installed
+            # since this package is not installed, skip it
+            continue
+
+        if not installed_version and not version_installable:
+            status = False
             data = dict(msg="no available installation candidate for %s" % package)
             return (status, data)
 

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -54,7 +54,7 @@
 
 # https://github.com/ansible/ansible/issues/30638
 - block:
-  - name: Do nothing to install foo=1.0.1 since foo is not installed and only_upgrade is set
+  - name: Don't install foo=1.0.1 since foo is not installed and only_upgrade is set
     apt:
       name: foo=1.0.1
       state: present
@@ -73,24 +73,30 @@
       name: foo=1.0.0
       allow_unauthenticated: yes
 
-  - name: Upgrade foo to 1.0.1
+  - name: Upgrade foo to 1.0.1 but don't upgrade foobar since it is not installed
     apt:
-      name: foo=1.0.1
+      name: foobar=1.0.1,foo=1.0.1
       state: present
       only_upgrade: yes
       allow_unauthenticated: yes
     register: apt_result
 
   - name: Check install with dpkg
-    shell: dpkg-query -l foo
+    shell: "dpkg-query -l {{ item }}"
     register: dpkg_result
+    ignore_errors: yes
+    loop:
+      - foobar
+      - foo
 
   - name: Check if install was successful
     assert:
       that:
         - "apt_result is success"
-        - "dpkg_result is success"
-        - "'1.0.1' in dpkg_result.stdout"
+        - "dpkg_result.results[0] is failure"
+        - "'1.0.1' not in dpkg_result.results[0].stdout"
+        - "dpkg_result.results[1] is success"
+        - "'1.0.1' in dpkg_result.results[1].stdout"
   always:
     - name: Clean up
       apt:


### PR DESCRIPTION
##### SUMMARY
#78781 fixed only_upgrade=True for an individual package, but returned from the function early, rather than just skipping the particular package.

Before 04e892757941bf77198692bbe37041d7a8cbf999, if a package was not installed and only_upgrade == True, the package wasn't added to the list of packages to install (this line would be False https://github.com/ansible/ansible/commit/04e892757941bf77198692bbe37041d7a8cbf999#diff-821fcd0036eed7308025fa9e825de90fb23fd6ffe6d86e82db56802c5fddc0f7L695, as would be the elif below that), and the function would continue on to the next package.

This reinstates that and I added a test. I've also added it to the backport for 2.13.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
apt
