### PR TITLE
Docs: true/false with boolean values in reference_appendices

### DIFF
--- a/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
+++ b/docs/docsite/rst/reference_appendices/YAMLSyntax.rst
@@ -74,8 +74,8 @@ These are called "Flow collections".
 
 Ansible doesn't really use these too much, but you can also specify a :ref:`boolean value <playbooks_variables>` (true/false) in several forms::
 
-    create_key: yes
-    needs_agent: no
+    create_key: true
+    needs_agent: false
     knows_oop: True
     likes_emacs: TRUE
     uses_cvs: false

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -795,14 +795,14 @@ and backups, which most file based modules also support:
 
         - name: run validation, this will change a lot as needed. We assume it returns an error when not passing, use `failed_when` if otherwise.
           shell: run_validation_commmand
-          become: yes
+          become: true
           become_user: requiredbyapp
           environment:
             WEIRD_REQUIREMENT: 1
      rescue:
         - name: restore backup file to original, in the hope the previous configuration was working.
           copy:
-             remote_src: yes
+             remote_src: true
              dest: /x/y/z
              src: "{{ updated['backup_file'] }}"
      always:

--- a/docs/docsite/rst/reference_appendices/general_precedence.rst
+++ b/docs/docsite/rst/reference_appendices/general_precedence.rst
@@ -101,7 +101,7 @@ When set in a playbook, variables follow the same inheritance rules as playbook 
 
    - hosts: cloud
      gather_facts: false
-     become: yes
+     become: true
      vars:
        ansible_become_user: admin
      tasks:

--- a/docs/docsite/rst/reference_appendices/test_strategies.rst
+++ b/docs/docsite/rst/reference_appendices/test_strategies.rst
@@ -31,7 +31,7 @@ things in your playbooks.
      - ansible.builtin.service:
          name: foo
          state: started
-         enabled: yes
+         enabled: true
 
 If you think the service may not be started, the best thing to do is request it to be started.  If the service fails to start, Ansible
 will yell appropriately. (This should not be confused with whether the service is doing something functional, which we'll show more about how to
@@ -55,7 +55,7 @@ want certain steps to execute in normal mode even when the ``--check`` flag is u
 
    tasks:
      - ansible.builtin.script: verify.sh
-       check_mode: no
+       check_mode: false
 
 Modules That Are Useful for Testing
 ```````````````````````````````````


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #78924
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Based on [steering committee vote to use true/false for booleans, ](https://github.com/ansible-community/community-topics/discussions/120) the desired changes were: change `yes` to `true` and `no` to `false`.
This PR is regarding these changes in `docs/docsite/rst/reference_appendices/`
The changes were done on files:
* `reference_appendices/general_precedence.rst`
* `reference_appendices/test_strategies.rst`
* `reference_appendices/faq.rst`
* `reference_appendices/YAMLSyntax.rst`
