### PR TITLE
Added the emphasize changelog

### DIFF
--- a/docs/docsite/rst/community/collection_development_process.rst
+++ b/docs/docsite/rst/community/collection_development_process.rst
@@ -43,7 +43,7 @@ We do not merge every PR. See :ref:`collection_quickstart` for  tips to make you
 
 .. _collection_changelog_fragments:
 
-Creating changelog fragments 
+Creating changelog fragments
 -----------------------------
 
 Most changelogs should emphasize the impact of the change on the end user of the feature or collection, unless the change impacts developers directly. Consider what the user needs to know about this change and write the changelog to convey that detail.

--- a/docs/docsite/rst/community/collection_development_process.rst
+++ b/docs/docsite/rst/community/collection_development_process.rst
@@ -43,8 +43,10 @@ We do not merge every PR. See :ref:`collection_quickstart` for  tips to make you
 
 .. _collection_changelog_fragments:
 
-Creating changelog fragments
+Creating changelog fragments 
 -----------------------------
+
+Most changelogs should emphasize the impact of the change on the end user of the feature or collection, unless the change impacts developers directly. Consider what the user needs to know about this change and write the changelog to convey that detail.
 
 Changelogs help users and developers keep up with changes to Ansible collections. Many collections build changelogs for each release from fragments. For collections that use this model, you **must** add a changelog fragment to any PR that changes functionality or fixes a bug.
 


### PR DESCRIPTION
This is a proposed change to the changelog fragment. Emphasize changelogs should be written for users most of the time #77988

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
