### PR TITLE
[stable-2.14] ansible-test - Update Python 3.11 support. (#78840)

### DIFF
--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,6 +1,6 @@
-base image=quay.io/ansible/base-test-container:3.6.0 python=3.10,2.7,3.5,3.6,3.7,3.8,3.9,3.11 seccomp=unconfined
-default image=quay.io/ansible/default-test-container:6.8.0 python=3.10,2.7,3.5,3.6,3.7,3.8,3.9,3.11 seccomp=unconfined context=collection
-default image=quay.io/ansible/ansible-core-test-container:6.8.0 python=3.10,2.7,3.5,3.6,3.7,3.8,3.9,3.11 seccomp=unconfined context=ansible-core
+base image=quay.io/ansible/base-test-container:3.6.0 python=3.11,2.7,3.5,3.6,3.7,3.8,3.9,3.10 seccomp=unconfined
+default image=quay.io/ansible/default-test-container:6.8.0 python=3.11,2.7,3.5,3.6,3.7,3.8,3.9,3.10 seccomp=unconfined context=collection
+default image=quay.io/ansible/ansible-core-test-container:6.8.0 python=3.11,2.7,3.5,3.6,3.7,3.8,3.9,3.10 seccomp=unconfined context=ansible-core
 alpine3 image=quay.io/ansible/alpine3-test-container:4.7.0 python=3.10
 centos7 image=quay.io/ansible/centos7-test-container:4.7.0 python=2.7 seccomp=unconfined
 fedora36 image=quay.io/ansible/fedora36-test-container:4.7.0 python=3.10 seccomp=unconfined

--- a/test/lib/ansible_test/_data/requirements/sanity.mypy.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.mypy.txt
@@ -13,8 +13,8 @@ types-Jinja2==2.11.9
 types-MarkupSafe==1.1.10
 types-paramiko==2.8.13
 types-PyYAML==5.4.12
-types-requests==2.28.8
-types-setuptools==63.4.0
+types-requests==2.28.10
+types-setuptools==65.3.0
 types-toml==0.10.8
-types-urllib3==1.26.22
-typing-extensions==4.3.0
+types-urllib3==1.26.24
+typing_extensions==4.3.0

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
@@ -9,5 +9,5 @@ pylint==2.15.3
 PyYAML==6.0
 tomli==2.0.1
 tomlkit==0.11.4
-typing-extensions==4.3.0
+typing_extensions==4.3.0
 wrapt==1.14.1

--- a/test/lib/ansible_test/_data/requirements/sanity.yamllint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.yamllint.txt
@@ -1,4 +1,4 @@
 # edit "sanity.yamllint.in" and generate with: hacking/update-sanity-requirements.py --test yamllint
-pathspec==0.9.0
+pathspec==0.10.1
 PyYAML==6.0
-yamllint==1.27.1
+yamllint==1.28.0

--- a/test/sanity/code-smell/docs-build.json
+++ b/test/sanity/code-smell/docs-build.json
@@ -1,6 +1,5 @@
 {
     "disabled": true,
-    "maximum_python_version": "3.10",
     "no_targets": true,
     "output": "path-line-column-message"
 }

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -1,6 +1,6 @@
 # edit "docs-build.requirements.in" and generate with: hacking/update-sanity-requirements.py --test docs-build
 aiofiles==22.1.0
-aiohttp==3.8.1
+aiohttp==3.8.3
 aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.1
@@ -45,6 +45,6 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 straight.plugin==1.5.0
 Twiggy==0.5.1
-typing-extensions==4.3.0
+typing_extensions==4.3.0
 urllib3==1.26.12
 yarl==1.8.1


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/78840

- Update sanity test requirements to fully support Python 3.11.
- Make Python 3.11 the default in the base and default test containers.

(cherry picked from commit 4d25233ece21c545254149ffe78291c734076609)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
