### PR TITLE
Ensure we are passing ciphers to all url_get calls

### DIFF
--- a/changelogs/fragments/79717-get-url-ciphers.yml
+++ b/changelogs/fragments/79717-get-url-ciphers.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- get_url - Ensure we are passing ciphers to all url_get calls (https://github.com/ansible/ansible/issues/79717)

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -609,7 +609,7 @@ def main():
     start = datetime.datetime.utcnow()
     method = 'HEAD' if module.check_mode else 'GET'
     tmpsrc, info = url_get(module, url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest, method,
-                           unredirected_headers=unredirected_headers, decompress=decompress, use_netrc=use_netrc)
+                           unredirected_headers=unredirected_headers, decompress=decompress, ciphers=ciphers, use_netrc=use_netrc)
     result['elapsed'] = (datetime.datetime.utcnow() - start).seconds
     result['src'] = tmpsrc
 

--- a/test/integration/targets/get_url/tasks/ciphers.yml
+++ b/test/integration/targets/get_url/tasks/ciphers.yml
@@ -6,7 +6,7 @@
   register: good_ciphers
 
 - name: test bad cipher
-  uri:
+  get_url:
     url: https://{{ httpbin_host }}/get
     ciphers: ECDHE-ECDSA-AES128-SHA
     dest: '{{ remote_tmp_dir }}/bad_cipher_get.json'


### PR DESCRIPTION
##### SUMMARY
Ensure we are passing ciphers to all url_get calls. Fixes #79717

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/get_url.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
