### PR TITLE
Fix macos defaults

### DIFF
--- a/changelogs/fragments/79999-ansible-user-tweak-macos-defaults.yaml
+++ b/changelogs/fragments/79999-ansible-user-tweak-macos-defaults.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - 'ansible_user_module - tweaked macos user defaults to reflect expected defaults (https://github.com/ansible/ansible/issues/44316)'

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -2377,7 +2377,7 @@ class DarwinUser(User):
         if self.password:
             cmd += ['-passwd', '/Users/%s' % self.name, self.password]
         else:
-            cmd += ['-create', '/Users/%s' % self.name, 'Password', '*']
+            cmd += ['-passwd', '/Users/%s' % self.name, '']
         (rc, out, err) = self.execute_command(cmd)
         if rc != 0:
             self.module.fail_json(msg='Error when changing password', err=err, out=out, rc=rc)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -2524,7 +2524,7 @@ class DarwinUser(User):
         self._make_group_numerical()
         if self.uid is None:
             self.uid = str(self._get_next_uid(self.system))
-        
+
         # Homedir is not created by default
         if self.create_home:
             if self.home is None:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -2513,10 +2513,18 @@ class DarwinUser(User):
         if rc != 0:
             self.module.fail_json(msg='Cannot create user "%s".' % self.name, err=err, out=out, rc=rc)
 
+        # Make the Gecos (alias display name) default to username
+        if self.comment is None:
+            self.comment = self.name
+
+        # Make user group default to 'staff'
+        if self.group is None:
+            self.group = 'staff'
+
         self._make_group_numerical()
         if self.uid is None:
             self.uid = str(self._get_next_uid(self.system))
-
+        
         # Homedir is not created by default
         if self.create_home:
             if self.home is None:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -2377,7 +2377,7 @@ class DarwinUser(User):
         if self.password:
             cmd += ['-passwd', '/Users/%s' % self.name, self.password]
         else:
-            cmd += ['-passwd', '/Users/%s' % self.name, '']
+            cmd += ['-create', '/Users/%s' % self.name, 'Password', '*']
         (rc, out, err) = self.execute_command(cmd)
         if rc != 0:
             self.module.fail_json(msg='Error when changing password', err=err, out=out, rc=rc)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -28,6 +28,7 @@ options:
     comment:
         description:
             - Optionally sets the description (aka I(GECOS)) of user account.
+            - On macOS, this defaults to the O(username) option.
         type: str
     hidden:
         description:
@@ -49,6 +50,7 @@ options:
     group:
         description:
             - Optionally sets the user's primary group (takes a group name).
+            - On macOS, this defaults to V('staff')
         type: str
     groups:
         description:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -28,7 +28,7 @@ options:
     comment:
         description:
             - Optionally sets the description (aka I(GECOS)) of user account.
-            - On macOS, this defaults to the O(username) option.
+            - On macOS, this defaults to the O(name) option.
         type: str
     hidden:
         description:

--- a/test/integration/targets/user/tasks/test_create_user.yml
+++ b/test/integration/targets/user/tasks/test_create_user.yml
@@ -36,10 +36,10 @@
 
 - name: run existing user check tests
   user:
-    name: "{{ user_names.stdout_lines | random }}"
+    name: '{{ user_names.stdout_lines | random }}'
     state: present
     create_home: no
-  loop: "{{ range(1, 5+1) | list }}"
+  loop: '{{ range(1, 5+1) | list }}'
   register: user_test1
 
 - debug:
@@ -55,11 +55,11 @@
 - name: validate changed results for testcase 1
   assert:
     that:
-      - "user_test1.results[0] is not changed"
-      - "user_test1.results[1] is not changed"
-      - "user_test1.results[2] is not changed"
-      - "user_test1.results[3] is not changed"
-      - "user_test1.results[4] is not changed"
+      - 'user_test1.results[0] is not changed'
+      - 'user_test1.results[1] is not changed'
+      - 'user_test1.results[2] is not changed'
+      - 'user_test1.results[3] is not changed'
+      - 'user_test1.results[4] is not changed'
       - "user_test1.results[0]['state'] == 'present'"
       - "user_test1.results[1]['state'] == 'present'"
       - "user_test1.results[2]['state'] == 'present'"
@@ -70,10 +70,6 @@
   when: ansible_facts.system == 'Darwin'
   command: dscl . -read /Users/ansibulluser
   register: user_test2
-
-- debug:
-    var: user_test2
-    verbosity: 2
 
 - name: validate user defaults for MacOS
   when: ansible_facts.system == 'Darwin'

--- a/test/integration/targets/user/tasks/test_create_user.yml
+++ b/test/integration/targets/user/tasks/test_create_user.yml
@@ -36,10 +36,10 @@
 
 - name: run existing user check tests
   user:
-    name: "{{ user_names.stdout_lines | random }}"
+    name: '{{ user_names.stdout_lines | random }}'
     state: present
     create_home: no
