### PR TITLE
ansible-test - Adjust vcenter test plugin behavior

### DIFF
--- a/changelogs/fragments/ansible-test-govcsim.yml
+++ b/changelogs/fragments/ansible-test-govcsim.yml
@@ -1,5 +1,5 @@
 breaking_changes:
-  - ansible-test - The ``vcenter`` test plugin now defaults to using a user-provided static configuration instead of the ``govcsim`` simulator.
+  - ansible-test - The ``vcenter`` test plugin now defaults to using a user-provided static configuration instead of the ``govcsim`` simulator for collections.
                    Set the ``ANSIBLE_VCSIM_CONTAINER`` environment variable to ``govcsim`` to use the simulator.
                    Keep in mind that the simulator is deprecated and will be removed in a future release.
 deprecated_features:

--- a/test/integration/targets/ansible-test-cloud-vcenter/aliases
+++ b/test/integration/targets/ansible-test-cloud-vcenter/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+shippable/generic/group1
+context/controller

--- a/test/integration/targets/ansible-test-cloud-vcenter/tasks/main.yml
+++ b/test/integration/targets/ansible-test-cloud-vcenter/tasks/main.yml
@@ -1,0 +1,6 @@
+- name: Verify endpoints respond
+  uri:
+    url: "{{ item }}"
+    validate_certs: no
+  with_items:
+    - http://{{ vcenter_hostname }}:5000/  # control endpoint for the simulator

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/vcenter.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/vcenter.py
@@ -18,6 +18,10 @@ from ....containers import (
     run_support_container,
 )
 
+from .... data import (
+    data_context,
+)
+
 from . import (
     CloudEnvironment,
     CloudEnvironmentConfig,
@@ -40,11 +44,17 @@ class VcenterProvider(CloudProvider):
             self.image = 'quay.io/ansible/vcenter-test-container:1.7.0'
 
         # VMware tests can be run on govcsim or BYO with a static config file.
-        # The simulator is the default if no config is provided.
-        self.vmware_test_platform = os.environ.get('VMWARE_TEST_PLATFORM', 'static')
+        # When testing ansible-core, the simulator is the default if no config is provided. This facilitates easier testing of the plugin's container support.
+        # When testing a collection, static config is the default if no config is provided.
+        default_mode = 'govcsim' if data_context().content.is_ansible else 'static'
+
+        self.vmware_test_platform = os.environ.get('VMWARE_TEST_PLATFORM', default_mode)
 
         if self.vmware_test_platform == 'govcsim':
-            display.warning('The govcsim simulator is deprecated and will be removed in a future version of ansible-test. Use a static configuration instead.')
+            display.warning(
+                'The govcsim simulator is deprecated and will be removed in a future version of ansible-test. Use a static configuration instead.',
+                unique=True,
+            )
 
             self.uses_docker = True
             self.uses_config = False


### PR DESCRIPTION
##### SUMMARY

The previous change to the default mode of operation for the plugin is now limited to collections.

This enables easier testing of the plugin in core, so the previously removed tests have been restored.

This is a follow-up to https://github.com/ansible/ansible/pull/79793

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

ansible-test
