### PR TITLE
local connection: avoid tb when running in container with invalid user

### DIFF
--- a/changelogs/fragments/local_bad_user.yml
+++ b/changelogs/fragments/local_bad_user.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - connection local now avoids traceback on invalid user being used to execuet ansible (valid in host, but not in container).

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -18,12 +18,12 @@ DOCUMENTATION = '''
         - The remote user is ignored, the user with which the ansible CLI was executed is used instead.
 '''
 
+import fcntl
+import getpass
 import os
 import pty
 import shutil
 import subprocess
-import fcntl
-import getpass
 
 import ansible.constants as C
 from ansible.errors import AnsibleError, AnsibleFileNotFound
@@ -47,7 +47,11 @@ class Connection(ConnectionBase):
 
         super(Connection, self).__init__(*args, **kwargs)
         self.cwd = None
-        self.default_user = getpass.getuser()
+        try:
+            self.default_user = getpass.getuser()
+        except KeyError:
+            display.vv("Current user (uid=%s) does not seem to exist on this system, leaving user empty." % os.getuid())
+            self.default_user = ""
 
     def _connect(self):
         ''' connect to the local host; nothing to do here '''


### PR DESCRIPTION

(cherry picked from commit 5f3a6b78db093f8d1b062bbd70ac6bf375fdca04)


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
connection/local