### PR TITLE
[2.14] don't ignore templated _raw_params that k=v parser failed to parse (#79913)

### DIFF
--- a/changelogs/fragments/79862-fix-varargs.yml
+++ b/changelogs/fragments/79862-fix-varargs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- TaskExecutor - don't ignore templated _raw_params that k=v parser failed to parse (https://github.com/ansible/ansible/issues/79862)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -515,6 +515,10 @@ class TaskExecutor:
                                     "(see https://docs.ansible.com/ansible/devel/reference_appendices/faq.html#argsplat-unsafe)")
                 variable_params.update(self._task.args)
                 self._task.args = variable_params
+            else:
+                # if we didn't get a dict, it means there's garbage remaining after k=v parsing, just give up
+                # see https://github.com/ansible/ansible/issues/79862
+                raise AnsibleError(f"invalid or malformed argument: '{variable_params}'")
 
         # update no_log to task value, now that we have it templated
         no_log = self._task.no_log

--- a/test/integration/targets/tasks/playbook.yml
+++ b/test/integration/targets/tasks/playbook.yml
@@ -1,0 +1,24 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    # make sure tasks with an undefined variable in the name are gracefully handled
+    - name: "Task name with undefined variable: {{ not_defined }}"
+      debug:
+        msg: Hello
+
+    # ensure we properly test for an action name, not a task name when cheking for a meta task
+    - name: "meta"
+      debug:
+        msg: Hello
+
+    - name: ensure malformed raw_params on arbitrary actions are not ignored
+      debug:
+        garbage {{"with a template"}}
+      ignore_errors: true
+      register: bad_templated_raw_param
+
+    - assert:
+        that:
+        - bad_templated_raw_param is failed
+        - |
+          "invalid or malformed argument: 'garbage with a template'" in bad_templated_raw_param.msg

--- a/test/integration/targets/tasks/playbook.yml
+++ b/test/integration/targets/tasks/playbook.yml
@@ -6,11 +6,6 @@
       debug:
         msg: Hello
 
-    # ensure we properly test for an action name, not a task name when cheking for a meta task
-    - name: "meta"
-      debug:
-        msg: Hello
-
     - name: ensure malformed raw_params on arbitrary actions are not ignored
       debug:
         garbage {{"with a template"}}

--- a/test/integration/targets/tasks/runme.sh
+++ b/test/integration/targets/tasks/runme.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ansible-playbook playbook.yml "$@"

--- a/test/integration/targets/tasks/tasks/main.yml
+++ b/test/integration/targets/tasks/tasks/main.yml
@@ -1,4 +1,0 @@
-# make sure tasks with an undefined variable in the name are gracefully handled
-- name: "Task name with undefined variable: {{ not_defined }}"
-  debug:
-    msg: Hello


### PR DESCRIPTION
##### SUMMARY
backport of #79913 

    don't ignore templated _raw_params that k=v parser failed to parse (#79913)
    
    fixes #79862
    
    (cherry picked from commit e1d298ed61eed9250752fbd25ac8eae4944ec1bf)


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
TaskExecutor

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
