### PR TITLE
runtime-metadata sanity test: ensure redirects are FQCRs

### DIFF
--- a/changelogs/fragments/78802-sanity-meta-runtime.yml
+++ b/changelogs/fragments/78802-sanity-meta-runtime.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - "ansible-test runtime-metadata sanity test - ensure that ``redirect`` entries in ``meta/runtime.yml`` are FQCRs (https://github.com/ansible/ansible/pull/78802)."
+  - "ansible-test runtime-metadata sanity test - ensure that ``redirect`` entries in ``meta/runtime.yml`` contain collection names (https://github.com/ansible/ansible/pull/78802)."
 bugfixes:
   - "ansible-test runtime-metadata sanity test - do not crash on YAML parsing errors without a context mark (https://github.com/ansible/ansible/pull/78802)."

--- a/changelogs/fragments/78802-sanity-meta-runtime.yml
+++ b/changelogs/fragments/78802-sanity-meta-runtime.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - "ansible-test runtime-metadata sanity test - ensure that ``redirect`` entries in ``meta/runtime.yml`` contain collection names (https://github.com/ansible/ansible/pull/78802)."
+  - "ansible-test runtime-metadata sanity test - ensure that ``redirect`` entries in ``meta/runtime.yml`` contain collection names, except for ``module_utils`` plugin redirects and ``import_redirect`` redirects (https://github.com/ansible/ansible/pull/78802)."
 bugfixes:
   - "ansible-test runtime-metadata sanity test - do not crash on YAML parsing errors without a context mark (https://github.com/ansible/ansible/pull/78802)."

--- a/changelogs/fragments/78802-sanity-meta-runtime.yml
+++ b/changelogs/fragments/78802-sanity-meta-runtime.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ansible-test runtime-metadata sanity test - ensure that ``redirect`` entries in ``meta/runtime.yml`` are FQCRs (https://github.com/ansible/ansible/pull/78802)."

--- a/changelogs/fragments/78802-sanity-meta-runtime.yml
+++ b/changelogs/fragments/78802-sanity-meta-runtime.yml
@@ -1,2 +1,4 @@
 minor_changes:
   - "ansible-test runtime-metadata sanity test - ensure that ``redirect`` entries in ``meta/runtime.yml`` are FQCRs (https://github.com/ansible/ansible/pull/78802)."
+bugfixes:
+  - "ansible-test runtime-metadata sanity test - do not crash on YAML parsing errors without a context mark (https://github.com/ansible/ansible/pull/78802)."

--- a/test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/meta/runtime.yml
+++ b/test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/meta/runtime.yml
@@ -2,4 +2,4 @@ requires_ansible: '>=2.11'  # force ansible-doc to check the Ansible version (re
 plugin_routing:
   modules:
     hi:
-      redirect: hello
+      redirect: ns.col2.hello

--- a/test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/meta/runtime.yml
+++ b/test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/meta/runtime.yml
@@ -3,3 +3,10 @@ plugin_routing:
   modules:
     hi:
       redirect: ns.col2.hello
+    hiya:
+      redirect: ns.col2.package.subdir.hiya
+  module_utils:
+    hi:
+      redirect: ns.col2
+    hello:
+      redirect: ns.col2.hiya

--- a/test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/meta/runtime.yml
+++ b/test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/meta/runtime.yml
@@ -7,6 +7,6 @@ plugin_routing:
       redirect: ns.col2.package.subdir.hiya
   module_utils:
     hi:
-      redirect: ns.col2
+      redirect: ansible_collections.ns.col2.plugins.module_utils
     hello:
       redirect: ns.col2.hiya

--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
@@ -16,7 +16,17 @@ from voluptuous.humanize import humanize_error
 
 from ansible.module_utils.compat.version import StrictVersion, LooseVersion
 from ansible.module_utils.six import string_types
+from ansible.utils.collection_loader import AnsibleCollectionRef
 from ansible.utils.version import SemanticVersion
+
+
+def fqcr(value):
+    """Validate a FQCR."""
+    if not isinstance(value, string_types):
+        raise Invalid('Must be a string that is a FQCR')
+    if not AnsibleCollectionRef.is_valid_fqcr(value):
+        raise Invalid('Must be a FQCR')
+    return value
 
 
 def isodate(value, check_deprecation_date=False, is_tombstone=False):
@@ -188,7 +198,7 @@ def validate_metadata_file(path, is_ansible, check_deprecation_dates=False):
         Schema({
             ('deprecation'): Any(deprecation_schema),
             ('tombstone'): Any(tombstoning_schema),
-            ('redirect'): Any(*string_types),
+            ('redirect'): fqcr,
         }, extra=PREVENT_EXTRA),
     )
 

