### PR TITLE
Docs: Replace Latin in the network folder

### DIFF
--- a/docs/docsite/rst/network/getting_started/first_inventory.rst
+++ b/docs/docsite/rst/network/getting_started/first_inventory.rst
@@ -394,7 +394,7 @@ This is an example using an extract from a  YAML inventory, as the INI format do
    ...
 
 To use an inline vaulted variables with an INI inventory you need to store it in a 'vars' file in YAML format,
-it can reside in host_vars/ or group_vars/ to be automatically picked up or referenced from a play via ``vars_files`` or ``include_vars``.
+it can reside in host_vars/ or group_vars/ to be automatically picked up or referenced from a play through ``vars_files`` or ``include_vars``.
 
 To run a playbook with this setup, drop the ``-k`` flag and add a flag for your ``vault-id``:
 

--- a/docs/docsite/rst/network/getting_started/index.rst
+++ b/docs/docsite/rst/network/getting_started/index.rst
@@ -8,7 +8,7 @@ Ansible collections support a wide range of vendors, device types, and actions, 
 
 - Automate repetitive tasks to speed routine network changes and free up your time for more strategic work
 - Leverage the same simple, powerful, and agentless automation tool for network tasks that operations and development use
-- Separate the data model (in a playbook or role) from the execution layer (via Ansible modules) to manage heterogeneous network devices
+- Separate the data model (in a playbook or role) from the execution layer (through Ansible modules) to manage heterogeneous network devices
 - Benefit from community and vendor-generated sample playbooks and roles to help accelerate network automation projects
 - Communicate securely with network hardware over SSH or HTTPS
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -322,7 +322,7 @@ Error: "Authentication failed"
 
 **Platforms:** Any
 
-Occurs if the credentials (username, passwords, or ssh keys) passed to ``ansible-connection`` (via ``ansible`` or ``ansible-playbook``) can not be used to connect to the remote device.
+Occurs if the credentials (username, passwords, or ssh keys) passed to ``ansible-connection`` (through ``ansible`` or ``ansible-playbook``) can not be used to connect to the remote device.
 
 
 
@@ -336,7 +336,7 @@ For example:
 
 Suggestions to resolve:
 
-If you are specifying credentials via ``password:`` (either directly or via ``provider:``) or the environment variable `ANSIBLE_NET_PASSWORD` it is possible that ``paramiko`` (the Python SSH library that Ansible uses) is using ssh keys, and therefore the credentials you are specifying are being ignored. To find out if this is the case, disable "look for keys". This can be done like this:
+If you are specifying credentials through ``password:`` (either directly or through ``provider:``) or the environment variable `ANSIBLE_NET_PASSWORD` it is possible that ``paramiko`` (the Python SSH library that Ansible uses) is using ssh keys, and therefore the credentials you are specifying are being ignored. To find out if this is the case, disable "look for keys". This can be done like this:
 
 .. code-block:: yaml
 
@@ -724,9 +724,9 @@ Example Ansible inventory file
     ansible_password=!vault...
 
 
-.. note:: Using ``ProxyCommand`` with passwords via variables
+.. note:: Using ``ProxyCommand`` with passwords through variables
 
-   By design, SSH doesn't support providing passwords via environment variables.
+   By design, SSH doesn't support providing passwords through environment variables.
    This is done to prevent secrets from leaking out, for example in ``ps`` output.
 
    We recommend using SSH Keys, and if needed an ssh-agent, rather than passwords, where ever possible.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Replace latin terms with english in the network folder as per the [style guide](https://docs.ansible.com/ansible/latest/dev_guide/style_guide/index.html#avoid-using-latin-phrases).

As per the issue #78999, excludes platform sub-folder.

Fixes #78999

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME

Documentation: Network
