### PR TITLE
Added ignore revs file for tracking commits with bulk sanity changes

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# Bulk PowerShell sanity fixes
+6def4a3180fe03981ba64c6d8db28fed3bb39c0c


### PR DESCRIPTION
##### SUMMARY
The changes in https://github.com/ansible/ansible/pull/78938 had some bulk sanity changes which we want to ignore from displaying in the blame. GitHub supports using this file in it's UI and it can also be used by the `git blame` CLI.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Git stuff