### PR TITLE
Ensure that we do not squash keywords in validate

### DIFF
--- a/changelogs/fragments/79021-dont-squash-in-validate.yml
+++ b/changelogs/fragments/79021-dont-squash-in-validate.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- keyword inheritance - Ensure that we do not squash keywords in validate
+  (https://github.com/ansible/ansible/issues/79021)

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -211,7 +211,7 @@ class FieldAttributeBase:
                     method(attribute, name, getattr(self, name))
                 else:
                     # and make sure the attribute is of the type it should be
-                    value = getattr(self, name)
+                    value = getattr(self, f'_{name}', Sentinel)
                     if value is not None:
                         if attribute.isa == 'string' and isinstance(value, (list, dict)):
                             raise AnsibleParserError(

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -298,8 +298,10 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
         '''
         Generic logic to get the attribute or parent attribute for a block value.
         '''
-        extend = self.fattributes.get(attr).extend
-        prepend = self.fattributes.get(attr).prepend
+        fattr = self.fattributes[attr]
+
+        extend = getattr(fattr, 'extend', False)
+        prepend = getattr(fattr, 'prepend', False)
 
         try:
             # omit self, and only get parent values

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -300,8 +300,8 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
         '''
         fattr = self.fattributes[attr]
 
-        extend = getattr(fattr, 'extend', False)
-        prepend = getattr(fattr, 'prepend', False)
+        extend = fattr.extend
+        prepend = fattr.prepend
 
         try:
             # omit self, and only get parent values

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -463,8 +463,8 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
         '''
         fattr = self.fattributes[attr]
 
-        extend = getattr(fattr, 'extend', False)
-        prepend = getattr(fattr, 'prepend', False)
+        extend = fattr.extend
+        prepend = fattr.prepend
 
         try:
             # omit self, and only get parent values

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -461,8 +461,10 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
         '''
         Generic logic to get the attribute or parent attribute for a task value.
         '''
-        extend = self.fattributes.get(attr).extend
-        prepend = self.fattributes.get(attr).prepend
+        fattr = self.fattributes[attr]
+
+        extend = getattr(fattr, 'extend', False)
+        prepend = getattr(fattr, 'prepend', False)
 
         try:
             # omit self, and only get parent values

--- a/test/integration/targets/keyword_inheritance/aliases
+++ b/test/integration/targets/keyword_inheritance/aliases
@@ -1,0 +1,3 @@
+shippable/posix/group4
+context/controller
+needs/target/setup_test_user

--- a/test/integration/targets/keyword_inheritance/roles/whoami/tasks/main.yml
+++ b/test/integration/targets/keyword_inheritance/roles/whoami/tasks/main.yml
@@ -1,0 +1,3 @@
+- command: whoami
+  register: result
+  failed_when: result.stdout_lines|first != 'ansibletest0'

--- a/test/integration/targets/keyword_inheritance/runme.sh
+++ b/test/integration/targets/keyword_inheritance/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ANSIBLE_ROLES_PATH=../ ansible-playbook -i ../../inventory test.yml "$@"

--- a/test/integration/targets/keyword_inheritance/test.yml
+++ b/test/integration/targets/keyword_inheritance/test.yml
@@ -1,0 +1,8 @@
+- hosts: testhost
+  gather_facts: false
+  become_user: ansibletest0
+  become: yes
+  roles:
+    - role: setup_test_user
+      become_user: root
+    - role: whoami

--- a/test/integration/targets/omit/75692.yml
+++ b/test/integration/targets/omit/75692.yml
@@ -2,28 +2,29 @@
   hosts: testhost
   gather_facts: false
   become: yes
-  become_user: nobody
   roles:
     - name: setup_test_user
   tasks:
-    - shell: whoami
-      register: inherited
+    - become_user: nobody
+      block:
+        - shell: whoami
+          register: inherited
 
-    - shell: whoami
-      register: explicit_no
-      become: false
+        - shell: whoami
+          register: explicit_no
+          become: false
 
-    - shell: whoami
-      register: omited_inheritance
-      become: '{{ omit }}'
+        - shell: whoami
+          register: omited_inheritance
+          become: '{{ omit }}'
 
-    - shell: whoami
-      register: explicit_yes
-      become: yes
+        - shell: whoami
+          register: explicit_yes
+          become: yes
 
-    - name: ensure omit works with inheritance
-      assert:
-        that:
-          - inherited.stdout == omited_inheritance.stdout
-          - inherited.stdout == explicit_yes.stdout
-          - inherited.stdout != explicit_no.stdout
+        - name: ensure omit works with inheritance
+          assert:
+            that:
+              - inherited.stdout == omited_inheritance.stdout
+              - inherited.stdout == explicit_yes.stdout
+              - inherited.stdout != explicit_no.stdout

--- a/test/integration/targets/omit/75692.yml
+++ b/test/integration/targets/omit/75692.yml
@@ -2,29 +2,30 @@
   hosts: testhost
   gather_facts: false
   become: yes
+  # become_user needed at play level for testing this behavior
+  become_user: nobody
   roles:
     - name: setup_test_user
+      become_user: root
   tasks:
-    - become_user: nobody
-      block:
-        - shell: whoami
-          register: inherited
+    - shell: whoami
+      register: inherited
 
-        - shell: whoami
-          register: explicit_no
-          become: false
+    - shell: whoami
+      register: explicit_no
+      become: false
 
-        - shell: whoami
-          register: omited_inheritance
-          become: '{{ omit }}'
+    - shell: whoami
+      register: omited_inheritance
+      become: '{{ omit }}'
 
-        - shell: whoami
-          register: explicit_yes
-          become: yes
+    - shell: whoami
+      register: explicit_yes
+      become: yes
 
-        - name: ensure omit works with inheritance
-          assert:
-            that:
-              - inherited.stdout == omited_inheritance.stdout
-              - inherited.stdout == explicit_yes.stdout
-              - inherited.stdout != explicit_no.stdout
+    - name: ensure omit works with inheritance
+      assert:
+        that:
+          - inherited.stdout == omited_inheritance.stdout
+          - inherited.stdout == explicit_yes.stdout
+          - inherited.stdout != explicit_no.stdout


### PR DESCRIPTION
##### SUMMARY
Ensure that we do not squash keywords in validate. Fixes #79021

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/base.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
