### PR TITLE
Add condition that causes a when to skip a task to output msg

### DIFF
--- a/changelogs/fragments/skip-conditional.yml
+++ b/changelogs/fragments/skip-conditional.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Added the conditional that was False if ``when`` caused a task to skip under ``failed_condition``.

--- a/changelogs/fragments/skip-conditional.yml
+++ b/changelogs/fragments/skip-conditional.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- Added the conditional that was False if ``when`` caused a task to skip under ``failed_condition``.
+- Added the conditional that was False if ``when`` caused a task to skip under ``false_condition``.

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -450,11 +450,11 @@ class TaskExecutor:
         # the fact that the conditional may specify that the task be skipped due to a
         # variable not being present which would otherwise cause validation to fail
         try:
-            conditional_result, failed_condition = self._task.evaluate_conditional_with_result(templar, tempvars)
+            conditional_result, false_condition = self._task.evaluate_conditional_with_result(templar, tempvars)
             if not conditional_result:
                 display.debug("when evaluation is False, skipping this task")
                 return dict(changed=False, skipped=True, skip_reason='Conditional result was False',
-                            failed_condition=failed_condition, _ansible_no_log=no_log)
+                            false_condition=false_condition, _ansible_no_log=no_log)
         except AnsibleError as e:
             # loop error takes precedence
             if self._loop_eval_error is not None:

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -450,9 +450,11 @@ class TaskExecutor:
         # the fact that the conditional may specify that the task be skipped due to a
         # variable not being present which would otherwise cause validation to fail
         try:
-            if not self._task.evaluate_conditional(templar, tempvars):
+            conditional_result, failed_condition = self._task.evaluate_conditional_with_result(templar, tempvars)
+            if not conditional_result:
                 display.debug("when evaluation is False, skipping this task")
-                return dict(changed=False, skipped=True, skip_reason='Conditional result was False', _ansible_no_log=no_log)
+                return dict(changed=False, skipped=True, skip_reason='Conditional result was False',
+                            failed_condition=failed_condition, _ansible_no_log=no_log)
         except AnsibleError as e:
             # loop error takes precedence
             if self._loop_eval_error is not None:

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -59,8 +59,7 @@ class Conditional:
         if not isinstance(value, list):
             setattr(self, name, [value])
 
-    def evaluate_conditional(self, templar: Templar, all_vars: dict[str, t.Any]
-    ) -> bool:
+    def evaluate_conditional(self, templar: Templar, all_vars: dict[str, t.Any]) -> bool:
         '''
         Loops through the conditionals set on this object, returning
         False if any of them evaluate as such.

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -16,10 +16,12 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 import ast
+import typing as t
 
 from jinja2.compiler import generate
 from jinja2.exceptions import UndefinedError
@@ -28,6 +30,7 @@ from ansible.errors import AnsibleError, AnsibleUndefinedVariable
 from ansible.module_utils.six import text_type
 from ansible.module_utils._text import to_native
 from ansible.playbook.attribute import FieldAttribute
+from ansible.template import Templar
 from ansible.utils.display import Display
 
 display = Display()
@@ -35,20 +38,22 @@ display = Display()
 
 class Conditional:
 
-    '''
+    """
     This is a mix-in class, to be used with Base to allow the object
     to be run conditionally when a condition is met or skipped.
-    '''
+    """
 
-    when = FieldAttribute(isa='list', default=list, extend=True, prepend=True)
+    when = FieldAttribute(isa="list", default=list, extend=True, prepend=True)
 
     def __init__(self, loader=None):
         # when used directly, this class needs a loader, but we want to
         # make sure we don't trample on the existing one if this class
         # is used as a mix-in with a playbook base class
-        if not hasattr(self, '_loader'):
+        if not hasattr(self, "_loader"):
             if loader is None:
-                raise AnsibleError("a loader must be specified when using Conditional() directly")
+                raise AnsibleError(
+                    "a loader must be specified when using Conditional() directly"
+                )
             else:
                 self._loader = loader
         super(Conditional, self).__init__()
@@ -57,25 +62,37 @@ class Conditional:
         if not isinstance(value, list):
             setattr(self, name, [value])
 
