### PR TITLE
Fix arg splitting and key/value parsing

### DIFF
--- a/changelogs/fragments/parsing-splitter-fixes.yml
+++ b/changelogs/fragments/parsing-splitter-fixes.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - Fix exceptions caused by various inputs when performing arg splitting or parsing key/value pairs.
+    Resolves issue https://github.com/ansible/ansible/issues/46379
+  - Fix incorrect parsing of multi-line Jinja2 blocks when performing arg splitting or parsing key/value pairs.

--- a/changelogs/fragments/parsing-splitter-fixes.yml
+++ b/changelogs/fragments/parsing-splitter-fixes.yml
@@ -1,4 +1,5 @@
 bugfixes:
   - Fix exceptions caused by various inputs when performing arg splitting or parsing key/value pairs.
     Resolves issue https://github.com/ansible/ansible/issues/46379
+    and issue https://github.com/ansible/ansible/issues/61497
   - Fix incorrect parsing of multi-line Jinja2 blocks when performing arg splitting or parsing key/value pairs.

--- a/test/units/parsing/test_splitter.py
+++ b/test/units/parsing/test_splitter.py
@@ -96,15 +96,15 @@ SPLIT_DATA = (
         {u'_raw_params': u'One\n  Two\n    Three\n'}),
 )
 
-SPLIT_ARGS = ((test[0], test[1]) for test in SPLIT_DATA)
-PARSE_KV = ((test[0], test[2]) for test in SPLIT_DATA)
+SPLIT_ARGS = tuple((test[0], test[1]) for test in SPLIT_DATA)
+PARSE_KV = tuple((test[0], test[2]) for test in SPLIT_DATA)
 
 
-@pytest.mark.parametrize("args, expected", SPLIT_ARGS)
+@pytest.mark.parametrize("args, expected", SPLIT_ARGS, ids=[str(arg[0]) for arg in SPLIT_ARGS])
 def test_split_args(args, expected):
     assert split_args(args) == expected
 
 
-@pytest.mark.parametrize("args, expected", PARSE_KV)
+@pytest.mark.parametrize("args, expected", PARSE_KV, ids=[str(arg[0]) for arg in PARSE_KV])
 def test_parse_kv(args, expected):
     assert parse_kv(args) == expected

--- a/test/units/parsing/test_splitter.py
+++ b/test/units/parsing/test_splitter.py
@@ -26,6 +26,9 @@ from ansible.errors import AnsibleParserError
 import pytest
 
 SPLIT_DATA = (
+    (None,
+        [],
+        {}),
     (u'',
         [],
         {}),
@@ -53,6 +56,12 @@ SPLIT_DATA = (
     (u'a="nest\'ed"',
         [u'a="nest\'ed"'],
         {u'a': u'nest\'ed'}),
+    (u' ',
+        [u' '],
+        {u'_raw_params': u' '}),
+    (u'\\ ',
+        [u' '],
+        {u'_raw_params': u' '}),
     (u'a\\=escaped',
         [u'a\\=escaped'],
         {u'_raw_params': u'a=escaped'}),
@@ -77,6 +86,9 @@ SPLIT_DATA = (
     (u'not jinja}}',
         [u'not', u'jinja}}'],
         {u'_raw_params': u'not jinja}}'}),
+    (u'a={{multiline\njinja}}',
+        [u'a={{multiline\njinja}}'],
+        {u'a': u'{{multiline\njinja}}'}),
     (u'a={{jinja}}',
         [u'a={{jinja}}'],
         {u'a': u'{{jinja}}'}),
@@ -116,6 +128,9 @@ SPLIT_DATA = (
     (u'One\n  Two\n    Three\n',
         [u'One\n ', u'Two\n   ', u'Three\n'],
         {u'_raw_params': u'One\n  Two\n    Three\n'}),
+    (u'\nOne\n  Two\n    Three\n',
+        [u'\n', u'One\n ', u'Two\n   ', u'Three\n'],
+        {u'_raw_params': u'\nOne\n  Two\n    Three\n'}),
 )
 
 PARSE_KV_CHECK_RAW = (


### PR DESCRIPTION
##### SUMMARY

Fix arg splitting and key/value parsing:

- Fix IndexError exceptions caused by parsing a leading newline, space or escaped space.
- Fix an AttributeError exception in `parse_args` when parsing `None`.
- Fix incorrect parsing of multi-line Jinja2 blocks, which resulted in doubling newlines.
- Remove unreachable exception handlers in the `parse_kv` function.
  The unreachable code was verified through analysis of the code as well as use of the `atheris` fuzzer.
- Remove unnecessary code in the `split_args` function.
- Add an optimization to `split_args` for the empty args case.

Improve the splitter unit tests:

- Drop the trailing `-expectedXXX` suffixes from test names generated by parametrize.
- Fill in gaps in unit test code coverage. Unit tests now provide full code coverage.

Resolves https://github.com/ansible/ansible/issues/46379
Resolves https://github.com/ansible/ansible/issues/61497

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/parsing/splitter.py