### PR TITLE
ansible-doc and validate-modules: remove underscore deprecation handling for collections

### DIFF
--- a/changelogs/fragments/79362-validate-modules-underscore.yml
+++ b/changelogs/fragments/79362-validate-modules-underscore.yml
@@ -1,0 +1,6 @@
+breaking_changes:
+  - "ansible-doc - no longer treat plugins in collections whose name starts with ``_`` as deprecated
+     (https://github.com/ansible/ansible/pull/79217)."
+  - "ansible-test sanity - previously plugins and modules in collections whose name started with ``_``
+     were treated as deprecated, even when they were not marked as deprecated in ``meta/runtime.yml``.
+     This is no longer the case (https://github.com/ansible/ansible/pull/79362)."

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -496,7 +496,7 @@ class DocCLI(CLI, RoleMixin):
 
                 pbreak = plugin.split('.')
                 # TODO: add mark for deprecated collection plugins
-                if pbreak[-1].startswith('_') and plugin.startswith('ansible.builtin.'):
+                if pbreak[-1].startswith('_') and plugin.startswith(('ansible.builtin.', 'ansible.legacy.')):
                     # Handle deprecated ansible.builtin plugins
                     pbreak[-1] = pbreak[-1][1:]
                     plugin = '.'.join(pbreak)

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -495,7 +495,9 @@ class DocCLI(CLI, RoleMixin):
                     desc = desc[:linelimit] + '...'
 
                 pbreak = plugin.split('.')
-                if pbreak[-1].startswith('_'):  # Handle deprecated # TODO: add mark for deprecated collection plugins
+                # TODO: add mark for deprecated collection plugins
+                if pbreak[-1].startswith('_') and plugin.startswith('ansible.builtin.'):
+                    # Handle deprecated ansible.builtin plugins
                     pbreak[-1] = pbreak[-1][1:]
                     plugin = '.'.join(pbreak)
                     deprecated.append("%-*s %-*.*s" % (displace, plugin, linelimit, len(desc), desc))

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -794,7 +794,7 @@ def author(value):
 
 def doc_schema(module_name, for_collection=False, deprecated_module=False, plugin_type='module'):
 
-    if module_name.startswith('_'):
+    if module_name.startswith('_') and not for_collection:
         module_name = module_name[1:]
         deprecated_module = True
     if for_collection is False and plugin_type == 'connection' and module_name == 'paramiko_ssh':


### PR DESCRIPTION
##### SUMMARY
Right now all plugins whose name starts with `_` are treated as deprecated by `ansible-doc -l` and by the validate-modules sanity test. However they are not shown as deprecated in ansible-doc itself. While this is OK for plugins contained in ansible-core itself, it does not make sense for plugins in collections, since deprecation there is done differently. Also these two components are the only one that strip the leading underscore for collection plugins, causing problems both in documentation (`name:` contains the wrong name) and for users (`ansible-doc -l` shows a name that does not work).

(Was part of #79218.)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-doc
validate-modules
