### PR TITLE
Communication docs: note that editing Matrix messages causes IRC spam

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -49,7 +49,7 @@ The Ansible community maintains its own Matrix homeserver at ``ansible.im``, how
 Matrix chat supports:
 
 * persistence (when you log on, you see all messages since you last logged off)
-* edits (so you can fix your typos - **NOTE** that every edit on Matrix causes the message to be sent again to IRC, so please avoid editing multiple times!)
+* edits (Lets you fix typos and so on. **NOTE** Each edit you make on Matrix re-sends the message to IRC. Please try to avoid multiple edits!)
 * replies to individual users
 * reactions/emojis
 * bridging to IRC

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -49,7 +49,7 @@ The Ansible community maintains its own Matrix homeserver at ``ansible.im``, how
 Matrix chat supports:
 
 * persistence (when you log on, you see all messages since you last logged off)
-* edits (so you can fix your typos)
+* edits (so you can fix your typos - **NOTE** that every edit on Matrix causes the message to be sent again to IRC, so please avoid editing multiple times!)
 * replies to individual users
 * reactions/emojis
 * bridging to IRC


### PR DESCRIPTION
##### SUMMARY
The current wording apparently encourages folks to edit their messages, while they're not being aware that evey edit creates another copy of the message for IRC users (sometimes just parts of it, but often enough the full message is sent again).

CC @GregSutcliffe

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/community/communication.rst
