### PR TITLE
ansible-test - Avoid direct use of `errno`.

### DIFF
--- a/changelogs/fragments/ansible-test-errno.yml
+++ b/changelogs/fragments/ansible-test-errno.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Update error handling code to use Python 3.x constructs, avoiding direct use of ``errno``.

--- a/test/lib/ansible_test/_internal/commands/coverage/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/coverage/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import collections.abc as c
-import errno
 import json
 import os
 import re
@@ -135,11 +134,8 @@ def get_coverage_files(language: str, path: t.Optional[str] = None) -> list[str]
     try:
         coverage_files = [os.path.join(coverage_dir, f) for f in os.listdir(coverage_dir)
                           if '=coverage.' in f and '=%s' % language in f]
-    except IOError as ex:
-        if ex.errno == errno.ENOENT:
-            return []
-
-        raise
+    except FileNotFoundError:
+        return []
 
     return coverage_files
 

--- a/test/lib/ansible_test/_internal/core_ci.py
+++ b/test/lib/ansible_test/_internal/core_ci.py
@@ -8,7 +8,6 @@ import os
 import re
 import traceback
 import uuid
-import errno
 import time
 import typing as t
 
@@ -347,18 +346,14 @@ class AnsibleCoreCI:
         try:
             self.connection = None
             os.remove(self.path)
-        except OSError as ex:
-            if ex.errno != errno.ENOENT:
-                raise
+        except FileNotFoundError:
+            pass
 
     def _load(self):
         """Load instance information."""
         try:
             data = read_text_file(self.path)
-        except IOError as ex:
-            if ex.errno != errno.ENOENT:
-                raise
-
+        except FileNotFoundError:
             return False
 
         if not data.startswith('{'):

--- a/test/lib/ansible_test/_internal/io.py
+++ b/test/lib/ansible_test/_internal/io.py
@@ -1,7 +1,6 @@
 """Functions for disk IO."""
 from __future__ import annotations
 
-import errno
 import io
 import json
 import os
@@ -32,11 +31,7 @@ def read_binary_file(path: str) -> bytes:
 
 def make_dirs(path: str) -> None:
     """Create a directory at path, including any necessary parent directories."""
-    try:
-        os.makedirs(to_bytes(path))
-    except OSError as ex:
-        if ex.errno != errno.EEXIST:
-            raise
+    os.makedirs(to_bytes(path), exist_ok=True)
 
 
 def write_json_file(path: str,

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -22,7 +22,6 @@ import argparse
 import ast
 import datetime
 import json
-import errno
 import os
 import re
 import subprocess
@@ -2467,12 +2466,9 @@ class GitCache:
                 self.head_tree = self._get_module_files()
             else:
                 raise
-        except OSError as ex:
-            if ex.errno == errno.ENOENT:
-                # fallback when git is not installed
-                self.head_tree = self._get_module_files()
-            else:
-                raise
+        except FileNotFoundError:
+            # fallback when git is not installed
+            self.head_tree = self._get_module_files()
 
         allowed_exts = ('.py', '.ps1')
         if plugin_type != 'module':


### PR DESCRIPTION
##### SUMMARY

Error handling on Python 3.x no longer requires the use of `errno` to identify specific errors.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
