### PR TITLE
Fix getting timeout for get mounts facts on Linux

### DIFF
--- a/changelogs/fragments/79844-fix-timeout-mounts-linux.yml
+++ b/changelogs/fragments/79844-fix-timeout-mounts-linux.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup gather_timeout - Fix timeout in get_mounts_facts for linux.

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -538,7 +538,7 @@ class LinuxHardware(Hardware):
         # start threads to query each mount
         results = {}
         pool = ThreadPool(processes=min(len(mtab_entries), cpu_count()))
-        maxtime = globals().get('GATHER_TIMEOUT') or timeout.DEFAULT_GATHER_TIMEOUT
+        maxtime = timeout.GATHER_TIMEOUT or timeout.DEFAULT_GATHER_TIMEOUT
         for fields in mtab_entries:
             # Transform octal escape sequences
             fields = [self._replace_octal_escapes(field) for field in fields]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

* Fix how to get the gather_timeout setting while getting the
mounts facts on Linux.

Fixes #79844

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
setup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

With this simple playbook:
```yaml
---
- hosts: all
  gather_facts: false
  tasks:
    - name: Test setup
      ansible.builtin.setup:
        gather_subset:
          - mounts
        gather_timeout: 600
```
The module argument ```gather_timeout``` is not used in the while getting the mounts facts on Linux.