### PR TITLE
ansible-galaxy collection|role init - fix preserving symlinks

### DIFF
--- a/changelogs/fragments/79134-ansible-galaxy-init-symlinks.yml
+++ b/changelogs/fragments/79134-ansible-galaxy-init-symlinks.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy collection/role init - preserve symlinks (https://github.com/ansible/ansible/issues/39334).

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1162,11 +1162,16 @@ class GalaxyCLI(CLI):
                         df.write(b_rendered)
                 else:
                     f_rel_path = os.path.relpath(os.path.join(root, f), obj_skeleton)
-                    shutil.copyfile(os.path.join(root, f), os.path.join(obj_path, f_rel_path))
+                    shutil.copyfile(os.path.join(root, f), os.path.join(obj_path, f_rel_path), follow_symlinks=False)
 
             for d in dirs:
                 b_dir_path = to_bytes(os.path.join(obj_path, rel_root, d), errors='surrogate_or_strict')
-                if not os.path.exists(b_dir_path):
+                if os.path.exists(b_dir_path):
+                    continue
+                b_src_dir = to_bytes(os.path.join(root, d), errors='surrogate_or_strict')
+                if os.path.islink(b_src_dir):
+                    shutil.copyfile(b_src_dir, b_dir_path, follow_symlinks=False)
+                else:
                     os.makedirs(b_dir_path)
 
         display.display("- %s %s was created successfully" % (galaxy_type.title(), obj_name))

--- a/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
@@ -92,6 +92,65 @@
     - (init_custom_path_actual.files | map(attribute='path') | list)[2] | basename in ['docs', 'plugins', 'roles', 'meta']
     - (init_custom_path_actual.files | map(attribute='path') | list)[3] | basename in ['docs', 'plugins', 'roles', 'meta']
 
+- name: test using a custom skeleton for collection init
+  block:
+    - name: create skeleton directories
+      file:
+        path: "{{ galaxy_dir }}/scratch/skeleton/{{ item }}"
+        state: directory
+      loop:
+        - custom_skeleton
+        - custom_skeleton/plugins
+        - inventory
+
+    - name: create files
+      file:
+        path: "{{ galaxy_dir }}/scratch/skeleton/{{ item }}"
+        state: touch
+      loop:
+        - inventory/foo.py
+        - galaxy.yml
+
+    - name: create symlinks
+      file:
+        path: "{{ galaxy_dir }}/scratch/skeleton/{{ item.link }}"
+        src: "{{ galaxy_dir }}/scratch/skeleton/{{ item.source }}"
+        state: link
+      loop:
+        - link: custom_skeleton/plugins/inventory
+          source: inventory
+        - link: custom_skeleton/galaxy.yml
+          source: galaxy.yml
+
+    - name: initialize a collection using the skeleton
+      command: ansible-galaxy collection init ansible_test.my_collection {{ init_path }} {{ skeleton }}
+      vars:
+        init_path: '--init-path {{ galaxy_dir }}/scratch/skeleton'
+        skeleton: '--collection-skeleton {{ galaxy_dir }}/scratch/skeleton/custom_skeleton'
+
+    - name: stat expected collection contents
+      stat:
+        path: "{{ galaxy_dir }}/scratch/skeleton/ansible_test/my_collection/{{ item }}"
+      register: stat_result
+      loop:
+        - plugins
+        - plugins/inventory
+        - galaxy.yml
+        - plugins/inventory/foo.py
+
+    - assert:
+        that:
+          - stat_result.results[0].stat.isdir
+          - stat_result.results[1].stat.islnk
+          - stat_result.results[2].stat.islnk
+          - stat_result.results[3].stat.isreg
+
+  always:
+    - name: cleanup
+      file:
+        path: "{{ galaxy_dir }}/scratch/skeleton"
+        state: absent
+
 - name: create collection for ignored files and folders
   command: ansible-galaxy collection init ansible_test.ignore
   args:


### PR DESCRIPTION
##### SUMMARY
Fix using `ansible-galaxy collection|role init` with a custom skeleton that contains symlinks.

Fixes #39334

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy collection|role init
