### PR TITLE
filter/test plugin listing, fix bug on file sorting

### DIFF
--- a/changelogs/fragments/adoc_fix_list.yml
+++ b/changelogs/fragments/adoc_fix_list.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-doc now will correctly display short descriptions on listing filters/tests no matter the directory sorting.

--- a/lib/ansible/plugins/list.py
+++ b/lib/ansible/plugins/list.py
@@ -112,10 +112,7 @@ def _list_plugins_from_paths(ptype, dirs, collection, depth=0):
 def _list_j2_plugins_from_file(collection, plugin_path, ptype, plugin_name):
 
     ploader = getattr(loader, '{0}_loader'.format(ptype))
-    if collection in ('ansible.builtin', 'ansible.legacy'):
-        file_plugins = ploader.all()
-    else:
-        file_plugins = ploader.get_contained_plugins(collection, plugin_path, plugin_name)
+    file_plugins = ploader.get_contained_plugins(collection, plugin_path, plugin_name)
     return file_plugins
 
 


### PR DESCRIPTION
avoid legacy/builtin special casing for 'all'

this was 'working' cause of directory sorting, but if the directory sorted otherwise, we get issue linked below

Fixes #79577
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-doc
