### PR TITLE
ansible-test - Support pytest assertion rewriting

### DIFF
--- a/changelogs/fragments/ansible-test-pytest-assertion-rewriting.yml
+++ b/changelogs/fragments/ansible-test-pytest-assertion-rewriting.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - ansible-test - Add support for ``pylint`` assertion rewriting when running unit tests on Python 3.5 and later.
+                   Resolves issue https://github.com/ansible/ansible/issues/68032
+known_issues:
+  - ansible-test - Unit tests for collections do not support ``pylint`` assertion rewriting on Python 2.7.

--- a/test/integration/targets/ansible-test-units-assertions/aliases
+++ b/test/integration/targets/ansible-test-units-assertions/aliases
@@ -1,0 +1,4 @@
+shippable/generic/group1  # runs in the default test container
+context/controller
+needs/target/collection
+needs/target/ansible-test

--- a/test/integration/targets/ansible-test-units-assertions/ansible_collections/ns/col/tests/unit/plugins/modules/test_assertion.py
+++ b/test/integration/targets/ansible-test-units-assertions/ansible_collections/ns/col/tests/unit/plugins/modules/test_assertion.py
@@ -1,0 +1,6 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+def test_assertion():
+    assert dict(yes=True) == dict(no=False)

--- a/test/integration/targets/ansible-test-units-assertions/runme.sh
+++ b/test/integration/targets/ansible-test-units-assertions/runme.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+source ../collection/setup.sh
+
+set -x
+
+options=$("${TEST_DIR}"/../ansible-test/venv-pythons.py --only-versions)
+IFS=', ' read -r -a pythons <<< "${options}"
+
+for python in "${pythons[@]}"; do
+  if ansible-test units --color --truncate 0 --python "${python}" --requirements "${@}" 2>&1 | tee pylint.log; then
+    echo "Test did not fail as expected."
+    exit 1
+  fi
+
+  if [ "${python}" = "2.7" ]; then
+    grep "^E  *AssertionError$" pylint.log
+  else
+
+    grep "^E  *AssertionError: assert {'yes': True} == {'no': False}$" pylint.log
+  fi
+done

--- a/test/integration/targets/ansible-test/venv-pythons.py
+++ b/test/integration/targets/ansible-test/venv-pythons.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Return target Python options for use with ansible-test."""
 
+import argparse
 import os
 import shutil
 import subprocess
@@ -10,6 +11,11 @@ from ansible import release
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--only-versions', action='store_true')
+
+    options = parser.parse_args()
+
     ansible_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(release.__file__))))
     source_root = os.path.join(ansible_root, 'test', 'lib')
 
@@ -33,6 +39,10 @@ def main():
             print(f'{executable} - {"fail" if process.returncode else "pass"}', file=sys.stderr)
 
             if not process.returncode:
+                if options.only_versions:
+                    args.append(python_version)
+                    continue
+
                 args.extend(['--target-python', f'venv/{python_version}'])
 
     print(' '.join(args))


### PR DESCRIPTION
##### SUMMARY

Add support for `pytest` assertion rewriting when running unit tests on Python 3.5 and later.

Resolves https://github.com/ansible/ansible/issues/68032

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

This implementation depends on a few more internals pytest and the Ansible collection loader.

It only supports Python 3.5+ since the implementation of `AssertionRewritingHook` in pytest for Python 2.7 is much more complex and not suitable for calling from the Ansible collection loader.