### PR TITLE
Add build and publish GHA workflow

### DIFF
--- a/.github/workflows/buildandpublish.yml
+++ b/.github/workflows/buildandpublish.yml
@@ -1,0 +1,31 @@
+name: Build and publish Ansible
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  build-and-publish:
+    name: Build and publish Ansible to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+    - name: Publish Ansible distribution to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
##### SUMMARY

Add a Github Action workflow to build and publish Ansible sdist, triggered by a v* tag.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Release Pull Request


