### PR TITLE
Replace deprecated stacked `@classmethod` and `@property`

### DIFF
--- a/changelogs/fragments/no-stacked-descriptors.yaml
+++ b/changelogs/fragments/no-stacked-descriptors.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- Playbook objects - Replace deprecated stacked ``@classmethod`` and ``@property``

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -70,12 +70,22 @@ def _validate_action_group_metadata(action, found_group_metadata, fq_group_name)
         display.warning(" ".join(metadata_warnings))
 
 
+class ClassProperty:
+    def __set_name__(self, owner, name):
+        self.name = name
+
+    def __get__(self, obj, objtype=None):
+        return getattr(objtype, f'_{self.name}')()
+
+
 class FieldAttributeBase:
 
-    @classmethod  # type: ignore[misc]
-    @property
-    def fattributes(cls):
-        return cls._fattributes()
+    fattributes = ClassProperty()
+
+    # @classmethod
+    # @property
+    # def fattributes(cls):
+    #     return cls._fattributes()
 
     # mypy complains with "misc: Decorated property not supported"
     # when @property and @cache are used together,

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -70,7 +70,7 @@ def _validate_action_group_metadata(action, found_group_metadata, fq_group_name)
         display.warning(" ".join(metadata_warnings))
 
 
-class ClassProperty:
+class _ClassProperty:
     def __set_name__(self, owner, name):
         self.name = name
 
@@ -80,16 +80,8 @@ class ClassProperty:
 
 class FieldAttributeBase:
 
-    fattributes = ClassProperty()
+    fattributes = _ClassProperty()
 
-    # @classmethod
-    # @property
-    # def fattributes(cls):
-    #     return cls._fattributes()
-
-    # mypy complains with "misc: Decorated property not supported"
-    # when @property and @cache are used together,
-    # split fattributes above into two methods
     @classmethod
     @cache
     def _fattributes(cls):


### PR DESCRIPTION
##### SUMMARY
Replace deprecated stacked `@classmethod` and `@property`

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/base.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
