### PR TITLE
Bump antsibull-docs version from 1.6.1 to 1.7.0

### DIFF
--- a/test/sanity/code-smell/docs-build.requirements.in
+++ b/test/sanity/code-smell/docs-build.requirements.in
@@ -6,4 +6,4 @@ sphinx-notfound-page
 sphinx-ansible-theme
 straight.plugin
 rstcheck < 4  # match version used in other sanity tests
-antsibull-docs == 1.6.1  # currently approved version
+antsibull-docs == 1.7.0  # currently approved version

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -5,7 +5,7 @@ aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.1
 antsibull-core==1.2.0
-antsibull-docs==1.6.1
+antsibull-docs==1.7.0
 async-timeout==4.0.2
 asyncio-pool==0.6.0
 attrs==22.1.0


### PR DESCRIPTION
##### SUMMARY
Bumps the version of antsibull-docs from 1.6.1 to 1.7.0 for the docs build. The changes affecting the docs build are:

Bugfixes:
- Avoid long aliases list to make left column in option tables too wide (https://github.com/ansible-collections/amazon.aws/issues/1101).

Features/improvements:
- `toctree` elements in `docs/docsite/extra-docs.yml` can now specify a title to override the default (title from the referenced RST file).
- The collection index pages now contain the supported versions of ansible-core of the collection in case collection's `meta/runtime.yml` specifies `requires_ansible`.
- Use code formatting for all values, such as choice entries, defaults, and samples.

([Full changelog](https://github.com/ansible-community/antsibull-docs/blob/main/CHANGELOG.rst#v1-7-0))

CC @samccann

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
docs build
docs build sanity test
