### PR TITLE
fixed misleading setup example

### DIFF
--- a/lib/ansible/modules/setup.py
+++ b/lib/ansible/modules/setup.py
@@ -133,7 +133,7 @@ EXAMPLES = r"""
       - '!<any valid subset>'
       - facter
 
-- name: Display only selected facts
+- name: Filter and return only selected facts
   ansible.builtin.setup:
     filter:
       - 'ansible_distribution'

--- a/lib/ansible/modules/setup.py
+++ b/lib/ansible/modules/setup.py
@@ -133,7 +133,7 @@ EXAMPLES = r"""
       - '!<any valid subset>'
       - facter
 
-- name: Collect only selected facts
+- name: Display only selected facts
   ansible.builtin.setup:
     filter:
       - 'ansible_distribution'


### PR DESCRIPTION
##### SUMMARY

From: 'Collect only selected facts' to 'Display only selected facts'
The example is demonstrating 'filter' option, which does not affect what facts are collected, only what facts are displayed.

Fixes #79462. 

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
lib/ansible/modules/setup.py

##### ADDITIONAL INFORMATION
Before change:
```paste below
name: Collect only selected facts
  ansible.builtin.setup:
    filter:
      - 'ansible_distribution'
```
After:
```
name: Display only selected facts
  ansible.builtin.setup:
    filter:
      - 'ansible_distribution'
```

