### PR TITLE
mention acl in permissions errors

### DIFF
--- a/changelogs/fragments/mention_acl.yml
+++ b/changelogs/fragments/mention_acl.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - updated error messages to include 'acl' and not just mode changes when failing to set required permissions on remote.

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -674,7 +674,7 @@ class ActionBase(ABC):
             res = self._remote_chmod(remote_paths, 'u+x')
             if res['rc'] != 0:
                 raise AnsibleError(
-                    'Failed to set file mode on remote temporary files '
+                    'Failed to set file mode or acl on remote temporary files '
                     '(rc: {0}, err: {1})'.format(
                         res['rc'],
                         to_native(res['stderr'])))
@@ -689,9 +689,9 @@ class ActionBase(ABC):
         if remote_user in self._get_admin_users():
             raise AnsibleError(
                 'Failed to change ownership of the temporary files Ansible '
-                'needs to create despite connecting as a privileged user. '
-                'Unprivileged become user would be unable to read the '
-                'file.')
+                '(via chmod nor setfacl) needs to create despite connecting as a '
+                'privileged user. Unprivileged become user would be unable to read'
+                ' the file.')
 
         # Step 3d: Try macOS's special chmod + ACL
         # macOS chmod's +a flag takes its own argument. As a slight hack, we

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -427,7 +427,7 @@ class TestActionBase(unittest.TestCase):
             'stderr': '',
         }
         assertThrowRegex(
-            'Failed to set file mode on remote temporary file',
+            'Failed to set file mode or acl on remote temporary files',
             execute=True)
         action_base._remote_chmod.return_value = {
             'rc': 0,


### PR DESCRIPTION
  as chmod/mode is not the only thing we attempt and Ubuntu not shipping acl
  in newer versions can lead to some confusion

  fixes #79146
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
action base