### PR TITLE
normal action plugin: remove superfluous code

### DIFF
--- a/changelogs/fragments/79690-normal-action-undefined.yml
+++ b/changelogs/fragments/79690-normal-action-undefined.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "normal action plugin - remove obsolete ``if`` (https://github.com/ansible/ansible/pull/79690)."

--- a/lib/ansible/plugins/action/normal.py
+++ b/lib/ansible/plugins/action/normal.py
@@ -33,11 +33,6 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
-        if result.get('invocation', {}).get('module_args'):
-            # avoid passing to modules in case of no_log
-            # should not be set anymore but here for backwards compatibility
-            del result['invocation']['module_args']
-
         # FUTURE: better to let _execute_module calculate this internally?
         wrap_async = self._task.async_val and not self._connection.has_native_async
 

--- a/lib/ansible/plugins/action/normal.py
+++ b/lib/ansible/plugins/action/normal.py
@@ -33,7 +33,6 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
-        # FUTURE: better to let _execute_module calculate this internally?
         wrap_async = self._task.async_val and not self._connection.has_native_async
 
         # do work!
@@ -41,7 +40,6 @@ class ActionModule(ActionBase):
 
         # hack to keep --verbose from showing all the setup module result
         # moved from setup module as now we filter out all _ansible_ from result
-        # FIXME: is this still accurate with gather_facts etc, or does it need support for FQ and other names?
         if self._task.action in C._ACTION_SETUP:
             result['_ansible_verbose_override'] = True
 

--- a/lib/ansible/plugins/action/normal.py
+++ b/lib/ansible/plugins/action/normal.py
@@ -33,24 +33,22 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
-        if not result.get('skipped'):
+        if result.get('invocation', {}).get('module_args'):
+            # avoid passing to modules in case of no_log
+            # should not be set anymore but here for backwards compatibility
+            del result['invocation']['module_args']
 
-            if result.get('invocation', {}).get('module_args'):
-                # avoid passing to modules in case of no_log
-                # should not be set anymore but here for backwards compatibility
-                del result['invocation']['module_args']
+        # FUTURE: better to let _execute_module calculate this internally?
+        wrap_async = self._task.async_val and not self._connection.has_native_async
 
-            # FUTURE: better to let _execute_module calculate this internally?
-            wrap_async = self._task.async_val and not self._connection.has_native_async
+        # do work!
+        result = merge_hash(result, self._execute_module(task_vars=task_vars, wrap_async=wrap_async))
 
-            # do work!
-            result = merge_hash(result, self._execute_module(task_vars=task_vars, wrap_async=wrap_async))
-
-            # hack to keep --verbose from showing all the setup module result
-            # moved from setup module as now we filter out all _ansible_ from result
-            # FIXME: is this still accurate with gather_facts etc, or does it need support for FQ and other names?
-            if self._task.action in C._ACTION_SETUP:
-                result['_ansible_verbose_override'] = True
+        # hack to keep --verbose from showing all the setup module result
+        # moved from setup module as now we filter out all _ansible_ from result
+        # FIXME: is this still accurate with gather_facts etc, or does it need support for FQ and other names?
+        if self._task.action in C._ACTION_SETUP:
+            result['_ansible_verbose_override'] = True
 
         if not wrap_async:
             # remove a temporary path we created


### PR DESCRIPTION
##### SUMMARY
While looking at the `normal` action plugin, I was wondering why the `if not wrap_async` wasn't failing because `wrap_async` was only defined if `not result.get('skipped')`. While investigating I found out that `not result.get('skipped')` can never be `False` since `result` returned by `super.run()` can never contain `skipped`.

This makes the `normal` action plugin easier to digest both for humans as for static analyzers.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
normal action plugin
