### PR TITLE
combine - merge two identical vars when list_merge=append or list_merge=prepend

### DIFF
--- a/changelogs/fragments/79312-fix-combine-append-prepend-when-vars-are-equal.yml
+++ b/changelogs/fragments/79312-fix-combine-append-prepend-when-vars-are-equal.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - combine - ``combine()`` filter did not merge two identical vars when using options ``list_merge='append'`` or ``list_merge='prepend'``. fix for ``def merge_hash`` function, defined in ``lib/ansible/utils/vars.py`` which is used by ``combine()``, to now append / prepend when merging vars which are equal (https://github.com/ansible/ansible/issues/79293).

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -106,7 +106,7 @@ def merge_hash(x, y, recursive=True, list_merge='replace'):
     # list_merge != append and list_merge != prepend), return y
     # (this `if` can be remove without impact on the function
     #  except performance)
-    if x == {} or (x == y and list_merge != 'append' and list_merge != 'prepend'):
+    if x == {} or (x == y and list_merge not in ('append', 'prepend')):
         return y.copy()
     if y == {}:
         return x

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -102,10 +102,11 @@ def merge_hash(x, y, recursive=True, list_merge='replace'):
     # verify x & y are dicts
     _validate_mutable_mappings(x, y)
 
-    # to speed things up: if x is empty or equal to y, return y
+    # to speed things up: if x is empty or (x equal to y and
+    # list_merge != append and list_merge != prepend), return y
     # (this `if` can be remove without impact on the function
     #  except performance)
-    if x == {} or x == y:
+    if x == {} or (x == y and list_merge != 'append' and list_merge != 'prepend'):
         return y.copy()
     if y == {}:
         return x


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Resolves #79293
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
resolves `combine()` filter plugin not appending / prepending properly when the two vars to be combined are equal

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
###### test.yaml playbook used to reproduce issue
```test.yaml
---
- hosts: localhost
  gather_facts: false
  vars:
    "data":
      "profile_list":
        - "test"
        #- "Profile1"
    "new_data":
      "profile_list":
        - "test"
        #- "Profile2"
  tasks:
    - name: combine
      set_fact:
        data: "{{ data | default({}, true) | combine(new_data, recursive=True, list_merge='append') }}"
    - name: print
      debug:
        var: data
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
###### Before change:
```
$ ansible-playbook test.yaml
[DEPRECATION WARNING]: Ansible will require Python 3.8 or newer on the controller starting with Ansible 2.12. Current version: 3.6.8 (default, Nov 16 2020,
16:55:22) [GCC 4.8.5 20150623 (Red Hat 4.8.5-44)]. This feature will be removed from ansible-core in version 2.12. Deprecation warnings can be disabled by
setting deprecation_warnings=False in ansible.cfg.
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ********************************************************************************************************************************************

TASK [combine] **********************************************************************************************************************************************
ok: [localhost]

TASK [print] ************************************************************************************************************************************************
ok: [localhost] => {
    "data": {
        "profile_list": [
            "test"
        ]
    }
}

PLAY RECAP **************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

$
```

###### After change:
```
$ ansible-playbook test.yaml
[DEPRECATION WARNING]: Ansible will require Python 3.8 or newer on the controller starting with Ansible 2.12. Current version: 3.6.8 (default, Nov 16 2020,
16:55:22) [GCC 4.8.5 20150623 (Red Hat 4.8.5-44)]. This feature will be removed from ansible-core in version 2.12. Deprecation warnings can be disabled by
setting deprecation_warnings=False in ansible.cfg.
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ********************************************************************************************************************************************

TASK [combine] **********************************************************************************************************************************************
ok: [localhost]

TASK [print] ************************************************************************************************************************************************
ok: [localhost] => {
    "data": {
        "profile_list": [
            "test",
            "test"
        ]
    }
}

PLAY RECAP **************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

$
```
