### PR TITLE
optimize host_group_vars and vars plugin loading

### DIFF
--- a/changelogs/fragments/79945-host_group_vars-improvements.yml
+++ b/changelogs/fragments/79945-host_group_vars-improvements.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Cache host_group_vars after instantiating it once since it is stateless. Also limit the amount of repetitive work it needs to do every time it runs.
+  - Call PluginLoader.all() once for vars plugins, and load vars plugins that run automatically or are enabled specifically after that.

--- a/changelogs/fragments/79945-host_group_vars-improvements.yml
+++ b/changelogs/fragments/79945-host_group_vars-improvements.yml
@@ -1,3 +1,5 @@
-minor_changes:
-  - Cache host_group_vars after instantiating it once since it is stateless. Also limit the amount of repetitive work it needs to do every time it runs.
-  - Call PluginLoader.all() once for vars plugins, and load vars plugins that run automatically or are enabled specifically after that.
+bugfixes:
+  - Cache host_group_vars after instantiating it once and limit the amount of repetitive work it needs to do every time it runs.
+  - Call PluginLoader.all() once for vars plugins, and load vars plugins that run automatically or are enabled specifically by name subsequently.
+deprecated_features:
+  - Old style vars plugins which use the entrypoints `get_host_vars` or `get_group_vars` are deprecated. The plugin should be updated to inherit from `BaseVarsPlugin` and define a `get_vars` method as the entrypoint.

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -18,6 +18,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from collections.abc import Mapping, MutableMapping
+from enum import Enum
 from itertools import chain
 
 from ansible import constants as C
@@ -53,9 +54,14 @@ def to_safe_group_name(name, replacer="_", force=False, silent=False):
     return name
 
 
+class InventoryObjectType(Enum):
+    HOST = 0
+    GROUP = 0
+
+
 class Group:
     ''' a group of ansible hosts '''
-    base_type = 'Group'
+    base_type = InventoryObjectType.GROUP
 
     # __slots__ = [ 'name', 'hosts', 'vars', 'child_groups', 'parent_groups', 'depth', '_hosts_cache' ]
 

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -56,7 +56,7 @@ def to_safe_group_name(name, replacer="_", force=False, silent=False):
 
 class InventoryObjectType(Enum):
     HOST = 0
-    GROUP = 0
+    GROUP = 1
 
 
 class Group:

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -55,6 +55,7 @@ def to_safe_group_name(name, replacer="_", force=False, silent=False):
 
 class Group:
     ''' a group of ansible hosts '''
+    base_type = 'Group'
 
     # __slots__ = [ 'name', 'hosts', 'vars', 'child_groups', 'parent_groups', 'depth', '_hosts_cache' ]
 

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -21,7 +21,7 @@ __metaclass__ = type
 
 from collections.abc import Mapping, MutableMapping
 
-from ansible.inventory.group import Group
+from ansible.inventory.group import Group, InventoryObjectType
 from ansible.parsing.utils.addresses import patterns
 from ansible.utils.vars import combine_vars, get_unique_id
 
@@ -31,7 +31,7 @@ __all__ = ['Host']
 
 class Host:
     ''' a single ansible host '''
-    base_type = 'Host'
+    base_type = InventoryObjectType.HOST
 
     # __slots__ = [ 'name', 'vars', 'groups' ]
 

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -31,6 +31,7 @@ __all__ = ['Host']
 
 class Host:
     ''' a single ansible host '''
+    base_type = 'Host'
 
     # __slots__ = [ 'name', 'vars', 'groups' ]
 

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -149,3 +149,6 @@ class AnsibleJinja2Plugin(AnsiblePlugin):
     @property
     def j2_function(self):
         return self._function
+
+
+PLUGIN_INSTANCE_CACHE = {}  # type: dict[str, dict[str, AnsiblePlugin]]

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -149,6 +149,3 @@ class AnsibleJinja2Plugin(AnsiblePlugin):
     @property
     def j2_function(self):
         return self._function
