### PR TITLE
* Adding the capability to include scsi_disk_data for the SCSI disks.

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -676,18 +676,18 @@ class LinuxHardware(Hardware):
 
         try:
             for device in os.listdir('/sys/bus/scsi/devices'):
-                match = re.search('(\d{1,}):(\d{1,}):(\d{1,}):(\d{1,})', device)
+                match = re.search('(\\d{1,}):(\\d{1,}):(\\d{1,}):(\\d{1,})', device)
                 if match:
                     disk_name = os.listdir(os.path.join('/sys/bus/scsi/devices', device, 'block'))[0]
                     host_controller_name = get_file_content('/sys/class/scsi_host/host{id}/proc_name'.format(id=match.group(1)))
                     disk_scsi_data[disk_name] = {
                         'scsi_host_id': match.group(1),
-                        'scsi_host_name' : host_controller_name,
+                        'scsi_host_name': host_controller_name,
                         'scsi_channel_number': match.group(2),
                         'scsi_target_number': match.group(3),
                         'lun_number': match.group(4)
                     }
-        except:
+        except OSError:
             pass
 
         devs_wwn = {}

--- a/test/integration/targets/facts_linux_hardware/aliases
+++ b/test/integration/targets/facts_linux_hardware/aliases
@@ -1,0 +1,1 @@
+context/target

--- a/test/integration/targets/facts_linux_hardware/aliases
+++ b/test/integration/targets/facts_linux_hardware/aliases
@@ -1,1 +1,6 @@
+needs/privileged
+needs/root
 context/target
+shippable/posix/group1
+skip/freebsd
+skip/osx

--- a/test/integration/targets/facts_linux_hardware/tasks/main.yml
+++ b/test/integration/targets/facts_linux_hardware/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+
+- name: check whether we can see the /sys/bus/scsi/devices
+  ansible.builtin.find:
+    path: '/sys/bus/scsi/devices'
+  register: pathstat
+
+- debug:
+    msg: "This test will work on a linux server, with --docker-privileged. Tests are abandoned."
+  when: pathstat.examined == 0
+
+- block:
+    - name: run matched facts 
+      ansible.builtin.setup:
+        gather_subset:
+          - hardware
+          - '!all'
+      register: setup
+
+    - debug:
+        var: ansible_facts.devices
+    
+    - name: assert 
+      assert:
+        success_msg: success
+        that:
+          - ansible_facts.devices.sda.scsi_disk_data.lun_number is defined
+          - ansible_facts.devices.sda.scsi_disk_data.scsi_channel_number is defined
+          - ansible_facts.devices.sda.scsi_disk_data.scsi_host_id is defined
+          - ansible_facts.devices.sda.scsi_disk_data.scsi_host_name is defined
+          - ansible_facts.devices.sda.scsi_disk_data.scsi_target_number is defined
+  when: pathstat.examined != 0


### PR DESCRIPTION
 - scsi_host_id
 - scsi_host_name
 - scsi_channel_number
 - scsi_target_number
 - lun_number
* Retuned data is identical to lsscsi command.
* Integration tests are included.

##### SUMMARY

This PR adds adds the capability to fetch SCSI disk details from Linux Machines. SCSI details for the disks are a great help for playbooks involving RAID controllers or VMware to trace back the physical disks to the OS disks.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
linux facts hardware

##### ADDITIONAL INFORMATION

For example, this capability will allow tracking physical devices to the OS disks, with ease.

```
- name: Add disks with specified shares to the virtual machine
  community.vmware.vmware_guest_disk:
    hostname: "{{ vcenter_hostname }}"
    username: "{{ vcenter_username }}"
    password: "{{ vcenter_password }}"
    datacenter: "{{ datacenter_name }}"
    name: "Test_VM"
    disk:
      - size_gb: 1
        state: present
        scsi_controller: 1
        unit_number: 1
  delegate_to: localhost
  register: test_custom_shares

- name: gather hardware subset
  ansible.builtin.setup:
    gather_subset:
      - hardware
      - '!min'
      - '!all'
 
- name: create a volume group
   community.general.lvg:
    vg: vg.services
    pvs: "{{ item }}"
    pesize: 32
  with_items: "{{ ansible_facts.devices }}"
  when:
     - item.scsi_disk_data.lun_number is defined
     - item.scsi_disk_data.lun_number == 1
     - item.scsi_disk_data.scsi_host_id is defined
     - item.scsi_disk_data.scsi_host_id == 1
```
