### PR TITLE
file lookup now works with general lookup error framework (#79339)

### DIFF
--- a/changelogs/fragments/file_lookup_errors.yml
+++ b/changelogs/fragments/file_lookup_errors.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - file lookup now plays nice with generic lookup ``errors`` option.

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -50,7 +50,7 @@ RETURN = """
     elements: str
 """
 
-from ansible.errors import AnsibleError, AnsibleOptionsError
+from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleLookupError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils._text import to_text
 from ansible.utils.display import Display
@@ -81,8 +81,8 @@ class LookupModule(LookupBase):
                     ret.append(contents)
                 else:
                     # TODO: only add search info if abs path?
-                    raise AnsibleError("file not found, use -vvvvv to see paths searched")
+                    raise AnsibleOptionsError("file not found, use -vvvvv to see paths searched")
             except AnsibleError as e:
-                raise AnsibleOptionsError("The 'file' lookup had an issue accessing the file '%s'" % term, orig_exc=e)
+                raise AnsibleLookupError("The 'file' lookup had an issue accessing the file '%s'" % term, orig_exc=e)
 
         return ret


### PR DESCRIPTION
* file lookup now works with general lookup error framework

(cherry picked from commit 3448fcabc539fb2d3351c20a5b82c3558d037c75)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lookup/file

##### ADDITIONAL INFORMATION
This is a bugfix backport for the change backported in #79245.