### PR TITLE
validate-modules: the 'forced_action_plugin' attribute was renamed to 'action' and the extra data was not used anymore

### DIFF
--- a/changelogs/fragments/validate-modules-forced_action_plugin.yml
+++ b/changelogs/fragments/validate-modules-forced_action_plugin.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "validate-modules sanity test - remove support for the never implemented ``forced_action_plugin`` attribute (https://github.com/ansible/ansible/pull/79317)."

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -864,9 +864,6 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False, plugi
                 'action_group': add_default_attributes({
                     Required('membership'): list_string_types,
                 }),
-                'forced_action_plugin': add_default_attributes({
-                    Required('action_plugin'): any_string_types,
-                }),
                 'platform': add_default_attributes({
                     Required('platforms'): Any(list_string_types, *string_types)
                 }),


### PR DESCRIPTION
##### SUMMARY
So let's remove it from the schema.

@bcoca or do you want this to stay?

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
validate-modules schema
