### PR TITLE
Suppress traceback when bad escape is used (#79364)

### DIFF
--- a/lib/ansible/modules/replace.py
+++ b/lib/ansible/modules/replace.py
@@ -284,21 +284,27 @@ def main():
         section = contents
 
     mre = re.compile(params['regexp'], re.MULTILINE)
-    result = re.subn(mre, params['replace'], section, 0)
+    try:
+        result = re.subn(mre, params['replace'], section, 0)
 
-    if result[1] > 0 and section != result[0]:
-        if pattern:
-            result = (contents[:indices[0]] + result[0] + contents[indices[1]:], result[1])
-        msg = '%s replacements made' % result[1]
-        changed = True
-        if module._diff:
-            res_args['diff'] = {
-                'before_header': path,
-                'before': contents,
-                'after_header': path,
-                'after': result[0],
-            }
-    else:
+        if result[1] > 0 and section != result[0]:
+            if pattern:
+                result = (contents[:indices[0]] + result[0] + contents[indices[1]:], result[1])
+            msg = '%s replacements made' % result[1]
+            changed = True
+            if module._diff:
+                res_args['diff'] = {
+                    'before_header': path,
+                    'before': contents,
+                    'after_header': path,
+                    'after': result[0],
+                }
+        else:
+            msg = ''
+            changed = False
+    except re.error as e:
+        if not e.args[0].startswith('bad escape'):
+            raise e
         msg = ''
         changed = False
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change fixes the issue generating traceback in the replace module, when an incorrect escape string is used.
The idea is simple: to wrap the code with try-except construction, checking for "bad escape" exception
Fixes #79364 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
replace

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. Create test yml file with content:
```
---
- name: Test replace module error
  hosts: localhost
  gather_facts: no

  tasks:
    - name: Test replace with bad escape
      replace:
        path: /dev/null
        after: ^
        before: $
        regexp: \.
        replace: '\D'
```
2. Run ansible-playbook on it
ansible-playbook replace.yml -vvv

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```paste below
[root@031c65b08de0 ~]# ansible-playbook replace.yml 
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'

PLAY [Test replace module error] ************************************************

TASK [Test replace with bad escape] *********************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: re.error: bad escape \D at position 0
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/usr/lib64/python3.10/sre_parse.py\", line 1051, in parse_template\n    this = chr(ESCAPES[this][1])\nKeyError: '\\\\D'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1670317550.8197122-91-246835423739476/AnsiballZ_replace.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1670317550.8197122-91-246835423739476/AnsiballZ_replace.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1670317550.8197122-91-246835423739476/AnsiballZ_replace.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible.modules.replace', init_globals=dict(_module_fqn='ansible.modules.replace', _modlib_path=modlib_path),\n  File \"/usr/lib64/python3.10/runpy.py\", line 224, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib64/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_replace_payload_mt09r04w/ansible_replace_payload.zip/ansible/modules/replace.py\", line 316, in <module>\n  File \"/tmp/ansible_replace_payload_mt09r04w/ansible_replace_payload.zip/ansible/modules/replace.py\", line 286, in main\n  File \"/usr/lib64/python3.10/re.py\", line 220, in subn\n    return _compile(pattern, flags).subn(repl, string, count)\n  File \"/usr/lib64/python3.10/re.py\", line 326, in _subx\n    template = _compile_repl(template, pattern)\n  File \"/usr/lib64/python3.10/re.py\", line 317, in _compile_repl\n    return sre_parse.parse_template(repl, pattern)\n  File \"/usr/lib64/python3.10/sre_parse.py\", line 1054, in parse_template\n    raise s.error('bad escape %s' % this, len(this))\nre.error: bad escape \\D at position 0\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

PLAY RECAP **********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```
after:
```
[root@354ccbb0a6e4 ~]#  ansible-playbook replace.yml -vvv
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.
ansible-playbook [core 2.15.0.dev0]
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.10/site-packages/ansible_core-2.15.0.dev0-py3.10.egg/ansible
  ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.10.8 (main, Nov 14 2022, 00:00:00) [GCC 12.2.1 20220819 (Red Hat 12.2.1-2)] (/usr/bin/python)
  jinja version = 3.1.2
  libyaml = True
No config file found; using defaults
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: replace.yml ***********************************************************
1 plays in replace.yml

PLAY [Test replace module error] ************************************************

TASK [Test replace with bad escape] *********************************************
task path: /root/replace.yml:7
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir "` echo /root/.ansible/tmp/ansible-tmp-1670317629.3855224-186-89325011212833 `" && echo ansible-tmp-1670317629.3855224-186-89325011212833="` echo /root/.ansible/tmp/ansible-tmp-1670317629.3855224-186-89325011212833 `" ) && sleep 0'
Using module file /usr/local/lib/python3.10/site-packages/ansible_core-2.15.0.dev0-py3.10.egg/ansible/modules/replace.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-182ww134ll5/tmpblo20kze TO /root/.ansible/tmp/ansible-tmp-1670317629.3855224-186-89325011212833/AnsiballZ_replace.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1670317629.3855224-186-89325011212833/ /root/.ansible/tmp/ansible-tmp-1670317629.3855224-186-89325011212833/AnsiballZ_replace.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1670317629.3855224-186-89325011212833/AnsiballZ_replace.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1670317629.3855224-186-89325011212833/ > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "after": "^",
            "attributes": null,
            "backup": false,
            "before": "$",
            "encoding": "utf-8",
            "group": null,
            "mode": null,
            "owner": null,
            "path": "/dev/null",
            "regexp": "\\.",
            "replace": "\\D",
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "unsafe_writes": false,
            "validate": null
        }
    },
    "msg": "",
    "rc": 0
}

PLAY RECAP **********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```