### PR TITLE
[stable-2.13] Update Ansible release version to v2.13.6.post0.

### DIFF
--- a/lib/ansible/release.py
+++ b/lib/ansible/release.py
@@ -19,6 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-__version__ = '2.13.6'
+__version__ = '2.13.6.post0'
 __author__ = 'Ansible, Inc.'
 __codename__ = "Nobody's Fault but Mine"


### PR DESCRIPTION
##### SUMMARY
Release version bump to tag 2.13.6post0. Resets version to post0.

##### ISSUE TYPE
- Release Pull Request