### PR TITLE
Allow test to run on system with selinux enabled

### DIFF
--- a/test/units/module_utils/basic/test_filesystem.py
+++ b/test/units/module_utils/basic/test_filesystem.py
@@ -143,6 +143,8 @@ class TestOtherFilesystem(ModuleTestCase):
             argument_spec=dict(),
         )
 
+        am.selinux_enabled = lambda: False
+
         file_args = {
             'path': '/path/to/file',
             'mode': None,


### PR DESCRIPTION
##### SUMMARY
Allow test to run on system with selinux enabled. Fixes #77564

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/units/module_utils/basic/test_filesystem.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
