### PR TITLE
replace yes/no with true/false in docstrings

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -68,7 +68,7 @@ options:
     type: str
   install_recommends:
     description:
-      - Corresponds to the C(--no-install-recommends) option for I(apt). C(yes) installs recommended packages.  C(no) does not install
+      - Corresponds to the C(--no-install-recommends) option for I(apt). C(true) installs recommended packages.  C(false) does not install
         recommended packages. By default, Ansible will use the same defaults as the operating system. Suggested packages are never installed.
     aliases: [ install-recommends ]
     type: bool
@@ -141,14 +141,14 @@ options:
      version_added: "1.6"
   autoremove:
     description:
-      - If C(yes), remove unused dependency packages for all module states except I(build-dep). It can also be used as the only option.
+      - If C(true), remove unused dependency packages for all module states except I(build-dep). It can also be used as the only option.
       - Previous to version 2.4, autoclean was also an alias for autoremove, now it is its own separate command. See documentation for further information.
     type: bool
     default: 'no'
     version_added: "2.1"
   autoclean:
     description:
-      - If C(yes), cleans the local repository of retrieved package files that can no longer be downloaded.
+      - If C(true), cleans the local repository of retrieved package files that can no longer be downloaded.
     type: bool
     default: 'no'
     version_added: "2.4"
@@ -170,7 +170,7 @@ options:
   fail_on_autoremove:
     description:
       - 'Corresponds to the C(--no-remove) option for C(apt).'
-      - 'If C(yes), it is ensured that no packages will be removed or the task will fail.'
+      - 'If C(true), it is ensured that no packages will be removed or the task will fail.'
       - 'C(fail_on_autoremove) is only supported with state except C(absent)'
     type: bool
     default: 'no'
@@ -202,7 +202,7 @@ attributes:
     platform:
         platforms: debian
 notes:
-   - Three of the upgrade modes (C(full), C(safe) and its alias C(yes)) required C(aptitude) up to 2.3, since 2.4 C(apt-get) is used as a fall-back.
+   - Three of the upgrade modes (C(full), C(safe) and its alias C(true)) required C(aptitude) up to 2.3, since 2.4 C(apt-get) is used as a fall-back.
    - In most cases, packages installed with apt will start newly installed services by default. Most distributions have mechanisms to avoid this.
      For example when installing Postgresql-9.5 in Debian 9, creating an excutable shell script (/usr/sbin/policy-rc.d) that throws
      a return code of 101 will stop Postgresql 9.5 starting up after install. Remove the file or remove its execute permission afterwards.

--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -74,7 +74,7 @@ options:
         default: present
     validate_certs:
         description:
-            - If C(no), SSL certificates for the target url will not be validated. This should only be used
+            - If C(false), SSL certificates for the target url will not be validated. This should only be used
               on personally controlled sites using self-signed certificates.
         type: bool
         default: 'yes'

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -64,7 +64,7 @@ options:
         version_added: '2.10'
     validate_certs:
         description:
-            - If C(no), SSL certificates for the target repo will not be validated. This should only be used
+            - If C(false), SSL certificates for the target repo will not be validated. This should only be used
               on personally controlled sites using self-signed certificates.
         type: bool
         default: 'yes'

--- a/lib/ansible/modules/assemble.py
+++ b/lib/ansible/modules/assemble.py
@@ -36,7 +36,7 @@ options:
     required: true
   backup:
     description:
-    - Create a backup file (if C(yes)), including the timestamp information so
+    - Create a backup file (if C(true)), including the timestamp information so
       you can get the original file back if you somehow clobbered it
       incorrectly.
     type: bool
@@ -48,8 +48,8 @@ options:
     version_added: '1.4'
   remote_src:
     description:
-    - If C(no), it will search for src at originating/master machine.
-    - If C(yes), it will go to the remote/target machine for the src.
+    - If C(false), it will search for src at originating/master machine.
+    - If C(true), it will go to the remote/target machine for the src.
     type: bool
     default: yes
     version_added: '1.4'

--- a/lib/ansible/modules/assert.py
+++ b/lib/ansible/modules/assert.py
@@ -36,7 +36,7 @@ options:
     version_added: "2.7"
   quiet:
     description:
