### PR TITLE
Upgrade antsibull-docs to 1.6.1

### DIFF
--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -1,7 +1,8 @@
 # pip packages required to build docsite
 # these requirements are as loosely defined as possible
 # if you want known good versions of these dependencies
-# use known_good_reqs.txt instead
+# use test/sanity/code-smell/docs-build.requirements.txt
+# instead
 
 antsibull-docs >= 1.0.0, < 2.0.0
 docutils

--- a/test/sanity/code-smell/docs-build.requirements.in
+++ b/test/sanity/code-smell/docs-build.requirements.in
@@ -6,4 +6,4 @@ sphinx-notfound-page
 sphinx-ansible-theme
 straight.plugin
 rstcheck < 4  # match version used in other sanity tests
-antsibull-docs == 1.6.0  # currently approved version
+antsibull-docs == 1.6.1  # currently approved version

--- a/test/sanity/code-smell/docs-build.requirements.in
+++ b/test/sanity/code-smell/docs-build.requirements.in
@@ -6,4 +6,4 @@ sphinx-notfound-page
 sphinx-ansible-theme
 straight.plugin
 rstcheck < 4  # match version used in other sanity tests
-antsibull-docs == 1.5.0  # currently approved version
+antsibull-docs == 1.6.0  # currently approved version

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -5,7 +5,7 @@ aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.1
 antsibull-core==1.2.0
-antsibull-docs==1.6.0
+antsibull-docs==1.6.1
 async-timeout==4.0.2
 asyncio-pool==0.6.0
 attrs==22.1.0

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -5,7 +5,7 @@ aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.1
 antsibull-core==1.2.0
-antsibull-docs==1.5.0
+antsibull-docs==1.6.0
 async-timeout==4.0.2
 asyncio-pool==0.6.0
 attrs==22.1.0


### PR DESCRIPTION
##### SUMMARY
This is needed to allow the `choices` syntax for the `combine` filter docs (https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/filter/combine.yml#L26-L32). Also it fixes several bugs on the docsite:
- top-level (module/plugin/role) version_added for collection names with `_` in it is wrongly escaped, see for example: https://docs.ansible.com/ansible/devel/collections/community/hashi_vault/vault_kv2_get_module.html
- INI examples for lists uses invalid syntax that produces wrong results: https://docs.ansible.com/ansible/devel/collections/ansible/builtin/host_group_vars_vars.html#parameter-_valid_extensions
- INI examples for options without defaults prints `None` instead of `VALUE`: https://docs.ansible.com/ansible/devel/collections/ansible/builtin/host_group_vars_vars.html#parameter-stage

This PR also updates a wrong comment in docs/docsite/requirements.txt regarding where the 'known good' antsibull-docs version is taken from (we forgot to update it in a65fbfad5b20b23b41c4f8cdd82161bb8c365953).

CC @samccann @mattclay

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
docsite rendering
