### PR TITLE
Use python re to parse service output instead of grep

### DIFF
--- a/changelogs/fragments/78541-service-facts-re.yml
+++ b/changelogs/fragments/78541-service-facts-re.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- service_facts - Use python re to parse service output instead of grep
+  (https://github.com/ansible/ansible/issues/78541)


### PR DESCRIPTION
##### SUMMARY
Use python re to parse service output instead of grep. Fixes #78541

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/service_facts.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
