### PR TITLE
ansible-galaxy - fix delayed role api check

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -33,6 +33,7 @@ from shutil import rmtree
 
 from ansible import context
 from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.user_agent import user_agent
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.common.yaml import yaml_dump, yaml_load
@@ -105,9 +106,7 @@ class GalaxyRole(object):
 
     @property
     def api(self):
-        # prevent recursive imports
-        from ansible.cli.galaxy import RoleDistributionServer
-        if isinstance(self._api, RoleDistributionServer):
+        if not isinstance(self._api, GalaxyAPI):
             return self._api.api
         return self._api
 

--- a/test/integration/targets/ansible-galaxy-role/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/main.yml
@@ -1,3 +1,6 @@
+- name: Install role from Galaxy (should not fail with AttributeError)
+  command: ansible-galaxy role install ansible.nope -vvvv --ignore-errors
+
 - name: Archive directories
   file:
     state: directory


### PR DESCRIPTION
##### SUMMARY
Use GalaxyAPI for isinstance check instead of RoleDistributionServer, since the latter is (usually) defined in `__main__` and importing from ansible.cli.galaxy won't reference the same object.

Fixes https://github.com/ansible/ansible/pull/79090#issuecomment-1279835982

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy role