### PR TITLE
ansible-playbook -K breaks when passwords have quotes

### DIFF
--- a/changelogs/fragments/79837-unquoting-only-when-origin-is-ini.yml
+++ b/changelogs/fragments/79837-unquoting-only-when-origin-is-ini.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-playbook -K breaks when passwords have quotes (https://github.com/ansible/ansible/issues/79836).

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -148,7 +148,7 @@ def ensure_type(value, value_type, origin=None):
             else:
                 errmsg = 'string'
 
-        elif value_type == 'string_literal':
+        elif value_type == 'raw':
             value = to_text(value, errors='surrogate_or_strict')
 
         # defaults to string type

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -148,6 +148,9 @@ def ensure_type(value, value_type, origin=None):
             else:
                 errmsg = 'string'
 
+        elif value_type == 'string_literal':
+            value = to_text(value, errors='surrogate_or_strict')
+
         # defaults to string type
         elif isinstance(value, (string_types, AnsibleVaultEncryptedUnicode)):
             value = unquote(to_text(value, errors='surrogate_or_strict'))

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -144,16 +144,17 @@ def ensure_type(value, value_type, origin=None):
 
         elif value_type in ('str', 'string'):
             if isinstance(value, (string_types, AnsibleVaultEncryptedUnicode, bool, int, float, complex)):
-                value = unquote(to_text(value, errors='surrogate_or_strict'))
+                value = to_text(value, errors='surrogate_or_strict')
+                if origin == 'ini':
+                    value = unquote(value)
             else:
                 errmsg = 'string'
 
-        elif value_type == 'raw':
-            value = to_text(value, errors='surrogate_or_strict')
-
         # defaults to string type
         elif isinstance(value, (string_types, AnsibleVaultEncryptedUnicode)):
-            value = unquote(to_text(value, errors='surrogate_or_strict'))
+            value = to_text(value, errors='surrogate_or_strict')
+            if origin == 'ini':
+                value = unquote(value)
 
         if errmsg:
             raise ValueError('Invalid type provided for "%s": %s' % (errmsg, to_native(value)))

--- a/lib/ansible/plugins/become/sudo.py
+++ b/lib/ansible/plugins/become/sudo.py
@@ -63,6 +63,7 @@ DOCUMENTATION = """
         become_pass:
             description: Password to pass to sudo
             required: False
+            type: string_literal
             vars:
               - name: ansible_become_password
               - name: ansible_become_pass

--- a/lib/ansible/plugins/become/sudo.py
+++ b/lib/ansible/plugins/become/sudo.py
@@ -63,7 +63,6 @@ DOCUMENTATION = """
         become_pass:
             description: Password to pass to sudo
             required: False
-            type: raw
             vars:
               - name: ansible_become_password
               - name: ansible_become_pass

--- a/lib/ansible/plugins/become/sudo.py
+++ b/lib/ansible/plugins/become/sudo.py
@@ -63,7 +63,7 @@ DOCUMENTATION = """
         become_pass:
             description: Password to pass to sudo
             required: False
-            type: string_literal
+            type: raw
             vars:
               - name: ansible_become_password
               - name: ansible_become_pass

--- a/test/units/config/test_manager.py
+++ b/test/units/config/test_manager.py
@@ -65,6 +65,14 @@ ensure_test_data = [
     ('None', 'none', type(None))
 ]
 
+ensure_unquoting_test_data = [
+    ('"value"', '"value"', 'str', 'env'),
+    ('"value"', '"value"', 'str', 'yaml'),
+    ('"value"', 'value', 'str', 'ini'),
+    ('\'value\'', 'value', 'str', 'ini'),
+    ('\'\'value\'\'', '\'value\'', 'str', 'ini'),
+    ('""value""', '"value"', 'str', 'ini')
+]
 
 class TestConfigManager:
     @classmethod
@@ -78,6 +86,11 @@ class TestConfigManager:
     @pytest.mark.parametrize("value, expected_type, python_type", ensure_test_data)
     def test_ensure_type(self, value, expected_type, python_type):
         assert isinstance(ensure_type(value, expected_type), python_type)
+
+    @pytest.mark.parametrize("value, expected_value, value_type, origin", ensure_unquoting_test_data)
+    def test_ensure_type_unquoting(self, value, expected_value, value_type, origin):
+        actual_value = ensure_type(value, value_type, origin)
+        assert actual_value == expected_value
 
     def test_resolve_path(self):
         assert os.path.join(curdir, 'test.yml') == resolve_path('./test.yml', cfg_file)

--- a/test/units/config/test_manager.py
+++ b/test/units/config/test_manager.py
@@ -74,6 +74,7 @@ ensure_unquoting_test_data = [
     ('""value""', '"value"', 'str', 'ini')
 ]
 
+
 class TestConfigManager:
     @classmethod
     def setup_class(cls):


### PR DESCRIPTION
##### SUMMARY
Fixes #79836 ("ansible-playbook -K breaks when passwords have quotes ")

ansible.config.manager.py ensure_type deliberately removes quotes from string and default value types, which causes sudo passwords starts and ends with quotes (" and ') to fail and needs double quoting. Since passwords are to be forwarded to sudo 'as is', I added a 'string_literal' type which does not remove quotes from the value. This enables passwords, like `"hello"` to go through sudo without issue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.config.manager
ansible.plugins.become.sudo 

##### ADDITIONAL INFORMATION
If my password is `"hello"` entering it as `'"hello"'` in the become prompt works, entering it plain does not work.
