### PR TITLE
Docs:  file parameter import_tasks and include_tasks

### DIFF
--- a/lib/ansible/modules/import_tasks.py
+++ b/lib/ansible/modules/import_tasks.py
@@ -18,8 +18,8 @@ version_added: "2.4"
 options:
   free-form:
     description:
-      - The name of the imported file is specified directly without any other option.
-      - Most keywords, including loops and conditionals, only applied to the imported tasks, not to this statement itself.
+      - Specifies the name of the imported file directly without any other option C(- import_tasks: file.yml).
+      - Most keywords, including loops and conditionals, only apply to the imported tasks, not to this statement itself.
       - If you need any of those to apply, use M(ansible.builtin.include_tasks) instead.
   file:
     description:

--- a/lib/ansible/modules/import_tasks.py
+++ b/lib/ansible/modules/import_tasks.py
@@ -21,6 +21,11 @@ options:
       - The name of the imported file is specified directly without any other option.
       - Most keywords, including loops and conditionals, only applied to the imported tasks, not to this statement itself.
       - If you need any of those to apply, use M(ansible.builtin.include_tasks) instead.
+  file:
+    description:
+      - Specifies the name of the file that lists tasks to add to the current playbook.
+    type: str
+    version_added: '2.7'
 extends_documentation_fragment:
     - action_common_attributes
     - action_common_attributes.conn
@@ -50,7 +55,8 @@ EXAMPLES = r'''
         msg: task1
 
     - name: Include task list in play
-      ansible.builtin.import_tasks: stuff.yaml
+      ansible.builtin.import_tasks:
+        file: stuff.yaml
 
     - ansible.builtin.debug:
         msg: task10

--- a/lib/ansible/modules/import_tasks.py
+++ b/lib/ansible/modules/import_tasks.py
@@ -18,7 +18,7 @@ version_added: "2.4"
 options:
   free-form:
     description:
-      - Specifies the name of the imported file directly without any other option C(- import_tasks: file.yml).
+      - "Specifies the name of the imported file directly without any other option C(- import_tasks: file.yml)."
       - Most keywords, including loops and conditionals, only apply to the imported tasks, not to this statement itself.
       - If you need any of those to apply, use M(ansible.builtin.include_tasks) instead.
   file:

--- a/lib/ansible/modules/import_tasks.py
+++ b/lib/ansible/modules/import_tasks.py
@@ -18,7 +18,8 @@ version_added: "2.4"
 options:
   free-form:
     description:
-      - "Specifies the name of the imported file directly without any other option C(- import_tasks: file.yml)."
+      - |
+        Specifies the name of the imported file directly without any other option C(- import_tasks: file.yml).
       - Most keywords, including loops and conditionals, only apply to the imported tasks, not to this statement itself.
       - If you need any of those to apply, use M(ansible.builtin.include_tasks) instead.
   file:

--- a/lib/ansible/modules/include_tasks.py
+++ b/lib/ansible/modules/include_tasks.py
@@ -28,9 +28,10 @@ options:
     version_added: '2.7'
   free-form:
     description:
-      - |
-        Supplying a file name via free-form C(- include_tasks: file.yml) of a file to be included is the equivalent
-        of specifying an argument of I(file).
+      - Specifies the name of the imported file directly without any other option C(- include_tasks: file.yml).
+      - Is the equivalent of specifying an argument for the I(file) parameter.
+      - Most keywords, including loop, with_items, and conditionals, apply to this statement unlike M(ansible.builtin.import_tasks).
+      - The do-until loop is not supported.
 extends_documentation_fragment:
     - action_common_attributes
     - action_common_attributes.conn

--- a/lib/ansible/modules/include_tasks.py
+++ b/lib/ansible/modules/include_tasks.py
@@ -28,7 +28,7 @@ options:
     version_added: '2.7'
   free-form:
     description:
-      - Specifies the name of the imported file directly without any other option C(- include_tasks: file.yml).
+      - "Specifies the name of the imported file directly without any other option C(- include_tasks: file.yml)."
       - Is the equivalent of specifying an argument for the I(file) parameter.
       - Most keywords, including loop, with_items, and conditionals, apply to this statement unlike M(ansible.builtin.import_tasks).
       - The do-until loop is not supported.

--- a/lib/ansible/modules/include_tasks.py
+++ b/lib/ansible/modules/include_tasks.py
@@ -28,7 +28,8 @@ options:
     version_added: '2.7'
   free-form:
     description:
-      - "Specifies the name of the imported file directly without any other option C(- include_tasks: file.yml)."
+      - |
+        Specifies the name of the imported file directly without any other option C(- include_tasks: file.yml).
       - Is the equivalent of specifying an argument for the I(file) parameter.
       - Most keywords, including loop, with_items, and conditionals, apply to this statement unlike M(ansible.builtin.import_tasks).
       - The do-until loop is not supported.

--- a/lib/ansible/modules/include_tasks.py
+++ b/lib/ansible/modules/include_tasks.py
@@ -18,9 +18,7 @@ version_added: '2.4'
 options:
   file:
     description:
-      - The name of the imported file is specified directly without any other option.
-      - Unlike M(ansible.builtin.import_tasks), most keywords, including loop, with_items, and conditionals, apply to this statement.
-      - The do until loop is not supported on M(ansible.builtin.include_tasks).
+      - Specifies the name of the file that lists tasks to add to the current playbook.
     type: str
     version_added: '2.7'
   apply:
@@ -60,7 +58,8 @@ EXAMPLES = r'''
         msg: task1
 
     - name: Include task list in play
-      ansible.builtin.include_tasks: stuff.yaml
+      ansible.builtin.include_tasks:
+        file: stuff.yaml
 
     - ansible.builtin.debug:
         msg: task10


### PR DESCRIPTION
##### SUMMARY
Fixes issue #79022 by adding the `file:` parameter to the import_tasks module and revising the description for the `file:` parameter in the include_tasks module.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
import_tasks and include_tasks

##### ADDITIONAL INFORMATION
See issue #79022
