### PR TITLE
Disable F37 podman tests for ansible-test

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -124,8 +124,6 @@ stages:
           targets:
             - name: Alpine 3.17
               test: alpine/3.17
-            - name: Fedora 37
-              test: fedora/37
             - name: RHEL 8.7
               test: rhel/8.7
             - name: RHEL 9.1


### PR DESCRIPTION
##### SUMMARY

The recent update from podman 4.3.1 to 4.4.1 has broken container management. Removing the tests from the CI matrix until the issue is resolved.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

.azure-pipelines/azure-pipelines.yml
