### PR TITLE
Do not crash templating when filter/test name is not a valid Ansible plugin name

### DIFF
--- a/changelogs/fragments/78913-template-missing-filter-test.yml
+++ b/changelogs/fragments/78913-template-missing-filter-test.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Do not crash when templating an expression with a test or filter that is not a valid Ansible filter name (https://github.com/ansible/ansible/issues/78912, https://github.com/ansible/ansible/pull/78913)."

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -872,16 +872,9 @@ class PluginLoader:
         path = plugin_load_context.plugin_resolved_path
         redirected_names = plugin_load_context.redirect_list or []
 
-        try:
-            if path not in self._module_cache:
-                self._module_cache[path] = self._load_module_source(name, path)
-                found_in_cache = False
-        except Exception as e:
-            if self.type in ('filter', 'test'):
-                # missing and broken filters/tests are handled a bit differently
-                # raise an AnsibleError to reflect this is a broken plugin
-                raise AnsibleError(to_native(e))
-            raise
+        if path not in self._module_cache:
+            self._module_cache[path] = self._load_module_source(name, path)
+            found_in_cache = False
 
         self._load_config_defs(name, self._module_cache[path], path)
 
@@ -1227,7 +1220,7 @@ class Jinja2Loader(PluginLoader):
         try:
             pkg = import_module(acr.n_python_package_name)
         except ImportError as e:
-            raise AnsibleError(to_native(e))
+            raise KeyError(to_native(e))
 
         parent_prefix = acr.collection
         if acr.subdirs:
@@ -1242,8 +1235,6 @@ class Jinja2Loader(PluginLoader):
                     # use 'parent' loader class to find files, but cannot return this as it can contain
                     # multiple plugins per file
                     plugin_impl = super(Jinja2Loader, self).get_with_context(module_name, *args, **kwargs)
-                except AnsibleError:
-                    raise
                 except Exception as e:
                     raise KeyError(to_native(e))
 

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -427,8 +427,10 @@ class JinjaPluginIntercept(MutableMapping):
             plugin = None
             try:
                 plugin = self._pluginloader.get(key)
-            except (AnsibleError, KeyError) as e:
+            except AnsibleError as e:
                 raise TemplateSyntaxError('Could not load "%s": %s' % (key, to_native(e)), 0)
+            except KeyError as e:
+                plugin = None
             except Exception as e:
                 display.vvvv('Unexpected plugin load (%s) exception: %s' % (key, to_native(e)))
                 raise e

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -440,7 +440,7 @@ class JinjaPluginIntercept(MutableMapping):
                 self._delegatee[key] = plugin.j2_function
                 self._loaded_builtins.add(key)
 
-        # let it trigger keyerror if we could not find ours or jinja2 one
+        # raise template syntax error if we could not find ours or jinja2 one
         try:
             func = self._delegatee[key]
         except KeyError as e:

--- a/test/integration/targets/templating/tasks/main.yml
+++ b/test/integration/targets/templating/tasks/main.yml
@@ -16,3 +16,20 @@
   vars:
     # Kind of hack to just send a JSON string through jinja, by templating out nothing
     foo: '{{ "" }}{"null": null, "true": true, "false": false}'
+
+- name: Make sure that test with name that isn't a valid Ansible plugin name does not result in a crash (1/2)
+  set_fact:
+    foo: '{{ [{"failed": false}] | selectattr("failed", "==", true) }}'
+
+- name: Make sure that test with name that isn't a valid Ansible plugin name does not result in a crash (2/2)
+  template:
+    src: invalid_test_name.j2
+    dest: /tmp/foo
+  ignore_errors: true
+  register: result
+
+- assert:
+    that:
+      - result is failed
+      - >-
+        "TemplateRuntimeError: No test named 'asdf '" in result.msg

--- a/test/integration/targets/templating/tasks/main.yml
+++ b/test/integration/targets/templating/tasks/main.yml
@@ -32,4 +32,4 @@
     that:
       - result is failed
       - >-
-        "TemplateRuntimeError: No test named 'asdf '" in result.msg
+        "TemplateSyntaxError: Could not load \"asdf \": 'invalid plugin name: ansible.builtin.asdf '" in result.msg

--- a/test/integration/targets/templating/templates/invalid_test_name.j2
+++ b/test/integration/targets/templating/templates/invalid_test_name.j2
@@ -1,0 +1,1 @@
+{{ [{"failed": false}] | selectattr("failed", "asdf ", true) }}


### PR DESCRIPTION
##### SUMMARY
Fixes #78912.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/template/__init__.py`
