### PR TITLE
fix azure extend_group name for consistency

### DIFF
--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -9705,7 +9705,7 @@ action_groups:
   azure:
     - metadata:
         extend_group:
-          - azure.azcollection.azure
+          - azure.azcollection.all
   cpm:
     - metadata:
         extend_group:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

In `azure.azcollection` collection, the group name `azure.azcollection.all` was defined by https://github.com/ansible-collections/azure/pull/874 .
On the other hands, `azure` legacy group name in ansible-core points `azure.azcollection.azure` by `extend_group`.
https://github.com/ansible/ansible/blob/v2.13.4/lib/ansible/config/ansible_builtin_runtime.yml#L9705-L9708

We discussed the approach to keep consistency group name at https://github.com/ansible-collections/azure/issues/977 .

Then I fixed `extend_group` from `azure.azcollection.azure` to `azure.azcollection.all` 


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `config/ansible_builtin_runtime.yml`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

According to this fix, we can keep using `azure` [legacy group name](https://docs.ansible.com/ansible/latest/user_guide/playbooks_module_defaults.html#module-defaults-groups) as bellow.
<!--- Paste verbatim command output below, e.g. before and after your change -->


```yaml
---
- hosts: localhost
  connection: local
  gather_facts: false

  module_defaults:
    group/azure:
      resource_group: rg01

  tasks:
    - name: vnet
      azure.azcollection.azure_rm_virtualnetwork:
        name: rg01_nw
        address_prefixes_cidr:
          - 172.16.0.0/16
```
