### PR TITLE
[stable-2.14] Remove outdated note on relative imports in docs (#79873)

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_program_flow_modules.rst
@@ -341,12 +341,6 @@ Files that are included from :file:`module_utils` are themselves scanned for
 imports of other Python modules from :file:`module_utils` to be included in
 the zipfile as well.
 
-.. warning::
-    At present, the Ansiballz Framework cannot determine whether an import
-    should be included if it is a relative import. Always use an absolute
-    import that has :py:mod:`ansible.module_utils` in it to allow Ansiballz to
-    determine that the file should be included.
-
 
 .. _flow_passing_module_args:
 


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/79873

(cherry picked from commit 58461bc20408955a0efc37be8bce97efb387bcd5)

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

docs/docsite/rst/dev_guide/developing_program_flow_modules.rst