### PR TITLE
[2.14] Do not crash templating when filter/test name is not a valid Ansible plugin name

### DIFF
--- a/changelogs/fragments/78913-template-missing-filter-test.yml
+++ b/changelogs/fragments/78913-template-missing-filter-test.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Do not crash when templating an expression with a test or filter that is not a valid Ansible filter name (https://github.com/ansible/ansible/issues/78912, https://github.com/ansible/ansible/pull/78913)."

--- a/test/integration/targets/templating/tasks/main.yml
+++ b/test/integration/targets/templating/tasks/main.yml
@@ -16,3 +16,20 @@
   vars:
     # Kind of hack to just send a JSON string through jinja, by templating out nothing
     foo: '{{ "" }}{"null": null, "true": true, "false": false}'
+
+- name: Make sure that test with name that isn't a valid Ansible plugin name does not result in a crash (1/2)
+  set_fact:
+    foo: '{{ [{"failed": false}] | selectattr("failed", "==", true) }}'
+
+- name: Make sure that test with name that isn't a valid Ansible plugin name does not result in a crash (2/2)
+  template:
+    src: invalid_test_name.j2
+    dest: /tmp/foo
+  ignore_errors: true
+  register: result
+
+- assert:
+    that:
+      - result is failed
+      - >-
+        "TemplateSyntaxError: Could not load \"asdf \": 'invalid plugin name: ansible.builtin.asdf '" in result.msg

--- a/test/integration/targets/templating/templates/invalid_test_name.j2
+++ b/test/integration/targets/templating/templates/invalid_test_name.j2
@@ -1,0 +1,1 @@
+{{ [{"failed": false}] | selectattr("failed", "asdf ", true) }}


### PR DESCRIPTION
##### SUMMARY
Backport of #78913 to stable-2.14.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/template/__init__.py`
