### PR TITLE
Prototype vars and inventory dump performance tweaks

### DIFF
--- a/lib/ansible/utils/path.py
+++ b/lib/ansible/utils/path.py
@@ -101,9 +101,10 @@ def basedir(source):
     elif os.path.isfile(source):
         dname = os.path.dirname(source)
 
-    if dname:
-        # don't follow symlinks for basedir, enables source re-use
-        dname = os.path.abspath(dname)
+    # FIXME: normalize this earlier, it gets called millions of times
+    # if dname:
+    #     # don't follow symlinks for basedir, enables source re-use
+    #     dname = os.path.abspath(dname)
 
     return to_text(dname, errors='surrogate_or_strict')
 

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -66,6 +66,9 @@ def _validate_mutable_mappings(a, b):
     # If this becomes generally needed, change the signature to operate on
     # a variable number of arguments instead.
 
+    # FIXME: find a cheaper or earlier solution to this; the isinstance is incredibly expensive and gets called millions of times!
+    return
+
     if not (isinstance(a, MutableMapping) and isinstance(b, MutableMapping)):
         myvars = []
         for x in [a, b]:

--- a/lib/ansible/vars/clean.py
+++ b/lib/ansible/vars/clean.py
@@ -131,14 +131,15 @@ def clean_facts(facts):
     # remove common connection vars
     remove_keys.update(fact_keys.intersection(C.COMMON_CONNECTION_VARS))
 
-    # next we remove any connection plugin specific vars
-    for conn_path in connection_loader.all(path_only=True):
-        conn_name = os.path.splitext(os.path.basename(conn_path))[0]
-        re_key = re.compile('^ansible_%s_' % re.escape(conn_name))
-        for fact_key in fact_keys:
-            # most lightweight VM or container tech creates devices with this pattern, this avoids filtering them out
-            if (re_key.match(fact_key) and not fact_key.endswith(('_bridge', '_gwbridge'))) or fact_key.startswith('ansible_become_'):
-                remove_keys.add(fact_key)
+    # FIXME: this is busted for collections and incredibly expensive since it's not cached
+    # # next we remove any connection plugin specific vars
+    # for conn_path in connection_loader.all(path_only=True):
+    #     conn_name = os.path.splitext(os.path.basename(conn_path))[0]
+    #     re_key = re.compile('^ansible_%s_' % re.escape(conn_name))
+    #     for fact_key in fact_keys:
+    #         # most lightweight VM or container tech creates devices with this pattern, this avoids filtering them out
+    #         if (re_key.match(fact_key) and not fact_key.endswith(('_bridge', '_gwbridge'))) or fact_key.startswith('ansible_become_'):
+    #             remove_keys.add(fact_key)
 
     # remove some KNOWN keys
     for hard in C.RESTRICTED_RESULT_KEYS + C.INTERNAL_RESULT_KEYS:


### PR DESCRIPTION
##### SUMMARY
Demo elimination of unnecessary disk I/O that slows down host/group vars resolution and inventory dumps.

fixes #79664 (poorly; these changes are not production-ready but just show the issues and suggest fixes)

Running `ansible-inventory` with these changes against [this inventory script](https://gist.github.com/nitzmahone/2348775c22c6a6f0c35b1cb0e56ed097) with 100 groups of 500 hosts each (50k hosts total) reduces the inventory dump wall clock time by ~ an order of magnitude:

devel:
```
(ansible-dev39) [mdavis@mdavis-p1 TEMP_slowinv]$ time ansible-inventory -i ./inv.py --list --output /dev/null

real    0m50.638s
user    0m43.346s
sys     0m6.845s
```

this branch:
```
(ansible-dev39) [mdavis@mdavis-p1 TEMP_slowinv]$ time ansible-inventory -i ./inv.py --list --output /dev/null

real    0m5.495s
user    0m5.151s
sys     0m0.337s
```

Some notes about the rationale for the changes:

PluginLoader.all():
* makes heavy use of globbing to find builtin and legacy plugins
* does not cache path traversal info or missing paths, only source for loaded plugins
* does not cache config defs for loaded plugins

host_group_vars vars plugin:
* overuses `os.path.realpath()`, which is incredibly expensive; normalize paths earlier, or maybe not at all- penalty for duplicates is likely much less than the aggregate cost of the calls
* does not cache missing paths/files

utils/path.py basedir() helper:
* normalize with abspath() earlier or cache the normalized result; abspath calls are very expensive and occurring on every `get_vars` call

utils/vars.py _validate_mutable_mappings() helper:
* this gets called millions of times during combine_vars; normalize things earlier or catch the immutability problems at the call sites- the `isinstance` calls are surprisingly expensive when called so frequently

vars/clean.py clean_facts():
* excessive (and incomplete for collections!) use of PluginLoader.all() with connection plugins to get var prefixes to clean
* cache the needed dynamic info

vars/plugins.py get_vars_from_path():
* excessive use of PluginLoader.all() for vars plugins (cache findings)
* excessive creation of vars plugins instances; builtin host_group_vars is basically stateless. Either cache instances or cache vars_plugins configs- the plugin setup and config is what's killing us when this is called millions of times.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-inventory, vars plugins
