### PR TITLE
[backport][2.12][PR #79468] Set explicit meta `long_description_content_type`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -319,6 +319,7 @@ static_setup_params = dict(
     name='ansible-core',
     version=__version__,
     description='Radically simple IT automation',
+    long_description_content_type='text/x-rst',
     author=__author__,
     author_email='info@ansible.com',
     url='https://ansible.com/',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

This is necessary for `twine check --strict` to pass.

(cherry picked from commit 80551633c7b4ed782c293b09b04d77d8385614c4)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Packaging Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`setup.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This is necessary for `twine check --strict` to pass.
It's a backport of #79468.