### PR TITLE
Add example of yaml file with --extra-vars

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -331,7 +331,7 @@ When passing variables with ``--extra-vars``, you must escape quotes and other s
     ansible-playbook arcade.yml --extra-vars '{"name":"Conan O'\\\''Brien"}'
     ansible-playbook script.yml --extra-vars "{\"dialog\":\"He said \\\"I just can\'t get enough of those single and double-quotes"\!"\\\"\"}"
 
-If you have a lot of special characters, use a JSON or YAML file containing the variable definitions.
+If you have a lot of special characters, use a JSON or YAML file containing the variable definitions. Prepend with `@`.
 
 vars from a JSON or YAML file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -339,6 +339,7 @@ vars from a JSON or YAML file
 .. code-block:: text
 
     ansible-playbook release.yml --extra-vars "@some_file.json"
+    ansible-playbook release.yml --extra-vars "@some_file.yaml"
 
 
 .. _ansible_variable_precedence:

--- a/docs/docsite/rst/playbook_guide/playbooks_variables.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_variables.rst
@@ -331,10 +331,11 @@ When passing variables with ``--extra-vars``, you must escape quotes and other s
     ansible-playbook arcade.yml --extra-vars '{"name":"Conan O'\\\''Brien"}'
     ansible-playbook script.yml --extra-vars "{\"dialog\":\"He said \\\"I just can\'t get enough of those single and double-quotes"\!"\\\"\"}"
 
-If you have a lot of special characters, use a JSON or YAML file containing the variable definitions. Prepend with `@`.
 
 vars from a JSON or YAML file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you have a lot of special characters, use a JSON or YAML file containing the variable definitions. Prepend both JSON and YAML filenames with `@`.
 
 .. code-block:: text
 


### PR DESCRIPTION
##### SUMMARY

Add example in docs for using a yaml file with `--extra-vars`. From the docs it is not obvious that when using `--extra-vars` with a file the filename argument needs to be prefixed with `@`

This is already documented in the code. https://github.com/ansible/ansible/blob/devel/lib/ansible/cli/arguments/option_helpers.py#L363-L367

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
docs, playbook_variables.rst

