### PR TITLE
Don't assume column index for netmask and broadcast

### DIFF
--- a/changelogs/fragments/79117-bsd-ifconfig-inet-fix.yml
+++ b/changelogs/fragments/79117-bsd-ifconfig-inet-fix.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- BSD network facts - Do not assume column indexes, look for ``network`` and
+  ``broadcast`` for determining the correct columns when parsing ``inet`` line
+  (https://github.com/ansible/ansible/issues/79117)

--- a/changelogs/fragments/79117-bsd-ifconfig-inet-fix.yml
+++ b/changelogs/fragments/79117-bsd-ifconfig-inet-fix.yml
@@ -1,4 +1,4 @@
 bugfixes:
-- BSD network facts - Do not assume column indexes, look for ``network`` and
+- BSD network facts - Do not assume column indexes, look for ``netmask`` and
   ``broadcast`` for determining the correct columns when parsing ``inet`` line
   (https://github.com/ansible/ansible/issues/79117)

--- a/test/units/module_utils/facts/network/test_generic_bsd.py
+++ b/test/units/module_utils/facts/network/test_generic_bsd.py
@@ -173,3 +173,45 @@ class TestGenericBsdNetworkNetBSD(unittest.TestCase):
                               'filter': '*'}
         mock_module.get_bin_path = Mock(return_value=None)
         return mock_module
+
+    def test_ensure_correct_netmask_parsing(self):
+        n = generic_bsd.GenericBsdIfconfigNetwork(None)
+        lines = [
+            'inet 192.168.7.113 netmask 0xffffff00 broadcast 192.168.7.255',
+            'inet 10.109.188.206 --> 10.109.188.206 netmask 0xffffe000',
+        ]
+        expected = [
+            (
+                {
+                    'ipv4': [
+                        {
+                            'address': '192.168.7.113',
+                            'netmask': '255.255.255.0',
+                            'network': '192.168.7.0',
+                            'broadcast': '192.168.7.255'
+                        }
+                    ]
+                },
+                {'all_ipv4_addresses': ['192.168.7.113']},
+            ),
+            (
+                {
+                    'ipv4': [
+                        {
+                            'address': '10.109.188.206',
+                            'netmask': '255.255.224.0',
+                            'network': '10.109.160.0',
+                            'broadcast': '10.109.191.255'
+                        }
+                    ]
+                },
+                {'all_ipv4_addresses': ['10.109.188.206']},
+            ),
+        ]
+        for i, line in enumerate(lines):
+            words = line.split()
+            current_if = {'ipv4': []}
+            ips = {'all_ipv4_addresses': []}
+            n.parse_inet_line(words, current_if, ips)
+            self.assertDictEqual(current_if, expected[i][0])
+            self.assertDictEqual(ips, expected[i][1])


### PR DESCRIPTION
##### SUMMARY
Don't assume column index for netmask and broadcast. Fixes #79117
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/network/generic_bsd.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
