### PR TITLE
Fix reusing connections if the name redirects to the same plugin

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -542,7 +542,15 @@ class TaskExecutor:
         # get the connection and the handler for this execution
         if (not self._connection or
                 not getattr(self._connection, 'connected', False) or
-                not self._connection.matches_name([current_connection]) or
+                not (
+                    (load_info := self._shared_loader_obj.connection_loader.get_with_context(
+                        self._play_context.connection,
+                        self._play_context,
+                        self._new_stdin,
+                        task_uuid=self._task._uuid,
+                        ansible_playbook_pid=to_text(os.getppid()))) and
+                        load_info.plugin_load_context.resolved and load_info.object.ansible_name == self._connection.ansible_name
+                ) or
                 # pc compare, left here for old plugins, but should be irrelevant for those
                 # using get_option, since they are cleared each iteration.
                 self._play_context.remote_addr != self._connection._play_context.remote_addr):

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -543,13 +543,8 @@ class TaskExecutor:
         if (not self._connection or
                 not getattr(self._connection, 'connected', False) or
                 not (
-                    (load_info := self._shared_loader_obj.connection_loader.get_with_context(
-                        current_connection,
-                        self._play_context,
-                        self._new_stdin,
-                        task_uuid=self._task._uuid,
-                        ansible_playbook_pid=to_text(os.getppid()))) and
-                        load_info.plugin_load_context.resolved and load_info.object.ansible_name == self._connection.ansible_name
+                    (context := connection_loader.find_plugin_with_context(current_connection)) and
+                    context.resolved and context.resolved_fqcn == self._connection.ansible_name
                 ) or
                 # pc compare, left here for old plugins, but should be irrelevant for those
                 # using get_option, since they are cleared each iteration.
@@ -949,7 +944,7 @@ class TaskExecutor:
         # (really paramiko), eventually this should move to task object itself.
         conn_type = self._play_context.connection
 
-        connection, plugin_load_context = self._shared_loader_obj.connection_loader.get_with_context(
+        connection, plugin_load_context = connection_loader.get_with_context(
             conn_type,
             self._play_context,
             self._new_stdin,

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -544,7 +544,7 @@ class TaskExecutor:
                 not getattr(self._connection, 'connected', False) or
                 not (
                     (load_info := self._shared_loader_obj.connection_loader.get_with_context(
-                        self._play_context.connection,
+                        current_connection,
                         self._play_context,
                         self._new_stdin,
                         task_uuid=self._task._uuid,

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/meta/runtime.yml
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/meta/runtime.yml
@@ -7,6 +7,8 @@ plugin_routing:
       tombstone:
         removal_date: '2020-01-01'
   connection:
+    redirected_localconn:
+      redirect: testns.testcoll.localconn
     redirected_local:
       redirect: ansible.builtin.local
   modules:

--- a/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/connection/localconn.py
+++ b/test/integration/targets/collections/collection_root_user/ansible_collections/testns/testcoll/plugins/connection/localconn.py
@@ -16,6 +16,13 @@ DOCUMENTATION = """
         default: the_default
         vars:
             - name: ansible_localconn_connectionvar
+      count_commands:
+        description:
+          - include the number of commands the connection has run in stdout
+        default: false
+        type: bool
+        vars:
+          - name: ansible_localconn_command_count
 """
 
 
@@ -23,11 +30,23 @@ class Connection(ConnectionBase):
     transport = 'local'
     has_pipelining = True
 
+    def __init__(self, *args, **kwargs):
+        self._cmds_run = 0
+        super().__init__(*args, **kwargs)
+
+    @property
+    def connected(self):
+        return True
+
     def _connect(self):
         return self
 
     def exec_command(self, cmd, in_data=None, sudoable=True):
-        stdout = 'localconn ran {0}'.format(to_native(cmd))
+        if self.get_option('count_commands'):
+            self._cmds_run += 1
+            stdout = 'localconn ran {0} ({1})'.format(to_native(cmd), self._cmds_run)
+        else:
+            stdout = 'localconn ran {0}'.format(to_native(cmd))
         stderr = 'connectionvar is {0}'.format(to_native(self.get_option('connectionvar')))
         return (0, stdout, stderr)
 

--- a/test/integration/targets/collections/test_collection_meta.yml
+++ b/test/integration/targets/collections/test_collection_meta.yml
@@ -6,6 +6,21 @@
     # redirect connection
     ansible_connection: testns.testcoll.redirected_local
   tasks:
+  - name: test loop reusing connection with different names that resolve to the same plugin
+    raw: noop
+    register: connected_test
+    vars:
+      ansible_localconn_command_count: True
+      ansible_connection: "{{ item }}"
+    loop:
+      - testns.testcoll.localconn
+      - testns.testcoll.redirected_localconn
+
+  - assert:
+      that:
+        - connected_test.results[0].stdout == "localconn ran noop (1)"
+        - connected_test.results[1].stdout == "localconn ran noop (2)"
+
   - assert:
       that: ('data' | testns.testcoll.testfilter) == 'data_via_testfilter_from_userdir'
 


### PR DESCRIPTION
##### SUMMARY
The existing code `self._connection.matches_name([current_connection])` fixed reloading connection plugins excessively if they were already in the redirect chain, but would still reload connections if a name further back in the redirect chain was used since the current plugin won't know of that alias.

For example, assuming there is no legacy override for the local connection, this would load `ansible.builtin.local` twice:
```yaml
- hosts: all
  tasks:
    - command: echo test
      vars:
        ansible_connection: "{{ item }}"
      loop:
        - ansible.builtin.local
        - local
```
This fixes that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
