### PR TITLE
Update dnf.py

### DIFF
--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -317,7 +317,14 @@ EXAMPLES = '''
   ansible.builtin.dnf:
     name: "*"
     state: latest
-    update_only: true
+
+- name: Update the webserver, depending on which is installed on the system. Do not install the other one
+  ansible.builtin.dnf:
+    name:
+      - httpd
+      - nginx
+    state: latest
+    update_only: yes
 
 - name: Install the nginx rpm from a remote repo
   ansible.builtin.dnf:

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -317,6 +317,7 @@ EXAMPLES = '''
   ansible.builtin.dnf:
     name: "*"
     state: latest
+    update_only: true
 
 - name: Install the nginx rpm from a remote repo
   ansible.builtin.dnf:


### PR DESCRIPTION
##### SUMMARY
Fix ansible-lint error: "Package installs should not use latest."

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- Docs examples

##### ADDITIONAL INFORMATION
Example
```bash
[localhost:: ~ ]:$ cat test.yml 
- name: test playbook
  hosts: all
  tasks:
  - name: Upgrade all packages
    ansible.builtin.dnf:
      name: "*"
      state: latest
[localhost:: ~ ]:$ ansible-lint --version|grep using
ansible-lint 6.10.0 using ansible 2.14.1

[localhost:: ~ ]:$ ansible-lint test.yml 
WARNING  Overriding detected file kind 'yaml' with 'playbook' for given positional argument: test.yml
WARNING  Listing 2 violation(s) that are fatal
name[casing]: All names should start with an uppercase letter. (warning)
test.yml:1

package-latest: Package installs should not use latest.
test.yml:4 Task/Handler: Upgrade all packages

You can skip specific rules or tags by adding them to your configuration file:
# .config/ansible-lint.yml
warn_list:  # or 'skip_list' to silence them completely
  - package-latest  # Package installs should not use latest.

               Rule Violation Summary               
 count tag            profile  rule associated tags 
     1 name[casing]   moderate idiom (warning)      
     1 package-latest safety   idempotency          

Failed after basic profile, 1/5 star rating: 1 failure(s), 1 warning(s) on 1 files.
A new release of ansible-lint is available: 6.10.0 → 6.10.2

[localhost:: ~ ]:$ echo -e "      update_only: true" >> test.yml

[localhost:: ~ ]:$ ansible-lint test.yml 
WARNING  Overriding detected file kind 'yaml' with 'playbook' for given positional argument: test.yml
WARNING  Listing 1 violation(s) that are fatal
name[casing]: All names should start with an uppercase letter. (warning)
test.yml:1


              Rule Violation Summary              
 count tag          profile  rule associated tags 
     1 name[casing] moderate idiom (warning)      

Passed with basic profile, 1/5 star rating: 0 failure(s), 1 warning(s) on 1 files.
A new release of ansible-lint is available: 6.10.0 → 6.10.2
```
