### PR TITLE
Adding two new os.path filters and its docs

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -2021,17 +2021,6 @@ To join one or more path components:
 
 .. versionadded:: 2.10
 
-.. code-block:: yaml+jinja
-
-    {{ path | commonpath }}
-
-To get Normalize path, eliminating double slashes, etc. (new in version 2.10):
-
-.. code-block:: yaml+jinja
-
-    {{ path | normpath }}
-
-To get the longest common sub-path, given a sequence of path names. (new in version 2.10):
 
 Manipulating strings
 ====================

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -2021,6 +2021,18 @@ To join one or more path components:
 
 .. versionadded:: 2.10
 
+.. code-block:: yaml+jinja
+
+    {{ path | commonpath }}
+
+To get Normalize path, eliminating double slashes, etc. (new in version 2.10):
+
+.. code-block:: yaml+jinja
+
+    {{ path | normpath }}
+
+To get the longest common sub-path, given a sequence of path names. (new in version 2.10):
+
 Manipulating strings
 ====================
 

--- a/lib/ansible/plugins/filter/commonpath.yml
+++ b/lib/ansible/plugins/filter/commonpath.yml
@@ -1,0 +1,24 @@
+DOCUMENTATION:
+  name: commonpath
+  author: Shivam Durgbuns
+  version_added: "2.15"
+  short_description: gets the common path
+  description:
+    - Returns the longest common path from the given list of paths.
+  options:
+    _input:
+      description: A list of paths
+      type: list of path
+      required: true
+  seealso:
+    - plugin: ansible.builtin.basename
+      plugin_type: filter
+EXAMPLES: |
+
+  # To get the longest common path(ex. '/foo/bar') from the given list of paths(ex. ['/foo/bar/foobar','/foo/bar']) 
+  {{ listofpaths | commonpath }}
+
+RETURN:
+  _value:
+    description: The longest common path from the given list of paths.
+    type: path

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -565,6 +565,16 @@ def path_join(paths):
         raise AnsibleFilterTypeError("|path_join expects string or sequence, got %s instead." % type(paths))
 
 
+def commonpath(paths):
+    '''
+    takes a list of paths and it returns the longest common path from the given list.
+    '''
+    if is_sequence(paths):
+        return os.path.commonpath(paths)
+    else:
+        raise AnsibleFilterTypeError("|path_join expects sequence, got %s instead." % type(paths))
+
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -600,6 +610,8 @@ class FilterModule(object):
             'win_basename': partial(unicode_wrap, ntpath.basename),
             'win_dirname': partial(unicode_wrap, ntpath.dirname),
             'win_splitdrive': partial(unicode_wrap, ntpath.splitdrive),
+            'commonpath': commonpath,
+            'normpath': partial(unicode_wrap, os.path.normpath),
 
             # file glob
             'fileglob': fileglob,

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -566,13 +566,18 @@ def path_join(paths):
 
 
 def commonpath(paths):
-    '''
-    takes a list of paths and it returns the longest common path from the given list.
-    '''
-    if is_sequence(paths):
-        return os.path.commonpath(paths)
-    else:
+    """
+    Retrieve the longest common path from the given list.
+
+    :param paths: A list of file system paths.
+    :type paths: List[str]
+    :returns: The longest common path.
+    :rtype: str
+    """
+    if not is_sequence(paths):
         raise AnsibleFilterTypeError("|path_join expects sequence, got %s instead." % type(paths))
+
+    return os.path.commonpath(paths)
 
 
 class FilterModule(object):
@@ -611,7 +616,6 @@ class FilterModule(object):
             'win_dirname': partial(unicode_wrap, ntpath.dirname),
             'win_splitdrive': partial(unicode_wrap, ntpath.splitdrive),
             'commonpath': commonpath,
-            'normpath': partial(unicode_wrap, os.path.normpath),
 
             # file glob
             'fileglob': fileglob,


### PR DESCRIPTION
Signed-off-by: Shivam Durgbuns <sdurgbun@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding two new filters based on os.path, specifically: `os.path.commonpath`, `os.path.normpath`
Fixes #78675 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
core


