### PR TITLE
Add an integration test to ensure that defaults don't count towards mutually exclusive

### DIFF
--- a/test/integration/targets/argspec/library/argspec.py
+++ b/test/integration/targets/argspec/library/argspec.py
@@ -23,6 +23,10 @@ def main():
                 'type': 'str',
                 'choices': ['absent', 'present'],
             },
+            'default_value': {
+                'type': 'bool',
+                'default': True,
+            },
             'path': {},
             'content': {},
             'mapping': {
@@ -246,7 +250,7 @@ def main():
             ('state', 'present', ('path', 'content'), True),
         ),
         mutually_exclusive=(
-            ('path', 'content'),
+            ('path', 'content', 'default_value',),
         ),
         required_one_of=(
             ('required_one_of_one', 'required_one_of_two'),


### PR DESCRIPTION
##### SUMMARY

`mutually_exclusive` currently ignores values set by `defaults`.

Add a test to ensure any change to this behaviour is deliberate.

##### ISSUE TYPE

- Test Pull Request

##### COMPONENT NAME

test/integration/targets/argspec/library/argspec.py

##### ADDITIONAL INFORMATION

