### PR TITLE
Fixed memory facts for OpenBSD

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/openbsd.py
+++ b/lib/ansible/module_utils/facts/hardware/openbsd.py
@@ -94,7 +94,7 @@ class OpenBSDHardware(Hardware):
         rc, out, err = self.module.run_command("/usr/bin/vmstat")
         if rc == 0:
             memory_facts['memfree_mb'] = int(out.splitlines()[-1].split()[4]) // 1024
-            memory_facts['memtotal_mb'] = int(self.sysctl['hw.usermem']) // 1024 // 1024
+            memory_facts['memtotal_mb'] = int(self.sysctl['hw.physmem']) // 1024 // 1024
 
         # Get swapctl info. swapctl output looks like:
         # total: 69268 1K-blocks allocated, 0 used, 69268 available


### PR DESCRIPTION
Fixes #77448 

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changed memtotal in openbsd.py to access the correct memory from the OpenBSD docs.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
openbsd

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Clones changes from stale branch #77572 