-
-
-PLUGIN_INSTANCE_CACHE = {}  # type: dict[str, dict[str, AnsiblePlugin]]

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -872,12 +872,12 @@ class PluginLoader:
         if name in self.aliases:
             name = self.aliases[name]
 
-        if self._plugin_instance_cache is not None and name in self._plugin_instance_cache:
+        if self._plugin_instance_cache and (cached_load_result := self._plugin_instance_cache.get(name)):
             # Resolving the FQCN is slow, even if we've passed in the resolved FQCN.
             # Short-circuit here if we've previously resolved this name.
             # This will need to be restricted if non-vars plugins start using the cache, since
             # some non-fqcn plugin need to be resolved again with the collections list.
-            return get_with_context_result(*self._plugin_instance_cache[name])
+            return get_with_context_result(*cached_load_result)
 
         plugin_load_context = self.find_plugin_with_context(name, collection_list=collection_list)
         if not plugin_load_context.resolved or not plugin_load_context.plugin_resolved_path:
@@ -887,19 +887,19 @@ class PluginLoader:
         fq_name = plugin_load_context.resolved_fqcn
         if '.' not in fq_name and plugin_load_context.plugin_resolved_collection:
             fq_name = '.'.join((plugin_load_context.plugin_resolved_collection, fq_name))
-        name = plugin_load_context.plugin_resolved_name
+        resolved_type_name = plugin_load_context.plugin_resolved_name
         path = plugin_load_context.plugin_resolved_path
-        if self._plugin_instance_cache is not None and name in self._plugin_instance_cache:
+        if self._plugin_instance_cache and (cached_load_result := self._plugin_instance_cache.get(fq_name)):
             # This is unused by vars plugins, but it's here in case the instance cache expands to other plugin types.
             # We get here if we've seen this plugin before, but it wasn't called with the resolved FQCN.
-            return get_with_context_result(*self._plugin_instance_cache[name])
+            return get_with_context_result(*cached_load_result)
         redirected_names = plugin_load_context.redirect_list or []
 
         if path not in self._module_cache:
-            self._module_cache[path] = self._load_module_source(name, path)
+            self._module_cache[path] = self._load_module_source(resolved_type_name, path)
             found_in_cache = False
 
-        self._load_config_defs(name, self._module_cache[path], path)
+        self._load_config_defs(resolved_type_name, self._module_cache[path], path)
 
         obj = getattr(self._module_cache[path], self.class_name)
 
@@ -916,26 +916,27 @@ class PluginLoader:
                 return get_with_context_result(None, plugin_load_context)
 
         # FIXME: update this to use the load context
-        self._display_plugin_load(self.class_name, name, self._searched_paths, path, found_in_cache=found_in_cache, class_only=class_only)
+        self._display_plugin_load(self.class_name, resolved_type_name, self._searched_paths, path, found_in_cache=found_in_cache, class_only=class_only)
 
         if not class_only:
             try:
                 # A plugin may need to use its _load_name in __init__ (for example, to set
                 # or get options from config), so update the object before using the constructor
                 instance = object.__new__(obj)
-                self._update_object(instance, name, path, redirected_names, fq_name)
+                self._update_object(instance, resolved_type_name, path, redirected_names, fq_name)
                 obj.__init__(instance, *args, **kwargs)  # pylint: disable=unnecessary-dunder-call
                 obj = instance
             except TypeError as e:
                 if "abstract" in e.args[0]:
                     # Abstract Base Class or incomplete plugin, don't load
-                    display.v('Returning not found on "%s" as it has unimplemented abstract methods; %s' % (name, to_native(e)))
+                    display.v('Returning not found on "%s" as it has unimplemented abstract methods; %s' % (resolved_type_name, to_native(e)))
                     return get_with_context_result(None, plugin_load_context)
                 raise
 
