### PR TITLE
Add support for importlib.resources

### DIFF
--- a/hacking/test-module.py
+++ b/hacking/test-module.py
@@ -44,6 +44,7 @@ import ansible.utils.vars as utils_vars
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.utils.jsonify import jsonify
 from ansible.parsing.splitter import parse_kv
+from ansible.plugins.loader import init_plugin_loader
 from ansible.executor import module_common
 import ansible.constants as C
 from ansible.module_utils._text import to_native, to_text
@@ -266,6 +267,7 @@ def rundebug(debugger, modfile, argspath, modname, module_style, interpreters):
 def main():
 
     options, args = parse()
+    init_plugin_loader()
     interpreters = get_interpreters(options.interpreter)
     (modfile, modname, module_style) = boilerplate_module(options.module_path, options.module_args, interpreters, options.check, options.filename)
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -101,7 +101,7 @@ from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.common.file import is_executable
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.vault import PromptVaultSecret, get_file_vault_secret
-from ansible.plugins.loader import add_all_plugin_dirs
+from ansible.plugins.loader import add_all_plugin_dirs, init_plugin_loader
 from ansible.release import __version__
 from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.collection_loader._collection_finder import _get_collection_name_from_path
@@ -153,6 +153,8 @@ class CLI(ABC):
         running an Ansible command.
         """
         self.parse()
+        # Initialize plugin loader after parse, so that the init code can utilize parsed arguments
+        init_plugin_loader()
 
         display.vv(to_text(opt_help.version(self.parser.prog)))
 
@@ -522,6 +524,10 @@ class CLI(ABC):
 
     @staticmethod
     def _play_prereqs():
+        # TODO: evaluate moving all of the code that touches ``AnsibleCollectionConfig``
+        # into ``init_plugin_loader`` so that we can specifically remove
+        # ``AnsibleCollectionConfig.playbook_paths`` to make it immutable after instantiation
+
         options = context.CLIARGS
 
         # all needs loader

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -98,6 +98,7 @@ from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.inventory.manager import InventoryManager
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.common.file import is_executable
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.vault import PromptVaultSecret, get_file_vault_secret
@@ -153,8 +154,13 @@ class CLI(ABC):
         running an Ansible command.
         """
         self.parse()
+
         # Initialize plugin loader after parse, so that the init code can utilize parsed arguments
-        init_plugin_loader()
+        cli_collections_path = context.CLIARGS.get('collections_path') or []
+        if not is_sequence(cli_collections_path):
+            # In some contexts ``collections_path`` is singular
+            cli_collections_path = [cli_collections_path]
+        init_plugin_loader(cli_collections_path)
 
         display.vv(to_text(opt_help.version(self.parser.prog)))
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1307,7 +1307,7 @@ class GalaxyCLI(CLI):
         collection_requirements = []
         role_requirements = []
         if context.CLIARGS['type'] == 'collection':
