### PR TITLE
[stable-2.14] ansible-test - Update pylint to 2.15.4.

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-2.15.4.yml
+++ b/changelogs/fragments/ansible-test-pylint-2.15.4.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Update the ``pylint`` sanity test to use version 2.15.4.

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.in
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.in
@@ -1,2 +1,2 @@
-pylint == 2.15.3  # currently vetted version
+pylint == 2.15.4  # currently vetted version
 pyyaml  # needed for collection_detail.py

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
@@ -1,13 +1,13 @@
 # edit "sanity.pylint.in" and generate with: hacking/update-sanity-requirements.py --test pylint
-astroid==2.12.10
+astroid==2.12.11
 dill==0.3.5.1
 isort==5.10.1
 lazy-object-proxy==1.7.1
 mccabe==0.7.0
 platformdirs==2.5.2
-pylint==2.15.3
+pylint==2.15.4
 PyYAML==6.0
 tomli==2.0.1
-tomlkit==0.11.4
+tomlkit==0.11.5
 typing_extensions==4.3.0
 wrapt==1.14.1


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/79103

(cherry picked from commit 14e7f05318ddc421330209eece0e891d0eaef10d)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
