### PR TITLE
fall back to stderr/stdin for terminal with detection

### DIFF
--- a/changelogs/fragments/79780-fix-column-width-detection.yaml
+++ b/changelogs/fragments/79780-fix-column-width-detection.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - terminal width detection from stdout now falls back to stderr and stdin, keeping terminal width when piping ansible output (https://github.com/ansible/ansible/pull/79780)
+  - terminal width detection from stdout now falls back to stderr and stdin, keeping terminal width when piping ansible output (https://github.com/ansible/ansible/pull/79780).

--- a/changelogs/fragments/79780-fix-column-width-detection.yaml
+++ b/changelogs/fragments/79780-fix-column-width-detection.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - terminal width detection from stdout now falls back to stderr and stdin, keeping terminal width when piping ansible output (https://github.com/ansible/ansible/pull/79780)

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -519,8 +519,12 @@ class Display(metaclass=Singleton):
         return result
 
     def _set_column_width(self):
-        if os.isatty(1):
-            tty_size = unpack('HHHH', fcntl.ioctl(1, TIOCGWINSZ, pack('HHHH', 0, 0, 0, 0)))[1]
-        else:
-            tty_size = 0
+        tty_size = 0
+
+        # Try to detect terminal width from stdout, stderr or stdin
+        for fd in (1, 2, 0):
+            if os.isatty(fd):
+                tty_size = unpack('HHHH', fcntl.ioctl(fd, TIOCGWINSZ, pack('HHHH', 0, 0, 0, 0)))[1]
+                break
+
         self.columns = max(79, tty_size - 1)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
this allows to use pipes without truncating the output while keeping compability with #70199 (commit: 45e0f747)

for example: `ansible-doc -l | grep ...`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
display

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Before:
```
$ ansible-doc -l | grep deb
ansible.builtin.debconf                                          Configure ...
ansible.builtin.debug                                            Print stat...
```
After:
```
$ ansible-doc -l | grep deb
ansible.builtin.debconf                                          Configure a .deb package                                                                                                                                          
ansible.builtin.debug                                            Print statements during execution 
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
