### PR TITLE
Apply minor formatting changes to "playbooks directory" section

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -189,10 +189,10 @@ You can have most of the subdirectories you would expect, such ``files/``, ``var
 
 Also, playbooks within a collection follow the same guidelines as any playbooks except for these few adjustments:
 
- - Directory: It must be in ``/playbooks directory``.
+ - Directory: It must be in the ``playbooks/`` directory.
  - Hosts: The host should be defined as a variable so the users of a playbook do not mistakenly run the plays against their entire inventory (if the host is set to all). For example - ``hosts: '{{target|default("all")}}'``.
 
-To run the plays, users can now use such commands as ``ansible-playbook --e 'targets=webservers'`` or ``ansible-playbook --limit webservers``. Either way, the collection owner should document their playbooks and how to use them in the ``/docs`` folder or ``README`` file.
+To run the plays, users can now use such commands as ``ansible-playbook --e 'targets=webservers'`` or ``ansible-playbook --limit webservers``. Either way, the collection owner should document their playbooks and how to use them in the ``docs/`` folder or ``README`` file.
 
 .. _developing_collections_tests_directory:
 


### PR DESCRIPTION
##### SUMMARY
Shortened the inline literal and moved several directory forward slashes to match the other directory names in the section.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs
