### PR TITLE
sanity tests - ignore pre-release versions for deprecation comparisons

### DIFF
--- a/changelogs/fragments/20221021-deprecated-sanity.yml
+++ b/changelogs/fragments/20221021-deprecated-sanity.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- sanity tests - updates the collection-deprecated-version tests to ignore the ``prerelease`` component of the collection version ().

--- a/test/integration/targets/ansible-test-sanity-pylint/aliases
+++ b/test/integration/targets/ansible-test-sanity-pylint/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group3  # runs in the distro test containers
+shippable/generic/group1  # runs in the default test container
+context/controller
+needs/target/collection

--- a/test/integration/targets/ansible-test-sanity-pylint/ansible_collections/ns/col/galaxy.yml
+++ b/test/integration/targets/ansible-test-sanity-pylint/ansible_collections/ns/col/galaxy.yml
@@ -1,0 +1,6 @@
+namespace: ns
+name: col
+version:
+readme: README.rst
+authors:
+    - Ansible

--- a/test/integration/targets/ansible-test-sanity-pylint/ansible_collections/ns/col/plugins/lookup/deprecated.py
+++ b/test/integration/targets/ansible-test-sanity-pylint/ansible_collections/ns/col/plugins/lookup/deprecated.py
@@ -1,0 +1,23 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+name: deprecated
+short_description: lookup
+description: Lookup.
+author:
+  - Ansible Core Team
+'''
+
+EXAMPLES = '''#'''
+RETURN = '''#'''
+
+from ansible.plugins.lookup import LookupBase
+from ansible.utils.display import Display
+
+
+class LookupModule(LookupBase):
+    def run(self, **kwargs):
+        return []

--- a/test/integration/targets/ansible-test-sanity-pylint/ansible_collections/ns/col/plugins/lookup/deprecated.py
+++ b/test/integration/targets/ansible-test-sanity-pylint/ansible_collections/ns/col/plugins/lookup/deprecated.py
@@ -15,7 +15,6 @@ EXAMPLES = '''#'''
 RETURN = '''#'''
 
 from ansible.plugins.lookup import LookupBase
-from ansible.utils.display import Display
 
 
 class LookupModule(LookupBase):

--- a/test/integration/targets/ansible-test-sanity-pylint/expected.txt
+++ b/test/integration/targets/ansible-test-sanity-pylint/expected.txt
@@ -1,0 +1,1 @@
+plugins/lookup/deprecated.py:26:0: collection-deprecated-version: Deprecated version ('2.0.0') found in call to Display.deprecated or AnsibleModule.deprecate

--- a/test/integration/targets/ansible-test-sanity-pylint/expected.txt
+++ b/test/integration/targets/ansible-test-sanity-pylint/expected.txt
@@ -1,1 +1,1 @@
-plugins/lookup/deprecated.py:26:0: collection-deprecated-version: Deprecated version ('2.0.0') found in call to Display.deprecated or AnsibleModule.deprecate
+plugins/lookup/deprecated.py:27:0: collection-deprecated-version: Deprecated version ('2.0.0') found in call to Display.deprecated or AnsibleModule.deprecate

--- a/test/integration/targets/ansible-test-sanity-pylint/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-pylint/runme.sh
@@ -8,6 +8,8 @@ source ../collection/setup.sh
 # This avoids the need to create ignore entries for the tests.
 
 echo "
+from ansible.utils.display import Display
+
 display = Display()
 display.deprecated('', version='2.0.0', collection_name='ns.col')" >> plugins/lookup/deprecated.py
 

--- a/test/integration/targets/ansible-test-sanity-pylint/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-pylint/runme.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu
+
+source ../collection/setup.sh
+
+# Create test scenarios at runtime that do not pass sanity tests.
+# This avoids the need to create ignore entries for the tests.
+
+echo "
+display = Display()
+display.deprecated('', version='2.0.0', collection_name='ns.col')" >> plugins/lookup/deprecated.py
+
+# Verify deprecation checking works for normal releases and pre-releases.
+
+for version in 2.0.0 2.0.0-dev0; do
+  echo "Checking version: ${version}"
+  sed "s/^version:.*\$/version: ${version}/" < galaxy.yml > galaxy.yml.tmp
+  mv galaxy.yml.tmp galaxy.yml
+  ansible-test sanity --test pylint --color --failure-ok --lint "${@}" 1> actual-stdout.txt 2> actual-stderr.txt
+  diff -u "${TEST_DIR}/expected.txt" actual-stdout.txt
+  grep -f "${TEST_DIR}/expected.txt" actual-stderr.txt
+done

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py
@@ -202,7 +202,12 @@ class AnsibleDeprecatedChecker(BaseChecker):
     @property
     def collection_version(self) -> t.Optional[SemanticVersion]:
         """Return the collection version, or None if ansible-core is being tested."""
-        return SemanticVersion(self.config.collection_version) if self.config.collection_version is not None else None
+        if self.config.collection_version is None:
+            return None
+        sem_ver = SemanticVersion(self.config.collection_version)
+        # Ignore pre-release for version comparison to catch issues before the final release is cut.
+        sem_ver.prerelease = ()
+        return sem_ver
 
     @check_messages(*(MSGS.keys()))
     def visit_call(self, node):


### PR DESCRIPTION
##### SUMMARY

When running the `collection-deprecated-version` tests it's preferable for the sanity tests to fail before we try to cut the final release.  So ignore the "pre-release" information for the purposes of this specific test.

##### ISSUE TYPE

- Test Pull Request

##### COMPONENT NAME

test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py

##### ADDITIONAL INFORMATION

This means that for example a deprecation slated for `6.0.0` will trigger a sanity test failure once galaxy.yml has been updated to something like `6.0.0-rc1` or `6.0.0-dev0`.  Rather than at the very last moment during the release process.