### PR TITLE
ansible-test - Support Podman 4.4.0+

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -124,6 +124,8 @@ stages:
           targets:
             - name: Alpine 3.17
               test: alpine/3.17
+            - name: Fedora 37
+              test: fedora/37
             - name: RHEL 8.7
               test: rhel/8.7
             - name: RHEL 9.1

--- a/changelogs/fragments/ansible-test-podman-chroot.yml
+++ b/changelogs/fragments/ansible-test-podman-chroot.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Support Podman 4.4.0+ by adding the ``SYS_CHROOT`` capability when running containers.

--- a/test/lib/ansible_test/_internal/host_profiles.py
+++ b/test/lib/ansible_test/_internal/host_profiles.py
@@ -516,6 +516,13 @@ class DockerProfile(ControllerHostProfile[DockerConfig], SshTargetHostProfile[Do
 
         cgroup_version = get_docker_info(self.args).cgroup_version
 
+        # Podman 4.4.0 updated containers/common to 0.51.0, which removed the SYS_CHROOT capability from the default list.
+        # This capability is needed by services such as sshd, so is unconditionally added here.
+        # See: https://github.com/containers/podman/releases/tag/v4.4.0
+        # See: https://github.com/containers/common/releases/tag/v0.51.0
+        # See: https://github.com/containers/common/pull/1240
+        options.extend(('--cap-add', 'SYS_CHROOT'))
+
         # Without AUDIT_WRITE the following errors may appear in the system logs of a container after attempting to log in using SSH:
         #
         #   fatal: linux_audit_write_entry failed: Operation not permitted


### PR DESCRIPTION
##### SUMMARY

ansible-test - Support Podman 4.4.0+ by adding the `SYS_CHROOT` capability when running containers.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
