### PR TITLE
ansible-test - Remove obsolete DirectoryTarget.

### DIFF
--- a/test/lib/ansible_test/_internal/commands/sanity/integration_aliases.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/integration_aliases.py
@@ -240,8 +240,8 @@ class IntegrationAliasesTest(SanitySingleVersion):
         clouds = get_cloud_platforms(args, posix_targets)
         cloud_targets = ['cloud/%s/' % cloud for cloud in clouds]
 
-        all_cloud_targets = tuple(filter_targets(posix_targets, ['cloud/'], directories=False, errors=False))
-        invalid_cloud_targets = tuple(filter_targets(all_cloud_targets, cloud_targets, include=False, directories=False, errors=False))
+        all_cloud_targets = tuple(filter_targets(posix_targets, ['cloud/'], errors=False))
+        invalid_cloud_targets = tuple(filter_targets(all_cloud_targets, cloud_targets, include=False, errors=False))
 
         messages = []
 
@@ -254,13 +254,13 @@ class IntegrationAliasesTest(SanitySingleVersion):
                     messages.append(SanityMessage('invalid alias `%s`' % alias, '%s/aliases' % target.path))
 
         messages += self.check_ci_group(
-            targets=tuple(filter_targets(posix_targets, ['cloud/', '%s/generic/' % self.TEST_ALIAS_PREFIX], include=False, directories=False, errors=False)),
+            targets=tuple(filter_targets(posix_targets, ['cloud/', '%s/generic/' % self.TEST_ALIAS_PREFIX], include=False, errors=False)),
             find=self.format_test_group_alias('linux').replace('linux', 'posix'),
             find_incidental=['%s/posix/incidental/' % self.TEST_ALIAS_PREFIX],
         )
 
         messages += self.check_ci_group(
-            targets=tuple(filter_targets(posix_targets, ['%s/generic/' % self.TEST_ALIAS_PREFIX], directories=False, errors=False)),
+            targets=tuple(filter_targets(posix_targets, ['%s/generic/' % self.TEST_ALIAS_PREFIX], errors=False)),
             find=self.format_test_group_alias('generic'),
         )
 
@@ -273,7 +273,7 @@ class IntegrationAliasesTest(SanitySingleVersion):
                 find_incidental = ['%s/%s/incidental/' % (self.TEST_ALIAS_PREFIX, cloud), '%s/cloud/incidental/' % self.TEST_ALIAS_PREFIX]
 
             messages += self.check_ci_group(
-                targets=tuple(filter_targets(posix_targets, ['cloud/%s/' % cloud], directories=False, errors=False)),
+                targets=tuple(filter_targets(posix_targets, ['cloud/%s/' % cloud], errors=False)),
                 find=find,
                 find_incidental=find_incidental,
             )
@@ -331,11 +331,11 @@ class IntegrationAliasesTest(SanitySingleVersion):
     ) -> list[SanityMessage]:
         """Check the CI groups set in the provided targets and return a list of messages with any issues found."""
         all_paths = set(target.path for target in targets)
-        supported_paths = set(target.path for target in filter_targets(targets, [find], directories=False, errors=False))
-        unsupported_paths = set(target.path for target in filter_targets(targets, [self.UNSUPPORTED], directories=False, errors=False))
+        supported_paths = set(target.path for target in filter_targets(targets, [find], errors=False))
+        unsupported_paths = set(target.path for target in filter_targets(targets, [self.UNSUPPORTED], errors=False))
 
         if find_incidental:
-            incidental_paths = set(target.path for target in filter_targets(targets, find_incidental, directories=False, errors=False))
+            incidental_paths = set(target.path for target in filter_targets(targets, find_incidental, errors=False))
         else:
             incidental_paths = set()
 

--- a/test/lib/ansible_test/_internal/target.py
+++ b/test/lib/ansible_test/_internal/target.py
@@ -73,23 +73,22 @@ def walk_internal_targets(
     """Return a tuple of matching completion targets."""
     targets = tuple(targets)
 
-    include_targets = sorted(filter_targets(targets, includes, directories=False), key=lambda include_target: include_target.name)
+    include_targets = sorted(filter_targets(targets, includes), key=lambda include_target: include_target.name)
 
     if requires:
-        require_targets = set(filter_targets(targets, requires, directories=False))
+        require_targets = set(filter_targets(targets, requires))
         include_targets = [require_target for require_target in include_targets if require_target in require_targets]
 
     if excludes:
-        list(filter_targets(targets, excludes, include=False, directories=False))
+        list(filter_targets(targets, excludes, include=False))
 
-    internal_targets = set(filter_targets(include_targets, excludes, errors=False, include=False, directories=False))
+    internal_targets = set(filter_targets(include_targets, excludes, errors=False, include=False))
     return tuple(sorted(internal_targets, key=lambda sort_target: sort_target.name))
 
 
 def filter_targets(targets: c.Iterable[TCompletionTarget],
                    patterns: list[str],
                    include: bool = True,
-                   directories: bool = True,
                    errors: bool = True,
                    ) -> c.Iterable[TCompletionTarget]:
     """Iterate over the given targets and filter them based on the supplied arguments."""
@@ -130,10 +129,7 @@ def filter_targets(targets: c.Iterable[TCompletionTarget],
         if match != include:
             continue
 
-        if directories and matched_directories:
-            yield DirectoryTarget(to_text(sorted(matched_directories, key=len)[0]), target.modules)
-        else:
-            yield target
+        yield target
 
     if errors:
         if unmatched:
@@ -439,16 +435,6 @@ class CompletionTarget(metaclass=abc.ABCMeta):
             return '%s (%s)' % (self.name, ', '.join(self.modules))
 
         return self.name
-
-
-class DirectoryTarget(CompletionTarget):
-    """Directory target."""
-    def __init__(self, path: str, modules: tuple[str, ...]) -> None:
-        super().__init__()
-
-        self.name = path
-        self.path = path
-        self.modules = modules
 
 
 class TestTarget(CompletionTarget):


### PR DESCRIPTION
##### SUMMARY

Remove obsolete DirectoryTarget.

This code has been unused since at least the 2.9 release.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
