### PR TITLE
add task for testing to remove gpg key using key id

### DIFF
--- a/test/integration/targets/rpm_key/tasks/rpm_key.yaml
+++ b/test/integration/targets/rpm_key/tasks/rpm_key.yaml
@@ -123,6 +123,32 @@
   assert:
     that: "'rsa sha1 (md5) pgp md5 OK' in sl_check.stdout or 'digests signatures OK' in sl_check.stdout"
 
+- name: get keyid
+  shell: "rpm -q gpg-pubkey | head -n 1 | xargs rpm -q --qf %{version}"
+  register: key_id
+
+- name: remove GPG key using keyid
+  rpm_key:
+    state: absent
+    key: "{{ key_id.stdout }}"
+  register: remove_keyid
+  failed_when: remove_keyid.changed == false
+
+- name: remove GPG key using keyid (idempotent)
+  rpm_key:
+    state: absent
+    key: "{{ key_id.stdout }}"
+  register: key_id_idempotence
+
+- name: verify idempotent (key_id)
+  assert:
+    that: "not key_id_idempotence.changed"
+
+- name: add very first key on system again
+  rpm_key:
+    state: present
+    key: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/RPM-GPG-KEY-EPEL-7
+
 - name: Issue 20325 - Verify fingerprint of key, invalid fingerprint - EXPECTED FAILURE
   rpm_key:
     key: https://ci-files.testing.ansible.com/test/integration/targets/rpm_key/RPM-GPG-KEY.dag


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
At integration test for rpm_key module, there are various methods for adding/removing gpg keys.
However removing gpg key using key id is missing. This PR adds it.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #79584 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rpm_key

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Following is the output from tasks I added.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [get keyid] *********************************************************************************************************************************************************************************************
changed: [localhost] => {"changed": true, "cmd": "rpm -q gpg-pubkey | head -n 1 | xargs rpm -q --qf %{version}", "delta": "0:00:00.017863", "end": "2023-01-13 08:31:36.406416", "msg": "", "rc": 0, "start": "2023-01-13 08:31:36.388553", "stderr": "", "stderr_lines": [], "stdout": "352c64e5", "stdout_lines": ["352c64e5"]}

TASK [remove GPG key using keyid] ****************************************************************************************************************************************************************************
changed: [localhost] => {"changed": true, "failed_when_result": false}

TASK [remove GPG key using keyid (idempotent)] ***************************************************************************************************************************************************************
ok: [localhost] => {"changed": false}

TASK [verify idempotent (key_id)] ****************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [add very first key on system again] ********************************************************************************************************************************************************************
changed: [localhost] => {"changed": true}
```
