### PR TITLE
ansible-galaxy - make collection/role page size and http error codes to retry configurable

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -634,7 +634,7 @@ class GalaxyCLI(CLI):
 
         galaxy_options = {}
         for optional_key in ['clear_response_cache', 'no_cache', 'timeout', 'collection_page_size', 'role_page_size']:
-            if optional_key in context.CLIARGS:
+            if optional_key in context.CLIARGS and context.CLIARGS[optional_key] is not None:
                 galaxy_options[optional_key] = context.CLIARGS[optional_key]
 
         config_servers = []

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -294,7 +294,10 @@ class GalaxyAPI:
 
         self.collection_page_size = collection_page_size
         self.role_page_size = role_page_size
-        self.retry_http_error_codes = retry_http_error_codes
+        if retry_http_error_codes is not None:
+            self.retry_http_error_codes = retry_http_error_codes
+        else:
+            self.retry_http_error_codes = RETRY_HTTP_ERROR_CODES
 
     def __str__(self):
         # type: (GalaxyAPI) -> str

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -262,6 +262,7 @@ class GalaxyAPI:
             timeout=60,
             collection_page_size=None,
             role_page_size=None,
+            retry_http_error_codes=None,
     ):
         self.galaxy = galaxy
         self.name = name
@@ -293,7 +294,7 @@ class GalaxyAPI:
 
         self.collection_page_size = collection_page_size
         self.role_page_size = role_page_size
-        self.retry_http_errors = RETRY_HTTP_ERROR_CODES
+        self.retry_http_error_codes = retry_http_error_codes
 
     def __str__(self):
         # type: (GalaxyAPI) -> str

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -885,7 +885,7 @@ class GalaxyAPI:
         else:
             results_key = 'results'
 
-        if 'count' in data and data['count'] < len(data[results_key]) * COLLECTION_PAGE_MULTIPLIER:
+        if data.get('count', float('inf')) < len(data[results_key]) * COLLECTION_PAGE_MULTIPLIER:
             self.collection_page_size = data['count']
         else:
             self.collection_page_size = len(data[results_key]) * COLLECTION_PAGE_MULTIPLIER

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -72,6 +72,10 @@ def get_test_galaxy_api(url, version, token_ins=None, token_value=None, no_cache
     api._available_api_versions = {version: '%s' % version}
     api.token = token_ins
 
+    # default for Galaxy to avoid needing to mock an extra api call
+    api.collection_page_size = 100
+    api.role_page_size = 50
+
     return api
 
 

--- a/test/units/galaxy/test_role_install.py
+++ b/test/units/galaxy/test_role_install.py
@@ -39,7 +39,7 @@ def reset_cli_args():
 @pytest.fixture(autouse=True)
 def galaxy_server():
     context.CLIARGS._store = {'ignore_certs': False}
-    galaxy_api = api.GalaxyAPI(None, 'test_server', 'https://galaxy.ansible.com')
+    galaxy_api = api.GalaxyAPI(None, 'test_server', 'https://galaxy.ansible.com', role_page_size=50)
     return galaxy_api
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes #79554

* Add per-server/CLI configuration for the page size
* Keep the current default page sizes for Galaxy (50 for roles, 100 for collections), but give servers more control. The default page size is the default from the server multiplied by 10 for collections and 5 for roles.
* Add server configuration option `retry_http_error_codes` to handle rate limit errors

Also fixes an issue where `timeout` defined for a Galaxy server was ignored.

* [ ] Tests
* [ ] Changelog

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy
