### PR TITLE
DNM Fix using a fully qualified ansible.builtin module after legacy module

### DIFF
--- a/changelogs/fragments/ansible-builtin-module-cache-path.yml
+++ b/changelogs/fragments/ansible-builtin-module-cache-path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix using a fully qualified ansible.builtin Python module after calling a custom ansible.legacy Python module by the short name.

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1147,7 +1147,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
             compression_method = zipfile.ZIP_STORED
 
         lookup_path = os.path.join(C.DEFAULT_LOCAL_TMP, 'ansiballz_cache')
-        cached_module_filename = os.path.join(lookup_path, "%s-%s" % (remote_module_fqn, module_compression))
+        cached_module_filename = os.path.join(lookup_path, "%s-%s-%s" % (module_name, remote_module_fqn, module_compression))
 
         zipdata = None
         # Optimization -- don't lock if the module has already been cached

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1147,7 +1147,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
             compression_method = zipfile.ZIP_STORED
 
         lookup_path = os.path.join(C.DEFAULT_LOCAL_TMP, 'ansiballz_cache')
-        cached_module_filename = os.path.join(lookup_path, "%s-%s-%s" % (module_name, remote_module_fqn, module_compression))
+        cached_module_filename = os.path.join(lookup_path, "%s-%s" % (remote_module_fqn, module_compression))
 
         zipdata = None
         # Optimization -- don't lock if the module has already been cached

--- a/test/integration/targets/plugin_loader/override/legacy.yml
+++ b/test/integration/targets/plugin_loader/override/legacy.yml
@@ -1,0 +1,12 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - ping:
+    register: legacy
+  - ansible.builtin.ping:
+    register: builtin
+  - assert:
+      that:
+        - legacy['ping'] == 'legacy'
+        - builtin['ping'] == 'pong'

--- a/test/integration/targets/plugin_loader/override/library/ping.py
+++ b/test/integration/targets/plugin_loader/override/library/ping.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: ping
+version_added: historical
+short_description: Try to connect to host, verify a usable python and return C(pong) on success
+description:
+  - A trivial test module, this module always returns C(pong) on successful
+    contact. It does not make sense in playbooks, but it is useful from
+    C(/usr/bin/ansible) to verify the ability to login and that a usable Python is configured.
+  - This is NOT ICMP ping, this is just a trivial test module that requires Python on the remote-node.
+  - For Windows targets, use the M(ansible.windows.win_ping) module instead.
+  - For Network targets, use the M(ansible.netcommon.net_ping) module instead.
+options:
+  data:
+    description:
+      - Data to return for the C(ping) return value.
+      - If this parameter is set to C(crash), the module will cause an exception.
+    type: str
+    default: pong
+extends_documentation_fragment:
+    - action_common_attributes
+attributes:
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
+    platform:
+        platforms: posix
+seealso:
+  - module: ansible.netcommon.net_ping
+  - module: ansible.windows.win_ping
+author:
+  - Ansible Core Team
+  - Michael DeHaan
+'''
+
+EXAMPLES = '''
+# Test we can logon to 'webservers' and execute python with json lib.
+# ansible webservers -m ansible.builtin.ping
+
+- name: Example from an Ansible Playbook
+  ansible.builtin.ping:
+
+- name: Induce an exception to see what happens
+  ansible.builtin.ping:
+    data: crash
+'''
+
+RETURN = '''
+ping:
+    description: Value provided with the data parameter.
+    returned: success
+    type: str
+    sample: pong
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            data=dict(type='str', default='legacy'),
+        ),
+        supports_check_mode=True
+    )
+
+    if module.params['data'] == 'crash':
+        raise Exception("boom")
+
+    result = dict(
+        ping=module.params['data'],
+    )
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/plugin_loader/override/library/ping.py
+++ b/test/integration/targets/plugin_loader/override/library/ping.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
-
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
 # (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
