### PR TITLE
File lookup handle missing file more gracefully (#79230)

### DIFF
--- a/changelogs/fragments/file_lookup_fix.yml
+++ b/changelogs/fragments/file_lookup_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - file lookup now handles missing files more gracefully.

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -50,7 +50,7 @@ RETURN = """
     elements: str
 """
 
-from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils._text import to_text
 from ansible.utils.display import Display
@@ -67,11 +67,10 @@ class LookupModule(LookupBase):
 
         for term in terms:
             display.debug("File lookup term: %s" % term)
-
             # Find the file in the expected search path
-            lookupfile = self.find_file_in_search_path(variables, 'files', term)
-            display.vvvv(u"File lookup using %s as file" % lookupfile)
             try:
+                lookupfile = self.find_file_in_search_path(variables, 'files', term, ignore_missing=True)
+                display.vvvv(u"File lookup using %s as file" % lookupfile)
                 if lookupfile:
                     b_contents, show_data = self._loader._get_file_contents(lookupfile)
                     contents = to_text(b_contents, errors='surrogate_or_strict')
@@ -81,8 +80,9 @@ class LookupModule(LookupBase):
                         contents = contents.rstrip()
                     ret.append(contents)
                 else:
-                    raise AnsibleParserError()
-            except AnsibleParserError:
-                raise AnsibleError("could not locate file in lookup: %s" % term)
+                    # TODO: only add search info if abs path?
+                    raise AnsibleError("file not found, use -vvvvv to see paths searched")
+            except AnsibleError as e:
+                raise AnsibleOptionsError("The 'file' lookup had an issue accessing the file '%s'" % term, orig_exc=e)
 
         return ret


### PR DESCRIPTION
 previously it would have a 2nd tb due to bad error raising
 also remove superfluous warning

(cherry picked from commit aaab0791d9507b64ea04903bf35500c87ebb33b4)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lookup/file