### PR TITLE
[backport][2.14][PRs #78402 #79289] Enable the `reboot` integration test in CI

### DIFF
--- a/test/integration/targets/reboot/aliases
+++ b/test/integration/targets/reboot/aliases
@@ -1,5 +1,5 @@
 context/target
 destructive
 needs/root
-shippable/posix/group3
+shippable/posix/group2
 skip/docker

--- a/test/integration/targets/reboot/aliases
+++ b/test/integration/targets/reboot/aliases
@@ -1,2 +1,5 @@
-# No current way to split controller and test node
-unsupported
+context/target
+destructive
+needs/root
+shippable/posix/group3
+skip/docker

--- a/test/integration/targets/reboot/tasks/main.yml
+++ b/test/integration/targets/reboot/tasks/main.yml
@@ -1,39 +1,41 @@
+- name: Check split state
+  stat:
+    path: "{{ output_dir }}"
+  register: split
+  ignore_errors: yes
+
+- name: >-
+    Memorize whether we're in a containerized environment
+    and/or a split controller mode
+  set_fact:
+    in_container_env: >-
+      {{
+        ansible_facts.virtualization_type | default('')
+        in ['docker', 'container', 'containerd']
+      }}
+    in_split_controller_mode: >-
+      {{ split is not success or not split.stat.exists }}
+
+- name: Explain why testing against a container is not an option
+  debug:
+    msg: >-
+      This test is attempting to reboot the whole host operating system.
+      The current target is a containerized environment. Containers
+      cannot be reboot like VMs. This is why the test is being skipped.
+  when: in_container_env
+
+- name: Explain why testing against the same host is not an option
+  debug:
+    msg: >-
+      This test is attempting to reboot the whole host operating system.
+      This means it would interrupt itself trying to reboot own
+      environment. It needs to target a separate VM or machine to be
+      able to function so it's being skipped in the current invocation.
+  when: not in_split_controller_mode
+
 - name: Test reboot
-  when: ansible_facts.virtualization_type | default('') not in ['docker', 'container', 'containerd']
+  when: not in_container_env and in_split_controller_mode
   block:
-    # This block can be removed once we have a mechanism in ansible-test to separate
-    # the control node from the managed node.
-    - block:
-        - name: Write temp file for sanity checking this is not the controller
-          copy:
-            content: 'I am the control node'
-            dest: /tmp/Anything-Nutlike-Nuzzle-Plow-Overdue
-          delegate_to: localhost
-          connection: local
-          when: inventory_hostname == ansible_play_hosts[0]
-
-        - name: See if the temp file exists on the managed node
-          stat:
-            path: /tmp/Anything-Nutlike-Nuzzle-Plow-Overdue
-          register: controller_temp_file
-
-        - name: EXPECT FAILURE | Check if the managed node is the control node
-          assert:
-            msg: >
-              This test must be run manually by modifying the inventory file to point
-              "{{ inventory_hostname }}" at a remote host rather than "{{ ansible_host }}".
-              Skipping reboot test.
-            that:
-              - not controller_temp_file.stat.exists
-      always:
-        - name: Cleanup temp file
-          file:
-            path: /tmp/Anything-Nutlike-Nuzzle-Plow-Overdue
-            state: absent
-          delegate_to: localhost
-          connection: local
-          when: inventory_hostname == ansible_play_hosts[0]
-
     - import_tasks: test_standard_scenarios.yml
     - import_tasks: test_reboot_command.yml
     - import_tasks: test_invalid_parameter.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

Co-Authored-By: Matt Clay <matt@mystile.com>
(cherry picked from commit bb7ad0f)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/integration/targets/reboot

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
It wasn't possible to run this test in CI in the past before ansible-core started supporting split-controller testing. But now that it does, this has to be enabled to prevent regressions.
It's a backport of #78402 and #79289.