### PR TITLE
Example corresponding yum command for `list` not highlighted properly

### DIFF
--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -49,7 +49,7 @@ options:
     version_added: "2.0"
   list:
     description:
-      - "Package name to run the equivalent of yum list C(--show-duplicates <package>) against. In addition to listing packages,
+      - "Package name to run the equivalent of C(yum list --show-duplicates <package>) against. In addition to listing packages,
         use can also list the following: C(installed), C(updates), C(available) and C(repos)."
       - This parameter is mutually exclusive with I(name).
     type: str


### PR DESCRIPTION
##### SUMMARY
The entire yum command should be highlighted, not only its options.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
