### PR TITLE
ansible-test - cloud/scaleway - Add support for project ID in config

### DIFF
--- a/changelogs/fragments/79141-ansible-test-cloud-scaleway-config.yml
+++ b/changelogs/fragments/79141-ansible-test-cloud-scaleway-config.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - cloud/scaleway - Add support for project ID in config

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/scaleway.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/scaleway.py
@@ -41,13 +41,15 @@ class ScalewayCloudEnvironment(CloudEnvironment):
 
         env_vars = dict(
             SCW_API_KEY=parser.get('default', 'key'),
-            SCW_ORG=parser.get('default', 'org')
+            SCW_ORG=parser.get('default', 'org'),
+            SCW_PROJECT=parser.get('default', 'project')
         )
 
         display.sensitive.add(env_vars['SCW_API_KEY'])
 
         ansible_vars = dict(
             scw_org=parser.get('default', 'org'),
+            scw_project=parser.get('default', 'project'),
         )
 
         return CloudEnvironmentConfig(

--- a/test/lib/ansible_test/config/cloud-config-scaleway.ini.template
+++ b/test/lib/ansible_test/config/cloud-config-scaleway.ini.template
@@ -11,3 +11,4 @@
 [default]
 key = @KEY
 org = @ORG
+project = @PROJECT


### PR DESCRIPTION
##### SUMMARY

Add support for `project` in `ansible-test` Scaleway cloud config.
This can be used in future Scaleway modules integration tests stored `community.general` collection

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

- `ansible-test`
- `cloud/scaleway`

##### ADDITIONAL INFORMATION

Scaleway developers documentation specifying the `project_id` requirements : https://developers.scaleway.com/en/

required for : https://github.com/ansible-collections/community.general/pull/5359
