### PR TITLE
argspec - fix validating type for required options that are None

### DIFF
--- a/changelogs/fragments/79677-fix-argspec-type-check.yml
+++ b/changelogs/fragments/79677-fix-argspec-type-check.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module/role argument spec - validate the type for options that are None when the option is required or has a non-None default (https://github.com/ansible/ansible/issues/79656).

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -600,7 +600,7 @@ def _validate_argument_types(argument_spec, parameters, prefix='', options_conte
             continue
 
         value = parameters[param]
-        if value is None:
+        if value is None and not spec.get('required') and spec.get('default') is None:
             continue
 
         wanted_type = spec.get('type')

--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -381,7 +381,7 @@ def check_type_str(value, allow_conversion=True, param=None, prefix=''):
     if isinstance(value, string_types):
         return value
 
-    if allow_conversion:
+    if allow_conversion:  # and value is not None?
         return to_native(value, errors='surrogate_or_strict')
 
     msg = "'{0!r}' is not a string and conversion is not allowed".format(value)

--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -381,7 +381,7 @@ def check_type_str(value, allow_conversion=True, param=None, prefix=''):
     if isinstance(value, string_types):
         return value
 
-    if allow_conversion:  # and value is not None?
+    if allow_conversion:
         return to_native(value, errors='surrogate_or_strict')
 
     msg = "'{0!r}' is not a string and conversion is not allowed".format(value)

--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -381,7 +381,7 @@ def check_type_str(value, allow_conversion=True, param=None, prefix=''):
     if isinstance(value, string_types):
         return value
 
-    if allow_conversion:
+    if allow_conversion and value is not None:
         return to_native(value, errors='surrogate_or_strict')
 
     msg = "'{0!r}' is not a string and conversion is not allowed".format(value)

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -666,9 +666,6 @@ def main():
             # we've done all we can do; just tell the user it's busted and get out
             module.fail_json(msg="{0} must be installed and visible from {1}.".format(apt_pkg_name, sys.executable))
 
-    if not repo:
-        module.fail_json(msg='Please set argument \'repo\' to a non-empty value')
-
     if isinstance(distro, aptsources_distro.Distribution):
         sourceslist = UbuntuSourcesList(module)
     else:

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -666,6 +666,9 @@ def main():
             # we've done all we can do; just tell the user it's busted and get out
             module.fail_json(msg="{0} must be installed and visible from {1}.".format(apt_pkg_name, sys.executable))
 
+    if not repo:
+        module.fail_json(msg='Please set argument \'repo\' to a non-empty value')
+
     if isinstance(distro, aptsources_distro.Distribution):
         sourceslist = UbuntuSourcesList(module)
     else:

--- a/test/integration/targets/apt_repository/tasks/apt.yml
+++ b/test/integration/targets/apt_repository/tasks/apt.yml
@@ -224,7 +224,7 @@
 - assert:
     that:
       - result is failed
-      - result.msg == 'Please set argument \'repo\' to a non-empty value'
+      - result.msg.startswith("argument 'repo' is of type <class 'NoneType'> and we were unable to convert to str")
 
 - name: Test apt_repository with an empty value for repo
   apt_repository:

--- a/test/integration/targets/roles_arg_spec/roles/c/meta/main.yml
+++ b/test/integration/targets/roles_arg_spec/roles/c/meta/main.yml
@@ -2,6 +2,15 @@ argument_specs:
     main:
         short_description: Main entry point for role C.
         options:
+            c_dict:
+                type: "dict"
+                required: true
             c_int:
                 type: "int"
+                required: true
+            c_list:
+                type: "list"
+                required: true
+            c_raw:
+                type: "raw"
                 required: true

--- a/test/integration/targets/roles_arg_spec/test.yml
+++ b/test/integration/targets/roles_arg_spec/test.yml
@@ -145,7 +145,10 @@
   hosts: localhost
   gather_facts: false
   vars:
+    c_dict: {}
     c_int: 1
+    c_list: []
+    c_raw: ~
     a_str: "some string"
     a_int: 42
   tasks:
@@ -157,6 +160,126 @@
         include_role:
           name: c
 
+- name: "New play to reset vars: Test nested role including/importing role fails with null required options"
+  hosts: localhost
+  gather_facts: false
+  vars:
+    a_main_spec:
+      a_str:
+        required: true
+        type: "str"
+    c_main_spec:
+      c_int:
+        required: true
+        type: "int"
+      c_list:
+        required: true
+        type: "list"
+      c_dict:
+        required: true
+        type: "dict"
+      c_raw:
+        required: true
+        type: "raw"
+    # role c calls a's main and alternate entrypoints
+    a_str: ''
+    c_dict: {}
+    c_int: 0
+    c_list: []
+    c_raw: ~
+  tasks:
+    # TODO: None does not fail str type conversion. Should it?
+    #- name: test type coercion fails on None for required str
+    #  block:
+    #    - name: "Test import_role of role C (missing a_str)"
+    #      import_role:
+    #        name: c
+    #      vars:
+    #        a_str: ~
+    #    - fail:
+    #        msg: "Should not get here"
+    #  rescue:
+    #    - debug:
+    #        var: ansible_failed_result
+    #    - name: "Validate import_role failure"
+    #      assert:
+    #        that:
+    #          # NOTE: a bug here that prevents us from getting ansible_failed_task
+    #          - ansible_failed_result.argument_errors == [error]
+    #          - ansible_failed_result.argument_spec_data == a_main_spec
+    #      vars:
+    #        error: >-
+    #          argument 'a_str' is of type <class 'NoneType'> and we were unable to convert to str:
+    #          'None' is not a string and conversion is not allowed
+
+    - name: test type coercion fails on None for required int
+      block:
+        - name: "Test import_role of role C (missing c_int)"
+          import_role:
+            name: c
+          vars:
+            c_int: ~
+        - fail:
+            msg: "Should not get here"
+      rescue:
+        - debug:
+            var: ansible_failed_result
+        - name: "Validate import_role failure"
+          assert:
+            that:
+              # NOTE: a bug here that prevents us from getting ansible_failed_task
+              - ansible_failed_result.argument_errors == [error]
+              - ansible_failed_result.argument_spec_data == c_main_spec
+          vars:
+            error: >-
+              argument 'c_int' is of type <class 'NoneType'> and we were unable to convert to int:
+              <class 'NoneType'> cannot be converted to an int
+
+    - name: test type coercion fails on None for required list
+      block:
+        - name: "Test import_role of role C (missing c_list)"
+          import_role:
+            name: c
+          vars:
+            c_list: ~
+        - fail:
+            msg: "Should not get here"
+      rescue:
+        - debug:
+            var: ansible_failed_result
+        - name: "Validate import_role failure"
+          assert:
+            that:
+              # NOTE: a bug here that prevents us from getting ansible_failed_task
+              - ansible_failed_result.argument_errors == [error]
+              - ansible_failed_result.argument_spec_data == c_main_spec
+          vars:
+            error: >-
+              argument 'c_list' is of type <class 'NoneType'> and we were unable to convert to list:
+              <class 'NoneType'> cannot be converted to a list
+
+    - name: test type coercion fails on None for required dict
+      block:
+        - name: "Test import_role of role C (missing c_dict)"
+          import_role:
+            name: c
+          vars:
+            c_dict: ~
+        - fail:
+            msg: "Should not get here"
+      rescue:
+        - debug:
+            var: ansible_failed_result
+        - name: "Validate import_role failure"
+          assert:
+            that:
+              # NOTE: a bug here that prevents us from getting ansible_failed_task
+              - ansible_failed_result.argument_errors == [error]
+              - ansible_failed_result.argument_spec_data == c_main_spec
+          vars:
+            error: >-
+              argument 'c_dict' is of type <class 'NoneType'> and we were unable to convert to dict:
+              <class 'NoneType'> cannot be converted to a dict
 
 - name: "New play to reset vars: Test nested role including/importing role fails"
   hosts: localhost
@@ -171,13 +294,15 @@
         required: true
         type: "int"
 
+    c_int: 100
+    c_list: []
+    c_dict: {}
+    c_raw: ~
   tasks:
       - block:
         - name: "Test import_role of role C (missing a_str)"
           import_role:
             name: c
-          vars:
-            c_int: 100
 
         - fail:
             msg: "Should not get here"
@@ -202,7 +327,6 @@
           include_role:
             name: c
           vars:
-            c_int: 200
             a_str: "some string"
 
         - fail:

--- a/test/integration/targets/roles_arg_spec/test.yml
+++ b/test/integration/targets/roles_arg_spec/test.yml
@@ -188,30 +188,28 @@
     c_list: []
     c_raw: ~
   tasks:
-    # TODO: Uncomment once there is a way to turn off type conversion
-    # See https://github.com/ansible/ansible/issues/77159
-    #- name: test type coercion fails on None for required str
-    #  block:
-    #    - name: "Test import_role of role C (missing a_str)"
-    #      import_role:
-    #        name: c
-    #      vars:
-    #        a_str: ~
-    #    - fail:
-    #        msg: "Should not get here"
-    #  rescue:
-    #    - debug:
-    #        var: ansible_failed_result
-    #    - name: "Validate import_role failure"
-    #      assert:
-    #        that:
-    #          # NOTE: a bug here that prevents us from getting ansible_failed_task
-    #          - ansible_failed_result.argument_errors == [error]
-    #          - ansible_failed_result.argument_spec_data == a_main_spec
-    #      vars:
-    #        error: >-
-    #          argument 'a_str' is of type <class 'NoneType'> and we were unable to convert to str:
-    #          'None' is not a string and conversion is not allowed
+    - name: test type coercion fails on None for required str
+      block:
+        - name: "Test import_role of role C (missing a_str)"
+          import_role:
+            name: c
+          vars:
+            a_str: ~
+        - fail:
+            msg: "Should not get here"
+      rescue:
+        - debug:
+            var: ansible_failed_result
+        - name: "Validate import_role failure"
+          assert:
+            that:
+              # NOTE: a bug here that prevents us from getting ansible_failed_task
+              - ansible_failed_result.argument_errors == [error]
+              - ansible_failed_result.argument_spec_data == a_main_spec
+          vars:
+            error: >-
+              argument 'a_str' is of type <class 'NoneType'> and we were unable to convert to str:
+              'None' is not a string and conversion is not allowed
 
     - name: test type coercion fails on None for required int
       block:

--- a/test/integration/targets/roles_arg_spec/test.yml
+++ b/test/integration/targets/roles_arg_spec/test.yml
@@ -188,7 +188,8 @@
     c_list: []
     c_raw: ~
   tasks:
-    # TODO: None does not fail str type conversion. Should it?
+    # TODO: Uncomment once there is a way to turn off type conversion
+    # See https://github.com/ansible/ansible/issues/77159
     #- name: test type coercion fails on None for required str
     #  block:
     #    - name: "Test import_role of role C (missing a_str)"


### PR DESCRIPTION
##### SUMMARY
Fixes #79656

Fix skipping validating the type for all options that are None, even when None is not the default (e.g. when the option is required).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ArgumentSpecValidator