-    def evaluate_conditional(self, templar, all_vars):
-        '''
+    def evaluate_conditional(
+        self, templar: Templar, all_vars: dict[str, t.Any]
+    ) -> bool:
+        """
         Loops through the conditionals set on this object, returning
         False if any of them evaluate as such.
-        '''
+        """
+        return self.evaluate_conditional_with_result(templar, all_vars)[0]
 
+    def evaluate_conditional_with_result(
+        self, templar: Templar, all_vars: dict[str, t.Any]
+    ) -> tuple[bool, t.Optional[str]]:
+        """
+        Loops through the conditionals set on this object, returning
+        False if any of them evaluate as such as well as the condition
+        that was false.
+        """
         # since this is a mix-in, it may not have an underlying datastructure
         # associated with it, so we pull it out now in case we need it for
         # error reporting below
         ds = None
-        if hasattr(self, '_ds'):
-            ds = getattr(self, '_ds')
+        if hasattr(self, "_ds"):
+            ds = getattr(self, "_ds")
 
         result = True
+        failed_conditional: t.Optional[str] = None
         try:
             for conditional in self.when:
 
                 # do evaluation
-                if conditional is None or conditional == '':
+                if conditional is None or conditional == "":
                     res = True
                 elif isinstance(conditional, bool):
                     res = conditional
@@ -88,33 +105,40 @@ class Conditional:
 
                 display.debug("Evaluated conditional (%s): %s" % (conditional, res))
                 if not result:
+                    failed_conditional = conditional
                     break
 
         except Exception as e:
-            raise AnsibleError("The conditional check '%s' failed. The error was: %s" % (to_native(conditional), to_native(e)), obj=ds)
+            raise AnsibleError(
+                "The conditional check '%s' failed. The error was: %s"
+                % (to_native(conditional), to_native(e)),
+                obj=ds,
+            )
 
-        return result
+        return result, failed_conditional
 
     def _check_conditional(self, conditional, templar, all_vars):
-        '''
+        """
         This method does the low-level evaluation of each conditional
         set on this object, using jinja2 to wrap the conditionals for
         evaluation.
