### PR TITLE
Remove unneeded fallback code for nested defined/undefined tests

### DIFF
--- a/changelogs/fragments/remove-nested-defined-fallback-code.yml
+++ b/changelogs/fragments/remove-nested-defined-fallback-code.yml
@@ -1,0 +1,2 @@
+minor_chages:
+  - Remove fallback code for when ``defined``/``undefined`` tests were used on objects containing nested undefined variables; due to changes in lazy evalution of Jinja2 expressions it is no longer needed.

--- a/changelogs/fragments/remove-nested-defined-fallback-code.yml
+++ b/changelogs/fragments/remove-nested-defined-fallback-code.yml
@@ -1,2 +1,2 @@
-minor_chages:
+minor_changes:
   - Remove fallback code for when ``defined``/``undefined`` tests were used on objects containing nested undefined variables; due to changes in lazy evalution of Jinja2 expressions it is no longer needed.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The code used to handle defined/undefined tests on objects containing nested undefined variables. Due to changes in lazy evalution of Jinja2 expressions it is no longer needed, see #56116.

ci_complete
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/playbook/conditional.py`