### PR TITLE
builtin lookup plugin password: fix example

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -110,7 +110,7 @@ EXAMPLES = """
 
 - name: create random but idempotent password
   ansible.builtin.set_fact:
-    password: "{{ lookup('ansible.builtin.password', '/dev/null', seed=inventory_hostname) }}"
+    password: "{{ lookup('ansible.builtin.password', '/dev/null seed=' + inventory_hostname) }}"
 """
 
 RETURN = """


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
all parameters must be passed space-delimited as part of the single argument string, the last example had this wrong.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.builtin.password

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
