### PR TITLE
package_facts requires python-rpm on SUSE systems in ansible 2.12.1

### DIFF
--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -38,6 +38,8 @@ requirements:
     - For 'portage' support it requires the C(qlist) utility, which is part of 'app-portage/portage-utils'.
     - For Debian-based systems C(python-apt) package must be installed on targeted hosts.
     - For SUSE-based systems C(python3-rpm) package must be installed on targeted hosts.
+    - For RPM based systems, rpm python bindings must be installed, this is normally the default. 
+      SUSE stopped doing this so you'll need the C(python3-rpm) package.
 author:
   - Matthew Jones (@matburt)
   - Brian Coca (@bcoca)

--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -37,6 +37,7 @@ version_added: "2.5"
 requirements:
     - For 'portage' support it requires the C(qlist) utility, which is part of 'app-portage/portage-utils'.
     - For Debian-based systems C(python-apt) package must be installed on targeted hosts.
+    - For SUSE-based systems C(python3-rpm) package must be installed on targeted hosts.
 author:
   - Matthew Jones (@matburt)
   - Brian Coca (@bcoca)

--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -38,8 +38,7 @@ requirements:
     - For 'portage' support it requires the C(qlist) utility, which is part of 'app-portage/portage-utils'.
     - For Debian-based systems C(python-apt) package must be installed on targeted hosts.
     - For SUSE-based systems C(python3-rpm) package must be installed on targeted hosts.
-    - For RPM based systems, rpm python bindings must be installed, this is normally the default. 
-      SUSE stopped doing this so you'll need the C(python3-rpm) package.
+      This package is required because SUSE does not include RPM Python bindings by default.
 author:
   - Matthew Jones (@matburt)
   - Brian Coca (@bcoca)


### PR DESCRIPTION
##### SUMMARY
This change fixes the missing documention requirement for python-rpm on SUSE distributions.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
The file where this change occurs is:
[https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/package_facts.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/package_facts.py#L40)

##### ADDITIONAL INFORMATION
This PR fixes #79661 
