### PR TITLE
[2.14] ansible-galaxy - fix global toggle to ignore certs

### DIFF
--- a/changelogs/fragments/79561-fix-a-g-global-ignore-certs-cfg.yml
+++ b/changelogs/fragments/79561-fix-a-g-global-ignore-certs-cfg.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix using ``GALAXY_IGNORE_CERTS`` when downloading tarballs from Galaxy servers (https://github.com/ansible/ansible/issues/79557).
+  - Fix using ``GALAXY_IGNORE_CERTS`` in conjunction with collections in requirements files which specify a specific ``source`` that isn't in the configured servers.


### PR DESCRIPTION
##### SUMMARY
Backport for #79561

Fixes https://github.com/ansible/ansible/issues/79557, introduced in 2.14 in https://github.com/ansible/ansible/commit/fa35aa4865780cd0ddbcc060f9e95e59e1c1646b

Fix ignoring certs when downloading tarballs

Fix ignoring certs when downloading a collection from a specific source that isn't in the configured servers list

(cherry picked from commit acbf4cc60e9338dc08421c8355d69bfcdfde0280)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy collection

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
