### PR TITLE
Truthy value should be one of false or true

### DIFF
--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -108,7 +108,7 @@ EXAMPLES = '''
 - name: Restart service cron on centos, in all cases, also issue daemon-reload to pick up config changes
   ansible.builtin.systemd:
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
     name: crond
 
 - name: Reload service httpd, in all cases
@@ -119,22 +119,22 @@ EXAMPLES = '''
 - name: Enable service httpd and ensure it is not masked
   ansible.builtin.systemd:
     name: httpd
-    enabled: yes
+    enabled: true
     masked: no
 
 - name: Enable a timer unit for dnf-automatic
   ansible.builtin.systemd:
     name: dnf-automatic.timer
     state: started
-    enabled: yes
+    enabled: true
 
 - name: Just force systemd to reread configs (2.4 and above)
   ansible.builtin.systemd:
-    daemon_reload: yes
+    daemon_reload: true
 
 - name: Just force systemd to re-execute itself (2.8 and above)
   ansible.builtin.systemd:
-    daemon_reexec: yes
+    daemon_reexec: true
 
 - name: Run a user service when XDG_RUNTIME_DIR is not set on remote login
   ansible.builtin.systemd:


### PR DESCRIPTION
##### SUMMARY
Truthy value should be one of false or true.
Otherwise ansible-lint  (which seems to rely on yamllint) complains: https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.builtin.systemd
