### PR TITLE
[stable-2.13] Use python re to parse service output instead of grep (#79015)

### DIFF
--- a/changelogs/fragments/78541-service-facts-re.yml
+++ b/changelogs/fragments/78541-service-facts-re.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- service_facts - Use python re to parse service output instead of grep
+  (https://github.com/ansible/ansible/issues/78541)

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -89,6 +89,7 @@ ansible_facts:
 '''
 
 
+import os
 import platform
 import re
 from ansible.module_utils.basic import AnsibleModule
@@ -104,16 +105,19 @@ class BaseService(object):
 class ServiceScanService(BaseService):
 
     def _list_sysvinit(self, services):
-
-        rc, stdout, stderr = self.module.run_command("%s --status-all 2>&1 | grep -E \"\\[ (\\+|\\-) \\]\"" % self.service_path, use_unsafe_shell=True)
+        rc, stdout, stderr = self.module.run_command("%s --status-all" % self.service_path)
+        if rc == 4 and not os.path.exists('/etc/init.d'):
+            # This function is not intended to run on Red Hat but it could happen
+            # if `chkconfig` is not installed. `service` on RHEL9 returns rc 4
+            # when /etc/init.d is missing, add the extra guard of checking /etc/init.d
+            # instead of solely relying on rc == 4
+            return
         if rc != 0:
             self.module.warn("Unable to query 'service' tool (%s): %s" % (rc, stderr))
-        for line in stdout.split("\n"):
-            line_data = line.split()
-            if len(line_data) < 4:
-                continue  # Skipping because we expected more data
-            service_name = " ".join(line_data[3:])
-            if line_data[1] == "+":
+        p = re.compile(r'^\s*\[ (?P<state>\+|\-) \]\s+(?P<name>.+)$', flags=re.M)
+        for match in p.finditer(stdout):
+            service_name = match.group('name')
+            if match.group('state') == "+":
                 service_state = "running"
             else:
                 service_state = "stopped"


### PR DESCRIPTION
* Use python re to parse service output instead of grep. Fixes #78541

* Add clog frag

* Add an extra guard to abort if rc is 4, and /etc/init.d is missing
(cherry picked from commit 4458128)


Co-authored-by: Matt Martz <matt@sivel.net>