### PR TITLE
ansible-galaxy collection list - only error for unusable paths if collection paths are configured

### DIFF
--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -71,11 +71,13 @@ class PrependListAction(argparse.Action):
             help=help,
             metavar=metavar
         )
+        self.sentinel = True
 
     def __call__(self, parser, namespace, values, option_string=None):
         items = copy.copy(ensure_value(namespace, self.dest, []))
         items[0:0] = values
         setattr(namespace, self.dest, items)
+        self.sentinel = False
 
 
 def ensure_value(namespace, name, value):

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1678,9 +1678,11 @@ class GalaxyCLI(CLI):
             display.warning(w)
 
         if not path_found:
-            cli_option_provided = any(not arg.sentinel for arg in self.collection_parser.choices['list']._actions if arg.dest == 'collections_path')
-            if C.COLLECTIONS_PATHS or cli_option_provided:
-                raise AnsibleOptionsError("- None of the provided paths were usable. Please specify a valid path with --{0}s-path".format(context.CLIARGS['type']))
+            error_msg = "- None of the provided paths were usable. Please specify a valid path with --{0}s-path".format(context.CLIARGS['type'])
+            if C.COLLECTIONS_PATHS:
+                raise AnsibleOptionsError(error_msg)
+            elif any(not arg.sentinel for arg in self.collection_parser.choices['list']._actions if arg.dest == 'collections_path'):
+                raise AnsibleOptionsError(error_msg)
 
         if output_format == 'json':
             display.display(json.dumps(collections_in_paths))

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1265,9 +1265,6 @@ class GalaxyCLI(CLI):
 
         :param artifacts_manager: Artifacts manager.
         """
-        if context.CLIARGS['collections_path'] is None:
-            raise AnsibleOptionsError("- you must specify a valid collection path to install collections")
-
         install_items = context.CLIARGS['args']
         requirements_file = context.CLIARGS['requirements']
         collection_path = None
@@ -1286,6 +1283,8 @@ class GalaxyCLI(CLI):
         collection_requirements = []
         role_requirements = []
         if context.CLIARGS['type'] == 'collection':
+            if context.CLIARGS['collections_path'] is None:
+                raise AnsibleOptionsError("- you must specify a valid collection path to install collections")
             collection_path = GalaxyCLI._resolve_path(context.CLIARGS['collections_path'])
             requirements = self._require_one_of_collections_requirements(
                 install_items, requirements_file,
@@ -1325,6 +1324,8 @@ class GalaxyCLI(CLI):
                     display_func(two_type_warning.format('collection'))
                 else:
                     collection_path = self._get_default_collection_path()
+                    if collection_path is None:
+                        raise AnsibleOptionsError("- you must specify a valid collection path to install collections")
                     collection_requirements = requirements['collections']
             else:
                 # roles were specified directly, so we'll just go out grab them

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -122,7 +122,7 @@ def ensure_type(value, value_type, origin=None):
 
         elif value_type == 'pathspec':
             if isinstance(value, string_types):
-                value = value.split(os.pathsep)
+                value = value.split(os.pathsep) if value else ''
 
             if isinstance(value, Sequence):
                 value = [resolve_path(x, basedir=basedir) for x in value]

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -122,7 +122,7 @@ def ensure_type(value, value_type, origin=None):
 
         elif value_type == 'pathspec':
             if isinstance(value, string_types):
-                value = value.split(os.pathsep) if value else ''
+                value = value.split(os.pathsep) if value else []
 
             if isinstance(value, Sequence):
                 value = [resolve_path(x, basedir=basedir) for x in value]

--- a/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
@@ -147,7 +147,6 @@
 - name: test json is emitted when configured collection paths are empty
   command: "ansible-galaxy collection list --format json"
   register: empty_list_result
-  ignore_errors: True
   environment:
     ANSIBLE_COLLECTIONS_PATH: ""
 

--- a/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
@@ -133,7 +133,7 @@
   with_items: "{{ list_single_result_json.results }}"
 
 - name: test that no json is emitted when no collection paths are usable
-  command: "ansible-galaxy collection list --format json"
+  command: "ansible-galaxy collection list --format json -p ./bad_path"
   register: list_result_error
   ignore_errors: True
   environment:
@@ -142,6 +142,18 @@
 - assert:
     that:
       - "'{}' not in list_result_error.stdout"
+      - list_result_error.stderr.search("None of the provided paths were usable.")
+
+- name: test json is emitted when configured collection paths are empty
+  command: "ansible-galaxy collection list --format json"
+  register: empty_list_result
+  ignore_errors: True
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: ""
+
+- assert:
+    that:
+      - "'{}' in empty_list_result.stdout"
 
 - name: install an artifact to the second collections path
   command: ansible-galaxy collection install namespace1.name1 -s galaxy_ng {{ galaxy_verbosity }} -p "{{ galaxy_dir }}/prod"

--- a/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
@@ -142,7 +142,7 @@
 - assert:
     that:
       - "'{}' not in list_result_error.stdout"
-      - list_result_error.stderr.search("None of the provided paths were usable.")
+      - list_result_error.stderr is search("None of the provided paths were usable.")
 
 - name: test json is emitted when configured collection paths are empty
   command: "ansible-galaxy collection list --format json"


### PR DESCRIPTION
##### SUMMARY
Fixes #73127

This allows configuring collection search paths to an empty list, which wasn't possible with pathspec types previously. If the configured collection paths is empty `ansible-galaxy collection list` won't error because no usable search paths were found.

There's an issue with my logic for determining -p - if it is the same as one of the python sys paths that are automatically picked up and it (and any COLLECTIONS_PATHS) are not usable, this won't error like it should. Not sure how to fix that without setting a sentinel default and creating the real value later... marked as a draft while I try to fix that.

I also changed determining usable paths to include the `ansible_collections` directory for consistency. `-p collections/ansible_collections/` and `-p collections/` search the same path, but won't have the same behavior if the external directory exists and `ansible_collections` does not.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy collection list

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
