### PR TITLE
Restrict kubernetes below v25.3.0

### DIFF
--- a/test/integration/targets/inventory_kubevirt_conformance/constraints.txt
+++ b/test/integration/targets/inventory_kubevirt_conformance/constraints.txt
@@ -1,3 +1,4 @@
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
 ruamel.yaml < 0.17 ; python_version <= '2.7'  # ruamel.yaml 0.17 and later are not tested with Python 2.7
 ruamel.yaml.clib <= 0.2.2 ; python_version < '3.5'  # ruamel.yaml.clib 0.2.3 and later requires Python 3.5 or later
+kubernetes < 25.3.0

--- a/test/integration/targets/inventory_kubevirt_conformance/constraints.txt
+++ b/test/integration/targets/inventory_kubevirt_conformance/constraints.txt
@@ -1,4 +1,4 @@
 setuptools < 45 ; python_version <= '2.7' # setuptools 45 and later require python 3.5 or later
 ruamel.yaml < 0.17 ; python_version <= '2.7'  # ruamel.yaml 0.17 and later are not tested with Python 2.7
 ruamel.yaml.clib <= 0.2.2 ; python_version < '3.5'  # ruamel.yaml.clib 0.2.3 and later requires Python 3.5 or later
-kubernetes < 25.3.0
+kubernetes < 25.3.0  # newer versions no longer pass tests


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
inventory_kubevirt_conformance integration test

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The new release seems to be causing test failures.
