### PR TITLE
ansible-galaxy - reinstall non-galaxy requirements only as needed

### DIFF
--- a/changelogs/fragments/79112-a-g-version-validation.yml
+++ b/changelogs/fragments/79112-a-g-version-validation.yml
@@ -1,3 +1,20 @@
+minor_changes:
+  - >
+    ansible-galaxy collection install - fix consistency when installing type ``url`` or ``file``
+    requirements by resolving dependencies and determining satisfied requirements from the result.
+    Previously, tarfiles were were always reinstalled if the dependency resolver ran, and could
+    be short-circuited if all type ``galaxy`` requirements were satisfied.
+    Now ``url`` and ``file`` types are always reinstalled, rather than circumstantially on
+    unrelated requirements.
+  - ansible-galaxy collection - consolidate message when an invalid version is encountered so it's
+    the same regardless of codepath.
 bugfixes:
-  - ansible-galaxy collection - enforce str versions when loading user-requested requirements (https://github.com/ansible/ansible/issues/78067, https://github.com/ansible/ansible/issues/79109).
-  - ansible-galaxy collection - fix installing pre-releases from virtual sources (https://github.com/ansible/ansible/issues/79168).
+  - >
+    ansible-galaxy collection - allow pre-releases without --pre if the pre-release is already installed
+    or if the requirement is a pre-release.
+  - >
+    ansible-galaxy collection - enforce str versions when loading user-requested requirements
+    (https://github.com/ansible/ansible/issues/78067, https://github.com/ansible/ansible/issues/79109).
+  - >
+    ansible-galaxy collection - fix installing pre-releases from virtual sources
+    (https://github.com/ansible/ansible/issues/79168).

--- a/changelogs/fragments/79112-a-g-version-validation.yml
+++ b/changelogs/fragments/79112-a-g-version-validation.yml
@@ -1,11 +1,4 @@
 minor_changes:
-  - >
-    ansible-galaxy collection install - fix consistency when installing type ``url`` or ``file``
-    requirements by resolving dependencies and determining satisfied requirements from the result.
-    Previously, tarfiles were were always reinstalled if the dependency resolver ran, and could
-    be short-circuited if all type ``galaxy`` requirements were satisfied.
-    Now ``url`` and ``file`` types are always reinstalled, rather than circumstantially on
-    unrelated requirements.
   - ansible-galaxy collection - consolidate message when an invalid version is encountered so it's
     the same regardless of codepath.
 bugfixes:

--- a/changelogs/fragments/79112-a-g-version-validation.yml
+++ b/changelogs/fragments/79112-a-g-version-validation.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-galaxy collection - enforce str versions when loading user-requested requirements (https://github.com/ansible/ansible/issues/78067, https://github.com/ansible/ansible/issues/79109).
+  - ansible-galaxy collection - fix installing pre-releases from virtual sources (https://github.com/ansible/ansible/issues/79168).

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1754,39 +1754,6 @@ def _resolve_depenency_map(
         # malformed requirements
         raise AnsibleError(f"{e}") from e
 
-    # This is arguably a bug, but this short-circuit is here for backwards compatibility...
-    # Context: when the dependency resolver runs, tarfile and url requirements are always
-    # reinstalled because only galaxy type uses the preferred candidates in _find_matches.
-    # However, the dependency resolver doesn't always run for url/tarfile types,
-    # only if a collection by that name + version isn't installed at all or if another
-    # collection is (potentially) missing.
-    # TL;DR: unrelated requirements (which may not even end up installed) cause all tarfile/url
-    # requirements to be reinstalled, whereas without this they would always be reinstalled.
-    if (
-        # Exclude all conditions which require dependency resolution
-        preferred_candidates is not None  # None for --force-with-deps/download
-        and not force
-        and not upgrade
-        and requested_requirements == collection_dep_resolver.provider.unrolled_user_requirements  # no ephemeral deps
-    ):
-        for req in collection_dep_resolver.provider.unrolled_user_requirements:
-            installed = False
-            for exs in collection_dep_resolver.provider._preferred_candidates:
-                if req.fqcn == exs.fqcn and not meets_requirements(exs.ver, req.ver):
-                    break
-                elif req.fqcn == exs.fqcn and meets_requirements(exs.ver, req.ver):
-                    installed = True
-            else:
-                if installed:
-                    continue
-            satisfied = False
-            break
-        else:
-            satisfied = True
-
-        if satisfied:
-            return {}
-
     try:
         dependency_mapping = collection_dep_resolver.resolve(
             collection_dep_resolver.provider.unrolled_user_requirements,

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -20,20 +20,18 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 if t.TYPE_CHECKING:
-    from ansible.galaxy.dependency_resolution.dataclasses import (
-        Candidate, Requirement,
-    )
+    from ansible.galaxy.dependency_resolution.dataclasses import Candidate
     from ansible.galaxy.token import GalaxyToken
 
 from ansible.errors import AnsibleError
 from ansible.galaxy import get_collections_galaxy_meta_info
-from ansible.galaxy.dependency_resolution.dataclasses import _GALAXY_YAML
+from ansible.galaxy.dependency_resolution.dataclasses import _GALAXY_YAML, Requirement
 from ansible.galaxy.user_agent import user_agent
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.module_utils.common.yaml import yaml_load
-from ansible.module_utils.six import raise_from
+from ansible.module_utils.six import raise_from, string_types
 from ansible.module_utils.urls import open_url
 from ansible.utils.display import Display
 from ansible.utils.sentinel import Sentinel

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -20,18 +20,20 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 if t.TYPE_CHECKING:
-    from ansible.galaxy.dependency_resolution.dataclasses import Candidate
+    from ansible.galaxy.dependency_resolution.dataclasses import (
+        Candidate, Requirement,
+    )
     from ansible.galaxy.token import GalaxyToken
 
 from ansible.errors import AnsibleError
 from ansible.galaxy import get_collections_galaxy_meta_info
-from ansible.galaxy.dependency_resolution.dataclasses import _GALAXY_YAML, Requirement
+from ansible.galaxy.dependency_resolution.dataclasses import _GALAXY_YAML
 from ansible.galaxy.user_agent import user_agent
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.common._collections_compat import MutableMapping
 from ansible.module_utils.common.yaml import yaml_load
-from ansible.module_utils.six import raise_from, string_types
+from ansible.module_utils.six import raise_from
 from ansible.module_utils.urls import open_url
 from ansible.utils.display import Display
 from ansible.utils.sentinel import Sentinel

--- a/lib/ansible/galaxy/dependency_resolution/__init__.py
+++ b/lib/ansible/galaxy/dependency_resolution/__init__.py
@@ -34,6 +34,7 @@ def build_collection_dependency_resolver(
         upgrade=False,  # type: bool
         include_signatures=True,  # type: bool
         offline=False,  # type: bool
+        force=False,  # type: bool
 ):  # type: (...) -> CollectionDependencyResolver
     """Return a collection dependency resolver.
 
@@ -50,6 +51,7 @@ def build_collection_dependency_resolver(
             with_pre_releases=with_pre_releases,
             upgrade=upgrade,
             include_signatures=include_signatures,
+            force=force,
         ),
         CollectionDependencyReporter(),
     )

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -559,7 +559,7 @@ class _ComputedReqKindsMixin:
         if not self.is_scm:
             version_req = "A SemVer-compliant version or '*' is required. See https://semver.org to learn how to compose it correctly."
         else:
-            version_req = f"A string version is required."
+            version_req = "A string version is required."
 
         name = self.fqcn if self.fqcn is not None else self
         version_err = f"Invalid version found for the collection '{name}': {self.ver} ({type(self.ver)}). {version_req}"

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -430,11 +430,15 @@ class _ComputedReqKindsMixin:
         if req_type not in {'galaxy', 'subdirs'} and req_version == '*':
             req_version = art_mgr.get_direct_collection_version(tmp_inst_req)
 
-        return cls(
+        req = cls(
             req_name, req_version,
             req_source, req_type,
             req_signature_sources,
         )
+        # a version requirement might be a range of versions, but must at least be a str
+        if not isinstance(req_version, string_types):
+            req.validate_version()
+        return req
 
     def __repr__(self):
         return (

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -434,12 +434,12 @@ class CollectionDependencyProviderBase(AbstractProvider):
         # NOTE: pre-releases is when there are several user requirements
         # NOTE: and one of them is a pre-release that also matches a
         # NOTE: transitive dependency of another requirement.
-        allow_pre_release = (
-            self._with_pre_releases
-            or self._is_user_requested(candidate)
-            or (requirement.ver != '*' and is_pre_release(requirement.ver))
-        )
-
+        allow_pre_release = self._with_pre_releases or not (
+            requirement.ver == '*' or
+            requirement.ver.startswith('<') or
+            requirement.ver.startswith('>') or
+            requirement.ver.startswith('!=')
+        ) or self._is_user_requested(candidate)
         if is_pre_release(candidate.ver) and not allow_pre_release:
             return False
 

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -401,7 +401,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
                 try:
                     match.assert_version()
                 except TypeError as ex:
-                    raise ValueError(version_err) from ex
+                    raise ValueError(ex) from ex
                 matches.append(match)
             return matches
 

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -46,6 +46,24 @@ RESOLVELIB_UPPERBOUND = SemanticVersion("0.10.0")
 RESOLVELIB_VERSION = SemanticVersion.from_loose_version(LooseVersion(resolvelib_version))
 
 
+def get_virtual_requirement_dependencies(requirement, artifacts_manager, seen=None):
+    if seen is None:
+        seen = set()
+    elif requirement in seen:
+        yield from ()
+
+    seen.add(requirement)
+    requirement.assert_version()  # assert version before assuming it's hashable
+
+    if requirement.is_virtual:
+        for dep_name, dep_req in artifacts_manager.get_direct_collection_dependencies(requirement).items():
+            dep = Requirement.from_requirement_dict({'name': dep_name, 'version': dep_req}, artifacts_manager)
+            for dep in get_virtual_requirement_dependencies(dep, artifacts_manager, seen):
+                yield dep
+    else:
+        yield requirement
+
+
 class PinnedCandidateRequests(Set):
     """Custom set class to store Candidate objects. Excludes the 'signatures' attribute when determining if a Candidate instance is in the set."""
     CANDIDATE_ATTRS = ('fqcn', 'ver', 'src', 'type')
@@ -87,6 +105,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
             with_pre_releases=False,  # type: bool
             upgrade=False,  # type: bool
             include_signatures=True,  # type: bool
+            force=False,  # type: bool
     ):  # type: (...) -> None
         r"""Initialize helper attributes.
 
@@ -117,17 +136,39 @@ class CollectionDependencyProviderBase(AbstractProvider):
             Requirement.from_requirement_dict,
             art_mgr=concrete_artifacts_manager,
         )
+
+        _direct_requests = []
+        _ephemeral_request_dependencies = []
+        for request in user_requirements or ():
+            if request.is_virtual:
+                _ephemeral_request_dependencies.extend(get_virtual_requirement_dependencies(request, concrete_artifacts_manager))
+            _direct_requests.append(request)
+
+        self.unrolled_user_requirements = _direct_requests + _ephemeral_request_dependencies
+
         self._pinned_candidate_requests = PinnedCandidateRequests(
             # NOTE: User-provided signatures are supplemental, so signatures
             # NOTE: are not used to determine if a candidate is user-requested
             Candidate(req.fqcn, req.ver, req.src, req.type, None)
-            for req in (user_requirements or ())
+            for req in self.unrolled_user_requirements
             if req.is_concrete_artifact or (
                 req.ver != '*' and
                 not req.ver.startswith(('<', '>', '!='))
             )
         )
-        self._preferred_candidates = set(preferred_candidates or ())
+        requested_requirement_names = {req.fqcn for req in _direct_requests}
+        ephemeral_dep_names = {req.fqcn for req in _ephemeral_request_dependencies}
+
+        self._preferred_candidates = set()
+        # FIXME: the logic for force probably needs to be improved to properly match differing src/type
+        for preference in preferred_candidates or ():
+            if force and preference.fqcn in requested_requirement_names:
+                continue
+            elif preference.fqcn in ephemeral_dep_names and preference.fqcn not in requested_requirement_names:
+                # Backwards compat to ensure we always reinstall SCM direct requests
+                continue
+            else:
+                self._preferred_candidates.add(preference)
         self._with_deps = with_deps
         self._with_pre_releases = with_pre_releases
         self._upgrade = upgrade
@@ -357,7 +398,10 @@ class CollectionDependencyProviderBase(AbstractProvider):
                 # NOTE: Another known mistake is setting a minor part of the SemVer notation
                 # NOTE: skipping the "patch" bit like "1.0" which is assumed non-compliant even
                 # NOTE: after the conversion to string.
-                match.validate_version()
+                try:
+                    match.assert_version()
+                except TypeError as ex:
+                    raise ValueError(version_err) from ex
                 matches.append(match)
             return matches
 
@@ -434,12 +478,17 @@ class CollectionDependencyProviderBase(AbstractProvider):
         # NOTE: pre-releases is when there are several user requirements
         # NOTE: and one of them is a pre-release that also matches a
         # NOTE: transitive dependency of another requirement.
-        allow_pre_release = self._with_pre_releases or not (
-            requirement.ver == '*' or
-            requirement.ver.startswith('<') or
-            requirement.ver.startswith('>') or
-            requirement.ver.startswith('!=')
-        ) or self._is_user_requested(candidate)
+        allow_pre_release = (
+            self._with_pre_releases or not (
+                requirement.ver == '*' or
+                requirement.ver.startswith('<') or
+                requirement.ver.startswith('>') or
+                requirement.ver.startswith('!=')
+            )
+            or is_pre_release(requirement.ver)  # allow pre-releases if the requirement was one, like pip
+            or self._is_user_requested(candidate)
+            or candidate in self._preferred_candidates  # if a pre-release was already installed
+        )
         if is_pre_release(candidate.ver) and not allow_pre_release:
             return False
 

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/reinstalling.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/reinstalling.yml
@@ -2,30 +2,43 @@
   command: 'ansible-galaxy collection install git+file://{{ test_repo_path }}/.git#/collection_1/'
   register: installed
 
-- name: SCM collections don't have a concrete artifact version so the collection should always be reinstalled
+- name: assert the virtual dependency is already installed with an identical version
+  assert:
+    that:
+      - >
+        "'ansible_test.collection_1:1.0.0' is already installed, skipping." in installed.stdout
+      - >
+        "'ansible_test.collection_2:1.0.0' is already installed, skipping." in installed.stdout
+
+- name: Force reinstalling a collection
+  command: 'ansible-galaxy collection install git+file://{{ test_repo_path }}/.git#/collection_1/ --force'
+  register: installed
+
+- name: assert only the direct request was resinstalled with --force
+  assert:
+    that:
+      - "'Created collection for ansible_test.collection_1' in installed.stdout"
+      - >
+        "'ansible_test.collection_2:1.0.0' is already installed, skipping." in installed.stdout
+
+- name: Force reinstalling a collection and its dependency
+  command: 'ansible-galaxy collection install git+file://{{ test_repo_path }}/.git#/collection_1/ --force-with-deps'
+  register: installed
+
+- name: assert the SCM collection and its dependency was reinstalled
   assert:
     that:
       - "'Created collection for ansible_test.collection_1' in installed.stdout"
       - "'Created collection for ansible_test.collection_2' in installed.stdout"
 
-- name: The collection should also be reinstalled when --force flag is used
-  command: 'ansible-galaxy collection install git+file://{{ test_repo_path }}/.git#/collection_1/ --force'
+- name: Install a different version of the collection without --force
+  command: 'ansible-galaxy collection install git+file://{{ test_repo_path }}/.git#/collection_1/,v0.0.9'
   register: installed
 
-- assert:
+- name: assert the collection was reinstalled
+  assert:
     that:
       - "'Created collection for ansible_test.collection_1' in installed.stdout"
-      # The dependency is also an SCM collection, so it should also be reinstalled
-      - "'Created collection for ansible_test.collection_2' in installed.stdout"
-
-- name: The collection should also be reinstalled when --force-with-deps is used
-  command: 'ansible-galaxy collection install git+file://{{ test_repo_path }}/.git#/collection_1/ --force-with-deps'
-  register: installed
-
-- assert:
-    that:
-      - "'Created collection for ansible_test.collection_1' in installed.stdout"
-      - "'Created collection for ansible_test.collection_2' in installed.stdout"
 
 - include_tasks: ./empty_installed_collections.yml
   when: cleanup

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/setup_multi_collection_repo.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/setup_multi_collection_repo.yml
@@ -56,6 +56,12 @@
     regexp: '^build_ignore'
     line: "build_ignore: ['foo.txt', 'foobar/*']"
 
+- name: Update collection version
+  lineinfile:
+    path: '{{ test_repo_path }}/collection_1/galaxy.yml'
+    regexp: '^version:'
+    line: 'version: 0.0.9'
+
 - name: Commit the changes
   command: '{{ item }}'
   args:
@@ -63,6 +69,22 @@
   loop:
     - git add ./
     - git commit -m 'add collections'
+    - git tag -a v0.0.9 -m "version 0.0.9"
+
+- name: Add another version
+  lineinfile:
+    path: '{{ test_repo_path }}/collection_1/galaxy.yml'
+    regexp: '^version:'
+    line: 'version: 1.0.0'
+
+- name: Commit the changes
+  command: '{{ item }}'
+  args:
+    chdir: '{{ test_repo_path }}'
+  loop:
+    - git add ./
+    - git commit -m 'update collections'
+    - git tag -a v1.0.0 -m "version 1.0.0"
 
 - name: Build the actual artifact for ansible_test.collection_1 for comparison
   command: "ansible-galaxy collection build ansible_test/collection_1 --output-path {{ galaxy_dir }}"

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/test_invalid_version.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/test_invalid_version.yml
@@ -1,4 +1,26 @@
 - block:
+  - name: create requirements file (necessary test an int requirement version)
+    copy:
+      dest: "{{ galaxy_dir }}/requirement_with_int_version.yml"
+      content: |
+        collections:
+          - name: file://{{ test_repo_path }}/.git#collection_2
+            type: git
+            version: 12345
+
+  - name: test installing a virtual collection with an integer version
+    command: 'ansible-galaxy collection install -r {{ galaxy_dir }}/requirement_with_int_version.yml'
+    ignore_errors: yes
+    register: invalid_scm_version
+
+  - assert:
+      that:
+        - invalid_scm_version is failed
+        - msg in invalid_scm_version.stderr
+    vars:
+      # FIXME quotation marks
+      msg: "Invalid version found for the collection '\"virtual collection Git repo\"'. A string version is required."
+
   - name: test installing a collection with an invalid float version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#float_version_collection -vvvvvv'
     ignore_errors: yes
@@ -10,8 +32,7 @@
         - msg in invalid_version_result.stderr
     vars:
       req: error_test.float_version_collection:1.0
-      ver: "1.0 (<class 'float'>)"
-      msg: "Invalid version found for the collection '{{ req }}': {{ ver }}. A SemVer-compliant version or '*' is required."
+      msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
 
   - name: test installing a collection with an invalid non-SemVer string version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#not_semantic_version_collection -vvvvvv'
@@ -24,8 +45,7 @@
         - msg in invalid_version_result.stderr
     vars:
       req: error_test.not_semantic_version_collection:1.0
-      ver: "1.0 (<class 'str'>)"
-      msg: "Invalid version found for the collection '{{ req }}': {{ ver }}. A SemVer-compliant version or '*' is required."
+      msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
 
   - name: test installing a collection with an invalid list version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#list_version_collection -vvvvvv'
@@ -54,5 +74,10 @@
       msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
 
   always:
+  - name: remove requirements file
+    file:
+      path: "{{ galaxy_dir }}/requirement_with_int_version.yml"
+      state: absent
+
   - include_tasks: ./empty_installed_collections.yml
     when: cleanup

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/test_invalid_version.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/test_invalid_version.yml
@@ -18,8 +18,8 @@
         - invalid_scm_version is failed
         - msg in invalid_scm_version.stderr
     vars:
-      # FIXME quotation marks
-      msg: "Invalid version found for the collection '\"virtual collection Git repo\"'. A string version is required."
+      ver: "12345 (<class 'int'>)"
+      msg: "Invalid version found for the collection '\"virtual collection Git repo\"': {{ ver }}. A string version is required."
 
   - name: test installing a collection with an invalid float version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#float_version_collection -vvvvvv'
@@ -31,8 +31,9 @@
         - invalid_version_result is failed
         - msg in invalid_version_result.stderr
     vars:
-      req: error_test.float_version_collection:1.0
-      msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
+      req: error_test.float_version_collection
+      ver: "1.0 (<class 'float'>)"
+      msg: "Invalid version found for the collection '{{ req }}': {{ ver }}. A SemVer-compliant version or '*' is required."
 
   - name: test installing a collection with an invalid non-SemVer string version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#not_semantic_version_collection -vvvvvv'
@@ -44,8 +45,9 @@
         - invalid_version_result is failed
         - msg in invalid_version_result.stderr
     vars:
-      req: error_test.not_semantic_version_collection:1.0
-      msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
+      req: error_test.not_semantic_version_collection
+      ver: "1.0 (<class 'str'>)"
+      msg: "Invalid version found for the collection '{{ req }}': {{ ver }}. A SemVer-compliant version or '*' is required."
 
   - name: test installing a collection with an invalid list version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#list_version_collection -vvvvvv'
@@ -57,8 +59,9 @@
         - invalid_version_result is failed
         - msg in invalid_version_result.stderr
     vars:
-      req: "error_test.list_version_collection:['1.0.0']"
-      msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
+      req: error_test.list_version_collection
+      ver: "['1.0.0'] (<class 'list'>)"
+      msg: "Invalid version found for the collection '{{ req }}': {{ ver }}. A SemVer-compliant version or '*' is required."
 
   - name: test installing a collection with an invalid dict version value
     command: 'ansible-galaxy collection install git+file://{{ test_error_repo_path }}/.git#dict_version_collection -vvvvvv'
@@ -70,8 +73,9 @@
         - invalid_version_result is failed
         - msg in invalid_version_result.stderr
     vars:
-      req: "error_test.dict_version_collection:{'broken': 'version'}"
-      msg: "Invalid version found for the collection '{{ req }}'. A SemVer-compliant version or '*' is required."
+      req: error_test.dict_version_collection
+      ver: "{'broken': 'version'} (<class 'dict'>)"
+      msg: "Invalid version found for the collection '{{ req }}': {{ ver }}. A SemVer-compliant version or '*' is required."
 
   always:
   - name: remove requirements file

--- a/test/integration/targets/ansible-galaxy-collection/tasks/upgrade.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/upgrade.yml
@@ -187,7 +187,9 @@
   register: result
 
 - assert:
-    that: "\"'namespace1.name1:1.1.0-beta.1' is already installed, skipping.\" in result.stdout"
+    that: msg in result.stdout
+  vars:
+    msg: "Nothing to do. All requested collections are already installed. If you want to reinstall them, consider using `--force`."
 
 # With deps
 

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -890,7 +890,7 @@ def test_collection_install_with_url(monkeypatch, collection_install):
     mock_open = MagicMock(return_value=BytesIO())
     monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
 
-    mock_metadata = MagicMock(return_value={'namespace': 'foo', 'name': 'bar', 'version': 'v1.0.0'})
+    mock_metadata = MagicMock(return_value={'namespace': 'foo', 'name': 'bar', 'version': '1.0.0'})
     monkeypatch.setattr(collection.concrete_artifact_manager, '_get_meta_from_tar', mock_metadata)
 
     galaxy_args = ['ansible-galaxy', 'collection', 'install', 'https://foo/bar/foo-bar-v1.0.0.tar.gz',
@@ -902,7 +902,7 @@ def test_collection_install_with_url(monkeypatch, collection_install):
 
     assert mock_install.call_count == 1
     requirements = [('%s.%s' % (r.namespace, r.name), r.ver, r.src, r.type,) for r in mock_install.call_args[0][0]]
-    assert requirements == [('foo.bar', 'v1.0.0', 'https://foo/bar/foo-bar-v1.0.0.tar.gz', 'url')]
+    assert requirements == [('foo.bar', '1.0.0', 'https://foo/bar/foo-bar-v1.0.0.tar.gz', 'url')]
     assert mock_install.call_args[0][1] == collection_path
     assert len(mock_install.call_args[0][2]) == 1
     assert mock_install.call_args[0][2][0].api_server == 'https://galaxy.ansible.com'

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -810,7 +810,7 @@ def test_install_installed_collection(monkeypatch, tmp_path_factory, galaxy_serv
     cli.run()
 
     expected = "Nothing to do. All requested collections are already installed. If you want to reinstall them, consider using `--force`."
-    assert mock_display.mock_calls[1][1][0] == expected
+    assert mock_display.mock_calls[-1][1][0] == expected
 
 
 def test_install_collection(collection_artifact, monkeypatch):
@@ -941,9 +941,9 @@ def test_install_collections_existing_without_force(collection_artifact, monkeyp
 
     # Filter out the progress cursor display calls.
     display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2] and len(m[1]) == 1]
-    assert len(display_msgs) == 1
+    assert len(display_msgs) == 2
 
-    assert display_msgs[0] == 'Nothing to do. All requested collections are already installed. If you want to reinstall them, consider using `--force`.'
+    assert display_msgs[1] == 'Nothing to do. All requested collections are already installed. If you want to reinstall them, consider using `--force`.'
 
     for msg in display_msgs:
         assert 'WARNING' not in msg

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -806,6 +806,9 @@ def test_install_installed_collection(monkeypatch, tmp_path_factory, galaxy_serv
     mock_get_versions = MagicMock(return_value=['1.2.3', '1.3.0'])
     monkeypatch.setattr(galaxy_server, 'get_collection_versions', mock_get_versions)
 
+    mock_get_dependencies = MagicMock(return_value={})
+    monkeypatch.setattr(collection.galaxy_api_proxy.MultiGalaxyAPIProxy, 'get_collection_dependencies', mock_get_dependencies)
+
     cli = GalaxyCLI(args=['ansible-galaxy', 'collection', 'install', 'namespace.collection'])
     cli.run()
 
@@ -955,6 +958,9 @@ def test_install_missing_metadata_warning(collection_artifact, monkeypatch):
 
     mock_display = MagicMock()
     monkeypatch.setattr(Display, 'display', mock_display)
+
+    mock_get_dependencies = MagicMock(return_value={})
+    monkeypatch.setattr(collection.galaxy_api_proxy.MultiGalaxyAPIProxy, 'get_collection_dependencies', mock_get_dependencies)
 
     for file in [b'MANIFEST.json', b'galaxy.yml']:
         b_path = os.path.join(collection_path, file)


### PR DESCRIPTION
##### SUMMARY
This would change non-galaxy requirements to only be reinstalled without `--force` if the version (of the built collection) differs. Since this isn't backwards compatible, it could possible be put behind a toggle or be made more accurate by comparing the collection contents or origin.

Most of this is #79112, POC is in f40d31a311c69e5b055e78c0d4f44f35b1a84759.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy collection install