### PR TITLE
Update playbooks_tests.rst

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_tests.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_tests.rst
@@ -461,7 +461,7 @@ When looking to determine types, it may be tempting to use the ``type_debug`` fi
           a_list: ["a", "list"]
         assert:
           that:
-          # Note that a string is classed as also being "iterable", "sequence" and "mapping"
+          # Note that a string is classed as also being "iterable" and "sequence", but not "mapping"
           - a_string is string
 
           # Note that a dictionary is classed as not being a "string", but is "iterable", "sequence" and "mapping"


### PR DESCRIPTION
##### SUMMARY
Part of the documentation incorrectly describes a string as being classed as a mapping.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
Part of the documentation incorrectly describes a string as being classed as a mapping.  An assert shows this is false.  Changed incorrect line in documentation.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Documentation: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_tests.html#type-tests

##### ADDITIONAL INFORMATION
Strings are not mappings, as the following code shows:

      - name: "String interpretation"
        vars:
          a_string: "A string"
        assert:
          that:
            - a_string is not mapping
