### PR TITLE
user - add parameter for password expiration warning days 

### DIFF
--- a/changelogs/fragments/user-add-password-exp-warning.yml
+++ b/changelogs/fragments/user-add-password-exp-warning.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - user - add new option ``password_expire_warn`` (supported on Linux only) to set the number of days of warning before a password change is required (https://github.com/ansible/ansible/issues/79882).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -257,7 +257,7 @@ options:
             - Number of days of warning before password expires.
             - Supported on Linux only.
         type: int
-        version_added: "2.15"
+        version_added: "2.16"
     umask:
         description:
             - Sets the umask of the user.

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -32,6 +32,7 @@
 - import_tasks: test_expires_new_account.yml
 - import_tasks: test_expires_new_account_epoch_negative.yml
 - import_tasks: test_expires_min_max.yml
+- import_tasks: test_expires_warn.yml
 - import_tasks: test_shadow_backup.yml
 - import_tasks: test_ssh_key_passphrase.yml
 - import_tasks: test_password_lock.yml

--- a/test/integration/targets/user/tasks/test_expires_warn.yml
+++ b/test/integration/targets/user/tasks/test_expires_warn.yml
@@ -1,0 +1,36 @@
+# https://github.com/ansible/ansible/issues/79882
+- name: Test setting warning days
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
+  block:
+    - name: create user
+      user:
+        name: ansibulluser
+        state: present
+
+    - name: add warning days for password
+      user:
+        name: ansibulluser
+        password_expire_warn: 28
+      register: pass_warn_1_0
+
+    - name: again add warning days for password
+      user:
+        name: ansibulluser
+        password_expire_warn: 28
+      register: pass_warn_1_1
+
+    - name: validate result for warning days
+      assert:
+        that:
+          - pass_warn_1_0 is changed
+          - pass_warn_1_1 is not changed
+
+    - name: Get shadow data for ansibulluser
+      getent:
+        database: shadow
+        key: ansibulluser
+
+    - name: Ensure number of warning days was set properly
+      assert:
+        that:
+          - ansible_facts.getent_shadow['ansibulluser'][4] == '28'


### PR DESCRIPTION
##### SUMMARY
This pull request adds a new parameter for the user module to set the warning days for password expiration.

##### ISSUE TYPE
- Feature Pull Request

Related to #79882

##### COMPONENT NAME
user

##### ADDITIONAL INFORMATION
Example usage:
```yaml
- name: Set number of warning days for password expiration
  ansible.builtin.user:
    name: jane157
    password_expire_warn: 30
```

Can be validated using `chage` command:
```sh
$ chage -l jane157
...
Number of days of warning before password expires	: 30
```
