### PR TITLE
Fix password lookup rewrites file when using encrypt

### DIFF
--- a/changelogs/fragments/79431-fix-password-lookup-rewrites.yml
+++ b/changelogs/fragments/79431-fix-password-lookup-rewrites.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes the password lookup to not rewrite files if they are not changed when using the "encrypt" parameter (#79430).

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -366,11 +366,12 @@ class LookupModule(LookupBase):
 
             ident = params['ident']
             if encrypt and not ident:
-                changed = True
                 try:
                     ident = BaseHash.algorithms[encrypt].implicit_ident
                 except KeyError:
                     ident = None
+                if ident:
+                    changed = True
 
             if changed and b_path != to_bytes('/dev/null'):
                 content = _format_content(plaintext_password, salt, encrypt=encrypt, ident=ident)

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -529,6 +529,9 @@ class TestLookupModuleWithPasslib(BaseTestLookupModule):
         for result in results:
             self.assertEqual(result, u'$pbkdf2-sha256$20000$ODc2NTQzMjE$Uikde0cv0BKaRaAXMrUQB.zvG4GmnjClwjghwIRf2gU')
 
+        # Assert the password file is not rewritten
+        mock_write_file.assert_not_called()
+
 
 @pytest.mark.skipif(passlib is None, reason='passlib must be installed to run these tests')
 class TestLookupModuleWithPasslibWrappedAlgo(BaseTestLookupModule):

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -520,10 +520,8 @@ class TestLookupModuleWithPasslib(BaseTestLookupModule):
             self.assertEqual(int(str_parts[2]), crypt_parts['rounds'])
             self.assertIsInstance(result, text_type)
 
-    @patch.object(PluginLoader, '_get_paths')
     @patch('ansible.plugins.lookup.password._write_password_file')
-    def test_password_already_created_encrypt(self, mock_get_paths, mock_write_file):
-        mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
+    def test_password_already_created_encrypt(self, mock_write_file):
         password.os.path.exists = lambda x: x == to_bytes('/path/to/somewhere')
 
         with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:


### PR DESCRIPTION
##### SUMMARY
This fixes a bug where the password file is always rewritten when using the encrypt parameter. The bug was introduced with commit 1bd7dcf339dd8b6c50bc16670be2448a206f4fdb.

Fixes: #79430.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
password lookup
