### PR TITLE
Drop requirement for matching sanity constraints

### DIFF
--- a/test/sanity/code-smell/test-constraints.py
+++ b/test/sanity/code-smell/test-constraints.py
@@ -65,12 +65,6 @@ def main():
                     # keeping constraints for tests other than sanity tests in one file helps avoid conflicts
                     print('%s:%d:%d: put the constraint (%s%s) in `%s`' % (path, lineno, 1, name, raw_constraints, constraints_path))
 
-    for name, requirements in frozen_sanity.items():
-        if len(set(req[3].group('constraints').strip() for req in requirements)) != 1:
-            for req in requirements:
-                print('%s:%d:%d: sanity constraint (%s) does not match others for package `%s`' % (
-                    req[0], req[1], req[3].start('constraints') + 1, req[3].group('constraints'), name))
-
 
 def check_ansible_test(path: str, requirements: list[tuple[int, str, re.Match]]) -> None:
     sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.parent.joinpath('lib')))


### PR DESCRIPTION
##### SUMMARY

Each sanity test uses its own virtual environment, so there is no risk of conflicting requirements between tests.

It may still be a good idea to make an effort to keep frozen requirements in sync between tests.

Making it a hard requirement unnecessarily complicates updating individual tests and increases the risk of incorrect manual changes.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

test/sanity/code-smell/test-constraints.py
