### PR TITLE
Allow -eu and -eux for `#!/bin/sh`

### DIFF
--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/shebang.py
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/shebang.py
@@ -13,6 +13,8 @@ def main():
         b'#!/bin/bash -eu',
         b'#!/bin/bash -eux',
         b'#!/bin/sh',
+        b'#!/bin/sh -eu',
+        b'#!/bin/sh -eux',
         b'#!/usr/bin/env bash',
         b'#!/usr/bin/env fish',
         b'#!/usr/bin/env pwsh',


### PR DESCRIPTION
##### SUMMARY
Currently, if you want the `-eu` flags, you need to use `#!/bin/bash` instead of `#!/bin/sh`. I don't know any reason why not to allow `#!/bin/sh -eu` too. These flags are also described in the [spec]( https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#set):
> These options can also be specified as options to [sh](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/sh.html).

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
- sanity/code-smell/shebang