### PR TITLE
Don't request cache updates when only testing modes

### DIFF
--- a/test/integration/targets/apt_repository/tasks/mode.yaml
+++ b/test/integration/targets/apt_repository/tasks/mode.yaml
@@ -20,6 +20,7 @@
     repo: "{{ test_repo_spec }}"
     state: present
     mode: 0600
+    update_cache: false
   register: mode_given_results
 
 - name: Gather mode_given_as_literal_yaml stat
@@ -41,6 +42,7 @@
   apt_repository:
     repo: "{{ test_repo_spec }}"
     state: present
+    update_cache: false
   register: no_mode_results
 
 - name: Gather no mode stat
@@ -63,6 +65,7 @@
     repo: "{{ test_repo_spec }}"
     state: present
     mode: "0600"
+    update_cache: false
   register: mode_given_string_results
 
 - name: Gather mode_given_string stat
@@ -81,6 +84,7 @@
     repo: "{{ test_repo_spec }}"
     state: present
     mode: "600"
+    update_cache: false
   register: mode_given_string_600_results
 
 - name: Gather mode_given_600_string stat
@@ -103,6 +107,7 @@
     repo: "{{ test_repo_spec }}"
     state: present
     mode: 600
+    update_cache: false
   register: mode_given_short_results
 
 - name: Gather mode_given_yaml_literal_600 stat


### PR DESCRIPTION
##### SUMMARY
Don't request repo updates when only testing modes
##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/integration/targets/apt_repository/tasks/mode.yaml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
