### PR TITLE
[stable-2.14] Ensure that we do not squash keywords in validate (#79049)

### DIFF
--- a/changelogs/fragments/79021-dont-squash-in-validate.yml
+++ b/changelogs/fragments/79021-dont-squash-in-validate.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- keyword inheritance - Ensure that we do not squash keywords in validate
+  (https://github.com/ansible/ansible/issues/79021)

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -211,7 +211,7 @@ class FieldAttributeBase:
                     method(attribute, name, getattr(self, name))
                 else:
                     # and make sure the attribute is of the type it should be
-                    value = getattr(self, name)
+                    value = getattr(self, f'_{name}', Sentinel)
                     if value is not None:
                         if attribute.isa == 'string' and isinstance(value, (list, dict)):
                             raise AnsibleParserError(

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -298,8 +298,10 @@ class Block(Base, Conditional, CollectionSearch, Taggable):
         '''
         Generic logic to get the attribute or parent attribute for a block value.
         '''
-        extend = self.fattributes.get(attr).extend
-        prepend = self.fattributes.get(attr).prepend
+        fattr = self.fattributes[attr]
+
+        extend = fattr.extend
+        prepend = fattr.prepend
 
         try:
             # omit self, and only get parent values

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -461,8 +461,10 @@ class Task(Base, Conditional, Taggable, CollectionSearch):
         '''
         Generic logic to get the attribute or parent attribute for a task value.
         '''
-        extend = self.fattributes.get(attr).extend
-        prepend = self.fattributes.get(attr).prepend
+        fattr = self.fattributes[attr]
+
+        extend = fattr.extend
+        prepend = fattr.prepend
 
         try:
             # omit self, and only get parent values

--- a/test/integration/targets/keyword_inheritance/aliases
+++ b/test/integration/targets/keyword_inheritance/aliases
@@ -1,0 +1,3 @@
+shippable/posix/group4
+context/controller
+needs/target/setup_test_user

--- a/test/integration/targets/keyword_inheritance/roles/whoami/tasks/main.yml
+++ b/test/integration/targets/keyword_inheritance/roles/whoami/tasks/main.yml
@@ -1,0 +1,3 @@
+- command: whoami
+  register: result
+  failed_when: result.stdout_lines|first != 'ansibletest0'

--- a/test/integration/targets/keyword_inheritance/runme.sh
+++ b/test/integration/targets/keyword_inheritance/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ANSIBLE_ROLES_PATH=../ ansible-playbook -i ../../inventory test.yml "$@"

--- a/test/integration/targets/keyword_inheritance/test.yml
+++ b/test/integration/targets/keyword_inheritance/test.yml
@@ -1,0 +1,8 @@
+- hosts: testhost
+  gather_facts: false
+  become_user: ansibletest0
+  become: yes
+  roles:
+    - role: setup_test_user
+      become_user: root
+    - role: whoami

--- a/test/integration/targets/omit/75692.yml
+++ b/test/integration/targets/omit/75692.yml
@@ -2,7 +2,6 @@
   hosts: testhost
   gather_facts: false
   become: yes
-  # become_user needed at play level for testing this behavior
   become_user: nobody
   roles:
     - name: setup_test_user

--- a/test/integration/targets/omit/75692.yml
+++ b/test/integration/targets/omit/75692.yml
@@ -2,6 +2,7 @@
   hosts: testhost
   gather_facts: false
   become: yes
+  # become_user needed at play level for testing this behavior
   become_user: nobody
   roles:
     - name: setup_test_user


### PR DESCRIPTION
* Ensure that we do not squash keywords in validate. Fixes #79021

* become_user: nobody should only apply to the test tasks, not the setup_test_user role

* Update how become_user is specified

* Add test to ensure keyword inheritance is working for become

* Add clog frag

* Cache fattributes to prevent re-calculation

* ci_complete

* Remove unnecessary getattr. (cherry picked from commit 420564c5bcf752a821ae0599c3bd01ffba40f3ea)

Co-authored-by: Matt Martz <matt@sivel.net>