### PR TITLE
[78461] Deprecation: warn_change: add param to module.deprecate to inform of a change instead of removal.

### DIFF
--- a/changelogs/fragments/79181-add-deprecate-warn-change.yml
+++ b/changelogs/fragments/79181-add-deprecate-warn-change.yml
@@ -1,4 +1,4 @@
 minor_changes:
 - deprecate - add ``warn_change`` parameter to warn users about deprecations 
-  that don't remove features. New wording `This feature will change in 
-  test.test in version 1.0.0.`
+  that don't remove features. New wording ``This feature will change in 
+  test.test in version 1.0.0.`` (https://github.com/ansible/ansible/pull/79181).

--- a/changelogs/fragments/79181-add-deprecate-warn-change.yml
+++ b/changelogs/fragments/79181-add-deprecate-warn-change.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- deprecate - add ``warn_change`` parameter to warn users about deprecations 
+  that don't remove features. New wording `This feature will change in 
+  test.test in version 1.0.0.`

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -577,10 +577,10 @@ class AnsibleModule(object):
         warn(warning)
         self.log('[WARNING] %s' % warning)
 
-    def deprecate(self, msg, version=None, date=None, collection_name=None):
+    def deprecate(self, msg, version=None, date=None, collection_name=None, warn_change=False):
         if version is not None and date is not None:
             raise AssertionError("implementation error -- version and date must not both be set")
-        deprecate(msg, version=version, date=date, collection_name=collection_name)
+        deprecate(msg, version=version, date=date, collection_name=collection_name, warn_change=warn_change)
         # For compatibility, we accept that neither version nor date is set,
         # and treat that the same as if version would haven been set
         if date is not None:

--- a/lib/ansible/module_utils/common/warnings.py
+++ b/lib/ansible/module_utils/common/warnings.py
@@ -18,14 +18,19 @@ def warn(warning):
         raise TypeError("warn requires a string not a %s" % type(warning))
 
 
-def deprecate(msg, version=None, date=None, collection_name=None):
+def deprecate(msg, version=None, date=None, collection_name=None, warn_change=False):
     if isinstance(msg, string_types):
         # For compatibility, we accept that neither version nor date is set,
         # and treat that the same as if version would haven been set
         if date is not None:
-            _global_deprecations.append({'msg': msg, 'date': date, 'collection_name': collection_name})
+            deprecation = {'msg': msg, 'date': date, 'collection_name': collection_name}
         else:
-            _global_deprecations.append({'msg': msg, 'version': version, 'collection_name': collection_name})
+            deprecation = {'msg': msg, 'version': version, 'collection_name': collection_name}
+
+        if warn_change:
+            deprecation['warn_change'] = True
+
+        _global_deprecations.append(deprecation)
     else:
         raise TypeError("deprecate requires a string not a %s" % type(msg))
 

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -320,7 +320,7 @@ class Display(metaclass=Singleton):
             else:
                 self.display("<%s> %s" % (host, msg), color=C.COLOR_VERBOSE, stderr=to_stderr)
 
-    def get_deprecation_message(self, msg, version=None, removed=False, date=None, collection_name=None,  warn_change=False):
+    def get_deprecation_message(self, msg, version=None, removed=False, date=None, collection_name=None, warn_change=False):
         ''' used to print out a deprecation message.'''
         msg = msg.strip()
         if msg and msg[-1] not in ['!', '?', '.']:

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -368,7 +368,7 @@ class Display(metaclass=Singleton):
         if not removed and not C.DEPRECATION_WARNINGS:
             return
 
-        message_text = self.get_deprecation_message(msg, version=version, removed=removed, warn_change=warn_change, date=date, collection_name=collection_name)
+        message_text = self.get_deprecation_message(msg, version=version, removed=removed, date=date, collection_name=collection_name, warn_change=warn_change)
 
         if removed:
             raise AnsibleError(message_text)

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -364,7 +364,7 @@ class Display(metaclass=Singleton):
 
         return message_text
 
-    def deprecated(self, msg, version=None, removed=False, warn_change=False, date=None, collection_name=None):
+    def deprecated(self, msg, version=None, removed=False, date=None, collection_name=None, warn_change=False):
         if not removed and not C.DEPRECATION_WARNINGS:
             return
 

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -320,7 +320,7 @@ class Display(metaclass=Singleton):
             else:
                 self.display("<%s> %s" % (host, msg), color=C.COLOR_VERBOSE, stderr=to_stderr)
 
-    def get_deprecation_message(self, msg, version=None, removed=False, warn_change=False, date=None, collection_name=None):
+    def get_deprecation_message(self, msg, version=None, removed=False, date=None, collection_name=None,  warn_change=False):
         ''' used to print out a deprecation message.'''
         msg = msg.strip()
         if msg and msg[-1] not in ['!', '?', '.']:

--- a/test/units/module_utils/common/warnings/test_deprecate.py
+++ b/test/units/module_utils/common/warnings/test_deprecate.py
@@ -99,3 +99,9 @@ def test_get_deprecation_messages(deprecation_messages, reset):
 def test_deprecate_failure(test_case):
     with pytest.raises(TypeError, match='deprecate requires a string not a %s' % type(test_case)):
         deprecate(test_case)
+
+
+def test_deprecate_warn_changes():
+    deprecate(msg='Feature will change.', version='1.0.0', collection_name='test.test', warn_change=True)
+    assert warnings._global_deprecations == [
+        {'msg': 'Feature will change.', 'version': '1.0.0', 'collection_name': 'test.test', 'warn_change': True}]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #78461.
This PR adds a new param (`warn_change`) to `AnsibleModule.deprecate` to inform the user that a feature is going to change, but no necessarily to be removed.

Before this PR, the deprecation message looked like this.
`This feature will be removed from test.test in version 1.0.0.`

Now, if the method `deprecate` is invoked with `warn_change=True`, the message reads:
`This feature will change in test.test in version 1.0.0.`
The developer is expected to provide context in the deprecation message beforehand.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Basic

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Test module
library/my_test.py
```
#!/usr/bin/python
from __future__ import (absolute_import, division, print_function)
__metaclass__ = type
from ansible.module_utils.basic import AnsibleModule


def run_module():
    module_args = dict(warn_changes=dict(type='bool', default=None))
    result = dict(changed=False)
    module = AnsibleModule(argument_spec=module_args)

    if module.params['warn_changes'] is None:
        module.deprecate(
            'Test feature will change in 1.0.0',
            version='1.0.0', collection_name='test.test', warn_change=True)

    module.exit_json(**result)


def main():
    run_module()


if __name__ == '__main__':
    main()

```


invoked with:
```
ANSIBLE_LIBRARY=./library ./ansible/lib/ansible/cli/adhoc.py -m my_test localhost
```

Output:
```
[DEPRECATION WARNING]: Test feature will change in 1.0.0. This feature will 
change in test.test in version 1.0.0. Deprecation warnings can be disabled by 
setting deprecation_warnings=False in ansible.cfg.
localhost | SUCCESS => {
    "changed": false
}

```

See original issue for further discussion.
