### PR TITLE
[stable-2.14] Restrict `wheel` below v0.38.0 under Pythons < 3.7

### DIFF
--- a/changelogs/fragments/79187--wheel-0.38.0.yml
+++ b/changelogs/fragments/79187--wheel-0.38.0.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test - Add ``wheel < 0.38.0`` constraint for Python 3.6 and earlier.

--- a/test/integration/targets/pip/meta/main.yml
+++ b/test/integration/targets/pip/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
   - setup_remote_tmp_dir
+  - setup_remote_constraints

--- a/test/integration/targets/pip/tasks/main.yml
+++ b/test/integration/targets/pip/tasks/main.yml
@@ -37,6 +37,7 @@
     - name: ensure wheel is installed
       pip:
         name: wheel
+        extra_args: "-c {{ remote_constraints }}"
 
     - include_tasks: pip.yml
   always:

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -14,3 +14,4 @@ mock >= 2.0.0 # needed for features backported from Python 3.6 unittest.mock (as
 pytest-mock >= 1.4.0 # needed for mock_use_standalone_module pytest option
 setuptools < 45 ; python_version == '2.7' # setuptools 45 and later require python 3.5 or later
 pyspnego >= 0.1.6 ; python_version >= '3.10' # bug in older releases breaks on Python 3.10
+wheel < 0.38.0 ; python_version < '3.7' # wheel 0.38.0 and later require python 3.7 or later


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/79187

* Restrict `wheel` below v0.38.0 under Pythons < 3.7

* Add a change note for PR #79187

* Update changelogs/fragments/79187--wheel-0.38.0.yml

Co-authored-by: Matt Clay <matt@mystile.com>

* Use constraints file when installing wheel.

Co-authored-by: Matt Clay <matt@mystile.com>

(cherry picked from commit a76bbb18a5a80cda0d9683677aa8d5cd8a2e6093)

Co-authored-by: Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
