### PR TITLE
Mentions 'meta: flush_handlers' task

### DIFF
--- a/docs/docsite/rst/reference_appendices/test_strategies.rst
+++ b/docs/docsite/rst/reference_appendices/test_strategies.rst
@@ -180,7 +180,6 @@ This is the great culmination of embedded tests:
 
          - common
          - webserver
-         - apply_testing_checks
 
       post_tasks:
 
@@ -188,7 +187,10 @@ This is the great culmination of embedded tests:
           ansible.builtin.command: /usr/bin/add_back_to_pool {{ inventory_hostname }}
           delegate_to: 127.0.0.1
 
-If you need a handler to run before a particular role, use the ``meta`` module with the ``flush_handlers`` option. Consider placing this task in your test role itself. For more information, see :ref:`handlers`.
+        - name: run the test role
+          include_role:
+            name: apply_testing_checks
+
 
 Of course in the above, the "take out of the pool" and "add back" steps would be replaced with a call to an Ansible load balancer
 module or appropriate shell command.  You might also have steps that use a monitoring module to start and end an outage window

--- a/docs/docsite/rst/reference_appendices/test_strategies.rst
+++ b/docs/docsite/rst/reference_appendices/test_strategies.rst
@@ -188,6 +188,8 @@ This is the great culmination of embedded tests:
           ansible.builtin.command: /usr/bin/add_back_to_pool {{ inventory_hostname }}
           delegate_to: 127.0.0.1
 
+If you need a handler to run before a particular role, use the ``meta`` module with the ``flush_handlers`` option. Consider placing this task in your test role itself. For more information, see :ref:`handlers`.
+
 Of course in the above, the "take out of the pool" and "add back" steps would be replaced with a call to an Ansible load balancer
 module or appropriate shell command.  You might also have steps that use a monitoring module to start and end an outage window
 for the machine.

--- a/docs/docsite/rst/reference_appendices/test_strategies.rst
+++ b/docs/docsite/rst/reference_appendices/test_strategies.rst
@@ -176,21 +176,26 @@ This is the great culmination of embedded tests:
           ansible.builtin.command: /usr/bin/take_out_of_pool {{ inventory_hostname }}
           delegate_to: 127.0.0.1
 
-      roles:
+      tasks:
 
-         - common
-         - webserver
+        - ansible.builtin.include_role:
+            name: "{{ item }}"
+          loop:
+            - common
+            - webserver
+
+        - name: run any notified handlers
+          ansible.builtin.meta: flush_handlers
+
+        - name: test the configuration
+          ansible.builtin.include_role:
+            name: apply_testing_checks
 
       post_tasks:
 
         - name: add back to load balancer pool
           ansible.builtin.command: /usr/bin/add_back_to_pool {{ inventory_hostname }}
           delegate_to: 127.0.0.1
-
-        - name: run the test role
-          include_role:
-            name: apply_testing_checks
-
 
 Of course in the above, the "take out of the pool" and "add back" steps would be replaced with a call to an Ansible load balancer
 module or appropriate shell command.  You might also have steps that use a monitoring module to start and end an outage window


### PR DESCRIPTION
##### SUMMARY

Encourage users to use `meta: flush_handlers` task in the test role itself

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
docs.ansible.com

Fixes  #59109
