### PR TITLE
ansible-galaxy - enforce string versions and fix installing prereleases from scm sources

### DIFF
--- a/changelogs/fragments/79112-a-g-version-validation.yml
+++ b/changelogs/fragments/79112-a-g-version-validation.yml
@@ -1,3 +1,20 @@
+minor_changes:
+  - >
+    ansible-galaxy collection install - fix consistency when installing type ``url`` or ``file``
+    requirements by resolving dependencies and determining satisfied requirements from the result.
+    Previously, tarfiles were were always reinstalled if the dependency resolver ran, and could
+    be short-circuited if all type ``galaxy`` requirements were satisfied.
+    Now ``url`` and ``file`` types are always reinstalled, rather than circumstantially on
+    unrelated requirements.
+  - ansible-galaxy collection - consolidate message when an invalid version is encountered so it's
+    the same regardless of codepath.
 bugfixes:
-  - ansible-galaxy collection - enforce str versions when loading user-requested requirements (https://github.com/ansible/ansible/issues/78067, https://github.com/ansible/ansible/issues/79109).
-  - ansible-galaxy collection - fix installing pre-releases from virtual sources (https://github.com/ansible/ansible/issues/79168).
+  - >
+    ansible-galaxy collection - allow pre-releases without --pre if the pre-release is already installed
+    or if the requirement is a pre-release.
+  - >
+    ansible-galaxy collection - enforce str versions when loading user-requested requirements
+    (https://github.com/ansible/ansible/issues/78067, https://github.com/ansible/ansible/issues/79109).
+  - >
+    ansible-galaxy collection - fix installing pre-releases from virtual sources
+    (https://github.com/ansible/ansible/issues/79168).

--- a/changelogs/fragments/79112-a-g-version-validation.yml
+++ b/changelogs/fragments/79112-a-g-version-validation.yml
@@ -1,11 +1,4 @@
 minor_changes:
-  - >
-    ansible-galaxy collection install - fix consistency when installing type ``url`` or ``file``
-    requirements by resolving dependencies and determining satisfied requirements from the result.
-    Previously, tarfiles were were always reinstalled if the dependency resolver ran, and could
-    be short-circuited if all type ``galaxy`` requirements were satisfied.
-    Now ``url`` and ``file`` types are always reinstalled, rather than circumstantially on
-    unrelated requirements.
   - ansible-galaxy collection - consolidate message when an invalid version is encountered so it's
     the same regardless of codepath.
 bugfixes:

--- a/changelogs/fragments/79112-a-g-version-validation.yml
+++ b/changelogs/fragments/79112-a-g-version-validation.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-galaxy collection - enforce str versions when loading user-requested requirements (https://github.com/ansible/ansible/issues/78067, https://github.com/ansible/ansible/issues/79109).
+  - ansible-galaxy collection - fix installing pre-releases from virtual sources (https://github.com/ansible/ansible/issues/79168).

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -505,8 +505,20 @@ def build_collection(u_collection_path, u_output_path, force):
     return collection_output
 
 
+def process_virtual_requirements(requirement, resolved_requirements, artifacts_manager):
+    # type: (Requirement, t.Iterable[Requirement], ConcreteArtifactsManager) -> None
+    requirement.validate_version()
+
+    if requirement.is_virtual:
+        for dep_name, dep_req in artifacts_manager.get_direct_collection_dependencies(requirement).items():
+            dep = Requirement.from_requirement_dict({'name': dep_name, 'version': dep_req}, artifacts_manager)
+            process_virtual_requirements(dep, resolved_requirements, artifacts_manager)
+    else:
+        resolved_requirements.add(requirement)
+
+
 def download_collections(
-        collections,  # type: t.Iterable[Requirement]
+        collections,  # type: t.List[Requirement]
         output_path,  # type: str
         apis,  # type: t.Iterable[GalaxyAPI]
         no_deps,  # type: bool
@@ -523,6 +535,14 @@ def download_collections(
     :param no_deps: Ignore any collection dependencies and only download the base requirements.
     :param allow_pre_release: Do not ignore pre-release versions when selecting the latest.
     """
+    for install_req in list(collections):
+        if not install_req.is_virtual:
+            continue
+        virtual_direct_requests = set()  # type: t.Set[Requirement]
+        process_virtual_requirements(install_req, virtual_direct_requests, artifacts_manager)
+        collections.remove(install_req)
+        collections += list(virtual_direct_requests)
+
     with _display_progress("Process download dependency map"):
         dep_map = _resolve_depenency_map(
             set(collections),
@@ -649,7 +669,7 @@ def publish_collection(collection_path, api, wait, timeout):
 
 
 def install_collections(
-        collections,  # type: t.Iterable[Requirement]
+        collections,  # type: t.List[Requirement]
         output_path,  # type: str
         apis,  # type: t.Iterable[GalaxyAPI]
         ignore_errors,  # type: bool
@@ -678,20 +698,15 @@ def install_collections(
         for coll in find_existing_collections(output_path, artifacts_manager)
     }
 
-    unsatisfied_requirements = set(
-        chain.from_iterable(
-            (
-                Requirement.from_dir_path(sub_coll, artifacts_manager)
-                for sub_coll in (
-                    artifacts_manager.
-                    get_direct_collection_dependencies(install_req).
-                    keys()
-                )
-            )
-            if install_req.is_subdirs else (install_req, )
-            for install_req in collections
-        ),
-    )
+    for install_req in list(collections):
+        if not install_req.is_virtual:
+            continue
+        virtual_direct_requests = set()  # type: t.Set[Requirement]
+        process_virtual_requirements(install_req, virtual_direct_requests, artifacts_manager)
+        collections.remove(install_req)
+        collections += list(virtual_direct_requests)
+
+    unsatisfied_requirements = set(collections)
     requested_requirements_names = {req.fqcn for req in unsatisfied_requirements}
 
     # NOTE: Don't attempt to reevaluate already installed deps
@@ -700,7 +715,7 @@ def install_collections(
         req
         for req in unsatisfied_requirements
         for exs in existing_collections
-        if req.fqcn == exs.fqcn and meets_requirements(exs.ver, req.ver)
+        if req.fqcn == exs.fqcn and meets_requirements(exs.ver, req.ver) and not req.is_dir
     }
 
     if not unsatisfied_requirements and not upgrade:

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -505,20 +505,8 @@ def build_collection(u_collection_path, u_output_path, force):
     return collection_output
 
 
-def process_virtual_requirements(requirement, resolved_requirements, artifacts_manager):
-    # type: (Requirement, t.Iterable[Requirement], ConcreteArtifactsManager) -> None
-    requirement.validate_version()
-
-    if requirement.is_virtual:
-        for dep_name, dep_req in artifacts_manager.get_direct_collection_dependencies(requirement).items():
-            dep = Requirement.from_requirement_dict({'name': dep_name, 'version': dep_req}, artifacts_manager)
-            process_virtual_requirements(dep, resolved_requirements, artifacts_manager)
-    else:
-        resolved_requirements.add(requirement)
-
-
 def download_collections(
-        collections,  # type: t.List[Requirement]
+        collections,  # type: t.Iterable[Requirement]
         output_path,  # type: str
         apis,  # type: t.Iterable[GalaxyAPI]
         no_deps,  # type: bool
@@ -535,14 +523,6 @@ def download_collections(
     :param no_deps: Ignore any collection dependencies and only download the base requirements.
     :param allow_pre_release: Do not ignore pre-release versions when selecting the latest.
     """
-    for install_req in list(collections):
-        if not install_req.is_virtual:
-            continue
-        virtual_direct_requests = set()  # type: t.Set[Requirement]
-        process_virtual_requirements(install_req, virtual_direct_requests, artifacts_manager)
-        collections.remove(install_req)
-        collections += list(virtual_direct_requests)
-
     with _display_progress("Process download dependency map"):
         dep_map = _resolve_depenency_map(
             set(collections),
@@ -669,7 +649,7 @@ def publish_collection(collection_path, api, wait, timeout):
 
 
 def install_collections(
-        collections,  # type: t.List[Requirement]
+        collections,  # type: t.Iterable[Requirement]
         output_path,  # type: str
         apis,  # type: t.Iterable[GalaxyAPI]
         ignore_errors,  # type: bool
@@ -694,55 +674,10 @@ def install_collections(
     :param force_deps: Re-install a collection as well as its dependencies if they have already been installed.
     """
     existing_collections = {
-        Requirement(coll.fqcn, coll.ver, coll.src, coll.type, None)
+        Candidate(coll.fqcn, coll.ver, coll.src, coll.type, None)
         for coll in find_existing_collections(output_path, artifacts_manager)
     }
-
-    for install_req in list(collections):
-        if not install_req.is_virtual:
-            continue
-        virtual_direct_requests = set()  # type: t.Set[Requirement]
-        process_virtual_requirements(install_req, virtual_direct_requests, artifacts_manager)
-        collections.remove(install_req)
-        collections += list(virtual_direct_requests)
-
-    unsatisfied_requirements = set(collections)
-    requested_requirements_names = {req.fqcn for req in unsatisfied_requirements}
-
-    # NOTE: Don't attempt to reevaluate already installed deps
-    # NOTE: unless `--force` or `--force-with-deps` is passed
-    unsatisfied_requirements -= set() if force or force_deps else {
-        req
-        for req in unsatisfied_requirements
-        for exs in existing_collections
-        if req.fqcn == exs.fqcn and meets_requirements(exs.ver, req.ver) and not req.is_dir
-    }
-
-    if not unsatisfied_requirements and not upgrade:
-        display.display(
-            'Nothing to do. All requested collections are already '
-            'installed. If you want to reinstall them, '
-            'consider using `--force`.'
-        )
-        return
-
-    # FIXME: This probably needs to be improved to
-    # FIXME: properly match differing src/type.
-    existing_non_requested_collections = {
-        coll for coll in existing_collections
-        if coll.fqcn not in requested_requirements_names
-    }
-
-    preferred_requirements = (
-        [] if force_deps
-        else existing_non_requested_collections if force
-        else existing_collections
-    )
-    preferred_collections = {
-        # NOTE: No need to include signatures if the collection is already installed
-        Candidate(coll.fqcn, coll.ver, coll.src, coll.type, None)
-        for coll in preferred_requirements
-    }
+    preferred_collections = existing_collections if not force_deps else set()
     with _display_progress("Process install dependency map"):
         dependency_map = _resolve_depenency_map(
             collections,
@@ -754,7 +689,15 @@ def install_collections(
             upgrade=upgrade,
             include_signatures=not disable_gpg_verify,
             offline=offline,
+            force=force,
         )
+    if not dependency_map:
+        display.display(
+            'Nothing to do. All requested collections are already '
+            'installed. If you want to reinstall them, '
+            'consider using `--force`.'
+        )
+        return
 
     keyring_exists = artifacts_manager.keyring is not None
     with _display_progress("Starting collection install process"):
@@ -1808,6 +1751,7 @@ def _resolve_depenency_map(
         upgrade,  # type: bool
         include_signatures,  # type: bool
         offline,  # type: bool
+        force=False,  # type: bool
 ):  # type: (...) -> dict[str, Candidate]
     """Return the resolved dependency map."""
     if not HAS_RESOLVELIB:
@@ -1834,20 +1778,26 @@ def _resolve_depenency_map(
         elif not req.specifier.contains(RESOLVELIB_VERSION.vstring):
             raise AnsibleError(f"ansible-galaxy requires {req.name}{req.specifier}")
 
-    collection_dep_resolver = build_collection_dependency_resolver(
-        galaxy_apis=galaxy_apis,
-        concrete_artifacts_manager=concrete_artifacts_manager,
-        user_requirements=requested_requirements,
-        preferred_candidates=preferred_candidates,
-        with_deps=not no_deps,
-        with_pre_releases=allow_pre_release,
-        upgrade=upgrade,
-        include_signatures=include_signatures,
-        offline=offline,
-    )
     try:
-        return collection_dep_resolver.resolve(
-            requested_requirements,
+        collection_dep_resolver = build_collection_dependency_resolver(
+            galaxy_apis=galaxy_apis,
+            concrete_artifacts_manager=concrete_artifacts_manager,
+            user_requirements=requested_requirements,
+            preferred_candidates=preferred_candidates,
+            with_deps=not no_deps,
+            with_pre_releases=allow_pre_release,
+            upgrade=upgrade,
+            include_signatures=include_signatures,
+            offline=offline,
+            force=force,
+        )
+    except TypeError as e:
+        # malformed requirements
+        raise AnsibleError(f"{e}") from e
+
+    try:
+        dependency_mapping = collection_dep_resolver.resolve(
+            collection_dep_resolver.provider.unrolled_user_requirements,
             max_rounds=2000000,  # NOTE: same constant pip uses
         ).mapping
     except CollectionDependencyResolutionImpossible as dep_exc:
@@ -1899,3 +1849,12 @@ def _resolve_depenency_map(
         raise AnsibleError('\n'.join(error_msg_lines)) from dep_exc
     except ValueError as exc:
         raise AnsibleError(to_native(exc)) from exc
+
+    # NOTE: Return {} for a lack of unsatisfied collections.
+    # All callers pass installed collections as preferred candidates, and don't have access to the finalized preferred candidates.
+    if dependency_mapping and all(
+        candidate in collection_dep_resolver.provider._preferred_candidates
+        for candidate in dependency_mapping.values()
+    ):
+        return {}
+    return dependency_mapping

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1795,6 +1795,39 @@ def _resolve_depenency_map(
         # malformed requirements
         raise AnsibleError(f"{e}") from e
 
+    # This is arguably a bug, but this short-circuit is here for backwards compatibility...
+    # Context: when the dependency resolver runs, tarfile and url requirements are always
+    # reinstalled because only galaxy type uses the preferred candidates in _find_matches.
+    # However, the dependency resolver doesn't always run for url/tarfile types,
+    # only if a collection by that name + version isn't installed at all or if another
+    # collection is (potentially) missing.
+    # TL;DR: unrelated requirements (which may not even end up installed) cause all tarfile/url
+    # requirements to be reinstalled, whereas without this they would always be reinstalled.
+    if (
+        # Exclude all conditions which require dependency resolution
+        preferred_candidates is not None  # None for --force-with-deps/download
+        and not force
+        and not upgrade
+        and requested_requirements == collection_dep_resolver.provider.unrolled_user_requirements  # no ephemeral deps
+    ):
+        for req in collection_dep_resolver.provider.unrolled_user_requirements:
+            installed = False
+            for exs in collection_dep_resolver.provider._preferred_candidates:
+                if req.fqcn == exs.fqcn and not meets_requirements(exs.ver, req.ver):
+                    break
+                elif req.fqcn == exs.fqcn and meets_requirements(exs.ver, req.ver):
+                    installed = True
+            else:
+                if installed:
+                    continue
+            satisfied = False
+            break
+        else:
+            satisfied = True
+
+        if satisfied:
+            return {}
+
     try:
         dependency_mapping = collection_dep_resolver.resolve(
             collection_dep_resolver.provider.unrolled_user_requirements,

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -20,7 +20,9 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 if t.TYPE_CHECKING:
-    from ansible.galaxy.dependency_resolution.dataclasses import Candidate
+    from ansible.galaxy.dependency_resolution.dataclasses import (
+        Candidate, Requirement,
+    )
     from ansible.galaxy.token import GalaxyToken
 
 from ansible.errors import AnsibleError

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -20,9 +20,7 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 if t.TYPE_CHECKING:
-    from ansible.galaxy.dependency_resolution.dataclasses import (
-        Candidate, Requirement,
-    )
+    from ansible.galaxy.dependency_resolution.dataclasses import Candidate
     from ansible.galaxy.token import GalaxyToken
 
 from ansible.errors import AnsibleError

--- a/lib/ansible/galaxy/dependency_resolution/__init__.py
+++ b/lib/ansible/galaxy/dependency_resolution/__init__.py
@@ -34,6 +34,7 @@ def build_collection_dependency_resolver(
         upgrade=False,  # type: bool
         include_signatures=True,  # type: bool
         offline=False,  # type: bool
+        force=False,  # type: bool
 ):  # type: (...) -> CollectionDependencyResolver
     """Return a collection dependency resolver.
 
@@ -50,6 +51,7 @@ def build_collection_dependency_resolver(
             with_pre_releases=with_pre_releases,
             upgrade=upgrade,
             include_signatures=include_signatures,
+            force=force,
         ),
         CollectionDependencyReporter(),
     )

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -559,7 +559,7 @@ class _ComputedReqKindsMixin:
         if not self.is_scm:
             version_req = "A SemVer-compliant version or '*' is required. See https://semver.org to learn how to compose it correctly."
         else:
-            version_req = f"A string version is required."
+            version_req = "A string version is required."
 
         name = self.fqcn if self.fqcn is not None else self
         version_err = f"Invalid version found for the collection '{name}': {self.ver} ({type(self.ver)}). {version_req}"

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -430,11 +430,15 @@ class _ComputedReqKindsMixin:
         if req_type not in {'galaxy', 'subdirs'} and req_version == '*':
             req_version = art_mgr.get_direct_collection_version(tmp_inst_req)
 
-        return cls(
+        req = cls(
             req_name, req_version,
             req_source, req_type,
             req_signature_sources,
         )
+        # a version requirement might be a range of versions, but must at least be a str
+        if not isinstance(req_version, string_types):
+            req.validate_version()
+        return req
 
     def __repr__(self):
         return (

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -434,12 +434,12 @@ class CollectionDependencyProviderBase(AbstractProvider):
         # NOTE: pre-releases is when there are several user requirements
         # NOTE: and one of them is a pre-release that also matches a
         # NOTE: transitive dependency of another requirement.
-        allow_pre_release = (
-            self._with_pre_releases
-            or self._is_user_requested(candidate)
-            or (requirement.ver != '*' and is_pre_release(requirement.ver))
-        )
-
+        allow_pre_release = self._with_pre_releases or not (
+            requirement.ver == '*' or
+            requirement.ver.startswith('<') or
+            requirement.ver.startswith('>') or
+            requirement.ver.startswith('!=')
+        ) or self._is_user_requested(candidate)
         if is_pre_release(candidate.ver) and not allow_pre_release:
             return False
 

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -25,7 +25,6 @@ from ansible.galaxy.dependency_resolution.versioning import (
     is_pre_release,
     meets_requirements,
 )
-from ansible.module_utils.six import string_types
 from ansible.utils.version import SemanticVersion, LooseVersion
 
 from collections.abc import Set

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -401,7 +401,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
                 try:
                     match.assert_version()
                 except TypeError as ex:
-                    raise ValueError(version_err) from ex
+                    raise ValueError(ex) from ex
                 matches.append(match)
             return matches
 

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/test_invalid_version.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/test_invalid_version.yml
@@ -1,4 +1,26 @@
 - block:
+  - name: create requirements file (necessary test an int requirement version)
+    copy:
+      dest: "{{ galaxy_dir }}/requirement_with_int_version.yml"
+      content: |
+        collections:
+          - name: file://{{ test_repo_path }}/.git#collection_2
+            type: git
+            version: 12345
+
+  - name: test installing a virtual collection with an integer version
+    command: 'ansible-galaxy collection install -r {{ galaxy_dir }}/requirement_with_int_version.yml'
+    ignore_errors: yes
+    register: invalid_scm_version
+
+  - assert:
+      that:
+        - invalid_scm_version is failed
+        - msg in invalid_scm_version.stderr
+    vars:
+      # FIXME quotation marks
+      msg: "Invalid version found for the collection '\"virtual collection Git repo\"'. A string version is required."
+
   - name: test installing a collection with an invalid float version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#float_version_collection -vvvvvv'
     ignore_errors: yes
@@ -10,8 +32,7 @@
         - msg in invalid_version_result.stderr
     vars:
       req: error_test.float_version_collection:1.0
-      ver: "1.0 (<class 'float'>)"
-      msg: "Invalid version found for the collection '{{ req }}': {{ ver }}. A SemVer-compliant version or '*' is required."
+      msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
 
   - name: test installing a collection with an invalid non-SemVer string version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#not_semantic_version_collection -vvvvvv'
@@ -24,8 +45,7 @@
         - msg in invalid_version_result.stderr
     vars:
       req: error_test.not_semantic_version_collection:1.0
-      ver: "1.0 (<class 'str'>)"
-      msg: "Invalid version found for the collection '{{ req }}': {{ ver }}. A SemVer-compliant version or '*' is required."
+      msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
 
   - name: test installing a collection with an invalid list version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#list_version_collection -vvvvvv'
@@ -54,5 +74,10 @@
       msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
 
   always:
+  - name: remove requirements file
+    file:
+      path: "{{ galaxy_dir }}/requirement_with_int_version.yml"
+      state: absent
+
   - include_tasks: ./empty_installed_collections.yml
     when: cleanup

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/test_invalid_version.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/test_invalid_version.yml
@@ -18,8 +18,8 @@
         - invalid_scm_version is failed
         - msg in invalid_scm_version.stderr
     vars:
-      # FIXME quotation marks
-      msg: "Invalid version found for the collection '\"virtual collection Git repo\"'. A string version is required."
+      ver: "12345 (<class 'int'>)"
+      msg: "Invalid version found for the collection '\"virtual collection Git repo\"': {{ ver }}. A string version is required."
 
   - name: test installing a collection with an invalid float version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#float_version_collection -vvvvvv'
@@ -31,8 +31,9 @@
         - invalid_version_result is failed
         - msg in invalid_version_result.stderr
     vars:
-      req: error_test.float_version_collection:1.0
-      msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
+      req: error_test.float_version_collection
+      ver: "1.0 (<class 'float'>)"
+      msg: "Invalid version found for the collection '{{ req }}': {{ ver }}. A SemVer-compliant version or '*' is required."
 
   - name: test installing a collection with an invalid non-SemVer string version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#not_semantic_version_collection -vvvvvv'
@@ -44,8 +45,9 @@
         - invalid_version_result is failed
         - msg in invalid_version_result.stderr
     vars:
-      req: error_test.not_semantic_version_collection:1.0
-      msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
+      req: error_test.not_semantic_version_collection
+      ver: "1.0 (<class 'str'>)"
+      msg: "Invalid version found for the collection '{{ req }}': {{ ver }}. A SemVer-compliant version or '*' is required."
 
   - name: test installing a collection with an invalid list version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#list_version_collection -vvvvvv'
@@ -57,8 +59,9 @@
         - invalid_version_result is failed
         - msg in invalid_version_result.stderr
     vars:
-      req: "error_test.list_version_collection:['1.0.0']"
-      msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
+      req: error_test.list_version_collection
+      ver: "['1.0.0'] (<class 'list'>)"
+      msg: "Invalid version found for the collection '{{ req }}': {{ ver }}. A SemVer-compliant version or '*' is required."
 
   - name: test installing a collection with an invalid dict version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#dict_version_collection -vvvvvv'
@@ -70,8 +73,9 @@
         - invalid_version_result is failed
         - msg in invalid_version_result.stderr
     vars:
-      req: "error_test.dict_version_collection:{'broken': 'version'}"
-      msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
+      req: error_test.dict_version_collection
+      ver: "{'broken': 'version'} (<class 'dict'>)"
+      msg: "Invalid version found for the collection '{{ req }}': {{ ver }}. A SemVer-compliant version or '*' is required."
 
   always:
   - name: remove requirements file

--- a/test/integration/targets/ansible-galaxy-collection/tasks/upgrade.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/upgrade.yml
@@ -187,7 +187,9 @@
   register: result
 
 - assert:
-    that: "\"'namespace1.name1:1.1.0-beta.1' is already installed, skipping.\" in result.stdout"
+    that: msg in result.stdout
+  vars:
+    msg: "Nothing to do. All requested collections are already installed. If you want to reinstall them, consider using `--force`."
 
 # With deps
 

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -880,7 +880,7 @@ def test_collection_install_with_url(monkeypatch, collection_install):
     mock_open = MagicMock(return_value=BytesIO())
     monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
 
-    mock_metadata = MagicMock(return_value={'namespace': 'foo', 'name': 'bar', 'version': 'v1.0.0'})
+    mock_metadata = MagicMock(return_value={'namespace': 'foo', 'name': 'bar', 'version': '1.0.0'})
     monkeypatch.setattr(collection.concrete_artifact_manager, '_get_meta_from_tar', mock_metadata)
 
     galaxy_args = ['ansible-galaxy', 'collection', 'install', 'https://foo/bar/foo-bar-v1.0.0.tar.gz',
@@ -892,7 +892,7 @@ def test_collection_install_with_url(monkeypatch, collection_install):
 
     assert mock_install.call_count == 1
     requirements = [('%s.%s' % (r.namespace, r.name), r.ver, r.src, r.type,) for r in mock_install.call_args[0][0]]
-    assert requirements == [('foo.bar', 'v1.0.0', 'https://foo/bar/foo-bar-v1.0.0.tar.gz', 'url')]
+    assert requirements == [('foo.bar', '1.0.0', 'https://foo/bar/foo-bar-v1.0.0.tar.gz', 'url')]
     assert mock_install.call_args[0][1] == collection_path
     assert len(mock_install.call_args[0][2]) == 1
     assert mock_install.call_args[0][2][0].api_server == 'https://galaxy.ansible.com'

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -809,7 +809,7 @@ def test_install_installed_collection(monkeypatch, tmp_path_factory, galaxy_serv
     cli.run()
 
     expected = "Nothing to do. All requested collections are already installed. If you want to reinstall them, consider using `--force`."
-    assert mock_display.mock_calls[1][1][0] == expected
+    assert mock_display.mock_calls[-1][1][0] == expected
 
 
 def test_install_collection(collection_artifact, monkeypatch):


### PR DESCRIPTION
##### SUMMARY

Fix unhandled tracebacks in the dep resolver by enforcing string versions when loading Requirements.

Fix installing prereleases from virtual dependencies without `--pre` by adding them as direct requests before resolving dependencies.

Fixes #79109
Fixes #79168
Fixes #78067

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy
