### PR TITLE
[CI] Move running `reboot` integration test to group 2

### DIFF
--- a/test/integration/targets/reboot/aliases
+++ b/test/integration/targets/reboot/aliases
@@ -1,5 +1,5 @@
 context/target
 destructive
 needs/root
-shippable/posix/group3
+shippable/posix/group2
 skip/docker


### PR DESCRIPTION
##### SUMMARY
Not sure why CI didn't catch this in https://github.com/ansible/ansible/pull/78402, but I'm seeing this error for other pull requests:

```
00:23 ERROR: Found 2 integration-aliases issue(s) which need to be resolved:
00:23 ERROR: test/integration/targets/reboot/aliases:0:0: Target of type TARGET cannot be in these groups: shippable/posix/group3/ (0%)
00:23 ERROR: test/integration/targets/reboot/aliases:0:0: Target of type TARGET must be in at least one of these groups: shippable/posix/group1/, shippable/posix/group2/ (0%)
```

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/integration/targets/reboot