### PR TITLE
Fix hardcoded python call

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -82,7 +82,7 @@ gettext_generate_rst: collections_meta config cli keywords testing
 ansible_structure:
 	# We must have python and python-packaging for the version_helper
 	# script so use it for version comparison
-	if python -c "import sys, packaging.version as p; sys.exit(not p.Version('$(MAJOR_VERSION)') >  p.Version('2.10'))" ; then \
+	if $(PYTHON) -c "import sys, packaging.version as p; sys.exit(not p.Version('$(MAJOR_VERSION)') >  p.Version('2.10'))" ; then \
 		echo "Creating symlinks in ansible_structure"; \
 		ln -sf ../rst/ansible_index.rst rst/index.rst; \
 		ln -sf ../dev_guide/ansible_index.rst rst/dev_guide/index.rst; \


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix the hardcoded call and instead use the variable defined further up. Makes it easier to build on Debian/Ubuntu where python is called as `python3`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
