### PR TITLE
set antsibull-docs to 1.7.3

### DIFF
--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -1,0 +1,14 @@
+# pip packages required to build docsite
+# These requirements drift from test/sanity/code-smell/docs-build.requirements.txt
+# only for antsibull-docs minor (bugfix) releases. 
+
+jinja2==3.1.2
+PyYAML==6.0
+resolvelib==0.8.1
+rstcheck==3.5.0
+sphinx == 4.2.0
+sphinx-ansible-theme==0.9.1
+sphinx-notfound-page==0.8.3
+straight.plugin==1.5.0
+antsibull-docs == 1.7.3  # Drifted from CI. currently approved version
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allowing `anstibull-docs` version to drift from CI container to provide minor bugfixes.

Related to https://github.com/ansible/ansible/pull/79395
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/known_good_reqs.txt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
