### PR TITLE
[sanity validate-modules] Allow argspec modifiers identified as valid components of the docsting

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -356,7 +356,7 @@ class DocCLI(CLI, RoleMixin):
 
     # default ignore list for detailed views
     IGNORE = ('module', 'docuri', 'version_added', 'version_added_collection', 'short_description', 'now_date', 'plainexamples', 'returndocs', 'collection')
-
+    ARGUMENT_SPEC_MODIFIERS = ('mutually_exclusive', 'required_if', 'required_together', 'required_one_of', 'required_by', 'no_log')
     # Warning: If you add more elements here, you also need to add it to the docsite build (in the
     # ansible-community/antsibull repo)
     _ITALIC = re.compile(r"\bI\(([^)]+)\)")
@@ -1218,8 +1218,17 @@ class DocCLI(CLI, RoleMixin):
         if doc.pop('has_action', False):
             text.append("  * note: %s\n" % "This module has a corresponding action plugin.")
 
+        if doc.pop('supports_check_mode', False):
+            text.append("  * note: %s\n" % "This module supports check mode.")
+
         if doc.get('options', False):
             text.append("OPTIONS (= is mandatory):\n")
+
+            for k in DocCLI.ARGUMENT_SPEC_MODIFIERS:
+                if doc.get(k):
+                    text.append(DocCLI._dump_yaml({k: doc[k]}, ""))
+                    doc.pop(k)
+
             DocCLI.add_fields(text, doc.pop('options'), limit, opt_indent)
             text.append('')
 

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -815,9 +815,9 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False, plugi
         'options': Any(None, *list_dict_option_schema(for_collection, plugin_type)),
         'extends_documentation_fragment': Any(list_string_types, *string_types),
         'version_added_collection': collection_name,
-        'required_if': Any(None, list),
+        'mutually_exclusive': argument_spec_modifiers['mutually_exclusive'],
         'supports_check_mode': bool,
-        'mutually_exclusive': Any(None, list),
+        'required_if': argument_spec_modifiers['required_if'],
     }
     if plugin_type == 'module':
         doc_schema_dict[Required('author')] = All(Any(None, list_string_types, *string_types), author)

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -535,7 +535,9 @@ def list_dict_option_schema(for_collection, plugin_type):
         'type': option_types,
         # in case of type='list' elements define type of individual item in list
         'elements': element_types,
+        'no_log': bool,
     }
+    basic_option_schema.update(argument_spec_modifiers)
     if plugin_type != 'module':
         basic_option_schema['name'] = Any(*string_types)
         deprecated_schema = All(
@@ -813,6 +815,9 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False, plugi
         'options': Any(None, *list_dict_option_schema(for_collection, plugin_type)),
         'extends_documentation_fragment': Any(list_string_types, *string_types),
         'version_added_collection': collection_name,
+        'required_if': Any(None, list),
+        'supports_check_mode': bool,
+        'mutually_exclusive': Any(None, list),
     }
     if plugin_type == 'module':
         doc_schema_dict[Required('author')] = All(Any(None, list_string_types, *string_types), author)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes added help us generate argspec dynamically from the module DOCSTRING itself without sanity complaining about it. 
Being able to generate argspec [dynamically](https://github.com/ansible-collections/cisco.ios/pull/713) reduces the need for argspec to be explicitly present as a component resulting in a significant amount of reduction of code lines in collection code. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sanity/validate_modules/schema.py

<!--- ##### ADDITIONAL INFORMATION -->
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
