### PR TITLE
EOL Ansible 6

### DIFF
--- a/docs/docsite/sphinx_conf/ansible_conf.py
+++ b/docs/docsite/sphinx_conf/ansible_conf.py
@@ -156,7 +156,7 @@ html_theme_options = {
 html_context = {
     'display_github': 'True',
     'show_sphinx': False,
-    'is_eol': False,
+    'is_eol': True,
     'github_user': 'ansible',
     'github_repo': 'ansible',
     'github_version': 'devel/docs/docsite/rst/',


### PR DESCRIPTION
##### SUMMARY
Makes Ansible 6 EOL after the 6.7.0 release.

Fixes #79378

##### ISSUE TYPE
- Docs Pull Request
