### PR TITLE
Add OAuth1 authentication to uri module

### DIFF
--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -220,9 +220,9 @@ options:
     description:
       - Use L(OAuth 1.0a,https://oauth.net/core/1.0a/) to perform the authentication.
       - Requires the Python library L(oauthlib,https://oauthlib.readthedocs.io/en/latest/installation.html) to be installed.
-      - A valid access token must be previously L(obtained,https://www.soapui.org/docs/oauth1/oauth1-overview/) by your consumer app.
       - If I(signature_method) is one of the RSA options, the library variant C(oauthlib[signedtoken]) is required.
-      - Other dictionary keys are necessary, depending on the I(signature_method) (see U(https://oauthlib.readthedocs.io/en/latest/oauth1/client.html)).
+      - A valid access token must be previously L(obtained,https://www.soapui.org/docs/oauth1/oauth1-overview/) by your consumer app.
+      - Other sub-options are required, depending on the I(signature_method) (see U(https://oauthlib.readthedocs.io/en/latest/oauth1/client.html)).
     type: dict
     default: {}
     version_added: '2.15'

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -463,6 +463,13 @@
     - PyOpenSSL
   when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
 
+
+- name: install oauthlib
+  pip:
+    name: "{{ item }}"
+  with_items:
+    - oauthlib[signedtoken]
+
 - name: validate the status_codes are correct
   uri:
     url: "https://{{ httpbin_host }}/status/202"

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -59,7 +59,7 @@ lib/ansible/modules/systemd_service.py validate-modules:parameter-invalid
 lib/ansible/modules/systemd_service.py validate-modules:return-syntax-error
 lib/ansible/modules/sysvinit.py validate-modules:return-syntax-error
 lib/ansible/modules/uri.py validate-modules:doc-required-mismatch
-# lib/ansible/modules/uri.py validate-modules:nonexistent-parameter-documented
+lib/ansible/modules/uri.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/user.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/user.py validate-modules:use-run-command-not-popen
 lib/ansible/modules/yum.py pylint:disallowed-name

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -59,6 +59,7 @@ lib/ansible/modules/systemd_service.py validate-modules:parameter-invalid
 lib/ansible/modules/systemd_service.py validate-modules:return-syntax-error
 lib/ansible/modules/sysvinit.py validate-modules:return-syntax-error
 lib/ansible/modules/uri.py validate-modules:doc-required-mismatch
+# lib/ansible/modules/uri.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/user.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/user.py validate-modules:use-run-command-not-popen
 lib/ansible/modules/yum.py pylint:disallowed-name


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since I have to access APIs protected by OAuth 1.0a, and I could not find any Ansible modules addressing that authentication method, I wrote a custom module starting from `ansible.builtin.uri`.
Then I thought that my contribution could help the main project.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
uri

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The additional feature requires the [oauthlib](https://oauthlib.readthedocs.io/en/latest/index.html) Python library, and does not break the other functions.
As stated in the documentation fragment, a valid OAuth access token must be previously [obtained](https://www.soapui.org/docs/oauth1/oauth1-overview/) by the consumer app.

Probably, it is also possible to add support for OAuth 2.0, since that is also supported by `oauthlib`.

I don't know how frequent my use case is, but OAuth is widely adopted on the web.
If you think this is helpful, I am happy to contribute.