### PR TITLE
Fix broken reference to FAQ

### DIFF
--- a/lib/ansible/plugins/doc_fragments/validate.py
+++ b/lib/ansible/plugins/doc_fragments/validate.py
@@ -16,7 +16,6 @@ options:
     - A temporary file path is used to validate, passed in through '%s' which must be present as in the examples below.
     - Also, the command is passed securely so shell features such as expansion and pipes will not work.
     - For an example on how to handle more complex validation than what this
-      option provides, see L("The 'validate' option is not enough for my needs, what do I
-      do?",https://docs.ansible.com/ansible/devel/reference_appendices/faq.html#the-validate-option-is-not-enough-for-my-needs-what-do-i-do).
+      option provides, see R(handling complex validation,complex_configuration_validation).
     type: str
 '''

--- a/lib/ansible/plugins/doc_fragments/validate.py
+++ b/lib/ansible/plugins/doc_fragments/validate.py
@@ -15,7 +15,8 @@ options:
     - The validation command to run before copying the updated file into the final destination.
     - A temporary file path is used to validate, passed in through '%s' which must be present as in the examples below.
     - Also, the command is passed securely so shell features such as expansion and pipes will not work.
-    - For an example on how to handle more complex validation than what this option provides,
-      see L(Complex configuration validation,https://docs.ansible.com/ansible/devel/reference_appendices/faq.html).
+    - For an example on how to handle more complex validation than what this
+      option provides, see L("The 'validate' option is not enough for my needs, what do I
+      do?",https://docs.ansible.com/ansible/devel/reference_appendices/faq.html#the-validate-option-is-not-enough-for-my-needs-what-do-i-do).
     type: str
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The "validate" documentation fragment refers to a section called "Complex configuration validation" in the FAQ, but this section doesn't exist under that name, but rather under "The 'validate' option is not enough for my needs, what do I do?". This PR fixes the reference.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

"validate" documentation fragment

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
None