### PR TITLE
set_stats, make issues more transparent

### DIFF
--- a/lib/ansible/executor/stats.py
+++ b/lib/ansible/executor/stats.py
@@ -22,7 +22,9 @@ __metaclass__ = type
 from collections.abc import MutableMapping
 
 from ansible.utils.vars import merge_hash
+from ansible.utils.display import Display
 
+display = Display()
 
 class AggregateStats:
     ''' holds stats about per-host activity during playbook runs '''
@@ -91,6 +93,7 @@ class AggregateStats:
 
         # mismatching types
         if not isinstance(what, type(self.custom[host][which])):
+            display.warning("Mismatching types in stats")
             return None
 
         if isinstance(what, MutableMapping):

--- a/lib/ansible/executor/stats.py
+++ b/lib/ansible/executor/stats.py
@@ -26,6 +26,7 @@ from ansible.utils.display import Display
 
 display = Display()
 
+
 class AggregateStats:
     ''' holds stats about per-host activity during playbook runs '''
 


### PR DESCRIPTION
##### SUMMARY
That the stat module doesn't throw a warning (or even an error) when the Types are mismatched, is for me dangerous. This makes debugging a lot harder and in general more difficult to find small mistakes. Just returning "None" without any feedback to the user, is not transparent and can lead to dangerous errors, which are nearly impossible to find. 
This change is a small one and just an option. One also could throw an exception, but this could theoretically break some code (bad code in my opinion). With this small edit, no old code would break, but it can help find errors faster. 

##### ISSUE TYPE
Transparency, make Ansible easier to work with (Feature Pull Request I assume)

##### ADDITIONAL INFORMATION
The warning message is just a placeholder and can be changed easily. As long as there is a warning/error or just an info that something went wrong, would improve the Ansible experience.





