### PR TITLE
check_mode page text and code blocks should use consistent booleans

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_checkmode.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_checkmode.rst
@@ -27,8 +27,8 @@ Enforcing or preventing check mode on tasks
 
 If you want certain tasks to run in check mode always, or never, regardless of whether you run the playbook with or without ``--check``, you can add the ``check_mode`` option to those tasks:
 
-  - To force a task to run in check mode, even when the playbook is called without ``--check``, set ``check_mode: yes``.
-  - To force a task to run in normal mode and make changes to the system, even when the playbook is called with ``--check``, set ``check_mode: no``.
+  - To force a task to run in check mode, even when the playbook is called without ``--check``, set ``check_mode: true``.
+  - To force a task to run in normal mode and make changes to the system, even when the playbook is called with ``--check``, set ``check_mode: false``.
 
 For example:
 
@@ -47,9 +47,9 @@ For example:
       check_mode: true
       register: changes_to_important_config
 
-Running single tasks with ``check_mode: yes`` can be useful for testing Ansible modules, either to test the module itself or to test the conditions under which a module would make changes. You can register variables (see :ref:`playbooks_conditionals`) on these tasks for even more detail on the potential changes.
+Running single tasks with ``check_mode: true`` can be useful for testing Ansible modules, either to test the module itself or to test the conditions under which a module would make changes. You can register variables (see :ref:`playbooks_conditionals`) on these tasks for even more detail on the potential changes.
 
-.. note:: Prior to version 2.2 only the equivalent of ``check_mode: no`` existed. The notation for that was ``always_run: yes``.
+.. note:: Prior to version 2.2 only the equivalent of ``check_mode: false`` existed. The notation for that was ``always_run: true``.
 
 Skipping tasks or ignoring errors in check mode
 -----------------------------------------------
@@ -92,7 +92,7 @@ Diff mode produces a large amount of output, so it is best used when checking a 
 Enforcing or preventing diff mode on tasks
 ------------------------------------------
 
-Because the ``--diff`` option can reveal sensitive information, you can disable it for a task by specifying ``diff: no``. For example:
+Because the ``--diff`` option can reveal sensitive information, you can disable it for a task by specifying ``diff: false``. For example:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
##### SUMMARY
We should consistently use the same wording for booleans in examples and in descriptions. This page uses true/false in the code blocks but yes/no in the main text.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
[docs/docsite/rst/playbook_guide/playbooks_checkmode.rst](https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/playbook_guide/playbooks_checkmode.rst)

##### ADDITIONAL INFORMATION
This PR fixes #80012  
