### PR TITLE
Fix winRM error "Read timed out."

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -426,8 +426,8 @@ class Connection(ConnectionBase):
                         winrm_kwargs['read_timeout_sec'] = self._winrm_read_timeout
                     else:
                         display.warning(\
-                        "ansible_winrm_read_timeout must be least 12 seconds higher than ansible_winrm_connection_timeout, resetting it: {0}"\
-                        .format(winrm_kwargs['read_timeout_sec']))
+                            "ansible_winrm_read_timeout must be least 10 seconds higher than ansible_winrm_connection_timeout, resetting it: {0}"\
+                            .format(winrm_kwargs['read_timeout_sec']))
                 protocol = Protocol(endpoint, transport=transport, **winrm_kwargs)
 
                 # open the shell from connect so we know we're able to talk to the server

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -425,8 +425,8 @@ class Connection(ConnectionBase):
                     if self._winrm_read_timeout and self._winrm_read_timeout > winrm_kwargs['read_timeout_sec']:
                         winrm_kwargs['read_timeout_sec'] = self._winrm_read_timeout
                     else:
-                        display.warning(\
-                            "ansible_winrm_read_timeout must be least 10 seconds higher than ansible_winrm_connection_timeout, resetting it: {0}"\
+                        display.warning(
+                            "ansible_winrm_read_timeout must be least 10 seconds higher than ansible_winrm_connection_timeout, resetting it: {0}"
                             .format(winrm_kwargs['read_timeout_sec']))
                 protocol = Protocol(endpoint, transport=transport, **winrm_kwargs)
 


### PR DESCRIPTION
The winRM error "winrm connection error: HTTPSConnectionPool(host='1.2.3.4', port=5986): Read timed out. (read timeout=nnn)" is thrown and causes the ansible task to fail. It happens very unpredictable and seemingly randomly on networks with long latency and/or turnaround trips (when the ansible controller client is far away from the winRM-service network wise)

It does not help (very little) to adjust the winrm setting 'ansible_winrm_connection_timeout' to different values, the exception is still thrown seemingly randomly and unpredictable regardless of of the value of 'ansible_winrm_connection_timeout'
  

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Reduces (makes it more unlikely) that the winRM error "winrm connection error: HTTPSConnectionPool(host='172.16.76.240', port=5986): Read timed out. (read timeout=nnn)" is thrown during a winRM-session.

Related to  #23320

This patch should be applied at all support branches (we are running ansible 2.9, therefore targeting that one)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Connection plugin winrm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Conceptual explanation of the nature of the problem.

We have a client (on the ansible controller) and we have the server which is the winRM-service on the manged windows host.
The client server communication protocol is the WS-Management protocol. The client can set a operation timeout parameter on the ansible level, called 'ansible_winrm_connection_timeout' in ansible. This variable is populated down the chain to the connection plugin winrm.py where this variable is assigned to the winrm variables 'operation_timeout_sec' and read_timeout_sec' like this:

```
Line 409: winrm_kwargs['operation_timeout_sec'] = self._winrm_connection_timeout
Line 410: winrm_kwargs['read_timeout_sec'] = self._winrm_connection_timeout + 1

```

Further down the call stack the protocol.py is called where these timeout parameters are set:

```
Line 81:  self.read_timeout_sec = read_timeout_sec
Line 82:  self.operation_timeout_sec = operation_timeout_sec
```

Its ensured that the read_timeout_sec > operation_timeout_sec Note !! The code ensures that the read timeout **is always exactly 1 second greater** than the operation timeout. However, this is the **root cause for the intermittent "read timed out" errors that occurs in some networks.**

This doc line from protocol.py is important:
        @param int operation_timeout_sec: maximum allowed time in seconds for any single wsman HTTP operation (default 20). Note that operation timeouts while receiving output (the only wsman operation that should take any significant time, and where these timeouts are expected) will be silently retried indefinitely. # NOQA

The operation timeout parameter is then assigned the WS-Man data structure

Line 219: w:OperationTimeout': 'PT{0}S'.format(int(self.operation_timeout_sec))

The WS-Man protocol operation parameter is assigned the operation_timeout_sec value. This is determined by the client (ansible controller) and is then passed to the server (the WinRM-service) as the desired maximum operation timeout parameter. When the the command takes longer than this timeout, the server will send back the error code WinRMOperationTimeoutError (2150858793) in a Ws-Man message back to the client. What is important here is that this timer runs on the windows host and expires on that host. The expiration message will be packed into an WS-Man message and sent back to the client which will unpack the message and raise this exception:

```
Line 262: # convert receive timeout code to WinRMOperationTimeoutError
Line 263: if fault_data['wsmanfault_code'] == '2150858793':
Line 264:   raise WinRMOperationTimeoutError()
```

The client raises the exception WinRMOperationTimeoutError which is a perfectly fine exception that only means that the winRM service has not completed the command yet (still working/long running commands).

```
Line: 452: except WinRMOperationTimeoutError:
Line: 453:     # this is an expected error when waiting for a long-running process, just silently retry
Line: 454:     pass
```


In the meanwhile there is another timer running in parallel with the WS-Man timeout. This is the read_timeout_sec parameter which is used in the transport layer in file transport.py. Note that this timer runs on the client (the ansible controller). So this timer when it expires does not need to traverse any network in a protocol and is immediately processed  by the client-code. 

Line: 328: response = self.session.send(prepared_request, timeout=self.read_timeout_sec)

This timeout (which is exactly 1 second greater than the WS-Man operation timeout) is passed to the actual HTTP-request (which Ws-Man is using underneath)

If the timeout is reached by the http-request (which is running on the client, the ansible controller) the following exception is raised:

Line 331:
```
        except requests.HTTPError as ex:
            if ex.response.status_code == 401:
                raise InvalidCredentialsError("the specified credentials were rejected by the server")
            if ex.response.content:
                response_text = self._get_message_response_text(ex.response)
            else:
                response_text = ''

            raise WinRMTransportError('http', ex.response.status_code, response_text)
```

The timeout exception will clearly **be raised again and propagated upwards and causing the current win_command to fail with the error message**:

msg": "winrm connection error: HTTPSConnectionPool(host='172.16.76.240', port=5986): Read timed out. (read timeout=201)",

Note ! Here I set the ansible connection_timeout to 200 in the ansible config and as can be seen the http request in the transport layer expired the timer at exactly 200+1=201 seconds. Note! The error message is always literal "Read timed out. (read timeout=" , nothing else. It looks the same as already reported in issue: https://github.com/ansible/ansible/issues/23320 but the heading is not correct in that issue when it specifies "Windows: WinRM is very sensitive to network issues (ReadTimeout)" The word "ReadTimeout" is not present in any log files that I have seen, but the error message reported in the issue #23320 is exatcly the same described here.

What should have happen here is that the WS-Man operation timeout should have **expired BEFORE the read timeout on the transport layer.** Again, note that the WS-Man operation timeout is running on the WinRM-service on the server and the HTTP read timeout is running on the client, so different machines, two timers running at the same time at different machines.

On a normal working network 1 second should be enough for the HTTP-wrapped WS-Man XML-code message to make its way
back to the client (the ansible controller). The HTTP read timeout timer will never expire in these scenarious (normal network).
But, on some networks or during certain times when the network is busy or with many intermediate routers/switches 1 second is NOT enough. In such cases the HTTP-timer will expire BEFORE the Ws-Man message is received by the client. Thus causing the running win_command to fail in the ansible task.


Solution

If we now ensure that the DIFFERENCE between these two timeout parameters is greater than 1 second, You can set 5-10 seconds, this issue will  be eliminated in most cases. We have verified that at our sites (we have thousands of ansible clients) and we have not received this error since the difference between the timeouts has been increased (we have 10 seconds which probably is unnecessary to high). Of course can this exception be thrown if there is a **real network problem** between the client and the server, and in such cases it should be thrown of course.


PSRP

I looked into the PSRP-module by @jborean93.

In the file 'psrp.py' (https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/connection/psrp.py) @jborean93 introduced two timeouts:

```
  operation_timeout:
    description:
    - Sets the WSMan timeout for each operation.
    - This is measured in seconds.
    - This should not exceed the value for C(connection_timeout).
    type: int
    vars:
    - name: ansible_psrp_operation_timeout

  read_timeout:
    description:
    - The read timeout for receiving data from the remote host.
    - This value must always be greater than I(operation_timeout).
    - This option requires pypsrp >= 0.3.
    - This is measured in seconds.
    type: int
    vars:
    - name: ansible_psrp_read_timeout
    default: 30
    version_added: '2.8'
    default: 20
```

Here we can see that the read timeout on the client side is 10 seconds higher than the WS-Man operation timeout on the serverside by default: (30 vs 20). So when using PSRP this issue is unlikely to happen (not frequently as in winRM at least)


The Patch

The fix is to implement the same timeout parameters as in PSRP and ensure that the difference is at least n seconds (suggestion 10 seconds). This patch has been run in our production environments (several thousands of ansible winrm-clients) in several months and we have not seen this winRM Read timed out error occur since that except for a few cases on a really broken network.


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
