### PR TITLE
Fix EPEL setup for integration tests on RHEL 7

### DIFF
--- a/test/integration/targets/setup_epel/tasks/main.yml
+++ b/test/integration/targets/setup_epel/tasks/main.yml
@@ -1,3 +1,8 @@
+- name: Enable RHEL7 extras
+  # EPEL 7 depends on RHEL 7 extras, which is not enabled by default on RHEL.
+  # See: https://docs.fedoraproject.org/en-US/epel/epel-policy/#_policy
+  command: yum-config-manager --enable rhel-7-server-rhui-extras-rpms
+  when: ansible_facts.distribution == 'RedHat' and ansible_facts.distribution_major_version == '7'
 - name: Install EPEL
   yum:
     name: https://ci-files.testing.ansible.com/test/integration/targets/setup_epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm

--- a/test/integration/targets/yum/tasks/yuminstallroot.yml
+++ b/test/integration/targets/yum/tasks/yuminstallroot.yml
@@ -76,13 +76,6 @@
     - ansible_facts["distribution_major_version"] == "7"
     - ansible_facts["distribution"] == "RedHat"
   block:
-    # Need to enable this RHUI repo for RHEL7 testing in AWS, CentOS has Extras
-    # enabled by default and this is not needed there.
-    - name: enable rhel-7-server-rhui-extras-rpms repo for RHEL7
-      command: yum-config-manager --enable rhel-7-server-rhui-extras-rpms
-    - name: update cache to pull repodata
-      yum:
-        update_cache: yes
     - name: install required packages for buildah test
       yum:
         state: present
@@ -137,5 +130,3 @@
         state: absent
         name:
           - buildah
-    - name: disable rhel-7-server-rhui-extras-rpms repo for RHEL7
-      command: yum-config-manager --disable rhel-7-server-rhui-extras-rpms


### PR DESCRIPTION
##### SUMMARY

Fix EPEL setup for integration tests on RHEL 7.

This resolves CI failures attempting to install `rpmfluff` due to the removal of `createrepo_c` from EPEL 7.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2155359

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

setup_epel
