### PR TITLE
Correct and illustrate both "mode" types

### DIFF
--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -160,7 +160,7 @@ EXAMPLES = r'''
     dest: /etc/foo.conf
     owner: foo
     group: foo
-    mode: '0644'
+    mode: 0644
 
 - name: Copy file with owner and permission, using symbolic representation
   ansible.builtin.copy:
@@ -184,7 +184,7 @@ EXAMPLES = r'''
     dest: /etc/ntp.conf
     owner: root
     group: root
-    mode: '0644'
+    mode: '644'
     backup: yes
 
 - name: Copy a new "sudoers" file into place, after passing validation with visudo


### PR DESCRIPTION
##### SUMMARY
Make "mode" examples consistent with the second bullet point under "description". A mode should EITHER have a leading 0, or be quoted without the leading 0 at the front. While technically valid, '0644' is confusing and does not follow either guideline properly.


##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
