### PR TITLE
ansible-galaxy install - delay api check until a role is installed from a server

### DIFF
--- a/changelogs/fragments/ansible-galaxy-install-delay-initial-api-call.yml
+++ b/changelogs/fragments/ansible-galaxy-install-delay-initial-api-call.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy role install - determine the best distribution server for roles when a GalaxyRole needs to make an API call.

--- a/changelogs/fragments/ansible-galaxy-install-delay-initial-api-call.yml
+++ b/changelogs/fragments/ansible-galaxy-install-delay-initial-api-call.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ansible-galaxy role install - determine the best distribution server for roles when a GalaxyRole needs to make an API call.
+  - ansible-galaxy - make initial call to Galaxy server on-demand only when installing, getting info about, and listing roles.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1199,7 +1199,7 @@ class GalaxyCLI(CLI):
         for role in context.CLIARGS['args']:
 
             role_info = {'path': roles_path}
-            gr = GalaxyRole(self.galaxy, self.api, role)
+            gr = GalaxyRole(self.galaxy, self.lazy_role_api, role)
 
             install_info = gr.install_info
             if install_info:
@@ -1539,7 +1539,7 @@ class GalaxyCLI(CLI):
 
             if role_name:
                 # show the requested role, if it exists
-                gr = GalaxyRole(self.galaxy, self.api, role_name, path=os.path.join(role_path, role_name))
+                gr = GalaxyRole(self.galaxy, self.lazy_role_api, role_name, path=os.path.join(role_path, role_name))
                 if os.path.isdir(gr.path):
                     role_found = True
                     display.display('# %s' % os.path.dirname(gr.path))
@@ -1558,7 +1558,7 @@ class GalaxyCLI(CLI):
                 display.display('# %s' % role_path)
                 path_files = os.listdir(role_path)
                 for path_file in path_files:
-                    gr = GalaxyRole(self.galaxy, self.api, path_file, path=path)
+                    gr = GalaxyRole(self.galaxy, self.lazy_role_api, path_file, path=path)
                     if gr.metadata:
                         _display_role(gr)
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -174,7 +174,7 @@ def validate_signature_count(value):
 
 @dataclass
 class RoleDistributionServer:
-    _api: t.Union[str, None]
+    _api: t.Union[GalaxyAPI, None]
     api_servers: list[GalaxyAPI]
 
     @property

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1275,7 +1275,7 @@ class GalaxyCLI(CLI):
             requirements_file = GalaxyCLI._resolve_path(requirements_file)
 
         # delay equivalent of self.api, so the GalaxyRole checks api versions once it's making an api call
-        role_api = RoleAPI(self.api_servers)
+        role_api = RoleAPI(self._api, self.api_servers)
 
         two_type_warning = "The requirements file '%s' contains {0}s which will be ignored. To install these {0}s " \
                            "run 'ansible-galaxy {0} install -r' or to install both at the same time run " \

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -224,7 +224,6 @@ class GalaxyCLI(CLI):
 
         self.api_servers = []
         self.galaxy = None
-        self._api = None
         self.lazy_role_api = None
         super(GalaxyCLI, self).__init__(args)
 
@@ -707,7 +706,7 @@ class GalaxyCLI(CLI):
 
         # checks api versions once a GalaxyRole makes an api call
         # self.api can be used to evaluate the best server immediately
