### PR TITLE
[stable-2.14] ansible-test - Fix pylint support on Python 3.11.

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-2.15.5.yml
+++ b/changelogs/fragments/ansible-test-pylint-2.15.5.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - ansible-test - Update the ``pylint`` sanity test to use version 2.15.5.
+  - ansible-test - Update the ``pylint`` sanity test requirements to resolve crashes on Python 3.11.
+                   (https://github.com/ansible/ansible/issues/78882)

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.in
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.in
@@ -1,2 +1,2 @@
-pylint == 2.15.4  # currently vetted version
+pylint == 2.15.5  # currently vetted version
 pyyaml  # needed for collection_detail.py

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
@@ -1,11 +1,11 @@
 # edit "sanity.pylint.in" and generate with: hacking/update-sanity-requirements.py --test pylint
-astroid==2.12.11
-dill==0.3.5.1
+astroid==2.12.12
+dill==0.3.6
 isort==5.10.1
 lazy-object-proxy==1.7.1
 mccabe==0.7.0
 platformdirs==2.5.2
-pylint==2.15.4
+pylint==2.15.5
 PyYAML==6.0
 tomli==2.0.1
 tomlkit==0.11.5


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/79194

(cherry picked from commit 645b6b858151a67eddcb63a6b5f726072271e6d9)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