-            collection_path = GalaxyCLI._resolve_path(context.CLIARGS['collections_path'] or AnsibleCollectionConfig.collection_paths)
+            collection_path = GalaxyCLI._resolve_path(context.CLIARGS['collections_path'])
             requirements = self._require_one_of_collections_requirements(
                 install_items, requirements_file,
                 signatures=signatures,

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1251,7 +1251,7 @@ class GalaxyCLI(CLI):
     def execute_verify(self, artifacts_manager=None):
 
         collections = context.CLIARGS['args']
-        search_paths = context.CLIARGS['collections_path'] or AnsibleCollectionConfig.collection_paths
+        search_paths = AnsibleCollectionConfig.collection_paths
         ignore_errors = context.CLIARGS['ignore_errors']
         local_verify_only = context.CLIARGS['offline']
         requirements_file = context.CLIARGS['requirements']

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -12,6 +12,7 @@ from ansible.cli import CLI
 
 import json
 import os.path
+import pathlib
 import re
 import shutil
 import sys
@@ -97,7 +98,8 @@ def with_collection_artifacts_manager(wrapped_method):
             return wrapped_method(*args, **kwargs)
 
         # FIXME: use validate_certs context from Galaxy servers when downloading collections
-        artifacts_manager_kwargs = {'validate_certs': context.CLIARGS['resolved_validate_certs']}
+        # .get used here for when this is used in a non-CLI context
+        artifacts_manager_kwargs = {'validate_certs': context.CLIARGS.get('resolved_validate_certs', True)}
 
         keyring = context.CLIARGS.get('keyring', None)
         if keyring is not None:
@@ -154,8 +156,8 @@ def _get_collection_widths(collections):
     fqcn_set = {to_text(c.fqcn) for c in collections}
     version_set = {to_text(c.ver) for c in collections}
 
-    fqcn_length = len(max(fqcn_set, key=len))
-    version_length = len(max(version_set, key=len))
+    fqcn_length = len(max(fqcn_set or [''], key=len))
+    version_length = len(max(version_set or [''], key=len))
 
     return fqcn_length, version_length
 
@@ -268,7 +270,6 @@ class GalaxyCLI(CLI):
 
         collections_path = opt_help.argparse.ArgumentParser(add_help=False)
         collections_path.add_argument('-p', '--collections-path', dest='collections_path', type=opt_help.unfrack_path(pathsep=True),
-                                      default=AnsibleCollectionConfig.collection_paths,
                                       action=opt_help.PrependListAction,
                                       help="One or more directories to search for collections in addition "
                                       "to the default COLLECTIONS_PATHS. Separate multiple paths "
@@ -1250,7 +1251,7 @@ class GalaxyCLI(CLI):
     def execute_verify(self, artifacts_manager=None):
 
         collections = context.CLIARGS['args']
-        search_paths = context.CLIARGS['collections_path']
+        search_paths = context.CLIARGS['collections_path'] or AnsibleCollectionConfig.collection_paths
         ignore_errors = context.CLIARGS['ignore_errors']
         local_verify_only = context.CLIARGS['offline']
         requirements_file = context.CLIARGS['requirements']
@@ -1306,7 +1307,7 @@ class GalaxyCLI(CLI):
         collection_requirements = []
         role_requirements = []
         if context.CLIARGS['type'] == 'collection':
-            collection_path = GalaxyCLI._resolve_path(context.CLIARGS['collections_path'])
+            collection_path = GalaxyCLI._resolve_path(context.CLIARGS['collections_path'] or AnsibleCollectionConfig.collection_paths)
             requirements = self._require_one_of_collections_requirements(
                 install_items, requirements_file,
                 signatures=signatures,
@@ -1577,7 +1578,9 @@ class GalaxyCLI(CLI):
             display.warning(w)
 
         if not path_found:
-            raise AnsibleOptionsError("- None of the provided paths were usable. Please specify a valid path with --{0}s-path".format(context.CLIARGS['type']))
+            raise AnsibleOptionsError(
+                "- None of the provided paths were usable. Please specify a valid path with --{0}s-path".format(context.CLIARGS['type'])
+            )
 
         return 0
 
@@ -1592,100 +1595,66 @@ class GalaxyCLI(CLI):
             artifacts_manager.require_build_metadata = False
 
         output_format = context.CLIARGS['output_format']
-        collections_search_paths = set(context.CLIARGS['collections_path'])
         collection_name = context.CLIARGS['collection']
-        default_collections_path = AnsibleCollectionConfig.collection_paths
+        default_collections_path = set(C.COLLECTIONS_PATHS)
+        collections_search_paths = (
+            set(context.CLIARGS['collections_path'] or []) | default_collections_path | set(AnsibleCollectionConfig.collection_paths)
+        )
         collections_in_paths = {}
 
         warnings = []
         path_found = False
         collection_found = False
+
+        namespace_filter = None
+        collection_filter = None
+        if collection_name:
+            # list a specific collection
+
+            validate_collection_name(collection_name)
+            namespace_filter, collection_filter = collection_name.split('.')
+
+        collections = list(find_existing_collections(
+            list(collections_search_paths),
+            artifacts_manager,
+            namespace_filter=namespace_filter,
+            collection_filter=collection_filter,
+            dedupe=False
+        ))
+
+        seen = set()
+        fqcn_width, version_width = _get_collection_widths(collections)
+        for collection in sorted(collections, key=lambda c: c.src):
+            collection_found = True
+            collection_path = pathlib.Path(to_text(collection.src)).parent.parent.as_posix()
+
+            if output_format in {'yaml', 'json'}:
+                collections_in_paths[collection_path] = {
+                    collection.fqcn: {'version': collection.ver} for collection in collections
+                }
+            else:
+                if collection_path not in seen:
+                    _display_header(
+                        collection_path,
+                        'Collection',
+                        'Version',
+                        fqcn_width,
+                        version_width
+                    )
+                    seen.add(collection_path)
+                _display_collection(collection, fqcn_width, version_width)
+
+        path_found = False
         for path in collections_search_paths:
-            collection_path = GalaxyCLI._resolve_path(path)
             if not os.path.exists(path):
                 if path in default_collections_path:
                     # don't warn for missing default paths
                     continue
-                warnings.append("- the configured path {0} does not exist.".format(collection_path))
-                continue
-
-            if not os.path.isdir(collection_path):
-                warnings.append("- the configured path {0}, exists, but it is not a directory.".format(collection_path))
-                continue
-
-            path_found = True
-
-            if collection_name:
-                # list a specific collection
-
-                validate_collection_name(collection_name)
-                namespace, collection = collection_name.split('.')
-
-                collection_path = validate_collection_path(collection_path)
-                b_collection_path = to_bytes(os.path.join(collection_path, namespace, collection), errors='surrogate_or_strict')
-
-                if not os.path.exists(b_collection_path):
-                    warnings.append("- unable to find {0} in collection paths".format(collection_name))
-                    continue
-
-                if not os.path.isdir(collection_path):
-                    warnings.append("- the configured path {0}, exists, but it is not a directory.".format(collection_path))
-                    continue
-
-                collection_found = True
-
-                try:
-                    collection = Requirement.from_dir_path_as_unknown(
-                        b_collection_path,
-                        artifacts_manager,
-                    )
-                except ValueError as val_err:
-                    six.raise_from(AnsibleError(val_err), val_err)
-
-                if output_format in {'yaml', 'json'}:
-                    collections_in_paths[collection_path] = {
-                        collection.fqcn: {'version': collection.ver}
-                    }
-
-                    continue
-
-                fqcn_width, version_width = _get_collection_widths([collection])
-
-                _display_header(collection_path, 'Collection', 'Version', fqcn_width, version_width)
-                _display_collection(collection, fqcn_width, version_width)
-
+                warnings.append("- the configured path {0} does not exist.".format(path))
+            elif os.path.exists(path) and not os.path.isdir(path):
+                warnings.append("- the configured path {0}, exists, but it is not a directory.".format(path))
             else:
-                # list all collections
-                collection_path = validate_collection_path(path)
-                if os.path.isdir(collection_path):
-                    display.vvv("Searching {0} for collections".format(collection_path))
-                    collections = list(find_existing_collections(
-                        collection_path, artifacts_manager,
-                    ))
-                else:
-                    # There was no 'ansible_collections/' directory in the path, so there
-                    # or no collections here.
-                    display.vvv("No 'ansible_collections' directory found at {0}".format(collection_path))
-                    continue
-
-                if not collections:
-                    display.vvv("No collections found at {0}".format(collection_path))
-                    continue
-
-                if output_format in {'yaml', 'json'}:
-                    collections_in_paths[collection_path] = {
-                        collection.fqcn: {'version': collection.ver} for collection in collections
-                    }
-
-                    continue
-
-                # Display header
-                fqcn_width, version_width = _get_collection_widths(collections)
-                _display_header(collection_path, 'Collection', 'Version', fqcn_width, version_width)
-
-                # Sort collections by the namespace and name
-                for collection in sorted(collections, key=to_text):
-                    _display_collection(collection, fqcn_width, version_width)
+                path_found = True
 
         # Do not warn if the specific collection was found in any of the search paths
         if collection_found and collection_name:
@@ -1694,8 +1663,10 @@ class GalaxyCLI(CLI):
         for w in warnings:
             display.warning(w)
 
-        if not path_found:
-            raise AnsibleOptionsError("- None of the provided paths were usable. Please specify a valid path with --{0}s-path".format(context.CLIARGS['type']))
+        if not collections and not path_found:
+            raise AnsibleOptionsError(
+                "- None of the provided paths were usable. Please specify a valid path with --{0}s-path".format(context.CLIARGS['type'])
+            )
 
         if output_format == 'json':
             display.display(json.dumps(collections_in_paths))

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -29,7 +29,7 @@ from ansible.module_utils.connection import Connection, ConnectionError, send_da
 from ansible.module_utils.service import fork_process
 from ansible.parsing.ajson import AnsibleJSONEncoder, AnsibleJSONDecoder
 from ansible.playbook.play_context import PlayContext
-from ansible.plugins.loader import connection_loader
+from ansible.plugins.loader import connection_loader, init_plugin_loader
 from ansible.utils.path import unfrackpath, makedirs_safe
 from ansible.utils.display import Display
 from ansible.utils.jsonrpc import JsonRpcServer
@@ -230,6 +230,7 @@ def main(args=None):
     parser.add_argument('playbook_pid')
     parser.add_argument('task_uuid')
     args = parser.parse_args(args[1:] if args is not None else args)
+    init_plugin_loader()
 
     # initialize verbosity
     display.verbosity = args.verbosity

--- a/lib/ansible/collections/list.py
+++ b/lib/ansible/collections/list.py
@@ -5,11 +5,13 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import sys
 
 from collections import defaultdict
 
 from ansible.errors import AnsibleError
-from ansible.collections import is_collection_path
+from ansible.cli.galaxy import with_collection_artifacts_manager
+from ansible.galaxy.collection import find_existing_collections
 from ansible.module_utils._text import to_bytes
 from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.collection_loader._collection_finder import _get_collection_name_from_path
@@ -18,14 +20,13 @@ from ansible.utils.display import Display
 display = Display()
 
 
-def list_collections(coll_filter=None, search_paths=None, dedupe=False):
+@with_collection_artifacts_manager
+def list_collections(coll_filter=None, search_paths=None, dedupe=True, artifacts_manager=None):
 
     collections = {}
-    for candidate in list_collection_dirs(search_paths=search_paths, coll_filter=coll_filter):
-        if os.path.exists(candidate):
-            collection = _get_collection_name_from_path(candidate)
-            if collection not in collections or not dedupe:
-                collections[collection] = candidate
+    for candidate in list_collection_dirs(search_paths=search_paths, coll_filter=coll_filter, artifacts_manager=artifacts_manager, dedupe=dedupe):
+        collection = _get_collection_name_from_path(candidate)
+        collections[collection] = candidate
     return collections
 
 
@@ -59,7 +60,8 @@ def list_valid_collection_paths(search_paths=None, warn=False):
         yield path
 
 
-def list_collection_dirs(search_paths=None, coll_filter=None):
+@with_collection_artifacts_manager
+def list_collection_dirs(search_paths=None, coll_filter=None, artifacts_manager=None, dedupe=True):
     """
     Return paths for the specific collections found in passed or configured search paths
     :param search_paths: list of text-string paths, if none load default config
@@ -67,48 +69,18 @@ def list_collection_dirs(search_paths=None, coll_filter=None):
     :return: list of collection directory paths
     """
 
-    collection = None
-    namespace = None
+    namespace_filter = None
+    collection_filter = None
     if coll_filter is not None:
         if '.' in coll_filter:
             try:
-                (namespace, collection) = coll_filter.split('.')
+                namespace_filter, collection_filter = coll_filter.split('.')
             except ValueError:
                 raise AnsibleError("Invalid collection pattern supplied: %s" % coll_filter)
         else:
-            namespace = coll_filter
+            namespace_filter = coll_filter
 
-    collections = defaultdict(dict)
-    for path in list_valid_collection_paths(search_paths):
+    for req in find_existing_collections(search_paths, artifacts_manager, namespace_filter=namespace_filter,
+                                         collection_filter=collection_filter, dedupe=dedupe):
 
-        if os.path.basename(path) != 'ansible_collections':
-            path = os.path.join(path, 'ansible_collections')
-
-        b_coll_root = to_bytes(path, errors='surrogate_or_strict')
-
-        if os.path.exists(b_coll_root) and os.path.isdir(b_coll_root):
-
-            if namespace is None:
-                namespaces = os.listdir(b_coll_root)
-            else:
-                namespaces = [namespace]
-
-            for ns in namespaces:
-                b_namespace_dir = os.path.join(b_coll_root, to_bytes(ns))
-
-                if os.path.isdir(b_namespace_dir):
-
-                    if collection is None:
-                        colls = os.listdir(b_namespace_dir)
-                    else:
-                        colls = [collection]
-
-                    for mycoll in colls:
-
-                        # skip dupe collections as they will be masked in execution
-                        if mycoll not in collections[ns]:
-                            b_coll = to_bytes(mycoll)
-                            b_coll_dir = os.path.join(b_namespace_dir, b_coll)
-                            if is_collection_path(b_coll_dir):
-                                collections[ns][mycoll] = b_coll_dir
-                                yield b_coll_dir
+        yield to_bytes(req.src)

--- a/lib/ansible/collections/list.py
+++ b/lib/ansible/collections/list.py
@@ -5,7 +5,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import sys
 
 from collections import defaultdict
 

--- a/lib/ansible/compat/importlib_resources.py
+++ b/lib/ansible/compat/importlib_resources.py
@@ -1,0 +1,20 @@
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import sys
+
+HAS_IMPORTLIB_RESOURCES = False
+
+if sys.version_info < (3, 10):
+    try:
+        from importlib_resources import files  # type: ignore[import]
+    except ImportError:
+        files = None  # type: ignore[assignment]
+    else:
+        HAS_IMPORTLIB_RESOURCES = True
+else:
+    from importlib.resources import files
+    HAS_IMPORTLIB_RESOURCES = True

--- a/lib/ansible/plugins/list.py
+++ b/lib/ansible/plugins/list.py
@@ -44,6 +44,7 @@ def get_composite_name(collection, name, path, depth):
 
 
 def _list_plugins_from_paths(ptype, dirs, collection, depth=0):
+    # TODO: update to use importlib.resources
 
     plugins = {}
 
@@ -117,6 +118,7 @@ def _list_j2_plugins_from_file(collection, plugin_path, ptype, plugin_name):
 
 
 def list_collection_plugins(ptype, collections, search_paths=None):
+    # TODO: update to use importlib.resources
 
     # starts at  {plugin_name: filepath, ...}, but changes at the end
     plugins = {}

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -22,7 +22,6 @@ from ansible import __version__ as ansible_version
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsiblePluginCircularRedirect, AnsiblePluginRemovedError, AnsibleCollectionUnsupportedVersionError
 from ansible.module_utils._text import to_bytes, to_text, to_native
-from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.compat.importlib import import_module
 from ansible.module_utils.six import string_types
 from ansible.parsing.utils.yaml import from_yaml

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -98,7 +98,7 @@ class _AnsibleNSTraversable:
         return itertools.chain.from_iterable(p.iterdir() for p in self._paths if p.is_dir())
 
     def is_dir(self):
-        return any((p.is_dir() for p in self._paths))
+        return any(p.is_dir() for p in self._paths)
 
     def is_file(self):
         return False

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -102,6 +102,13 @@ class _AnsibleTraversableResources:
         except AttributeError:
             return package.__parent__
 
+    def _get_path(self, package):
+        try:
+            return package.origin
+        except AttributeError:
+            return package.__file__
+
+
     def _ensure_package(self, package):
         origin = getattr(package, 'origin', None)
         if origin and os.path.basename(origin) in ('__synthetic__', '__init__.py'):
@@ -118,9 +125,7 @@ class _AnsibleTraversableResources:
             raise TypeError('Expected string or module, got %r' % package.__class__.__name__)
 
         self._ensure_package(package)
-        package = self._get_name(package)
-
-        return pathlib.Path(package)
+        return pathlib.Path(self._get_path(package)).parent
 
 
 class _AnsibleCollectionFinder:

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -139,7 +139,7 @@ class _AnsibleNSTraversable:
     def _not_implemented(self, *args, **kwargs):
         raise NotImplementedError('not usable on namespaces')
 
-    joinpath = __truediv__ = __truediv__ = read_bytes = read_text = _not_implemented
+    joinpath = __truediv__ = read_bytes = read_text = _not_implemented
 
 
 class _AnsibleTraversableResources:

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -92,26 +92,32 @@ class _AnsibleTraversableResources:
 
     def _get_name(self, package):
         try:
+            # spec
             return package.name
         except AttributeError:
+            # module
             return package.__name__
 
     def _get_package(self, package):
         try:
-            return package.__package__
-        except AttributeError:
+            # spec
             return package.__parent__
+        except AttributeError:
+            # module
+            return package.__package__
 
     def _get_path(self, package):
         try:
+            # spec
             return package.origin
         except AttributeError:
+            # module
             return package.__file__
-
 
     def _ensure_package(self, package):
         origin = getattr(package, 'origin', None)
         if origin and os.path.basename(origin) in ('__synthetic__', '__init__.py'):
+            # Short circuit our loaders
             return
         if self._get_package(package) != package.__name__:
             raise TypeError('%r is not a package' % package.__name__)

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -143,17 +143,14 @@ class _AnsibleTraversableResources:
 
     def _is_ansible_ns_package(self, package):
         origin = getattr(package, 'origin', None)
-        return all(
-            (
-                origin,
-                any(
-                    (
-                        origin == SYNTHETIC_PACKAGE_NAME,
-                        os.path.basename(origin) in ('__synthetic__', '__init__.py'),
-                    )
-                )
-            )
-        )
+        if not origin:
+            return False
+
+        if origin == SYNTHETIC_PACKAGE_NAME:
+            return True
+
+        module_filename = os.path.basename(origin)
+        return module_filename in {'__synthetic__', '__init__.py'}
 
     def _ensure_package(self, package):
         if self._is_ansible_ns_package(package):

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -39,12 +39,6 @@ except ImportError:
     reload_module = reload  # type: ignore[name-defined]  # pylint:disable=undefined-variable
 
 try:
-    from importlib.resources import Package
-    from importlib.resources.abc import TraversableResources, Traversable
-except ImportError:
-    TraversableResources = object
-
-try:
     from importlib.util import spec_from_loader
 except ImportError:
     pass
@@ -91,7 +85,7 @@ except AttributeError:  # Python 2
 PB_EXTENSIONS = ('.yml', '.yaml')
 
 
-class _AnsibleTraversableResources(TraversableResources):
+class _AnsibleTraversableResources:
     def __init__(self, package, loader):
         self._package = package
         self._loader = loader

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -176,7 +176,7 @@ class _AnsibleTraversableResources:
             raise TypeError('Expected string or module, got %r' % package.__class__.__name__)
 
         self._ensure_package(package)
-        if parts[0] == 'ansible_collections' and len(parts) < 3:
+        if is_ns:
             return _AnsibleNSTraversable(*package.submodule_search_locations)
         return pathlib.Path(self._get_path(package)).parent
 

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -95,7 +95,7 @@ class _AnsibleNSTraversable:
         return '_AnsibleNSTraversable(\'%s\')' % '\', \''.join(map(to_text, self._paths))
 
     def iterdir(self):
-        return itertools.chain(*[list(p.iterdir()) for p in self._paths if p.is_dir()])
+        return itertools.chain.from_iterable(p.iterdir() for p in self._paths if p.is_dir())
 
     def is_dir(self):
         return any((p.is_dir() for p in self._paths))
@@ -104,7 +104,7 @@ class _AnsibleNSTraversable:
         return False
 
     def glob(self, pattern):
-        return itertools.chain(*[list(p.glob(pattern)) for p in self._paths if p.is_dir()])
+        return itertools.chain.from_iterable(p.glob(pattern) for p in self._paths if p.is_dir())
 
     def _not_implemented(self, *args, **kwargs):
         raise NotImplementedError('not usable on namespaces')

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -127,7 +127,7 @@ class _AnsibleNSTraversable:
         self._paths = [pathlib.Path(p) for p in paths]
 
     def __repr__(self):
-        return '_AnsibleNSTraversable(\'%s\')' % '\', \''.join(map(to_text, self._paths))
+        return "_AnsibleNSTraversable('%s')" % "', '".join(map(to_text, self._paths))
 
     def iterdir(self):
         return itertools.chain.from_iterable(p.iterdir() for p in self._paths if p.is_dir())
@@ -152,7 +152,7 @@ class _AnsibleTraversableResources(TraversableResources):
     collection Python loaders.
 
     The result of ``files`` will depend on whether a particular collection, or
-    a sub package of a collection was refernced, as opposed to
+    a sub package of a collection was referenced, as opposed to
     ``ansible_collections`` or a particular namespace. For a collection and
     its subpackages, a ``pathlib.Path`` instance will be returned, whereas
     for the higher level namespace packages, ``_AnsibleNSTraversable``

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -40,6 +40,11 @@ except ImportError:
     reload_module = reload  # type: ignore[name-defined]  # pylint:disable=undefined-variable
 
 try:
+    from importlib.abc import TraversableResources
+except ImportError:
+    TraversableResources = object  # type: ignore[assignment,misc]
+
+try:
     from importlib.util import find_spec, spec_from_loader
 except ImportError:
     pass
@@ -142,7 +147,7 @@ class _AnsibleNSTraversable:
     joinpath = __truediv__ = read_bytes = read_text = _not_implemented
 
 
-class _AnsibleTraversableResources:
+class _AnsibleTraversableResources(TraversableResources):
     """Implements ``importlib.resources.abc.TraversableResources`` for the
     collection Python loaders.
 

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -124,6 +124,9 @@ class _AnsibleTraversableResources:
 
     def files(self):
         package = self._package
+        parts = package.split('.')
+        if parts[0] == 'ansible_collections' and len(parts) < 3:
+            raise TypeError('Cannot traverse ansible_collection packages below an individual collection')
 
         if isinstance(package, string_types):
             package = spec_from_loader(package, self._loader)

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -206,6 +206,9 @@ class _AnsibleTraversableResources:
 
         if isinstance(package, string_types):
             if is_ns:
+                # Don't use ``spec_from_loader`` here, because that will point
+                # to exactly 1 location for a namespace. Use ``find_spec``
+                # to get a list of all locations for the namespace
                 package = find_spec(package)
             else:
                 package = spec_from_loader(package, self._loader)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ jinja2 >= 3.0.0
 PyYAML >= 5.1  # PyYAML 5.1 is required for Python 3.8+ support
 cryptography
 packaging
+# importlib.resources in stdlib for py3.9 is lacking native hooks for
+# importlib.resources.files
+importlib_resources >= 5.0, < 5.1; python_version < '3.10'
 # NOTE: resolvelib 0.x version bumps should be considered major/breaking
 # NOTE: and we should update the upper cap with care, at least until 1.0
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69

--- a/test/integration/targets/ansible-doc/broken-docs/collections/ansible_collections/testns/testcol/MANIFEST.json
+++ b/test/integration/targets/ansible-doc/broken-docs/collections/ansible_collections/testns/testcol/MANIFEST.json
@@ -17,7 +17,7 @@
   "version": "0.1.1231", 
   "readme": "README.md", 
   "license_file": "COPYING", 
-  "homepage": "",
+  "homepage": ""
  }, 
  "file_manifest_file": {
   "format": 1, 

--- a/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/MANIFEST.json
+++ b/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/MANIFEST.json
@@ -17,7 +17,7 @@
   "version": "0.1.1231", 
   "readme": "README.md", 
   "license_file": "COPYING", 
-  "homepage": "",
+  "homepage": ""
  }, 
  "file_manifest_file": {
   "format": 1, 

--- a/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol2/MANIFEST.json
+++ b/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol2/MANIFEST.json
@@ -17,7 +17,7 @@
   "version": "1.2.0", 
   "readme": "README.md", 
   "license_file": "COPYING", 
-  "homepage": "",
+  "homepage": ""
  }, 
  "file_manifest_file": {
   "format": 1, 

--- a/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
@@ -137,7 +137,7 @@
   register: list_result_error
   ignore_errors: True
   environment:
-    ANSIBLE_COLLECTIONS_PATH: ""
+    ANSIBLE_COLLECTIONS_PATH: "i_dont_exist"
 
 - assert:
     that:

--- a/test/lib/ansible_test/_data/requirements/ansible.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible.txt
@@ -7,6 +7,9 @@ jinja2 >= 3.0.0
 PyYAML >= 5.1  # PyYAML 5.1 is required for Python 3.8+ support
 cryptography
 packaging
+# importlib.resources in stdlib for py3.9 is lacking native hooks for
+# importlib.resources.files
+importlib_resources >= 5.0, < 5.1; python_version < '3.10'
 # NOTE: resolvelib 0.x version bumps should be considered major/breaking
 # NOTE: and we should update the upper cap with care, at least until 1.0
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69

--- a/test/units/cli/test_doc.py
+++ b/test/units/cli/test_doc.py
@@ -5,7 +5,7 @@ __metaclass__ = type
 import pytest
 
 from ansible.cli.doc import DocCLI, RoleMixin
-from ansible.plugins.loader import module_loader
+from ansible.plugins.loader import module_loader, init_plugin_loader
 
 
 TTY_IFY_DATA = {
@@ -118,6 +118,7 @@ def test_builtin_modules_list():
     args = ['ansible-doc', '-l', 'ansible.builtin', '-t', 'module']
     obj = DocCLI(args=args)
     obj.parse()
+    init_plugin_loader()
     result = obj._list_plugins('module', module_loader)
     assert len(result) > 0
 

--- a/test/units/executor/module_common/test_recursive_finder.py
+++ b/test/units/executor/module_common/test_recursive_finder.py
@@ -29,7 +29,7 @@ from io import BytesIO
 import ansible.errors
 
 from ansible.executor.module_common import recursive_finder
-
+from ansible.plugins.loader import init_plugin_loader
 
 # These are the modules that are brought in by module_utils/basic.py  This may need to be updated
 # when basic.py gains new imports
@@ -79,6 +79,8 @@ ANSIBLE_LIB = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.pa
 
 @pytest.fixture
 def finder_containers():
+    init_plugin_loader()
+
     FinderContainers = namedtuple('FinderContainers', ['zf'])
 
     zipoutput = BytesIO()

--- a/test/units/executor/test_play_iterator.py
+++ b/test/units/executor/test_play_iterator.py
@@ -25,6 +25,7 @@ from unittest.mock import patch, MagicMock
 from ansible.executor.play_iterator import HostState, PlayIterator, IteratingStates, FailedStates
 from ansible.playbook import Playbook
 from ansible.playbook.play_context import PlayContext
+from ansible.plugins.loader import init_plugin_loader
 
 from units.mock.loader import DictDataLoader
 from units.mock.path import mock_unfrackpath_noop
@@ -286,6 +287,7 @@ class TestPlayIterator(unittest.TestCase):
         self.assertNotIn(hosts[0], failed_hosts)
 
     def test_play_iterator_nested_blocks(self):
+        init_plugin_loader()
         fake_loader = DictDataLoader({
             "test_play.yml": """
             - hosts: all

--- a/test/units/parsing/test_mod_args.py
+++ b/test/units/parsing/test_mod_args.py
@@ -10,6 +10,7 @@ import re
 
 from ansible.errors import AnsibleParserError
 from ansible.parsing.mod_args import ModuleArgsParser
+from ansible.plugins.loader import init_plugin_loader
 from ansible.utils.sentinel import Sentinel
 
 
@@ -119,6 +120,7 @@ class TestModArgsDwim:
         assert err.value.args[0] == msg
 
     def test_multiple_actions_ping_shell(self):
+        init_plugin_loader()
         args_dict = {'ping': 'data=hi', 'shell': 'echo hi'}
         m = ModuleArgsParser(args_dict)
         with pytest.raises(AnsibleParserError) as err:
@@ -129,6 +131,7 @@ class TestModArgsDwim:
         assert actions == set(['ping', 'shell'])
 
     def test_bogus_action(self):
+        init_plugin_loader()
         args_dict = {'bogusaction': {}}
         m = ModuleArgsParser(args_dict)
         with pytest.raises(AnsibleParserError) as err:

--- a/test/units/playbook/test_task.py
+++ b/test/units/playbook/test_task.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 from units.compat import unittest
 from unittest.mock import patch
 from ansible.playbook.task import Task
+from ansible.plugins.loader import init_plugin_loader
 from ansible.parsing.yaml import objects
 from ansible import errors
 
@@ -74,6 +75,7 @@ class TestTask(unittest.TestCase):
 
     @patch.object(errors.AnsibleError, '_get_error_lines_from_file')
     def test_load_task_kv_form_error_36848(self, mock_get_err_lines):
+        init_plugin_loader()
         ds = objects.AnsibleMapping(kv_bad_args_ds)
         ds.ansible_pos = ('test_task_faux_playbook.yml', 1, 1)
         mock_get_err_lines.return_value = (kv_bad_args_str, '')

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 
 import os
 import re
+from importlib import import_module
 
 from ansible import constants as C
 from units.compat import unittest
@@ -33,6 +34,7 @@ from ansible.module_utils.six.moves import shlex_quote, builtins
 from ansible.module_utils._text import to_bytes
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.action import ActionBase
+from ansible.plugins.loader import init_plugin_loader
 from ansible.template import Templar
 from ansible.vars.clean import clean_facts
 
@@ -109,6 +111,11 @@ class TestActionBase(unittest.TestCase):
         self.assertEqual(results, {})
 
     def test_action_base__configure_module(self):
+        init_plugin_loader()
+        # Pre-populate the ansible.builtin collection
+        # so reading the ansible_builtin_runtime.yml happens
+        # before the mock_open below
+        import_module('ansible_collections.ansible.builtin')
         fake_loader = DictDataLoader({
         })
 

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -29,7 +29,7 @@ from units.compat import unittest
 from ansible.errors import AnsibleError
 from ansible.plugins.cache import CachePluginAdjudicator
 from ansible.plugins.cache.memory import CacheModule as MemoryCache
-from ansible.plugins.loader import cache_loader
+from ansible.plugins.loader import cache_loader, init_plugin_loader
 from ansible.vars.fact_cache import FactCache
 
 import pytest
@@ -183,6 +183,7 @@ class TestFactCache(unittest.TestCase):
         assert len(self.cache.keys()) == 0
 
     def test_plugin_load_failure(self):
+        init_plugin_loader()
         # See https://github.com/ansible/ansible/issues/18751
         # Note no fact_connection config set, so this will fail
         with mock.patch('ansible.constants.CACHE_PLUGIN', 'json'):

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -27,6 +27,7 @@ from unittest.mock import patch
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleUndefinedVariable
 from ansible.module_utils.six import string_types
+from ansible.plugins.loader import init_plugin_loader
 from ansible.template import Templar, AnsibleContext, AnsibleEnvironment, AnsibleUndefined
 from ansible.utils.unsafe_proxy import AnsibleUnsafe, wrap_var
 from units.mock.loader import DictDataLoader
@@ -34,6 +35,7 @@ from units.mock.loader import DictDataLoader
 
 class BaseTemplar(object):
     def setUp(self):
+        init_plugin_loader()
         self.test_vars = dict(
             foo="bar",
             bam="{{foo}}",

--- a/test/units/utils/collection_loader/test_collection_loader.py
+++ b/test/units/utils/collection_loader/test_collection_loader.py
@@ -869,7 +869,7 @@ def test_importlib_resources():
     assert ansible_collections_ns._paths == [Path(p) / 'ansible_collections' for p in default_test_collection_paths[:2]]
     assert testcoll2 == second_path / 'ansible_collections' / 'testns' / 'testcoll2'
 
-    assert [p.name for p in module_utils.glob('*.py')] == ['__init__.py', 'my_other_util.py', 'my_util.py']
+    assert {p.name for p in module_utils.glob('*.py')} == {'__init__.py', 'my_other_util.py', 'my_util.py'}
     nestcoll_mu_init = first_path / 'ansible_collections' / 'testns' / 'testcoll' / 'plugins' / 'module_utils' / '__init__.py'
     assert next(module_utils.glob('__init__.py')) == nestcoll_mu_init
 


### PR DESCRIPTION
##### SUMMARY
Adds the ability to use `importlib.resources` for our custom python loaders

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/utils/collection_loader/_collection_finder.py

##### ADDITIONAL INFORMATION
```pycon
>>> import ansible.plugins.loader
>>> from importlib.resources import files
>>> p = files('ansible_collections')
>>> pprint.pprint(list(pp for pp in p.glob('*/*') if pp.is_dir()))
[PosixPath('/Users/sivel/.ansible/collections/ansible_collections/sivel/collection'),
 PosixPath('/Users/sivel/.ansible/collections/ansible_collections/sivel/test'),
 PosixPath('/Users/sivel/.ansible/collections/ansible_collections/sivel/jinja2'),
 PosixPath('/Users/sivel/.ansible/collections/ansible_collections/sivel/toiletwater'),
 PosixPath('/Users/sivel/.ansible/collections/ansible_collections/sivel/acd'),
 PosixPath('/Users/sivel/.ansible/collections/ansible_collections/community/docker'),
 PosixPath('/Users/sivel/tmp/collections/ansible_collections/community/general')]
>>> files('ansible_collections.sivel.toiletwater')
PosixPath('/Users/sivel/.ansible/collections/ansible_collections/sivel/toiletwater')
>>> files('ansible_collections.sivel.toiletwater.plugins')
PosixPath('/Users/sivel/.ansible/collections/ansible_collections/sivel/toiletwater/plugins')
>>> files('ansible_collections.sivel.toiletwater.plugins.filter')
PosixPath('/Users/sivel/.ansible/collections/ansible_collections/sivel/toiletwater/plugins/filter')
>>> files('ansible_collections.sivel.toiletwater.plugins.filter.ini')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sivel/git/pyenv/pyenv/versions/3.10.5/lib/python3.10/importlib/_common.py", line 22, in files
    return from_package(get_package(package))
  File "/Users/sivel/git/pyenv/pyenv/versions/3.10.5/lib/python3.10/importlib/_common.py", line 68, in get_package
    raise TypeError(f'{package!r} is not a package')
TypeError: 'ansible_collections.sivel.toiletwater.plugins.filter.ini' is not a package
>>> files('ansible.plugins.filter')
PosixPath('/Users/sivel/projects/ansibledev/ansible/lib/ansible/plugins/filter')
>>> next(files('ansible.plugins.filter').glob('bool.yml'))
PosixPath('/Users/sivel/projects/ansibledev/ansible/lib/ansible/plugins/filter/bool.yml')
```