### PR TITLE
ansible-test - fix ps argspec check inside cmdlet

### DIFF
--- a/changelogs/fragments/validate-module-ps-cmdlet.yml
+++ b/changelogs/fragments/validate-module-ps-cmdlet.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test - Fix validate-modules error when retrieving PowerShell argspec when retrieved inside a Cmdlet

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/failure/README.rst
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/failure/README.rst
@@ -1,0 +1,3 @@
+README
+------
+This is a simple collection used to test failures with ``ansible-test sanity --test validate-modules``.

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/failure/galaxy.yml
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/failure/galaxy.yml
@@ -1,0 +1,6 @@
+namespace: ns
+name: failure
+version: 1.0.0
+readme: README.rst
+authors:
+    - Ansible

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/failure/meta/main.yml
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/failure/meta/main.yml
@@ -1,0 +1,1 @@
+requires_ansible: '>=2.9'

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/failure/plugins/modules/failure_ps.ps1
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/failure/plugins/modules/failure_ps.ps1
@@ -1,0 +1,16 @@
+#!powershell
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+throw "test inner error message"
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, @{
+        options = @{
+            test = @{ type = 'str'; choices = @('foo', 'bar'); default = 'foo' }
+        }
+    })
+
+$module.Result.test = 'abc'
+
+$module.ExitJson()

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/failure/plugins/modules/failure_ps.yml
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/failure/plugins/modules/failure_ps.yml
@@ -1,0 +1,31 @@
+# Copyright (c) 2022 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: failure_ps
+  short_description: Short description for failure_ps module
+  description:
+  - Description for failure_ps module
+  options:
+    test:
+      description:
+      - Description for test module option
+      type: str
+      choices:
+      - foo
+      - bar
+      default: foo
+  author:
+  - Ansible Core Team
+
+EXAMPLES: |
+  - name: example for failure_ps
+    ns.col.failure_ps:
+      test: bar
+
+RETURN:
+  test:
+    description: The test return value
+    returned: always
+    type: str
+    sample: abc

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/ps_only/plugins/module_utils/share_module.psm1
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/ps_only/plugins/module_utils/share_module.psm1
@@ -1,0 +1,19 @@
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+Function Invoke-AnsibleModule {
+    <#
+        .SYNOPSIS
+        validate
+    #>
+    [CmdletBinding()]
+    param ()
+
+    $module = [Ansible.Basic.AnsibleModule]::Create(@(), @{
+            options = @{
+                test = @{ type = 'str' }
+            }
+        })
+    $module.ExitJson()
+}
+
+Export-ModuleMember -Function Invoke-AnsibleModule

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/ps_only/plugins/modules/in_function.ps1
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/ps_only/plugins/modules/in_function.ps1
@@ -1,0 +1,7 @@
+#!powershell
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell ..module_utils.share_module
+
+Invoke-AnsibleModule

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/ps_only/plugins/modules/in_function.yml
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/ps_only/plugins/modules/in_function.yml
@@ -1,0 +1,25 @@
+# Copyright (c) 2022 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION:
+  module: in_function
+  short_description: Short description for in_function module
+  description:
+  - Description for in_function module
+  options:
+    test:
+      description: Description for test
+      type: str
+  author:
+  - Ansible Core Team
+
+EXAMPLES: |
+  - name: example for sidecar
+    ns.col.in_function:
+
+RETURN:
+  test:
+    description: The test return value
+    returned: always
+    type: str
+    sample: abc

--- a/test/integration/targets/ansible-test-sanity-validate-modules/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/runme.sh
@@ -15,3 +15,18 @@ fi
 
 # Use a PowerShell-only collection to verify that validate-modules does not load the collection loader multiple times.
 ansible-test sanity --test validate-modules --color --truncate 0 "${@}"
+
+cd ../failure
+
+if ansible-test sanity --test validate-modules --color --truncate 0 "${@}" 1> ansible-stdout.txt 2> ansible-stderr.txt; then
+  echo "ansible-test sanity for failure should cause failure"
+  exit 1
+fi
+
+cat ansible-stdout.txt
+cat ansible-stdout.txt | grep -q "ERROR: plugins/modules/failure_ps.ps1:0:0: import-error: Exception attempting to import module for argument_spec introspection"
+cat ansible-stdout.txt | grep -q "test inner error message"
+
+cat ansible-stderr.txt
+cat ansible-stderr.txt | grep -q "FATAL: The 1 sanity test(s) listed below (out of 1) failed"
+cat ansible-stderr.txt | grep -q "validate-modules"

--- a/test/integration/targets/ansible-test-sanity-validate-modules/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/runme.sh
@@ -24,9 +24,9 @@ if ansible-test sanity --test validate-modules --color --truncate 0 "${@}" 1> an
 fi
 
 cat ansible-stdout.txt
-cat ansible-stdout.txt | grep -q "ERROR: plugins/modules/failure_ps.ps1:0:0: import-error: Exception attempting to import module for argument_spec introspection"
-cat ansible-stdout.txt | grep -q "test inner error message"
+grep -q "ERROR: plugins/modules/failure_ps.ps1:0:0: import-error: Exception attempting to import module for argument_spec introspection" < ansible-stdout.txt
+grep -q "test inner error message" < ansible-stdout.txt
 
 cat ansible-stderr.txt
-cat ansible-stderr.txt | grep -q "FATAL: The 1 sanity test(s) listed below (out of 1) failed"
-cat ansible-stderr.txt | grep -q "validate-modules"
+grep -q "FATAL: The 1 sanity test(s) listed below (out of 1) failed" < ansible-stderr.txt
+grep -q "validate-modules" < ansible-stderr.txt

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/ps_argspec.ps1
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/ps_argspec.ps1
@@ -101,13 +101,21 @@ Add-CSharpType -References @(Get-Content -LiteralPath $manifest.ansible_basic -R
 
 $powershell.AddScript($module_code) > $null
 $powershell.Invoke() > $null
+$arg_spec = $powershell.Runspace.SessionStateProxy.GetVariable('ansibleTestArgSpec')
 
-if ($powershell.HadErrors) {
-    $powershell.Streams.Error
+if (-not $arg_spec) {
+    $err = $powershell.Streams.Error
+    if ($err) {
+        $err
+    }
+    else {
+        "Unknown error trying to get PowerShell arg spec"
+    }
+
     exit 1
 }
 
-$arg_spec = $powershell.Runspace.SessionStateProxy.GetVariable('ansibleTestArgSpec')
+
 Resolve-CircularReference -Hash $arg_spec
 
 ConvertTo-Json -InputObject $arg_spec -Compress -Depth 99


### PR DESCRIPTION
##### SUMMARY
The argspec code used by validate-module causes the module to exit early using the `exit` function. When wrapped inside a cmdlet this exit signals an error in the PowerShell pipeline but there is no error stream to indicate what went wrong. Change the code to only exit if the arg spec failed to be retrieved and provide at least some error message if no error record was present on a failure.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test