### PR TITLE
Log `runme.sh` execution in integration tests

### DIFF
--- a/changelogs/fragments/79263-runme-sh-logging-3cb482385bd59058.yaml
+++ b/changelogs/fragments/79263-runme-sh-logging-3cb482385bd59058.yaml
@@ -1,0 +1,10 @@
+---
+
+trivial:
+  - >-
+    integration tests — added command invocation logging via ``set -x``
+    to ``runme.sh`` scripts where it was missing and improved failing
+    fast in those scripts that use pipes (via ``set -o pipefail``).
+    See `PR #79263` https://github.com/ansible/ansible/pull/79263>`__.
+
+...

--- a/test/integration/targets/ansible-test-git/runme.sh
+++ b/test/integration/targets/ansible-test-git/runme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu -o pipefail
+set -eux -o pipefail
 
 # tests must be executed outside of the ansible source tree
 # otherwise ansible-test will test the ansible source instead of the test collection

--- a/test/integration/targets/entry_points/runme.sh
+++ b/test/integration/targets/entry_points/runme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eu -o pipefail
 source virtualenv.sh
 set +x
 unset PYTHONPATH

--- a/test/integration/targets/include_when_parent_is_dynamic/runme.sh
+++ b/test/integration/targets/include_when_parent_is_dynamic/runme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eux
 
 ansible-playbook playbook.yml "$@" > output.log 2>&1 || true
 

--- a/test/integration/targets/include_when_parent_is_static/runme.sh
+++ b/test/integration/targets/include_when_parent_is_static/runme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eux
 
 ansible-playbook playbook.yml "$@" > output.log 2>&1 || true
 

--- a/test/integration/targets/pyyaml/runme.sh
+++ b/test/integration/targets/pyyaml/runme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eu -o pipefail
 source virtualenv.sh
 set +x
 

--- a/test/integration/targets/subversion/runme.sh
+++ b/test/integration/targets/subversion/runme.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eux -o pipefail
 
 cleanup() {
     echo "Cleanup"

--- a/test/integration/targets/tags/runme.sh
+++ b/test/integration/targets/tags/runme.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
-set -eu
-
-# Using set -x for this test causes the Shippable console to stop receiving updates and the job to time out for macOS.
-# Once that issue is resolved the set -x option can be added above.
+set -eux -o pipefail
 
 # Run these using en_US.UTF-8 because list-tasks is a user output function and so it tailors its output to the
 # user's locale.  For unicode tags, this means replacing non-ascii chars with "?"

--- a/test/integration/targets/test_core/runme.sh
+++ b/test/integration/targets/test_core/runme.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eux
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook --vault-password-file vault-password runme.yml -i inventory "${@}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch adds `set -x` where it's missing in the integration tests. It also enables `pipefail` in `runme.sh` scripts that use pipes.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
integration tests

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
I've been staring at a CI log today, and it wasn't obvious what failed exactly. It seems reasonable to follow what other test scripts do and log what's being called better.