### PR TITLE
De-duplicate initialisation of ConnectionBase._connected

### DIFF
--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -72,8 +72,6 @@ class ConnectionBase(AnsiblePlugin):
         if not hasattr(self, '_display'):
             # Backwards compat: self._display isn't really needed, just import the global display and use that.
             self._display = display
-        if not hasattr(self, '_connected'):
-            self._connected = False
 
         self.success_key = None
         self.prompt = None


### PR DESCRIPTION
##### SUMMARY
Remove initialisation of ConnectionBase._connected that is repeated almost immediately after. I chose to keep the later, simpler code because it's already what has the final say

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
anisible.plugins.connection.ConnectionBase

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
