### PR TITLE
ansible-test - Update PSScriptAnalyzer to 1.21.0

### DIFF
--- a/changelogs/fragments/psscriptanalyzer-1.21.0.yml
+++ b/changelogs/fragments/psscriptanalyzer-1.21.0.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- >- 
+  ansible-test pslint - Upgrade PSScriptAnalyzer to ``1.21.0`` which enables the ``AvoidMultipleTypeAttributes``,
+  ``AvoidSemicolonsAsLineTerminators``, and ``AvoidUsingBrokenHashAlgorithms`` rules

--- a/lib/ansible/executor/powershell/async_wrapper.ps1
+++ b/lib/ansible/executor/powershell/async_wrapper.ps1
@@ -135,11 +135,11 @@ try {
 
     # populate initial results before we send the async data to avoid result race
     $result = @{
-        started = 1;
-        finished = 0;
-        results_file = $results_path;
-        ansible_job_id = $local_jid;
-        _ansible_suppress_tmpdir_delete = $true;
+        started = 1
+        finished = 0
+        results_file = $results_path
+        ansible_job_id = $local_jid
+        _ansible_suppress_tmpdir_delete = $true
         ansible_async_watchdog_pid = $watchdog_pid
     }
 

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Backup.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Backup.psm1
@@ -18,7 +18,7 @@ Function Backup-File {
     Process {
         $backup_path = $null
         if (Test-Path -LiteralPath $path -PathType Leaf) {
-            $backup_path = "$path.$pid." + [DateTime]::Now.ToString("yyyyMMdd-HHmmss") + ".bak";
+            $backup_path = "$path.$pid." + [DateTime]::Now.ToString("yyyyMMdd-HHmmss") + ".bak"
             Try {
                 Copy-Item -LiteralPath $path -Destination $backup_path
             }

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
@@ -354,16 +354,16 @@ Function Get-FileChecksum($path, $algorithm = 'sha1') {
             $hash = $raw_hash.Hash.ToLower()
         }
         Else {
-            $fp = [System.IO.File]::Open($path, [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite);
-            $hash = [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower();
-            $fp.Dispose();
+            $fp = [System.IO.File]::Open($path, [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+            $hash = [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower()
+            $fp.Dispose()
         }
     }
     ElseIf (Test-Path -LiteralPath $path -PathType Container) {
-        $hash = "3";
+        $hash = "3"
     }
     Else {
-        $hash = "1";
+        $hash = "1"
     }
     return $hash
 }

--- a/test/integration/targets/win_script/files/test_script_with_args.ps1
+++ b/test/integration/targets/win_script/files/test_script_with_args.ps1
@@ -2,5 +2,5 @@
 # passed to the script.
 
 foreach ($i in $args) {
-    Write-Host $i;
+    Write-Host $i
 }

--- a/test/integration/targets/win_script/files/test_script_with_errors.ps1
+++ b/test/integration/targets/win_script/files/test_script_with_errors.ps1
@@ -2,7 +2,7 @@
 
 trap {
     Write-Error -ErrorRecord $_
-    exit 1;
+    exit 1
 }
 
 throw "Oh noes I has an error"

--- a/test/integration/targets/windows-minimal/library/win_ping_set_attr.ps1
+++ b/test/integration/targets/windows-minimal/library/win_ping_set_attr.ps1
@@ -16,16 +16,16 @@
 
 # POWERSHELL_COMMON
 
-$params = Parse-Args $args $true;
+$params = Parse-Args $args $true
 
-$data = Get-Attr $params "data" "pong";
+$data = Get-Attr $params "data" "pong"
 
 $result = @{
     changed = $false
     ping = "pong"
-};
+}
 
 # Test that Set-Attr will replace an existing attribute.
 Set-Attr $result "ping" $data
 
-Exit-Json $result;
+Exit-Json $result

--- a/test/integration/targets/windows-minimal/library/win_ping_strict_mode_error.ps1
+++ b/test/integration/targets/windows-minimal/library/win_ping_strict_mode_error.ps1
@@ -16,15 +16,15 @@
 
 # POWERSHELL_COMMON
 
-$params = Parse-Args $args $true;
+$params = Parse-Args $args $true
 
 $params.thisPropertyDoesNotExist
 
-$data = Get-Attr $params "data" "pong";
+$data = Get-Attr $params "data" "pong"
 
 $result = @{
     changed = $false
     ping = $data
-};
+}
 
-Exit-Json $result;
+Exit-Json $result

--- a/test/integration/targets/windows-minimal/library/win_ping_syntax_error.ps1
+++ b/test/integration/targets/windows-minimal/library/win_ping_syntax_error.ps1
@@ -18,13 +18,13 @@
 
 $blah = 'I can't quote my strings correctly.'
 
-$params = Parse-Args $args $true;
+$params = Parse-Args $args $true
 
-$data = Get-Attr $params "data" "pong";
+$data = Get-Attr $params "data" "pong"
 
 $result = @{
     changed = $false
     ping = $data
-};
+}
 
-Exit-Json $result;
+Exit-Json $result

--- a/test/integration/targets/windows-minimal/library/win_ping_throw.ps1
+++ b/test/integration/targets/windows-minimal/library/win_ping_throw.ps1
@@ -18,13 +18,13 @@
 
 throw
 
-$params = Parse-Args $args $true;
+$params = Parse-Args $args $true
 
-$data = Get-Attr $params "data" "pong";
+$data = Get-Attr $params "data" "pong"
 
 $result = @{
     changed = $false
     ping = $data
-};
+}
 
-Exit-Json $result;
+Exit-Json $result

--- a/test/integration/targets/windows-minimal/library/win_ping_throw_string.ps1
+++ b/test/integration/targets/windows-minimal/library/win_ping_throw_string.ps1
@@ -18,13 +18,13 @@
 
 throw "no ping for you"
 
-$params = Parse-Args $args $true;
+$params = Parse-Args $args $true
 
-$data = Get-Attr $params "data" "pong";
+$data = Get-Attr $params "data" "pong"
 
 $result = @{
     changed = $false
     ping = $data
-};
+}
 
-Exit-Json $result;
+Exit-Json $result

--- a/test/lib/ansible_test/_data/requirements/sanity.pslint.ps1
+++ b/test/lib/ansible_test/_data/requirements/sanity.pslint.ps1
@@ -28,8 +28,10 @@ Function Install-PSModule {
     }
 }
 
+# Versions changes should be made first in ansible-test which is then synced to
+# the default-test-container over time
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-Install-PSModule -Name PSScriptAnalyzer -RequiredVersion 1.20.0
+Install-PSModule -Name PSScriptAnalyzer -RequiredVersion 1.21.0
 
 if ($IsContainer) {
     # PSScriptAnalyzer contain lots of json files for the UseCompatibleCommands check. We don't use this rule so by

--- a/test/lib/ansible_test/_util/controller/sanity/pslint/settings.psd1
+++ b/test/lib/ansible_test/_util/controller/sanity/pslint/settings.psd1
@@ -1,37 +1,40 @@
 @{
-    Rules = @{
-        PSAvoidLongLines = @{
-            Enable = $true
+    Rules        = @{
+        PSAvoidLongLines                   = @{
+            Enable            = $true
             MaximumLineLength = 160
         }
-        PSPlaceOpenBrace = @{
+        PSAvoidSemicolonsAsLineTerminators = @{
             Enable = $true
-            OnSameLine = $true
-            IgnoreOneLineBlock = $true
-            NewLineAfter = $true
         }
-        PSPlaceCloseBrace = @{
-            Enable = $true
+        PSPlaceOpenBrace                   = @{
+            Enable             = $true
+            OnSameLine         = $true
             IgnoreOneLineBlock = $true
-            NewLineAfter = $true
-            NoEmptyLineBefore = $false
+            NewLineAfter       = $true
         }
-        PSUseConsistentIndentation = @{
-            Enable = $true
-            IndentationSize = 4
+        PSPlaceCloseBrace                  = @{
+            Enable             = $true
+            IgnoreOneLineBlock = $true
+            NewLineAfter       = $true
+            NoEmptyLineBefore  = $false
+        }
+        PSUseConsistentIndentation         = @{
+            Enable              = $true
+            IndentationSize     = 4
             PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
-            Kind = 'space'
+            Kind                = 'space'
         }
-        PSUseConsistentWhitespace = @{
-            Enable = $true
-            CheckInnerBrace = $true
-            CheckOpenBrace = $true
-            CheckOpenParen = $true
-            CheckOperator = $true
-            CheckPipe = $true
-            CheckPipeForRedundantWhitespace = $false
-            CheckSeparator = $true
-            CheckParameter = $false
+        PSUseConsistentWhitespace          = @{
+            Enable                                  = $true
+            CheckInnerBrace                         = $true
+            CheckOpenBrace                          = $true
+            CheckOpenParen                          = $true
+            CheckOperator                           = $true
+            CheckPipe                               = $true
+            CheckPipeForRedundantWhitespace         = $false
+            CheckSeparator                          = $true
+            CheckParameter                          = $false
             IgnoreAssignmentOperatorInsideHashTable = $false
         }
     }

--- a/test/lib/ansible_test/_util/controller/sanity/pslint/settings.psd1
+++ b/test/lib/ansible_test/_util/controller/sanity/pslint/settings.psd1
@@ -1,40 +1,40 @@
 @{
-    Rules        = @{
-        PSAvoidLongLines                   = @{
-            Enable            = $true
+    Rules = @{
+        PSAvoidLongLines = @{
+            Enable = $true
             MaximumLineLength = 160
         }
         PSAvoidSemicolonsAsLineTerminators = @{
             Enable = $true
         }
-        PSPlaceOpenBrace                   = @{
-            Enable             = $true
-            OnSameLine         = $true
+        PSPlaceOpenBrace = @{
+            Enable = $true
+            OnSameLine = $true
             IgnoreOneLineBlock = $true
-            NewLineAfter       = $true
+            NewLineAfter = $true
         }
-        PSPlaceCloseBrace                  = @{
-            Enable             = $true
+        PSPlaceCloseBrace = @{
+            Enable = $true
             IgnoreOneLineBlock = $true
-            NewLineAfter       = $true
-            NoEmptyLineBefore  = $false
+            NewLineAfter = $true
+            NoEmptyLineBefore = $false
         }
-        PSUseConsistentIndentation         = @{
-            Enable              = $true
-            IndentationSize     = 4
+        PSUseConsistentIndentation = @{
+            Enable = $true
+            IndentationSize = 4
             PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
-            Kind                = 'space'
+            Kind = 'space'
         }
-        PSUseConsistentWhitespace          = @{
-            Enable                                  = $true
-            CheckInnerBrace                         = $true
-            CheckOpenBrace                          = $true
-            CheckOpenParen                          = $true
-            CheckOperator                           = $true
-            CheckPipe                               = $true
-            CheckPipeForRedundantWhitespace         = $false
-            CheckSeparator                          = $true
-            CheckParameter                          = $false
+        PSUseConsistentWhitespace = @{
+            Enable = $true
+            CheckInnerBrace = $true
+            CheckOpenBrace = $true
+            CheckOpenParen = $true
+            CheckOperator = $true
+            CheckPipe = $true
+            CheckPipeForRedundantWhitespace = $false
+            CheckSeparator = $true
+            CheckParameter = $false
             IgnoreAssignmentOperatorInsideHashTable = $false
         }
     }


### PR DESCRIPTION
##### SUMMARY
Upgrade PSScriptAnalyzer in ansible-test to 1.21.0 which enables 3 new rules and includes a few bugfixes. When testing against `ansible.windows` and `community.windows` I see some of the following errors:

* `win_uri` - AvoidUsingBrokenHashAlgorithms - Can just update to use SHA256 for download checksums
* `slurp` - AvoidSemicolonsAsLineTerminators
* `win_domain` - AvoidSemicolonsAsLineTerminators
* `win_environment` - AvoidSemicolonsAsLineTerminators
* `win_path` - AvoidSemicolonsAsLineTerminators
* `win_disk_facts` - AvoidSemicolonsAsLineTerminators
* `win_dns_record` - AvoidSemicolonsAsLineTerminators
* `win_file_version` - AvoidSemicolonsAsLineTerminators
* `win_iis_virtualdirectory` - AvoidSemicolonsAsLineTerminators
* `win_iis_website` - AvoidSemicolonsAsLineTerminators
* `win_lineinfile` - AvoidSemicolonsAsLineTerminators
* `win_rabbitmq_plugin` - AvoidSemicolonsAsLineTerminators

The `AvoidSemicolonsAsLineTerminators` rule is optional but I thought it best to enable. There's an auto formatting rule to fix this with PSSA so fixing these errors won't be too hard to do but will leave it up to the WWG to decide whether we want to keep that enabled or leave it disabled.

##### ISSUE TYPE
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
ansible-test pslint