### PR TITLE
Move collection playbook output from "warning" to "-v"

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -103,7 +103,7 @@ class PlaybookExecutor:
                     playbook_collection = _get_collection_name_from_path(playbook)
 
                 if playbook_collection:
-                    display.warning("running playbook inside collection {0}".format(playbook_collection))
+                    display.v("running playbook inside collection {0}".format(playbook_collection))
                     AnsibleCollectionConfig.default_collection = playbook_collection
                 else:
                     AnsibleCollectionConfig.default_collection = None

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -99,7 +99,7 @@ class PlaybookExecutor:
                     playbook_collection = resource[2]
                 else:
                     playbook_path = playbook
-                    # not fqcn, but might still be colleciotn playbook
+                    # not fqcn, but might still be collection playbook
                     playbook_collection = _get_collection_name_from_path(playbook)
 
                 if playbook_collection:


### PR DESCRIPTION
##### SUMMARY

(This is my first contribution, sorry in advance if I've done anything wrong!)

- The playbook-inside-collection feature prints a warning when there is nothing to warn about. Change from `warning` to `v`.
- Also fixed a minor non-functional typo in a comment.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

`lib/ansible/executor/playbook_executor.py`

##### ADDITIONAL INFORMATION

There is a nice feature where you can distribute playbooks inside collections and run them from inside the collection.

[The documentation](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_structure.html#collection-directories-and-files) describes it as a new feature in `ansible-core 2.11`:

> In prior releases, you could reference playbooks in this directory using the full path to the playbook file from the        command line. In ansible-core 2.11 and later, you can use the FQCN, `namespace.collection.playbook` (with or without         extension), to reference the playbooks from the command line or from `import_playbook`. This will keep the playbook in 'collection context’, as if you had added `collections: [ namespace.collection ]` to it.

But when you use that feature, you get a warning:

`[WARNING]: running playbook inside collection <collection name>`

The feature appears to NOT be deprecated or discouraged. There is no way to avoid or "fix" the warning state, unless you run your own playbook outside of the collection.

But it still could be useful to know that the playbook is coming from a collection, for debugging purposes.

So this pull request changes the `display.warning` to `display.v`, so we don't have a warning which implies that something bad is happening, but you can use `-v` if you still want the output.

It also fixes a minor typo in a comment (`colleciotn` to `collection`).

```
# before
ansible-playbook -i hosts namespace.collection.playbook
[WARNING]: running playbook inside collection namespace.collection

# after
## no warning output by default
ansible-playbook -i hosts namespace.collection.playbook

## debugging info is still available with -v
ansible-playbook -i hosts namespace.collection.playbook -v
running playbook inside collection namespace.collection
```
