### PR TITLE
fix: ensure path to collection argument doesn't have a backslash

### DIFF
--- a/changelogs/fragments/79705-fix-ensure-path-to-collection-argument-doesnt-have-backslash.yml
+++ b/changelogs/fragments/79705-fix-ensure-path-to-collection-argument-doesnt-have-backslash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - ensure path to ansible collection when installing or downloading doesn't have a backslash (https://github.com/ansible/ansible/pull/79705).

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -422,6 +422,12 @@ class CLI(ABC):
                     skip_tags.add(tag.strip())
             options.skip_tags = list(skip_tags)
 
+        # Make sure path argument doesn't have a backslash
+        if hasattr(options, 'action') and (options.action == 'install' or options.action == 'download'):
+            if hasattr(options, 'args') and len(options.args) > 0:
+                path = options.args[0]
+                options.args = path.rstrip("/")
+
         # process inventory options except for CLIs that require their own processing
         if hasattr(options, 'inventory') and not self.SKIP_INVENTORY_DEFAULTS:
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -425,8 +425,7 @@ class CLI(ABC):
         # Make sure path argument doesn't have a backslash
         if hasattr(options, 'action') and (options.action == 'install' or options.action == 'download'):
             if hasattr(options, 'args') and len(options.args) > 0:
-                path = options.args[0]
-                options.args = path.rstrip("/")
+                options.args = [path.rstrip("/") for path in options.args]
 
         # process inventory options except for CLIs that require their own processing
         if hasattr(options, 'inventory') and not self.SKIP_INVENTORY_DEFAULTS:


### PR DESCRIPTION
##### SUMMARY

When I wanted to install an Ansible collection by providing a local path to collection, I encountered the following error:

```
Traceback (most recent call last):
  File "/usr/bin/ansible-galaxy", line 128, in <module>
    exit_code = cli.run()
  File "/usr/lib/python3/dist-packages/ansible/cli/galaxy.py", line 570, in run
    return context.CLIARGS['func']()
  File "/usr/lib/python3/dist-packages/ansible/cli/galaxy.py", line 86, in method_wrapper
    return wrapped_method(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/ansible/cli/galaxy.py", line 1207, in execute_install
    self._execute_install_collection(
  File "/usr/lib/python3/dist-packages/ansible/cli/galaxy.py", line 1235, in _execute_install_collection
    install_collections(
  File "/usr/lib/python3/dist-packages/ansible/galaxy/collection/__init__.py", line 576, in install_collections
    install(concrete_coll_pin, output_path, artifacts_manager)
  File "/usr/lib/python3/dist-packages/ansible/galaxy/collection/__init__.py", line 1119, in install
    install_src(collection, b_artifact_path, b_collection_path, artifacts_manager)
  File "/usr/lib/python3/dist-packages/ansible/galaxy/collection/__init__.py", line 1200, in install_src
    collection_output_path = _build_collection_dir(
  File "/usr/lib/python3/dist-packages/ansible/galaxy/collection/__init__.py", line 1045, in _build_collection_dir
    existing_is_exec = os.stat(src_file).st_mode & stat.S_IXUSR
FileNotFoundError: [Errno 2] No such file or directory: b'cloud.terraform/ests/config.yml'
```

If you look into the last line of error there's an error on the path: `ests` should be `tests`. Back-tracing from where the issue originates, I figured out the issue occurs when I call the `ansible-galaxy collection install` command like this:
```
ansible-galaxy collection install <path/to/collection>/
```
instead of doing it like this:
```
ansible-galaxy collection install <path/to/collection>
```
Notice the `backslash` parameter in the first command. This backslash causes the following command: https://github.com/ansible/ansible/blob/e41d2874a67ade813ffaf2ebfff67987291d53c0/lib/ansible/galaxy/collection/__init__.py#L1210 to slice the first character of the subdirectory - which breaks the path and causes the error.

It's a minor issue but causes quite an unrelated error, not easy to figure out what's wrong in the command. This is not only true for the `install` command but for the `download` command as well. 

This PR addresses the backslash and removes it, in case it is present.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ansible/cli/__init__.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

In order to reproduce this, just clone one of the Ansible collections into an arbitrary directory and try installing it using the `<path/to/collection>`. If you will add the backslash at the end, the command will fail.

<!--- Paste verbatim command output below, e.g. before and after your change -->
