### PR TITLE
ansible-galaxy - fix turning off the ConcreteArtifactManager's validate certs at the global level

### DIFF
--- a/changelogs/fragments/79561-fix-a-g-global-ignore-certs-cfg.yml
+++ b/changelogs/fragments/79561-fix-a-g-global-ignore-certs-cfg.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix using ``GALAXY_IGNORE_CERTS`` when downloading tarballs from Galaxy servers (https://github.com/ansible/ansible/issues/79557).
+  - Fix using ``GALAXY_IGNORE_CERTS`` in conjunction with collections in requirements files which specify a specific ``source`` that isn't in the configured servers.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -584,7 +584,6 @@ class GalaxyCLI(CLI):
         options = super(GalaxyCLI, self).post_process_args(options)
 
         # ensure we have 'usable' cli option
-        validate_certs_or_sentinel = (None if options.ignore_certs is None else not options.ignore_certs)
         setattr(options, 'validate_certs', (None if options.ignore_certs is None else not options.ignore_certs))
         # the default if validate_certs is None
         setattr(options, 'resolved_validate_certs', (options.validate_certs if options.validate_certs is not None else not C.GALAXY_IGNORE_CERTS))

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -79,7 +79,7 @@ SERVER_DEF = [
 # config definition fields
 SERVER_ADDITIONAL = {
     'v3': {'default': 'False'},
-    'validate_certs': {'default': True, 'cli': [{'name': 'validate_certs'}]},
+    'validate_certs': {'cli': [{'name': 'validate_certs'}]},
     'timeout': {'default': '60', 'cli': [{'name': 'timeout'}]},
     'token': {'default': None},
 }
@@ -96,7 +96,8 @@ def with_collection_artifacts_manager(wrapped_method):
         if 'artifacts_manager' in kwargs:
             return wrapped_method(*args, **kwargs)
 
-        artifacts_manager_kwargs = {'validate_certs': context.CLIARGS['validate_certs']}
+        # FIXME: use validate_certs context from Galaxy servers when downloading collections
+        artifacts_manager_kwargs = {'validate_certs': context.CLIARGS['resolved_validate_certs']}
 
         keyring = context.CLIARGS.get('keyring', None)
         if keyring is not None:
@@ -240,8 +241,7 @@ class GalaxyCLI(CLI):
         common.add_argument('--token', '--api-key', dest='api_key',
                             help='The Ansible Galaxy API key which can be found at '
                                  'https://galaxy.ansible.com/me/preferences.')
-        common.add_argument('-c', '--ignore-certs', action='store_true', dest='ignore_certs', help='Ignore SSL certificate validation errors.',
-                            default=C.GALAXY_IGNORE_CERTS)
+        common.add_argument('-c', '--ignore-certs', action='store_true', dest='ignore_certs', help='Ignore SSL certificate validation errors.', default=None)
         common.add_argument('--timeout', dest='timeout', type=int,
                             help="The time to wait for operations against the galaxy server, defaults to 60s.")
 
@@ -584,7 +584,10 @@ class GalaxyCLI(CLI):
         options = super(GalaxyCLI, self).post_process_args(options)
 
         # ensure we have 'usable' cli option
+        validate_certs_or_sentinel = (None if options.ignore_certs is None else not options.ignore_certs)
         setattr(options, 'validate_certs', (None if options.ignore_certs is None else not options.ignore_certs))
+        # the default if validate_certs is None
+        setattr(options, 'resolved_validate_certs', (options.validate_certs if options.validate_certs is not None else not C.GALAXY_IGNORE_CERTS))
 
         display.verbosity = options.verbosity
         return options
@@ -642,6 +645,8 @@ class GalaxyCLI(CLI):
             token_val = server_options['token'] or NoTokenSentinel
             username = server_options['username']
             v3 = server_options.pop('v3')
+            if server_options['validate_certs'] is None:
+                server_options['validate_certs'] = context.CLIARGS['resolved_validate_certs']
             validate_certs = server_options['validate_certs']
 
             if v3:
@@ -677,8 +682,7 @@ class GalaxyCLI(CLI):
         cmd_server = context.CLIARGS['api_server']
         cmd_token = GalaxyToken(token=context.CLIARGS['api_key'])
 
-        # resolve validate_certs
-        validate_certs = True if context.CLIARGS['validate_certs'] is None else context.CLIARGS['validate_certs']
+        validate_certs = context.CLIARGS['resolved_validate_certs']
         if cmd_server:
             # Cmd args take precedence over the config entry but fist check if the arg was a name and use that config
             # entry, otherwise create a new API entry for the server specified.
@@ -844,7 +848,7 @@ class GalaxyCLI(CLI):
                     name=coll_req['name'],
                 ),
                 coll_req['source'],
-                validate_certs=not context.CLIARGS['ignore_certs'],
+                validate_certs=context.CLIARGS['resolved_validate_certs'],
             ),
         )
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -84,10 +84,6 @@ SERVER_ADDITIONAL = {
     'token': {'default': None},
 }
 
