### PR TITLE
Fix reporting of deprecated arguments for modules

### DIFF
--- a/changelogs/fragments/79681-argspec-param-deprecation.yml
+++ b/changelogs/fragments/79681-argspec-param-deprecation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "argument spec validation - again report deprecated parameters for Python-based modules. This was accidentally removed in ansible-core 2.11 when argument spec validation was refactored (https://github.com/ansible/ansible/issues/79680, https://github.com/ansible/ansible/pull/79681)."

--- a/lib/ansible/module_utils/errors.py
+++ b/lib/ansible/module_utils/errors.py
@@ -75,6 +75,10 @@ class ArgumentValueError(AnsibleValidationError):
     """Error with parameter value"""
 
 
+class DeprecationError(AnsibleValidationError):
+    """Error processing parameter deprecations"""
+
+
 class ElementError(AnsibleValidationError):
     """Error when validating elements"""
 

--- a/test/integration/targets/argspec/library/argspec.py
+++ b/test/integration/targets/argspec/library/argspec.py
@@ -139,6 +139,35 @@ def main():
                     },
                 },
             },
+            'deprecation_aliases': {
+                'type': 'str',
+                'aliases': [
+                    'deprecation_aliases_version',
+                    'deprecation_aliases_date',
+                ],
+                'deprecated_aliases': [
+                    {
+                        'name': 'deprecation_aliases_version',
+                        'version': '2.0.0',
+                        'collection_name': 'foo.bar',
+                    },
+                    {
+                        'name': 'deprecation_aliases_date',
+                        'date': '2023-01-01',
+                        'collection_name': 'foo.bar',
+                    },
+                ],
+            },
+            'deprecation_param_version': {
+                'type': 'str',
+                'removed_in_version': '2.0.0',
+                'removed_from_collection': 'foo.bar',
+            },
+            'deprecation_param_date': {
+                'type': 'str',
+                'removed_at_date': '2023-01-01',
+                'removed_from_collection': 'foo.bar',
+            },
         },
         required_if=(
             ('state', 'present', ('path', 'content'), True),

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -366,6 +366,30 @@
       foo: bar
   register: argspec_apply_defaults_one
 
+- argspec:
+    required: value
+    required_one_of_one: value
+    deprecation_aliases_version: value
+  register: deprecation_alias_version
+
+- argspec:
+    required: value
+    required_one_of_one: value
+    deprecation_aliases_date: value
+  register: deprecation_alias_date
+
+- argspec:
+    required: value
+    required_one_of_one: value
+    deprecation_param_version: value
+  register: deprecation_param_version
+
+- argspec:
+    required: value
+    required_one_of_one: value
+    deprecation_param_date: value
+  register: deprecation_param_date
+
 - assert:
     that:
       - argspec_required_fail is failed
@@ -446,3 +470,24 @@
       - "argspec_apply_defaults_none.apply_defaults == {'foo': none, 'bar': 'baz'}"
       - "argspec_apply_defaults_empty.apply_defaults == {'foo': none, 'bar': 'baz'}"
       - "argspec_apply_defaults_one.apply_defaults == {'foo': 'bar', 'bar': 'baz'}"
+
+      - deprecation_alias_version.deprecations | length == 1
+      - deprecation_alias_version.deprecations[0].msg == "Alias 'deprecation_aliases_version' is deprecated. See the module docs for more information"
+      - deprecation_alias_version.deprecations[0].collection_name == 'foo.bar'
+      - deprecation_alias_version.deprecations[0].version == '2.0.0'
+      - "'date' not in deprecation_alias_version.deprecations[0]"
+      - deprecation_alias_date.deprecations | length == 1
+      - deprecation_alias_date.deprecations[0].msg == "Alias 'deprecation_aliases_date' is deprecated. See the module docs for more information"
+      - deprecation_alias_date.deprecations[0].collection_name == 'foo.bar'
+      - deprecation_alias_date.deprecations[0].date == '2023-01-01'
+      - "'version' not in deprecation_alias_date.deprecations[0]"
+      - deprecation_param_version.deprecations | length == 1
+      - deprecation_param_version.deprecations[0].msg == "Param 'deprecation_param_version' is deprecated. See the module docs for more information"
+      - deprecation_param_version.deprecations[0].collection_name == 'foo.bar'
+      - deprecation_param_version.deprecations[0].version == '2.0.0'
+      - "'date' not in deprecation_param_version.deprecations[0]"
+      - deprecation_param_date.deprecations | length == 1
+      - deprecation_param_date.deprecations[0].msg == "Param 'deprecation_param_date' is deprecated. See the module docs for more information"
+      - deprecation_param_date.deprecations[0].collection_name == 'foo.bar'
+      - deprecation_param_date.deprecations[0].date == '2023-01-01'
+      - "'version' not in deprecation_param_date.deprecations[0]"


### PR DESCRIPTION
##### SUMMARY
Make `removed_at_date` and `removed_in_version` in argument spec working again. Also adds some basic tests so this shouldn't happen again so easily.

Fixes #79680.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/common/arg_spec.py
