### PR TITLE
Avoid trailing spaces in unit test

### DIFF
--- a/test/units/executor/module_common/test_module_common.py
+++ b/test/units/executor/module_common/test_module_common.py
@@ -43,15 +43,16 @@ class TestStripComments:
         assert amc._strip_comments(all_comments) == u""
 
     def test_all_whitespace(self):
-        # Note: Do not remove the spaces on the blank lines below.  They're
-        # test data to show that the lines get removed despite having spaces
-        # on them
-        all_whitespace = u"""
-              
+        all_whitespace = (
+            '\n'
+            '              \n'
+            '\n'
+            '                \n'
+            '\t\t\r\n'
+            '\n'
+            '            '
+        )
 
-                
-\t\t\r\n
-            """  # nopep8
         assert amc._strip_comments(all_whitespace) == u""
 
     def test_somewhat_normal(self):


### PR DESCRIPTION
##### SUMMARY

This avoids the risk of the test becoming invalid due to automatic end-of-line space removal.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

test/units/executor/module_common/test_module_common.py