### PR TITLE
Remove trailing spaces from lines in YAML

### DIFF
--- a/changelogs/fragments/79422-fix-file-touch-check-mode-status.yaml
+++ b/changelogs/fragments/79422-fix-file-touch-check-mode-status.yaml
@@ -1,3 +1,3 @@
 bugfixes:
-  - file - touch action in check mode was always returning ok. Fix now evaluates the different conditions and 
+  - file - touch action in check mode was always returning ok. Fix now evaluates the different conditions and
     returns the appropriate changed status. (https://github.com/ansible/ansible/issues/79360)

--- a/changelogs/fragments/ansible-test-container-management.yml
+++ b/changelogs/fragments/ansible-test-container-management.yml
@@ -1,5 +1,5 @@
 major_changes:
-  - ansible-test - Docker and Podman are now supported on hosts with cgroup v2 unified. 
+  - ansible-test - Docker and Podman are now supported on hosts with cgroup v2 unified.
                    Previously only cgroup v1 and cgroup v2 hybrid were supported.
   - ansible-test - Docker Desktop on WSL2 is now supported (additional configuration required).
   - ansible-test - Podman on WSL2 is now supported.

--- a/changelogs/fragments/ansible-test-payload-file-permissions.yml
+++ b/changelogs/fragments/ansible-test-payload-file-permissions.yml
@@ -5,5 +5,5 @@ bugfixes:
                    (Resolves issue https://github.com/ansible/ansible/issues/75079)
 breaking_changes:
   - ansible-test - Integration tests which depend on specific file permissions when running in an ansible-test managed
-                   host environment may require changes. Tests that require permissions other than ``755`` or ``644`` 
+                   host environment may require changes. Tests that require permissions other than ``755`` or ``644``
                    may need to be updated to set the necessary permissions as part of the test run.

--- a/changelogs/fragments/psscriptanalyzer-1.21.0.yml
+++ b/changelogs/fragments/psscriptanalyzer-1.21.0.yml
@@ -1,4 +1,4 @@
 minor_changes:
-- >- 
+- >-
   ansible-test pslint - Upgrade PSScriptAnalyzer to ``1.21.0`` which enables the ``AvoidMultipleTypeAttributes``,
   ``AvoidSemicolonsAsLineTerminators``, and ``AvoidUsingBrokenHashAlgorithms`` rules

--- a/lib/ansible/plugins/filter/b64decode.yml
+++ b/lib/ansible/plugins/filter/b64decode.yml
@@ -7,7 +7,7 @@ DOCUMENTATION:
     - Base64 decoding function.
     - The return value is a string.
     - Trying to store a binary blob in a string most likely corrupts the binary. To base64 decode a binary blob,
-      use the ``base64`` command  and pipe the encoded data through standard input. 
+      use the ``base64`` command  and pipe the encoded data through standard input.
       For example, in the ansible.builtin.shell`` module, ``cmd="base64 --decode > myfile.bin" stdin="{{ encoded }}"``.
   positional: _input
   options:

--- a/lib/ansible/plugins/filter/to_yaml.yml
+++ b/lib/ansible/plugins/filter/to_yaml.yml
@@ -25,18 +25,18 @@ DOCUMENTATION:
 
     # TODO: find docs for these
     #allow_unicode:
-    #  description: 
+    #  description:
     #  type: bool
     #  default: true
     #default_flow_style
     #default_style
-    #canonical=None, 
-    #width=None, 
-    #line_break=None, 
-    #encoding=None, 
-    #explicit_start=None, 
-    #explicit_end=None, 
-    #version=None, 
+    #canonical=None,
+    #width=None,
+    #line_break=None,
+    #encoding=None,
+    #explicit_start=None,
+    #explicit_end=None,
+    #version=None,
     #tags=None
 
 EXAMPLES: |

--- a/test/integration/targets/apt_key/tasks/main.yml
+++ b/test/integration/targets/apt_key/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - import_tasks: 'apt_key_inline_data.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')
- 
+
 - import_tasks: 'file.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')
 

--- a/test/integration/targets/become/tasks/main.yml
+++ b/test/integration/targets/become/tasks/main.yml
@@ -11,8 +11,8 @@
     ansible_become_user: "{{ become_test_config.user }}"
     ansible_become_method: "{{ become_test_config.method }}"
     ansible_become_password: "{{ become_test_config.password | default(None) }}"
-  loop: "{{ 
-    (become_methods | selectattr('skip', 'undefined') | list)+ 
+  loop: "{{
+    (become_methods | selectattr('skip', 'undefined') | list)+
     (become_methods | selectattr('skip', 'defined') | rejectattr('skip') | list)
     }}"
   loop_control:

--- a/test/integration/targets/check_mode/roles/test_check_mode/tasks/main.yml
+++ b/test/integration/targets/check_mode/roles/test_check_mode/tasks/main.yml
@@ -25,8 +25,8 @@
   register: foo
 
 - name: verify that the file was marked as changed in check mode
-  assert: 
-    that: 
+  assert:
+    that:
       - "template_result is changed"
       - "not foo.stat.exists"
 
@@ -44,7 +44,7 @@
   check_mode: no
 
 - name: verify that the file was not changed
-  assert: 
-    that: 
+  assert:
+    that:
       - "checkmode_disabled is changed"
       - "template_result2 is not changed"

