### PR TITLE
Docs: Typo in Alibaba Cloud Compute Services Guide

### DIFF
--- a/docs/docsite/rst/scenario_guides/guide_alicloud.rst
+++ b/docs/docsite/rst/scenario_guides/guide_alicloud.rst
@@ -35,13 +35,13 @@ To pass authentication credentials as environment variables::
     export ALICLOUD_ACCESS_KEY='Alicloud123'
     export ALICLOUD_SECRET_KEY='AlicloudSecret123'
 
-To store authentication credentials in a vars_file, encrypt them with :ref:`Ansible Vault<vault>` to keep them secure, then list them::
+To store authentication credentials in a vars_files, encrypt them with :ref:`Ansible Vault<vault>` to keep them secure, then list them::
 
     ---
     alicloud_access_key: "--REMOVED--"
     alicloud_secret_key: "--REMOVED--"
 
-Note that if you store your credentials in a vars_file, you need to refer to them in each Alicloud module. For example::
+Note that if you store your credentials in a vars_files, you need to refer to them in each Alicloud module. For example::
 
     - ali_instance:
         alicloud_access_key: "{{alicloud_access_key}}"

--- a/docs/docsite/rst/scenario_guides/guide_alicloud.rst
+++ b/docs/docsite/rst/scenario_guides/guide_alicloud.rst
@@ -35,7 +35,10 @@ To pass authentication credentials as environment variables::
     export ALICLOUD_ACCESS_KEY='Alicloud123'
     export ALICLOUD_SECRET_KEY='AlicloudSecret123'
 
-To store authentication credentials in a vars_files, encrypt them with :ref:`Ansible Vault<vault>` to keep them secure, then list them::
+To store authentication credentials in a vars_files, encrypt them with :ref:`Ansible Vault<vault>` to keep them secure, then list them:
+
+.. code-block:: yaml
+
 
     ---
     alicloud_access_key: "--REMOVED--"

--- a/docs/docsite/rst/scenario_guides/guide_alicloud.rst
+++ b/docs/docsite/rst/scenario_guides/guide_alicloud.rst
@@ -44,7 +44,9 @@ To store authentication credentials in a vars_files, encrypt them with :ref:`Ans
     alicloud_access_key: "--REMOVED--"
     alicloud_secret_key: "--REMOVED--"
 
-Note that if you store your credentials in a vars_files, you need to refer to them in each Alicloud module. For example::
+Note that if you store your credentials in a vars_files, you need to refer to them in each Alicloud module. For example:
+
+.. code-block:: yaml
 
     - ali_instance:
         alicloud_access_key: "{{alicloud_access_key}}"

--- a/docs/docsite/rst/scenario_guides/guide_alicloud.rst
+++ b/docs/docsite/rst/scenario_guides/guide_alicloud.rst
@@ -39,7 +39,6 @@ To store authentication credentials in a vars_files, encrypt them with :ref:`Ans
 
 .. code-block:: yaml
 
-
     ---
     alicloud_access_key: "--REMOVED--"
     alicloud_secret_key: "--REMOVED--"


### PR DESCRIPTION
##### SUMMARY
In the Alibaba Cloud Compute Services Guide page, What should be written as vars_files is written as vras_file.

page(https://docs.ansible.com/ansible/devel/scenario_guides/guide_alicloud.html)

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
Noted statements in the Authentication section.

##### ADDITIONAL INFORMATION
Correct vars_file to vars_files.
