### PR TITLE
Read editor command from ANSIBLE_VAULT_EDITOR, falling back to EDITOR

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -13,6 +13,17 @@ ANSIBLE_HOME:
     section: defaults
   type: path
   version_added: '2.14'
+ANSIBLE_VAULT_EDITOR:
+  name: Editor program to use with ansible-vault
+  description:
+  - Allows to set an editor different from system-wide, falls back to $EDITOR
+  default: null
+  env:
+  - name: ANSIBLE_VAULT_EDITOR
+  ini:
+  - key: vault_editor
+    section: defaults
+  type: string
 ANSIBLE_CONNECTION_PATH:
   name: Path of ansible-connection script
   default: null

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -1123,7 +1123,7 @@ class VaultEditor:
             os.chown(dest, prev.st_uid, prev.st_gid)
 
     def _editor_shell_command(self, filename):
-        env_editor = os.environ.get('ANSIBLE_EDITOR', os.environ.get('EDITOR', 'vi'))
+        env_editor = getattr(C, 'ANSIBLE_VAULT_EDITOR') or os.environ.get('EDITOR', 'vi')
         editor = shlex.split(env_editor)
         editor.append(filename)
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -1123,7 +1123,7 @@ class VaultEditor:
             os.chown(dest, prev.st_uid, prev.st_gid)
 
     def _editor_shell_command(self, filename):
-        env_editor = os.environ.get('EDITOR', 'vi')
+        env_editor = os.environ.get('ANSIBLE_EDITOR', os.environ.get('EDITOR', 'vi'))
         editor = shlex.split(env_editor)
         editor.append(filename)
 


### PR DESCRIPTION
##### SUMMARY

This PR adds possibility to define editor for `ansible-vault edit` command different from system wide. So users can, for example, set secure editor to edit their vaults without sacrificing UX in other use cases.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ansible-vault

##### ADDITIONAL INFORMATION

To use ansible-vault edit/create commands with secured editor I have to define EDITOR environment variable for every invocation separately:

```shell
EDITOR='nvim --cmd "let g:incognito=v:true"' ansible-vault edit vault.yml
```

… then in neovim config:

```lua
if vim.g.incognito then
  opt.shada = nil
  opt.shadafile = 'NONE'
  opt.backup = false
  opt.writebackup = false
  opt.swapfile = false
  opt.undofile = false
end

-- Persistent undo
if vim.fn.has 'persistent_undo' and not vim.g.incognito then
  opt.undofile = true
  if not vim.fn.has 'win32' then
    opt.undodir = vim.fn.stdpath 'data' .. '/undo//'
  end
end
```

With this change it will be possible leave original EDITOR and set ANSIBLE_EDITOR

```shell
export EDITOR=nvim
export ANSIBLE_VAULT_EDITOR='nvim --cmd "let g:incognito=v:true"'
```

… then just use ansible-vault

```shell
ansible-vault edit vault.yml
```
