### PR TITLE
Fix typo, make sure docs include a warning, not a comment

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_collections_shared.rst
+++ b/docs/docsite/rst/dev_guide/developing_collections_shared.rst
@@ -78,7 +78,7 @@ You can use git repositories for collection dependencies during local developmen
 
    dependencies: {'git@github.com:organization/repo_name.git': 'devel'}
 
-.. warning
+.. warning::
 
    Do not use git repositories as dependencies for published collections. Dependencies for published collections must be other published collections.
 


### PR DESCRIPTION
##### SUMMARY
Adds `::` to make sure the warning text is parsed and presented as a warning. 

As noted in https://github.com/ansible/ansible/pull/75266#pullrequestreview-1284119393, this warning was being parsed as a comment.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
collections docs

##### ADDITIONAL INFORMATION
N/A
