### PR TITLE
2.14: Correctly count rescued tasks in play stats (#79724)

### DIFF
--- a/changelogs/fragments/79711-fix-play-stats-rescued.yml
+++ b/changelogs/fragments/79711-fix-play-stats-rescued.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Correctly count rescued tasks in play recap (https://github.com/ansible/ansible/issues/79711)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -571,7 +571,7 @@ class PlayIterator:
         Given the current HostState state, determines if the current block, or any child blocks,
         are in rescue mode.
         '''
-        if state.get_current_block().rescue:
+        if state.run_state == IteratingStates.TASKS and state.get_current_block().rescue:
             return True
         if state.tasks_child_state is not None:
             return self.is_any_block_rescuing(state.tasks_child_state)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -551,6 +551,8 @@ class StrategyBase:
                 role_ran = True
                 ignore_errors = original_task.ignore_errors
                 if not ignore_errors:
+                    # save the current state before failing it for later inspection
+                    state_when_failed = iterator.get_state_for_host(original_host.name)
                     display.debug("marking %s as failed" % original_host.name)
                     if original_task.run_once:
                         # if we're using run_once, we have to fail every host here
@@ -568,7 +570,7 @@ class StrategyBase:
                     # if we're iterating on the rescue portion of a block then
                     # we save the failed task in a special var for use
                     # within the rescue/always
-                    if iterator.is_any_block_rescuing(state):
+                    if iterator.is_any_block_rescuing(state_when_failed):
                         self._tqm._stats.increment('rescued', original_host.name)
                         iterator._play._removed_hosts.remove(original_host.name)
                         self._variable_manager.set_nonpersistent_facts(

--- a/test/integration/targets/blocks/79711.yml
+++ b/test/integration/targets/blocks/79711.yml
@@ -1,0 +1,17 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - block:
+      - block:
+          - debug:
+          - name: EXPECTED FAILURE
+            fail:
+        rescue:
+          - debug:
+          - debug:
+          - name: EXPECTED FAILURE
+            fail:
+        always:
+          - debug:
+      always:
+        - debug:

--- a/test/integration/targets/blocks/runme.sh
+++ b/test/integration/targets/blocks/runme.sh
@@ -127,3 +127,12 @@ rm -f 78612.out
 
 ansible-playbook -vv 43191.yml
 ansible-playbook -vv 43191-2.yml
+
+# https://github.com/ansible/ansible/issues/79711
+set +e
+ANSIBLE_FORCE_HANDLERS=0 ansible-playbook -vv 79711.yml | tee 79711.out
+set -e
+[ "$(grep -c 'ok=5' 79711.out)" -eq 1 ]
+[ "$(grep -c 'failed=1' 79711.out)" -eq 1 ]
+[ "$(grep -c 'rescued=1' 79711.out)" -eq 1 ]
+rm -f 79711.out


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #79724

(cherry picked from commit e38b3e64fd5f9bb6c5ca9462150c89f0932fd2c4)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/executor/play_iterator.py`
`lib/ansible/plugins/strategy/__init__.py`

##### ADDITIONAL INFORMATION
