### PR TITLE
Make rmdir more reliable for galaxy collection install

### DIFF
--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1449,7 +1449,10 @@ def install(collection, path, artifacts_manager):  # FIXME: mv to dataclasses?
     )
 
     if os.path.exists(b_collection_path):
-        shutil.rmtree(b_collection_path)
+        # See bug #79408 for details on ignoring_errors
+        shutil.rmtree(b_collection_path, ignore_errors=True)
+        if os.path.exists(b_collection_path):
+            raise AnsibleError("Failed to remove the existing collection at '%s'." % b_collection_path)
 
     if collection.is_dir:
         install_src(collection, b_artifact_path, b_collection_path, artifacts_manager)


### PR DESCRIPTION
##### SUMMARY
Avoid failing to remove directory due to files being already removed from disk.

Fixes: #79408

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
galaxy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```