### PR TITLE
Data tagging delayed to 2.16

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_15.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_15.rst
@@ -48,7 +48,6 @@ Release Manager
 Planned work
 ============
 
-* Data Tagging
 * Proxy prompting over queue from forks
 
 Delayed work
@@ -56,4 +55,4 @@ Delayed work
 
 The following work has been delayed and retargeted for a future release:
 
-* N/A
+* Data Tagging


### PR DESCRIPTION
##### SUMMARY
Data tagging delayed to 2.16

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
