### PR TITLE
ansible-inventory prevent duplicating host entries

### DIFF
--- a/changelogs/fragments/ainv_limit_fix.yml
+++ b/changelogs/fragments/ainv_limit_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-inventory will no longer duplicate host entries if they were part of a group's childrens tree.

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -340,6 +340,7 @@ class InventoryCLI(CLI):
     def yaml_inventory(self, top):
 
         seen_hosts = set()
+        seen_groups = set()
 
         def format_group(group, available_hosts):
             results = {}
@@ -351,7 +352,11 @@ class InventoryCLI(CLI):
             results[group.name]['children'] = {}
             for subgroup in group.child_groups:
                 if subgroup.name != 'all':
-                    results[group.name]['children'].update(format_group(subgroup, available_hosts))
+                    if subgroup.name in seen_groups:
+                        results[group.name]['children'].update({subgroup.name:{}})
+                    else:
+                        results[group.name]['children'].update(format_group(subgroup, available_hosts))
+                        seen_groups.add(subgroup.name)
 
             # hosts for group
             results[group.name]['hosts'] = {}
@@ -374,6 +379,7 @@ class InventoryCLI(CLI):
             # remove empty groups
             if not results[group.name]:
                 del results[group.name]
+
 
             return results
 

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -307,7 +307,7 @@ class InventoryCLI(CLI):
             results = {}
             results[group.name] = {}
             if group.name != 'all':
-                results[group.name]['hosts'] = [h.name for h in group.hosts if h in available_hosts]
+                results[group.name]['hosts'] = [h.name for h in group.hosts if h.name in available_hosts]
             results[group.name]['children'] = []
             for subgroup in group.child_groups:
                 results[group.name]['children'].append(subgroup.name)
@@ -324,12 +324,11 @@ class InventoryCLI(CLI):
 
             return results
 
-        available_hosts = self.inventory.get_hosts(top.name)
-        results = format_group(top, available_hosts)
+        hosts = self.inventory.get_hosts(top.name)
+        results = format_group(top, [h.name for h in hosts])
 
         # populate meta
         results['_meta'] = {'hostvars': {}}
-        hosts = self.inventory.get_hosts()
         for host in hosts:
             hvars = self._get_host_variables(host)
             if hvars:
@@ -353,7 +352,7 @@ class InventoryCLI(CLI):
             for subgroup in group.child_groups:
                 if subgroup.name != 'all':
                     if subgroup.name in seen_groups:
-                        results[group.name]['children'].update({subgroup.name:{}})
+                        results[group.name]['children'].update({subgroup.name: {}})
                     else:
                         results[group.name]['children'].update(format_group(subgroup, available_hosts))
                         seen_groups.add(subgroup.name)
@@ -362,7 +361,7 @@ class InventoryCLI(CLI):
             results[group.name]['hosts'] = {}
             if group.name != 'all':
                 for h in group.hosts:
-                    if h not in available_hosts:
+                    if h.name not in available_hosts:
                         continue  # observe limit
                     myvars = {}
                     if h.name not in seen_hosts:  # avoid defining host vars more than once
@@ -380,13 +379,13 @@ class InventoryCLI(CLI):
             if not results[group.name]:
                 del results[group.name]
 
-
             return results
 
-        available_hosts = self.inventory.get_hosts(top.name)
+        available_hosts = [h.name for h in self.inventory.get_hosts(top.name)]
         return format_group(top, available_hosts)
 
     def toml_inventory(self, top):
+        seen_hosts = set()
         seen_hosts = set()
         has_ungrouped = bool(next(g.hosts for g in top.child_groups if g.name == 'ungrouped'))
 
@@ -404,7 +403,7 @@ class InventoryCLI(CLI):
 
             if group.name != 'all':
                 for host in group.hosts:
-                    if host not in available_hosts:
+                    if host.name not in available_hosts:
                         continue
                     if host.name not in seen_hosts:
                         seen_hosts.add(host.name)
@@ -426,7 +425,7 @@ class InventoryCLI(CLI):
 
             return results
 
-        available_hosts = self.inventory.get_hosts(top.name)
+        available_hosts = [h.name for h in self.inventory.get_hosts(top.name)]
         results = format_group(top, available_hosts)
 
         return results

--- a/test/integration/targets/ansible-inventory/files/complex.ini
+++ b/test/integration/targets/ansible-inventory/files/complex.ini
@@ -1,0 +1,35 @@
+ihavenogroup
+
+[all]
+hostinall
+
+[all:vars]
+ansible_connection=local
+
+[test_group1]
+test1 myvar=something
+test2 myvar=something2
+test3
+
+[test_group2]
+test1
+test4
+test5
+
+[test_group3]
+test2 othervar=stuff
+test3
+test6
+
+[parent_1:children]
+test_group1
+
+[parent_2:children]
+test_group1
+
+[parent_3:children]
+test_group2
+test_group3
+
+[parent_3]
+test2

