### PR TITLE
fixes typo in Ansible 7 roadmap

### DIFF
--- a/docs/docsite/rst/roadmap/COLLECTIONS_7.rst
+++ b/docs/docsite/rst/roadmap/COLLECTIONS_7.rst
@@ -46,7 +46,7 @@ Release schedule
 Ansible minor releases
 =======================
 
-Ansible 7.x minor releases will occur approximately every four weeks if changes to collections have been made or to align to a later ansible-core-2.14.x.  Ansible 7.x minor releases may contain new features but not backwards incompatibilities.  In practice, this means we will include new collection versions where either the patch or the minor version number has changed but not when the major number has changed. For example, if Ansible-7.0.0 ships with community.crypto 2.3.0; Ansible-6.1.0 may ship with community.crypto 2.4.0 but would not ship with community.crypto 3.0.0.
+Ansible 7.x minor releases will occur approximately every four weeks if changes to collections have been made or to align to a later ansible-core-2.14.x.  Ansible 7.x minor releases may contain new features but not backwards incompatibilities.  In practice, this means we will include new collection versions where either the patch or the minor version number has changed but not when the major number has changed. For example, if Ansible-7.0.0 ships with community.crypto 2.3.0; Ansible-7.1.0 may ship with community.crypto 2.4.0 but would not ship with community.crypto 3.0.0.
 
 
 .. note::


### PR DESCRIPTION
##### SUMMARY
Following up on https://github.com/ansible/ansible/pull/79598/commits/1e2ff6bec0dadf073703f5007ec039a2f555bdc6.

The Ansible 8 roadmap was copied from the Ansible 7 roadmap, which had a typo in it (an instance of Ansible 6.x was not changed). The commit above corrected the typo in the Ansible 8 roadmap.

This PR corrects the typo in the Ansible 7 roadmap. Ideally it would be backported as well.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Roadmaps.

##### ADDITIONAL INFORMATION
N/A
