### PR TITLE
FIX - Reboot - delete useless parameter async, not supported

### DIFF
--- a/changelogs/fragments/fix-reboot-plugin.yml
+++ b/changelogs/fragments/fix-reboot-plugin.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixing reboot async parameter, delete the parameter (https://github.com/ansible/ansible/issues/71517).

--- a/changelogs/fragments/fix-reboot-plugin.yml
+++ b/changelogs/fragments/fix-reboot-plugin.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fixing reboot async parameter, delete the parameter (https://github.com/ansible/ansible/issues/71517).
+  - Stopped misleadingly advertising ``async`` mode support in the ``reboot`` module (https://github.com/ansible/ansible/issues/71517).

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -408,7 +408,6 @@ class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
         self._supports_check_mode = True
-        self._supports_async = True
 
         # If running with local connection, fail so we don't reboot ourselves
         if self._connection.transport == 'local':


### PR DESCRIPTION
##### SUMMARY
Reboot module doesn't supported async

Fixes #71517

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
reboot


