### PR TITLE
systemd: ignore errors during daemon_reload and daemon_reexec when running in a chroot

### DIFF
--- a/changelogs/fragments/79643-fix-systemd-daemon-reload-in-chroot.yml
+++ b/changelogs/fragments/79643-fix-systemd-daemon-reload-in-chroot.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - systemd - daemon-reload and daemon-reexec ignore errors when running in a chroot (https://github.com/ansible/ansible/pull/79643)

--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -391,13 +391,19 @@ def main():
     if module.params['daemon_reload'] and not module.check_mode:
         (rc, out, err) = module.run_command("%s daemon-reload" % (systemctl))
         if rc != 0:
-            module.fail_json(msg='failure %d during daemon-reload: %s' % (rc, err))
+            if is_chroot(module) or os.environ.get('SYSTEMD_OFFLINE') == '1':
+                module.warn('daemon-reload failed, but target is a chroot or systemd is offline. Continuing. Error was: %d / %s' % (rc, err))
+            else:
+                module.fail_json(msg='failure %d during daemon-reload: %s' % (rc, err))
 
     # Run daemon-reexec
     if module.params['daemon_reexec'] and not module.check_mode:
         (rc, out, err) = module.run_command("%s daemon-reexec" % (systemctl))
         if rc != 0:
-            module.fail_json(msg='failure %d during daemon-reexec: %s' % (rc, err))
+            if is_chroot(module) or os.environ.get('SYSTEMD_OFFLINE') == '1':
+                module.warn('daemon-reexec failed, but target is a chroot or systemd is offline. Continuing. Error was: %d / %s' % (rc, err))
+            else:
+                module.fail_json(msg='failure %d during daemon-reexec: %s' % (rc, err))
 
     if unit:
         found = False


### PR DESCRIPTION
##### SUMMARY

This turns the systemd module's daemon_reload and daemon_reexec commands into no-ops when the target is a chroot.

This is needed as the chroot doesn't run systemd, which will make any module invocation containing one of those two commands fail with something like "systemd isn't active". This is what you get without this PR.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
systemd module

##### ADDITIONAL INFORMATION

The patch assumes that if the target is a chroot, it doesn't run systemd. I'm not sure if this is always the case; there might be people out there that somehow run systemd in a chroot, if this is at all possible/feasible. For those people, daemon_reload and daemon_reexec would work properly without this PR, and do nothing with the PR. So a cleaner solution that would cover this case might be to actually detect a running/active systemd rather than a chroot. Still, without this PR, the much more common case of someone trying to run systemd daemon_reload against a chroot will fail, which seems to be the more severe problem for me (my use case was https://github.com/multi-io/armbox, which uses Armbian to debootstrap a Debian system for ARM boards in a chroot, then uses Ansible to provision it).