-        self.lazy_role_api = RoleDistributionServer(self._api, self.api_servers)
+        self.lazy_role_api = RoleDistributionServer(None, self.api_servers)
 
         return context.CLIARGS['func']()
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -43,7 +43,7 @@ from ansible.galaxy.collection.concrete_artifact_manager import (
 from ansible.galaxy.collection.gpg import GPG_ERROR_MAP
 from ansible.galaxy.dependency_resolution.dataclasses import Requirement
 
-from ansible.galaxy.role import GalaxyRole
+from ansible.galaxy.role import GalaxyRole, RoleAPI
 from ansible.galaxy.token import BasicAuthToken, GalaxyToken, KeycloakToken, NoTokenSentinel
 from ansible.module_utils.ansible_release import __version__ as ansible_version
 from ansible.module_utils.common.collections import is_iterable
@@ -701,7 +701,7 @@ class GalaxyCLI(CLI):
     def _get_default_collection_path(self):
         return C.COLLECTIONS_PATHS[0]
 
-    def _parse_requirements_file(self, requirements_file, allow_old_format=True, artifacts_manager=None, validate_signature_options=True):
+    def _parse_requirements_file(self, requirements_file, allow_old_format=True, artifacts_manager=None, validate_signature_options=True, role_api=None):
         """
         Parses an Ansible requirement.yml file and returns all the roles and/or collections defined in it. There are 2
         requirements file format:
@@ -757,7 +757,7 @@ class GalaxyCLI(CLI):
                 display.vvv("found role %s in yaml file" % to_text(role))
                 if "name" not in role and "src" not in role:
                     raise AnsibleError("Must specify name or src for role")
-                return [GalaxyRole(self.galaxy, self.api, **role)]
+                return [GalaxyRole(self.galaxy, role_api, **role)]
             else:
                 b_include_path = to_bytes(requirement["include"], errors="surrogate_or_strict")
                 if not os.path.isfile(b_include_path):
@@ -766,7 +766,7 @@ class GalaxyCLI(CLI):
 
                 with open(b_include_path, 'rb') as f_include:
                     try:
-                        return [GalaxyRole(self.galaxy, self.api, **r) for r in
+                        return [GalaxyRole(self.galaxy, role_api, **r) for r in
                                 (RoleRequirement.role_yaml_parse(i) for i in yaml_load(f_include))]
                     except Exception as e:
                         raise AnsibleError("Unable to load data from include requirements file: %s %s"
@@ -1274,6 +1274,9 @@ class GalaxyCLI(CLI):
         if requirements_file:
             requirements_file = GalaxyCLI._resolve_path(requirements_file)
 
+        # delay equivalent of self.api, so the GalaxyRole checks api versions once it's making an api call
+        role_api = RoleAPI(self.api_servers)
+
         two_type_warning = "The requirements file '%s' contains {0}s which will be ignored. To install these {0}s " \
                            "run 'ansible-galaxy {0} install -r' or to install both at the same time run " \
                            "'ansible-galaxy install -r' without a custom install path." % to_text(requirements_file)
@@ -1307,6 +1310,7 @@ class GalaxyCLI(CLI):
                     requirements_file,
                     artifacts_manager=artifacts_manager,
                     validate_signature_options=will_install_collections,
+                    role_api=role_api,
                 )
                 role_requirements = requirements['roles']
 
@@ -1327,7 +1331,7 @@ class GalaxyCLI(CLI):
                 # (and their dependencies, unless the user doesn't want us to).
                 for rname in context.CLIARGS['args']:
                     role = RoleRequirement.role_yaml_parse(rname.strip())
-                    role_requirements.append(GalaxyRole(self.galaxy, self.api, **role))
+                    role_requirements.append(GalaxyRole(self.galaxy, role_api, **role))
 
         if not role_requirements and not collection_requirements:
             display.display("Skipping install, no requirements found")
@@ -1335,7 +1339,7 @@ class GalaxyCLI(CLI):
 
         if role_requirements:
             display.display("Starting galaxy role install process")
-            self._execute_install_role(role_requirements)
+            self._execute_install_role(role_requirements, role_api)
 
         if collection_requirements:
             display.display("Starting galaxy collection install process")
@@ -1389,7 +1393,7 @@ class GalaxyCLI(CLI):
 
         return 0
 
-    def _execute_install_role(self, requirements):
+    def _execute_install_role(self, requirements, role_api):
         role_file = context.CLIARGS['requirements']
         no_deps = context.CLIARGS['no_deps']
         force_deps = context.CLIARGS['force_with_deps']
@@ -1438,7 +1442,7 @@ class GalaxyCLI(CLI):
                         display.debug('Installing dep %s' % dep)
                         dep_req = RoleRequirement()
                         dep_info = dep_req.role_yaml_parse(dep)
-                        dep_role = GalaxyRole(self.galaxy, self.api, **dep_info)
+                        dep_role = GalaxyRole(self.galaxy, role_api, **dep_info)
                         if '.' not in dep_role.name and '.' not in dep_role.src and dep_role.scm is None:
                             # we know we can skip this, as it's not going to
                             # be found on galaxy.ansible.com

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -27,6 +27,7 @@ import datetime
 import os
 import tarfile
 import tempfile
+import typing as t
 
 from collections.abc import MutableSequence
 from dataclasses import dataclass
@@ -49,8 +50,8 @@ display = Display()
 class RoleAPI:
     from ansible.galaxy.api import GalaxyAPI
 
-    _api: str|None
-    api_servers: list[GalaxyAPI]|None
+    _api: t.Union[str, None]
+    api_servers: list[GalaxyAPI]
 
     @property
     def api(self):

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -48,6 +48,7 @@ display = Display()
 
 @dataclass
 class RoleAPI:
+    # prevent recursive import
     from ansible.galaxy.api import GalaxyAPI
 
     _api: t.Union[str, None]

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -45,7 +45,8 @@ display = Display()
 
 
 class RoleAPI:
-    def __init__(self, api_servers):
+    def __init__(self, preferred_api, api_servers):
+        self._api = preferred_api
         self.api_servers = api_servers
 
     @property

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -27,10 +27,8 @@ import datetime
 import os
 import tarfile
 import tempfile
-import typing as t
 
 from collections.abc import MutableSequence
-from dataclasses import dataclass
 from shutil import rmtree
 
 from ansible import context
@@ -44,34 +42,6 @@ from ansible.playbook.role.requirement import RoleRequirement
 from ansible.utils.display import Display
 
 display = Display()
-
-
-@dataclass
-class RoleAPI:
-    # prevent recursive import
-    from ansible.galaxy.api import GalaxyAPI
-
-    _api: t.Union[str, None]
-    api_servers: list[GalaxyAPI]
-
-    # a copy of GalaxyCLI.api
-    @property
-    def api(self):
-        if self._api:
-            return self._api
-
-        for server in self.api_servers:
-            try:
-                if u'v1' in server.available_api_versions:
-                    self._api = server
-                    break
-            except Exception:
-                continue
-
-        if not self._api:
-            self._api = self.api_servers[0]
-
-        return self._api
 
 
 class GalaxyRole(object):
@@ -135,7 +105,9 @@ class GalaxyRole(object):
 
     @property
     def api(self):
-        if isinstance(self._api, RoleAPI):
+        # prevent recursive imports
+        from ansible.cli.galaxy import RoleDistributionServer
+        if isinstance(self._api, RoleDistributionServer):
             return self._api.api
         return self._api
 

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -44,6 +44,29 @@ from ansible.utils.display import Display
 display = Display()
 
 
+class RoleAPI:
+    def __init__(self, api_servers):
+        self.api_servers = api_servers
+
+    @property
+    def api(self):
+        if self._api:
+            return self._api
+
+        for server in self.api_servers:
+            try:
+                if u'v1' in server.available_api_versions:
+                    self._api = server
+                    break
+            except Exception:
+                continue
+
+        if not self._api:
+            self._api = self.api_servers[0]
+
+        return self._api
+
+
 class GalaxyRole(object):
 
     SUPPORTED_SCMS = set(['git', 'hg'])
@@ -63,7 +86,7 @@ class GalaxyRole(object):
         display.debug('Validate TLS certificates: %s' % self._validate_certs)
 
         self.galaxy = galaxy
-        self.api = api
+        self._api = api
 
         self.name = name
         self.version = version
@@ -102,6 +125,12 @@ class GalaxyRole(object):
 
     def __eq__(self, other):
         return self.name == other.name
+
+    @property
+    def api(self):
+        if isinstance(self._api, RoleAPI):
+            return self._api.api
+        return self._api
 
     @property
     def metadata(self):

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -53,6 +53,7 @@ class RoleAPI:
     _api: t.Union[str, None]
     api_servers: list[GalaxyAPI]
 
+    # a copy of GalaxyCLI.api
     @property
     def api(self):
         if self._api:

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -29,6 +29,7 @@ import tarfile
 import tempfile
 
 from collections.abc import MutableSequence
+from dataclasses import dataclass
 from shutil import rmtree
 
 from ansible import context
@@ -44,10 +45,12 @@ from ansible.utils.display import Display
 display = Display()
 
 
+@dataclass
 class RoleAPI:
-    def __init__(self, preferred_api, api_servers):
-        self._api = preferred_api
-        self.api_servers = api_servers
+    from ansible.galaxy.api import GalaxyAPI
+
+    _api: str|None
+    api_servers: list[GalaxyAPI]|None
 
     @property
     def api(self):

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -103,8 +103,11 @@ f_ansible_galaxy_status "install of local git repo"
 mkdir -p "${galaxy_testdir}"
 pushd "${galaxy_testdir}"
 
+    # minimum verbosity is hardcoded to include calls to Galaxy
     ansible-galaxy install git+file:///"${galaxy_local_test_role_git_repo}" "$@" -vvvv 2>&1 | tee out.txt
-    grep out.txt -e "https://galaxy.ansible.com" && "$(cat out.txt; exit 1)"  # should not call Galaxy
+
+    # Test no initial call is made to Galaxy
+    grep out.txt -e "https://galaxy.ansible.com" && cat out.txt && exit 1
 
     # Test that the role was installed to the expected directory
     [[ -d "${HOME}/.ansible/roles/${galaxy_local_test_role}" ]]

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -103,7 +103,8 @@ f_ansible_galaxy_status "install of local git repo"
 mkdir -p "${galaxy_testdir}"
 pushd "${galaxy_testdir}"
 
-    ansible-galaxy install git+file:///"${galaxy_local_test_role_git_repo}" "$@"
+    ansible-galaxy install git+file:///"${galaxy_local_test_role_git_repo}" "$@" -vvvv 2>&1 | tee out.txt
+    grep out.txt -e "https://galaxy.ansible.com" && "$(cat out.txt; exit 1)"  # should not call Galaxy
 
     # Test that the role was installed to the expected directory
     [[ -d "${HOME}/.ansible/roles/${galaxy_local_test_role}" ]]


### PR DESCRIPTION
##### SUMMARY
When installing roles there's always an initial call made to the distribution servers to see if any handle the v1 API. If the role isn't being installed from a server then this isn't necessary.

Pass a shared object instead to each GalaxyRole so the initial call is made when one of the roles use the api.
 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy install|info|list