### PR TITLE
Allow modules to declare environment variables in options

### DIFF
--- a/changelogs/fragments/79471-env-modules.yml
+++ b/changelogs/fragments/79471-env-modules.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Allow modules to declare environment variables for options in documentation (https://github.com/ansible/ansible/pull/79471)."

--- a/docs/templates/config.rst.j2
+++ b/docs/templates/config.rst.j2
@@ -207,6 +207,8 @@ you can use the command line utility mentioned above (`ansible-config`) to brows
 
 {%   endfor %}
 
+.. _ansible_configuration_env_vars:
+
 Environment Variables
 =====================
 

--- a/lib/ansible/plugins/doc_fragments/files.py
+++ b/lib/ansible/plugins/doc_fragments/files.py
@@ -77,6 +77,9 @@ options:
     type: bool
     default: no
     version_added: '2.2'
+    env:
+      - name: ANSIBLE_UNSAFE_WRITES
+        version_added: '2.11'
   attributes:
     description:
     - The attributes the resulting filesystem object should have.

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -36,15 +36,15 @@ def merge_fragment(target, source):
 
 
 def _process_versions_and_dates(fragment, is_module, return_docs, callback):
-    def process_deprecation(deprecation, top_level=False):
+    def process_deprecation(deprecation, top_level=False, treat_as_plugin=False):
         collection_name = 'removed_from_collection' if top_level else 'collection_name'
         if not isinstance(deprecation, MutableMapping):
             return
-        if (is_module or top_level) and 'removed_in' in deprecation:  # used in module deprecations
+        if ((is_module and not treat_as_plugin) or top_level) and 'removed_in' in deprecation:  # used in module deprecations
             callback(deprecation, 'removed_in', collection_name)
         if 'removed_at_date' in deprecation:
             callback(deprecation, 'removed_at_date', collection_name)
-        if not (is_module or top_level) and 'version' in deprecation:  # used in plugin option deprecations
+        if not ((is_module and not treat_as_plugin) or top_level) and 'version' in deprecation:  # used in plugin option deprecations
             callback(deprecation, 'version', collection_name)
 
     def process_option_specifiers(specifiers):
@@ -54,7 +54,7 @@ def _process_versions_and_dates(fragment, is_module, return_docs, callback):
             if 'version_added' in specifier:
                 callback(specifier, 'version_added', 'version_added_collection')
             if isinstance(specifier.get('deprecated'), MutableMapping):
-                process_deprecation(specifier['deprecated'])
+                process_deprecation(specifier['deprecated'], treat_as_plugin=True)
 
     def process_options(options):
         for option in options.values():

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -62,9 +62,9 @@ def _process_versions_and_dates(fragment, is_module, return_docs, callback):
                 continue
             if 'version_added' in option:
                 callback(option, 'version_added', 'version_added_collection')
+            if isinstance(option.get('env'), list):
+                process_option_specifiers(option['env'])
             if not is_module:
-                if isinstance(option.get('env'), list):
-                    process_option_specifiers(option['env'])
                 if isinstance(option.get('ini'), list):
                     process_option_specifiers(option['ini'])
                 if isinstance(option.get('vars'), list):

--- a/test/integration/targets/ansible-doc/randommodule-text.output
+++ b/test/integration/targets/ansible-doc/randommodule-text.output
@@ -19,6 +19,7 @@ OPTIONS (= is mandatory):
           env:
           - deprecated:
               alternative: none
+              collection_name: testns.testcol
               removed_in: 2.0.0
               version: 2.0.0
               why: Test deprecation

--- a/test/integration/targets/ansible-doc/randommodule.output
+++ b/test/integration/targets/ansible-doc/randommodule.output
@@ -24,12 +24,14 @@
                         {
                             "deprecated": {
                                 "alternative": "none",
+                                "collection_name": "testns.testcol",
                                 "removed_in": "2.0.0",
                                 "version": "2.0.0",
                                 "why": "Test deprecation"
                             },
                             "name": "TEST_ENV",
-                            "version_added": "1.0.0"
+                            "version_added": "1.0.0",
+                            "version_added_collection": "testns.testcol"
                         }
                     ],
                     "options": {

--- a/test/units/utils/test_plugin_docs.py
+++ b/test/units/utils/test_plugin_docs.py
@@ -35,7 +35,6 @@ ADD_TESTS = [
                         'removed_in': '2.0.0',
                     },
                     'env': [
-                        # should not be touched since this isn't a plugin
                         {
                             'version_added': '1.3.0',
                             'deprecated': {
@@ -98,11 +97,12 @@ ADD_TESTS = [
                         'removed_in': '2.0.0',
                     },
                     'env': [
-                        # should not be touched since this isn't a plugin
                         {
                             'version_added': '1.3.0',
+                            'version_added_collection': 'foo.bar',
                             'deprecated': {
                                 'version': '2.0.0',
+                                'collection_name': 'foo.bar',
                             },
                         },
                     ],


### PR DESCRIPTION
##### SUMMARY
Allows modules to declare environment variable fallbacks for options. Right now modules have to do this in the description.

Also declares `ANSIBLE_UNSAFE_WRITES` in the `files` docs fragment, which was added in ansible-core 2.11 and at the moment isn't explicitly documented.

Needs an antsibull-docs PR to avoid this leading to broken documentation (https://github.com/ansible-community/antsibull-docs/pull/75).

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
validate-modules sanity test
lib/ansible/plugins/doc_fragments/files.py