-        '''
+        """
 
         original = conditional
 
         if templar.is_template(conditional):
-            display.warning('conditional statements should not include jinja2 '
-                            'templating delimiters such as {{ }} or {%% %%}. '
-                            'Found: %s' % conditional)
+            display.warning(
+                "conditional statements should not include jinja2 "
+                "templating delimiters such as {{ }} or {%% %%}. "
+                "Found: %s" % conditional
+            )
 
         # make sure the templar is using the variables specified with this method
         templar.available_variables = all_vars
 
         try:
             # if the conditional is "unsafe", disable lookups
-            disable_lookups = hasattr(conditional, '__UNSAFE__')
+            disable_lookups = hasattr(conditional, "__UNSAFE__")
             conditional = templar.template(conditional, disable_lookups=disable_lookups)
 
             if not isinstance(conditional, text_type) or conditional == "":
@@ -122,7 +146,7 @@ class Conditional:
 
             # update the lookups flag, as the string returned above may now be unsafe
             # and we don't want future templating calls to do unsafe things
-            disable_lookups |= hasattr(conditional, '__UNSAFE__')
+            disable_lookups |= hasattr(conditional, "__UNSAFE__")
 
             # First, we do some low-level jinja2 parsing involving the AST format of the
             # statement to ensure we don't do anything unsafe (using the disable_lookup flag above)
@@ -137,12 +161,13 @@ class Conditional:
                             if inside_call and node.s.startswith("__"):
                                 # calling things with a dunder is generally bad at this point...
                                 raise AnsibleError(
-                                    "Invalid access found in the conditional: '%s'" % conditional
+                                    "Invalid access found in the conditional: '%s'"
+                                    % conditional
                                 )
                             elif inside_yield:
                                 # we're inside a yield, so recursively parse and traverse the AST
                                 # of the result to catch forbidden syntax from executing
-                                parsed = ast.parse(node.s, mode='exec')
+                                parsed = ast.parse(node.s, mode="exec")
                                 cnv = CleansingNodeVisitor()
                                 cnv.visit(parsed)
                     # iterate over all child nodes
@@ -150,12 +175,13 @@ class Conditional:
                         self.generic_visit(
                             child_node,
                             inside_call=inside_call,
-                            inside_yield=inside_yield
+                            inside_yield=inside_yield,
                         )
+
             try:
                 res = templar.environment.parse(conditional, None, None)
                 res = generate(res, templar.environment, None, None)
-                parsed = ast.parse(res, mode='exec')
+                parsed = ast.parse(res, mode="exec")
 
                 cnv = CleansingNodeVisitor()
                 cnv.visit(parsed)
@@ -165,7 +191,9 @@ class Conditional:
             # and finally we generate and template the presented string and look at the resulting string
             # NOTE The spaces around True and False are intentional to short-circuit literal_eval for
             #      jinja2_native=False and avoid its expensive calls.
-            presented = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % conditional
+            presented = (
+                "{%% if %s %%} True {%% else %%} False {%% endif %%}" % conditional
+            )
             val = templar.template(presented, disable_lookups=disable_lookups).strip()
             if val == "True":
                 return True
@@ -174,4 +202,6 @@ class Conditional:
             else:
                 raise AnsibleError("unable to evaluate conditional: %s" % original)
         except (AnsibleUndefinedVariable, UndefinedError) as e:
-            raise AnsibleUndefinedVariable("error while evaluating conditional (%s): %s" % (original, e))
+            raise AnsibleUndefinedVariable(
+                "error while evaluating conditional (%s): %s" % (original, e)
+            )

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -87,7 +87,7 @@ class Conditional:
             ds = getattr(self, "_ds")
 
         result = True
-        failed_conditional: t.Optional[str] = None
+        false_condition: t.Optional[str] = None
         try:
             for conditional in self.when:
 
@@ -105,7 +105,7 @@ class Conditional:
 
                 display.debug("Evaluated conditional (%s): %s" % (conditional, res))
                 if not result:
-                    failed_conditional = conditional
+                    false_condition = conditional
                     break
 
         except Exception as e:
@@ -115,7 +115,7 @@ class Conditional:
                 obj=ds,
             )
 
-        return result, failed_conditional
+        return result, false_condition
 
     def _check_conditional(self, conditional, templar, all_vars):
         """

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -16,8 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Make coding more python3-ish
-from __future__ import absolute_import, division, print_function
-
+from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import ast
@@ -38,22 +37,20 @@ display = Display()
 
 class Conditional:
 
-    """
+    '''
     This is a mix-in class, to be used with Base to allow the object
     to be run conditionally when a condition is met or skipped.
-    """
+    '''
 
-    when = FieldAttribute(isa="list", default=list, extend=True, prepend=True)
+    when = FieldAttribute(isa='list', default=list, extend=True, prepend=True)
 
     def __init__(self, loader=None):
         # when used directly, this class needs a loader, but we want to
         # make sure we don't trample on the existing one if this class
         # is used as a mix-in with a playbook base class
-        if not hasattr(self, "_loader"):
+        if not hasattr(self, '_loader'):
             if loader is None:
-                raise AnsibleError(
-                    "a loader must be specified when using Conditional() directly"
-                )
+                raise AnsibleError("a loader must be specified when using Conditional() directly")
             else:
                 self._loader = loader
         super(Conditional, self).__init__()
@@ -62,29 +59,27 @@ class Conditional:
         if not isinstance(value, list):
             setattr(self, name, [value])
 
-    def evaluate_conditional(
-        self, templar: Templar, all_vars: dict[str, t.Any]
+    def evaluate_conditional(self, templar: Templar, all_vars: dict[str, t.Any]
     ) -> bool:
-        """
+        '''
         Loops through the conditionals set on this object, returning
         False if any of them evaluate as such.
-        """
+        '''
         return self.evaluate_conditional_with_result(templar, all_vars)[0]
 
-    def evaluate_conditional_with_result(
-        self, templar: Templar, all_vars: dict[str, t.Any]
-    ) -> tuple[bool, t.Optional[str]]:
+    def evaluate_conditional_with_result(self, templar: Templar, all_vars: dict[str, t.Any]) -> tuple[bool, t.Optional[str]]:
         """
         Loops through the conditionals set on this object, returning
         False if any of them evaluate as such as well as the condition
         that was false.
         """
+
         # since this is a mix-in, it may not have an underlying datastructure
         # associated with it, so we pull it out now in case we need it for
         # error reporting below
         ds = None
