### PR TITLE
Fix skipping symlinks to files outside of a collection

### DIFF
--- a/changelogs/fragments/79064-a-g-fix-restricting-file-symlinks.yml
+++ b/changelogs/fragments/79064-a-g-fix-restricting-file-symlinks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy collection install - exclude symlinks to files outside of the collection when installing a directory/git repository.

--- a/changelogs/fragments/79064-a-g-fix-restricting-file-symlinks.yml
+++ b/changelogs/fragments/79064-a-g-fix-restricting-file-symlinks.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ansible-galaxy collection install - exclude symlinks to files outside of the collection when installing a directory/git repository.
+  - ansible-galaxy collection install - exclude symlinks to files outside of the collection when installing from a directory/git repository.

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1381,8 +1381,8 @@ def _build_collection_dir(b_collection_path, b_collection_output, collection_man
             base_directories.append(src_file)
             os.mkdir(dest_file, mode)
         else:
-            if os.path.isfile(src_file) and os.path.islink(src_path):
-                b_link_target = os.path.realpath(src_path)
+            if os.path.isfile(src_file) and os.path.islink(src_file):
+                b_link_target = os.path.realpath(src_file)
                 if not _is_child_path(b_link_target, b_collection_path):
                     continue
 

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1381,6 +1381,11 @@ def _build_collection_dir(b_collection_path, b_collection_output, collection_man
             base_directories.append(src_file)
             os.mkdir(dest_file, mode)
         else:
+            if os.path.isfile(src_file) and os.path.islink(src_path):
+                b_link_target = os.path.realpath(src_path)
+                if not _is_child_path(b_link_target, b_collection_path):
+                    continue
+
             # do not follow symlinks to ensure the original link is used
             shutil.copyfile(src_file, dest_file, follow_symlinks=False)
 

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -780,17 +780,34 @@
     - name: create symlink_dirs collection
       command: ansible-galaxy collection init symlink_dirs.symlink_dirs --init-path "{{ galaxy_dir }}/scratch"
 
+    - name: create directory and file outside the collection to test excluding those symlinks
+      file:
+        path: "{{ item.path }}"
+        state: "{{ item.state }}"
+      loop:
+        - path: "{{ galaxy_dir }}/scratch/external_folder"
+          state: directory
+        - path: "{{ galaxy_dir }}/scratch/external_file"
+          state: touch
+
     - name: create directory in collection
       file:
         path: "{{ galaxy_dir }}/scratch/symlink_dirs/symlink_dirs/folderA"
         state: directory
 
-    - name: create symlink to folderA
+    - name: create symlinks
       file:
-        dest: "{{ galaxy_dir }}/scratch/symlink_dirs/symlink_dirs/folderB"
-        src: ./folderA
+        dest: "{{ item.dest }}"
+        src: "{{ item.src }}"
         state: link
         force: yes
+      loop:
+        - dest: "{{ galaxy_dir }}/scratch/symlink_dirs/symlink_dirs/folderB"
+          src: ./folderA
+        - dest: "{{ galaxy_dir }}/scratch/symlink_dirs/symlink_dirs/folderC"
+          src: "{{ galaxy_dir }}/scratch/external_folder"
+        - dest: "{{ galaxy_dir }}/scratch/symlink_dirs/symlink_dirs/fileA"
+          src: "{{ galaxy_dir }}/scratch/external_file"
 
     - name: install symlink_dirs collection from source
       command: ansible-galaxy collection install {{ galaxy_dir }}/scratch/symlink_dirs/
@@ -807,6 +824,8 @@
       loop:
       - folderA
       - folderB
+      - folderC
+      - fileA
 
     - name: assert install collection with symlink_dirs - {{ test_id }}
       assert:
@@ -815,6 +834,8 @@
         - install_symlink_dirs_actual.results[0].stat.isdir
         - install_symlink_dirs_actual.results[1].stat.islnk
         - install_symlink_dirs_actual.results[1].stat.lnk_target == './folderA'
+        - install_symlink_dirs_actual.results[2].stat.exists == false
+        - install_symlink_dirs_actual.results[3].stat.exists == false
   always:
     - name: clean up symlink_dirs collection directory
       file:

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -771,6 +771,48 @@
     - install_symlink_actual.results[5].stat.islnk
     - install_symlink_actual.results[5].stat.lnk_target == '../REÅDMÈ.md'
 
+# Test installing a collection from source excludes symlinks to external files
+- name: test excluding symlinks to external files
+  vars:
+    ns: external_symlink
+    col: symlink
+  block:
+    - name: create symlink_dirs collection
+      command: "ansible-galaxy collection init {{ ns }}.{{ col }} --init-path {{ galaxy_dir }}/scratch"
+
+    - name: create directory and file outside the collection to test excluding those symlinks
+      file:
+        path: "{{ galaxy_dir }}/scratch/external_file"
+        state: touch
+
+    - name: create symlink
+      file:
+        dest: "{{ galaxy_dir }}/scratch/{{ ns }}/{{ col }}/fileA"
+        src: "{{ galaxy_dir }}/scratch/external_file"
+        state: link
+        force: yes
+
+    - name: install symlink_dirs collection from source
+      command: ansible-galaxy collection install {{ galaxy_dir }}/scratch/{{ ns }}/
+      environment:
+        ANSIBLE_COLLECTIONS_PATHS: "{{ galaxy_dir }}/ansible_collections"
+      register: install_symlink_dirs
+
+    - name: get result of installed collection - {{ test_id }}
+      stat:
+        path: "{{ galaxy_dir }}/ansible_collections/{{ ns }}/{{ col }}/fileA"
+      register: install_symlink_dirs_actual
+
+    - name: verify symlink outside of the collection was not included - {{ test_id }}
+      assert:
+        that:
+        - '"Installing ''{{ ns }}.{{ col }}:1.0.0'' to" in install_symlink_dirs.stdout'
+        - install_symlink_dirs_actual.stat.exists == false
+  always:
+    - name: clean up symlink_dirs collection directory
+      file:
+        path: "{{ galaxy_dir }}/scratch/{{ ns }}"
+        state: absent
 
 # Testing an install from source to check that symlinks to directories
 # are preserved (see issue https://github.com/ansible/ansible/issues/78442)
@@ -780,34 +822,17 @@
     - name: create symlink_dirs collection
       command: ansible-galaxy collection init symlink_dirs.symlink_dirs --init-path "{{ galaxy_dir }}/scratch"
 
-    - name: create directory and file outside the collection to test excluding those symlinks
-      file:
-        path: "{{ item.path }}"
-        state: "{{ item.state }}"
-      loop:
-        - path: "{{ galaxy_dir }}/scratch/external_folder"
-          state: directory
-        - path: "{{ galaxy_dir }}/scratch/external_file"
-          state: touch
-
     - name: create directory in collection
       file:
         path: "{{ galaxy_dir }}/scratch/symlink_dirs/symlink_dirs/folderA"
         state: directory
 
-    - name: create symlinks
+    - name: create symlink to folderA
       file:
-        dest: "{{ item.dest }}"
-        src: "{{ item.src }}"
+        dest: "{{ galaxy_dir }}/scratch/symlink_dirs/symlink_dirs/folderB"
+        src: ./folderA
         state: link
         force: yes
-      loop:
-        - dest: "{{ galaxy_dir }}/scratch/symlink_dirs/symlink_dirs/folderB"
-          src: ./folderA
-        - dest: "{{ galaxy_dir }}/scratch/symlink_dirs/symlink_dirs/folderC"
-          src: "{{ galaxy_dir }}/scratch/external_folder"
-        - dest: "{{ galaxy_dir }}/scratch/symlink_dirs/symlink_dirs/fileA"
-          src: "{{ galaxy_dir }}/scratch/external_file"
 
     - name: install symlink_dirs collection from source
       command: ansible-galaxy collection install {{ galaxy_dir }}/scratch/symlink_dirs/
@@ -824,8 +849,6 @@
       loop:
       - folderA
       - folderB
-      - folderC
-      - fileA
 
     - name: assert install collection with symlink_dirs - {{ test_id }}
       assert:
@@ -834,8 +857,6 @@
         - install_symlink_dirs_actual.results[0].stat.isdir
         - install_symlink_dirs_actual.results[1].stat.islnk
         - install_symlink_dirs_actual.results[1].stat.lnk_target == './folderA'
-        - install_symlink_dirs_actual.results[2].stat.exists == false
-        - install_symlink_dirs_actual.results[3].stat.exists == false
   always:
     - name: clean up symlink_dirs collection directory
       file:


### PR DESCRIPTION
##### SUMMARY
Overlooked in https://github.com/ansible/ansible/pull/78983. Symlinks to directories outside a collection are stripped out while building the manifest, but symlinks to files are handled in _build_collection_tar/_build_collection_dir.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy collection install src_dir|repo
