### PR TITLE
ansible-test - Deprecate the govcsim container.

### DIFF
--- a/changelogs/fragments/ansible-test-govcsim.yml
+++ b/changelogs/fragments/ansible-test-govcsim.yml
@@ -1,0 +1,8 @@
+breaking_changes:
+  - ansible-test - The ``vcenter`` test plugin now defaults to using a user-provided static configuration instead of the ``govcsim`` simulator.
+                   Set the ``ANSIBLE_VCSIM_CONTAINER`` environment variable to ``govcsim`` to use the simulator.
+                   Keep in mind that the simulator is deprecated and will be removed in a future release.
+deprecated_features:
+  - ansible-test - The ``govcsim`` simulator in the ``vcenter`` test plugin is now deprecated.
+                   It will be removed in a future release.
+                   Users should switch to providing their own test environment through a static configuration file.

--- a/test/integration/targets/ansible-test-cloud-vcenter/aliases
+++ b/test/integration/targets/ansible-test-cloud-vcenter/aliases
@@ -1,3 +1,0 @@
-cloud/vcenter
-shippable/generic/group1
-context/controller

--- a/test/integration/targets/ansible-test-cloud-vcenter/tasks/main.yml
+++ b/test/integration/targets/ansible-test-cloud-vcenter/tasks/main.yml
@@ -1,6 +1,0 @@
-- name: Verify endpoints respond
-  uri:
-    url: "{{ item }}"
-    validate_certs: no
-  with_items:
-    - http://{{ vcenter_hostname }}:5000/  # control endpoint for the simulator

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/vcenter.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/vcenter.py
@@ -40,9 +40,11 @@ class VcenterProvider(CloudProvider):
 
         # VMware tests can be run on govcsim or BYO with a static config file.
         # The simulator is the default if no config is provided.
-        self.vmware_test_platform = os.environ.get('VMWARE_TEST_PLATFORM', 'govcsim')
+        self.vmware_test_platform = os.environ.get('VMWARE_TEST_PLATFORM', 'static')
 
         if self.vmware_test_platform == 'govcsim':
+            display.warning('The govcsim simulator is deprecated and will be removed in a future version of ansible-test. Use a static configuration instead.')
+
             self.uses_docker = True
             self.uses_config = False
         elif self.vmware_test_platform == 'static':


### PR DESCRIPTION
##### SUMMARY

Deprecate the govcsim container.

Also remove the integration tests for the `vcenter` test plugin, since the tests relied on using the simulator.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
