### PR TITLE
Upgrade antsibull-docs to 1.6.1 (#78872)

### DIFF
--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -1,7 +1,8 @@
 # pip packages required to build docsite
 # these requirements are as loosely defined as possible
 # if you want known good versions of these dependencies
-# use known_good_reqs.txt instead
+# use test/sanity/code-smell/docs-build.requirements.txt
+# instead
 
 antsibull-docs >= 1.0.0, < 2.0.0
 docutils

--- a/test/sanity/code-smell/docs-build.requirements.in
+++ b/test/sanity/code-smell/docs-build.requirements.in
@@ -6,4 +6,4 @@ sphinx-notfound-page
 sphinx-ansible-theme
 straight.plugin
 rstcheck < 4  # match version used in other sanity tests
-antsibull-docs == 1.5.0  # currently approved version
+antsibull-docs == 1.6.1  # currently approved version

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -5,7 +5,7 @@ aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.1
 antsibull-core==1.2.0
-antsibull-docs==1.5.0
+antsibull-docs==1.6.1
 async-timeout==4.0.2
 asyncio-pool==0.6.0
 attrs==22.1.0


### PR DESCRIPTION
* Bump antsibull-docs version to 1.6.1 to fully support filter docs.

(cherry picked from commit d93883645cb7d2bb9f9be98d7c5dfddd3de36222)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/sanity/code-smell/docs-build.requirements.in
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
