### PR TITLE
ansible-test: do not trigger all tests when .github/BOTMETA.yml is changed

### DIFF
--- a/changelogs/fragments/79472-ansible-test-botmeta.yml
+++ b/changelogs/fragments/79472-ansible-test-botmeta.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ansible-test - do not trigger running *all* tests when ``.github/BOTMETA.yml`` is changed in collections (https://github.com/ansible/ansible/pull/79472)."

--- a/test/lib/ansible_test/_internal/classification/__init__.py
+++ b/test/lib/ansible_test/_internal/classification/__init__.py
@@ -639,6 +639,9 @@ class PathMapper:
         if path.startswith('docs/'):
             return minimal
 
+        if path == '.github/BOTMETA.yml':
+            return minimal
+
         if '/' not in path:
             if path in (
                     '.gitignore',


### PR DESCRIPTION
##### SUMMARY
This avoids running **all** tests when `.github/BOTMETA.yml` is changed, which commonly happens in collections using @ansibullbot when a new module or plugin is added. Fixing this reduces CI speed a lot for such PRs, and avoids unnecessary annoyances to PR authors such as https://github.com/ansible-collections/community.general/pull/5606#issuecomment-1328073770 (which happens because every push to the PR runs all tests, including the ones from some other module that access the GH API).

This affects at least community.general and community.network, since these use the bot and use ansible-test's change detection.

CC @Andersson007

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
