### PR TITLE
[stable-2.12] Restrict `wheel` below v0.38.0 under Pythons < 3.7

### DIFF
--- a/changelogs/fragments/79187--wheel-0.38.0.yml
+++ b/changelogs/fragments/79187--wheel-0.38.0.yml
@@ -1,0 +1,2 @@
+bugfixes:
+    - ansible-test - Add ``wheel < 0.38.0`` constraint for Python 3.6 and earlier.

--- a/test/integration/targets/pip/meta/main.yml
+++ b/test/integration/targets/pip/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
   - prepare_tests
+  - setup_remote_constraints

--- a/test/integration/targets/pip/tasks/main.yml
+++ b/test/integration/targets/pip/tasks/main.yml
@@ -37,6 +37,7 @@
     - name: ensure wheel is installed
       pip:
         name: wheel
+        extra_args: "-c {{ remote_constraints }}"
 
     - include_tasks: pip.yml
   always:

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -6,6 +6,7 @@ jinja2 < 2.11 ; python_version < '2.7' # jinja2 2.11 and later require python 2.
 urllib3 < 1.24 ; python_version < '2.7' # urllib3 1.24 and later require python 2.7 or later
 pywinrm >= 0.3.0 # message encryption support
 wheel < 0.30.0 ; python_version < '2.7' # wheel 0.30.0 and later require python 2.7 or later
+wheel < 0.38.0 ; python_version >= '2.7' and python_version < '3.7' # wheel 0.38.0 and later require python 3.7 or later
 idna < 2.6, >= 2.5 # linode requires idna < 2.9, >= 2.5, requests requires idna < 2.6, but cryptography will cause the latest version to be installed instead
 paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for python 2.6
 pytest < 3.3.0, >= 3.1.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 2.6


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/79187

* Restrict `wheel` below v0.38.0 under Pythons < 3.7

* Add a change note for PR #79187

* Update changelogs/fragments/79187--wheel-0.38.0.yml

Co-authored-by: Matt Clay <matt@mystile.com>

* Use constraints file when installing wheel.

Co-authored-by: Matt Clay <matt@mystile.com>

(cherry picked from commit a76bbb18a5a80cda0d9683677aa8d5cd8a2e6093)

Co-authored-by: Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