-# override default if the generic is set
-if C.GALAXY_IGNORE_CERTS is not None:
-    SERVER_ADDITIONAL['validate_certs'].update({'default': not C.GALAXY_IGNORE_CERTS})
-
 
 def with_collection_artifacts_manager(wrapped_method):
     """Inject an artifacts manager if not passed explicitly.
@@ -682,8 +678,7 @@ class GalaxyCLI(CLI):
         cmd_token = GalaxyToken(token=context.CLIARGS['api_key'])
 
         # resolve validate_certs
-        v_config_default = True if C.GALAXY_IGNORE_CERTS is None else not C.GALAXY_IGNORE_CERTS
-        validate_certs = v_config_default if context.CLIARGS['validate_certs'] is None else context.CLIARGS['validate_certs']
+        validate_certs = True if context.CLIARGS['validate_certs'] is None else context.CLIARGS['validate_certs']
         if cmd_server:
             # Cmd args take precedence over the config entry but fist check if the arg was a name and use that config
             # entry, otherwise create a new API entry for the server specified.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -244,7 +244,8 @@ class GalaxyCLI(CLI):
         common.add_argument('--token', '--api-key', dest='api_key',
                             help='The Ansible Galaxy API key which can be found at '
                                  'https://galaxy.ansible.com/me/preferences.')
-        common.add_argument('-c', '--ignore-certs', action='store_true', dest='ignore_certs', help='Ignore SSL certificate validation errors.', default=None)
+        common.add_argument('-c', '--ignore-certs', action='store_true', dest='ignore_certs', help='Ignore SSL certificate validation errors.',
+                            default=C.GALAXY_IGNORE_CERTS)
         common.add_argument('--timeout', dest='timeout', type=int,
                             help="The time to wait for operations against the galaxy server, defaults to 60s.")
 

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -329,6 +329,7 @@ def test_validate_certs(global_ignore_certs, monkeypatch):
         (None, True),
         (None, False),
         (True, None),
+        (True, True),
         (True, False),
     ]
 )
@@ -358,17 +359,17 @@ def test_validate_certs_with_server_url(ignore_certs_cli, ignore_certs_cfg, monk
 
 @pytest.mark.parametrize(
     # False/True/omitted, True/omitted
-    "general_config,cli_ignore_certs",
+    "ignore_certs_cli,ignore_certs_cfg",
     [
         (None, None),
         (None, True),
+        (None, False),
         (True, None),
         (True, True),
-        (False, None),
-        (False, True),
+        (True, False),
     ]
 )
-def test_validate_certs_server_config(general_config, cli_ignore_certs, monkeypatch):
+def test_validate_certs_server_config(ignore_certs_cfg, ignore_certs_cli, monkeypatch):
     server_names = ['server1', 'server2', 'server3']
     cfg_lines = [
         "[galaxy]",
@@ -388,10 +389,10 @@ def test_validate_certs_server_config(general_config, cli_ignore_certs, monkeypa
         'install',
         'namespace.collection:1.0.0',
     ]
-    if cli_ignore_certs:
+    if ignore_certs_cli:
         cli_args.append('--ignore-certs')
-    if general_config is not None:
-        monkeypatch.setattr(C, 'GALAXY_IGNORE_CERTS', general_config)
+    if ignore_certs_cfg is not None:
+        monkeypatch.setattr(C, 'GALAXY_IGNORE_CERTS', ignore_certs_cfg)
 
     with tempfile.NamedTemporaryFile(suffix='.cfg') as tmp_file:
         tmp_file.write(to_bytes('\n'.join(cfg_lines), errors='surrogate_or_strict'))
@@ -408,8 +409,8 @@ def test_validate_certs_server_config(general_config, cli_ignore_certs, monkeypa
 
     # (not) --ignore-certs > server's validate_certs > (not) GALAXY_IGNORE_CERTS > True
     assert galaxy_cli.api_servers[0].validate_certs is False
-    assert galaxy_cli.api_servers[1].validate_certs is (False if cli_ignore_certs else True)
-    assert galaxy_cli.api_servers[2].validate_certs is (False if cli_ignore_certs else not general_config if general_config is not None else True)
+    assert galaxy_cli.api_servers[1].validate_certs is (False if ignore_certs_cli else True)
+    assert galaxy_cli.api_servers[2].validate_certs is (False if ignore_certs_cli else not ignore_certs_cfg if ignore_certs_cfg is not None else True)
 
 
 def test_build_collection_no_galaxy_yaml():

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -321,6 +321,7 @@ def test_validate_certs(global_ignore_certs, monkeypatch):
     assert len(galaxy_cli.api_servers) == 1
     assert galaxy_cli.api_servers[0].validate_certs is not global_ignore_certs
 
+
 @pytest.mark.parametrize(
     "ignore_certs_cli,ignore_certs_cfg",
     [
@@ -353,6 +354,7 @@ def test_validate_certs_with_server_url(ignore_certs_cli, ignore_certs_cfg, monk
     assert len(galaxy_cli.api_servers) == 1
     validate_certs = (False if ignore_certs_cli else not ignore_certs_cfg if ignore_certs_cfg is not None else True)
     assert galaxy_cli.api_servers[0].validate_certs == validate_certs
+
 
 @pytest.mark.parametrize(
     # False/True/omitted, True/omitted


### PR DESCRIPTION
##### SUMMARY
Fixes #79557

I think this started in fa35aa4865780cd0ddbcc060f9e95e59e1c1646b. The default from `--ignore-certs` was replaced with None (I think to handle server config depending on if the CLI option is sentinel). 


With that change, the only way to set the ConcreteArtifactManager's _validate_certs attr is to use `--ignore-certs`. Otherwise, the ConcreteArtifactManager's `_validate_certs` attr is always None (and open_url uses cert validation in that case).

~The global config's default was also changed to None though in that commit, so I think we could keep it as the default without changing non-broken behavior.~

Keeping the default the same (the two config sources have different precedence), and added a new attr rather than maintaining the same pattern in 4 places.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