-        if hasattr(self, "_ds"):
-            ds = getattr(self, "_ds")
+        if hasattr(self, '_ds'):
+            ds = getattr(self, '_ds')
 
         result = True
         false_condition: t.Optional[str] = None
@@ -92,7 +87,7 @@ class Conditional:
             for conditional in self.when:
 
                 # do evaluation
-                if conditional is None or conditional == "":
+                if conditional is None or conditional == '':
                     res = True
                 elif isinstance(conditional, bool):
                     res = conditional
@@ -109,36 +104,30 @@ class Conditional:
                     break
 
         except Exception as e:
-            raise AnsibleError(
-                "The conditional check '%s' failed. The error was: %s"
-                % (to_native(conditional), to_native(e)),
-                obj=ds,
-            )
+            raise AnsibleError("The conditional check '%s' failed. The error was: %s" % (to_native(conditional), to_native(e)), obj=ds)
 
         return result, false_condition
 
     def _check_conditional(self, conditional, templar, all_vars):
-        """
+        '''
         This method does the low-level evaluation of each conditional
         set on this object, using jinja2 to wrap the conditionals for
         evaluation.
-        """
+        '''
 
         original = conditional
 
         if templar.is_template(conditional):
-            display.warning(
-                "conditional statements should not include jinja2 "
-                "templating delimiters such as {{ }} or {%% %%}. "
-                "Found: %s" % conditional
-            )
+            display.warning('conditional statements should not include jinja2 '
+                            'templating delimiters such as {{ }} or {%% %%}. '
+                            'Found: %s' % conditional)
 
         # make sure the templar is using the variables specified with this method
         templar.available_variables = all_vars
 
         try:
             # if the conditional is "unsafe", disable lookups
-            disable_lookups = hasattr(conditional, "__UNSAFE__")
+            disable_lookups = hasattr(conditional, '__UNSAFE__')
             conditional = templar.template(conditional, disable_lookups=disable_lookups)
 
             if not isinstance(conditional, text_type) or conditional == "":
@@ -146,7 +135,7 @@ class Conditional:
 
             # update the lookups flag, as the string returned above may now be unsafe
             # and we don't want future templating calls to do unsafe things
-            disable_lookups |= hasattr(conditional, "__UNSAFE__")
+            disable_lookups |= hasattr(conditional, '__UNSAFE__')
 
             # First, we do some low-level jinja2 parsing involving the AST format of the
             # statement to ensure we don't do anything unsafe (using the disable_lookup flag above)
@@ -161,13 +150,12 @@ class Conditional:
                             if inside_call and node.s.startswith("__"):
                                 # calling things with a dunder is generally bad at this point...
                                 raise AnsibleError(
-                                    "Invalid access found in the conditional: '%s'"
-                                    % conditional
+                                    "Invalid access found in the conditional: '%s'" % conditional
                                 )
                             elif inside_yield:
                                 # we're inside a yield, so recursively parse and traverse the AST
                                 # of the result to catch forbidden syntax from executing
-                                parsed = ast.parse(node.s, mode="exec")
+                                parsed = ast.parse(node.s, mode='exec')
                                 cnv = CleansingNodeVisitor()
                                 cnv.visit(parsed)
                     # iterate over all child nodes
@@ -175,13 +163,12 @@ class Conditional:
                         self.generic_visit(
                             child_node,
                             inside_call=inside_call,
-                            inside_yield=inside_yield,
+                            inside_yield=inside_yield
                         )
-
             try:
                 res = templar.environment.parse(conditional, None, None)
                 res = generate(res, templar.environment, None, None)
-                parsed = ast.parse(res, mode="exec")
+                parsed = ast.parse(res, mode='exec')
 
                 cnv = CleansingNodeVisitor()
                 cnv.visit(parsed)
@@ -191,9 +178,7 @@ class Conditional:
             # and finally we generate and template the presented string and look at the resulting string
             # NOTE The spaces around True and False are intentional to short-circuit literal_eval for
             #      jinja2_native=False and avoid its expensive calls.
-            presented = (
-                "{%% if %s %%} True {%% else %%} False {%% endif %%}" % conditional
-            )
+            presented = "{%% if %s %%} True {%% else %%} False {%% endif %%}" % conditional
             val = templar.template(presented, disable_lookups=disable_lookups).strip()
             if val == "True":
                 return True
@@ -202,6 +187,4 @@ class Conditional:
             else:
                 raise AnsibleError("unable to evaluate conditional: %s" % original)
         except (AnsibleUndefinedVariable, UndefinedError) as e:
-            raise AnsibleUndefinedVariable(
-                "error while evaluating conditional (%s): %s" % (original, e)
-            )
+            raise AnsibleUndefinedVariable("error while evaluating conditional (%s): %s" % (original, e))

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml_lossy_verbose.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml_lossy_verbose.stdout
@@ -43,7 +43,7 @@ fatal: [testhost]: FAILED! =>
 TASK [Skipped task] ************************************************************
 skipping: [testhost] => 
     changed: false
-    failed_condition: false
+    false_condition: false
     skip_reason: Conditional result was False
 
 TASK [Task with var in name (foo bar)] *****************************************
@@ -121,7 +121,7 @@ ok: [testhost] => (item=debug-3) =>
     msg: debug-3
 skipping: [testhost] => (item=debug-4)  => 
     ansible_loop_var: item
-    failed_condition: item != 4
+    false_condition: item != 4
     item: 4
 fatal: [testhost]: FAILED! => 
     msg: One or more items failed
@@ -201,11 +201,11 @@ skipping: [testhost] =>
 TASK [debug] *******************************************************************
 skipping: [testhost] => (item=1)  => 
     ansible_loop_var: item
-    failed_condition: false
+    false_condition: false
     item: 1
 skipping: [testhost] => (item=2)  => 
     ansible_loop_var: item
-    failed_condition: false
+    false_condition: false
     item: 2
 skipping: [testhost] => 
     msg: All items skipped

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml_lossy_verbose.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml_lossy_verbose.stdout
@@ -43,6 +43,7 @@ fatal: [testhost]: FAILED! =>
 TASK [Skipped task] ************************************************************
 skipping: [testhost] => 
     changed: false
+    failed_condition: false
     skip_reason: Conditional result was False
 
 TASK [Task with var in name (foo bar)] *****************************************
@@ -120,6 +121,7 @@ ok: [testhost] => (item=debug-3) =>
     msg: debug-3
 skipping: [testhost] => (item=debug-4)  => 
     ansible_loop_var: item
+    failed_condition: item != 4
     item: 4
 fatal: [testhost]: FAILED! => 
     msg: One or more items failed
@@ -199,9 +201,11 @@ skipping: [testhost] =>
 TASK [debug] *******************************************************************
 skipping: [testhost] => (item=1)  => 
     ansible_loop_var: item
+    failed_condition: false
     item: 1
 skipping: [testhost] => (item=2)  => 
     ansible_loop_var: item
+    failed_condition: false
     item: 2
 skipping: [testhost] => 
     msg: All items skipped

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml_verbose.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml_verbose.stdout
@@ -45,6 +45,7 @@ fatal: [testhost]: FAILED! =>
 TASK [Skipped task] ************************************************************
 skipping: [testhost] => 
     changed: false
+    failed_condition: false
     skip_reason: Conditional result was False
 
 TASK [Task with var in name (foo bar)] *****************************************
@@ -126,6 +127,7 @@ ok: [testhost] => (item=debug-3) =>
     msg: debug-3
 skipping: [testhost] => (item=debug-4)  => 
     ansible_loop_var: item
+    failed_condition: item != 4
     item: 4
 fatal: [testhost]: FAILED! => 
     msg: One or more items failed
@@ -206,9 +208,11 @@ skipping: [testhost] =>
 TASK [debug] *******************************************************************
 skipping: [testhost] => (item=1)  => 
     ansible_loop_var: item
+    failed_condition: false
     item: 1
 skipping: [testhost] => (item=2)  => 
     ansible_loop_var: item
+    failed_condition: false
     item: 2
 skipping: [testhost] => 
     msg: All items skipped

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml_verbose.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml_verbose.stdout
@@ -45,7 +45,7 @@ fatal: [testhost]: FAILED! =>
 TASK [Skipped task] ************************************************************
 skipping: [testhost] => 
     changed: false
-    failed_condition: false
+    false_condition: false
     skip_reason: Conditional result was False
 
 TASK [Task with var in name (foo bar)] *****************************************
@@ -127,7 +127,7 @@ ok: [testhost] => (item=debug-3) =>
     msg: debug-3
 skipping: [testhost] => (item=debug-4)  => 
     ansible_loop_var: item
-    failed_condition: item != 4
+    false_condition: item != 4
     item: 4
 fatal: [testhost]: FAILED! => 
     msg: One or more items failed
@@ -208,11 +208,11 @@ skipping: [testhost] =>
 TASK [debug] *******************************************************************
 skipping: [testhost] => (item=1)  => 
     ansible_loop_var: item
-    failed_condition: false
+    false_condition: false
     item: 1
 skipping: [testhost] => (item=2)  => 
     ansible_loop_var: item
-    failed_condition: false
+    false_condition: false
     item: 2
 skipping: [testhost] => 
     msg: All items skipped

--- a/test/integration/targets/no_log/runme.sh
+++ b/test/integration/targets/no_log/runme.sh
@@ -5,7 +5,7 @@ set -eux
 # This test expects 7 loggable vars and 0 non-loggable ones.
 # If either mismatches it fails, run the ansible-playbook command to debug.
 [ "$(ansible-playbook no_log_local.yml -i ../../inventory -vvvvv "$@" | awk \
-'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "26/0" ]
+'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "27/0" ]
 
 # deal with corner cases with no log and loops
 # no log enabled, should produce 6 censored messages

--- a/test/integration/targets/test_core/tasks/main.yml
+++ b/test/integration/targets/test_core/tasks/main.yml
@@ -146,11 +146,11 @@
   assert:
     that:
       - skipped_task is skipped
-      - skipped_task.failed_condition == False
+      - skipped_task.false_condition == False
       - executed_task is not skipped
       - misuse_of_skipped is failure
       - skipped_task_multi_condition is skipped
-      - skipped_task_multi_condition.failed_condition == "foo == 'bar'"
+      - skipped_task_multi_condition.false_condition == "foo == 'bar'"
 
 - name: Not an async task
   set_fact:

--- a/test/integration/targets/test_core/tasks/main.yml
+++ b/test/integration/targets/test_core/tasks/main.yml
@@ -126,6 +126,16 @@
     hello: world
   register: executed_task
 
+- name: Skip me with multiple conditions
+  set_fact:
+    hello: world
+  when:
+  - True == True
+  - foo == 'bar'
+  vars:
+    foo: foo
+  register: skipped_task_multi_condition
+
 - name: Try skipped test on non-dictionary
   set_fact:
     hello: "{{ 'nope' is skipped }}"
@@ -136,8 +146,11 @@
   assert:
     that:
       - skipped_task is skipped
+      - skipped_task.failed_condition == False
       - executed_task is not skipped
       - misuse_of_skipped is failure
+      - skipped_task_multi_condition is skipped
+      - skipped_task_multi_condition.failed_condition == "foo == 'bar'"
 
 - name: Not an async task
   set_fact:

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -329,6 +329,7 @@ class TestTaskExecutor(unittest.TestCase):
         # other reason is that if I specify 0 here, the test fails. ;)
         mock_task.async_val = 1
         mock_task.poll = 0
+        mock_task.evaluate_conditional_with_result.return_value = (True, None)
 
         mock_play_context = MagicMock()
         mock_play_context.post_validate.return_value = None


### PR DESCRIPTION
##### SUMMARY
If a `when` condition is `False` and a task is skipped, return `false_condition` with the value of the condition that failed to show what condition caused the task to skip.

A new return value was used instead of updating `skip_reason` as there's a good chance people already do `when: prev_task.skip_reason == 'Conditional result was False'` and changing this line would cause a break. This also only shows the first condition that failed as Ansible does a short circuit check and returns as soon as one conditional if False.

A verbosity level of 1 must be used to see this return value and looks something like

```
# -v
skipping: [localhost] => {"false_condition": "jordan2 == 'foo'"}

# -vvv
skipping: [localhost] => {
    "false_condition": "jordan2 == 'foo'"
}
```

It also looks like the following for the yaml callback

```yaml
skipping: [localhost] =>
  false_condition: jordan2 == 'foo'
```

Fixes: https://github.com/ansible/ansible/issues/30864

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
conditional