-      - Set this to C(yes) to avoid verbose output.
+      - Set this to C(true) to avoid verbose output.
     type: bool
     default: no
     version_added: "2.8"

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -81,7 +81,7 @@ options:
     type: bool
     default: yes
     description:
-      - If set to C(yes), append a newline to stdin data.
+      - If set to C(true), append a newline to stdin data.
     version_added: "2.8"
   strip_empty_ends:
     description:

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -55,8 +55,8 @@ options:
   force:
     description:
     - Influence whether the remote file must always be replaced.
-    - If C(yes), the remote file will be replaced when contents are different than the source.
-    - If C(no), the file will only be transferred if the destination does not exist.
+    - If C(true), the remote file will be replaced when contents are different than the source.
+    - If C(false), the file will only be transferred if the destination does not exist.
     type: bool
     default: yes
     version_added: '1.1'
@@ -87,8 +87,8 @@ options:
   remote_src:
     description:
     - Influence whether C(src) needs to be transferred or already is present remotely.
-    - If C(no), it will search for C(src) on the controller node.
-    - If C(yes) it will search for C(src) on the managed (remote) node.
+    - If C(false), it will search for C(src) on the controller node.
+    - If C(true) it will search for C(src) on the managed (remote) node.
     - C(remote_src) supports recursive copying as of version 2.8.
     - C(remote_src) only works with C(mode=preserve) as of version 2.6.
     - Autodecryption of files does not work when C(remote_src=yes).

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -97,7 +97,7 @@ options:
 
   autoremove:
     description:
-      - If C(yes), removes all "leaf" packages from the system that were originally
+      - If C(true), removes all "leaf" packages from the system that were originally
         installed as dependencies of user-installed packages but which are no longer
         required by any such package. Should be used alone or when state is I(absent)
     type: bool
@@ -135,14 +135,14 @@ options:
     version_added: "2.7"
   security:
     description:
-      - If set to C(yes), and C(state=latest) then only installs updates that have been marked security related.
+      - If set to C(true), and C(state=latest) then only installs updates that have been marked security related.
       - Note that, similar to C(dnf upgrade-minimal), this filter applies to dependencies as well.
     type: bool
     default: "no"
     version_added: "2.7"
   bugfix:
     description:
-      - If set to C(yes), and C(state=latest) then only installs updates that have been marked bugfix related.
+      - If set to C(true), and C(state=latest) then only installs updates that have been marked bugfix related.
       - Note that, similar to C(dnf upgrade-minimal), this filter applies to dependencies as well.
     default: "no"
     type: bool
@@ -173,15 +173,15 @@ options:
     type: str
   validate_certs:
     description:
-      - This only applies if using a https url as the source of the rpm. e.g. for localinstall. If set to C(no), the SSL certificates will not be validated.
-      - This should only set to C(no) used on personally controlled sites using self-signed certificates as it avoids verifying the source site.
+      - This only applies if using a https url as the source of the rpm. e.g. for localinstall. If set to C(false), the SSL certificates will not be validated.
+      - This should only set to C(false) used on personally controlled sites using self-signed certificates as it avoids verifying the source site.
     type: bool
     default: "yes"
     version_added: "2.7"
   sslverify:
     description:
       - Disables SSL validation of the repository server for this transaction.
-      - This should be set to C(no) if one of the configured repositories is using an untrusted or self-signed certificate.
+      - This should be set to C(false) if one of the configured repositories is using an untrusted or self-signed certificate.
     type: bool
     default: "yes"
     version_added: "2.13"
@@ -232,7 +232,7 @@ options:
     version_added: "2.8"
   allowerasing:
     description:
-      - If C(yes) it allows  erasing  of  installed  packages to resolve dependencies.
+      - If C(true) it allows  erasing  of  installed  packages to resolve dependencies.
     required: false
     type: bool
     default: "no"

--- a/lib/ansible/modules/fetch.py
+++ b/lib/ansible/modules/fetch.py
@@ -36,9 +36,9 @@ options:
   fail_on_missing:
     version_added: '1.1'
     description:
-    - When set to C(yes), the task will fail if the remote file cannot be read for any reason.
+    - When set to C(true), the task will fail if the remote file cannot be read for any reason.
     - Prior to Ansible 2.5, setting this would only fail if the source file was missing.
-    - The default was changed to C(yes) in Ansible 2.5.
+    - The default was changed to C(true) in Ansible 2.5.
     type: bool
     default: yes
   validate_checksum:
