### PR TITLE
Fix #80020 typos confusing `pylint` for `pytest`

### DIFF
--- a/changelogs/fragments/ansible-test-pytest-assertion-rewriting.yml
+++ b/changelogs/fragments/ansible-test-pytest-assertion-rewriting.yml
@@ -1,5 +1,5 @@
 bugfixes:
-  - ansible-test - Add support for ``pylint`` assertion rewriting when running unit tests on Python 3.5 and later.
+  - ansible-test - Add support for ``pytest`` assertion rewriting when running unit tests on Python 3.5 and later.
                    Resolves issue https://github.com/ansible/ansible/issues/68032
 known_issues:
-  - ansible-test - Unit tests for collections do not support ``pylint`` assertion rewriting on Python 2.7.
+  - ansible-test - Unit tests for collections do not support ``pytest`` assertion rewriting on Python 2.7.

--- a/test/integration/targets/ansible-test-units-assertions/runme.sh
+++ b/test/integration/targets/ansible-test-units-assertions/runme.sh
@@ -8,15 +8,15 @@ options=$("${TEST_DIR}"/../ansible-test/venv-pythons.py --only-versions)
 IFS=', ' read -r -a pythons <<< "${options}"
 
 for python in "${pythons[@]}"; do
-  if ansible-test units --color --truncate 0 --python "${python}" --requirements "${@}" 2>&1 | tee pylint.log; then
+  if ansible-test units --color --truncate 0 --python "${python}" --requirements "${@}" 2>&1 | tee pytest.log; then
     echo "Test did not fail as expected."
     exit 1
   fi
 
   if [ "${python}" = "2.7" ]; then
-    grep "^E  *AssertionError$" pylint.log
+    grep "^E  *AssertionError$" pytest.log
   else
 
-    grep "^E  *AssertionError: assert {'yes': True} == {'no': False}$" pylint.log
+    grep "^E  *AssertionError: assert {'yes': True} == {'no': False}$" pytest.log
   fi
 done

--- a/test/lib/ansible_test/_util/target/pytest/plugins/ansible_pytest_collections.py
+++ b/test/lib/ansible_test/_util/target/pytest/plugins/ansible_pytest_collections.py
@@ -34,8 +34,8 @@ def collection_pypkgpath(self):
 
 def enable_assertion_rewriting_hook():  # type: () -> None
     """
-    Enable pylint's AssertionRewritingHook on Python 3.x.
-    This is necessary because the Ansible collection loader intercepts imports before the pylint provided loader ever sees them.
+    Enable pytest's AssertionRewritingHook on Python 3.x.
+    This is necessary because the Ansible collection loader intercepts imports before the pytest provided loader ever sees them.
     """
     import sys
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

$sbj

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
pytest plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This just fixes typos from the previous PR.