### PR TITLE
Revise "mode" description in ansible.builtin.copy

### DIFF
--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -64,9 +64,9 @@ options:
     description:
     - The permissions of the destination file or directory.
     - For those used to C(/usr/bin/chmod), remember that modes are actually octal numbers.
-      To prevent unexpected results of decimal to octal conversion, you B(must) add a leading zero 
-      (like C(0644) or C(01777)) to the number. Though not required, you should also quote the number 
-      (like C('0644') or C('01777')) to make it a string. The combination of these two elements guarantee 
+      To prevent unexpected results of decimal to octal conversion, you B(must) add a leading zero
+      (like C(0644) or C(01777)) to the number. Though not required, you should also quote the number
+      (like C('0644') or C('01777')) to make it a string. The combination of these two elements guarantee
       Ansible receives a string the YAML parser can interpret correctly into the desired permissions.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
     - As of Ansible 2.3, the mode may also be the special string C(preserve).

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -65,7 +65,7 @@ options:
     - The permissions of the destination file or directory.
     - For those used to C(/usr/bin/chmod), remember that modes are actually octal numbers.
       To prevent unexpected results of decimal to octal conversion, you B(must) add a leading zero
-      to the number (B)and wrap the number in quotes (like C('0644') or C('01777')) to pass it to
+      to the number B(and) wrap the number in quotes (like C('0644') or C('01777')) to pass it to
       the YAML parser as a string. This guarantees that Ansible correctly interprets the desired permissions.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
     - As of Ansible 2.3, the mode may also be the special string C(preserve).

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -63,11 +63,11 @@ options:
   mode:
     description:
     - The permissions of the destination file or directory.
-    - For those used to C(/usr/bin/chmod) remember that modes are actually octal numbers.
-      You must either add a leading zero so that Ansible's YAML parser knows it is an octal number
-      (like C(0644) or C(01777)) or quote it (like C('644') or C('1777')) so Ansible receives a string
-      and can do its own conversion from string into number. Giving Ansible a number without following
-      one of these rules will end up with a decimal number which will have unexpected results.
+    - For those used to C(/usr/bin/chmod), remember that modes are actually octal numbers.
+      To prevent unexpected results of decimal to octal conversion, you B(must) add a leading zero 
+      (like C(0644) or C(01777)) to the number. Though not required, you should also quote the number 
+      (like C('0644') or C('01777')) to make it a string. The combination of these two elements guarantee 
+      Ansible receives a string the YAML parser can interpret correctly into the desired permissions.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
     - As of Ansible 2.3, the mode may also be the special string C(preserve).
     - C(preserve) means that the file will be given the same permissions as the source file.

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -66,7 +66,7 @@ options:
     - For those used to C(/usr/bin/chmod), remember that modes are actually octal numbers.
       To prevent unexpected results of decimal to octal conversion, you B(must) add a leading zero
       (like C(0644) or C(01777)) to the number. You can also wrap the number in single quotes
-      (like C('0644') or C('01777')) to pass it to the YAML parser as a string. This guarantees that 
+      (like C('0644') or C('01777')) to pass it to the YAML parser as a string. This guarantees that
       Ansible correctly interprets the desired permissions.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
     - As of Ansible 2.3, the mode may also be the special string C(preserve).

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -65,9 +65,8 @@ options:
     - The permissions of the destination file or directory.
     - For those used to C(/usr/bin/chmod), remember that modes are actually octal numbers.
       To prevent unexpected results of decimal to octal conversion, you B(must) add a leading zero
-      (like C(0644) or C(01777)) to the number. You can also wrap the number in single quotes
-      (like C('0644') or C('01777')) to pass it to the YAML parser as a string. This guarantees that
-      Ansible correctly interprets the desired permissions.
+      to the number (B)and wrap the number in quotes (like C('0644') or C('01777')) to pass it to
+      the YAML parser as a string. This guarantees that Ansible correctly interprets the desired permissions.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
     - As of Ansible 2.3, the mode may also be the special string C(preserve).
     - C(preserve) means that the file will be given the same permissions as the source file.

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -65,9 +65,9 @@ options:
     - The permissions of the destination file or directory.
     - For those used to C(/usr/bin/chmod), remember that modes are actually octal numbers.
       To prevent unexpected results of decimal to octal conversion, you B(must) add a leading zero
-      (like C(0644) or C(01777)) to the number. Though not required, you should also quote the number
-      (like C('0644') or C('01777')) to make it a string. The combination of these two elements guarantee
-      Ansible receives a string the YAML parser can interpret correctly into the desired permissions.
+      (like C(0644) or C(01777)) to the number. You can also wrap the number in single quotes
+      (like C('0644') or C('01777')) to pass it to the YAML parser as a string. This guarantees that 
+      Ansible correctly interprets the desired permissions.
     - As of Ansible 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
     - As of Ansible 2.3, the mode may also be the special string C(preserve).
     - C(preserve) means that the file will be given the same permissions as the source file.


### PR DESCRIPTION
Clarify the "mode" description. 

##### SUMMARY
Current wording can be misinterpreted and does not strongly or clearly enough emphasize why one would want to use both the leading zero and quote, even though just a leading zero is sufficient and will work. Ansible-lint has a decent description of this too (risky-octal rule), but it does not currently flag an unquoted number with a leading zero, so we can't say in this documentation that it's required to do both.

See further conversation in #79991

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.builtin.copy

##### ADDITIONAL INFORMATION
If accepted, this should also be updated in the documentation for
ansible.builtin.assemble
ansible.builtin.file
ansible.builtin.replace
ansible.builtin.template
And all other examples in the documentation of a numeric mode should be updated for consistency following the recommendations above.