### PR TITLE
fix incorrect ansible_managed formatting

### DIFF
--- a/changelogs/fragments/79129-ansible-managed-filename-format.yaml
+++ b/changelogs/fragments/79129-ansible-managed-filename-format.yaml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - template - Fix for formatting issues when a template path contains
+    valid jinja/strftime pattern (especially line break one) and
+    using the template path in ansible_managed
+    (https://github.com/ansible/ansible/pull/79129)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -55,7 +55,7 @@ from ansible.template.vars import AnsibleJ2Vars
 from ansible.utils.display import Display
 from ansible.utils.listify import listify_lookup_plugin_terms
 from ansible.utils.native_jinja import NativeJinjaText
-from ansible.utils.unsafe_proxy import wrap_var
+from ansible.utils.unsafe_proxy import to_unsafe_text, wrap_var
 
 display = Display()
 
@@ -103,9 +103,9 @@ def generate_ansible_template_vars(path, fullpath=None, dest_path=None):
     managed_str = managed_default.format(
         host=temp_vars['template_host'],
         uid=temp_vars['template_uid'],
-        file=temp_vars['template_path'],
+        file=temp_vars['template_path'].replace('%', '%%'),
     )
-    temp_vars['ansible_managed'] = to_text(time.strftime(to_native(managed_str), time.localtime(os.path.getmtime(b_path))))
+    temp_vars['ansible_managed'] = to_unsafe_text(time.strftime(to_native(managed_str), time.localtime(os.path.getmtime(b_path))))
 
     return temp_vars
 

--- a/test/integration/targets/template/ansible_managed_79129.yml
+++ b/test/integration/targets/template/ansible_managed_79129.yml
@@ -1,0 +1,29 @@
+---
+- hosts: testhost
+  gather_facts: false
+  tasks:
+    - set_fact:
+        output_dir: "{{ lookup('env', 'OUTPUT_DIR') }}"
+
+    - name: check strftime
+      block:
+        - template:
+            src: "templates/%necho Onii-chan help Im stuck;exit 1%n.j2"
+            dest: "{{ output_dir }}/79129-strftime.sh"
+            mode: '0755'
+
+        - shell: "exec {{ output_dir | quote }}/79129-strftime.sh"
+
+    - name: check jinja template
+      block:
+        - template:
+            src: !unsafe "templates/completely{{ 1 % 0 }} safe template.j2"
+            dest: "{{ output_dir }}/79129-jinja.sh"
+            mode: '0755'
+
+        - shell: "exec {{ output_dir | quote }}/79129-jinja.sh"
+          register: result
+
+        - assert:
+            that:
+              - "'Hello' in result.stdout"

--- a/test/integration/targets/template/runme.sh
+++ b/test/integration/targets/template/runme.sh
@@ -8,7 +8,10 @@ ANSIBLE_ROLES_PATH=../ ansible-playbook template.yml -i ../../inventory -v "$@"
 ansible testhost -i testhost, -m debug -a 'msg={{ hostvars["localhost"] }}' -e "vars1={{ undef() }}" -e "vars2={{ vars1 }}"
 
 # Test for https://github.com/ansible/ansible/issues/27262
-ansible-playbook ansible_managed.yml -c  ansible_managed.cfg -i ../../inventory -v "$@"
+ANSIBLE_CONFIG=ansible_managed.cfg ansible-playbook ansible_managed.yml -i ../../inventory -v "$@"
+
+# Test for https://github.com/ansible/ansible/pull/79129
+ANSIBLE_CONFIG=ansible_managed.cfg ansible-playbook ansible_managed_79129.yml -i ../../inventory -v "$@"
 
 # Test for #42585
 ANSIBLE_ROLES_PATH=../ ansible-playbook custom_template.yml -i ../../inventory -v "$@"

--- a/test/integration/targets/template/templates/%necho Onii-chan help Im stuck;exit 1%n.j2
+++ b/test/integration/targets/template/templates/%necho Onii-chan help Im stuck;exit 1%n.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+echo 79129 test passed
+exit 0

--- a/test/integration/targets/template/templates/completely{{ 1 % 0 }} safe template.j2
+++ b/test/integration/targets/template/templates/completely{{ 1 % 0 }} safe template.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+echo Hello
+exit 0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Ansible breaks configs if file name contains `%` chars.
Especially `%n`_`[ame%]`_ which is a line break pattern according to [strftime (3)](https://manpages.debian.org/bullseye/manpages-dev/strftime.3.en.html)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`generate_ansible_template_vars()`

##### ADDITIONAL INFO
default value for `ansible_managed` is
```cfg
ansible_managed = Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}
```

if you put `{{ansible_managed}}` in jinja template and save in file named like `/etc/whatever/%name%.conf` it will split string to multiple lines and possibly break syntax

Simple test case:
```
>>> a = 'haha %name% haha %Y-%m-%d'
>>> time.strftime(a)
'haha \name% haha 2022-10-13'
```