### PR TITLE
[stable-2.14] Don't use color in jinja_plugins test.

### DIFF
--- a/test/integration/targets/jinja_plugins/tasks/main.yml
+++ b/test/integration/targets/jinja_plugins/tasks/main.yml
@@ -1,4 +1,6 @@
 - shell: ansible-playbook {{ verbosity }} playbook.yml
+  environment:
+    ANSIBLE_FORCE_COLOR: no
   args:
     chdir: '{{ role_path }}'
   vars:


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/79531

This should prevent color codes from interfering with string matches.

(cherry picked from commit 31f9d60b8d00452c96ebec423c6a263b9d2eebd7)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

jinja_plugins integration test