### PR TITLE
ansible-test, fix missing winrm inventory file

### DIFF
--- a/test/lib/ansible_test/_internal/inventory.py
+++ b/test/lib/ansible_test/_internal/inventory.py
@@ -52,7 +52,7 @@ def create_windows_inventory(args: EnvironmentConfig, path: str, target_hosts: l
             return
 
         try:
-            shutil.copyfile(path,first.config.path)
+            shutil.copyfile(path, first.config.path)
         except shutil.SameFileError:
             pass
 

--- a/test/lib/ansible_test/_internal/inventory.py
+++ b/test/lib/ansible_test/_internal/inventory.py
@@ -52,7 +52,7 @@ def create_windows_inventory(args: EnvironmentConfig, path: str, target_hosts: l
             return
 
         try:
-            shutil.copyfile(first.config.path, path)
+            shutil.copyfile(path,first.config.path)
         except shutil.SameFileError:
             pass
 


### PR DESCRIPTION
fixed issue causing windows integration test to fail using an inventory file

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
windows integration tests with inventory options results in a file does not exists error.
#Fixes #78941

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
integration tests

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
