### PR TITLE
Fix typo 'Ansbile'

### DIFF
--- a/lib/ansible/plugins/doc_fragments/action_common_attributes.py
+++ b/lib/ansible/plugins/doc_fragments/action_common_attributes.py
@@ -46,7 +46,7 @@ attributes:
     FILES = r'''
 attributes:
     safe_file_operations:
-      description: Uses Ansbile's strict file operation functions to ensure proper permissions and avoid data corruption
+      description: Uses Ansible's strict file operation functions to ensure proper permissions and avoid data corruption
     vault:
       description: Can automatically decrypt Ansible vaulted files
 '''

--- a/lib/ansible/plugins/doc_fragments/action_core.py
+++ b/lib/ansible/plugins/doc_fragments/action_core.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-# WARNING: this is mostly here as a convinence for documenting core behaviours, no plugin outside of ansbile-core should use this file
+# WARNING: this is mostly here as a convinence for documenting core behaviours, no plugin outside of ansible-core should use this file
 class ModuleDocFragment(object):
 
     # requires action_common


### PR DESCRIPTION
##### SUMMARY
Fixes a typo 'Ansbile' that appears in docs fragments.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs fragments