--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
@@ -29,15 +29,6 @@ def fqcr(value):
     return value
 
 
-def collection_name(value):
-    """Validate a collection name."""
-    if not isinstance(value, string_types):
-        raise Invalid('Must be a string that is a collection name')
-    if not AnsibleCollectionRef.is_valid_collection_name(value):
-        raise Invalid('Must be a collection name')
-    return value
-
-
 def isodate(value, check_deprecation_date=False, is_tombstone=False):
     """Validate a datetime.date or ISO 8601 date string."""
     # datetime.date objects come from YAML dates, these are ok
@@ -219,7 +210,7 @@ def validate_metadata_file(path, is_ansible, check_deprecation_dates=False):
         Schema({
             ('deprecation'): Any(deprecation_schema),
             ('tombstone'): Any(tombstoning_schema),
-            ('redirect'): Any(*string_types),  # TODO: use something like Any(fqcr, collection_name),
+            ('redirect'): Any(*string_types),
         }, extra=PREVENT_EXTRA),
     )
 
@@ -255,7 +246,7 @@ def validate_metadata_file(path, is_ansible, check_deprecation_dates=False):
 
     import_redirection_schema = Any(
         Schema({
-            ('redirect'): Any(fqcr, collection_name),
+            ('redirect'): Any(*string_types),
             # import_redirect doesn't currently support deprecation
         }, extra=PREVENT_EXTRA)
     )

--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
@@ -136,12 +136,15 @@ def validate_metadata_file(path, is_ansible, check_deprecation_dates=False):
         with open(path, 'r', encoding='utf-8') as f_path:
             routing = yaml.safe_load(f_path)
     except yaml.error.MarkedYAMLError as ex:
-        print('%s:%d:%d: YAML load failed: %s' % (path, ex.context_mark.line +
-                                                  1, ex.context_mark.column + 1, re.sub(r'\s+', ' ', str(ex))))
+        print('%s:%d:%d: YAML load failed: %s' % (
+            path,
+            ex.context_mark.line + 1 if ex.context_mark else 0,
+            ex.context_mark.column + 1 if ex.context_mark else 0,
+            re.sub(r'\s+', ' ', str(ex)),
+        ))
         return
     except Exception as ex:  # pylint: disable=broad-except
-        print('%s:%d:%d: YAML load failed: %s' %
-              (path, 0, 0, re.sub(r'\s+', ' ', str(ex))))
+        print('%s:%d:%d: YAML load failed: %s' % (path, 0, 0, re.sub(r'\s+', ' ', str(ex))))
         return
 
     if is_ansible:

--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
@@ -219,7 +219,7 @@ def validate_metadata_file(path, is_ansible, check_deprecation_dates=False):
         Schema({
             ('deprecation'): Any(deprecation_schema),
             ('tombstone'): Any(tombstoning_schema),
-            ('redirect'): Any(fqcr, collection_name),
+            ('redirect'): Any(*string_types),  # TODO: use something like Any(fqcr, collection_name),
         }, extra=PREVENT_EXTRA),
     )
 


### PR DESCRIPTION
##### SUMMARY
Now that #78755 makes ansible-core fail when it encounters a meta/runtime.yml redirect that is not a FQCR, update the runtime-metadata sanity test to prevent collections from accidentally adding these.

Also fixes crash when `meta/runtime.yml` accidentally starts with `foo---` instead of `---` (happens when someone types something in the wrong window...).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
