### PR TITLE
ansible-test - Update pylint to 2.16.0

### DIFF
--- a/test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/plugins/plugin_utils/check_pylint.py
+++ b/test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/plugins/plugin_utils/check_pylint.py
@@ -15,9 +15,4 @@ import string
 #   'Call' object has no attribute 'value'
 result = {None: None}[{}.get('something')]
 
-# pylint 2.3.1 and 2.4.4 report the following error but 2.5.0 and 2.6.0 do not
-#   blacklisted-name: Black listed name "foo"
-# see: https://github.com/PyCQA/pylint/issues/3701
-# regression: documented as a known issue and removed from ignore.txt so pylint can be upgraded to 2.6.0
-#             if future versions of pylint fix this issue then the ignore should be restored
 foo = {}.keys()

--- a/test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/sanity/ignore.txt
+++ b/test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/sanity/ignore.txt
@@ -1,6 +1,7 @@
 plugins/modules/bad.py import
 plugins/modules/bad.py pylint:ansible-bad-module-import
 plugins/lookup/bad.py import
+plugins/plugin_utils/check_pylint.py pylint:disallowed-name
 tests/integration/targets/hello/files/bad.py pylint:ansible-bad-function
 tests/integration/targets/hello/files/bad.py pylint:ansible-bad-import
 tests/integration/targets/hello/files/bad.py pylint:ansible-bad-import-from

--- a/test/integration/targets/module_utils/library/test.py
+++ b/test/integration/targets/module_utils/library/test.py
@@ -72,12 +72,12 @@ from ansible.module_utils.spam8.ham import eggs
 results['spam8'] = (bacon.data, eggs)
 
 # Test that import of module_utils/qux1/quux.py using as works
-from ansible.module_utils.qux1 import quux as one
-results['qux1'] = one.data
+from ansible.module_utils.qux1 import quux as two
+results['qux1'] = two.data
 
 # Test that importing qux2/quux.py and qux2/quuz.py using as works
-from ansible.module_utils.qux2 import quux as one, quuz as two
-results['qux2'] = (one.data, two.data)
+from ansible.module_utils.qux2 import quux as three, quuz as four
+results['qux2'] = (three.data, four.data)
 
 # Test depth
 from ansible.module_utils.a.b.c.d.e.f.g.h import data

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.in
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.in
@@ -1,2 +1,2 @@
-pylint == 2.15.10  # currently vetted version
+pylint == 2.16.0  # currently vetted version
 pyyaml  # needed for collection_detail.py

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
@@ -1,11 +1,11 @@
 # edit "sanity.pylint.in" and generate with: hacking/update-sanity-requirements.py --test pylint
-astroid==2.13.3
+astroid==2.14.1
 dill==0.3.6
-isort==5.11.4
+isort==5.12.0
 lazy-object-proxy==1.9.0
 mccabe==0.7.0
 platformdirs==2.6.2
-pylint==2.15.10
+pylint==2.16.0
 PyYAML==6.0
 tomli==2.0.1
 tomlkit==0.11.6

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test-target.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test-target.cfg
@@ -10,6 +10,7 @@ disable=
     raise-missing-from,  # Python 2.x does not support raise from
     super-with-arguments,  # Python 2.x does not support super without arguments
     redundant-u-string-prefix,  # Python 2.x support still required
+    broad-exception-raised,  # many exceptions with no need for a custom type
     too-few-public-methods,
     too-many-arguments,
     too-many-branches,
@@ -19,6 +20,7 @@ disable=
     too-many-nested-blocks,
     too-many-return-statements,
     too-many-statements,
+    use-dict-literal,  # ignoring as a common style issue
     useless-return,  # complains about returning None when the return type is optional
 
 [BASIC]

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test.cfg
@@ -8,6 +8,7 @@ disable=
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files
     import-outside-toplevel,  # common pattern in ansible related code
     raise-missing-from,  # Python 2.x does not support raise from
+    broad-exception-raised,  # many exceptions with no need for a custom type
     too-few-public-methods,
     too-many-public-methods,
     too-many-arguments,
@@ -18,6 +19,7 @@ disable=
     too-many-nested-blocks,
     too-many-return-statements,
     too-many-statements,
+    use-dict-literal,  # ignoring as a common style issue
     unspecified-encoding,  # always run with UTF-8 encoding enforced
     useless-return,  # complains about returning None when the return type is optional
 

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/code-smell.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/code-smell.cfg
@@ -17,6 +17,7 @@ disable=
     too-many-nested-blocks,
     too-many-return-statements,
     too-many-statements,
+    use-dict-literal,  # ignoring as a common style issue
     unspecified-encoding,  # always run with UTF-8 encoding enforced
     useless-return,  # complains about returning None when the return type is optional
 

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
@@ -9,7 +9,8 @@ disable=
     attribute-defined-outside-init,
     bad-indentation,
     bad-mcs-classmethod-argument,
-    broad-except,
+    broad-exception-caught,
+    broad-exception-raised,
     c-extension-no-member,
     cell-var-from-loop,
     chained-comparison,
@@ -113,7 +114,7 @@ disable=
     unused-import,
     unused-variable,
     unspecified-encoding,  # always run with UTF-8 encoding enforced
-    use-dict-literal,  # many occurrences
+    use-dict-literal,  # ignoring as a common style issue
     use-list-literal,  # many occurrences
     use-implicit-booleaness-not-comparison,  # many occurrences
     useless-object-inheritance,

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
@@ -10,7 +10,8 @@ disable=
     attribute-defined-outside-init,
     bad-indentation,
     bad-mcs-classmethod-argument,
-    broad-except,
+    broad-exception-caught,
+    broad-exception-raised,
     c-extension-no-member,
     cell-var-from-loop,
     chained-comparison,
@@ -108,7 +109,7 @@ disable=
     unused-import,
     unused-variable,
     unspecified-encoding,  # always run with UTF-8 encoding enforced
-    use-dict-literal,  # many occurrences
+    use-dict-literal,  # ignoring as a common style issue
     use-list-literal,  # many occurrences
     use-implicit-booleaness-not-comparison,  # many occurrences
     useless-object-inheritance,

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -129,6 +129,7 @@ lib/ansible/vars/hostvars.py pylint:disallowed-name
 test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/integration/targets/hello/files/bad.py pylint:ansible-bad-function # ignore, required for testing
 test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/integration/targets/hello/files/bad.py pylint:ansible-bad-import-from # ignore, required for testing
 test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/integration/targets/hello/files/bad.py pylint:ansible-bad-import # ignore, required for testing
+test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/plugins/plugin_utils/check_pylint.py pylint:disallowed-name # ignore, required for testing
 test/integration/targets/ansible-test-integration/ansible_collections/ns/col/plugins/modules/hello.py pylint:relative-beyond-top-level
 test/integration/targets/ansible-test-units/ansible_collections/ns/col/plugins/modules/hello.py pylint:relative-beyond-top-level
 test/integration/targets/ansible-test-units/ansible_collections/ns/col/tests/unit/plugins/modules/test_hello.py pylint:relative-beyond-top-level
@@ -192,6 +193,7 @@ test/support/network-integration/collections/ansible_collections/ansible/netcomm
 test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/netconf/default.py pylint:unnecessary-comprehension
 test/support/network-integration/collections/ansible_collections/cisco/ios/plugins/cliconf/ios.py pylint:arguments-renamed
 test/support/network-integration/collections/ansible_collections/cisco/ios/plugins/modules/ios_config.py pep8:E501
+test/support/network-integration/collections/ansible_collections/cisco/ios/plugins/modules/ios_config.py pylint:used-before-assignment
 test/support/network-integration/collections/ansible_collections/vyos/vyos/plugins/cliconf/vyos.py pylint:arguments-renamed
 test/support/network-integration/collections/ansible_collections/vyos/vyos/plugins/modules/vyos_command.py pep8:E231
 test/support/network-integration/collections/ansible_collections/vyos/vyos/plugins/modules/vyos_command.py pylint:disallowed-name


### PR DESCRIPTION
##### SUMMARY

ansible-test - Update pylint to 2.16.0.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

Omitting a changelog fragment, since this is a follow-up to https://github.com/ansible/ansible/pull/79819
