### PR TITLE
Change ansible_job_id format

### DIFF
--- a/changelogs/fragments/fix_jinja_native_async.yml
+++ b/changelogs/fragments/fix_jinja_native_async.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "jinja2_native - fix intermittent 'could not find job' failures when a value of ``ansible_job_id`` from a result of an async task was inadvertently changed during execution; to prevent this a format of ``ansible_job_id`` was changed."

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -319,7 +319,7 @@ def _create_powershell_wrapper(b_module_data, module_path, module_args,
 
         exec_manifest["actions"].insert(0, 'async_watchdog')
         exec_manifest["actions"].insert(0, 'async_wrapper')
-        exec_manifest["async_jid"] = str(random.randint(0, 999999999999))
+        exec_manifest["async_jid"] = f'j{random.randint(0, 999999999999)}'
         exec_manifest["async_timeout_sec"] = async_timeout
         exec_manifest["async_startup_timeout"] = C.config.get_config_value("WIN_ASYNC_STARTUP_TIMEOUT", variables=task_vars)
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1125,7 +1125,7 @@ class ActionBase(ABC):
             remote_files.append(remote_async_module_path)
 
             async_limit = self._task.async_val
-            async_jid = str(random.randint(0, 999999999999))
+            async_jid = f'j{random.randint(0, 999999999999)}'
 
             # call the interpreter for async_wrapper directly
             # this permits use of a script for an interpreter on non-Linux platforms

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -122,7 +122,7 @@
 - name: assert task failed correctly
   assert:
     that:
-    - async_result.ansible_job_id is match('\d+\.\d+')
+    - async_result.ansible_job_id is match('j\d+\.\d+')
     - async_result.finished == 1
     - async_result is finished
     - async_result is not changed
@@ -140,7 +140,7 @@
 - name: validate response
   assert:
     that:
-    - async_result.ansible_job_id is match('\d+\.\d+')
+    - async_result.ansible_job_id is match('j\d+\.\d+')
     - async_result.finished == 1
     - async_result is finished
     - async_result.changed == false
@@ -159,7 +159,7 @@
 - name: validate response
   assert:
     that:
-    - async_result.ansible_job_id is match('\d+\.\d+')
+    - async_result.ansible_job_id is match('j\d+\.\d+')
     - async_result.finished == 1
     - async_result is finished
     - async_result.changed == true
@@ -176,7 +176,7 @@
 - name: validate response
   assert:
     that:
-    - async_result.ansible_job_id is match('\d+\.\d+')
+    - async_result.ansible_job_id is match('j\d+\.\d+')
     - async_result.finished == 1
     - async_result is finished
     - async_result.changed == true

--- a/test/integration/targets/async_fail/tasks/main.yml
+++ b/test/integration/targets/async_fail/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: validate that by the end of the retry interval, we succeeded
   assert:
     that:
-    - async_result.ansible_job_id is match('\d+\.\d+')
+    - async_result.ansible_job_id is match('j\d+\.\d+')
     - async_result.finished == 1
     - async_result is finished
     - async_result is changed

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -135,8 +135,8 @@ run_test default test.yml
 # Check for async output
 # NOTE: regex to match 1 or more digits works for both BSD and GNU grep
 ansible-playbook -i inventory test_async.yml 2>&1 | tee async_test.out
-grep "ASYNC OK .* jid=[0-9]\{1,\}" async_test.out
-grep "ASYNC FAILED .* jid=[0-9]\{1,\}" async_test.out
+grep "ASYNC OK .* jid=j[0-9]\{1,\}" async_test.out
+grep "ASYNC FAILED .* jid=j[0-9]\{1,\}" async_test.out
 rm -f async_test.out
 
 # Hide skipped

--- a/test/integration/targets/win_async_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_async_wrapper/tasks/main.yml
@@ -12,12 +12,12 @@
 - name: validate response
   assert:
     that:
-    - asyncresult.ansible_job_id is match('\d+\.\d+')
+    - asyncresult.ansible_job_id is match('j\d+\.\d+')
     - asyncresult.started == 1
     - asyncresult is started
     - asyncresult.finished == 0
     - asyncresult is not finished
-    - asyncresult.results_file is search('\.ansible_async.+\d+\.\d+')
+    - asyncresult.results_file is search('\.ansible_async.+j\d+\.\d+')
      # ensure that async is actually async- this test will fail if # hosts > forks or if the target host is VERY slow
     - (lookup('pipe', 'date +%s') | int) - (start_timestamp | int) < 15
 
@@ -31,7 +31,7 @@
 - name: validate response
   assert:
     that:
-    - asyncresult.ansible_job_id is match('\d+\.\d+')
+    - asyncresult.ansible_job_id is match('j\d+\.\d+')
     - asyncresult.finished == 1
     - asyncresult is finished
     - asyncresult is changed
@@ -69,7 +69,7 @@
 - name: validate response
   assert:
     that:
-    - asyncresult.ansible_job_id is match('\d+\.\d+')
+    - asyncresult.ansible_job_id is match('j\d+\.\d+')
     - asyncresult.finished == 1
     - asyncresult is finished
     - asyncresult is changed
@@ -107,7 +107,7 @@
 - name: validate response
   assert:
     that:
-    - asyncresult.ansible_job_id is match('\d+\.\d+')
+    - asyncresult.ansible_job_id is match('j\d+\.\d+')
     - asyncresult.finished == 1
     - asyncresult is finished
     - asyncresult is not changed
@@ -125,7 +125,7 @@
 - name: validate response
   assert:
     that:
-    - asyncresult.ansible_job_id is match('\d+\.\d+')
+    - asyncresult.ansible_job_id is match('j\d+\.\d+')
     - asyncresult.finished == 1
     - asyncresult is finished
     - asyncresult is changed
@@ -143,7 +143,7 @@
 - name: validate response
   assert:
     that:
-    - asyncresult.ansible_job_id is match('\d+\.\d+')
+    - asyncresult.ansible_job_id is match('j\d+\.\d+')
     - asyncresult.finished == 1
     - asyncresult is finished
     - asyncresult is not changed
@@ -231,7 +231,7 @@
 #    - item is finished
 #    - item.slept_sec == 3
 #    - item is changed
-#    - item.ansible_job_id is match('\d+\.\d+')
+#    - item.ansible_job_id is match('j\d+\.\d+')
 #  with_items: "{{ asyncout.results }}"
 
 # this part of the test is flaky- Windows PIDs are reused aggressively, so this occasionally fails due to a new process with the same ID


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
...to be something that does not resemble float or other type which value could be changed by literal_eval that jinja2_native uses.

Specifically the format of '%d.%d' is converted from str to float and then back to float which may result in truncating the number resulting in the job not being found because the job id does not exist.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/action/__init__.py`
`lib/ansible/executor/powershell/module_manifest.py`
