### PR TITLE
ansible-test - Enable unused-import pylint rule

### DIFF
--- a/changelogs/fragments/ansible-test-unused-import-collections.yml
+++ b/changelogs/fragments/ansible-test-unused-import-collections.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Enable the ``unused-import`` rule for the ``pylint`` sanity test for collections.

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
@@ -109,7 +109,6 @@ disable=
     unsupported-delete-operation,
     unsupported-membership-test,
     unused-argument,
-    unused-import,
     unused-variable,
     unspecified-encoding,  # always run with UTF-8 encoding enforced
     use-dict-literal,  # ignoring as a common style issue


### PR DESCRIPTION
##### SUMMARY

This was previously enabled for core. This change enables it for collections.

This is [scheduled](https://github.com/ansible-collections/news-for-maintainers/issues/34) to be merged on Monday, February 13th.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test