### PR TITLE
[2.14] Fix up incorrectly quoted doc example (#79356)

### DIFF
--- a/docs/docsite/rst/playbook_guide/complex_data_manipulation.rst
+++ b/docs/docsite/rst/playbook_guide/complex_data_manipulation.rst
@@ -35,7 +35,7 @@ Use a loop to create exponential backoff for retries/until.
       ping:
       retries: 10
       delay: '{{item|int}}'
-      loop: '{{ range(1, 10)|map('pow', 2) }}'
+      loop: '{{ range(1, 10)|map("pow", 2) }}'
 
 
 .. _keys_from_dict_matching_list:


### PR DESCRIPTION
(cherry picked from commit e7730f5d6cfceba69b99808e7d390ef60d014ec3)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/79356

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/playbook_guide/complex_data_manipulation.rst