### PR TITLE
[stable-2.13] ansible-test - Fix `--prime-containers` and `--explain`…

### DIFF
--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -255,8 +255,6 @@ class ContainerHostProperties:
     audit_code: str
     max_open_files: int
     loginuid: t.Optional[int]
-    cgroups: tuple[CGroupEntry, ...]
-    mounts: tuple[MountEntry, ...]
     cgroup_v1: SystemdControlGroupV1Status
     cgroup_v2: bool
 
@@ -301,6 +299,16 @@ def detect_host_properties(args: CommonConfig) -> ContainerHostProperties:
     cmd = ['sh', '-c', ' && echo "-" && '.join(multi_line_commands)]
 
     stdout = run_utility_container(args, f'ansible-test-probe-{args.session_name}', cmd, options)[0]
+
+    if args.explain:
+        return ContainerHostProperties(
+            audit_code='???',
+            max_open_files=MAX_NUM_OPEN_FILES,
+            loginuid=LOGINUID_NOT_SET,
+            cgroup_v1=SystemdControlGroupV1Status.VALID,
+            cgroup_v2=False,
+        )
+
     blocks = stdout.split('\n-\n')
 
     values = blocks[0].split('\n')
@@ -383,8 +391,6 @@ def detect_host_properties(args: CommonConfig) -> ContainerHostProperties:
         audit_code=audit_code,
         max_open_files=hard_limit,
         loginuid=loginuid,
-        cgroups=cgroups,
-        mounts=mounts,
         cgroup_v1=cgroup_v1,
         cgroup_v2=cgroup_v2,
     )
@@ -767,6 +773,9 @@ class DockerInspect:
     @property
     def pid(self) -> int:
         """Return the PID of the init process."""
+        if self.args.explain:
+            return 0
+
         return self.state['Pid']
 
     @property

--- a/test/lib/ansible_test/_internal/host_profiles.py
+++ b/test/lib/ansible_test/_internal/host_profiles.py
@@ -76,6 +76,7 @@ from .docker_util import (
     run_utility_container,
     SystemdControlGroupV1Status,
     LOGINUID_NOT_SET,
+    UTILITY_IMAGE,
 )
 
 from .bootstrap import (
@@ -455,6 +456,10 @@ class DockerProfile(ControllerHostProfile[DockerConfig], SshTargetHostProfile[Do
         )
 
         if not container:
+            if self.args.prime_containers:
+                if init_config.command or init_probe:
+                    docker_pull(self.args, UTILITY_IMAGE)
+
             return
 
         self.container_name = container.name


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/79581

* Remove unused code.
* Fix explain errors.
* Fix `--prime-containers` with docker on cgroup v2. (cherry picked from commit da3b1d3f50bfbe118f2200e3e2ef109d87da4c2e)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
