### PR TITLE
Improve dirname and basename filter doc

### DIFF
--- a/lib/ansible/plugins/filter/basename.yml
+++ b/lib/ansible/plugins/filter/basename.yml
@@ -5,6 +5,8 @@ DOCUMENTATION:
   short_description: get a path's base name
   description:
     - Returns the last name component of a path, what is left in the string that is not 'dirname'.
+  notes:
+    - The result of this filter is different from the Unix basename program; where basename for '/foo/bar/' returns 'bar', the basename filter returns an empty string ('').
   options:
     _input:
       description: A path.
@@ -15,7 +17,7 @@ DOCUMENTATION:
       plugin: ansible.builtin.dirname
 EXAMPLES: |
 
-  # To get the last name of a file path, like 'foo.txt' out of '/etc/asdf/foo.txt'
+  # To get the last name of a file path, like 'foo.txt' out of '/etc/asdf/foo.txt'.
   {{ mypath | basename }}
 
 RETURN:

--- a/lib/ansible/plugins/filter/basename.yml
+++ b/lib/ansible/plugins/filter/basename.yml
@@ -6,7 +6,7 @@ DOCUMENTATION:
   description:
     - Returns the last name component of a path, what is left in the string that is not 'dirname'.
   notes:
-    - The result of this filter is different from the Unix basename program; where basename for '/foo/bar/' returns 'bar', the basename filter returns an empty string ('').
+    - The result of this filter is different from the Unix basename program; where basename for C(/foo/bar/) returns C(bar), the basename filter returns an empty string (C('')).
   options:
     _input:
       description: A path.

--- a/lib/ansible/plugins/filter/dirname.yml
+++ b/lib/ansible/plugins/filter/dirname.yml
@@ -5,6 +5,8 @@ DOCUMENTATION:
   short_description: get a path's directory name
   description:
     - Returns the 'head' component of a path, basically everything that is not the 'basename'.
+  notes:
+    - The result of this filter is different from the Unix dirname program; where dirname for '/foo/bar/' returns '/foo', the dirname filter returns the full path ('/foo/bar/').
   options:
     _input:
       description: A path.
@@ -15,7 +17,7 @@ DOCUMENTATION:
       plugin_type: filter
 EXAMPLES: |
 
-  # To get the dir name of a file path, like '/etc/asdf' out of '/etc/asdf/foo.txt'
+  # To get the dir name of a file path, like '/etc/asdf' out of '/etc/asdf/foo.txt'.
   {{ mypath | dirname }}
 
 RETURN:

--- a/lib/ansible/plugins/filter/dirname.yml
+++ b/lib/ansible/plugins/filter/dirname.yml
@@ -6,7 +6,7 @@ DOCUMENTATION:
   description:
     - Returns the 'head' component of a path, basically everything that is not the 'basename'.
   notes:
-    - The result of this filter is different from the Unix dirname program; where dirname for '/foo/bar/' returns '/foo', the dirname filter returns the full path ('/foo/bar/').
+    - The result of this filter is different from the Unix dirname program; where dirname for C(/foo/bar/) returns C(/foo), the dirname filter returns the full path (C(/foo/bar/)).
   options:
     _input:
       description: A path.


### PR DESCRIPTION
##### SUMMARY
Based on the Python documentation of [`os.path`](https://docs.python.org/3/library/os.path.html) this adds additional notes on the difference between the Unix `basename` and `dirname` programs and the basename and dirname filters.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- basename
- dirname

