### PR TITLE
update antsibull-docs to 1.7.3

### DIFF
--- a/test/sanity/code-smell/docs-build.requirements.in
+++ b/test/sanity/code-smell/docs-build.requirements.in
@@ -6,4 +6,4 @@ sphinx-notfound-page
 sphinx-ansible-theme
 straight.plugin
 rstcheck < 4  # match version used in other sanity tests
-antsibull-docs == 1.7.0  # currently approved version
+antsibull-docs == 1.7.3  # currently approved version

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -1,19 +1,19 @@
 # edit "docs-build.requirements.in" and generate with: hacking/update-sanity-requirements.py --test docs-build
 aiofiles==22.1.0
 aiohttp==3.8.3
-aiosignal==1.2.0
+aiosignal==1.3.1
 alabaster==0.7.12
 ansible-pygments==0.1.1
-antsibull-core==1.2.0
-antsibull-docs==1.7.0
+antsibull-core==1.3.1
+antsibull-docs==1.7.3
 async-timeout==4.0.2
 asyncio-pool==0.6.0
 attrs==22.1.0
-Babel==2.10.3
-certifi==2022.9.14
+Babel==2.11.0
+certifi==2022.9.24
 charset-normalizer==2.1.1
 docutils==0.17.1
-frozenlist==1.3.1
+frozenlist==1.3.3
 idna==3.4
 imagesize==1.4.1
 Jinja2==3.1.2
@@ -24,7 +24,7 @@ perky==0.5.5
 pydantic==1.10.2
 Pygments==2.13.0
 pyparsing==3.0.9
-pytz==2022.2.1
+pytz==2022.6
 PyYAML==6.0
 requests==2.28.1
 resolvelib==0.8.1
@@ -36,7 +36,7 @@ snowballstemmer==2.2.0
 Sphinx==4.2.0
 sphinx-ansible-theme==0.9.1
 sphinx-notfound-page==0.8.3
-sphinx-rtd-theme==1.0.0
+sphinx-rtd-theme==1.1.1
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0
@@ -45,6 +45,6 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 straight.plugin==1.5.0
 Twiggy==0.5.1
-typing_extensions==4.3.0
+typing_extensions==4.4.0
 urllib3==1.26.12
 yarl==1.8.1

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -1,19 +1,19 @@
 # edit "docs-build.requirements.in" and generate with: hacking/update-sanity-requirements.py --test docs-build
 aiofiles==22.1.0
 aiohttp==3.8.3
-aiosignal==1.3.1
+aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.1
-antsibull-core==1.3.1
+antsibull-core==1.2.0
 antsibull-docs==1.7.3
 async-timeout==4.0.2
 asyncio-pool==0.6.0
 attrs==22.1.0
-Babel==2.11.0
-certifi==2022.9.24
+Babel==2.10.3
+certifi==2022.9.14
 charset-normalizer==2.1.1
 docutils==0.17.1
-frozenlist==1.3.3
+frozenlist==1.3.1
 idna==3.4
 imagesize==1.4.1
 Jinja2==3.1.2
@@ -24,7 +24,7 @@ perky==0.5.5
 pydantic==1.10.2
 Pygments==2.13.0
 pyparsing==3.0.9
-pytz==2022.6
+pytz==2022.2.1
 PyYAML==6.0
 requests==2.28.1
 resolvelib==0.8.1
@@ -36,7 +36,7 @@ snowballstemmer==2.2.0
 Sphinx==4.2.0
 sphinx-ansible-theme==0.9.1
 sphinx-notfound-page==0.8.3
-sphinx-rtd-theme==1.1.1
+sphinx-rtd-theme==1.0.0
 sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.0
@@ -45,6 +45,6 @@ sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
 straight.plugin==1.5.0
 Twiggy==0.5.1
-typing_extensions==4.4.0
+typing_extensions==4.3.0
 urllib3==1.26.12
 yarl==1.8.1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
To support Ansible 7 release.  We recognize that the CI containers will be out of sync with minor changes to `ansibull-docs`.
ansibull-docs 1.7.3 fixes the following:

- Fix rendering of the action_group attribute (https://github.com/ansible-community/antsibull-docs/pull/62).
- Fix version_added processing for ansible.builtin 0.x to represent this as Ansible 0.x instead of ansible-core 0.x (https://github.com/ansible-community/antsibull-docs/pull/61).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/sanity/code-smell/docs-build.requirements.in
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
