### PR TITLE
Allow to mark plugins in collections as private

### DIFF
--- a/changelogs/fragments/79370-hidden-plugins.yml
+++ b/changelogs/fragments/79370-hidden-plugins.yml
@@ -1,3 +1,5 @@
 minor_changes:
-  - "Plugins in collections can now be marked as private by adding ``private: true`` to their routing information in ``meta/runtime.yml``.
-     This will prevent them being listed by ``ansible-doc --list`` (https://github.com/ansible/ansible/pull/79370)."
+  - >-
+    Plugins in collections can now be marked as private by adding ``private: true`` to their routing information in ``meta/runtime.yml``.
+    This will prevent them being listed by ``ansible-doc --list``. The JSON output of the documentation will contain ``"private": true``
+    (https://github.com/ansible/ansible/pull/79370).

--- a/changelogs/fragments/79370-hidden-plugins.yml
+++ b/changelogs/fragments/79370-hidden-plugins.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "Plugins in collections can now be marked as private by adding ``private: true`` to their routing information in ``meta/runtime.yml``.
+     This will prevent them being listed by ``ansible-doc --list`` (https://github.com/ansible/ansible/pull/79370)."

--- a/docs/docsite/rst/dev_guide/developing_collections_structure.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_structure.rst
@@ -253,6 +253,17 @@ A collection can store some additional metadata in a ``runtime.yml`` file in the
          util_dir.subdir.my_util:
            redirect: namespace.name.my_util
 
+  It is also possible to mark plugins as private to the collection by adding ``private: true``. This will prevent them from being listed by ansible-doc.
+
+  .. code:: yaml
+
+     plugin_routing:
+       modules:
+         some_private_module:
+           # This module can be used in roles in the collection, but should not be used
+           # by roles or playbooks outside this collection.
+           private: true
+
 - *import_redirection*
 
   A mapping of names for Python import statements and their redirected locations.

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -666,7 +666,8 @@ class DocCLI(CLI, RoleMixin):
         # Collect all proper collections that appear in the plugin list
         collections = set()
         for plugin in plugin_names:
-            collections.add('.'.join(plugin.split('.', 2)[:2]))
+            if plugin.count('.') >= 2:
+                collections.add('.'.join(plugin.split('.', 2)[:2]))
         collections.discard('ansible.builtin')
         collections.discard('ansible.legacy')
         # List private plugins for every collection

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -679,7 +679,12 @@ class DocCLI(CLI, RoleMixin):
         return result
 
     def _find_private_plugins(self, collection_name, plugin_type):
-        b_routing_meta_path = to_bytes(os.path.join(_get_collection_path(collection_name), 'meta/runtime.yml'))
+        try:
+            collection_path = _get_collection_path(collection_name)
+        except ValueError as exc:
+            display.vv('Error while finding collection path: %s' % exc)
+            return []
+        b_routing_meta_path = to_bytes(os.path.join(collection_path, 'meta/runtime.yml'))
         if not os.path.isfile(b_routing_meta_path):
             return []
         with open(b_routing_meta_path, 'rb') as fd:

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -17,13 +17,9 @@ import re
 import textwrap
 import traceback
 
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping  # type: ignore[no-redef,attr-defined]  # pylint: disable=ansible-bad-import-from
-
 import ansible.plugins.loader as plugin_loader
 
+from collections.abc import Mapping
 from pathlib import Path
 
 from ansible import constants as C

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -697,13 +697,17 @@ class DocCLI(CLI, RoleMixin):
         if plugin_type == 'module':
             plugin_type = 'modules'
 
-        if not isinstance(routing_dict.get('plugin_routing'), Mapping) or not isinstance(routing_dict['plugin_routing'].get(plugin_type), Mapping):
+        if (
+            not isinstance(routing_dict, Mapping) or
+            not isinstance(routing_dict.get('plugin_routing'), Mapping) or
+            not isinstance(routing_dict['plugin_routing'].get(plugin_type), Mapping)
+        ):
             return []
 
         return [
             f'{collection_name}.{plugin_name}'
             for plugin_name, plugin_record in routing_dict['plugin_routing'][plugin_type].items()
-            if plugin_record.get('private')
+            if isinstance(plugin_record, Mapping) and plugin_record.get('private')
         ]
 
     def _get_plugins_docs(self, plugin_type, names, fail_ok=False, fail_on_errors=True):

--- a/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/meta/runtime.yml
+++ b/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/meta/runtime.yml
@@ -1,0 +1,9 @@
+---
+
+plugin_routing:
+  filter:
+    hidden:
+      private: true
+  modules:
+    hidden:
+      private: true

--- a/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/filter/grouped.py
+++ b/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/filter/grouped.py
@@ -17,6 +17,10 @@ def meaningoflife(a):
     return 42
 
 
+def hidden(a):
+    return 'this is private!'
+
+
 class FilterModule(object):
     ''' Ansible core jinja2 filters '''
 
@@ -25,4 +29,5 @@ class FilterModule(object):
             'noop': nochange,
             'ultimatequestion': meaningoflife,
             'b64decode': nochange,   # here to colide with basename of builtin
+            'hidden': hidden,
         }

--- a/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/filter/hidden.yml
+++ b/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/filter/hidden.yml
@@ -1,0 +1,20 @@
+DOCUMENTATION:
+  name: hidden
+  author: Felix Fontein
+  version_added: 1.2.0
+  short_description: This is a private filter
+  description:
+    - You cannot list this one.
+  options:
+    _input:
+      description: Will be ignored.
+      type: raw
+      required: true
+
+EXAMPLES: |
+  something: "{{ (stuff | testns.testcol.hidden }}"
+
+RETURN:
+  _value:
+    description: guess
+    type: int

--- a/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/modules/hidden.py
+++ b/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/modules/hidden.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: hidden
+short_description: A hidden module
+description:
+    - This is private.
+author:
+    - Ansible Core Team
+version_added: 1.2.0
+'''
+
+EXAMPLES = '''
+'''
+
+RETURN = '''
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(),
+    )
+
+    module.exit_json(msg='This is private!')
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -30,6 +30,10 @@ ansible-doc --list testns.testcol --playbook-dir ./ 2>&1 | grep -v "Invalid coll
 # ensure we dont break on invalid collection name for list
 ansible-doc --list testns.testcol.fakemodule  --playbook-dir ./ 2>&1 | grep "Invalid collection name"
 
+# test that directly showing docs for private plugins in collections works
+ansible-doc testns.testcol.hidden -t filter --playbook-dir . | grep "TESTNS.TESTCOL.HIDDEN"
+ansible-doc testns.testcol.hidden -t module --playbook-dir . | grep "TESTNS.TESTCOL.HIDDEN"
+
 # test listing diff plugin types from collection
 for ptype in cache inventory lookup vars filter module
 do

--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
@@ -197,22 +197,19 @@ def validate_metadata_file(path, is_ansible, check_deprecation_dates=False):
         avoid_additional_data
     )
 
