### PR TITLE
[stable-2.13] ansible-test - Support RSA SHA-1 for SSH clients.

### DIFF
--- a/changelogs/fragments/ansible-test-container-management.yml
+++ b/changelogs/fragments/ansible-test-container-management.yml
@@ -39,6 +39,11 @@ minor_changes:
                    adding the ``retry/never`` alias. This is useful for tests that cannot pass on a retry or are too
                    slow to make retries useful.
   - ansible-test - The ``ansible-test env`` command now detects and reports the container ID if running in a container.
+  - ansible-test - SSH connections from OpenSSH 8.8+ to CentOS 6 containers now work without additional configuration.
+                   However, clients older than OpenSSH 7.0 can no longer connect to CentOS 6 containers as a result.
+                   The container must have ``centos6`` in the image name for this work-around to be applied.
+  - ansible-test - SSH shell connections from OpenSSH 8.8+ to ansible-test provisioned network instances now work without additional configuration.
+                   However, clients older than OpenSSH 7.0 can no longer open shell sessions for ansible-test provisioned network instances as a result.
 bugfixes:
   - ansible-test - Multiple containers now work under Podman without specifying the ``--docker-network`` option.
   - ansible-test - Prevent concurrent / repeat pulls of the same container image.

--- a/test/lib/ansible_test/_internal/connections.py
+++ b/test/lib/ansible_test/_internal/connections.py
@@ -34,6 +34,7 @@ from .docker_util import (
 
 from .ssh import (
     SshConnectionDetail,
+    ssh_options_to_list,
 )
 
 from .become import (
@@ -123,7 +124,7 @@ class SshConnection(Connection):
 
         self.options = ['-i', settings.identity_file]
 
-        ssh_options = dict(
+        ssh_options: dict[str, t.Union[int, str]] = dict(
             BatchMode='yes',
             StrictHostKeyChecking='no',
             UserKnownHostsFile='/dev/null',
@@ -131,8 +132,9 @@ class SshConnection(Connection):
             ServerAliveCountMax=4,
         )
 
-        for ssh_option in sorted(ssh_options):
-            self.options.extend(['-o', f'{ssh_option}={ssh_options[ssh_option]}'])
+        ssh_options.update(settings.options)
+
+        self.options.extend(ssh_options_to_list(ssh_options))
 
     def run(self,
             command,  # type: t.List[str]

--- a/test/lib/ansible_test/_internal/inventory.py
+++ b/test/lib/ansible_test/_internal/inventory.py
@@ -25,6 +25,10 @@ from .host_profiles import (
     WindowsRemoteProfile,
 )
 
+from .ssh import (
+    ssh_options_to_str,
+)
+
 
 def create_controller_inventory(args, path, controller_host):  # type: (EnvironmentConfig, str, ControllerHostProfile) -> None
     """Create and return inventory for use in controller-only integration tests."""
@@ -149,6 +153,7 @@ def create_posix_inventory(args, path, target_hosts, needs_ssh=False):  # type: 
             ansible_port=ssh.settings.port,
             ansible_user=ssh.settings.user,
             ansible_ssh_private_key_file=ssh.settings.identity_file,
+            ansible_ssh_extra_args=ssh_options_to_str(ssh.settings.options),
         )  # type: t.Dict[str, t.Optional[t.Union[str, int]]]
 
         if ssh.become:

--- a/test/lib/ansible_test/_internal/ssh.py
+++ b/test/lib/ansible_test/_internal/ssh.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import dataclasses
+import itertools
 import json
 import os
 import random
@@ -38,9 +39,39 @@ class SshConnectionDetail:
     identity_file: str
     python_interpreter: t.Optional[str] = None
     shell_type: t.Optional[str] = None
+    enable_rsa_sha1: bool = False
 
     def __post_init__(self):
         self.name = sanitize_host_name(self.name)
+
+    @property
+    def options(self) -> dict[str, str]:
+        """OpenSSH config options, which can be passed to the `ssh` CLI with the `-o` argument."""
+        options: dict[str, str] = {}
+
+        if self.enable_rsa_sha1:
+            # Newer OpenSSH clients connecting to older SSH servers must explicitly enable ssh-rsa support.
+            # OpenSSH 8.8, released on 2021-09-26, deprecated using RSA with the SHA-1 hash algorithm (ssh-rsa).
+            # OpenSSH 7.2, released on 2016-02-29, added support for using RSA with SHA-256/512 hash algorithms.
+            # See: https://www.openssh.com/txt/release-8.8
+            algorithms = '+ssh-rsa'  # append the algorithm to the default list, requires OpenSSH 7.0 or later
+
+            options.update(dict(
+                # Host key signature algorithms that the client wants to use.
+                # Available options can be found with `ssh -Q HostKeyAlgorithms` or `ssh -Q key` on older clients.
+                # This option was updated in OpenSSH 7.0, released on 2015-08-11, to support the "+" prefix.
+                # See: https://www.openssh.com/txt/release-7.0
+                HostKeyAlgorithms=algorithms,
+                # Signature algorithms that will be used for public key authentication.
+                # Available options can be found with `ssh -Q PubkeyAcceptedAlgorithms` or `ssh -Q key` on older clients.
+                # This option was added in OpenSSH 7.0, released on 2015-08-11.
+                # See: https://www.openssh.com/txt/release-7.0
+                # This option is an alias for PubkeyAcceptedAlgorithms, which was added in OpenSSH 8.5.
+                # See: https://www.openssh.com/txt/release-8.5
+                PubkeyAcceptedKeyTypes=algorithms,
+            ))
+
+        return options
 
 
 class SshProcess:
@@ -141,7 +172,7 @@ def create_ssh_command(
     if ssh.user:
         cmd.extend(['-l', ssh.user])  # user to log in as on the remote machine
 
-    ssh_options = dict(
+    ssh_options: dict[str, t.Union[int, str]] = dict(
         BatchMode='yes',
         ExitOnForwardFailure='yes',
         LogLevel='ERROR',
@@ -153,9 +184,7 @@ def create_ssh_command(
 
     ssh_options.update(options or {})
 
-    for key, value in sorted(ssh_options.items()):
-        cmd.extend(['-o', '='.join([key, str(value)])])
-
+    cmd.extend(ssh_options_to_list(ssh_options))
     cmd.extend(cli_args or [])
     cmd.append(ssh.host)
 
@@ -163,6 +192,18 @@ def create_ssh_command(
         cmd.append(command)
 
     return cmd
+
+
+def ssh_options_to_list(options: t.Union[dict[str, t.Union[int, str]], dict[str, str]]) -> list[str]:
+    """Format a dictionary of SSH options as a list suitable for passing to the `ssh` command."""
+    return list(itertools.chain.from_iterable(
+        ('-o', f'{key}={value}') for key, value in sorted(options.items())
+    ))
+
+
+def ssh_options_to_str(options: t.Union[dict[str, t.Union[int, str]], dict[str, str]]) -> str:
+    """Format a dictionary of SSH options as a string suitable for passing as `ansible_ssh_extra_args` in inventory."""
+    return shlex.join(ssh_options_to_list(options))
 
 
 def run_ssh_command(
@@ -245,7 +286,7 @@ def generate_ssh_inventory(ssh_connections):  # type: (t.List[SshConnectionDetai
                 ansible_pipelining='yes',
                 ansible_python_interpreter=ssh.python_interpreter,
                 ansible_shell_type=ssh.shell_type,
-                ansible_ssh_extra_args='-o UserKnownHostsFile=/dev/null',  # avoid changing the test environment
+                ansible_ssh_extra_args=ssh_options_to_str(dict(UserKnownHostsFile='/dev/null', **ssh.options)),  # avoid changing the test environment
                 ansible_ssh_host_key_checking='no',
             ))) for ssh in ssh_connections),
         ),


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/79594

(cherry picked from commit 75b60b17ee1ff18ded04cf07b71e4ee32e673a0b)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
