### PR TITLE
2.14: jinja2_native: preserve quotes in strings (#79119)

### DIFF
--- a/changelogs/fragments/79083-jinja2_native-preserve-quotes-in-strings.yml
+++ b/changelogs/fragments/79083-jinja2_native-preserve-quotes-in-strings.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "jinja2_native: preserve quotes in strings (https://github.com/ansible/ansible/issues/79083)"

--- a/lib/ansible/template/native_helpers.py
+++ b/lib/ansible/template/native_helpers.py
@@ -128,7 +128,7 @@ def ansible_native_concat(nodes):
         out = ''.join([to_text(v) for v in nodes])
 
     try:
-        return ast.literal_eval(
+        evaled = ast.literal_eval(
             # In Python 3.10+ ast.literal_eval removes leading spaces/tabs
             # from the given string. For backwards compatibility we need to
             # parse the string ourselves without removing leading spaces/tabs.
@@ -136,3 +136,9 @@ def ansible_native_concat(nodes):
         )
     except (ValueError, SyntaxError, MemoryError):
         return out
+
+    if isinstance(evaled, string_types):
+        quote = out[0]
+        return f'{quote}{evaled}{quote}'
+
+    return evaled

--- a/test/integration/targets/jinja2_native_types/runme.sh
+++ b/test/integration/targets/jinja2_native_types/runme.sh
@@ -7,4 +7,5 @@ ansible-playbook runtests.yml -v "$@"
 ansible-playbook --vault-password-file test_vault_pass test_vault.yml -v "$@"
 ansible-playbook test_hostvars.yml -v "$@"
 ansible-playbook nested_undefined.yml -v "$@"
+ansible-playbook test_preserving_quotes.yml -v "$@"
 unset ANSIBLE_JINJA2_NATIVE

--- a/test/integration/targets/jinja2_native_types/test_casting.yml
+++ b/test/integration/targets/jinja2_native_types/test_casting.yml
@@ -13,7 +13,7 @@
 
 - assert:
     that:
-        - 'int_to_str == "2"'
+        - int_to_str == "'2'"
         - 'int_to_str|type_debug in ["str", "unicode"]'
         - 'int_to_str2 == "2"'
         - 'int_to_str2|type_debug in ["NativeJinjaText"]'

--- a/test/integration/targets/jinja2_native_types/test_concatentation.yml
+++ b/test/integration/targets/jinja2_native_types/test_concatentation.yml
@@ -22,7 +22,7 @@
 
 - assert:
     that:
-        - 'string_sum == "12"'
+        - string_sum == "'12'"
         - 'string_sum|type_debug in ["str", "unicode"]'
 
 - name: add two lists

--- a/test/integration/targets/jinja2_native_types/test_preserving_quotes.yml
+++ b/test/integration/targets/jinja2_native_types/test_preserving_quotes.yml
@@ -1,0 +1,14 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - assert:
+        that:
+          - quoted_str == '"hello"'
+          - empty_quoted_str == '""'
+      vars:
+        third_nested_lvl: '"hello"'
+        second_nested_lvl: "{{ third_nested_lvl }}"
+        first_nested_lvl: "{{ second_nested_lvl }}"
+        quoted_str: "{{ first_nested_lvl }}"
+        empty_quoted_str: '""'
+        empty_str: "{{ empty_quoted_str}}"

--- a/test/integration/targets/jinja2_native_types/test_preserving_quotes.yml
+++ b/test/integration/targets/jinja2_native_types/test_preserving_quotes.yml
@@ -10,5 +10,5 @@
         second_nested_lvl: "{{ third_nested_lvl }}"
         first_nested_lvl: "{{ second_nested_lvl }}"
         quoted_str: "{{ first_nested_lvl }}"
-        empty_quoted_str: '""'
-        empty_str: "{{ empty_quoted_str}}"
+        empty_quoted_str: "{{ empty_str }}"
+        empty_str: '""'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of https://github.com/ansible/ansible/pull/79119 and https://github.com/ansible/ansible/pull/79131

(cherry picked from commit https://github.com/ansible/ansible/commit/d34b5786858f699ef36da6785464021889eaa672)
(cherry picked from commit https://github.com/ansible/ansible/commit/3a6eca6670de77dd7d9f2713e5e1289b4a005683)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/template/native_helpers.py`