### PR TITLE
Fix malformed docs for combine filter, add example

### DIFF
--- a/lib/ansible/plugins/filter/combine.yml
+++ b/lib/ansible/plugins/filter/combine.yml
@@ -1,3 +1,4 @@
+---
 DOCUMENTATION:
   name: combine
   version_added: "2.0"
@@ -20,24 +21,35 @@ DOCUMENTATION:
       type: bool
       default: false
     list_merge:
-      describe: Behaviour when encountering list elements.
+      description: |
+        Behaviour when encountering list elements.
+
+        + `replace`: overwrite older entries with newer ones
+        + `keep`: discard newer entries
+        + `append`: append newer entries to the older ones
+        + `prepend`: insert newer entries in front of the older ones
+        + `append_rp`: append newer entries to the older ones, overwrite duplicates
+        + `prepend_rp`: insert newer entries in front of the older ones, discard duplicates
+
       type: str
       default: replace
       choices:
-        replace: overwrite older entries with newer ones
-        keep: discard newer entries
-        append: append newer entries to the older ones
-        prepend: insert newer entries in front of the older ones
-        append_rp: append newer entries to the older ones, overwrite duplicates
-        prepend_rp: insert newer entries in front of the older ones, discard duplicates
+        - replace
+        - keep
+        - append
+        - prepend
+        - append_rp
+        - prepend_rp
 
 EXAMPLES: |
 
     # ab => {'a':1, 'b':3, 'c': 4}
     ab: {{ {'a':1, 'b':2} | combine({'b':3, 'c':4}) }}
 
-    # ab => {'a':1, 'b':3, 'c': 4}
     many: "{{ dict1 | combine(dict2, dict3, dict4) }}"
+
+    # deep => {'a':1, 'b': {'c': {'d': 42}}}
+    deep: {{ {'a':1, 'b': {'c': {'d': 12}}} | combine({'b': {'c': {'d': 42}}}) }}
 
 RETURN:
   _value:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fix malformed documentation for the `combine` filter introduced in 3b937123d26473b7005674b8915423e3f38f6105.

Currently the documentation page shows an error:

![image](https://user-images.githubusercontent.com/626791/192273059-df772129-0422-4bb8-9aec-aac05a45e954.png)

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ansible.builtin.combine`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

