### PR TITLE
[stable-2.12] Fix ansible-test-git test for newer git versions.

### DIFF
--- a/test/integration/targets/ansible-test/collection-tests/git-common.bash
+++ b/test/integration/targets/ansible-test/collection-tests/git-common.bash
@@ -45,7 +45,7 @@ cd "${GIT_TOP_LEVEL}"
 git init
 
 # add submodule
-git submodule add "${WORK_DIR}/sub" "${SUBMODULE_DST}"
+git -c protocol.file.allow=always submodule add "${WORK_DIR}/sub" "${SUBMODULE_DST}"
 
 # prepare for tests
 expected="${WORK_DIR}/expected.txt"


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/79210

The latest versions of `git` include a fix for CVE-2022-39253. The fix blocks the file protocol by default.

See: https://github.com/git/git/blob/45c9f05c44b1cb6bd2d6cb95a22cf5e3d21d5b63/Documentation/RelNotes/2.30.6.txt (cherry picked from commit 4202acb41b4ee42c5e9e52a07ac56d49045ec943)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

ansible-test-git integration test
