### PR TITLE
stable docs build: do not use YAML parsing/serialization for .deps files

### DIFF
--- a/hacking/build_library/build_ansible/command_plugins/docs_build.py
+++ b/hacking/build_library/build_ansible/command_plugins/docs_build.py
@@ -176,6 +176,10 @@ def generate_full_docs(args):
 
             deps_data['_ansible_core_version'] = ansible_core__version__
 
+            # antsibull-docs will choke when a key `_python` is found. Remove it to work around
+            # that until antsibull-docs is fixed.
+            deps_data.pop('_python', None)
+
             write_deps_file(modified_deps_file, deps_data)
 
             params = ['stable', '--deps-file', modified_deps_file]


### PR DESCRIPTION
##### SUMMARY
Right now the stable docs build fails when a `.deps` file has `_python` in it, since its value `>=3.9` is not a valid YAML value.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hacking/build_library/build_ansible/command_plugins/docs_build.py
