### PR TITLE
Use uri in uri test instead of get_url.

### DIFF
--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -132,7 +132,7 @@
       - "result.changed == true"
 
 - name: "get ca certificate {{ self_signed_host }}"
-  get_url:
+  uri:
     url: "http://{{ httpbin_host }}/ca2cert.pem"
     dest: "{{ remote_tmp_dir }}/ca2cert.pem"
 


### PR DESCRIPTION
##### SUMMARY

Use uri in uri test instead of get_url.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

uri integration test
