### PR TITLE
Update cliconf-> __init__.py -> get_capabilities()

### DIFF
--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -276,7 +276,7 @@ class CliconfBase(AnsiblePlugin):
                 'diff_replace': [list of supported replace values],
                 'output': [list of supported command output format]
             }
-        :return: capability as json string
+        :return: capability as dict
         """
         result = {}
         result['rpc'] = self.get_base_rpc()


### PR DESCRIPTION

##### SUMMARY
Doc string was incorrect. 
The `get_capabilities` method returns a Python Dict data structure not a JSON string as stated.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/cliconf/__init__.py#L279

##### ADDITIONAL INFORMATION
```paste below
>>> result = {}
>>> type(result)
<class 'dict'>
```
