### PR TITLE
document where to save cloud config files

### DIFF
--- a/test/lib/ansible_test/config/cloud-config-aws.ini.template
+++ b/test/lib/ansible_test/config/cloud-config-aws.ini.template
@@ -6,7 +6,9 @@
 # 2) Using the automatically provisioned AWS credentials in ansible-test.
 #
 # If you do not want to use the automatically provisioned temporary AWS credentials,
-# fill in the @VAR placeholders below and save this file without the .template extension.
+# fill in the @VAR placeholders below and save this file without the .template extension,
+# into the tests/integration directory of the collection you're testing.
+# If you need to omit optional fields like security_token, comment out that line.
 # This will cause ansible-test to use the given configuration instead of temporary credentials.
 #
 # NOTE: Automatic provisioning of AWS credentials requires an ansible-core-ci API key.

--- a/test/lib/ansible_test/config/cloud-config-azure.ini.template
+++ b/test/lib/ansible_test/config/cloud-config-azure.ini.template
@@ -6,7 +6,8 @@
 # 2) Using the automatically provisioned Azure credentials in ansible-test.
 #
 # If you do not want to use the automatically provisioned temporary Azure credentials,
-# fill in the values below and save this file without the .template extension.
+# fill in the values below and save this file without the .template extension,
+# into the tests/integration directory of the collection you're testing.
 # This will cause ansible-test to use the given configuration instead of temporary credentials.
 #
 # NOTE: Automatic provisioning of Azure credentials requires an ansible-core-ci API key in ~/.ansible-core-ci.key

--- a/test/lib/ansible_test/config/cloud-config-cloudscale.ini.template
+++ b/test/lib/ansible_test/config/cloud-config-cloudscale.ini.template
@@ -4,7 +4,7 @@
 #
 # 1) Running integration tests without using ansible-test.
 #
-# fill in the value below and save this file without the .template extension,
+# Fill in the value below and save this file without the .template extension,
 # into the tests/integration directory of the collection you're testing.
 
 [default]

--- a/test/lib/ansible_test/config/cloud-config-cloudscale.ini.template
+++ b/test/lib/ansible_test/config/cloud-config-cloudscale.ini.template
@@ -4,6 +4,8 @@
 #
 # 1) Running integration tests without using ansible-test.
 #
+# fill in the value below and save this file without the .template extension,
+# into the tests/integration directory of the collection you're testing.
 
 [default]
 cloudscale_api_token = @API_TOKEN

--- a/test/lib/ansible_test/config/cloud-config-cs.ini.template
+++ b/test/lib/ansible_test/config/cloud-config-cs.ini.template
@@ -6,7 +6,8 @@
 # 2) Using the automatically provisioned cloudstack-sim docker container in ansible-test.
 #
 # If you do not want to use the automatically provided CloudStack simulator,
-# fill in the @VAR placeholders below and save this file without the .template extension.
+# fill in the @VAR placeholders below and save this file without the .template extension,
+# into the tests/integration directory of the collection you're testing.
 # This will cause ansible-test to use the given configuration and not launch the simulator.
 #
 # It is recommended that you DO NOT use this template unless you cannot use the simulator.

--- a/test/lib/ansible_test/config/cloud-config-gcp.ini.template
+++ b/test/lib/ansible_test/config/cloud-config-gcp.ini.template
@@ -6,7 +6,8 @@
 # 2) Using the automatically provisioned cloudstack-sim docker container in ansible-test.
 #
 # If you do not want to use the automatically provided GCP simulator,
-# fill in the @VAR placeholders below and save this file without the .template extension.
+# fill in the @VAR placeholders below and save this file without the .template extension,
+# into the tests/integration directory of the collection you're testing.
 # This will cause ansible-test to use the given configuration and not launch the simulator.
 #
 # It is recommended that you DO NOT use this template unless you cannot use the simulator.

--- a/test/lib/ansible_test/config/cloud-config-hcloud.ini.template
+++ b/test/lib/ansible_test/config/cloud-config-hcloud.ini.template
@@ -6,7 +6,8 @@
 # 2) Using the automatically provisioned Hetzner Cloud credentials in ansible-test.
 #
 # If you do not want to use the automatically provisioned temporary Hetzner Cloud credentials,
-# fill in the @VAR placeholders below and save this file without the .template extension.
+# fill in the @VAR placeholders below and save this file without the .template extension,
+# into the tests/integration directory of the collection you're testing.
 # This will cause ansible-test to use the given configuration instead of temporary credentials.
 #
 # NOTE: Automatic provisioning of Hetzner Cloud credentials requires an ansible-core-ci API key.

--- a/test/lib/ansible_test/config/cloud-config-opennebula.ini.template
+++ b/test/lib/ansible_test/config/cloud-config-opennebula.ini.template
@@ -6,7 +6,8 @@
 # 2) Running integration tests against previously recorded XMLRPC fixtures
 #
 # If you want to test against a Live OpenNebula platform,
