### PR TITLE
File lookup handle missing file more gracefully

### DIFF
--- a/changelogs/fragments/file_lookup_fix.yml
+++ b/changelogs/fragments/file_lookup_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - file lookup now handles missing files more gracefully.

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -80,7 +80,7 @@ class LookupModule(LookupBase):
                         contents = contents.rstrip()
                     ret.append(contents)
                 else:
-                    raise AnsibleError("file not found")
+                    raise AnsibleError("file not found, use -vvvvv to see paths searched")
             except AnsibleError as e:
                 raise AnsibleOptionsError("The 'file' lookup had an issue accessing the file '%s'" % term, orig_exc=e)
 

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -69,7 +69,7 @@ class LookupModule(LookupBase):
             display.debug("File lookup term: %s" % term)
             # Find the file in the expected search path
             try:
-                lookupfile = self.find_file_in_search_path(variables, 'files', term)
+                lookupfile = self.find_file_in_search_path(variables, 'files', term, ignore_missing=True)
                 display.vvvv(u"File lookup using %s as file" % lookupfile)
                 if lookupfile:
                     b_contents, show_data = self._loader._get_file_contents(lookupfile)

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -80,6 +80,7 @@ class LookupModule(LookupBase):
                         contents = contents.rstrip()
                     ret.append(contents)
                 else:
+                    # TODO: only add search info if abs path?
                     raise AnsibleError("file not found, use -vvvvv to see paths searched")
             except AnsibleError as e:
                 raise AnsibleOptionsError("The 'file' lookup had an issue accessing the file '%s'" % term, orig_exc=e)


### PR DESCRIPTION
  previously it would have a 2nd tb due to bad error raising


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lookup/file
##### ADDITIONAL INFORMATION

what to run:
```
$ ansible -m debug -a 'msg="{{q("file", "/etc/nothere")}}"' localhost -vvv
```
before PR
```
[WARNING]: Unable to find '/etc/nothere' in expected paths (use -vvvvv to see paths)
exception during Jinja2 execution: Traceback (most recent call last):
  File "ansible/lib/ansible/plugins/lookup/file.py", line 84, in run
    raise AnsibleParserError()
ansible.errors.AnsibleParserError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "ansible/lib/ansible/template/__init__.py", line 831, in _lookup
    ran = instance.run(loop_terms, variables=self._available_variables, **kwargs)
  File "ansible/lib/ansible/plugins/lookup/file.py", line 86, in run
    raise AnsibleError("could not locate file in lookup: %s" % term)
ansible.errors.AnsibleError: could not locate file in lookup: /etc/nothere
localhost | FAILED! => {
    "msg": "An unhandled exception occurred while running the lookup plugin 'file'. Error was a <class 'ansible.errors.AnsibleError'>, original message: could not locate file in lookup: /etc/nothere. could not locate file in lookup: /etc/nothere"
}
```
after:
```
localhost | FAILED! => {
    "msg": "The 'file' lookup had an issue accessing the file '/etc/nothere'. file not found, use -vvvvv to see paths searched"
}
```
