### PR TITLE
added number of matches to replace parameter

### DIFF
--- a/changelogs/fragments/78866-replace-n-number-of-matches.yaml
+++ b/changelogs/fragments/78866-replace-n-number-of-matches.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+        - added new `numberofmatches` paramter to replace function to replace the first n number of occurances (https://github.com/ansible/ansible/issues/78866)

--- a/lib/ansible/modules/replace.py
+++ b/lib/ansible/modules/replace.py
@@ -103,7 +103,7 @@ options:
     version_added: "2.4"
   numberofmatches:
     description:
-      - Takes an int of value 'n' and replaces the 'first n number' of matches. 
+      - Takes an int of value 'n' and replaces the 'first n number' of matches.
         Default is set to '0' that means all the matches will get replaced.
     type: int
     default: 0
@@ -190,7 +190,7 @@ EXAMPLES = r'''
     regexp: 'Require\s+[^\n]+$'
     replace: 'Require ip {{ ips | join(" ") }}'
     numberofmatches: 1
-    
+
 '''
 
 RETURN = r'''#'''


### PR DESCRIPTION
Signed-off-by: Shivam Durgbuns <shivamdurgbuns@gmail.com>

##### SUMMARY
Added `numberofmatches` parameter to replace functionality to replace the first n number of matches during a replace function, the default is set to 0 i.e all the occurrences will be replaced.

Fixes: https://github.com/ansible/ansible/issues/78866

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
replace
