### PR TITLE
ansible-test - Improve pylint backwards compat

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-string-format.yml
+++ b/changelogs/fragments/ansible-test-pylint-string-format.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - ansible-test - Removed the ``ansible-format-automatic-specification`` rule from the ``pylint`` sanity test,
+  - ansible-test - Disabled the ``ansible-format-automatic-specification`` rule from the ``pylint`` sanity test,
                    now that Python 2.6 is no longer supported.

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/string_format.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/string_format.py
@@ -11,6 +11,9 @@ from pylint.checkers import utils
 from pylint.checkers.utils import check_messages
 
 MSGS = {
+    'E9305': ("disabled",  # kept for backwards compatibility with inline ignores, remove after 2.14 is EOL
+              "ansible-format-automatic-specification",
+              "disabled"),
     'E9390': ("bytes object has no .format attribute",
               "ansible-no-format-on-bytestring",
               "Used when a bytestring was used as a PEP 3101 format string "


### PR DESCRIPTION
##### SUMMARY

ansible-test - Improve pylint backwards compat for collections which still use inline ignores for the `ansible-format-automatic-specification` pylint rule.

This is a follow-up to https://github.com/ansible/ansible/pull/79985

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
