### PR TITLE
Remove unused stdlib imports from module_utils

### DIFF
--- a/changelogs/fragments/unused-imports-module-utils-stdlib.yml
+++ b/changelogs/fragments/unused-imports-module-utils-stdlib.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >
+    Remove unused Python stdlib imports from module_utils which were not present for backwards compatibility in:
+    common.file, compat.selectors, facts.network.iscsi, facts.network.nvme, yumdnf

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -4,15 +4,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import errno
 import os
 import stat
 import re
-import pwd
-import grp
 import time
-import shutil
-import traceback
 import fcntl
 import sys
 

--- a/lib/ansible/module_utils/compat/selectors.py
+++ b/lib/ansible/module_utils/compat/selectors.py
@@ -35,7 +35,6 @@ _BUNDLED_METADATA = {"pypi_name": "selectors2", "version": "1.1.1", "version_con
 #   Fix use of OSError exception for py3 and use the wrapper of kqueue.control so retries of
 #   interrupted syscalls work with kqueue
 
-import os.path
 import sys
 import types
 

--- a/lib/ansible/module_utils/facts/network/iscsi.py
+++ b/lib/ansible/module_utils/facts/network/iscsi.py
@@ -19,7 +19,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import sys
-import subprocess
 
 import ansible.module_utils.compat.typing as t
 

--- a/lib/ansible/module_utils/facts/network/nvme.py
+++ b/lib/ansible/module_utils/facts/network/nvme.py
@@ -19,7 +19,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import sys
-import subprocess
 
 import ansible.module_utils.compat.typing as t
 

--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -15,7 +15,6 @@ __metaclass__ = type
 import os
 import time
 import glob
-import tempfile
 from abc import ABCMeta, abstractmethod
 
 from ansible.module_utils._text import to_native


### PR DESCRIPTION
##### SUMMARY

Remove unused Python stdlib imports from module_utils which were not present for backwards compatibility in:

- common.file
- compat.selectors
- facts.network.iscsi
- facts.network.nvme
- yumdnf

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

module_utils