-__metaclass__ = type
-
+from __future__ import annotations
 
 DOCUMENTATION = '''
 ---

--- a/test/integration/targets/plugin_loader/override/library/ping.py
+++ b/test/integration/targets/plugin_loader/override/library/ping.py
@@ -1,11 +1,88 @@
-#!/usr/bin/python
-from __future__ import annotations
+# -*- coding: utf-8 -*-
 
-import json
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: ping
+version_added: historical
+short_description: Try to connect to host, verify a usable python and return C(pong) on success
+description:
+  - A trivial test module, this module always returns C(pong) on successful
+    contact. It does not make sense in playbooks, but it is useful from
+    C(/usr/bin/ansible) to verify the ability to login and that a usable Python is configured.
+  - This is NOT ICMP ping, this is just a trivial test module that requires Python on the remote-node.
+  - For Windows targets, use the M(ansible.windows.win_ping) module instead.
+  - For Network targets, use the M(ansible.netcommon.net_ping) module instead.
+options:
+  data:
+    description:
+      - Data to return for the C(ping) return value.
+      - If this parameter is set to C(crash), the module will cause an exception.
+    type: str
+    default: pong
+extends_documentation_fragment:
+    - action_common_attributes
+attributes:
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
+    platform:
+        platforms: posix
+seealso:
+  - module: ansible.netcommon.net_ping
+  - module: ansible.windows.win_ping
+author:
+  - Ansible Core Team
+  - Michael DeHaan
+'''
+
+EXAMPLES = '''
+# Test we can logon to 'webservers' and execute python with json lib.
+# ansible webservers -m ansible.builtin.ping
+
+- name: Example from an Ansible Playbook
+  ansible.builtin.ping:
+
+- name: Induce an exception to see what happens
+  ansible.builtin.ping:
+    data: crash
+'''
+
+RETURN = '''
+ping:
+    description: Value provided with the data parameter.
+    returned: success
+    type: str
+    sample: pong
+'''
+
+from ansible.module_utils.basic import AnsibleModule
 
 
 def main():
-    print(json.dumps(dict(changed=False, ping='legacy')))
+    module = AnsibleModule(
+        argument_spec=dict(
+            data=dict(type='str', default='legacy'),
+        ),
+        supports_check_mode=True
+    )
+
+    if module.params['data'] == 'crash':
+        raise Exception("boom")
+
+    result = dict(
+        ping=module.params['data'],
+    )
+
+    module.exit_json(**result)
 
 
 if __name__ == '__main__':

--- a/test/integration/targets/plugin_loader/override/library/ping.py
+++ b/test/integration/targets/plugin_loader/override/library/ping.py
@@ -1,88 +1,11 @@
-# -*- coding: utf-8 -*-
+#!/usr/bin/python
+from __future__ import annotations
 
-# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
-# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
-from __future__ import absolute_import, division, print_function
-__metaclass__ = type
-
-
-DOCUMENTATION = '''
----
-module: ping
-version_added: historical
-short_description: Try to connect to host, verify a usable python and return C(pong) on success
-description:
-  - A trivial test module, this module always returns C(pong) on successful
-    contact. It does not make sense in playbooks, but it is useful from
-    C(/usr/bin/ansible) to verify the ability to login and that a usable Python is configured.
-  - This is NOT ICMP ping, this is just a trivial test module that requires Python on the remote-node.
-  - For Windows targets, use the M(ansible.windows.win_ping) module instead.
-  - For Network targets, use the M(ansible.netcommon.net_ping) module instead.
-options:
-  data:
-    description:
-      - Data to return for the C(ping) return value.
-      - If this parameter is set to C(crash), the module will cause an exception.
-    type: str
-    default: pong
-extends_documentation_fragment:
-    - action_common_attributes
-attributes:
-    check_mode:
-        support: full
-    diff_mode:
-        support: none
-    platform:
-        platforms: posix
-seealso:
-  - module: ansible.netcommon.net_ping
-  - module: ansible.windows.win_ping
-author:
-  - Ansible Core Team
-  - Michael DeHaan
-'''
-
-EXAMPLES = '''
-# Test we can logon to 'webservers' and execute python with json lib.
-# ansible webservers -m ansible.builtin.ping
-
-- name: Example from an Ansible Playbook
-  ansible.builtin.ping:
-
-- name: Induce an exception to see what happens
-  ansible.builtin.ping:
-    data: crash
-'''
-
-RETURN = '''
-ping:
-    description: Value provided with the data parameter.
-    returned: success
-    type: str
-    sample: pong
-'''
-
-from ansible.module_utils.basic import AnsibleModule
+import json
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            data=dict(type='str', default='legacy'),
-        ),
-        supports_check_mode=True
-    )
-
-    if module.params['data'] == 'crash':
-        raise Exception("boom")
-
-    result = dict(
-        ping=module.params['data'],
-    )
-
-    module.exit_json(**result)
+    print(json.dumps(dict(changed=False, ping='legacy')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
Fix legacy modules being cached and subsequently incorrectly used for fully qualified ansible.builtin modules.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
plugin/loader.py