### PR TITLE
ansible-test - local change detection without --fork-point

### DIFF
--- a/changelogs/fragments/79734-ansible-test-change-detection.yml
+++ b/changelogs/fragments/79734-ansible-test-change-detection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ansible-test change detection - when using ``--changed`` outside of AZP, use ``git merge-base <branch> HEAD`` instead of ``git merge-base --fork-point <branch>`` (https://github.com/ansible/ansible/pull/79734)."

--- a/changelogs/fragments/79734-ansible-test-change-detection.yml
+++ b/changelogs/fragments/79734-ansible-test-change-detection.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "ansible-test change detection - when using ``--changed`` outside of AZP, use ``git merge-base <branch> HEAD`` instead of ``git merge-base --fork-point <branch>`` (https://github.com/ansible/ansible/pull/79734)."
+  - "ansible-test local change detection - use ``git merge-base <branch> HEAD`` instead of ``git merge-base --fork-point <branch>`` (https://github.com/ansible/ansible/pull/79734)."

--- a/test/lib/ansible_test/_internal/git.py
+++ b/test/lib/ansible_test/_internal/git.py
@@ -76,7 +76,7 @@ class Git:
 
     def get_branch_fork_point(self, branch: str) -> str:
         """Return a reference to the point at which the given branch was forked."""
-        cmd = ['merge-base', '--fork-point', branch]
+        cmd = ['merge-base', branch, 'HEAD']
         return self.run_git(cmd).strip()
 
     def is_valid_ref(self, ref: str) -> bool:


### PR DESCRIPTION
##### SUMMARY
Using `--fork-point` sometimes fails to find the common ancestor. Examples: https://github.com/ansible-collections/community.docker/actions/runs/3908720244/jobs/6688342848 and https://github.com/ansible-collections/community.docker/actions/runs/3908736018/jobs/6679125228

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
