### PR TITLE
Show filename additionally if missing secrets prevents decryption

### DIFF
--- a/changelogs/fragments/79732-filename_in_decrypt_error.yml
+++ b/changelogs/fragments/79732-filename_in_decrypt_error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vault - show filename additionally if missing secrets prevents decryption (https://github.com/ansible/ansible/issues/79723)

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -658,7 +658,10 @@ class VaultLib:
         b_vaulttext = to_bytes(vaulttext, errors='strict', encoding='utf-8')
 
         if self.secrets is None:
-            raise AnsibleVaultError("A vault password must be specified to decrypt data")
+            msg = "A vault password must be specified to decrypt data"
+            if filename:
+                msg += " in file %s" % to_native(filename)
+            raise AnsibleVaultError(msg)
 
         if not is_encrypted(b_vaulttext):
             msg = "input is not vault encrypted data. "


### PR DESCRIPTION
##### SUMMARY
Display the file name in addition to the error message `A vault password must be specified to decrypt the data` if decryption secrets are missing. If the file name is not provided, it is difficult to understand which of the vault files is causing the problem.

Fixes #79723

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vault
