### PR TITLE
Fixed incorrect spelling of the word overridden.

### DIFF
--- a/lib/ansible/modules/set_fact.py
+++ b/lib/ansible/modules/set_fact.py
@@ -45,7 +45,7 @@ extends_documentation_fragment:
     - action_core
 attributes:
     action:
-        details: While the action plugin does do some of the work it relies on the core engine to actually create the variables, that part cannot be overriden
+        details: While the action plugin does do some of the work it relies on the core engine to actually create the variables, that part cannot be overridden
         support: partial
     bypass_host_loop:
         support: none

--- a/lib/ansible/plugins/filter/to_json.yml
+++ b/lib/ansible/plugins/filter/to_json.yml
@@ -54,7 +54,7 @@ DOCUMENTATION:
       type: bool
   notes:
     - Both I(vault_to_text) and I(preprocess_unsafe) defaulted to C(False) between Ansible 2.9 and 2.12.
-    - 'These parameters to C(json.dumps) will be ignored, as they are overriden internally: I(cls), I(default)'
+    - 'These parameters to C(json.dumps) will be ignored, as they are overridden internally: I(cls), I(default)'
 
 EXAMPLES: |
   # dump variable in a template to create a JSON document

--- a/lib/ansible/plugins/filter/to_nice_json.yml
+++ b/lib/ansible/plugins/filter/to_nice_json.yml
@@ -41,7 +41,7 @@ DOCUMENTATION:
       type: bool
   notes:
     - Both I(vault_to_text) and I(preprocess_unsafe) defaulted to C(False) between Ansible 2.9 and 2.12.
-    - 'These parameters to C(json.dumps) will be ignored, they are overriden for internal use: I(cls), I(default), I(indent), I(separators), I(sort_keys).'
+    - 'These parameters to C(json.dumps) will be ignored, they are overridden for internal use: I(cls), I(default), I(indent), I(separators), I(sort_keys).'
 
 EXAMPLES: |
   # dump variable in a template to create a nicely formatted JSON document

--- a/lib/ansible/plugins/filter/to_nice_yaml.yml
+++ b/lib/ansible/plugins/filter/to_nice_yaml.yml
@@ -27,7 +27,7 @@ DOCUMENTATION:
     #default_style=None, canonical=None, width=None, line_break=None, encoding=None, explicit_start=None, explicit_end=None, version=None, tags=None
   notes:
     - More options may be available, see L(PyYAML documentation, https://pyyaml.org/wiki/PyYAMLDocumentation) for details.
-    - 'These parameters to C(yaml.dump) will be ignored, as they are overriden internally: I(default_flow_style)'
+    - 'These parameters to C(yaml.dump) will be ignored, as they are overridden internally: I(default_flow_style)'
 
 EXAMPLES: |
   # dump variable in a template to create a YAML document

--- a/test/integration/targets/delegate_to/delegate_local_from_root.yml
+++ b/test/integration/targets/delegate_to/delegate_local_from_root.yml
@@ -3,7 +3,7 @@
   gather_facts: false
   remote_user: root
   tasks:
-  - name: ensure we copy w/o errors due to remote user not being overriden
+  - name: ensure we copy w/o errors due to remote user not being overridden
     copy:
       src: testfile
       dest: "{{ playbook_dir }}"

--- a/test/integration/targets/module_utils_Ansible.Basic/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/module_utils_Ansible.Basic/library/ansible_basic_tests.ps1
@@ -87,7 +87,7 @@ Function Assert-DictionaryEqual {
 }
 
 Function Exit-Module {
-    # Make sure Exit actually calls exit and not our overriden test behaviour
+    # Make sure Exit actually calls exit and not our overridden test behaviour
     [Ansible.Basic.AnsibleModule]::Exit = { param([Int32]$rc) exit $rc }
     Write-Output -InputObject (ConvertTo-Json -InputObject $module.Result -Compress -Depth 99)
     $module.ExitJson()

--- a/test/integration/targets/plugin_loader/override/filters.yml
+++ b/test/integration/targets/plugin_loader/override/filters.yml
@@ -1,7 +1,7 @@
 - hosts: testhost
   gather_facts: false
   tasks:
-    - name: ensure local 'flag' filter works, 'flatten' is overriden and 'ternary' is still from core
+    - name: ensure local 'flag' filter works, 'flatten' is overridden and 'ternary' is still from core
       assert:
          that:
              - a|flag == 'flagged'

--- a/test/support/windows-integration/plugins/modules/win_stat.ps1
+++ b/test/support/windows-integration/plugins/modules/win_stat.ps1
@@ -95,7 +95,7 @@ If ($null -ne $info) {
         isreadonly = ($attributes -contains "ReadOnly")
         isreg = $false
         isshared = $false
-        nlink = 1  # Number of links to the file (hard links), overriden below if islnk
+        nlink = 1  # Number of links to the file (hard links), overridden below if islnk
         # lnk_target = islnk or isjunction Target of the symlink. Note that relative paths remain relative
         # lnk_source = islnk os isjunction Target of the symlink normalized for the remote filesystem
         hlnk_targets = @()


### PR DESCRIPTION
##### SUMMARY

Fixed the incorrect spelling of the word "overridden" in multiple locations.
