### PR TITLE
Restrict `hvac` Python distribution in py2 tests

### DIFF
--- a/test/integration/targets/lookup_hashi_vault/playbooks/install_dependencies.yml
+++ b/test/integration/targets/lookup_hashi_vault/playbooks/install_dependencies.yml
@@ -16,5 +16,5 @@
 
     - name: 'Install hvac Python package'
       pip:
-        name: "{{ hvac_package|default('hvac') }}"
+        name: "{{ hvac_package | default('hvac < 1.0.0') }}"
         extra_args: "-c {{ playbook_dir }}/../../../../lib/ansible_test/_data/requirements/constraints.txt"

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -48,7 +48,6 @@ setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require pyth
 cffi != 1.14.4 # Fails on systems with older gcc. Should be fixed in the next release. https://foss.heptapod.net/pypy/cffi/-/issues/480
 websocket-client < 1 ; python_version < '3'  # version 1.0.0 drops support for python 2
 certifi < 2020.4.5.2 ; python_version < '3'  # version 2020.4.5.2 drops support for python 2
-hvac < 1.0.0 ; python_version < '3'  # version 1.0.0 breaks and subsequently drops support for python 2
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.3.3

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -48,6 +48,7 @@ setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require pyth
 cffi != 1.14.4 # Fails on systems with older gcc. Should be fixed in the next release. https://foss.heptapod.net/pypy/cffi/-/issues/480
 websocket-client < 1 ; python_version < '3'  # version 1.0.0 drops support for python 2
 certifi < 2020.4.5.2 ; python_version < '3'  # version 2020.4.5.2 drops support for python 2
+hvac < 1.0.0 ; python_version < '3'  # version 1.0.0 breaks and subsequently drops support for python 2
 
 # freeze pylint and its requirements for consistent test results
 astroid == 2.3.3


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Testing Pull Request
- Maintenance Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/lib/ansible_test/_data/requirements/constraints.txt

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This package is incompatible with Python 2 starting v1.0.0.