### PR TITLE
Add missing type to the `reference` option of the documentation of the `git` module

### DIFF
--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -81,6 +81,7 @@ options:
     reference:
         description:
             - Reference repository (see "git clone --reference ...").
+        type: str
         version_added: "1.4"
     remote:
         description:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -35,7 +35,6 @@ lib/ansible/modules/file.py validate-modules:undocumented-parameter
 lib/ansible/modules/find.py use-argspec-type-path # fix needed
 lib/ansible/modules/git.py pylint:disallowed-name
 lib/ansible/modules/git.py use-argspec-type-path
-lib/ansible/modules/git.py validate-modules:doc-missing-type
 lib/ansible/modules/git.py validate-modules:doc-required-mismatch
 lib/ansible/modules/iptables.py pylint:disallowed-name
 lib/ansible/modules/lineinfile.py validate-modules:doc-choices-do-not-match-spec


### PR DESCRIPTION
##### SUMMARY

Add missing type to the `reference` option of the documentation of the `git` module

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

ansible-doc

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
