### PR TITLE
Enable pylint rules to detect pointless statements

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,4 @@
 # .git-blame-ignore-revs
 # Bulk PowerShell sanity fixes
 6def4a3180fe03981ba64c6d8db28fed3bb39c0c
+716631189cb5a3f66b3add98f39e64e98bc17bf7

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
@@ -62,8 +62,6 @@ disable=
     not-a-mapping,
     not-an-iterable,
     not-callable,
-    pointless-statement,
-    pointless-string-statement,
     possibly-unused-variable,
     protected-access,
     raise-missing-from,  # Python 2.x does not support raise from

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -183,6 +183,8 @@ test/support/integration/plugins/module_utils/network/common/utils.py pylint:unu
 test/support/integration/plugins/modules/sefcontext.py pylint:unused-import
 test/support/integration/plugins/modules/zypper.py pylint:unused-import
 test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/utils.py pylint:unused-import
+test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/connection/network_cli.py pylint:pointless-string-statement
+test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/filter/ipaddr.py pylint:pointless-string-statement
 test/support/windows-integration/plugins/action/win_reboot.py pylint:unused-import
 test/support/integration/plugins/modules/timezone.py pylint:disallowed-name
 test/support/integration/plugins/module_utils/compat/ipaddress.py future-import-boilerplate


### PR DESCRIPTION
##### SUMMARY

Enable pylint rules to detect pointless statements.

Also instruct `git blame` to ignore the commit used to convert pointless strings to comments.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

core