-        self._update_object(obj, name, path, redirected_names, fq_name)
+        self._update_object(obj, resolved_type_name, path, redirected_names, fq_name)
         if self._plugin_instance_cache is not None and getattr(obj, 'is_stateless', False):
-            self._plugin_instance_cache[fq_name] = (obj, plugin_load_context)
+            # store under both the originally requested name and the resolved FQ name
+            self._plugin_instance_cache[name] = self._plugin_instance_cache[fq_name] = (obj, plugin_load_context)
         return get_with_context_result(obj, plugin_load_context)
 
     def _display_plugin_load(self, class_name, name, searched_paths, path, found_in_cache=None, class_only=None):

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -886,7 +886,7 @@ class PluginLoader:
         class_only = kwargs.pop('class_only', False)
 
         fq_name = plugin_load_context.resolved_fqcn
-        if '.' not in fq_name:
+        if '.' not in fq_name and plugin_load_context.plugin_resolved_collection:
             fq_name = '.'.join((plugin_load_context.plugin_resolved_collection, fq_name))
         name = plugin_load_context.plugin_resolved_name
         path = plugin_load_context.plugin_resolved_path
@@ -943,7 +943,7 @@ class PluginLoader:
             return None, found_in_cache
 
         plugin, plugin_load_context = self._plugin_instance_cache[plugin_path]
-        if not plugin.__class__.reuse_instance:
+        if not getattr(plugin.__class__, 'reuse_instance', False):
             plugin = vars_loader.get_from_context(plugin_load_context).object
         else:
             found_in_cache = True

--- a/lib/ansible/plugins/vars/__init__.py
+++ b/lib/ansible/plugins/vars/__init__.py
@@ -22,7 +22,11 @@ from ansible.plugins import AnsiblePlugin
 from ansible.utils.path import basedir
 from ansible.utils.display import Display
 
+import os
+
 display = Display()
+
+CANONICAL_PATHS = {}
 
 
 class BaseVarsPlugin(AnsiblePlugin):
@@ -38,4 +42,6 @@ class BaseVarsPlugin(AnsiblePlugin):
 
     def get_vars(self, loader, path, entities):
         """ Gets variables. """
-        self._basedir = basedir(path)
+        if path not in CANONICAL_PATHS:
+            CANONICAL_PATHS[path] = os.path.realpath(basedir(path))
+        self._basedir = CANONICAL_PATHS[path]

--- a/lib/ansible/plugins/vars/__init__.py
+++ b/lib/ansible/plugins/vars/__init__.py
@@ -30,7 +30,7 @@ class BaseVarsPlugin(AnsiblePlugin):
     """
     Loads variables for groups and/or hosts
     """
-    is_stateless = False
+    cache_instance = False
 
     def __init__(self):
         """ constructor """

--- a/lib/ansible/plugins/vars/__init__.py
+++ b/lib/ansible/plugins/vars/__init__.py
@@ -30,8 +30,7 @@ class BaseVarsPlugin(AnsiblePlugin):
     """
     Loads variables for groups and/or hosts
     """
-    # set to True on subclasses that don't need reinstantiation per invocation
-    reuse_instance = False
+    is_stateless = False
 
     def __init__(self):
         """ constructor """

--- a/lib/ansible/plugins/vars/__init__.py
+++ b/lib/ansible/plugins/vars/__init__.py
@@ -22,11 +22,7 @@ from ansible.plugins import AnsiblePlugin
 from ansible.utils.path import basedir
 from ansible.utils.display import Display
 
-import os
-
 display = Display()
-
-CANONICAL_PATHS = {}
 
 
 class BaseVarsPlugin(AnsiblePlugin):
@@ -34,6 +30,7 @@ class BaseVarsPlugin(AnsiblePlugin):
     """
     Loads variables for groups and/or hosts
     """
+    is_stateless = False
 
     def __init__(self):
         """ constructor """
