### PR TITLE
docs: Extend password entry of ansible.builtin.user

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -87,12 +87,12 @@ options:
     password:
         description:
             - If provided, set the user's password to the provided encrypted hash (Linux) or plain text password (macOS).
-            - B(Linux:) Enter the hashed password as the value.
+            - B(Linux/Unix/POSIX:) Enter the hashed password as the value.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate the hash of a password.
             - To create an account with a locked/disabled password on Linux systems, set this to C('!') or C('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to C('*************').
-            - B(macOS:) Enter the cleartext password as the value. Be sure to take relevant security precautions.
+            - B(OS X/macOS:) Enter the cleartext password as the value. Be sure to take relevant security precautions.
         type: str
     state:
         description:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -87,10 +87,10 @@ options:
     password:
         description:
             - Optionally set the user's password hash to this value.
-            - Do B(not) put the actual password into this field.
+            - B(Linux:) Do not enter password in cleartext.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate the hash of a password.
-            - On macOS systems, this value has to be cleartext. Beware of security issues.
+            - B(macOS:) This value has to be cleartext. Beware of security issues.
             - To create an account with a locked/disabled password on Linux systems, set this to C('!') or C('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to C('*************').
         type: str

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -86,12 +86,13 @@ options:
         version_added: "2.0"
     password:
         description:
-            - Optionally set the user's password to this encrypted value.
+            - Optionally set the user's password hash to this value.
+            - Do B(not) put the actual password into this field.
+            - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
+              for details on various ways to generate the hash of a password.
             - On macOS systems, this value has to be cleartext. Beware of security issues.
             - To create an account with a locked/disabled password on Linux systems, set this to C('!') or C('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to C('*************').
-            - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
-              for details on various ways to generate these password values.
         type: str
     state:
         description:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -86,7 +86,7 @@ options:
         version_added: "2.0"
     password:
         description:
-            - Optionally set the user's password hash to this value.
+            - Optionally set the user password.
             - B(Linux:) Do not enter password in cleartext.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate the hash of a password.

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -87,7 +87,7 @@ options:
     password:
         description:
             - Optionally set the user password.
-            - B(Linux:) Do not enter password in cleartext.
+            - B(Linux:) Enter the hashed password as the value.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate the hash of a password.
             - B(macOS:) This value has to be cleartext. Beware of security issues.

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -86,13 +86,13 @@ options:
         version_added: "2.0"
     password:
         description:
-            - Optionally set the user password.
+            - If provided, set the user's password to the provided encrypted hash (Linux) or plain text password (macOS).
             - B(Linux:) Enter the hashed password as the value.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate the hash of a password.
-            - B(macOS:) Enter the cleartext password as the value. Be sure to take relevant security precautions.
             - To create an account with a locked/disabled password on Linux systems, set this to C('!') or C('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to C('*************').
+            - B(macOS:) Enter the cleartext password as the value. Be sure to take relevant security precautions.
         type: str
     state:
         description:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -90,7 +90,7 @@ options:
             - B(Linux:) Enter the hashed password as the value.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate the hash of a password.
-            - B(macOS:) This value has to be cleartext. Beware of security issues.
+            - B(macOS:) Enter the cleartext password as the value. Be sure to take relevant security precautions.
             - To create an account with a locked/disabled password on Linux systems, set this to C('!') or C('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to C('*************').
         type: str


### PR DESCRIPTION
##### SUMMARY
Clarify that `password` sets the password hash and not the actual password.
Fixes part of  #79684

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.builtin.user