--- a/test/integration/targets/ansible-inventory/filter_plugins/toml.py
+++ b/test/integration/targets/ansible-inventory/filter_plugins/toml.py
@@ -1,0 +1,50 @@
+# (c) 2017, Matt Martz <matt@sivel.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import functools
+
+from ansible.plugins.inventory.toml import HAS_TOML, toml_dumps
+try:
+    from ansible.plugins.inventory.toml import toml
+except ImportError:
+    pass
+
+from ansible.errors import AnsibleFilterError
+from ansible.module_utils._text import to_text
+from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.module_utils.six import string_types
+
+
+def _check_toml(func):
+    @functools.wraps(func)
+    def inner(o):
+        if not HAS_TOML:
+            raise AnsibleFilterError('The %s filter plugin requires the python "toml" library' % func.__name__)
+        return func(o)
+    return inner
+
+
+@_check_toml
+def from_toml(o):
+    if not isinstance(o, string_types):
+        raise AnsibleFilterError('from_toml requires a string, got %s' % type(o))
+    return toml.loads(to_text(o, errors='surrogate_or_strict'))
+
+
+@_check_toml
+def to_toml(o):
+    if not isinstance(o, MutableMapping):
+        raise AnsibleFilterError('to_toml requires a dict, got %s' % type(o))
+    return to_text(toml_dumps(o), errors='surrogate_or_strict')
+
+
+class FilterModule(object):
+    def filters(self):
+        return {
+            'to_toml': to_toml,
+            'from_toml': from_toml
+        }

--- a/test/integration/targets/ansible-inventory/tasks/json_output.yml
+++ b/test/integration/targets/ansible-inventory/tasks/json_output.yml
@@ -1,0 +1,32 @@
+- block:
+  - name: check baseline
+    command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml' --list
+    register: limited
+
+  - name: ensure non empty host list
+    assert:
+      that:
+        - "'something' in inv['_meta']['hostvars']"
+
+  - name: check that limit removes host
+    command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml'  --limit '!something' --list
+    register: limited
+
+  - name: ensure empty host list
+    assert:
+      that:
+        - "'something' not in inv['_meta']['hostvars']"
+
+  - name: check dupes
+    command: ansible-inventory -i '{{ role_path }}/files/complex.ini' --list
+    register: limited
+
+  - name: ensure host only appears on directly assigned
+    assert:
+      that:
+        - "'hosts' not in inv['parent_1']"
+        - "'hosts' not in inv['parent_2']"
+        - "'hosts' in inv['parent_3']"
+        - "'test1' in inv['test_group1']['hosts']"
+  vars:
+    inv: '{{limited.stdout|from_json }}'

--- a/test/integration/targets/ansible-inventory/tasks/json_output.yml
+++ b/test/integration/targets/ansible-inventory/tasks/json_output.yml
@@ -30,3 +30,4 @@
         - "'test1' in inv['test_group1']['hosts']"
   vars:
     inv: '{{limited.stdout|from_json }}'
+  delegate_to: localhost

--- a/test/integration/targets/ansible-inventory/tasks/main.yml
+++ b/test/integration/targets/ansible-inventory/tasks/main.yml
@@ -150,7 +150,7 @@
   command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml' --list
   register: limited
 
-- name: ensure empty host list
+- name: ensure non empty host list
   assert:
     that:
       - "'something' in inv['_meta']['hostvars']"
@@ -165,5 +165,19 @@
   assert:
     that:
       - "'something' not in inv['_meta']['hostvars']"
+  vars:
+    inv: '{{ limited.stdout|from_json}}'
+
+- name: check dupes
+  command: ansible-inventory -i '{{ role_path }}/files/complex.ini' --list
+  register: limited
+
+- name: ensure host only appears on directly assigned
+  assert:
+    that:
+      - "'hosts' not in inv['parent_1']"
+      - "'hosts' not in inv['parent_2']"
+      - "'hosts' in inv['parent_3']"
+      - "'test1' in inv['test_group_1']['hosts']"
   vars:
     inv: '{{ limited.stdout|from_json}}'

--- a/test/integration/targets/ansible-inventory/tasks/main.yml
+++ b/test/integration/targets/ansible-inventory/tasks/main.yml
@@ -146,38 +146,9 @@
     loop_var: toml_package
   when: toml_package is not contains 'tomllib' or (toml_package is contains 'tomllib' and ansible_facts.python.version_info >= [3, 11])
 
-- name: check baseline
-  command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml' --list
-  register: limited
 
-- name: ensure non empty host list
-  assert:
-    that:
-      - "'something' in inv['_meta']['hostvars']"
-  vars:
-    inv: '{{ limited.stdout|from_json}}'
-
-- name: check that limit removes host
-  command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml'  --limit '!something' --list
-  register: limited
-
-- name: ensure empty host list
-  assert:
-    that:
-      - "'something' not in inv['_meta']['hostvars']"
-  vars:
-    inv: '{{ limited.stdout|from_json}}'
-
-- name: check dupes
-  command: ansible-inventory -i '{{ role_path }}/files/complex.ini' --list
-  register: limited
-
-- name: ensure host only appears on directly assigned
-  assert:
-    that:
-      - "'hosts' not in inv['parent_1']"
-      - "'hosts' not in inv['parent_2']"
-      - "'hosts' in inv['parent_3']"
-      - "'test1' in inv['test_group1']['hosts']"
-  vars:
-    inv: '{{ limited.stdout|from_json}}'
+- include_tasks: output.yml
+  loop:
+    - json
+    - yaml
+    - toml

--- a/test/integration/targets/ansible-inventory/tasks/main.yml
+++ b/test/integration/targets/ansible-inventory/tasks/main.yml
@@ -178,6 +178,6 @@
       - "'hosts' not in inv['parent_1']"
       - "'hosts' not in inv['parent_2']"
       - "'hosts' in inv['parent_3']"
-      - "'test1' in inv['test_group_1']['hosts']"
+      - "'test1' in inv['test_group1']['hosts']"
   vars:
     inv: '{{ limited.stdout|from_json}}'

--- a/test/integration/targets/ansible-inventory/tasks/main.yml
+++ b/test/integration/targets/ansible-inventory/tasks/main.yml
@@ -147,7 +147,7 @@
   when: toml_package is not contains 'tomllib' or (toml_package is contains 'tomllib' and ansible_facts.python.version_info >= [3, 11])
 
 
-- include_tasks: {{item}}_output.yml
+- include_tasks: "{{item}}_output.yml"
   loop:
     - json
     - yaml

--- a/test/integration/targets/ansible-inventory/tasks/main.yml
+++ b/test/integration/targets/ansible-inventory/tasks/main.yml
@@ -147,7 +147,7 @@
   when: toml_package is not contains 'tomllib' or (toml_package is contains 'tomllib' and ansible_facts.python.version_info >= [3, 11])
 
 
-- include_tasks: output.yml
+- include_tasks: {{item}}_output.yml
   loop:
     - json
     - yaml

--- a/test/integration/targets/ansible-inventory/tasks/output.yml
+++ b/test/integration/targets/ansible-inventory/tasks/output.yml
@@ -9,7 +9,7 @@
         - "'something' in inv['_meta']['hostvars']"
 
   - name: check that limit removes host
-    command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml'  --limit '!something' --list
+    command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml'  --limit '!something' --list --{{item}}
     register: limited
 
   - name: ensure empty host list
@@ -18,7 +18,7 @@
         - "'something' not in inv['_meta']['hostvars']"
 
   - name: check dupes
-    command: ansible-inventory -i '{{ role_path }}/files/complex.ini' --list
+    command: ansible-inventory -i '{{ role_path }}/files/complex.ini' --list --{{item}}
     register: limited
 
   - name: ensure host only appears on directly assigned

--- a/test/integration/targets/ansible-inventory/tasks/output.yml
+++ b/test/integration/targets/ansible-inventory/tasks/output.yml
@@ -1,0 +1,32 @@
+- block:
+  - name: check baseline
+    command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml' --list --{{item}}
+    register: limited
+
+  - name: ensure non empty host list
+    assert:
+      that:
+        - "'something' in inv['_meta']['hostvars']"
+
+  - name: check that limit removes host
+    command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml'  --limit '!something' --list
+    register: limited
+
+  - name: ensure empty host list
+    assert:
+      that:
+        - "'something' not in inv['_meta']['hostvars']"
+
+  - name: check dupes
+    command: ansible-inventory -i '{{ role_path }}/files/complex.ini' --list
+    register: limited
+
+  - name: ensure host only appears on directly assigned
+    assert:
+      that:
+        - "'hosts' not in inv['parent_1']"
+        - "'hosts' not in inv['parent_2']"
+        - "'hosts' in inv['parent_3']"
+        - "'test1' in inv['test_group1']['hosts']"
+  vars:
+    inv: '{{ limited.stdout|from_{{item}} }}'

--- a/test/integration/targets/ansible-inventory/tasks/toml_output.yml
+++ b/test/integration/targets/ansible-inventory/tasks/toml_output.yml
@@ -1,25 +1,28 @@
 - block:
   - name: check baseline
-    command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml' --list --{{item}}
+    command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml' --list --toml
     register: limited
 
   - name: ensure non empty host list
     assert:
       that:
-        - "'something' in inv['_meta']['hostvars']"
+        - "'something' in inv['somegroup']['hosts']"
 
   - name: check that limit removes host
-    command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml'  --limit '!something' --list --{{item}}
+    command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml'  --limit '!something' --list --toml
     register: limited
+    ignore_errors: true
 
   - name: ensure empty host list
     assert:
       that:
-        - "'something' not in inv['_meta']['hostvars']"
+        - limited is failed
 
   - name: check dupes
-    command: ansible-inventory -i '{{ role_path }}/files/complex.ini' --list --{{item}}
+    command: ansible-inventory -i '{{ role_path }}/files/complex.ini' --list --toml
     register: limited
+
+  - debug: var=inv
 
   - name: ensure host only appears on directly assigned
     assert:
@@ -29,4 +32,4 @@
         - "'hosts' in inv['parent_3']"
         - "'test1' in inv['test_group1']['hosts']"
   vars:
-    inv: '{{ limited.stdout|from_{{item}} }}'
+    inv: '{{limited.stdout|from_toml}}'

--- a/test/integration/targets/ansible-inventory/tasks/toml_output.yml
+++ b/test/integration/targets/ansible-inventory/tasks/toml_output.yml
@@ -1,3 +1,9 @@
+- name: only test if have toml in python
+  command: "{{ansible_playbook_python}} -c 'import toml'"
+  ignore_errors: true
+  delegate_to: localhost
+  register: has_toml
+
 - block:
   - name: check baseline
     command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml' --list --toml
@@ -33,3 +39,5 @@
         - "'test1' in inv['test_group1']['hosts']"
   vars:
     inv: '{{limited.stdout|from_toml}}'
+  when: has_toml is success
+  delegate_to: localhost

--- a/test/integration/targets/ansible-inventory/tasks/yaml_output.yml
+++ b/test/integration/targets/ansible-inventory/tasks/yaml_output.yml
@@ -15,7 +15,7 @@
   - name: ensure empty host list
     assert:
       that:
-        -  not inv
+        - not inv
 
   - name: check dupes
     command: ansible-inventory -i '{{ role_path }}/files/complex.ini' --list --yaml

--- a/test/integration/targets/ansible-inventory/tasks/yaml_output.yml
+++ b/test/integration/targets/ansible-inventory/tasks/yaml_output.yml
@@ -31,3 +31,4 @@
         - "'hosts' not in inv['all']['children']['parent_2']['children']['test_group1']"
   vars:
     inv: '{{limited.stdout|from_yaml}}'
+  delegate_to: localhost

--- a/test/integration/targets/ansible-inventory/tasks/yaml_output.yml
+++ b/test/integration/targets/ansible-inventory/tasks/yaml_output.yml
@@ -1,0 +1,33 @@
+- block:
+  - name: check baseline
+    command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml' --list --yaml
+    register: limited
+
+  - name: ensure something in host list
+    assert:
+      that:
+        - "'something' in inv['all']['children']['somegroup']['hosts']"
+
+  - name: check that limit removes host
+    command: ansible-inventory -i '{{ role_path }}/files/valid_sample.yml'  --limit '!something' --list --yaml
+    register: limited
+
+  - name: ensure empty host list
+    assert:
+      that:
+        -  not inv
+
+  - name: check dupes
+    command: ansible-inventory -i '{{ role_path }}/files/complex.ini' --list --yaml
+    register: limited
+
+  - name: ensure host only appears on directly assigned
+    assert:
+      that:
+        - "'hosts' not in inv['all']['children']['parent_1']"
+        - "'hosts' not in inv['all']['children']['parent_2']"
+        - "'hosts' in inv['all']['children']['parent_3']"
+        - "'test1' in inv['all']['children']['parent_1']['children']['test_group1']['hosts']"
+        - "'hosts' not in inv['all']['children']['parent_2']['children']['test_group1']"
+  vars:
+    inv: '{{limited.stdout|from_yaml}}'


### PR DESCRIPTION
this happened after implementing limits we introduced a bug that a host would be duplicated if it existed in a group's children


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible-inventory