### PR TITLE
ansible-test - Fix integration test target filter.

### DIFF
--- a/changelogs/fragments/ansible-test-integration-targets-filter.yml
+++ b/changelogs/fragments/ansible-test-integration-targets-filter.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - ansible-test - Allow disabled, unsupported, unstable and destructive integration test targets to be selected using their respective prefixes.
+  - ansible-test - Allow unstable tests to run when targeted changes are made and the ``--allow-unstable-changed`` option is specified
+                   (resolves https://github.com/ansible/ansible/issues/74213).

--- a/test/integration/targets/ansible-test-integration-targets/aliases
+++ b/test/integration/targets/ansible-test-integration-targets/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group3  # runs in the distro test containers
+shippable/generic/group1  # runs in the default test container
+context/controller
+needs/target/collection

--- a/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/destructive_a/aliases
+++ b/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/destructive_a/aliases
@@ -1,0 +1,2 @@
+context/controller
+destructive

--- a/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/destructive_b/aliases
+++ b/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/destructive_b/aliases
@@ -1,0 +1,2 @@
+context/controller
+destructive

--- a/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/disabled_a/aliases
+++ b/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/disabled_a/aliases
@@ -1,0 +1,2 @@
+context/controller
+disabled

--- a/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/disabled_b/aliases
+++ b/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/disabled_b/aliases
@@ -1,0 +1,2 @@
+context/controller
+disabled

--- a/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/unstable_a/aliases
+++ b/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/unstable_a/aliases
@@ -1,0 +1,2 @@
+context/controller
+unstable

--- a/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/unstable_b/aliases
+++ b/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/unstable_b/aliases
@@ -1,0 +1,2 @@
+context/controller
+unstable

--- a/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/unsupported_a/aliases
+++ b/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/unsupported_a/aliases
@@ -1,0 +1,2 @@
+context/controller
+unsupported

--- a/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/unsupported_b/aliases
+++ b/test/integration/targets/ansible-test-integration-targets/ansible_collections/ns/col/tests/integration/targets/unsupported_b/aliases
@@ -1,0 +1,2 @@
+context/controller
+unsupported

--- a/test/integration/targets/ansible-test-integration-targets/runme.sh
+++ b/test/integration/targets/ansible-test-integration-targets/runme.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+test="$(pwd)/test.py"
+
+source ../collection/setup.sh
+
+set -x
+
+"${test}" -v

--- a/test/integration/targets/ansible-test-integration-targets/test.py
+++ b/test/integration/targets/ansible-test-integration-targets/test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+import subprocess
+import unittest
+
+
+class OptionsTest(unittest.TestCase):
+    options = (
+        'unsupported',
+        'disabled',
+        'unstable',
+        'destructive',
+    )
+
+    def test_options(self):
+        for option in self.options:
+            with self.subTest(option=option):
+                try:
+                    command = ['ansible-test', 'integration', '--list-targets']
+
+                    skip_all = subprocess.run([*command, f'{option}_a', f'{option}_b'], text=True, capture_output=True, check=True)
+                    allow_all = subprocess.run([*command, f'--allow-{option}', f'{option}_a', f'{option}_b'], text=True, capture_output=True, check=True)
+                    allow_first = subprocess.run([*command, f'{option}/{option}_a', f'{option}_b'], text=True, capture_output=True, check=True)
+                    allow_last = subprocess.run([*command, f'{option}_a', f'{option}/{option}_b'], text=True, capture_output=True, check=True)
+
+                    self.assertEqual(skip_all.stdout.splitlines(), [])
+                    self.assertEqual(allow_all.stdout.splitlines(), [f'{option}_a', f'{option}_b'])
+                    self.assertEqual(allow_first.stdout.splitlines(), [f'{option}_a'])
+                    self.assertEqual(allow_last.stdout.splitlines(), [f'{option}_b'])
+                except subprocess.CalledProcessError as ex:
+                    raise Exception(f'{ex}:\n>>> Standard Output:\n{ex.stdout}\n>>> Standard Error:\n{ex.stderr}') from ex
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/lib/ansible_test/_internal/commands/integration/filters.py
+++ b/test/lib/ansible_test/_internal/commands/integration/filters.py
@@ -109,19 +109,19 @@ class TargetFilter(t.Generic[THostConfig], metaclass=abc.ABCMeta):
 
         if not self.allow_destructive and not self.config.is_managed:
             override_destructive = set(target for target in self.include_targets if target.startswith('destructive/'))
-            override = [target.name for target in targets if override_destructive & set(target.skips)]
+            override = [target.name for target in targets if override_destructive & set(target.aliases)]
 
             self.skip('destructive', 'which require --allow-destructive or prefixing with "destructive/" to run on unmanaged hosts', targets, exclude, override)
 
         if not self.args.allow_disabled:
             override_disabled = set(target for target in self.args.include if target.startswith('disabled/'))
-            override = [target.name for target in targets if override_disabled & set(target.skips)]
+            override = [target.name for target in targets if override_disabled & set(target.aliases)]
 
             self.skip('disabled', 'which require --allow-disabled or prefixing with "disabled/"', targets, exclude, override)
 
         if not self.args.allow_unsupported:
             override_unsupported = set(target for target in self.args.include if target.startswith('unsupported/'))
-            override = [target.name for target in targets if override_unsupported & set(target.skips)]
+            override = [target.name for target in targets if override_unsupported & set(target.aliases)]
 
             self.skip('unsupported', 'which require --allow-unsupported or prefixing with "unsupported/"', targets, exclude, override)
 
@@ -131,7 +131,7 @@ class TargetFilter(t.Generic[THostConfig], metaclass=abc.ABCMeta):
             if self.args.allow_unstable_changed:
                 override_unstable |= set(self.args.metadata.change_description.focused_targets or [])
 
-            override = [target.name for target in targets if override_unstable & set(target.skips)]
+            override = [target.name for target in targets if override_unstable & set(target.aliases)]
 
             self.skip('unstable', 'which require --allow-unstable or prefixing with "unstable/"', targets, exclude, override)
 


### PR DESCRIPTION
##### SUMMARY

- Allow disabled, unsupported, unstable and destructive integration test targets to be selected using their respective prefixes.
- Allow unstable tests to run when targeted changes are made and the ``--allow-unstable-changed`` option is specified (resolves https://github.com/ansible/ansible/issues/74213).

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
