### PR TITLE
Add tests to validate `vars_files` first found behavior

### DIFF
--- a/test/integration/targets/vars_files/aliases
+++ b/test/integration/targets/vars_files/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group3
+context/controller

--- a/test/integration/targets/vars_files/inventory
+++ b/test/integration/targets/vars_files/inventory
@@ -1,0 +1,3 @@
+[testgroup]
+testhost foo=bar
+testhost2 foo=baz

--- a/test/integration/targets/vars_files/runme.sh
+++ b/test/integration/targets/vars_files/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible-playbook runme.yml -i inventory -v "$@"

--- a/test/integration/targets/vars_files/runme.yml
+++ b/test/integration/targets/vars_files/runme.yml
@@ -1,0 +1,22 @@
+---
+- hosts: testgroup
+  gather_facts: no
+  vars_files:
+    - "vars/common.yml"
+    -
+      - "vars/{{ foo }}.yml"
+      - "vars/defaults.yml"
+  tasks:
+    - import_tasks: validate.yml
+
+- hosts: testgroup
+  gather_facts: no
+  vars:
+    _vars_files:
+        - 'vars/{{ foo }}.yml'
+        - 'vars/defaults.yml'
+  vars_files:
+    - "vars/common.yml"
+    - "{{ lookup('first_found', _vars_files) }}"
+  tasks:
+    - import_tasks: validate.yml

--- a/test/integration/targets/vars_files/validate.yml
+++ b/test/integration/targets/vars_files/validate.yml
@@ -1,0 +1,11 @@
+- assert:
+    that:
+      - common is true
+- assert:
+    that:
+      - is_bar is true
+  when: inventory_hostname == 'testhost'
+- assert:
+    that:
+      - is_bar is false
+  when: inventory_hostname == 'testhost2'

--- a/test/integration/targets/vars_files/vars/bar.yml
+++ b/test/integration/targets/vars_files/vars/bar.yml
@@ -1,0 +1,1 @@
+is_bar: yes

--- a/test/integration/targets/vars_files/vars/common.yml
+++ b/test/integration/targets/vars_files/vars/common.yml
@@ -1,0 +1,1 @@
+common: yes

--- a/test/integration/targets/vars_files/vars/defaults.yml
+++ b/test/integration/targets/vars_files/vars/defaults.yml
@@ -1,0 +1,1 @@
+is_bar: no


### PR DESCRIPTION
##### SUMMARY
Add tests to validate `vars_files` first found behavior

This also includes a test showing how to use the `first_found` lookup in place of the list of lists syntax for `vars_files`

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/integration/targets/vars_files/aliases

##### ADDITIONAL INFORMATION
Technically now that I've validated an alternative that is more explicit in the outcome, we could proceed with deprecation of the list of lists syntax.