@@ -88,7 +88,7 @@ notes:
   file was impossible unless C(fail_on_missing) was set.
 - In Ansible 2.5 or later, playbook authors are encouraged to use
   C(fail_when) or C(ignore_errors) to get this ability. They may
-  also explicitly set C(fail_on_missing) to C(no) to get the
+  also explicitly set C(fail_on_missing) to C(false) to get the
   non-failing behaviour.
 seealso:
 - module: ansible.builtin.copy

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -73,7 +73,7 @@ options:
     description:
     - This flag indicates that filesystem links, if they exist, should be followed.
     - I(follow=yes) and I(state=link) can modify I(src) when combined with parameters such as I(mode).
-    - Previous to Ansible 2.5, this was C(no) by default.
+    - Previous to Ansible 2.5, this was C(false) by default.
     type: bool
     default: yes
     version_added: '1.8'

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -102,29 +102,29 @@ options:
         default: mtime
     hidden:
         description:
-            - Set this to C(yes) to include hidden files, otherwise they will be ignored.
+            - Set this to C(true) to include hidden files, otherwise they will be ignored.
         type: bool
         default: no
     follow:
         description:
-            - Set this to C(yes) to follow symlinks in path for systems with python 2.6+.
+            - Set this to C(true) to follow symlinks in path for systems with python 2.6+.
         type: bool
         default: no
     get_checksum:
         description:
-            - Set this to C(yes) to retrieve a file's SHA1 checksum.
+            - Set this to C(true) to retrieve a file's SHA1 checksum.
         type: bool
         default: no
     use_regex:
         description:
-            - If C(no), the patterns are file globs (shell).
-            - If C(yes), they are python regexes.
+            - If C(false), the patterns are file globs (shell).
+            - If C(true), they are python regexes.
         type: bool
         default: no
     depth:
         description:
             - Set the maximum number of levels to descend into.
-            - Setting recurse to C(no) will override this value, which is effectively depth 1.
+            - Setting recurse to C(false) will override this value, which is effectively depth 1.
             - Default is unlimited depth.
         type: int
         version_added: "2.6"

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -68,11 +68,11 @@ options:
     version_added: '2.1'
   force:
     description:
-      - If C(yes) and C(dest) is not a directory, will download the file every
-        time and replace the file if the contents change. If C(no), the file
+      - If C(true) and C(dest) is not a directory, will download the file every
+        time and replace the file if the contents change. If C(false), the file
         will only be downloaded if the destination does not exist. Generally
-        should be C(yes) only for small local files.
-      - Prior to 0.6, this module behaved as if C(yes) was the default.
+        should be C(true) only for small local files.
+      - Prior to 0.6, this module behaved as if C(true) was the default.
     type: bool
     default: no
     version_added: '0.7'
@@ -103,13 +103,13 @@ options:
     version_added: "2.0"
   use_proxy:
     description:
-      - if C(no), it will not use a proxy, even if one is defined in
+      - if C(false), it will not use a proxy, even if one is defined in
         an environment variable on the target hosts.
     type: bool
     default: yes
   validate_certs:
     description:
-      - If C(no), SSL certificates will not be validated.
+      - If C(false), SSL certificates will not be validated.
       - This should only be used on personally controlled sites using self-signed certificates.
     type: bool
     default: yes

--- a/lib/ansible/modules/getent.py
+++ b/lib/ansible/modules/getent.py
@@ -40,7 +40,7 @@ options:
         type: str
     fail_key:
         description:
-            - If a supplied key is missing this will make the task fail if C(yes).
+            - If a supplied key is missing this will make the task fail if C(true).
         type: bool
         default: 'yes'
 extends_documentation_fragment:

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -30,7 +30,7 @@ options:
             - The path of where the repository should be checked out. This
               is equivalent to C(git clone [repo_url] [directory]). The repository
               named in I(repo) is not appended to this path and the destination directory must be empty. This
-              parameter is required, unless I(clone) is set to C(no).
+              parameter is required, unless I(clone) is set to C(false).
         type: path
         required: true
     version:
@@ -54,7 +54,7 @@ options:
         description:
             - As of OpenSSH 7.5, "-o StrictHostKeyChecking=accept-new" can be
               used which is safer and will only accepts host keys which are
