### PR TITLE
user - fix comparing existing group names to group IDs

### DIFF
--- a/changelogs/fragments/79981-user-fix-groups-comparison.yml
+++ b/changelogs/fragments/79981-user-fix-groups-comparison.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - fix comparing group IDs to existing group names so groups are not always updated (https://github.com/ansible/ansible/issues/79956).

--- a/test/integration/targets/user/tasks/test_local.yml
+++ b/test/integration/targets/user/tasks/test_local.yml
@@ -86,9 +86,11 @@
     - testgroup3
     - testgroup4
     - testgroup5
+    - testgroup6
     - local_ansibulluser
   tags:
     - user_test_local_mode
+  register: test_groups
 
 - name: Create local_ansibulluser with groups
   user:
@@ -113,6 +115,18 @@
   tags:
     - user_test_local_mode
 
+- name: Append groups for local_ansibulluser (again)
+  user:
+    name: local_ansibulluser
+    state: present
+    local: yes
+    groups: ['testgroup3', 'testgroup4']
+    append: yes
+  register: local_user_test_4_again
+  ignore_errors: yes
+  tags:
+    - user_test_local_mode
+
 - name: Test append without groups for local_ansibulluser
   user:
     name: local_ansibulluser
@@ -130,6 +144,28 @@
     local: yes
     group: testgroup5
   register: local_user_test_6
+  tags:
+    - user_test_local_mode
+
+- name: Append groups for local_ansibulluser using group id
+  user:
+    name: local_ansibulluser
+    state: present
+    append: yes
+    groups: "{{ test_groups.results[5]['gid'] }}"
+  register: local_user_test_7
+  ignore_errors: yes
+  tags:
+    - user_test_local_mode
+
+- name: Append groups for local_ansibulluser using gid (again)
+  user:
+    name: local_ansibulluser
+    state: present
+    append: yes
+    groups: "{{ test_groups.results[5]['gid'] }}"
+  register: local_user_test_7_again
+  ignore_errors: yes
   tags:
     - user_test_local_mode
 
@@ -164,6 +200,7 @@
     - testgroup3
     - testgroup4
     - testgroup5
+    - testgroup6
     - local_ansibulluser
   tags:
     - user_test_local_mode
@@ -175,7 +212,10 @@
       - local_user_test_2 is not changed
       - local_user_test_3 is changed
       - local_user_test_4 is changed
+      - local_user_test_4_again is not changed
       - local_user_test_6 is changed
+      - local_user_test_7 is changed
+      - local_user_test_7_again is not changed
       - local_user_test_remove_1 is changed
       - local_user_test_remove_2 is not changed
   tags:


### PR DESCRIPTION
##### SUMMARY
Fixes #79956

`User().user_group_membership()` returns group names which are compared with the result from `User().get_groups_set()` which can return names or IDs. I added a new parameter to just return group names.

DarwinUser didn't allow group IDs for group modification, so also fixed that by using `get_groups_set` there as well.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
user module
