### PR TITLE
ansible-test - Enable trailing-comma-tuple pylint rule

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-trailing-comma-tuple.yml
+++ b/changelogs/fragments/ansible-test-pylint-trailing-comma-tuple.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Enable the ``trailing-comma-tuple`` rule in the ``pylint`` sanity test.

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
@@ -96,8 +96,6 @@ disable=
     too-many-public-methods,
     too-many-return-statements,
     too-many-statements,
-    trailing-comma-tuple,
-    trailing-comma-tuple,
     try-except-raise,
     unbalanced-tuple-unpacking,
     undefined-loop-variable,

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
@@ -92,8 +92,6 @@ disable=
     too-many-public-methods,
     too-many-return-statements,
     too-many-statements,
-    trailing-comma-tuple,
-    trailing-comma-tuple,
     try-except-raise,
     unbalanced-tuple-unpacking,
     undefined-loop-variable,

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -102,6 +102,7 @@ lib/ansible/module_utils/six/__init__.py no-dict-iteritems
 lib/ansible/module_utils/six/__init__.py no-dict-iterkeys
 lib/ansible/module_utils/six/__init__.py no-dict-itervalues
 lib/ansible/module_utils/six/__init__.py pylint:self-assigning-variable
+lib/ansible/module_utils/six/__init__.py pylint:trailing-comma-tuple
 lib/ansible/module_utils/six/__init__.py replace-urlopen
 lib/ansible/module_utils/urls.py pylint:arguments-renamed
 lib/ansible/module_utils/urls.py pylint:disallowed-name


### PR DESCRIPTION
##### SUMMARY

ansible-test - Enable trailing-comma-tuple pylint rule.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test
