### PR TITLE
Suppress traceback when bad escape is used (ansible#79364) 

### DIFF
--- a/lib/ansible/modules/replace.py
+++ b/lib/ansible/modules/replace.py
@@ -284,7 +284,10 @@ def main():
         section = contents
 
     mre = re.compile(params['regexp'], re.MULTILINE)
-    result = re.subn(mre, params['replace'], section, 0)
+    try:
+        result = re.subn(mre, params['replace'], section, 0)
+    except re.error as s:
+        module.fail_json(msg=str(s))
 
     if result[1] > 0 and section != result[0]:
         if pattern:


### PR DESCRIPTION
##### SUMMARY
Launch module.fail_json  when a bad escape is used as suggested by Sivel
My first  attemps of contribution, if I did anything wrong, I'm sorry in advance, just tell and I'll correct

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
replace

##### ADDITIONAL INFORMATION
Reused test playbook from a-mastermov :

```---
- name: Test replace module error
  hosts: localhost
  gather_facts: no

  tasks:
    - name: Test replace with bad escape
      replace:
        path: /dev/null
        after: ^
        before: $
        regexp: \.
        replace: '\D'
```
Run ansible-playbook  : ansible-playbook replace.yml

Before change
```
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can
become unstable at any point.
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Test replace module error] *************************************************************************************************************************************************************************************************************

TASK [Test replace with bad escape] **********************************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: re.error: bad escape \D at position 0
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/home/rperso/.ansible/tmp/ansible-tmp-1672693525.1035416-14540-219985575953942/AnsiballZ_replace.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/rperso/.ansible/tmp/ansible-tmp-1672693525.1035416-14540-219985575953942/AnsiballZ_replace.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/rperso/.ansible/tmp/ansible-tmp-1672693525.1035416-14540-219985575953942/AnsiballZ_replace.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible.modules.replace', init_globals=dict(_module_fqn='ansible.modules.replace', _modlib_path=modlib_path),\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/tmp/ansible_replace_payload_amppazku/ansible_replace_payload.zip/ansible/modules/replace.py\", line 317, in <module>\n  File \"/tmp/ansible_replace_payload_amppazku/ansible_replace_payload.zip/ansible/modules/replace.py\", line 287, in main\n  File \"/usr/lib64/python3.11/re/__init__.py\", line 196, in subn\n    return _compile(pattern, flags).subn(repl, string, count)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib64/python3.11/re/__init__.py\", line 317, in _subx\n    template = _compile_repl(template, pattern)\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib64/python3.11/re/__init__.py\", line 308, in _compile_repl\n    return _parser.parse_template(repl, pattern)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/usr/lib64/python3.11/re/_parser.py\", line 1078, in parse_template\n    raise s.error('bad escape %s' % this, len(this)) from None\nre.error: bad escape \\D at position 0\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   


```

After change
```
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can
become unstable at any point.
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Test replace module error] *************************************************************************************************************************************************************************************************************

TASK [Test replace with bad escape] **********************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "bad escape \\D at position 0"}

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```