### PR TITLE
user - Use -n instead of -N for luseradd on all distros (#75042)

### DIFF
--- a/changelogs/fragments/75042-lowercase-dash-n-with-luseradd-on-all-distros.yml
+++ b/changelogs/fragments/75042-lowercase-dash-n-with-luseradd-on-all-distros.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - fix creating a local user if the user group already exists (https://github.com/ansible/ansible/pull/75042)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -664,22 +664,26 @@ class User(object):
             # exists with the same name as the user to prevent
             # errors from useradd trying to create a group when
             # USERGROUPS_ENAB is set in /etc/login.defs.
-            if os.path.exists('/etc/redhat-release'):
-                dist = distro.version()
-                major_release = int(dist.split('.')[0])
-                if major_release <= 5 or self.local:
-                    cmd.append('-n')
+            if self.local:
+                # luseradd uses -n instead of -N
+                cmd.append('-n')
+            else:
+                if os.path.exists('/etc/redhat-release'):
+                    dist = distro.version()
+                    major_release = int(dist.split('.')[0])
+                    if major_release <= 5:
+                        cmd.append('-n')
+                    else:
+                        cmd.append('-N')
+                elif os.path.exists('/etc/SuSE-release'):
+                    # -N did not exist in useradd before SLE 11 and did not
+                    # automatically create a group
+                    dist = distro.version()
+                    major_release = int(dist.split('.')[0])
+                    if major_release >= 12:
+                        cmd.append('-N')
                 else:
                     cmd.append('-N')
-            elif os.path.exists('/etc/SuSE-release'):
-                # -N did not exist in useradd before SLE 11 and did not
-                # automatically create a group
-                dist = distro.version()
-                major_release = int(dist.split('.')[0])
-                if major_release >= 12:
-                    cmd.append('-N')
-            else:
-                cmd.append('-N')
 
         if self.groups is not None and len(self.groups):
             groups = self.get_groups_set()

--- a/test/integration/targets/user/tasks/test_local.yml
+++ b/test/integration/targets/user/tasks/test_local.yml
@@ -85,6 +85,7 @@
     - testgroup2
     - testgroup3
     - testgroup4
+    - local_ansibulluser
   tags:
     - user_test_local_mode
 
@@ -139,6 +140,7 @@
     - testgroup2
     - testgroup3
     - testgroup4
+    - local_ansibulluser
   tags:
     - user_test_local_mode
 


### PR DESCRIPTION
* Use -n instead of -N for luseradd on all distros

Co-authored-by: Chris James <git@etcet.net>
(cherry picked from commit ea351f0ae2bca23cdd7c24547a6607a50186a116)