### PR TITLE
Fix regex filter docs

### DIFF
--- a/lib/ansible/plugins/filter/regex_replace.yml
+++ b/lib/ansible/plugins/filter/regex_replace.yml
@@ -5,7 +5,7 @@ DOCUMENTATION:
   description:
     - Replace a substring defined by a regular expression with another defined by another regular expression based on the first match.
   notes:
-    - Maps to Python's C(regex.replace).
+    - Maps to Python's C(re.replace).
   positional: _input, _regex_match, _regex_replace
   options:
     _input:

--- a/lib/ansible/plugins/filter/regex_search.yml
+++ b/lib/ansible/plugins/filter/regex_search.yml
@@ -5,7 +5,7 @@ DOCUMENTATION:
   description:
     - Search in a string to extract the part that matches the regular expression.
   notes:
-    - Maps to Python's C(regex.search).
+    - Maps to Python's C(re.search).
   positional: _input, _regex
   options:
     _input:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix regex filter documentation.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Documentation
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
The documentation says that `regex_search` and `regex_replace` filter plugins map to the Python 'regex' module when it should say the 're' module. The distinction is important because of the third-party 'regex' module that has more features than the built-in 're' module. https://pypi.org/project/regex/
