### PR TITLE
Docs: syntax error in Parsing semi-structured text with Ansible

### DIFF
--- a/docs/docsite/rst/network/user_guide/cli_parsing.rst
+++ b/docs/docsite/rst/network/user_guide/cli_parsing.rst
@@ -439,7 +439,7 @@ Parsing with textfsm
 
 ``textfsm`` is a Python module which implements a template-based state machine for parsing semi-formatted text.
 
-The following sample``textfsm`` template is stored as ``templates/nxos_show_interface.textfsm``
+The following sample ``textfsm`` template is stored as ``templates/nxos_show_interface.textfsm``
 
 .. code-block:: text
 


### PR DESCRIPTION
##### SUMMARY
In the Parsing semi-structured text with Ansible page, Corrected a syntax error in the text..

page(https://docs.ansible.com/ansible/devel/network/user_guide/cli_parsing.html#parsing-with-textfsm)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
In the Parsing with textfsm section

##### ADDITIONAL INFORMATION
A syntax error was corrected in the Parsing with textfsm section.