### PR TITLE
Set locale for python apt

### DIFF
--- a/changelogs/fragments/79546-apt-fix-setting-locale.yml
+++ b/changelogs/fragments/79546-apt-fix-setting-locale.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt - set locale to fix updating the cache (https://github.com/ansible/ansible/issues/79523).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -354,6 +354,7 @@ warnings.filterwarnings('ignore', "apt API not stable yet", FutureWarning)
 import datetime
 import fnmatch
 import itertools
+import locale as locale_module
 import os
 import random
 import re
@@ -1218,6 +1219,7 @@ def main():
     # to make sure we use the best parsable locale when running commands
     # also set apt specific vars for desired behaviour
     locale = get_best_parsable_locale(module)
+    locale_module.setlocale(locale_module.LC_ALL, locale)
     # APT related constants
     APT_ENV_VARS = dict(
         DEBIAN_FRONTEND='noninteractive',

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -117,7 +117,7 @@
       - apt_update_cache_2_check_mode is not changed
       - apt_update_cache_2 is not changed
 
-- name: Test update_cache with LANG de_DE
+- name: Test update_cache with LC_ALL set to de_DE
   block:
     - name: get language pack
       command: locale-gen de_DE

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -117,28 +117,6 @@
       - apt_update_cache_2_check_mode is not changed
       - apt_update_cache_2 is not changed
 
-- name: Test update_cache with LC_ALL set to de_DE
-  block:
-    - name: get language pack
-      command: locale-gen de_DE
-      become: true
-
-    - name: update locale
-      command: update-locale
-      become: true
-
-    - name: update the cache with LANG env vars
-      apt:
-        update_cache: true
-      register: apt_update_cache_locale
-      ignore_errors: yes
-      environment:
-        LC_ALL: de_DE
-
-    - assert:
-        that:
-          - apt_update_cache_locale is success
-
 - name: uninstall apt bindings with apt again
   apt:
     pkg: [python-apt, python3-apt]

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -117,6 +117,28 @@
       - apt_update_cache_2_check_mode is not changed
       - apt_update_cache_2 is not changed
 
+- name: Test update_cache with LANG de_DE
+  block:
+    - name: get language pack
+      command: locale-gen de_DE
+      become: true
+
+    - name: update locale
+      command: update-locale
+      become: true
+
+    - name: update the cache with LANG env vars
+      apt:
+        update_cache: true
+      register: apt_update_cache_locale
+      ignore_errors: yes
+      environment:
+        LC_ALL: de_DE
+
+    - assert:
+        that:
+          - apt_update_cache_locale is success
+
 - name: uninstall apt bindings with apt again
   apt:
     pkg: [python-apt, python3-apt]


### PR DESCRIPTION
##### SUMMARY
We pass through the locale as an environment variable, but don't set it for the Python apt library.

Fixes #79523

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
apt module
