### PR TITLE
Fix yum exclude example to align to parameter doc

### DIFF
--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -353,7 +353,9 @@ EXAMPLES = '''
   ansible.builtin.yum:
     name: '*'
     state: latest
-    exclude: kernel*,foo*
+    exclude:
+      - kernel*
+      - foo*
 
 - name: Install the nginx rpm from a remote repo
   ansible.builtin.yum:


### PR DESCRIPTION
##### SUMMARY
See question https://stackoverflow.com/questions/74052545/ansible-yum-module-exclude-parameter-not-working-properly

The user tried to exclude with:
```yaml
exclude: nginx,docker
```
which is obviously not working from his description. Unfortunately, this is written as such in the existing examples whereas the expected data is a list according to the parameter description (L44 of this same file).
```yaml
exclude:
  - nginx
  - docker
```
This PR fixes the corresponding existing exclude example accordingly

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
