### PR TITLE
[stable-2.14] Fix link in compile sanity test docs.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/compile.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/compile.rst
@@ -28,5 +28,5 @@ as well as the additional Python versions supported only on targets:
 .. note::
 
    Ansible Collections can be
-   `configured <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/config/config.yml>_`
+   `configured <https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/config/config.yml>`_
    to support a subset of the target-only Python versions.


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/79672

(cherry picked from commit eae02bf5b8ada01a1606559d5e29776d696a9f33)

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

compile sanity test docs
