### PR TITLE
Docs: Add code-block wrappers to code examples in style_guide

### DIFF
--- a/docs/docsite/rst/dev_guide/style_guide/basic_rules.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/basic_rules.rst
@@ -61,7 +61,9 @@ For menu procedures, bold the menu names, button names, and so on to help the us
 3. In the **Open** dialog box, click **Save**.
 4. On the toolbar, click the **Open File** icon.
 
-For code or command snippets, use the RST `code-block directive <https://www.sphinx-doc.org/en/1.5/markup/code.html#directive-code-block>`_::
+For code or command snippets, use the RST `code-block directive <https://www.sphinx-doc.org/en/1.5/markup/code.html#directive-code-block>`_:
+
+.. code-block:: rst
 
    .. code-block:: bash
 

--- a/docs/docsite/rst/dev_guide/style_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/index.rst
@@ -192,7 +192,9 @@ Adding anchors
 
 * Include at least one anchor on every page
 * Place the main anchor above the main header
-* If the file has a unique title, use that for the main page anchor::
+* If the file has a unique title, use that for the main page anchor:
+
+.. code-block:: rst
 
    .. _unique_page::
 

--- a/docs/docsite/rst/dev_guide/style_guide/index.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/index.rst
@@ -194,7 +194,7 @@ Adding anchors
 * Place the main anchor above the main header
 * If the file has a unique title, use that for the main page anchor:
 
-.. code-block:: rst
+.. code-block:: text
 
    .. _unique_page::
 


### PR DESCRIPTION
List of changed files:
- docs/docsite/rst/dev-guide/style_guide/index.rst
- docs/docsite/rst/dev-guide/style_guide/basic_rules.rst

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Adds code-block wrappers to code example in [`docs/docsite/rst/dev-guide/style_guide/index.rst`](https://github.com/ansible/ansible/blob/538b99781f81b87ff2cd18ee6eae1db49a29c37a/docs/docsite/rst/dev_guide/style_guide/index.rst) and [`docs/docsite/rst/dev-guide/style_guide/basic_rules.rst`](https://github.com/ansible/ansible/blob/538b99781f81b87ff2cd18ee6eae1db49a29c37a/docs/docsite/rst/dev_guide/style_guide/basic_rules.rst)
- Fixes: #78967 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request