### PR TITLE
winrm - fix reducing 'Read timed out' error

### DIFF
--- a/changelogs/fragments/winrm-read-timeout.yml
+++ b/changelogs/fragments/winrm-read-timeout.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- winrm - Increase the read timeout to 10 seconds later than the operation timeout reducing the chances of a false read timeout

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -128,8 +128,29 @@ DOCUMENTATION = """
         type: str
       connection_timeout:
         description:
-            - Sets the operation and read timeout settings for the WinRM
+            - Despite its name, sets both the 'operation' and 'read' timeout settings for the WinRM
               connection.
+            - The operation timeout belongs to the WS-Man layer and runs on the winRM-service on the
+              managed windows host.
+            - The read timeout belongs to the underlying python Request call (http-layer) and runs
+              on the ansible controller.
+            - The operation timeout sets the WS-Man 'Operation timeout' that runs on the managed
+              windows host. The operation timeout specifies how long a command will run on the
+              winRM-service before it sends the message 'WinRMOperationTimeoutError' back to the
+              client. The client (silently) ignores this message and starts a new instance of the
+              operation timeout, waiting for the command to finish (long running commands).
+            - The read timeout sets the client HTTP-request timeout and specifies how long the
+              client (ansible controller) will wait for data from the server to come back over
+              the HTTP-connection (timeout for waiting for in-between messages from the server).
+              When this timer expires, an exception will be thrown and the ansible connection
+              will be terminated with the error message 'Read timed out'
+            - To avoid the above exception to be thrown, the read timeout will be set to 10
+              seconds higher than the WS-Man operation timeout, thus make the connection more
+              robust on networks with long latency and/or many hops between server and client
+              network wise.
+            - Setting the difference bewteen the operation and the read timeout to 10 seconds
+              alligns it to the defaults used in the winrm-module and the PSRP-module which also
+              uses 10 seconds (30 seconds for read timeout and 20 seconds for operation timeout)
             - Corresponds to the C(operation_timeout_sec) and
               C(read_timeout_sec) args in pywinrm so avoid setting these vars
               with this one.
@@ -443,7 +464,7 @@ class Connection(ConnectionBase):
                 winrm_kwargs = self._winrm_kwargs.copy()
                 if self._winrm_connection_timeout:
                     winrm_kwargs['operation_timeout_sec'] = self._winrm_connection_timeout
-                    winrm_kwargs['read_timeout_sec'] = self._winrm_connection_timeout + 1
+                    winrm_kwargs['read_timeout_sec'] = self._winrm_connection_timeout + 10
                 protocol = Protocol(endpoint, transport=transport, **winrm_kwargs)
 
                 # open the shell from connect so we know we're able to talk to the server


### PR DESCRIPTION
The winRM error "winrm connection error: HTTPSConnectionPool(host='1.2.3.4', port=5986): Read timed out. (read timeout=nnn)" is thrown and causes the ansible task to fail. It happens very unpredictable and seemingly randomly on networks with long latency and/or turnaround trips (when the ansible controller client is far away from the winRM-service network wise)

It does not help (very little) to adjust the winrm setting 'ansible_winrm_connection_timeout' to different values, the exception is still thrown seemingly randomly and unpredictable regardless of of the value of 'ansible_winrm_connection_timeout'
SUMMARY

Reduces (makes it more unlikely) that the winRM error "winrm connection error: HTTPSConnectionPool(host='172.16.76.240', port=5986): Read timed out. (read timeout=nnn)" is thrown during a winRM-session.

Related to https://github.com/ansible/ansible/issues/23320

ISSUE TYPE

    Bugfix Pull Request

COMPONENT NAME

Connection plugin winrm

ADDITIONAL INFORMATION

Conceptual explanation of the nature of the problem.

We have a client (on the ansible controller) and we have the server which is the winRM-service on the manged windows host.
The client server communication protocol is the WS-Management protocol. The client can set a operation timeout parameter on the ansible level, called 'ansible_winrm_connection_timeout' in ansible. This variable is populated down the chain to the connection plugin winrm.py where this variable is assigned to the winrm variables 'operation_timeout_sec' and read_timeout_sec' like this:

Line 409: winrm_kwargs['operation_timeout_sec'] = self._winrm_connection_timeout
Line 410: winrm_kwargs['read_timeout_sec'] = self._winrm_connection_timeout + 1

Further down the call stack the protocol.py is called where these timeout parameters are set:

Line 81:  self.read_timeout_sec = read_timeout_sec
Line 82:  self.operation_timeout_sec = operation_timeout_sec

Its ensured that the read_timeout_sec > operation_timeout_sec Note !! The code ensures that the read timeout is always exactly 1 second greater than the operation timeout. However, this is the root cause for the intermittent "read timed out" errors that occurs in some networks.

This doc line from protocol.py is important:
@param int operation_timeout_sec: maximum allowed time in seconds for any single wsman HTTP operation (default 20). Note that operation timeouts while receiving output (the only wsman operation that should take any significant time, and where these timeouts are expected) will be silently retried indefinitely. # NOQA

The operation timeout parameter is then assigned the WS-Man data structure

Line 219: w:OperationTimeout': 'PT{0}S'.format(int(self.operation_timeout_sec))

The WS-Man protocol operation parameter is assigned the operation_timeout_sec value. This is determined by the client (ansible controller) and is then passed to the server (the WinRM-service) as the desired maximum operation timeout parameter. When the the command takes longer than this timeout, the server will send back the error code WinRMOperationTimeoutError (2150858793) in a Ws-Man message back to the client. What is important here is that this timer runs on the windows host and expires on that host. The expiration message will be packed into an WS-Man message and sent back to the client which will unpack the message and raise this exception:

Line 262: # convert receive timeout code to WinRMOperationTimeoutError
Line 263: if fault_data['wsmanfault_code'] == '2150858793':
Line 264:   raise WinRMOperationTimeoutError()

The client raises the exception WinRMOperationTimeoutError which is a perfectly fine exception that only means that the winRM service has not completed the command yet (still working/long running commands).

Line: 452: except WinRMOperationTimeoutError:
Line: 453:     # this is an expected error when waiting for a long-running process, just silently retry
Line: 454:     pass

In the meanwhile there is another timer running in parallel with the WS-Man timeout. This is the read_timeout_sec parameter which is used in the transport layer in file transport.py. Note that this timer runs on the client (the ansible controller). So this timer when it expires does not need to traverse any network in a protocol and is immediately processed by the client-code.

Line: 328: response = self.session.send(prepared_request, timeout=self.read_timeout_sec)

This timeout (which is exactly 1 second greater than the WS-Man operation timeout) is passed to the actual HTTP-request (which Ws-Man is using underneath)

If the timeout is reached by the http-request (which is running on the client, the ansible controller) the following exception is raised:

Line 331:

        except requests.HTTPError as ex:
            if ex.response.status_code == 401:
                raise InvalidCredentialsError("the specified credentials were rejected by the server")
            if ex.response.content:
                response_text = self._get_message_response_text(ex.response)
            else:
                response_text = ''

            raise WinRMTransportError('http', ex.response.status_code, response_text)

The timeout exception will clearly be raised again and propagated upwards and causing the current win_command to fail with the error message:

msg": "winrm connection error: HTTPSConnectionPool(host='172.16.76.240', port=5986): Read timed out. (read timeout=201)",

Note ! Here I set the ansible connection_timeout to 200 in the ansible config and as can be seen the http request in the transport layer expired the timer at exactly 200+1=201 seconds. Note! The error message is always literal "Read timed out. (read timeout=" , nothing else. It looks the same as already reported in issue: https://github.com/ansible/ansible/issues/23320 but the heading is not correct in that issue when it specifies "Windows: WinRM is very sensitive to network issues (ReadTimeout)" The word "ReadTimeout" is not present in any log files that I have seen, but the error message reported in the issue https://github.com/ansible/ansible/issues/23320 is exatcly the same described here.

What should have happen here is that the WS-Man operation timeout should have expired BEFORE the read timeout on the transport layer. Again, note that the WS-Man operation timeout is running on the WinRM-service on the server and the HTTP read timeout is running on the client, so different machines, two timers running at the same time at different machines.

On a normal working network 1 second should be enough for the HTTP-wrapped WS-Man XML-code message to make its way
back to the client (the ansible controller). The HTTP read timeout timer will never expire in these scenarious (normal network).
But, on some networks or during certain times when the network is busy or with many intermediate routers/switches 1 second is NOT enough. In such cases the HTTP-timer will expire BEFORE the Ws-Man message is received by the client. Thus causing the running win_command to fail in the ansible task.

Solution

If we now ensure that the DIFFERENCE between these two timeout parameters is greater than 1 second, You can set 5-10 seconds, this issue will be eliminated in most cases. We have verified that at our sites (we have thousands of ansible clients) and we have not received this error since the difference between the timeouts has been increased (we have 10 seconds which probably is unnecessary to high). Of course can this exception be thrown if there is a real network problem between the client and the server, and in such cases it should be thrown of course.

The Patch

The fix is to implement the that the difference is at least n seconds (suggestion 10 seconds). This patch has been run in our production environments (several thousands of ansible winrm-clients) in several months and we have not seen this winRM Read timed out error occur since that except for a few cases on a really broken network.

Also clarified the documentation regarding the involved timeouts.