-  loop: "{{ range(1, 5+1) | list }}"
+  loop: '{{ range(1, 5+1) | list }}'
   register: user_test1
 
 - debug:
@@ -55,13 +55,29 @@
 - name: validate changed results for testcase 1
   assert:
     that:
-      - "user_test1.results[0] is not changed"
-      - "user_test1.results[1] is not changed"
-      - "user_test1.results[2] is not changed"
-      - "user_test1.results[3] is not changed"
-      - "user_test1.results[4] is not changed"
+      - 'user_test1.results[0] is not changed'
+      - 'user_test1.results[1] is not changed'
+      - 'user_test1.results[2] is not changed'
+      - 'user_test1.results[3] is not changed'
+      - 'user_test1.results[4] is not changed'
       - "user_test1.results[0]['state'] == 'present'"
       - "user_test1.results[1]['state'] == 'present'"
       - "user_test1.results[2]['state'] == 'present'"
       - "user_test1.results[3]['state'] == 'present'"
       - "user_test1.results[4]['state'] == 'present'"
+
+- name: register user informations
+  when: ansible_facts.system == 'Darwin'
+  command: dscl . -read /Users/ansibulluser
+  register: user_test2
+
+- debug:
+    var: user_test2
+    verbosity: 2
+
+- name: validate user defaults for MacOS
+  when: ansible_facts.system == 'Darwin'
+  assert:
+    that:
+      - "'RealName: ansibulluser' in user_test2.stdout_lines "
+      - "'PrimaryGroupID: 20' in user_test2.stdout_lines "

--- a/test/integration/targets/user/tasks/test_create_user.yml
+++ b/test/integration/targets/user/tasks/test_create_user.yml
@@ -36,10 +36,10 @@
 
 - name: run existing user check tests
   user:
-    name: '{{ user_names.stdout_lines | random }}'
+    name: "{{ user_names.stdout_lines | random }}"
     state: present
     create_home: no
-  loop: '{{ range(1, 5+1) | list }}'
+  loop: "{{ range(1, 5+1) | list }}"
   register: user_test1
 
 - debug:
@@ -55,11 +55,11 @@
 - name: validate changed results for testcase 1
   assert:
     that:
-      - 'user_test1.results[0] is not changed'
-      - 'user_test1.results[1] is not changed'
-      - 'user_test1.results[2] is not changed'
-      - 'user_test1.results[3] is not changed'
-      - 'user_test1.results[4] is not changed'
+      - "user_test1.results[0] is not changed"
+      - "user_test1.results[1] is not changed"
+      - "user_test1.results[2] is not changed"
+      - "user_test1.results[3] is not changed"
+      - "user_test1.results[4] is not changed"
       - "user_test1.results[0]['state'] == 'present'"
       - "user_test1.results[1]['state'] == 'present'"
       - "user_test1.results[2]['state'] == 'present'"

--- a/test/integration/targets/user/tasks/test_create_user.yml
+++ b/test/integration/targets/user/tasks/test_create_user.yml
@@ -36,10 +36,10 @@
 
 - name: run existing user check tests
   user:
-    name: '{{ user_names.stdout_lines | random }}'
+    name: "{{ user_names.stdout_lines | random }}"
     state: present
     create_home: no
-  loop: '{{ range(1, 5+1) | list }}'
+  loop: "{{ range(1, 5+1) | list }}"
   register: user_test1
 
 - debug:

--- a/test/integration/targets/user/tasks/test_create_user.yml
+++ b/test/integration/targets/user/tasks/test_create_user.yml
@@ -55,11 +55,11 @@
 - name: validate changed results for testcase 1
   assert:
     that:
-      - 'user_test1.results[0] is not changed'
-      - 'user_test1.results[1] is not changed'
-      - 'user_test1.results[2] is not changed'
-      - 'user_test1.results[3] is not changed'
-      - 'user_test1.results[4] is not changed'
+      - "user_test1.results[0] is not changed"
+      - "user_test1.results[1] is not changed"
+      - "user_test1.results[2] is not changed"
+      - "user_test1.results[3] is not changed"
+      - "user_test1.results[4] is not changed"
       - "user_test1.results[0]['state'] == 'present'"
       - "user_test1.results[1]['state'] == 'present'"
       - "user_test1.results[2]['state'] == 'present'"

--- a/test/integration/targets/user/vars/main.yml
+++ b/test/integration/targets/user/vars/main.yml
@@ -10,4 +10,4 @@ status_command:
 
 default_user_group:
   openSUSE Leap: users
-  MacOSX: admin
+  MacOSX: staff


### PR DESCRIPTION
##### SUMMARY

Fixes: #44316


**Note**: I closed my last PR ( #79415 ) and restarted fresh the changes.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION

As stated in #44316 , this fixes the defaults for users on MacOS. Preventing confusion where a Sysadmin would have expected Ansible to create a user with the same defaults as when using the GUI.

Also this fixes user accounts not working when setting "no password".
