### PR TITLE
Docs: Clarify note on tags

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_tags.rst
@@ -339,7 +339,7 @@ Once you have added tags to your tasks, includes, blocks, plays, roles, and impo
 * ``--tags tagged`` - run only tasks with at least one tag
 * ``--tags untagged`` - run only tasks with no tags
 
-For example, to run only tasks and blocks tagged ``configuration`` and ``packages`` in a very long playbook:
+For example, to run only tasks and blocks tagged either ``configuration`` or ``packages`` in a very long playbook:
 
 .. code-block:: bash
 


### PR DESCRIPTION
##### SUMMARY
The current wording could be read as "tasks that are tagged *both* configuration and packages" while in fact it is "tasks that are tagged *either* configuration *or* packages"


##### ISSUE TYPE
- Docs Pull Request
