### PR TITLE
Disable IP address lookups in iptables -module when listing

### DIFF
--- a/changelogs/fragments/78828-iptables-option-to-disable-dns-lookups.yml
+++ b/changelogs/fragments/78828-iptables-option-to-disable-dns-lookups.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - add parameter ``numeric`` to the iptables module to disable dns lookups when running list -action internally (https://github.com/ansible/ansible/issues/78793).

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -721,7 +721,8 @@ def set_chain_policy(iptables_path, module, params):
 
 def get_chain_policy(iptables_path, module, params):
     cmd = push_arguments(iptables_path, '-L', params, make_rule=False)
-    cmd.append('--numeric')
+    if module.numeric
+      cmd.append('--numeric')
     rc, out, _ = module.run_command(cmd, check_rc=True)
     chain_header = out.split("\n")[0]
     result = re.search(r'\(policy ([A-Z]+)\)', chain_header)
@@ -743,7 +744,8 @@ def create_chain(iptables_path, module, params):
 
 def check_chain_present(iptables_path, module, params):
     cmd = push_arguments(iptables_path, '-L', params, make_rule=False)
-    cmd.append('--numeric')
+    if module.numeric
+      cmd.append('--numeric')
     rc, _, __ = module.run_command(cmd, check_rc=False)
     return (rc == 0)
 
@@ -811,6 +813,7 @@ def main():
             flush=dict(type='bool', default=False),
             policy=dict(type='str', choices=['ACCEPT', 'DROP', 'QUEUE', 'RETURN']),
             chain_management=dict(type='bool', default=False),
+            numeric=dict(type='bool', default=False),
         ),
         mutually_exclusive=(
             ['set_dscp_mark', 'set_dscp_mark_class'],

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -721,7 +721,7 @@ def set_chain_policy(iptables_path, module, params):
 
 def get_chain_policy(iptables_path, module, params):
     cmd = push_arguments(iptables_path, '-L', params, make_rule=False)
-    if module.numeric
+    if module.params['numeric']:
       cmd.append('--numeric')
     rc, out, _ = module.run_command(cmd, check_rc=True)
     chain_header = out.split("\n")[0]
@@ -744,7 +744,7 @@ def create_chain(iptables_path, module, params):
 
 def check_chain_present(iptables_path, module, params):
     cmd = push_arguments(iptables_path, '-L', params, make_rule=False)
-    if module.numeric
+    if module.params['numeric']:
       cmd.append('--numeric')
     rc, _, __ = module.run_command(cmd, check_rc=False)
     return (rc == 0)

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -383,6 +383,15 @@ options:
     type: bool
     default: false
     version_added: "2.13"
+  numeric:
+    description:
+      - This parameter controls the running of the list -action of iptables, which is used internally by the module
+      - Does not affect the actual functionality. Use this if iptables hangs when creating chain or altering policy 
+      - If C(true), then iptables skips the DNS-lookup of the IP addresses in a chain when it uses the list -action
+      - Listing is used internally for example when setting a policy or creting of a chain
+    type: bool
+    default: false
+    version_added: "2.14"
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -386,12 +386,12 @@ options:
   numeric:
     description:
       - This parameter controls the running of the list -action of iptables, which is used internally by the module
-      - Does not affect the actual functionality. Use this if iptables hangs when creating chain or altering policy 
+      - Does not affect the actual functionality. Use this if iptables hangs when creating chain or altering policy
       - If C(true), then iptables skips the DNS-lookup of the IP addresses in a chain when it uses the list -action
       - Listing is used internally for example when setting a policy or creting of a chain
     type: bool
     default: false
-    version_added: "2.14"
+    version_added: "2.15"
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -722,7 +722,7 @@ def set_chain_policy(iptables_path, module, params):
 def get_chain_policy(iptables_path, module, params):
     cmd = push_arguments(iptables_path, '-L', params, make_rule=False)
     if module.params['numeric']:
-      cmd.append('--numeric')
+        cmd.append('--numeric')
     rc, out, _ = module.run_command(cmd, check_rc=True)
     chain_header = out.split("\n")[0]
     result = re.search(r'\(policy ([A-Z]+)\)', chain_header)
@@ -745,7 +745,7 @@ def create_chain(iptables_path, module, params):
 def check_chain_present(iptables_path, module, params):
     cmd = push_arguments(iptables_path, '-L', params, make_rule=False)
     if module.params['numeric']:
-      cmd.append('--numeric')
+        cmd.append('--numeric')
     rc, _, __ = module.run_command(cmd, check_rc=False)
     return (rc == 0)
 

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -721,6 +721,7 @@ def set_chain_policy(iptables_path, module, params):
 
 def get_chain_policy(iptables_path, module, params):
     cmd = push_arguments(iptables_path, '-L', params, make_rule=False)
+    cmd.append('--numeric')
     rc, out, _ = module.run_command(cmd, check_rc=True)
     chain_header = out.split("\n")[0]
     result = re.search(r'\(policy ([A-Z]+)\)', chain_header)
@@ -742,6 +743,7 @@ def create_chain(iptables_path, module, params):
 
 def check_chain_present(iptables_path, module, params):
     cmd = push_arguments(iptables_path, '-L', params, make_rule=False)
+    cmd.append('--numeric')
     rc, _, __ = module.run_command(cmd, check_rc=False)
     return (rc == 0)
 


### PR DESCRIPTION
##### SUMMARY
This PR adds just `--numeric` switch to iptables when running list action (`-L`) to disable the reverse lookups of the IP addresses. 

Fixes #78793


##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
iptables

##### ADDITIONAL INFORMATION
The list command in the `iptables` -module is only used internally to check the policy of a chain in `get_chain_policy()` or the existence of a chain in `check_chain_present()`. But since the list command actually also dumps the rules of a chain, iptables by default will do reverse lookups the IP addresses in the chain. And those lookups can freeze the action totally, if the defined DNS server is unreachable. 

Since in the listing the actual rules play no part in the functionality (only the policy-header is looked at or the return code of the iptables -command), the listing can be done in numeric format and it does not disturb the process.

