### PR TITLE
set RHEL 4 Edge pkg_mgr fact to ansible.posix.r4e_rpm_ostree

### DIFF
--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -41,6 +41,7 @@ PKG_MGRS = [{'path': '/usr/bin/rpm-ostree', 'name': 'atomic_container'},
             {'path': '/usr/sbin/sorcery', 'name': 'sorcery'},
             {'path': '/usr/bin/installp', 'name': 'installp'},
             {'path': '/QOpenSys/pkgs/bin/yum', 'name': 'yum'},
+            {'path': '/run/ostree-booted', 'name': 'ansible.posix.r4e_rpm_ostree'},
             ]
 
 
@@ -70,6 +71,9 @@ class PkgMgrFactCollector(BaseFactCollector):
 
     def _check_rh_versions(self, pkg_mgr_name, collected_facts):
         if os.path.exists('/run/ostree-booted'):
+            if (collected_facts['ansible_distribution'] == "RedHat") and (int(collected_facts['ansible_distribution_major_version']) > 7):
+                # Atomic Host was retired with RHEL7. RHEL8+ is RHEL for Edge.
+                return "ansible.posix.r4e_rpm_ostree"
             return "atomic_container"
 
         if collected_facts['ansible_distribution'] == 'Fedora':

--- a/test/units/module_utils/facts/test_ansible_collector.py
+++ b/test/units/module_utils/facts/test_ansible_collector.py
@@ -493,7 +493,10 @@ class TestPkgMgrOSTreeFacts(TestPkgMgrFacts):
         # Recollect facts
         self.setUp()
         self.assertIn('pkg_mgr', self.facts)
-        self.assertEqual(self.facts['pkg_mgr'], 'atomic_container')
+        if distribution == 'RedHat':
+            self.assertEqual(self.facts['pkg_mgr'], 'ansible.posix.r4e_rpm_ostree')
+        else:
+            self.assertEqual(self.facts['pkg_mgr'], 'atomic_container')
 
     def test_is_rhel_edge_ostree(self):
         self._recollect_facts('RedHat', 8)


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add pkg_mgr fact for RHEL for Edge.

Depends on merge and release of https://github.com/ansible-collections/ansible.posix/pull/393
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pkg_mgr.py