-    plugin_routing_schema = Any(
-        Schema({
-            ('deprecation'): Any(deprecation_schema),
-            ('tombstone'): Any(tombstoning_schema),
-            ('redirect'): fqcr,
-        }, extra=PREVENT_EXTRA),
-    )
+    generic_routing_schema = {
+        ('deprecation'): Any(deprecation_schema),
+        ('tombstone'): Any(tombstoning_schema),
+        ('redirect'): fqcr,
+        ('private'): bool,
+    }
+
+    plugin_routing_schema = Any(Schema(generic_routing_schema.copy(), extra=PREVENT_EXTRA))
 
     # Adjusted schema for module_utils
-    plugin_routing_schema_mu = Any(
-        Schema({
-            ('deprecation'): Any(deprecation_schema),
-            ('tombstone'): Any(tombstoning_schema),
-            ('redirect'): Any(*string_types),
-        }, extra=PREVENT_EXTRA),
-    )
+    plugin_routing_schema_mu_content = generic_routing_schema.copy()
+    plugin_routing_schema_mu_content['redirect'] = Any(*string_types)
+    plugin_routing_schema_mu = Any(Schema(plugin_routing_schema_mu_content, extra=PREVENT_EXTRA))
 
     list_dict_plugin_routing_schema = [{str_type: plugin_routing_schema}
                                        for str_type in string_types]


### PR DESCRIPTION
##### SUMMARY
This is a replacement for #79218 incorporating the review feedback by @s-hertel. Plugins in collections can be marked as private by adding `private: true` to their routing information.

For example for https://github.com/ansible-collections/community.sops/pull/98, applying the following diff marks the `community.sops._latest_version` filter as private and prevents it from being listed in `ansible-doc --list --type filter`:
```diff
diff --git a/meta/runtime.yml b/meta/runtime.yml
index d642fb8..2f404d4 100644
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -4,3 +4,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 requires_ansible: '>=2.9.10'
+
+plugin_routing:
+  filter:
+    _latest_version:
+      private: true
```
The documentation can still be viewed by running `ansible-doc --type filter community.sops._latest_version`. Also `--metadata-dump` shows the plugin as well. Both the regular ansible-doc JSON output and `--metadata-dump` include a `private: true` flag for private plugins.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-doc
runtime-metadata sanity test