@@ -42,6 +39,4 @@ class BaseVarsPlugin(AnsiblePlugin):
 
     def get_vars(self, loader, path, entities):
         """ Gets variables. """
-        if path not in CANONICAL_PATHS:
-            CANONICAL_PATHS[path] = os.path.realpath(basedir(path))
-        self._basedir = CANONICAL_PATHS[path]
+        self._basedir = basedir(path)

--- a/lib/ansible/plugins/vars/__init__.py
+++ b/lib/ansible/plugins/vars/__init__.py
@@ -30,7 +30,8 @@ class BaseVarsPlugin(AnsiblePlugin):
     """
     Loads variables for groups and/or hosts
     """
-    cache_instance = False
+    # set to True on subclasses that don't need reinstantiation per invocation
+    reuse_instance = False
 
     def __init__(self):
         """ constructor """

--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -78,7 +78,7 @@ def load_found_files(loader, data, found_files):
 class VarsModule(BaseVarsPlugin):
 
     REQUIRES_ENABLED = True
-    cache_instance = True
+    reuse_instance = True
 
     def get_vars(self, loader, path, entities, cache=True):
         ''' parses the inventory file '''

--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -138,7 +138,6 @@ class VarsModule(BaseVarsPlugin):
                     if os.path.isdir(opath):
                         self._display.debug("\tprocessing dir %s" % opath)
                         FOUND[key] = found_files = loader.find_vars_files(opath, entity_name)
-                        # FOUND[key] = found_files
                     elif not os.path.exists(opath):
                         # cache missing dirs so we don't have to keep looking for things beneath the
                         NAK.add(opath)

--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -78,7 +78,7 @@ def load_found_files(loader, data, found_files):
 class VarsModule(BaseVarsPlugin):
 
     REQUIRES_ENABLED = True
-    is_stateless = True
+    cache_instance = True
 
     def get_vars(self, loader, path, entities, cache=True):
         ''' parses the inventory file '''

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -109,6 +109,8 @@ def merge_hash(x, y, recursive=True, list_merge='replace'):
     #  except performance)
     if x == {} or x == y:
         return y.copy()
