### PR TITLE
validate-modules: don't fail on invalid YAML

### DIFF
--- a/changelogs/fragments/75837-validate-modules-invalid-yaml.yml
+++ b/changelogs/fragments/75837-validate-modules-invalid-yaml.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test sanity - correctly report invalid YAML in validate-modules (https://github.com/ansible/ansible/issues/75837).

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/invalid_yaml_syntax.py
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/invalid_yaml_syntax.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+- key: "value"wrong
+'''
+
+EXAMPLES = '''
+- key: "value"wrong
+'''
+
+RETURN = '''
+- key: "value"wrong
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    AnsibleModule(argument_spec=dict())
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansible-test-sanity-validate-modules/expected.txt
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/expected.txt
@@ -1,0 +1,5 @@
+plugins/modules/invalid_yaml_syntax.py:0:0: deprecation-mismatch: "meta/runtime.yml" and DOCUMENTATION.deprecation do not agree.
+plugins/modules/invalid_yaml_syntax.py:0:0: missing-documentation: No DOCUMENTATION provided
+plugins/modules/invalid_yaml_syntax.py:8:15: documentation-syntax-error: DOCUMENTATION is not valid YAML
+plugins/modules/invalid_yaml_syntax.py:12:15: invalid-examples: EXAMPLES is not valid YAML
+plugins/modules/invalid_yaml_syntax.py:16:15: return-syntax-error: RETURN is not valid YAML

--- a/test/integration/targets/ansible-test-sanity-validate-modules/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/runme.sh
@@ -4,7 +4,9 @@ source ../collection/setup.sh
 
 set -eux
 
-ansible-test sanity --test validate-modules --color --truncate 0 "${@}"
+ansible-test sanity --test validate-modules --color --truncate 0 --failure-ok --lint "${@}" 1> actual-stdout.txt 2> actual-stderr.txt
+diff -u "${TEST_DIR}/expected.txt" actual-stdout.txt
+grep -f "${TEST_DIR}/expected.txt" actual-stderr.txt
 
 cd ../ps_only
 

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/utils.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/utils.py
@@ -154,11 +154,9 @@ def parse_yaml(value, lineno, module, name, load_all=False, ansible_loader=False
         if load_all:
             data = list(data)
     except yaml.MarkedYAMLError as e:
-        e.problem_mark.line += lineno - 1
-        e.problem_mark.name = '%s.%s' % (module, name)
         errors.append({
             'msg': '%s is not valid YAML' % name,
-            'line': e.problem_mark.line + 1,
+            'line': e.problem_mark.line + lineno,
             'column': e.problem_mark.column + 1
         })
         traces.append(e)


### PR DESCRIPTION
##### SUMMARY

When validate-modules encounters invalid YAML (e.g. in the EXAMPLES section), it tries to reformat the exception to include the line number in the Python file instead of the line number of the embedded YAML document. However, PyYAML doesn't allow modification of the Mark object (anymore) which leads to a new exception being raised, instead of reporting the original exception.

As the original exception is not needed in other places anymore, we don't have to modify it at all and can just compute the right line number when reporting the error via ansible-test.

Fixes: #75837

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ADDITIONAL INFORMATION
Run `ansible-test sanity --test validate-modules` against [test.py](https://github.com/ansible/ansible/files/10359664/test.py.txt)

Expected:
```
ERROR: plugins/modules/test.py:40:17: invalid-examples: EXAMPLES is not valid YAML
```

Actual:
```
>>> Standard Error
Traceback (most recent call last):
  File "/home/evgeni/Devel/theforeman/foreman-ansible-modules/venv/lib/python3.11/site-packages/ansible_test/_util/controller/sanity/validate-modules/validate_modules/utils.py", line 155, in parse_yaml
    data = list(data)
           ^^^^^^^^^^
  File "/home/evgeni/.ansible/test/venv/sanity.validate-modules/3.11/8edfdacb/lib64/python3.11/site-packages/yaml/__init__.py", line 93, in load_all
    yield loader.get_data()
          ^^^^^^^^^^^^^^^^^
  File "/home/evgeni/.ansible/test/venv/sanity.validate-modules/3.11/8edfdacb/lib64/python3.11/site-packages/yaml/constructor.py", line 45, in get_data
    return self.construct_document(self.get_node())
                                   ^^^^^^^^^^^^^^^
  File "yaml/_yaml.pyx", line 665, in yaml._yaml.CParser.get_node
  File "yaml/_yaml.pyx", line 687, in yaml._yaml.CParser._compose_document
  File "yaml/_yaml.pyx", line 729, in yaml._yaml.CParser._compose_node
  File "yaml/_yaml.pyx", line 806, in yaml._yaml.CParser._compose_sequence_node
  File "yaml/_yaml.pyx", line 731, in yaml._yaml.CParser._compose_node
  File "yaml/_yaml.pyx", line 845, in yaml._yaml.CParser._compose_mapping_node
  File "yaml/_yaml.pyx", line 731, in yaml._yaml.CParser._compose_node
  File "yaml/_yaml.pyx", line 847, in yaml._yaml.CParser._compose_mapping_node
  File "yaml/_yaml.pyx", line 860, in yaml._yaml.CParser._parse_next_event
yaml.parser.ParserError: while parsing a block mapping
  in "<unicode string>", line 4, column 5
did not find expected key
  in "<unicode string>", line 4, column 22

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/evgeni/Devel/theforeman/foreman-ansible-modules/venv/lib64/python3.11/site-packages/ansible_test/_util/controller/sanity/validate-modules/validate.py", line 6, in <module>
    main()
  File "/home/evgeni/Devel/theforeman/foreman-ansible-modules/venv/lib/python3.11/site-packages/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py", line 2522, in main
    run()
  File "/home/evgeni/Devel/theforeman/foreman-ansible-modules/venv/lib/python3.11/site-packages/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py", line 2410, in run
    mv1.validate()
  File "/home/evgeni/Devel/theforeman/foreman-ansible-modules/venv/lib/python3.11/site-packages/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py", line 2203, in validate
    doc_info, docs = self._validate_docs()
                     ^^^^^^^^^^^^^^^^^^^^^
  File "/home/evgeni/Devel/theforeman/foreman-ansible-modules/venv/lib/python3.11/site-packages/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py", line 1104, in _validate_docs
    dummy, errors, traces = parse_yaml(examples_raw,
                            ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/evgeni/Devel/theforeman/foreman-ansible-modules/venv/lib/python3.11/site-packages/ansible_test/_util/controller/sanity/validate-modules/validate_modules/utils.py", line 157, in parse_yaml
    e.problem_mark.line += lineno - 1
    ^^^^^^^^^^^^^^^^^^^
AttributeError: attribute 'line' of 'yaml._yaml.Mark' objects is not writable
```