### PR TITLE
docsite: bump antsibull-docs, reference collection env var index

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_configuration.rst
+++ b/docs/docsite/rst/installation_guide/intro_configuration.rst
@@ -44,7 +44,7 @@ Environmental configuration
 Ansible also allows configuration of settings using environment variables.
 If these environment variables are set, they will override any setting loaded from the configuration file.
 
-You can get a full listing of available environment variables from :ref:`ansible_configuration_settings`.
+You can get a full listing of available environment variables for configuring core functionality from :ref:`ansible_configuration_settings`, and for configuring plugins in collections from :ref:`list_of_collection_env_vars`.
 
 
 .. _command_line_configuration:

--- a/docs/templates/config.rst.j2
+++ b/docs/templates/config.rst.j2
@@ -210,6 +210,8 @@ you can use the command line utility mentioned above (`ansible-config`) to brows
 Environment Variables
 =====================
 
+Other environment variables to configure plugins in collections can be found in :ref:`list_of_collection_env_vars`.
+
 .. envvar:: ANSIBLE_CONFIG
 
 

--- a/docs/templates/config.rst.j2
+++ b/docs/templates/config.rst.j2
@@ -207,6 +207,8 @@ you can use the command line utility mentioned above (`ansible-config`) to brows
 
 {%   endfor %}
 
+.. _list_of_ansible_env_vars:
+
 Environment Variables
 =====================
 

--- a/test/sanity/code-smell/docs-build.requirements.in
+++ b/test/sanity/code-smell/docs-build.requirements.in
@@ -6,4 +6,4 @@ sphinx-notfound-page
 sphinx-ansible-theme
 straight.plugin
 rstcheck < 4  # match version used in other sanity tests
-antsibull-docs == 1.7.3  # currently approved version
+antsibull-docs == 1.8.2  # currently approved version

--- a/test/sanity/code-smell/docs-build.requirements.in
+++ b/test/sanity/code-smell/docs-build.requirements.in
@@ -6,4 +6,4 @@ sphinx-notfound-page
 sphinx-ansible-theme
 straight.plugin
 rstcheck < 4  # match version used in other sanity tests
-antsibull-docs == 1.8.2  # currently approved version
+antsibull-docs == 1.9.0  # currently approved version

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -5,7 +5,7 @@ aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.1
 antsibull-core==1.2.0
-antsibull-docs==1.8.2
+antsibull-docs==1.9.0
 async-timeout==4.0.2
 asyncio-pool==0.6.0
 attrs==22.1.0

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -5,7 +5,7 @@ aiosignal==1.2.0
 alabaster==0.7.12
 ansible-pygments==0.1.1
 antsibull-core==1.2.0
-antsibull-docs==1.7.3
+antsibull-docs==1.8.2
 async-timeout==4.0.2
 asyncio-pool==0.6.0
 attrs==22.1.0


### PR DESCRIPTION
##### SUMMARY
As discussed in the DaWGs meeting.

The collection env var index looks like this: https://ansible.fontein.de/collections/environment_variables.html. It explicitly does not contain any env variable mentioned in https://docs.ansible.com/ansible/devel/reference_appendices/config.html#environment-variables.

Other relevant antsibull-docs changes:
- Automatically use a module's or plugin's short description as the "See also" description if no description is provided (https://github.com/ansible-community/antsibull-docs/issues/64, https://github.com/ansible-community/antsibull-docs/pull/74).
- Remove support for ``forced_action_plugin``, a module attribute that was removed during the development phase of attributes (https://github.com/ansible-community/antsibull-docs/pull/63).
- Stop mentioning the version features were added for Ansible if the Ansible version is before 2.7 (https://github.com/ansible-community/antsibull-docs/pull/76).
- Callback plugins: show type, render indexes of callback plugins per type (https://github.com/ansible-community/antsibull-docs/pull/90)

Potential more new features that would require a new antsibull-docs release:
 - ~~https://github.com/ansible-community/antsibull-docs/pull/65 - requires a core team decision on https://github.com/ansible/ansible/pull/79370 (will be discussed by core team internally next week)~~ (see https://github.com/ansible/ansible/pull/79370#issuecomment-1404251346)
 - ~~https://github.com/ansible-community/antsibull-docs/pull/75 - requires a core team decision on https://github.com/ansible/ansible/pull/79471~~ won't happen anytime soon

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docsite