+    if y == {}:
+        return x
 
     # in the following we will copy elements from y to x, but
     # we don't want to modify x, so we create a copy of it

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -184,6 +184,9 @@ class VariableManager:
 
             See notes in the VarsWithSources docstring for caveats and limitations of the source tracking
             '''
+            if new_data == {}:
+                return data
+
             if C.DEFAULT_DEBUG:
                 # Populate var sources dict
                 for key in new_data:

--- a/lib/ansible/vars/plugins.py
+++ b/lib/ansible/vars/plugins.py
@@ -90,7 +90,7 @@ def _plugin_should_run(plugin, stage):
 
     try:
         allowed_stages = plugin.get_option('stage')
-    except AttributeError:
+    except (AttributeError, KeyError):
         pass
 
     if allowed_stages:

--- a/lib/ansible/vars/plugins.py
+++ b/lib/ansible/vars/plugins.py
@@ -50,6 +50,14 @@ def get_plugin_vars(loader, plugin, path, entities):
     try:
         data = plugin.get_vars(loader, path, entities)
     except AttributeError:
+        if hasattr(plugin, 'get_host_vars') or hasattr(plugin, 'get_group_vars'):
+            display.deprecated(
+                f"The vars plugin {plugin.ansible_name} from {plugin._original_path} is relying "
+                "on the deprecated entrypoints 'get_host_vars' and 'get_group_vars'. "
+                "This plugin should be updated to inherit from BaseVarsPlugin and define "
+                "a 'get_vars' method as the main entrypoint instead.",
+                version="2.20",
+            )
         try:
             for entity in entities:
                 if isinstance(entity, Host):

--- a/lib/ansible/vars/plugins.py
+++ b/lib/ansible/vars/plugins.py
@@ -39,13 +39,13 @@ def initialize_vars_plugin_caches():
         # (builtins should have REQUIRES_ENABLED=True)
         plugin_name = auto_run_plugin._load_name
         auto.append(plugin_name)
-        if auto_run_plugin.is_stateless:
+        if auto_run_plugin.cache_instance:
             cached_stateless_vars_plugins[plugin_name] = auto_run_plugin
 
     for enabled_plugin in C.VARIABLE_PLUGINS_ENABLED:
         plugin = vars_loader.get(enabled_plugin)
         enabled.append(enabled_plugin)
-        if plugin.is_stateless:
+        if plugin.cache_instance:
             cached_stateless_vars_plugins[enabled_plugin] = plugin
 
     global cached_vars_plugin_order

--- a/test/integration/targets/old_style_vars_plugins/deprecation_warning/v2_vars_plugin.py
+++ b/test/integration/targets/old_style_vars_plugins/deprecation_warning/v2_vars_plugin.py
@@ -1,0 +1,6 @@
+class VarsModule:
+    def get_host_vars(self, entity):
+        return {}
+
+    def get_group_vars(self, entity):
+        return {}

--- a/test/integration/targets/old_style_vars_plugins/deprecation_warning/vars.py
+++ b/test/integration/targets/old_style_vars_plugins/deprecation_warning/vars.py
@@ -2,7 +2,7 @@ from ansible.plugins.vars import BaseVarsPlugin
 
 
 class VarsModule(BaseVarsPlugin):
-    REQUIRES_WHITELIST = False
+    REQUIRES_WHITELIST = True
 
     def get_vars(self, loader, path, entities):
         return {}

--- a/test/integration/targets/old_style_vars_plugins/runme.sh
+++ b/test/integration/targets/old_style_vars_plugins/runme.sh
@@ -30,13 +30,16 @@ cat << EOF > "test_task_vars.yml"
   - debug:
 EOF
 
-verbose_result="$(ANSIBLE_DEBUG=True ansible-playbook test_task_vars.yml)"
-test "$(grep -c "Loading VarsModule 'host_group_vars'" <<< "$verbose_result")" == 1
-test "$(grep -c "Loading VarsModule 'require_enabled'" <<< "$verbose_result")" -gt 50
-test "$(grep -c "Loading VarsModule 'auto_enabled'" <<< "$verbose_result")" -gt 50
+# hide the debug noise by dumping to a file
+trap 'rm -rf -- "out.txt"' EXIT
+
+ANSIBLE_DEBUG=True ansible-playbook test_task_vars.yml > out.txt
+[ "$(grep -c "Loading VarsModule 'host_group_vars'" out.txt)" == 1 ]
+[ "$(grep -c "Loading VarsModule 'require_enabled'" out.txt)" -gt 50 ]
+[ "$(grep -c "Loading VarsModule 'auto_enabled'" out.txt)" -gt 50 ]
 
 export ANSIBLE_VARS_ENABLED=ansible.builtin.host_group_vars
-verbose_result="$(ANSIBLE_DEBUG=True ansible-playbook test_task_vars.yml)"
-test "$(grep -c "Loading VarsModule 'host_group_vars'" <<< "$verbose_result")" == 1
-test "$(grep -c "Loading VarsModule 'require_enabled'" <<< "$verbose_result")" == 1
-test "$(grep -c "Loading VarsModule 'auto_enabled'" <<< "$verbose_result")" -gt 50
+ANSIBLE_DEBUG=True ansible-playbook test_task_vars.yml > out.txt
+[ "$(grep -c "Loading VarsModule 'host_group_vars'" out.txt)" == 1 ]
+[ "$(grep -c "Loading VarsModule 'require_enabled'" out.txt)" == 1 ]
+[ "$(grep -c "Loading VarsModule 'auto_enabled'" out.txt)" -gt 50 ]

--- a/test/integration/targets/old_style_vars_plugins/runme.sh
+++ b/test/integration/targets/old_style_vars_plugins/runme.sh
@@ -17,7 +17,7 @@ export ANSIBLE_VARS_PLUGINS=./deprecation_warning
 WARNING_1="The VarsModule class variable 'REQUIRES_WHITELIST' is deprecated. Use 'REQUIRES_ENABLED' instead."
 WARNING_2="The vars plugin v2_vars_plugin .* is relying on the deprecated entrypoints 'get_host_vars' and 'get_group_vars'"
 ANSIBLE_DEPRECATION_WARNINGS=True ANSIBLE_NOCOLOR=True ANSIBLE_FORCE_COLOR=False \
-        ansible-inventory -i localhost, --list all 2> err.txt
+        ansible-inventory -i localhost, --list all "$@" 2> err.txt
 for WARNING in "$WARNING_1" "$WARNING_2"; do
 	ansible localhost -m debug -a "msg={{ lookup('file', 'err.txt') | regex_replace('\n', '') }}" | grep "$WARNING"
 done
@@ -37,12 +37,12 @@ EOF
 trap 'rm -rf -- "out.txt"' EXIT
 
 ANSIBLE_DEBUG=True ansible-playbook test_task_vars.yml > out.txt
-[ "$(grep -c "Loading VarsModule 'host_group_vars'" out.txt)" == 1 ]
+[ "$(grep -c "Loading VarsModule 'host_group_vars'" out.txt)" -eq 1 ]
 [ "$(grep -c "Loading VarsModule 'require_enabled'" out.txt)" -gt 50 ]
 [ "$(grep -c "Loading VarsModule 'auto_enabled'" out.txt)" -gt 50 ]
 
 export ANSIBLE_VARS_ENABLED=ansible.builtin.host_group_vars
 ANSIBLE_DEBUG=True ansible-playbook test_task_vars.yml > out.txt
-[ "$(grep -c "Loading VarsModule 'host_group_vars'" out.txt)" == 1 ]
-[ "$(grep -c "Loading VarsModule 'require_enabled'" out.txt)" == 1 ]
+[ "$(grep -c "Loading VarsModule 'host_group_vars'" out.txt)" -eq 1 ]
+[ "$(grep -c "Loading VarsModule 'require_enabled'" out.txt)" -lt 3 ]
 [ "$(grep -c "Loading VarsModule 'auto_enabled'" out.txt)" -gt 50 ]

--- a/test/integration/targets/old_style_vars_plugins/runme.sh
+++ b/test/integration/targets/old_style_vars_plugins/runme.sh
@@ -12,12 +12,15 @@ export ANSIBLE_VARS_PLUGINS=./vars_plugins
 export ANSIBLE_VARS_ENABLED=require_enabled
 [ "$(ansible-inventory -i localhost, --list --yaml all "$@" | grep -c 'require_enabled')" = "1" ]
 
-# Test the deprecated class attribute
+# Test deprecated features
 export ANSIBLE_VARS_PLUGINS=./deprecation_warning
-WARNING="The VarsModule class variable 'REQUIRES_WHITELIST' is deprecated. Use 'REQUIRES_ENABLED' instead."
+WARNING_1="The VarsModule class variable 'REQUIRES_WHITELIST' is deprecated. Use 'REQUIRES_ENABLED' instead."
+WARNING_2="The vars plugin v2_vars_plugin .* is relying on the deprecated entrypoints 'get_host_vars' and 'get_group_vars'"
 ANSIBLE_DEPRECATION_WARNINGS=True ANSIBLE_NOCOLOR=True ANSIBLE_FORCE_COLOR=False \
-	ansible-inventory -i localhost, --list all 2> err.txt
-ansible localhost -m debug -a "msg={{ lookup('file', 'err.txt') | regex_replace('\n', '') }}" | grep "$WARNING"
+        ansible-inventory -i localhost, --list all 2> err.txt
+for WARNING in "$WARNING_1" "$WARNING_2"; do
+	ansible localhost -m debug -a "msg={{ lookup('file', 'err.txt') | regex_replace('\n', '') }}" | grep "$WARNING"
+done
 
 # Test how many times vars plugins are loaded for a simple play containing a task
 # host_group_vars is stateless, so we can load it once and reuse it, every other vars plugin should be instantiated before it runs

--- a/test/integration/targets/old_style_vars_plugins/runme.sh
+++ b/test/integration/targets/old_style_vars_plugins/runme.sh
@@ -18,3 +18,25 @@ WARNING="The VarsModule class variable 'REQUIRES_WHITELIST' is deprecated. Use '
 ANSIBLE_DEPRECATION_WARNINGS=True ANSIBLE_NOCOLOR=True ANSIBLE_FORCE_COLOR=False \
 	ansible-inventory -i localhost, --list all 2> err.txt
 ansible localhost -m debug -a "msg={{ lookup('file', 'err.txt') | regex_replace('\n', '') }}" | grep "$WARNING"
+
+# Test how many times vars plugins are loaded for a simple play containing a task
+# host_group_vars is stateless, so we can load it once and reuse it, every other vars plugin should be instantiated before it runs
+cat << EOF > "test_task_vars.yml"
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - debug:
+EOF
+
+verbose_result="$(ANSIBLE_DEBUG=True ansible-playbook test_task_vars.yml)"
+test "$(grep -c "Loading VarsModule 'host_group_vars'" <<< "$verbose_result")" == 1
+test "$(grep -c "Loading VarsModule 'require_enabled'" <<< "$verbose_result")" -gt 50
+test "$(grep -c "Loading VarsModule 'auto_enabled'" <<< "$verbose_result")" -gt 50
+
+export ANSIBLE_VARS_ENABLED=ansible.builtin.host_group_vars
+verbose_result="$(ANSIBLE_DEBUG=True ansible-playbook test_task_vars.yml)"
+test "$(grep -c "Loading VarsModule 'host_group_vars'" <<< "$verbose_result")" == 1
+test "$(grep -c "Loading VarsModule 'require_enabled'" <<< "$verbose_result")" == 1
+test "$(grep -c "Loading VarsModule 'auto_enabled'" <<< "$verbose_result")" -gt 50


### PR DESCRIPTION
##### SUMMARY
A targeted fix for host_group_vars efficiency based on changes that were in #79687 and #78814.

Using this [inventory script](https://gist.github.com/nitzmahone/2348775c22c6a6f0c35b1cb0e56ed097):

On devel:
```
$ time ansible-inventory -i ./inv.py --list --output /dev/null

real	1m14.201s
user	1m2.573s
sys	0m10.875s
```

On https://github.com/ansible/ansible/pull/79687:
```
$ time ansible-inventory -i ./inv.py --list --output /dev/null

real	0m7.197s
user	0m6.407s
sys	0m0.765s
```

The latest on this branch:
```
$ time ansible-inventory -i ./inv.py --list --output /dev/null

real	0m9.758s
user	0m8.792s
sys	0m0.918s
```

<details>
<summary>If you use a profiler and look at the specific function (`get_vars_from_path`), on devel the function accounts for ~78% of the runtime (it's the yellow one).</summary>
<div>
    <img src="https://user-images.githubusercontent.com/19572925/217396990-14d823de-44cc-439d-ad65-4d123f90e915.png" alt="image">
</div>
</details>

<details>
<summary>On #79687 it accounts for ~37% of the runtime (it's green).</summary>
<div>
    <img src="https://user-images.githubusercontent.com/19572925/217397089-6ad16dd4-236f-4be5-82c0-508be388a59b.png" alt="image">
</div>
</details>

<details>
<summary>The latest version on this branch it accounts for ~14% (it's blue).</summary>
<div>
    <img src="https://user-images.githubusercontent.com/19572925/234350489-e994da2f-84af-4f1c-a4c1-11c879da6a4a.png" alt="image">
</div>
</details>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
vars plugins
