### PR TITLE
[stable-2.14] ansible-test - Update distro containers to 4.8.0.

### DIFF
--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,9 +1,9 @@
 base image=quay.io/ansible/base-test-container:3.8.0 python=3.11,2.7,3.5,3.6,3.7,3.8,3.9,3.10 seccomp=unconfined
 default image=quay.io/ansible/default-test-container:6.11.0 python=3.11,2.7,3.5,3.6,3.7,3.8,3.9,3.10 seccomp=unconfined context=collection
 default image=quay.io/ansible/ansible-core-test-container:6.11.1 python=3.11,2.7,3.5,3.6,3.7,3.8,3.9,3.10 seccomp=unconfined context=ansible-core
-alpine3 image=quay.io/ansible/alpine3-test-container:4.7.0 python=3.10
-centos7 image=quay.io/ansible/centos7-test-container:4.7.0 python=2.7 seccomp=unconfined
-fedora36 image=quay.io/ansible/fedora36-test-container:4.7.0 python=3.10 seccomp=unconfined
-opensuse15 image=quay.io/ansible/opensuse15-test-container:4.7.0 python=3.6
-ubuntu2004 image=quay.io/ansible/ubuntu2004-test-container:4.7.0 python=3.8 seccomp=unconfined
-ubuntu2204 image=quay.io/ansible/ubuntu2204-test-container:4.7.0 python=3.10 seccomp=unconfined
+alpine3 image=quay.io/ansible/alpine3-test-container:4.8.0 python=3.10
+centos7 image=quay.io/ansible/centos7-test-container:4.8.0 python=2.7 seccomp=unconfined
+fedora36 image=quay.io/ansible/fedora36-test-container:4.8.0 python=3.10 seccomp=unconfined
+opensuse15 image=quay.io/ansible/opensuse15-test-container:4.8.0 python=3.6
+ubuntu2004 image=quay.io/ansible/ubuntu2004-test-container:4.8.0 python=3.8 seccomp=unconfined
+ubuntu2204 image=quay.io/ansible/ubuntu2204-test-container:4.8.0 python=3.10 seccomp=unconfined


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/78946

The updated containers include coverage 6.5.0..

(cherry picked from commit 5b239acb77cc72758c87eb322d7766fd2b621fbb)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
