### PR TITLE
[stable-2.12] Ansible.Basic.cs - Fix compile error on PS 7.3.x (#79848)

### DIFF
--- a/changelogs/fragments/powershell-7.3-fix.yml
+++ b/changelogs/fragments/powershell-7.3-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Ansible.Basic.cs - Ignore compiler warning (reported as an error) when running under PowerShell 7.3.x.

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -16,6 +16,10 @@ using Newtonsoft.Json;
 using System.Web.Script.Serialization;
 #endif
 
+// Newtonsoft.Json may reference a different System.Runtime version (6.x) than loaded by PowerShell 7.3 (7.x).
+// Ignore CS1701 so the code can be compiled when warnings are reported as errors.
+//NoWarn -Name CS1701 -CLR Core
+
 // System.Diagnostics.EventLog.dll reference different versioned dlls that are
 // loaded in PSCore, ignore CS1702 so the code will ignore this warning
 //NoWarn -Name CS1702 -CLR Core


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/79848

(cherry picked from commit 83fe75db07cb55dc2efeb437ce20b9d4462860c3)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/csharp/Ansible.Basic.cs