### PR TITLE
ansible-test: add --show-timings option for integration tests

### DIFF
--- a/changelogs/fragments/79622-ansible-test-integration-timings.yml
+++ b/changelogs/fragments/79622-ansible-test-integration-timings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ansible-test - the integration tests now support a ``--show-timings`` option that shows the time needed for every target that was run (https://github.com/ansible/ansible/pull/79622)."

--- a/test/lib/ansible_test/_internal/cli/commands/integration/__init__.py
+++ b/test/lib/ansible_test/_internal/cli/commands/integration/__init__.py
@@ -118,6 +118,12 @@ def add_integration_common(
     )
 
     parser.add_argument(
+        '--show-timings',
+        action='store_true',
+        help='at the end of all tests show the amount of seconds every test run took',
+    )
+
+    parser.add_argument(
         '--continue-on-error',
         action='store_true',
         help='continue after failed test',

--- a/test/lib/ansible_test/_internal/commands/integration/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/integration/__init__.py
@@ -447,6 +447,7 @@ def command_integration_filtered(
     start_at_task = args.start_at_task
 
     results = {}
+    timings = {}
 
     target_profile = host_state.target_profiles[0]
 
@@ -523,6 +524,7 @@ def command_integration_filtered(
                             setup_once=target.setup_once,
                             setup_always=target.setup_always,
                         )
+                        timings[target.name] = end_time - start_time
 
                         break
                     except SubprocessError:
@@ -570,6 +572,11 @@ def command_integration_filtered(
             )
 
             write_json_test_results(ResultType.DATA, result_name, data)
+
+            if args.show_timings:
+                display.notice('Test timings:')
+                for target, run_time in sorted(timings.items()):
+                    display.notice(f'  {target} - {run_time:.1f} seconds')
 
     if failed:
         raise ApplicationError('The %d integration test(s) listed below (out of %d) failed. See error output above for details:\n%s' % (

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -297,6 +297,7 @@ class IntegrationConfig(TestConfig):
         self.diff = args.diff
         self.no_temp_workdir: bool = args.no_temp_workdir
         self.no_temp_unicode: bool = args.no_temp_unicode
+        self.show_timings: bool = args.show_timings
 
         if self.list_targets:
             self.explain = True

--- a/test/utils/shippable/cloud.sh
+++ b/test/utils/shippable/cloud.sh
@@ -29,6 +29,6 @@ else
 fi
 
 # shellcheck disable=SC2086
-ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
+ansible-test integration --show-timings --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
     --remote-terminate always --remote-stage "${stage}" \
     --docker --python "${python}" --changed-all-target "${changed_all_target}" --changed-all-mode "${changed_all_mode}"

--- a/test/utils/shippable/generic.sh
+++ b/test/utils/shippable/generic.sh
@@ -14,5 +14,5 @@ else
 fi
 
 # shellcheck disable=SC2086
-ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
+ansible-test integration --show-timings --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
     --docker default --python "${python}"

--- a/test/utils/shippable/incidental/network.sh
+++ b/test/utils/shippable/incidental/network.sh
@@ -33,7 +33,7 @@ for python_version in "${python_versions[@]}"; do
     fi
 
     # shellcheck disable=SC2086
-    ansible-test network-integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
+    ansible-test network-integration --show-timings --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
         --platform "${platform}/${version}" \
         --docker default --python "${python_version}" \
         --remote-terminate "${terminate}" --remote-stage "${stage}" --remote-provider "${provider}"

--- a/test/utils/shippable/incidental/windows.sh
+++ b/test/utils/shippable/incidental/windows.sh
@@ -46,7 +46,7 @@ else
 fi
 
 # shellcheck disable=SC2086
-ansible-test windows-integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
+ansible-test windows-integration --show-timings --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
     "${platforms[@]}" \
     --docker default --python "${python_default}" \
     --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}"

--- a/test/utils/shippable/linux.sh
+++ b/test/utils/shippable/linux.sh
@@ -14,5 +14,5 @@ else
 fi
 
 # shellcheck disable=SC2086
-ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
+ansible-test integration --show-timings --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
     --docker "${image}"

--- a/test/utils/shippable/remote.sh
+++ b/test/utils/shippable/remote.sh
@@ -28,5 +28,5 @@ stage="${S:-prod}"
 provider="${P:-default}"
 
 # shellcheck disable=SC2086
-ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
+ansible-test integration --show-timings --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
     --python "${pyver}" --remote "${platform}/${version}" --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}" \

--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -87,7 +87,7 @@ for version in "${python_versions[@]}"; do
     fi
 
     # shellcheck disable=SC2086
-    ansible-test windows-integration --color -v --retry-on-error "${ci}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
+    ansible-test windows-integration --show-timings --color -v --retry-on-error "${ci}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
         "${platforms[@]}" --changed-all-target "${changed_all_target}" --changed-all-mode "${changed_all_mode}" \
         --docker default --python "${version}" \
         --remote-terminate "${terminate}" --remote-stage "${stage}" --remote-provider "${provider}"


### PR DESCRIPTION
##### SUMMARY
Allows to show which tests took how long.

Useful for balancing tests in different groups.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