--- a/test/integration/targets/file/tasks/link_rewrite.yml
+++ b/test/integration/targets/file/tasks/link_rewrite.yml
@@ -16,11 +16,11 @@
     dest: "{{ tempdir.path }}/somelink"
     state: link
 
-- stat: 
+- stat:
     path: "{{ tempdir.path }}/somelink"
   register: link
 
-- stat: 
+- stat:
     path: "{{ tempdir.path }}/somefile"
   register: file
 
@@ -32,12 +32,12 @@
 - file:
     path: "{{ tempdir.path }}/somelink"
     mode: 0644
-    
-- stat: 
+
+- stat:
     path: "{{ tempdir.path }}/somelink"
   register: link
 
-- stat: 
+- stat:
     path: "{{ tempdir.path }}/somefile"
   register: file
 

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -779,7 +779,7 @@
   register: touch_result_in_check_mode_fails_not_existing_group
 
 - assert:
-    that: 
+    that:
     - touch_result_in_check_mode_not_existing.changed
     - touch_result_in_check_mode_preserve_access_time.changed
     - touch_result_in_check_mode_change_only_mode.changed

--- a/test/integration/targets/get_url/tasks/use_netrc.yml
+++ b/test/integration/targets/get_url/tasks/use_netrc.yml
@@ -22,7 +22,7 @@
   register: response_failed
 
 - name: Parse token from msg.txt
-  set_fact: 
+  set_fact:
     token: "{{ (response_failed['content'] | b64decode | from_json).token }}"
 
 - name: assert Test Bearer authorization is failed with netrc
@@ -48,7 +48,7 @@
   register: response
 
 - name: Parse token from msg.txt
-  set_fact: 
+  set_fact:
     token: "{{ (response['content'] | b64decode | from_json).token }}"
 
 - name: assert Test Bearer authorization is successfull with use_netrc=False

--- a/test/integration/targets/known_hosts/tasks/main.yml
+++ b/test/integration/targets/known_hosts/tasks/main.yml
@@ -99,7 +99,7 @@
 # https://github.com/ansible/ansible/issues/78598
 # test removing nonexistent host key when the other keys exist for the host
 - name: remove different key
-  known_hosts: 
+  known_hosts:
     name: example.org
     key: "{{ example_org_ed25519_key }}"
     state: absent

--- a/test/integration/targets/lookup_fileglob/issue72873/test.yml
+++ b/test/integration/targets/lookup_fileglob/issue72873/test.yml
@@ -5,7 +5,7 @@
      dir: files
   tasks:
   - file: path='{{ dir }}' state=directory
-  
+
   - file: path='setvars.bat' state=touch  # in current directory!
 
   - file: path='{{ dir }}/{{ item }}' state=touch

--- a/test/integration/targets/lookup_url/meta/main.yml
+++ b/test/integration/targets/lookup_url/meta/main.yml
@@ -1,2 +1,2 @@
-dependencies: 
+dependencies:
   - prepare_http_tests

--- a/test/integration/targets/lookup_url/tasks/use_netrc.yml
+++ b/test/integration/targets/lookup_url/tasks/use_netrc.yml
@@ -18,7 +18,7 @@
     that:
     - "web_data.token.find('v=' ~ 'Zm9vOmJhcg==') == -1"
     fail_msg: "Was expecting 'foo:bar' in base64, but received: {{ web_data }}"
-    success_msg: "Expected Basic authentication even Bearer headers were sent"  
+    success_msg: "Expected Basic authentication even Bearer headers were sent"
 
 - name: test Url lookup with use_netrc=False
   set_fact:

--- a/test/integration/targets/unarchive/tasks/test_different_language_var.yml
+++ b/test/integration/targets/unarchive/tasks/test_different_language_var.yml
@@ -2,10 +2,10 @@
   when: ansible_os_family == 'Debian'
   block:
     - name: install fr language pack
-      apt: 
+      apt:
         name: language-pack-fr
         state: present
-      
+
     - name: create our unarchive destination
       file:
         path: "{{ remote_tmp_dir }}/test-unarchive-nonascii-くらとみ-tar-gz"

--- a/test/integration/targets/var_blending/roles/test_var_blending/tasks/main.yml
+++ b/test/integration/targets/var_blending/roles/test_var_blending/tasks/main.yml
@@ -1,4 +1,4 @@
-# test code 
+# test code
 # (c) 2014, Michael DeHaan <michael.dehaan@gmail.com>
 
 # This file is part of Ansible
@@ -22,7 +22,7 @@
     output_dir: "{{ lookup('env', 'OUTPUT_DIR') }}"
 
 - name: deploy a template that will use variables at various levels
-  template: src=foo.j2 dest={{output_dir}}/foo.templated 
+  template: src=foo.j2 dest={{output_dir}}/foo.templated
   register: template_result
 
 - name: copy known good into place
@@ -33,9 +33,9 @@
   register: diff_result
 
 - name: verify templated file matches known good
-  assert:  
-    that: 
-        - 'diff_result.stdout == ""' 
+  assert:
+    that:
+        - 'diff_result.stdout == ""'
 
 - name: check debug variable with same name as var content
   debug: var=same_value_as_var_name_var


### PR DESCRIPTION
##### SUMMARY

Remove trailing spaces from lines in YAML.

A follow-up PR will enable the yamllint rule for this.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

YAML files
