### PR TITLE
ansible-vault: add newline to the output of the 'encrypt_string' command

### DIFF
--- a/changelogs/fragments/79017-ansible-vault-string-encryption-ending-with-newline.yml
+++ b/changelogs/fragments/79017-ansible-vault-string-encryption-ending-with-newline.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ansible-vault encrypt_string - output had no newline at the end which caused broken output to stdout in some shells (e.g., trailing '%' sign in zsh). Fix now adds the newline character to the output by appending an additional element to the ``b_outs`` list (https://github.com/ansible/ansible/issues/78932)."

--- a/changelogs/fragments/79017-ansible-vault-string-encryption-ending-with-newline.yml
+++ b/changelogs/fragments/79017-ansible-vault-string-encryption-ending-with-newline.yml
@@ -1,2 +1,6 @@
 bugfixes:
-  - "ansible-vault encrypt_string - output had no newline at the end which caused broken output to stdout in some shells (e.g., trailing '%' sign in zsh). Fix now adds the newline character to the output by appending an additional element to the ``b_outs`` list (https://github.com/ansible/ansible/issues/78932)."
+  - >-
+    ansible-vault encrypt_string - started appending a line feed at the end of the encrypted string output. It was missing,
+    which cased problems identifying where this string ends in some some shells (like bash) or accidentally copying an
+    extra trailing terminator symbol (e.g., zsh adds prints out a ``%`` sign to signal where the original output stops)
+    (https://github.com/ansible/ansible/issues/78932).

--- a/changelogs/fragments/79017-ansible-vault-string-encryption-ending-with-newline.yml
+++ b/changelogs/fragments/79017-ansible-vault-string-encryption-ending-with-newline.yml
@@ -1,6 +1,6 @@
 bugfixes:
   - >-
-    ansible-vault encrypt_string - started appending a line feed at the end of the encrypted string output. It was missing,
-    which cased problems identifying where this string ends in some some shells (like bash) or accidentally copying an
-    extra trailing terminator symbol (e.g., zsh adds prints out a ``%`` sign to signal where the original output stops)
+    ansible-vault encrypt_string - started appending a line feed at the end of the encrypted string output. Missing newline
+    character caused problems identifying where the string ends in some shells (like bash) or accidentally copying an
+    extra trailing terminator symbol (e.g., zsh prints out a ``%`` sign to signal where the original output stops)
     (https://github.com/ansible/ansible/issues/78932).

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -384,7 +384,7 @@ class VaultCLI(CLI):
                 sys.stderr.write(err)
             b_outs.append(to_bytes(out))
 
-        self.editor.write_data(b'\n'.join(b_outs), context.CLIARGS['output_file'] or '-')
+        self.editor.write_data(b'\n'.join(b_outs) + b'\n', context.CLIARGS['output_file'] or '-')
 
         if sys.stdout.isatty():
             display.display("Encryption successful", stderr=True)

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -384,7 +384,9 @@ class VaultCLI(CLI):
                 sys.stderr.write(err)
             b_outs.append(to_bytes(out))
 
-        self.editor.write_data(b'\n'.join(b_outs) + b'\n', context.CLIARGS['output_file'] or '-')
+        # Output must end with a newline to prevent bug #78932
+        b_outs.append(b'')
+        self.editor.write_data(b'\n'.join(b_outs), context.CLIARGS['output_file'] or '-')
 
         if sys.stdout.isatty():
             display.display("Encryption successful", stderr=True)

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -384,7 +384,10 @@ class VaultCLI(CLI):
                 sys.stderr.write(err)
             b_outs.append(to_bytes(out))
 
-        # Output must end with a newline to prevent bug #78932
+        # The output must end with a newline to play nice with terminal representation.
+        # Refs:
+        # * https://stackoverflow.com/a/729795/595220
+        # * https://github.com/ansible/ansible/issues/78932
         b_outs.append(b'')
         self.editor.write_data(b'\n'.join(b_outs), context.CLIARGS['output_file'] or '-')
 


### PR DESCRIPTION
##### SUMMARY
Adds newline to the `ansible-vault encrypt_string ...` output.
Fixes #78932, more details here.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Ansible-vault: `encrypt_string` output