### PR TITLE
blockinfile - document multiline marker behavior

### DIFF
--- a/lib/ansible/modules/blockinfile.py
+++ b/lib/ansible/modules/blockinfile.py
@@ -36,6 +36,8 @@ options:
     - The marker line template.
     - C({mark}) will be replaced with the values in C(marker_begin) (default="BEGIN") and C(marker_end) (default="END").
     - Using a custom marker without the C({mark}) variable may result in the block being repeatedly inserted on subsequent playbook runs.
+    - Multi-line markers are not supported and will result in the block being repeatedly inserted on subsequent playbook runs.
+    - A newline is automatically appended by the module to C(marker_begin) and C(marker_end).
     type: str
     default: '# {mark} ANSIBLE MANAGED BLOCK'
   block:


### PR DESCRIPTION
##### SUMMARY
Document that blockinfile markers must be 1 line.

Fixes #76823

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
blockinfile
