### PR TITLE
docs: replace latin terms with english in the os_guide directory

### DIFF
--- a/docs/docsite/rst/os_guide/windows_faq.rst
+++ b/docs/docsite/rst/os_guide/windows_faq.rst
@@ -215,8 +215,8 @@ The value for ``ansible_shell_type`` should either be ``cmd`` or ``powershell``.
 Use ``cmd`` if the ``DefaultShell`` has not been configured on the SSH service
 and ``powershell`` if that has been set as the ``DefaultShell``.
 
-Why is connecting to a Windows host via SSH failing?
-````````````````````````````````````````````````````
+Why is connecting to a Windows host through SSH failing?
+````````````````````````````````````````````````````````
 Unless you are using ``Win32-OpenSSH`` as described above, you must connect to
 Windows hosts using :ref:`windows_winrm`. If your Ansible output indicates that
 SSH was used, either you did not set the connection vars properly or the host is not inheriting them correctly.

--- a/docs/docsite/rst/os_guide/windows_performance.rst
+++ b/docs/docsite/rst/os_guide/windows_performance.rst
@@ -48,7 +48,7 @@ to pre-emptively create native images for the assemblies that PowerShell relies 
 Fix high-CPU-on-boot for VMs/cloud instances
 --------------------------------------------
 If you are creating golden images to spawn instances from, you can avoid a disruptive
-high CPU task near startup via `processing the ngen queue <https://docs.microsoft.com/en-us/dotnet/framework/tools/ngen-exe-native-image-generator#native-image-service>`_
+high CPU task near startup through `processing the ngen queue <https://docs.microsoft.com/en-us/dotnet/framework/tools/ngen-exe-native-image-generator#native-image-service>`_
 within your golden image creation, if you know the CPU types won't change between
 golden image build process and runtime.
 

--- a/docs/docsite/rst/os_guide/windows_usage.rst
+++ b/docs/docsite/rst/os_guide/windows_usage.rst
@@ -35,12 +35,12 @@ Below are some examples of using all three options to install 7-Zip:
 .. code-block:: yaml+jinja
 
     # Install/uninstall with chocolatey
-    - name: Ensure 7-Zip is installed via Chocolatey
+    - name: Ensure 7-Zip is installed through Chocolatey
       win_chocolatey:
         name: 7zip
         state: present
 
-    - name: Ensure 7-Zip is not installed via Chocolatey
+    - name: Ensure 7-Zip is not installed through Chocolatey
       win_chocolatey:
         name: 7zip
         state: absent
@@ -51,12 +51,12 @@ Below are some examples of using all three options to install 7-Zip:
         url: https://www.7-zip.org/a/7z1701-x64.msi
         dest: C:\temp\7z.msi
 
-    - name: Ensure 7-Zip is installed via win_package
+    - name: Ensure 7-Zip is installed through win_package
       win_package:
         path: C:\temp\7z.msi
         state: present
 
-    - name: Ensure 7-Zip is not installed via win_package
+    - name: Ensure 7-Zip is not installed through win_package
       win_package:
         path: C:\temp\7z.msi
         state: absent
@@ -72,11 +72,11 @@ Below are some examples of using all three options to install 7-Zip:
         name: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{23170F69-40C1-2702-1701-000001000000}
       register: 7zip_installed
 
-    - name: Ensure 7-Zip is installed via win_command
+    - name: Ensure 7-Zip is installed through win_command
       win_command: C:\Windows\System32\msiexec.exe /i C:\temp\7z.msi /qn /norestart
       when: 7zip_installed.exists == false
 
-    - name: Ensure 7-Zip is uninstalled via win_command
+    - name: Ensure 7-Zip is uninstalled through win_command
       win_command: C:\Windows\System32\msiexec.exe /x {23170F69-40C1-2702-1701-000001000000} /qn /norestart
       when: 7zip_installed.exists == true
 

--- a/docs/docsite/rst/os_guide/windows_winrm.rst
+++ b/docs/docsite/rst/os_guide/windows_winrm.rst
@@ -341,28 +341,28 @@ Some system dependencies that must be installed prior to using Kerberos. The scr
 
 .. code-block:: shell
 
-    # Via Yum (RHEL/Centos/Fedora for the older version)
+    # Through Yum (RHEL/Centos/Fedora for the older version)
     yum -y install gcc python-devel krb5-devel krb5-libs krb5-workstation
 
-    # Via DNF (RHEL/Centos/Fedora for the newer version)
+    # Through DNF (RHEL/Centos/Fedora for the newer version)
     dnf -y install gcc python3-devel krb5-devel krb5-libs krb5-workstation
 
-    # Via Apt (Ubuntu)
+    # Through Apt (Ubuntu)
     sudo apt-get install python-dev libkrb5-dev krb5-user
 
-    # Via Portage (Gentoo)
+    # Through Portage (Gentoo)
     emerge -av app-crypt/mit-krb5
     emerge -av dev-python/setuptools
 
-    # Via Pkg (FreeBSD)
+    # Through Pkg (FreeBSD)
     sudo pkg install security/krb5
 
-    # Via OpenCSW (Solaris)
+    # Through OpenCSW (Solaris)
     pkgadd -d http://get.opencsw.org/now
     /opt/csw/bin/pkgutil -U
     /opt/csw/bin/pkgutil -y -i libkrb5_3
 
-    # Via Pacman (Arch Linux)
+    # Through Pacman (Arch Linux)
     pacman -S krb5
 
 
@@ -441,7 +441,7 @@ expiration. The temporary credential caches are deleted after each task
 completes and will not interfere with the default credential cache.
 
 To disable automatic ticket management, set ``ansible_winrm_kinit_mode=manual``
-via the inventory.
+through the inventory.
 
 Automatic ticket management requires a standard ``kinit`` binary on the control
 host system path. To specify a different location or binary name, set the
@@ -678,7 +678,7 @@ When setting up the inventory, the following variables are required:
     # ansible-vault edit group_vars/windows.yml
     ansible_connection: winrm
 
-    # May also be passed on the command-line via --user
+    # May also be passed on the command-line through --user
     ansible_user: Administrator
 
     # May also be supplied at runtime with --ask-pass


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Replace latin terms with english in the os_guide directory as per the [style guide](https://docs.ansible.com/ansible/latest/dev_guide/style_guide/index.html#avoid-using-latin-phrases).

Fixes #79003

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME

Documentation: OS Guide
