### PR TITLE
[stable-2.14] contributor_path: add doc link (#79138)

### DIFF
--- a/docs/docsite/rst/community/contributor_path.rst
+++ b/docs/docsite/rst/community/contributor_path.rst
@@ -57,7 +57,9 @@ Each Ansible project has its own set of contributor guidelines. Familarize yours
 Making your first contribution
 ==============================
 
-You can find some ideas on how you can contribute in :ref:`how_can_i_help` and the `collection repository <https://github.com/ansible-collections/>`_  ``README`` and ``CONTRIBUTING`` files. To make your first experience as smooth as possible, read the repository documentation carefully, then ask the repository maintainers for guidance if you have any questions.
+You can find some ideas on how you can contribute in :ref:`how_can_i_help`.
+
+If you are interested in contributing to collections, take a look at :ref:`collection contributions<collections_contributions>` and the `collection repository <https://github.com/ansible-collections/>`_'s  ``README`` and ``CONTRIBUTING`` files. To make your first experience as smooth as possible, read the repository documentation carefully, then ask the repository maintainers for guidance if you have any questions.
 
 You can also look for GitHub issues labeled with the ``easyfix``, ``good_first_issue``, and ``docs`` labels.  Add a comment on the GitHub issue to say you are looking at it and to ask for help if you need it.
 


### PR DESCRIPTION
(cherry picked from commit 808f5a0c038ec276f0945013e7ee1f0b2c2b4fbf)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/79138

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/community/contributor_path.rst