### PR TITLE
Treat plugins in collections whose name starts with `_` as private

### DIFF
--- a/changelogs/fragments/79217-private-collection-plugins-modules.yml
+++ b/changelogs/fragments/79217-private-collection-plugins-modules.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "ansible-doc - consider plugins whose name starts with an underscore inside collections as
+     private in the collection. Use extra verbosity (``-v``) to still list these (https://github.com/ansible/ansible/pull/79217)."

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -637,7 +637,7 @@ class DocCLI(CLI, RoleMixin):
 
         return coll_filter
 
-    def _list_plugins(self, plugin_type, content):
+    def _list_plugins(self, plugin_type, content, include_private=True):
 
         results = {}
         self.plugins = {}
@@ -645,6 +645,13 @@ class DocCLI(CLI, RoleMixin):
 
         coll_filter = self._get_collection_filter()
         self.plugins.update(list_plugins(plugin_type, coll_filter))
+
+        if not include_private:
+            for plugin in list(self.plugins):
+                if not plugin.startswith('ansible.builtin.'):
+                    idx = plugin.rfind('.')
+                    if idx >= 0 and plugin[idx:idx + 2] == '._':
+                        del self.plugins[plugin]
 
         # get appropriate content depending on option
         if content == 'dir':
@@ -783,7 +790,7 @@ class DocCLI(CLI, RoleMixin):
             elif plugin_type == 'role':
                 docs = self._create_role_list()
             else:
-                docs = self._list_plugins(plugin_type, content)
+                docs = self._list_plugins(plugin_type, content, include_private=(context.CLIARGS['verbosity'] > 0))
         else:
             # here we require a name
             if len(context.CLIARGS['args']) == 0:


### PR DESCRIPTION
##### SUMMARY
~~Right now all plugins whose name starts with `_` are treated as deprecated by `ansible-doc -l` and by the validate-modules sanity test. However they are not shown as deprecated in ansible-doc itself.~~ (This has been changed in #79362.)

This PR uses the `_` prefix **outside of ansible.builtin and ansible.legacy** to mean private. Thus such plugins will not be shown until the user uses extra verbosity (`-v`).

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
ansible-doc
