### PR TITLE
fix core devel doc output

### DIFF
--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -10,9 +10,9 @@ jinja2
 pygments >= 2.10.0
 pyyaml
 rstcheck
-sphinx
 sphinx-notfound-page >= 0.6
 sphinx-intl
 sphinx-ansible-theme >= 0.9.1
+sphinx
 resolvelib
 straight.plugin # Needed for hacking/build-ansible.py which is the backend build script


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, the core devel docs have wide spaces between bullet items and TOCs etc.
Seems to be due to incompatible versions of sphinx. Changing the order in this PR seems to fix the problem

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
docs/docsite/requirements.txt
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
