### PR TITLE
Remove unused internal imports from module_utils

### DIFF
--- a/changelogs/fragments/unused-imports-module-utils-internal.yml
+++ b/changelogs/fragments/unused-imports-module-utils-internal.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >
+    Remove unused internal imports from module_utils which were not present for backwards compatibility in:
+    common.file, common.parameters, facts.system.caps, yumdnf

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -17,8 +17,6 @@ import fcntl
 import sys
 
 from contextlib import contextmanager
-from ansible.module_utils._text import to_bytes, to_native, to_text
-from ansible.module_utils.six import b, binary_type
 from ansible.module_utils.common.warnings import deprecate
 
 try:

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -13,7 +13,6 @@ from itertools import chain
 
 from ansible.module_utils.common.collections import is_iterable
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
-from ansible.module_utils.common.text.formatters import lenient_lowercase
 from ansible.module_utils.common.warnings import warn
 from ansible.module_utils.errors import (
     AliasError,

--- a/lib/ansible/module_utils/facts/system/caps.py
+++ b/lib/ansible/module_utils/facts/system/caps.py
@@ -20,7 +20,6 @@ __metaclass__ = type
 
 import ansible.module_utils.compat.typing as t
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.facts.collector import BaseFactCollector
 
 

--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -18,7 +18,6 @@ import glob
 import tempfile
 from abc import ABCMeta, abstractmethod
 
-from ansible.module_utils._text import to_native
 from ansible.module_utils.six import with_metaclass
 
 yumdnf_argument_spec = dict(


### PR DESCRIPTION
##### SUMMARY

Remove unused internal imports from module_utils which were not present for backwards compatibility in:

- common.file
- common.parameters
- facts.system.caps
- yumdnf

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

module_utils
