### PR TITLE
ansible-test - Update coverage to version 6.5.0.

### DIFF
--- a/test/lib/ansible_test/_data/requirements/ansible-test.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible-test.txt
@@ -1,4 +1,4 @@
 # The test-constraints sanity test verifies this file, but changes must be made manually to keep it in up-to-date.
 virtualenv == 16.7.12 ; python_version < '3'
-coverage == 6.4.4 ; python_version >= '3.7' and python_version <= '3.11'
+coverage == 6.5.0 ; python_version >= '3.7' and python_version <= '3.11'
 coverage == 4.5.4 ; python_version >= '2.6' and python_version <= '3.6'

--- a/test/lib/ansible_test/_internal/coverage_util.py
+++ b/test/lib/ansible_test/_internal/coverage_util.py
@@ -64,7 +64,7 @@ class CoverageVersion:
 
 COVERAGE_VERSIONS = (
     # IMPORTANT: Keep this in sync with the ansible-test.txt requirements file.
-    CoverageVersion('6.4.4', 7, (3, 7), (3, 11)),
+    CoverageVersion('6.5.0', 7, (3, 7), (3, 11)),
     CoverageVersion('4.5.4', 0, (2, 6), (3, 6)),
 )
 """


### PR DESCRIPTION
##### SUMMARY

ansible-test - Update coverage to version 6.5.0.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

Skipping a changelog fragment since this will be backported to stable-2.14 before the first release and updates to coverage are already included in another changelog fragment (which does not specify the version).