### PR TITLE
fix network_connection_options text

### DIFF
--- a/docs/docsite/rst/network/getting_started/network_connection_options.rst
+++ b/docs/docsite/rst/network/getting_started/network_connection_options.rst
@@ -42,7 +42,7 @@ Using the global configuration (in :file:`ansible.cfg`)
 
 .. code-block:: ini
 
-  [persistent_connection ]
+  [persistent_connection]
   command_timeout = 30
 
 See :ref:`ansible_variable_precedence` for details on the relative precedence of each of these variables. See the individual connection type to understand each option.


### PR DESCRIPTION
##### SUMMARY
In the Network Module Description page, the ini file section name has an illegal space and is not reflected in the configuration.

Description page(https://docs.ansible.com/ansible/devel/network/getting_started/network_connection_options.html#setting-timeout-options)

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
Setting timeout options for using the global configuration (in ansible.cfg)

##### ADDITIONAL INFORMATION
I  erase an illegal space in Using the global configuration (in ansible.cfg)
