### PR TITLE
stable/2.12: ansible-galaxy - support ``resolvelib >= 0.5.3, < 0.10.0`` (#79399)

### DIFF
--- a/changelogs/fragments/79399-resolvelib_lt_0_10_0.yml
+++ b/changelogs/fragments/79399-resolvelib_lt_0_10_0.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-galaxy - support ``resolvelib >= 0.5.3, < 0.10.0``.

--- a/docs/docsite/known_good_reqs.txt
+++ b/docs/docsite/known_good_reqs.txt
@@ -9,7 +9,7 @@ docutils==0.16
 jinja2==3.0.1
 Pygments==2.9.0
 PyYAML==5.4.1
-resolvelib==0.5.4
+resolvelib==0.9.0
 rstcheck==3.3.1
 sphinx==4.0.2
 sphinx-notfound-page==0.7.1 # must be >= 0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ packaging
 # NOTE: resolvelib 0.x version bumps should be considered major/breaking
 # NOTE: and we should update the upper cap with care, at least until 1.0
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
-resolvelib >= 0.5.3, < 0.6.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, < 0.10.0  # dependency resolver used by ansible-galaxy

--- a/test/lib/ansible_test/_data/requirements/ansible.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible.txt
@@ -10,4 +10,4 @@ packaging
 # NOTE: resolvelib 0.x version bumps should be considered major/breaking
 # NOTE: and we should update the upper cap with care, at least until 1.0
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
-resolvelib >= 0.5.3, < 0.6.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, < 0.10.0  # dependency resolver used by ansible-galaxy

--- a/test/lib/ansible_test/_data/requirements/sanity.import.plugin.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.import.plugin.txt
@@ -2,7 +2,7 @@ jinja2 == 3.0.1
 PyYAML == 5.4.1
 cryptography == 3.3.2
 packaging == 21.0
-resolvelib == 0.5.4
+resolvelib == 0.9.0
 
 # dependencies
 MarkupSafe == 2.0.1

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -1,6 +1,6 @@
 jinja2 == 3.0.1
 pyyaml == 5.4.1
-resolvelib == 0.5.4
+resolvelib == 0.9.0
 sphinx == 2.1.2
 sphinx-notfound-page == 0.7.1
 sphinx-ansible-theme == 0.8.0

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -2,7 +2,7 @@ docutils == 0.17.1
 jinja2 == 3.0.1
 packaging == 21.0
 pyyaml == 5.4.1  # ansible-core requirement
-resolvelib == 0.5.4  # ansible-core requirement
+resolvelib == 0.9.0  # ansible-core requirement
 rstcheck == 3.3.1
 straight.plugin == 1.5.0
 antsibull-changelog == 0.9.0


### PR DESCRIPTION
* Upgrade `resolvelib >= 0.5.3, < 0.10.0`

https://pypi.org/project/resolvelib/0.9.0/ released on 2022-11-17:

  * https://github.com/sarugaku/resolvelib/blob/master/CHANGELOG.rst#090-2022-11-17
  * https://github.com/sarugaku/resolvelib/releases/tag/0.9.0

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>
(cherry picked from commit b148fd8dd74c8599f809f71117a86577ccfb0638)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
