### PR TITLE
[2.14] Docs: change devel for ansible 7

### DIFF
--- a/docs/docsite/sphinx_conf/ansible_conf.py
+++ b/docs/docsite/sphinx_conf/ansible_conf.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.join('ansible', 'lib'))
 # the repository version needs to be the one that is loaded:
 sys.path.insert(0, os.path.abspath(os.path.join('..', '..', '..', 'lib')))
 
-VERSION = 'devel'
+VERSION = '7'
 AUTHOR = 'Ansible, Inc'
 
 


### PR DESCRIPTION
##### SUMMARY
Changing the version from "devel" in docs/docsite/sphinx_conf/ansible_conf.py for Ansible 7. issue https://github.com/ansible/ansible/issues/79378

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Sphinx conf

##### ADDITIONAL INFORMATION
N/A
