### PR TITLE
Clarify that b64decode does not work with binary output

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -2061,6 +2061,8 @@ As of version 2.6, you can define the type of encoding to use, the default is ``
 
 .. note:: The ``string`` filter is only required for Python 2 and ensures that text to encode is a unicode string. Without that filter before b64encode the wrong value will be encoded.
 
+.. note:: The return value of b64decode is a string.  If you decrypt a binary blob using b64decode and then try to use it (for example by using :ref:`copy <copy_module>` to write it to a file) you will mostly likely find that your binary has been corrupted.  If need to take a base64 encoded binary and write it to disk it is best to use the system ``base64`` command via the :ref:`shell module <shell_module>`, piping in the encoded data using the ``stdin`` parameter. For example: ``shell: cmd="base64 --decode > myfile.bin" stdin="{{ encoded }}"``
+
 .. versionadded:: 2.6
 
 Managing UUIDs

--- a/docs/docsite/rst/playbook_guide/playbooks_filters.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_filters.rst
@@ -2061,7 +2061,7 @@ As of version 2.6, you can define the type of encoding to use, the default is ``
 
 .. note:: The ``string`` filter is only required for Python 2 and ensures that text to encode is a unicode string. Without that filter before b64encode the wrong value will be encoded.
 
-.. note:: The return value of b64decode is a string.  If you decrypt a binary blob using b64decode and then try to use it (for example by using :ref:`copy <copy_module>` to write it to a file) you will mostly likely find that your binary has been corrupted.  If need to take a base64 encoded binary and write it to disk it is best to use the system ``base64`` command via the :ref:`shell module <shell_module>`, piping in the encoded data using the ``stdin`` parameter. For example: ``shell: cmd="base64 --decode > myfile.bin" stdin="{{ encoded }}"``
+.. note:: The return value of b64decode is a string.  If you decrypt a binary blob using b64decode and then try to use it (for example by using :ref:`copy <copy_module>` to write it to a file) you will mostly likely find that your binary has been corrupted.  If you need to take a base64 encoded binary and write it to disk, it is best to use the system ``base64`` command with the :ref:`shell module <shell_module>`, piping in the encoded data using the ``stdin`` parameter. For example: ``shell: cmd="base64 --decode > myfile.bin" stdin="{{ encoded }}"``
 
 .. versionadded:: 2.6
 

--- a/lib/ansible/plugins/filter/b64decode.yml
+++ b/lib/ansible/plugins/filter/b64decode.yml
@@ -5,6 +5,8 @@ DOCUMENTATION:
   short_description: Decode a base64 string
   description:
     - Base64 decoding function.
+    - The return value is a string.
+    - To base64 decode a binary blob, use the ``base64`` command  and pipe the encoded data through standard input. For example, in the ansible.builtin.shell`` module, ``cmd="base64 --decode > myfile.bin" stdin="{{ encoded }}"``.
   positional: _input
   options:
     _input:

--- a/lib/ansible/plugins/filter/b64decode.yml
+++ b/lib/ansible/plugins/filter/b64decode.yml
@@ -7,8 +7,8 @@ DOCUMENTATION:
     - Base64 decoding function.
     - The return value is a string.
     - Trying to store a binary blob in a string most likely corrupts the binary. To base64 decode a binary blob,
-    - use the ``base64`` command  and pipe the encoded data through standard input. 
-    - For example, in the ansible.builtin.shell`` module, ``cmd="base64 --decode > myfile.bin" stdin="{{ encoded }}"``.
+      use the ``base64`` command  and pipe the encoded data through standard input. 
+      For example, in the ansible.builtin.shell`` module, ``cmd="base64 --decode > myfile.bin" stdin="{{ encoded }}"``.
   positional: _input
   options:
     _input:

--- a/lib/ansible/plugins/filter/b64decode.yml
+++ b/lib/ansible/plugins/filter/b64decode.yml
@@ -6,7 +6,7 @@ DOCUMENTATION:
   description:
     - Base64 decoding function.
     - The return value is a string.
-    - To base64 decode a binary blob, use the ``base64`` command  and pipe the encoded data through standard input. For example, in the ansible.builtin.shell`` module, ``cmd="base64 --decode > myfile.bin" stdin="{{ encoded }}"``.
+    - Trying to store a binary blob in a string most likely corrupts the binary. To base64 decode a binary blob, use the ``base64`` command  and pipe the encoded data through standard input. For example, in the ansible.builtin.shell`` module, ``cmd="base64 --decode > myfile.bin" stdin="{{ encoded }}"``.
   positional: _input
   options:
     _input:

--- a/lib/ansible/plugins/filter/b64decode.yml
+++ b/lib/ansible/plugins/filter/b64decode.yml
@@ -6,7 +6,9 @@ DOCUMENTATION:
   description:
     - Base64 decoding function.
     - The return value is a string.
-    - Trying to store a binary blob in a string most likely corrupts the binary. To base64 decode a binary blob, use the ``base64`` command  and pipe the encoded data through standard input. For example, in the ansible.builtin.shell`` module, ``cmd="base64 --decode > myfile.bin" stdin="{{ encoded }}"``.
+    - Trying to store a binary blob in a string most likely corrupts the binary. To base64 decode a binary blob,
+    - use the ``base64`` command  and pipe the encoded data through standard input. 
+    - For example, in the ansible.builtin.shell`` module, ``cmd="base64 --decode > myfile.bin" stdin="{{ encoded }}"``.
   positional: _input
   options:
     _input:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It is not clear from the current documentation that the b64decode filter cannot be used to decode a binary blob (which is what base64 encoding was invented for) which leads to issues like #72527 and #20150).  This clarifies a little.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
playbooks_filters documentation page

##### ADDITIONAL INFORMATION
![image](https://user-images.githubusercontent.com/633246/199599386-04f34aaf-6d51-4fec-bc31-d5b5915dcbb5.png)


