### PR TITLE
[2.14] fix MANIFEST.json metadata when installing collections from dir/git repo

### DIFF
--- a/changelogs/fragments/ansible-galaxy-install-git-src-manifest.yml
+++ b/changelogs/fragments/ansible-galaxy-install-git-src-manifest.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - fix installing collections in git repositories/directories which contain a MANIFEST.json file (https://github.com/ansible/ansible/issues/79796).

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1570,6 +1570,7 @@ def install_src(collection, b_collection_path, b_collection_output_path, artifac
     if 'build_ignore' not in collection_meta:  # installed collection, not src
         # FIXME: optimize this? use a different process? copy instead of build?
         collection_meta['build_ignore'] = []
+        collection_meta['manifest'] = Sentinel
     collection_manifest = _build_manifest(**collection_meta)
     file_manifest = _build_files_manifest(
         b_collection_path,

--- a/test/integration/targets/ansible-galaxy-collection-scm/meta/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 dependencies:
 - setup_remote_tmp_dir
+- setup_gnutar

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/main.yml
@@ -30,6 +30,7 @@
   - include_tasks: ./download.yml
   - include_tasks: ./setup_collection_bad_version.yml
   - include_tasks: ./test_invalid_version.yml
+  - include_tasks: ./test_manifest_metadata.yml
 
   always:
 

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/test_manifest_metadata.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/test_manifest_metadata.yml
@@ -1,0 +1,55 @@
+- name: Test installing a collection from a git repo containing a MANIFEST.json
+  block:
+  - name: Create a temp directory for building the collection
+    file:
+      path: '{{ galaxy_dir }}/scratch'
+      state: directory
+
+  - name: Initialize a collection
+    command: 'ansible-galaxy collection init namespace_3.collection_1'
+    args:
+      chdir: '{{ galaxy_dir }}/scratch'
+
+  - name: Build the collection
+    command: 'ansible-galaxy collection build namespace_3/collection_1'
+    args:
+      chdir: '{{ galaxy_dir }}/scratch'
+
+  - name: Initialize git repository
+    command: 'git init {{ scm_path }}/namespace_3'
+
+  - name: Create the destination for the collection
+    file:
+      path: '{{ scm_path }}/namespace_3/collection_1'
+      state: directory
+
+  - name: Unarchive the collection in the git repo
+    unarchive:
+      dest: '{{ scm_path }}/namespace_3/collection_1'
+      src: '{{ galaxy_dir }}/scratch/namespace_3-collection_1-1.0.0.tar.gz'
+      remote_src: yes
+
+  - name: Commit the changes
+    shell: git add ./; git commit -m 'add collection'
+    args:
+      chdir: '{{ scm_path }}/namespace_3'
+
+  - name: Install the collection in the git repository
+    command: 'ansible-galaxy collection install git+file://{{ scm_path }}/namespace_3/.git'
+    register: result
+
+  - name: Assert the collection was installed successfully
+    assert:
+      that:
+        - '"namespace_3.collection_1:1.0.0 was installed successfully" in result.stdout_lines'
+
+  always:
+  - name: Clean up directories from test
+    file:
+      path: '{{ galaxy_dir }}/scratch'
+      state: absent
+    loop:
+    - '{{ galaxy_dir }}/scratch'
+    - '{{ scm_path }}/namespace_3'
+
+  - include_tasks: ./empty_installed_collections.yml


### PR DESCRIPTION
##### SUMMARY
Backport for #79808

This is just adding the new key from https://github.com/ansible/ansible/pull/78422 to the metadata sourced from the MANIFEST.json before the build step.

(cherry picked from commit 321848e98d9e565ee3f78c8c37ca879a8e3c55c1)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy collection install