### PR TITLE
ansible-config, only subvalues should use yaml shorthand (#79073)

### DIFF
--- a/changelogs/fragments/adjust_config_list.yml
+++ b/changelogs/fragments/adjust_config_list.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-config limit shorthand format to assigned values

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -35,8 +35,12 @@ from ansible.utils.path import unfrackpath
 display = Display()
 
 
-def yaml_dump(data, default_flow_style=True):
-    return yaml.dump(data, Dumper=AnsibleDumper, default_flow_style=default_flow_style, default_style="''")
+def yaml_dump(data, default_flow_style=False, default_style=None):
+    return yaml.dump(data, Dumper=AnsibleDumper, default_flow_style=default_flow_style, default_style=default_style)
+
+
+def yaml_short(data):
+    return yaml_dump(data, default_flow_style=True, default_style="''")
 
 
 def get_constants():
@@ -305,7 +309,7 @@ class ConfigCLI(CLI):
                 elif subkey == 'vars':
                     if entry.startswith('_ansible_'):
                         continue
-                    data.append(prefix + '%s: %s' % (entry, to_text(yaml_dump(default), errors='surrogate_or_strict')))
+                    data.append(prefix + '%s: %s' % (entry, to_text(yaml_short(default), errors='surrogate_or_strict')))
                 data.append('')
 
         return data


### PR DESCRIPTION
* ensure we only use shorthand for assigned values
* fix ansible-config std display


(cherry picked from commit 27ab589ee874cac7aad65cfb3630a5b38082e4b8)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-config