-              not present or are the same. if C(yes), ensure that
+              not present or are the same. if C(true), ensure that
               "-o StrictHostKeyChecking=accept-new" is present as an ssh option.
         type: bool
         default: 'no'
@@ -99,10 +99,10 @@ options:
         version_added: "1.9"
     force:
         description:
-            - If C(yes), any modified files in the working
+            - If C(true), any modified files in the working
               repository will be discarded.  Prior to 0.7, this was always
-              C(yes) and could not be disabled.  Prior to 1.9, the default was
-              C(yes).
+              C(true) and could not be disabled.  Prior to 1.9, the default was
+              C(true).
         type: bool
         default: 'no'
         version_added: "0.7"
@@ -115,13 +115,13 @@ options:
         version_added: "1.2"
     clone:
         description:
-            - If C(no), do not clone the repository even if it does not exist locally.
+            - If C(false), do not clone the repository even if it does not exist locally.
         type: bool
         default: 'yes'
         version_added: "1.9"
     update:
         description:
-            - If C(no), do not retrieve new revisions from the origin repository.
+            - If C(false), do not retrieve new revisions from the origin repository.
             - Operations like archive will work on the existing (old) repository and might
               not respond to changes to the options version or remote.
         type: bool
@@ -135,7 +135,7 @@ options:
         version_added: "1.4"
     bare:
         description:
-            - If C(yes), repository will be created as a bare repo, otherwise
+            - If C(true), repository will be created as a bare repo, otherwise
               it will be a standard repo with a workspace.
         type: bool
         default: 'no'
@@ -149,7 +149,7 @@ options:
 
     recursive:
         description:
-            - If C(no), repository will be cloned without the --recursive
+            - If C(false), repository will be cloned without the --recursive
               option, skipping sub-modules.
         type: bool
         default: 'yes'
@@ -164,9 +164,9 @@ options:
 
     track_submodules:
         description:
-            - If C(yes), submodules will track the latest commit on their
+            - If C(true), submodules will track the latest commit on their
               master branch (or other branch specified in .gitmodules).  If
-              C(no), submodules will be kept at the revision specified by the
+              C(false), submodules will be kept at the revision specified by the
               main project. This is equivalent to specifying the --remote flag
               to git submodule update.
         type: bool
@@ -175,7 +175,7 @@ options:
 
     verify_commit:
         description:
-            - If C(yes), when cloning or checking out a I(version) verify the
+            - If C(true), when cloning or checking out a I(version) verify the
               signature of a GPG signed commit. This requires git version>=2.1.0
               to be installed. The commit MUST be signed and the public key MUST
               be present in the GPG keyring.

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -53,7 +53,7 @@ options:
     default: yes
   public:
     description:
-      - This option dictates whether the role's C(vars) and C(defaults) are exposed to the play. If set to C(yes)
+      - This option dictates whether the role's C(vars) and C(defaults) are exposed to the play. If set to C(true)
         the variables will be available to tasks following the C(include_role) task. This functionality differs from
         standard variable exposure for roles listed under the C(roles) header or C(import_role) as they are exposed
         to the play at playbook parsing time, and available to earlier roles and tasks as well.

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -33,7 +33,7 @@ options:
       choices: [ absent, present ]
     validate_certs:
       description:
-        - If C(no) and the C(key) is a url starting with https, SSL certificates will not be validated.
+        - If C(false) and the C(key) is a url starting with https, SSL certificates will not be validated.
         - This should only be used on personally controlled sites using self-signed certificates.
       type: bool
       default: 'yes'

--- a/lib/ansible/modules/set_fact.py
+++ b/lib/ansible/modules/set_fact.py
@@ -15,7 +15,7 @@ version_added: "1.2"
 description:
     - This action allows setting variables associated to the current host.
     - These variables will be available to subsequent plays during an ansible-playbook run via the host they were set on.
-    - Set C(cacheable) to C(yes) to save variables across executions using a fact cache.
+    - Set C(cacheable) to C(true) to save variables across executions using a fact cache.
       Variables will keep the set_fact precedence for the current run, but will used 'cached fact' precedence for subsequent ones.
     - Per the standard Ansible variable precedence rules, other types of variables have a higher priority, so this value may be overridden.
 options:

