### PR TITLE
docs: cgroupsv1 is required for ansible-test with docker

### DIFF
--- a/docs/docsite/rst/community/create_pr_quick_start.rst
+++ b/docs/docsite/rst/community/create_pr_quick_start.rst
@@ -155,6 +155,8 @@ See :ref:`module_contribution` for some general guidelines about Ansible module 
 Test your changes
 =================
 
+	If using the ``docker`` CLI program, the host must be configured to use cgroupsv1 (this is not required for ``podman``). This can be done by adding ``systemd.unified_cgroup_hierarchy=0`` to the kernel boot arguments (requires bootloader config update and reboot).
+
 1. Install ``flake8`` (``pip install flake8``, or install the corresponding package on your operating system).
 
 1. Run ``flake8`` against a changed file:


### PR DESCRIPTION
##### SUMMARY
Contributors new to Ansible collections will follow this site to learn how to test their changes https://docs.ansible.com/ansible/devel/community/create_pr_quick_start.html

The page recommends using `docker` (or `podman`) with `ansible-test`.

However, running `ansible-test` with `docker` on a host with `cgroupsv2` will fail as the container cannot start successfully. This change makes it clear that the host must be configured for `cgroupsv1` when using the docker CLI. `cgroupsv1` is not required if using `podman` with the docker shim, as it supports a host with `cgroupsv2`.

Hopefully this will help new contributors not get blocked on being unable to execute tests.

##### ISSUE TYPE
- Docs Pull Request
