### PR TITLE
2.14: Make using blocks as handlers a parser error (#79993)

### DIFF
--- a/changelogs/fragments/79968-blocks-handlers-error.yml
+++ b/changelogs/fragments/79968-blocks-handlers-error.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Make using blocks as handlers a parser error (https://github.com/ansible/ansible/issues/79968)

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -106,6 +106,8 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
             raise AnsibleAssertionError('The ds (%s) should be a dict but was a %s' % (ds, type(ds)))
 
         if 'block' in task_ds:
+            if use_handlers:
+                raise AnsibleParserError("Using a block as a handler is not supported.", obj=task_ds)
             t = Block.load(
                 task_ds,
                 play=play,

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -172,3 +172,12 @@ grep out.txt -e "handler ran"
 grep out.txt -e "after flush"
 
 ansible-playbook 79776.yml -i inventory.handlers "$@"
+
+ansible-playbook test_block_as_handler.yml "$@"  2>&1 | tee out.txt
+grep out.txt -e "ERROR! Using a block as a handler is not supported."
+
+ansible-playbook test_block_as_handler-include.yml "$@"  2>&1 | tee out.txt
+grep out.txt -e "ERROR! Using a block as a handler is not supported."
+
+ansible-playbook test_block_as_handler-import.yml "$@"  2>&1 | tee out.txt
+grep out.txt -e "ERROR! Using a block as a handler is not supported."

--- a/test/integration/targets/handlers/test_block_as_handler-import.yml
+++ b/test/integration/targets/handlers/test_block_as_handler-import.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - debug:
+  handlers:
+    - name: handler
+      import_tasks: test_block_as_handler-include_import-handlers.yml

--- a/test/integration/targets/handlers/test_block_as_handler-include.yml
+++ b/test/integration/targets/handlers/test_block_as_handler-include.yml
@@ -1,0 +1,8 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - command: echo
+      notify: handler
+  handlers:
+    - name: handler
+      include_tasks: test_block_as_handler-include_import-handlers.yml

--- a/test/integration/targets/handlers/test_block_as_handler-include_import-handlers.yml
+++ b/test/integration/targets/handlers/test_block_as_handler-include_import-handlers.yml
@@ -1,0 +1,8 @@
+- name: handler
+  block:
+    - name: due to how handlers are implemented, this is correct as it is equivalent to an implicit block
+      debug:
+    - name: this is a parser error, blocks as handlers are not supported
+      block:
+        - name: handler in a nested block
+          debug:

--- a/test/integration/targets/handlers/test_block_as_handler.yml
+++ b/test/integration/targets/handlers/test_block_as_handler.yml
@@ -1,0 +1,13 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - debug:
+  handlers:
+    - name: handler
+      block:
+        - name: due to how handlers are implemented, this is correct as it is equivalent to an implicit block
+          debug:
+        - name: this is a parser error, blocks as handlers are not supported
+          block:
+            - name: handler in a nested block
+              debug:

--- a/test/units/playbook/test_helpers.py
+++ b/test/units/playbook/test_helpers.py
@@ -160,20 +160,10 @@ class TestLoadListOfTasks(unittest.TestCase, MixinForMocks):
         self.assertIsInstance(block.always, list)
         self.assertEqual(len(block.always), 0)
 
-    def test_block_unknown_action_use_handlers(self):
-        ds = [{
-            'block': [{'action': 'foo_test_block_unknown_action'}]
-        }]
-        res = helpers.load_list_of_tasks(ds, play=self.mock_play, use_handlers=True,
-                                         variable_manager=self.mock_variable_manager, loader=self.fake_loader)
-        self._assert_is_task_list_or_blocks(res)
-        self.assertIsInstance(res[0], Block)
-        self._assert_default_block(res[0])
-
-    def test_one_bogus_block_use_handlers(self):
+    def test_block_use_handlers(self):
         ds = [{'block': True}]
         self.assertRaisesRegex(errors.AnsibleParserError,
-                               "A malformed block was encountered",
+                               "Using a block as a handler is not supported.",
                                helpers.load_list_of_tasks,
                                ds, play=self.mock_play, use_handlers=True,
                                variable_manager=self.mock_variable_manager, loader=self.fake_loader)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #79993

(cherry picked from commit bd329dc54329a126056723311abd7442ed6a0389)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/playbook/helpers.py`
