### PR TITLE
Docs: true/false with boolean values in docsite/rst/os_guide

### DIFF
--- a/docs/docsite/rst/os_guide/intro_bsd.rst
+++ b/docs/docsite/rst/os_guide/intro_bsd.rst
@@ -129,7 +129,7 @@ For example, given the inventory
   [test:vars]
   ansible_connection=ssh
   ansible_user=admin
-  ansible_become=yes
+  ansible_become=true
   ansible_become_user=root
   ansible_become_method=sudo
   ansible_interpreter_python_fallback=['/usr/local/bin/python', '/usr/local/bin/python3', '/usr/local/bin/python3.8']
@@ -213,7 +213,7 @@ You can either ignore it or get rid of it by setting the variable ``ansible_pyth
   [test:vars]
   ansible_connection=ssh
   ansible_user=admin
-  ansible_become=yes
+  ansible_become=true
   ansible_become_user=root
   ansible_become_method=sudo
   ansible_interpreter_python_fallback=['/usr/local/bin/python', '/usr/local/bin/python3', '/usr/local/bin/python3.8']

--- a/docs/docsite/rst/os_guide/windows_dsc.rst
+++ b/docs/docsite/rst/os_guide/windows_dsc.rst
@@ -205,10 +205,10 @@ For example, to define a ``[CimInstance]`` value in Ansible:
 
     # [CimInstance]AuthenticationInfo == MSFT_xWebAuthenticationInformation
     AuthenticationInfo:
-      Anonymous: no
-      Basic: yes
-      Digest: no
-      Windows: yes
+      Anonymous: false
+      Basic: true
+      Digest: false
+      Windows: true
 
 In the above example, the CIM instance is a representation of the class
 `MSFT_xWebAuthenticationInformation <https://github.com/dsccommunity/xWebAdministration/blob/master/source/DSCResources/MSFT_xWebSite/MSFT_xWebSite.schema.mof>`_.
@@ -317,7 +317,7 @@ to access the ``HKEY_CURRENT_USER`` hive of the Ansible user:
         ValueData: TestData
         PsDscRunAsCredential_username: '{{ ansible_user }}'
         PsDscRunAsCredential_password: '{{ ansible_password }}'
-      no_log: yes
+      no_log: true
 
 Custom DSC Resources
 ````````````````````
@@ -435,7 +435,7 @@ Interact with Azure
         ServiceName: ServiceName
         StorageAccountName: StorageAccountName
         InstanceSize: Medium
-        Windows: yes
+        Windows: true
         Ensure: Present
         Credential_username: '{{ ansible_user }}'
         Credential_password: '{{ ansible_password }}'
@@ -489,10 +489,10 @@ Setup IIS Website
           Port: 8080
           IPAddress: '*'
         AuthenticationInfo:
-          Anonymous: no
-          Basic: yes
-          Digest: no
-          Windows: yes
+          Anonymous: false
+          Basic: true
+          Digest: false
+          Windows: true
 
 .. seealso::
 

--- a/docs/docsite/rst/os_guide/windows_dsc.rst
+++ b/docs/docsite/rst/os_guide/windows_dsc.rst
@@ -187,7 +187,7 @@ For example:
     SourceCredential_username: AdminUser
     SourceCredential_password: PasswordForAdminUser
 
-.. Note:: On versions of Ansible older than 2.8, you should set ``no_log: yes``
+.. Note:: On versions of Ansible older than 2.8, you should set ``no_log: true``
     on the task definition in Ansible to ensure any credentials used are not
     stored in any log file or console output.
 

--- a/docs/docsite/rst/os_guide/windows_setup.rst
+++ b/docs/docsite/rst/os_guide/windows_setup.rst
@@ -495,7 +495,7 @@ Ansible, select one of these installation options:
     # main.yml
     - name: install Win32-OpenSSH service
       hosts: windows
-      gather_facts: no
+      gather_facts: false
       roles:
       - role: jborean93.win_openssh
         opt_openssh_setup_service: True

--- a/docs/docsite/rst/os_guide/windows_usage.rst
+++ b/docs/docsite/rst/os_guide/windows_usage.rst
@@ -161,8 +161,8 @@ access a folder on the same host:
         name: '{{ item.name }}'
         password: '{{ item.password }}'
         groups: LocalGroup
-        update_password: no
-        password_never_expires: yes
+        update_password: false
+        password_never_expires: true
       loop:
       - name: User1
         password: Password1
@@ -185,7 +185,7 @@ access a folder on the same host:
     - name: Remove parent inheritance of Development folder
       win_acl_inheritance:
         path: C:\Development
-        reorganize: yes
+        reorganize: true
         state: absent
 
 Domain
@@ -201,7 +201,7 @@ are created:
         name: '{{ item.name }}'
         upn: '{{ item.name }}@MY.DOMAIN.COM'
         password: '{{ item.password }}'
-        password_never_expires: no
+        password_never_expires: false
         groups:
         - Test User
         - Application


### PR DESCRIPTION
##### SUMMARY
Changes yes/no in os_guide documentation to true/false based on the recommendations per the [steering committee vote to use true/false for booleans](https://github.com/ansible-community/community-topics/discussions/120).

Fixes #78923.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/os_guide/*.rst