-# fill in the values below and save this file without the .template extension.
+# fill in the values below and save this file without the .template extension,
+# into the tests/integration directory of the collection you're testing.
 # This will cause ansible-test to use the given configuration.
 #
 # If you run with @FIXTURES enabled (true) then you can decide if you want to

--- a/test/lib/ansible_test/config/cloud-config-openshift.kubeconfig.template
+++ b/test/lib/ansible_test/config/cloud-config-openshift.kubeconfig.template
@@ -6,7 +6,8 @@
 # 2) Using the automatically provisioned openshift-origin docker container in ansible-test.
 #
 # If you do not want to use the automatically provided OpenShift container,
-# place your kubeconfig file next to this file, with the same name, but without the .template extension.
+# place your kubeconfig file next into the tests/integration directory of the collection you're testing,
+# with the same name is this file, but without the .template extension.
 # This will cause ansible-test to use the given configuration and not launch the automatically provided container.
 #
 # It is recommended that you DO NOT use this template unless you cannot use the automatically provided container.

--- a/test/lib/ansible_test/config/cloud-config-scaleway.ini.template
+++ b/test/lib/ansible_test/config/cloud-config-scaleway.ini.template
@@ -5,7 +5,8 @@
 # 1) Running integration tests without using ansible-test.
 #
 # If you want to test against the Vultr public API,
-# fill in the values below and save this file without the .template extension.
+# fill in the values below and save this file without the .template extension,
+# into the tests/integration directory of the collection you're testing.
 # This will cause ansible-test to use the given configuration.
 
 [default]

--- a/test/lib/ansible_test/config/cloud-config-vcenter.ini.template
+++ b/test/lib/ansible_test/config/cloud-config-vcenter.ini.template
@@ -6,7 +6,8 @@
 # 2) Using the automatically provisioned VMware credentials in ansible-test.
 #
 # If you do not want to use the automatically provisioned temporary VMware credentials,
-# fill in the @VAR placeholders below and save this file without the .template extension.
+# fill in the @VAR placeholders below and save this file without the .template extension,
+# into the tests/integration directory of the collection you're testing.
 # This will cause ansible-test to use the given configuration instead of temporary credentials.
 #
 # NOTE: Automatic provisioning of VMware credentials requires an ansible-core-ci API key.

--- a/test/lib/ansible_test/config/cloud-config-vultr.ini.template
+++ b/test/lib/ansible_test/config/cloud-config-vultr.ini.template
@@ -5,7 +5,8 @@
 # 1) Running integration tests without using ansible-test.
 #
 # If you want to test against the Vultr public API,
-# fill in the values below and save this file without the .template extension.
+# fill in the values below and save this file without the .template extension,
+# into the tests/integration directory of the collection you're testing.
 # This will cause ansible-test to use the given configuration.
 
 [default]

--- a/test/lib/ansible_test/config/inventory.networking.template
+++ b/test/lib/ansible_test/config/inventory.networking.template
@@ -6,7 +6,8 @@
 # 2) Using the `--platform` option to provision temporary network instances on EC2.
 #
 # If you do not want to use the automatically provisioned temporary network instances,
-# fill in the @VAR placeholders below and save this file without the .template extension.
+# fill in the @VAR placeholders below and save this file without the .template extension,
+# into the tests/integration directory of the collection you're testing.
 #
 # NOTE: Automatic provisioning of network instances on EC2 requires an ansible-core-ci API key.
 

--- a/test/lib/ansible_test/config/inventory.winrm.template
+++ b/test/lib/ansible_test/config/inventory.winrm.template
@@ -6,7 +6,8 @@
 # 1) Using the `--windows` option to provision temporary Windows instances on EC2.
 #
 # If you do not want to use the automatically provisioned temporary Windows instances,
-# fill in the @VAR placeholders below and save this file without the .template extension.
+# fill in the @VAR placeholders below and save this file without the .template extension,
+# into the tests/integration directory of the collection you're testing.
 #
 # NOTE: Automatic provisioning of Windows instances on EC2 requires an ansible-core-ci API key.
 #


### PR DESCRIPTION
##### SUMMARY

This fixes part of #79411.
This fixes the comment part.
And the part about the optional `security_token` field.
This does not modify the error message returned by `ansible-test`.

This should help with: https://github.com/ansible-collections/amazon.aws/issues/924

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
config

##### ADDITIONAL INFORMATION

I don't know what most of those files I modified are. I've only tested AWS stuff previously. So I need someone to confirm that the changes to those other files are applicable to those.

I did not modify the cloudscale one, because that's very barebones. I don't know if it's the same situation as the others.

I did not modify the openshift one, because it already had some mention of putting another file next to this one. That sounds possibly not right. Should both files go into `tests/integration` instead?