### PR TITLE
Update dev_guide.rst

### DIFF
--- a/docs/docsite/rst/galaxy/dev_guide.rst
+++ b/docs/docsite/rst/galaxy/dev_guide.rst
@@ -100,7 +100,7 @@ Using the ``import``, ``delete`` and ``setup`` commands to manage your roles on 
 #. Log in to the Galaxy website and open the `Preferences <https://galaxy.ansible.com/me/preferences>`_ view.
 #. Select **Show API key** and then copy it.
 
-#. Save your token in the `.ansible/galaxy_token` file.
+#. Save your token in the path set in the :ref:`GALAXY_TOKEN_PATH:`.
 
 
 Import a role

--- a/docs/docsite/rst/galaxy/dev_guide.rst
+++ b/docs/docsite/rst/galaxy/dev_guide.rst
@@ -100,7 +100,7 @@ Using the ``import``, ``delete`` and ``setup`` commands to manage your roles on 
 #. Log in to the Galaxy website and open the `Preferences <https://galaxy.ansible.com/me/preferences>`_ view.
 #. Select **Show API key** and then copy it.
 
-#. Save your token in the path set in the :ref:`GALAXY_TOKEN_PATH:`.
+#. Save your token in the path set in the :ref:`GALAXY_TOKEN_PATH`.
 
 
 Import a role

--- a/docs/docsite/rst/galaxy/dev_guide.rst
+++ b/docs/docsite/rst/galaxy/dev_guide.rst
@@ -95,32 +95,11 @@ Alternatively, the role_skeleton and ignoring of files can be configured via ans
 Authenticate with Galaxy
 ------------------------
 
-Using the ``import``, ``delete`` and ``setup`` commands to manage your roles on the Galaxy website requires authentication, and the ``login`` command
-can be used to do just that. Before you can use the ``login`` command, you must create an account on the Galaxy website.
+Using the ``import``, ``delete`` and ``setup`` commands to manage your roles on the Galaxy website requires authentication in the form of an API key, you must create an account on the Galaxy website.
 
-The ``login`` command requires using your GitHub credentials. You can use your username and password, or you can create a `personal access token <https://help.github.com/articles/creating-an-access-token-for-command-line-use/>`_. If you choose to create a token, grant minimal access to the token, as it is used just to verify identify.
+Log in to the galaxy website and visit https://galaxy.ansible.com/me/preferences and click `show api key`
 
-The following shows authenticating with the Galaxy website using a GitHub username and password:
-
-.. code-block:: text
-
-   $ ansible-galaxy login
-
-   We need your GitHub login to identify you.
-   This information will not be sent to Galaxy, only to api.github.com.
-   The password will not be displayed.
-
-   Use --github-token if you do not want to enter your password.
-
-   GitHub Username: dsmith
-   Password for dsmith:
-   Successfully logged into Galaxy as dsmith
-
-When you choose to use your username and password, your password is not sent to Galaxy. It is used to authenticates with GitHub and create a personal access token.
-It then sends the token to Galaxy, which in turn verifies that your identity and returns a Galaxy access token. After authentication completes the GitHub token is
-destroyed.
-
-If you do not want to use your GitHub password, or if you have two-factor authentication enabled with GitHub, use the ``--github-token`` option to pass a personal access token that you create.
+Put this token in the `/home/<username>/.ansible/galaxy_token` file.
 
 
 Import a role

--- a/docs/docsite/rst/galaxy/dev_guide.rst
+++ b/docs/docsite/rst/galaxy/dev_guide.rst
@@ -97,9 +97,10 @@ Authenticate with Galaxy
 
 Using the ``import``, ``delete`` and ``setup`` commands to manage your roles on the Galaxy website requires authentication in the form of an API key, you must create an account on the Galaxy website.
 
-Log in to the galaxy website and visit https://galaxy.ansible.com/me/preferences and click `show api key`
+#. Log in to the Galaxy website and open the `Preferences <https://galaxy.ansible.com/me/preferences>`_ view.
+#. Select **Show API key** and then copy it.
 
-Put this token in the `/home/<username>/.ansible/galaxy_token` file.
+#. Save your token in the `.ansible/galaxy_token` file.
 
 
 Import a role


### PR DESCRIPTION
##### SUMMARY
The login command was removed in late 2020. An API key is now required to publish roles or collections to Galaxy. The key can be found at https://galaxy.ansible.com/me/preferences, and passed to the ansible-galaxy CLI via a file at /home/<username>/.ansible/galaxy_token or (insecurely) via the `--token` command-line argument.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
