### PR TITLE
galaxy artifact_manager: no not decompress artifact upon retrieval

### DIFF
--- a/changelogs/fragments/79958-galaxy-no-decompression.yml
+++ b/changelogs/fragments/79958-galaxy-no-decompression.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - concrete_artifact_manager - disables on-the-fly decompression of artifacts
+                                when downloading from a galaxy server to avoid
+                                checksum mismatches

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -463,6 +463,7 @@ def _download_file(url, b_path, expected_hash, validate_certs, token=None, timeo
         validate_certs=validate_certs,
         headers=None if token is None else token.headers(),
         unredirected_headers=['Authorization'], http_agent=user_agent(),
+        decompress=False,
         timeout=timeout
     )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This patch disables the on-the-fly decompression of collection artifacts. The decompression would lead to mismatching checksums.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-galaxy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

fixes #79957