--- a/lib/ansible/modules/set_stats.py
+++ b/lib/ansible/modules/set_stats.py
@@ -28,7 +28,7 @@ options:
     default: no
   aggregate:
     description:
-        - Whether the provided value is aggregated to the existing stat C(yes) or will replace it C(no).
+        - Whether the provided value is aggregated to the existing stat C(true) or will replace it C(false).
     type: bool
     default: yes
 extends_documentation_fragment:
@@ -55,7 +55,7 @@ attributes:
         support: none
 notes:
     - In order for custom stats to be displayed, you must set C(show_custom_stats) in section C([defaults]) in C(ansible.cfg)
-      or by defining environment variable C(ANSIBLE_SHOW_CUSTOM_STATS) to C(yes). See the C(default) callback plugin for details.
+      or by defining environment variable C(ANSIBLE_SHOW_CUSTOM_STATS) to C(true). See the C(default) callback plugin for details.
 version_added: "2.3"
 '''
 

--- a/lib/ansible/modules/stat.py
+++ b/lib/ansible/modules/stat.py
@@ -48,7 +48,7 @@ options:
       - Use file magic and return data about the nature of the file. this uses
         the 'file' utility found on most Linux/Unix systems.
       - This will add both C(mime_type) and C(charset) fields to the return, if possible.
-      - In Ansible 2.3 this option changed from I(mime) to I(get_mime) and the default changed to C(yes).
+      - In Ansible 2.3 this option changed from I(mime) to I(get_mime) and the default changed to C(true).
     type: bool
     default: yes
     aliases: [ mime, mime_type, mime-type ]

--- a/lib/ansible/modules/subversion.py
+++ b/lib/ansible/modules/subversion.py
@@ -36,8 +36,8 @@ options:
     aliases: [ rev, version ]
   force:
     description:
-      - If C(yes), modified files will be discarded. If C(no), module will fail if it encounters modified files.
-        Prior to 1.9 the default was C(yes).
+      - If C(true), modified files will be discarded. If C(false), module will fail if it encounters modified files.
+        Prior to 1.9 the default was C(true).
     type: bool
     default: "no"
   in_place:
@@ -65,32 +65,32 @@ options:
     version_added: "1.4"
   checkout:
     description:
-     - If C(no), do not check out the repository if it does not exist locally.
+     - If C(false), do not check out the repository if it does not exist locally.
     type: bool
     default: "yes"
     version_added: "2.3"
   update:
     description:
-     - If C(no), do not retrieve new revisions from the origin repository.
+     - If C(false), do not retrieve new revisions from the origin repository.
     type: bool
     default: "yes"
     version_added: "2.3"
   export:
     description:
-      - If C(yes), do export instead of checkout/update.
+      - If C(true), do export instead of checkout/update.
     type: bool
     default: "no"
     version_added: "1.6"
   switch:
     description:
-      - If C(no), do not call svn switch before update.
+      - If C(false), do not call svn switch before update.
     default: "yes"
     version_added: "2.0"
     type: bool
   validate_certs:
     description:
-      - If C(no), passes the C(--trust-server-cert) flag to svn.
-      - If C(yes), does not pass the flag.
+      - If C(false), passes the C(--trust-server-cert) flag to svn.
+      - If C(true), does not pass the flag.
     default: "no"
     version_added: "2.11"
     type: bool

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -18,9 +18,9 @@ options:
   follow:
     description:
     - Determine whether symbolic links should be followed.
-    - When set to C(yes) symbolic links will be followed, if they exist.
-    - When set to C(no) symbolic links will not be followed.
-    - Previous to Ansible 2.4, this was hardcoded as C(yes).
+    - When set to C(true) symbolic links will be followed, if they exist.
+    - When set to C(false) symbolic links will not be followed.
+    - Previous to Ansible 2.4, this was hardcoded as C(true).
     type: bool
     default: no
     version_added: '2.4'

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -96,7 +96,7 @@ options:
     version_added: "2.1"
   remote_src:
     description:
-      - Set to C(yes) to indicate the archived file is already on the remote system and not local to the Ansible controller.
+      - Set to C(true) to indicate the archived file is already on the remote system and not local to the Ansible controller.
       - This option is mutually exclusive with C(copy).
     type: bool
     default: no
@@ -104,8 +104,8 @@ options:
   validate_certs:
     description:
       - This only applies if using a https URL as the source of the file.
-      - This should only set to C(no) used on personally controlled sites using self-signed certificate.
-      - Prior to 2.2 the code worked as if this was set to C(yes).
+      - This should only set to C(false) used on personally controlled sites using self-signed certificate.
+      - Prior to 2.2 the code worked as if this was set to C(true).
     type: bool
     default: yes
     version_added: "2.2"

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -104,8 +104,8 @@ options:
       - Whether or not the URI module should follow redirects. C(all) will follow all redirects.
         C(safe) will follow only "safe" redirects, where "safe" means that the client is only
         doing a GET or HEAD on the URI to which it is being redirected. C(none) will not follow
-        any redirects. Note that C(yes) and C(no) choices are accepted for backwards compatibility,
-        where C(yes) is the equivalent of C(all) and C(no) is the equivalent of C(safe). C(yes) and C(no)
+        any redirects. Note that C(true) and C(false) choices are accepted for backwards compatibility,
+        where C(true) is the equivalent of C(all) and C(false) is the equivalent of C(safe). C(true) and C(false)
         are deprecated and will be removed in some future version of Ansible.
     type: str
     choices: ['all', 'no', 'none', 'safe', 'urllib2', 'yes']
@@ -139,9 +139,9 @@ options:
     version_added: '2.1'
   validate_certs:
     description:
-      - If C(no), SSL certificates will not be validated.
-      - This should only set to C(no) used on personally controlled sites using self-signed certificates.
-      - Prior to 1.9.2 the code defaulted to C(no).
+      - If C(false), SSL certificates will not be validated.
+      - This should only set to C(false) used on personally controlled sites using self-signed certificates.
+      - Prior to 1.9.2 the code defaulted to C(false).
     type: bool
     default: yes
     version_added: '1.9.2'
@@ -171,19 +171,19 @@ options:
     version_added: '2.7'
   remote_src:
     description:
-      - If C(no), the module will search for the C(src) on the controller node.
-      - If C(yes), the module will search for the C(src) on the managed (remote) node.
+      - If C(false), the module will search for the C(src) on the controller node.
+      - If C(true), the module will search for the C(src) on the managed (remote) node.
     type: bool
     default: no
     version_added: '2.7'
   force:
     description:
-      - If C(yes) do not get a cached copy.
+      - If C(true) do not get a cached copy.
     type: bool
     default: no
   use_proxy:
     description:
-      - If C(no), it will not use a proxy, even if one is defined in an environment variable on the target hosts.
+      - If C(false), it will not use a proxy, even if one is defined in an environment variable on the target hosts.
     type: bool
     default: yes
   unix_socket:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -32,7 +32,7 @@ options:
     hidden:
         description:
             - macOS only, optionally hide the user from the login window and system preferences.
-            - The default will be C(yes) if the I(system) option is used.
+            - The default will be C(true) if the I(system) option is used.
         type: bool
         version_added: "2.6"
     non_unique:
@@ -61,8 +61,8 @@ options:
         elements: str
     append:
         description:
-            - If C(yes), add the user to the groups specified in C(groups).
-            - If C(no), user will only be added to the groups specified in C(groups),
+            - If C(true), add the user to the groups specified in C(groups).
+            - If C(false), user will only be added to the groups specified in C(groups),
               removing them from all other groups.
         type: bool
         default: no
@@ -101,7 +101,7 @@ options:
         default: present
     create_home:
         description:
-            - Unless set to C(no), a home directory will be made for the user
+            - Unless set to C(false), a home directory will be made for the user
               when the account is created or if the home directory does not exist.
             - Changed from C(createhome) to C(create_home) in Ansible 2.5.
         type: bool
@@ -109,13 +109,13 @@ options:
         aliases: [ createhome ]
     move_home:
         description:
-            - "If set to C(yes) when used with C(home: ), attempt to move the user's old home
+            - "If set to C(true) when used with C(home: ), attempt to move the user's old home
               directory to the specified directory if it isn't there already and the old home exists."
         type: bool
         default: no
     system:
         description:
-            - When creating an account C(state=present), setting this to C(yes) makes the user a system account.
+            - When creating an account C(state=present), setting this to C(true) makes the user a system account.
             - This setting cannot be changed on existing users.
         type: bool
         default: no

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -116,16 +116,16 @@ options:
     version_added: "1.9"
   validate_certs:
     description:
-      - This only applies if using a https url as the source of the rpm. e.g. for localinstall. If set to C(no), the SSL certificates will not be validated.
-      - This should only set to C(no) used on personally controlled sites using self-signed certificates as it avoids verifying the source site.
-      - Prior to 2.1 the code worked as if this was set to C(yes).
+      - This only applies if using a https url as the source of the rpm. e.g. for localinstall. If set to C(false), the SSL certificates will not be validated.
+      - This should only set to C(false) used on personally controlled sites using self-signed certificates as it avoids verifying the source site.
+      - Prior to 2.1 the code worked as if this was set to C(true).
     type: bool
     default: "yes"
     version_added: "2.1"
   sslverify:
     description:
       - Disables SSL validation of the repository server for this transaction.
-      - This should be set to C(no) if one of the configured repositories is using an untrusted or self-signed certificate.
+      - This should be set to C(false) if one of the configured repositories is using an untrusted or self-signed certificate.
     type: bool
     default: "yes"
     version_added: "2.13"
@@ -146,13 +146,13 @@ options:
     version_added: "2.3"
   security:
     description:
-      - If set to C(yes), and C(state=latest) then only installs updates that have been marked security related.
+      - If set to C(true), and C(state=latest) then only installs updates that have been marked security related.
     type: bool
     default: "no"
     version_added: "2.4"
   bugfix:
     description:
-      - If set to C(yes), and C(state=latest) then only installs updates that have been marked bugfix related.
+      - If set to C(true), and C(state=latest) then only installs updates that have been marked bugfix related.
     default: "no"
     type: bool
     version_added: "2.6"
@@ -193,7 +193,7 @@ options:
     version_added: "2.7"
   autoremove:
     description:
-      - If C(yes), removes all "leaf" packages from the system that were originally
+      - If C(true), removes all "leaf" packages from the system that were originally
         installed as dependencies of user-installed packages but which are no longer
         required by any such package. Should be used alone or when state is I(absent)
       - "NOTE: This feature requires yum >= 3.4.3 (RHEL/CentOS 7+)"

--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -21,7 +21,7 @@ description:
 options:
   async:
     description:
-      - If set to C(yes) Yum will download packages and metadata from this
+      - If set to C(true) Yum will download packages and metadata from this
         repo in parallel, if possible.
       - In ansible-core 2.11, 2.12, and 2.13 the default value is C(true).
       - This option has been deprecated in RHEL 8. If you're using one of the
@@ -117,7 +117,7 @@ options:
       - Tells yum whether or not it should perform a GPG signature check on
         packages.
       - No default setting. If the value is not set, the system setting from
-        C(/etc/yum.conf) or system default of C(no) will be used.
+        C(/etc/yum.conf) or system default of C(false) will be used.
     type: bool
   gpgkey:
     description:
@@ -289,7 +289,7 @@ options:
     default: 'no'
   skip_if_unavailable:
     description:
-      - If set to C(yes) yum will continue running if this repository cannot be
+      - If set to C(true) yum will continue running if this repository cannot be
         contacted for any reason. This should be set carefully as all repos are
         consulted for any given command.
     type: bool
@@ -299,7 +299,7 @@ options:
       - Whether yum should check the permissions on the paths for the
         certificates on the repository (both remote and local).
       - If we can't read any of the files then yum will force
-        I(skip_if_unavailable) to be C(yes). This is most useful for non-root
+        I(skip_if_unavailable) to be C(true). This is most useful for non-root
         processes which use yum on repos that have client cert files which are
         readable only by root.
     type: bool


### PR DESCRIPTION
##### SUMMARY
Now that the built docs use `true` and `false` for the boolean options (regardless of what is in the docstrings), the text that still uses `yes` and `no` is confusing and difficult for new users, plus it just looks odd.

For example, here's a param from the docs for the `git` module:

![Screen Shot 2022-11-01 at 11 21 56 AM](https://user-images.githubusercontent.com/879121/199284332-99423375-511f-402d-918d-a2a93bf985f3.png)

This PR updates the text portion of the module docs in the builtin collection to match the new boolean display.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com
ansible.builtin collection

##### ADDITIONAL INFORMATION
N/A
