### PR TITLE
[stable-2.13] ansible-test - fix warning to include image name (#79560)

### DIFF
--- a/changelogs/fragments/ansible-test-fix-warning-msg.yml
+++ b/changelogs/fragments/ansible-test-fix-warning-msg.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - fix warning message about failing to run an image to include the image name

--- a/test/lib/ansible_test/_internal/containers.py
+++ b/test/lib/ansible_test/_internal/containers.py
@@ -262,7 +262,7 @@ def run_container(
                 stdout = docker_run(args, image, options, cmd)[0]
         except SubprocessError as ex:
             display.error(ex.message)
-            display.warning('Failed to run docker image "{image}". Waiting a few seconds before trying again.')
+            display.warning(f'Failed to run docker image "{image}". Waiting a few seconds before trying again.')
             docker_rm(args, name)  # podman doesn't remove containers after create if run fails
             time.sleep(3)
         else:


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/79560

(cherry picked from commit 0a12d8a5bc820e5d12805af41b80351d0b635e63)

Co-authored-by: Martin Krizek <martin.krizek@gmail.com>

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test