### PR TITLE
Adding a timeout parameter to the HTTP request

### DIFF
--- a/hacking/azp/download.py
+++ b/hacking/azp/download.py
@@ -150,7 +150,8 @@ def download_run(args):
             with open(path, 'w') as metadata_fd:
                 metadata_fd.write(contents)
 
-    timeline_response = requests.get('https://dev.azure.com/ansible/ansible/_apis/build/builds/%s/timeline?api-version=6.0' % args.run)
+    # Warning: The 'requests.get' method does not use any 'timeout' threshold which may cause program to hang indefinitely.
+    timeline_response = requests.get('https://dev.azure.com/ansible/ansible/_apis/build/builds/%s/timeline?api-version=6.0' % args.run, timeout=0.4)
     timeline_response.raise_for_status()
     timeline = timeline_response.json()
     roots = set()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes timeout issue in HTTP get request

In the file: download.py, method: download_run, a request is made without a timeout parameter. The requests.get method in Python does not use any default timeout value and should be explicitly set. Otherwise, if the recipient server is unavailable to service the request, the application making the request may stall indefinitely.  

What should be the timeout value? A good practice is to set it under 500ms. This PR proposes the value to be 400ms. However, this may vary depending on the use case. More information is available in: https://docs.python-requests.org/en/latest/user/advanced/#timeouts


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hacking/azp/download.py