### PR TITLE
Adds code-block in collection documentation

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
@@ -132,7 +132,9 @@ After configuring one or more distribution servers, build a collection tarball. 
 
     collection_dir#> ansible-galaxy collection build
 
-This command builds a tarball of the collection in the current directory, which you can upload to your selected distribution server::
+This command builds a tarball of the collection in the current directory, which you can upload to your selected distribution server:
+
+.. code-block:: text
 
     my_collection/
     ├── galaxy.yml

--- a/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_distributing.rst
@@ -134,7 +134,7 @@ After configuring one or more distribution servers, build a collection tarball. 
 
 This command builds a tarball of the collection in the current directory, which you can upload to your selected distribution server:
 
-.. code-block:: text
+.. code-block:: shell
 
     my_collection/
     ├── galaxy.yml


### PR DESCRIPTION
##### SUMMARY
adds code-block:: text 

Fixes #78976

##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION
the code-block definition lexer used is 'text' which seems to be used most often.

other used code-block lexer used

- shell-session
- bash
- console

Which one is the preferred one and should all bash tree output be aligned?