### PR TITLE
Ansible.Basic.cs - Fix compile error on PS 7.3.x

### DIFF
--- a/changelogs/fragments/powershell-7.3-fix.yml
+++ b/changelogs/fragments/powershell-7.3-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Ansible.Basic.cs - Ignore compiler warning (reported as an error) when running under PowerShell 7.3.x.

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -16,6 +16,10 @@ using Newtonsoft.Json;
 using System.Web.Script.Serialization;
 #endif
 
+// Newtonsoft.Json may reference a different System.Runtime version (6.x) than loaded by PowerShell 7.3 (7.x).
+// Ignore CS1701 so the code can be compiled when warnings are reported as errors.
+//NoWarn -Name CS1701 -CLR Core
+
 // System.Diagnostics.EventLog.dll reference different versioned dlls that are
 // loaded in PSCore, ignore CS1702 so the code will ignore this warning
 //NoWarn -Name CS1702 -CLR Core


### PR DESCRIPTION
##### SUMMARY

Ansible.Basic.cs - Fix compile error on PS 7.3.x

This issue was discovered while trying to upgrade the base test container: https://github.com/ansible/ansible/pull/79846


##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/csharp/Ansible.Basic.cs

##### ADDITIONAL INFORMATION

The reported error is:

```
Line |
 247 |  …             throw [InvalidOperationException]"Failed to compile C# co …
     |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Failed to compile C# code:
error CS1701: Assuming assembly reference 'System.Runtime, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' used by 'Newtonsoft.Json' matches identity 'System.Runtime, Version=7.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' of 'System.Runtime', you may need to supply runtime policy
```

Which comes from: https://github.com/ansible/ansible/blob/10f0e5f6d4f1f65a02603c296ccf7fa0f7b48752/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.AddType.psm1#L247