### PR TITLE
Remove relative import from setup module

### DIFF
--- a/changelogs/fragments/79574-full-import.yml
+++ b/changelogs/fragments/79574-full-import.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup - avoid relative import of AnsibleModule.

--- a/lib/ansible/modules/setup.py
+++ b/lib/ansible/modules/setup.py
@@ -172,7 +172,7 @@ EXAMPLES = r"""
 """
 
 # import module snippets
-from ..module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.facts import ansible_collector, default_collectors


### PR DESCRIPTION
##### SUMMARY

Replaces relative import of AnsibleModule with full import.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
setup

##### ADDITIONAL INFORMATION

It should also be noted that this is the only import with `..` from the entire `lib/ansible`. There are few other such imports but only inside the tests.
