### PR TITLE
omit keyword should reset to context (#78917)

### DIFF
--- a/changelogs/fragments/fix_omit_key.yml
+++ b/changelogs/fragments/fix_omit_key.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - omit on keywords was resetting to default value, ignoring inheritance.

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -489,10 +489,7 @@ class FieldAttributeBase(metaclass=BaseMeta):
         # Resolve extended groups last, after caching the group in case they recursively refer to each other
         for include_group in include_groups:
             if not AnsibleCollectionRef.is_valid_fqcr(include_group):
-                include_group_collection = collection_name
                 include_group = collection_name + '.' + include_group
-            else:
-                include_group_collection = '.'.join(include_group.split('.')[0:2])
 
             dummy, group_actions = self._resolve_group(include_group, mandatory=False)
 
@@ -611,6 +608,26 @@ class FieldAttributeBase(metaclass=BaseMeta):
             value.post_validate(templar=templar)
         return value
 
+    def set_to_context(self, name):
+
+        attribute = self.fattributes[name]
+        if isinstance(attribute, NonInheritableFieldAttribute):
+            self.set_to_default(name)
+        else:
+            try:
+                setattr(self, name, self._get_parent_attribute(name))
+            except AttributeError:
+                # mostly playcontext as only tasks/handlers really resolve to parent
+                self.set_to_default(name)
+
+    def set_to_default(self, name):
+
+        attribute = self.fattributes[name]
+        if callable(attribute.default):
+            setattr(self, name, attribute.default())
+        else:
+            setattr(self, name, attribute.default)
+
     def post_validate(self, templar):
         '''
         we can't tell that everything is of the right type until we have
@@ -655,13 +672,11 @@ class FieldAttributeBase(metaclass=BaseMeta):
                     # if the attribute contains a variable, template it now
                     value = templar.template(getattr(self, name))
 
-                # if this evaluated to the omit value, set the value back to
-                # the default specified in the FieldAttribute and move on
+                # If this evaluated to the omit value, set the value back to inherited by context
+                # or default specified in the FieldAttribute and move on
                 if omit_value is not None and value == omit_value:
-                    if callable(attribute.default):
-                        setattr(self, name, attribute.default())
-                    else:
-                        setattr(self, name, attribute.default)
+                    self.set_to_context(name)
+                    self._finalized = True
                     continue
 
                 # and make sure the attribute is of the type it should be
@@ -810,10 +825,7 @@ class FieldAttributeBase(metaclass=BaseMeta):
             if name in data:
                 setattr(self, name, data[name])
             else:
-                if callable(attribute.default):
-                    setattr(self, name, attribute.default())
-                else:
-                    setattr(self, name, attribute.default)
+                self.set_to_context(name)
 
         # restore the UUID field
         setattr(self, '_uuid', data.get('uuid'))

--- a/test/integration/targets/omit/75692.yml
+++ b/test/integration/targets/omit/75692.yml
@@ -1,0 +1,29 @@
+- name: omit should reset to 'absent' or same context, not just 'default' value
+  hosts: testhost
+  gather_facts: false
+  become: yes
+  become_user: nobody
+  roles:
+    - name: setup_test_user
+  tasks:
+    - shell: whoami
+      register: inherited
+
+    - shell: whoami
+      register: explicit_no
+      become: false
+
+    - shell: whoami
+      register: omited_inheritance
+      become: '{{ omit }}'
+
+    - shell: whoami
+      register: explicit_yes
+      become: yes
+
+    - name: ensure omit works with inheritance
+      assert:
+        that:
+          - inherited.stdout == omited_inheritance.stdout
+          - inherited.stdout == explicit_yes.stdout
+          - inherited.stdout != explicit_no.stdout

--- a/test/integration/targets/omit/aliases
+++ b/test/integration/targets/omit/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group3
+needs/target/setup_test_user
 context/controller

--- a/test/integration/targets/omit/runme.sh
+++ b/test/integration/targets/omit/runme.sh
@@ -2,4 +2,4 @@
 
 set -eux
 
-ansible-playbook 48673.yml -i ../../inventory -v "$@"
+ANSIBLE_ROLES_PATH=../ ansible-playbook 48673.yml 75692.yml  -i ../../inventory -v "$@"


### PR DESCRIPTION
* omit keyword should reset to context

  ensure we use context/inheritance when calculating value, using default only when context is unavailable.

  fixes #75692

(cherry picked from commit 9650ddb11cd220845ca7996eeb620035f5e07a0a)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
playbook