### PR TITLE
ansible-galaxy - support ``resolvelib >= 0.5.3, < 0.10.0`` (#79399)

### DIFF
--- a/changelogs/fragments/79399-resolvelib_lt_0_10_0.yml
+++ b/changelogs/fragments/79399-resolvelib_lt_0_10_0.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-galaxy - support ``resolvelib >= 0.5.3, < 0.10.0``.

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -42,7 +42,7 @@ except ImportError:
 
 # TODO: add python requirements to ansible-test's ansible-core distribution info and remove the hardcoded lowerbound/upperbound fallback
 RESOLVELIB_LOWERBOUND = SemanticVersion("0.5.3")
-RESOLVELIB_UPPERBOUND = SemanticVersion("0.9.0")
+RESOLVELIB_UPPERBOUND = SemanticVersion("0.10.0")
 RESOLVELIB_VERSION = SemanticVersion.from_loose_version(LooseVersion(resolvelib_version))
 
 
@@ -220,7 +220,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
             Mapping of identifier, list of named tuple pairs.
             The named tuples have the entries ``requirement`` and ``parent``.
 
-        resolvelib >=0.8.0, <= 0.8.1
+        resolvelib >=0.8.0, <= 0.9.0
 
         :param identifier: The value returned by ``identify()``.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ packaging
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, < 0.9.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, < 0.10.0  # dependency resolver used by ansible-galaxy

--- a/test/lib/ansible_test/_data/requirements/ansible.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible.txt
@@ -12,4 +12,4 @@ packaging
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, < 0.9.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, < 0.10.0  # dependency resolver used by ansible-galaxy

--- a/test/sanity/code-smell/docs-build.requirements.in
+++ b/test/sanity/code-smell/docs-build.requirements.in
@@ -1,6 +1,6 @@
 jinja2
 pyyaml
-resolvelib < 0.9.0
+resolvelib < 0.10.0
 sphinx == 4.2.0
 sphinx-notfound-page
 sphinx-ansible-theme

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -27,7 +27,7 @@ pyparsing==3.0.9
 pytz==2022.2.1
 PyYAML==6.0
 requests==2.28.1
-resolvelib==0.8.1
+resolvelib==0.9.0
 rstcheck==3.5.0
 semantic-version==2.10.0
 sh==1.14.3

--- a/test/sanity/code-smell/package-data.requirements.in
+++ b/test/sanity/code-smell/package-data.requirements.in
@@ -1,7 +1,7 @@
 docutils < 0.18  # match version required by sphinx in the docs-build sanity test
 jinja2
 pyyaml  # ansible-core requirement
-resolvelib < 0.9.0
+resolvelib < 0.10.0
 rstcheck < 4  # match version used in other sanity tests
 straight.plugin
 antsibull-changelog

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -6,7 +6,7 @@ MarkupSafe==2.1.1
 packaging==21.3
 pyparsing==3.0.9
 PyYAML==6.0
-resolvelib==0.8.1
+resolvelib==0.9.0
 rstcheck==3.5.0
 semantic-version==2.10.0
 straight.plugin==1.5.0


### PR DESCRIPTION
* Upgrade `resolvelib >= 0.5.3, < 0.10.0`

https://pypi.org/project/resolvelib/0.9.0/ released on 2022-11-17:

  * https://github.com/sarugaku/resolvelib/blob/master/CHANGELOG.rst#090-2022-11-17
  * https://github.com/sarugaku/resolvelib/releases/tag/0.9.0

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>
(cherry picked from commit b148fd8dd74c8599f809f71117a86577ccfb0638)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
