### PR TITLE
strategy plugins: get the correctly templated and validated run_once value

### DIFF
--- a/changelogs/fragments/78492-fix-invalid-run_once-value.yml
+++ b/changelogs/fragments/78492-fix-invalid-run_once-value.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "strategy plugins: get the correctly templated and validated run_once value on strategy linear (https://github.com/ansible/ansible/issues/78492)"

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -35,6 +35,7 @@ from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleAssertionError, AnsibleParserError
 from ansible.executor.play_iterator import IteratingStates, FailedStates
 from ansible.module_utils._text import to_text
+from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.playbook.handler import Handler
 from ansible.playbook.included_file import IncludedFile
 from ansible.playbook.task import Task
@@ -213,7 +214,10 @@ class StrategyModule(StrategyBase):
                                 skip_rest = True
                                 break
 
-                        run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
+                        if templar.is_template(task.run_once):
+                            setattr(task, 'run_once', boolean(templar.template(task.run_once), strict=True))
+
+                        run_once = task.run_once or action and getattr(action, 'BYPASS_HOST_LOOP', False)
 
                         if (task.any_errors_fatal or run_once) and not task.ignore_errors:
                             any_errors_fatal = True

--- a/test/integration/targets/strategy_linear/runme.sh
+++ b/test/integration/targets/strategy_linear/runme.sh
@@ -5,3 +5,5 @@ set -eux
 ansible-playbook test_include_file_noop.yml -i inventory "$@"
 
 ansible-playbook task_action_templating.yml -i inventory "$@"
+
+ansible-playbook task_templated_run_once.yml -i inventory "$@"

--- a/test/integration/targets/strategy_linear/task_templated_run_once.yml
+++ b/test/integration/targets/strategy_linear/task_templated_run_once.yml
@@ -1,0 +1,20 @@
+- hosts: testhost,testhost2
+  gather_facts: no
+  vars:
+    run_once_flag: false
+  tasks:
+    - debug:
+        msg: "I am {{ item }}"
+      run_once: "{{ run_once_flag }}"
+      register: reg1
+      loop:
+        - "{{ inventory_hostname }}"
+
+    - assert:
+        that:
+          - "reg1.results[0].msg == 'I am testhost'"
+      when: inventory_hostname == 'testhost'
+    - assert:
+        that:
+          - "reg1.results[0].msg == 'I am testhost2'"
+      when: inventory_hostname == 'testhost2'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Related to #78517. When the value of `run_once` is a template expression whether the final value is `True` or `False`, `task.run_once` here is alway `True`. So there is a need to render `task.run_once` and update it in advance.
https://github.com/ansible/ansible/blob/ce6c9befb88dba43420e5c2867af8c4f9aee3ff9/lib/ansible/plugins/strategy/__init__.py#L446-L448

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #78492

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
linear strategy plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
