### PR TITLE
Update example to always init ANOTHER_LIBRARY_IMPORT_ERROR

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/import.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/import.rst
@@ -28,6 +28,7 @@ Instead of using ``import another_library``:
        ANOTHER_LIBRARY_IMPORT_ERROR = traceback.format_exc()
    else:
        HAS_ANOTHER_LIBRARY = True
+       ANOTHER_LIBRARY_IMPORT_ERROR = None
 
 .. note::
 


### PR DESCRIPTION
##### SUMMARY
Update example to always init ANOTHER_LIBRARY_IMPORT_ERROR
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guide/testing/sanity/import.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
