### PR TITLE
Add recent module to iptables builtin

### DIFF
--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -134,7 +134,7 @@ options:
     description:
       - Allows to dynamically create a list of IP addresses
     type: dict
-    version_added: "2.13"
+    version_added: "2.15"
     suboptions:
         name:
             description:

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -166,6 +166,7 @@ options:
             description:
                 - Netmask that will be applied to the recent list
             type: str
+            default: "255.255.255.255"
         side:
             description:
                 - Which side of the IP addresses to add
@@ -898,7 +899,7 @@ def main():
                             rttl=dict(type='bool', default=False),
                             seconds=dict(type='str'),
                             hitcount=dict(type='str'),
-                            mask=dict(type='str')
+                            mask=dict(type='str', default='255.255.255.255')
                         )),
             goto=dict(type='str'),
             in_interface=dict(type='str'),

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -148,14 +148,19 @@ options:
             default: rcheck
         seconds:
             description:
-                - Must be used in conjunction with one of the actions C(rcheck) or C(update)
-                - Narrow the match to only happen when the address is in the list and was seen within the last given number of seconds
+                - Must be used in conjunction with one of the actions C(rcheck)
+                  or C(update)
+                - Narrow the match to only happen when the address is in the
+                  list and was seen within the last given number of seconds
             type: str
         hitcount:
             description:
-                - Must be used in conjunction with one of the actions C(rcheck) or C(update)
-                - Narrow the match to only happen when the address is in the list and packets had been received greater than or equal to the given value
-                - This option may be used along with seconds to create an even narrower match requiring a certain number of hits within a specific time frame
+                - Must be used in conjunction with one of the actions C(rcheck)
+                  or C(update)
+                - Narrow the match to only happen when the address is in the
+                  list and packets had been received greater than or equal to the given value
+                - This option may be used along with seconds to create an even
+                  narrower match requiring a certain number of hits within a specific time frame
             type: str
         mask:
             description:
@@ -169,8 +174,11 @@ options:
             default: rsource
         rttl:
             description:
-                - This option may only be used in conjunction with one of the actions C(rcheck) or C(update)
-                - When used, this will narrow the match to only happen when the address is in the list and the  TTL of the current packet matches that of the packet which hit the C(set) action
+                - This option may only be used in conjunction with one of the
+                  actions C(rcheck) or C(update)
+                - When used, this will narrow the match to only happen when the
+                  address is in the list and the  TTL of the current packet
+                  matches that of the packet which hit the C(set) action
             type: bool
             default: False
         reap:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Add the `recent` module to the `iptables` builtin

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Also mentioned in #41147 (https://github.com/ansible/ansible/issues/41147#issuecomment-829380329)
