### PR TITLE
Allow pip like version syntax for installing collections

### DIFF
--- a/changelogs/fragments/galaxy-install-no-colon.yml
+++ b/changelogs/fragments/galaxy-install-no-colon.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ansible-galaxy - Add ability to specify collection versions on the CLI without the need for a colon.
+  Such as ``namespace.name==1.2.3`` vs ``namespace.name:1.2.3``.

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -295,7 +295,7 @@ class _ComputedReqKindsMixin:
     @classmethod
     def from_requirement_dict(cls, collection_req, art_mgr, validate_signature_options=True):
         req_name = collection_req.get('name', None)
-        req_version = collection_req.get('version', '*')
+        req_version = collection_req.get('version') or '*'
         req_type = collection_req.get('type')
         # TODO: decide how to deprecate the old src API behavior
         req_source = collection_req.get('source', None)

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -282,13 +282,12 @@ class _ComputedReqKindsMixin:
             try:
                 pkg_req = PkgReq(collection_input)
             except Exception as e:
-                raise AnsibleError(
-                    f'Unable to parse requirement {collection_input!r}: {e}'
-                )
-            req |= {
-                'name': pkg_req.name,
-                'version': to_text(pkg_req.specifier),
-            }
+                req['name'] = collection_input
+            else:
+                req |= {
+                    'name': pkg_req.name,
+                    'version': to_text(pkg_req.specifier),
+                }
         req['signatures'] = supplemental_signatures
 
         return cls.from_requirement_dict(req, artifacts_manager)

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -29,6 +29,7 @@ if t.TYPE_CHECKING:
 
 from ansible.errors import AnsibleError
 from ansible.galaxy.api import GalaxyAPI
+from ansible.galaxy.collection import HAS_PACKAGING, PkgReq
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.common.arg_spec import ArgumentSpecValidator
 from ansible.utils.collection_loader import AnsibleCollectionRef
@@ -271,10 +272,23 @@ class _ComputedReqKindsMixin:
         if _is_concrete_artifact_pointer(collection_input):
             # Arg is a file path or URL to a collection
             req['name'] = collection_input
-        else:
+        elif ':' in collection_input:
             req['name'], _sep, req['version'] = collection_input.partition(':')
             if not req['version']:
                 del req['version']
+        else:
+            if not HAS_PACKAGING:
+                raise AnsibleError("Failed to import packaging, check that a supported version is installed")
+            try:
+                pkg_req = PkgReq(collection_input)
+            except Exception as e:
+                raise AnsibleError(
+                    f'Unable to parse requirement {collection_input!r}: {e}'
+                )
+            req |= {
+                'name': pkg_req.name,
+                'version': to_text(pkg_req.specifier),
+            }
         req['signatures'] = supplemental_signatures
 
         return cls.from_requirement_dict(req, artifacts_manager)

--- a/test/integration/targets/ansible-galaxy-collection/tasks/upgrade.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/upgrade.yml
@@ -142,7 +142,7 @@
     - directory
 
 - name: install a collection
-  command: ansible-galaxy collection install namespace1.name1:0.0.1 {{ galaxy_verbosity }}
+  command: ansible-galaxy collection install namespace1.name1==0.0.1 {{ galaxy_verbosity }}
   register: result
   failed_when:
     - '"namespace1.name1:0.0.1 was installed successfully" not in result.stdout_lines'


### PR DESCRIPTION
##### SUMMARY
Allow pip like version syntax for installing collections

I'm always confused about the current syntax, I never remember that it is a `:`.

I usually end up with:

1. `namespace.name==1.2.3`
2. `namespace.name,==1.2.3`
3. `namespace.name???`
4. Go look at docs
5. `namespace.name:==1.2.3`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/galaxy/dependency_resolution/dataclasses.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
