### PR TITLE
Fix: documentation for per-task timeout

### DIFF
--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -509,7 +509,7 @@ Suggestions to resolve:
 
   Suggestions to resolve:
 
-  Some modules support a ``timeout`` variable.
+  Some modules support a ``timeout`` option.
   
   .. code-block:: yaml
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -509,7 +509,7 @@ Suggestions to resolve:
 
   Suggestions to resolve:
 
-  Some modules support a ``timeout`` option.
+  Some modules support a ``timeout`` option, which is different to the ``timeout`` keyword for tasks.
   
   .. code-block:: yaml
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -509,6 +509,8 @@ Suggestions to resolve:
 
   Suggestions to resolve:
 
+  Some modules support a ``timeout`` variable.
+  
   .. code-block:: yaml
 
       - name: save running-config
@@ -519,6 +521,8 @@ Suggestions to resolve:
 
 
   Suggestions to resolve:
+  
+  If the module does not support the ``timeout`` variable directly it can be set via the ``ansible_command_timeout variable
 
   .. code-block:: yaml
 

--- a/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network/user_guide/network_debug_troubleshooting.rst
@@ -522,7 +522,7 @@ Suggestions to resolve:
 
   Suggestions to resolve:
   
-  If the module does not support the ``timeout`` variable directly it can be set via the ``ansible_command_timeout variable
+  If the module does not support the ``timeout`` option directly, most networking connection plugins can enable similar functionality with the ``ansible_command_timeout``  variable.
 
   .. code-block:: yaml
 


### PR DESCRIPTION
##### SUMMARY
<!--- Your description here -->

Corrected the documentation regarding per-task timeouts. The timeout variable is not available in all modules in the way it is shown. See for example
```
- hosts: all                     
  tasks:                         
    - name: show version         
      cisco.nxos.nxos_command:   
        commands: "show version" 
        retries: 1               
        timeout: 60              
```
which leads to
```
fatal: [rcn-lab-s-2.lab.tmn.scc.kit.edu]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (cisco.nxos.nxos_command) module: timeout. Supported parameters include: interval, wait_for (waitfor), retries, commands, match."}
```

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr
