### PR TITLE
Update ansible-test openshift plugin tests

### DIFF
--- a/test/integration/targets/ansible-test-cloud-openshift/aliases
+++ b/test/integration/targets/ansible-test-cloud-openshift/aliases
@@ -1,3 +1,4 @@
 cloud/openshift
 shippable/generic/group1
+disabled  # the container crashes when using a non-default network on some docker hosts (such as Ubuntu 20.04)
 context/controller

--- a/test/integration/targets/ansible-test-cloud-openshift/aliases
+++ b/test/integration/targets/ansible-test-cloud-openshift/aliases
@@ -1,4 +1,3 @@
 cloud/openshift
 shippable/generic/group1
-disabled  # disabled due to requirements conflict: botocore 1.20.6 has requirement urllib3<1.27,>=1.25.4, but you have urllib3 1.24.3.
 context/controller

--- a/test/integration/targets/ansible-test-cloud-openshift/tasks/main.yml
+++ b/test/integration/targets/ansible-test-cloud-openshift/tasks/main.yml
@@ -1,6 +1,13 @@
+- name: Load kubeconfig
+  include_vars: "{{ lookup('env', 'K8S_AUTH_KUBECONFIG') }}"
+
+- name: Verify endpoints exist
+  assert:
+    that: clusters
+
 - name: Verify endpoints respond
   uri:
-    url: "{{ item }}"
+    url: "{{ item.cluster.server }}"
     validate_certs: no
   with_items:
-    - https://openshift-origin:8443/
+    - "{{ clusters }}"


### PR DESCRIPTION
##### SUMMARY

Update ansible-test openshift plugin tests to use config to get server endpoint.

Also update the comment explaining why the tests are disabled.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

ansible-test-cloud-openshift integration test