### PR TITLE
ansible-test - Remove auto format pylint rule

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-string-format.yml
+++ b/changelogs/fragments/ansible-test-pylint-string-format.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - Removed the ``ansible-format-automatic-specification`` rule from the ``pylint`` sanity test,
+                   now that Python 2.6 is no longer supported.

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/string_format.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/string_format.py
@@ -9,19 +9,8 @@ from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
 from pylint.checkers import utils
 from pylint.checkers.utils import check_messages
-try:
-    from pylint.checkers.utils import parse_format_method_string
-except ImportError:
-    # noinspection PyUnresolvedReferences
-    from pylint.checkers.strings import parse_format_method_string
 
 MSGS = {
-    'E9305': ("Format string contains automatic field numbering "
-              "specification",
-              "ansible-format-automatic-specification",
-              "Used when a PEP 3101 format string contains automatic "
-              "field numbering (e.g. '{}').",
-              {'minversion': (2, 6)}),
     'E9390': ("bytes object has no .format attribute",
               "ansible-no-format-on-bytestring",
               "Used when a bytestring was used as a PEP 3101 format string "
@@ -63,20 +52,6 @@ class AnsibleStringFormatChecker(BaseChecker):
 
         if isinstance(strnode.value, bytes):
             self.add_message('ansible-no-format-on-bytestring', node=node)
-            return
-        if not isinstance(strnode.value, str):
-            return
-
-        if node.starargs or node.kwargs:
-            return
-        try:
-            num_args = parse_format_method_string(strnode.value)[1]
-        except utils.IncompleteFormatString:
-            return
-
-        if num_args:
-            self.add_message('ansible-format-automatic-specification',
-                             node=node)
             return
 
 

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -80,7 +80,6 @@ lib/ansible/module_utils/distro/_distro.py future-import-boilerplate # ignore bu
 lib/ansible/module_utils/distro/_distro.py metaclass-boilerplate # ignore bundled
 lib/ansible/module_utils/distro/_distro.py no-assert
 lib/ansible/module_utils/distro/_distro.py pep8!skip # bundled code we don't want to modify
-lib/ansible/module_utils/distro/_distro.py pylint:ansible-format-automatic-specification # ignore bundled
 lib/ansible/module_utils/distro/_distro.py pylint:undefined-variable # ignore bundled
 lib/ansible/module_utils/distro/_distro.py pylint:using-constant-test # bundled code we don't want to modify
 lib/ansible/module_utils/distro/__init__.py empty-init # breaks namespacing, bundled, do not override


### PR DESCRIPTION
##### SUMMARY

Removed the ``ansible-format-automatic-specification`` rule from the ``pylint`` sanity test, now that Python 2.6 is no longer supported.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
