### PR TITLE
Replacing loose file permission with stricter permission

### DIFF
--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -427,7 +427,8 @@ class ZipArchive(object):
             unarchived = False
 
         # Get some information related to user/group ownership
-        umask = os.umask(0)
+        # Loose file permission has been replaced with stricter permission
+        umask = os.umask(0o777)
         os.umask(umask)
         systemtype = platform.system()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes Loose File Permission 
In file: unarchive.py, there is a method is_unarchived that grants permission to the others class which refers to all users except the owner and member of the file's group class. When a resource's permissions settings grant access to a broader range of actors than necessary, this could result in the exposure of sensitive data or the modification of the resource by unintended parties. This is especially dangerous if the resource is associated with program configuration, execution, or sensitive user data. This PR replaced the loose permission with stricter permission. More information is available in: https://cwe.mitre.org/data/definitions/732.html 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib/ansible/modules/unarchive.py