### PR TITLE
Make sure `var_options` is pre-templated for `reset_connection`

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1032,6 +1032,9 @@ class StrategyBase:
                 del self._active_connections[target_host]
             else:
                 connection = plugin_loader.connection_loader.get(play_context.connection, play_context, os.devnull)
+                for k in C.config.get_plugin_vars('connection', connection._load_name):
+                    if k in all_vars:
+                        all_vars[k] = templar.template(all_vars[k])
                 connection.set_options(task_keys=task.dump_attrs(), var_options=all_vars)
                 play_context.set_attributes_from_plugin(connection)
 


### PR DESCRIPTION
##### SUMMARY
Make sure `var_options` is pre-templated for `reset_connection`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/strategy/__init__.py

##### ADDITIONAL INFORMATION
Effectively duplicated from https://github.com/ansible/ansible/blob/dc3c88be8bbe10d6e206eafc8471a94e84108947/lib/ansible/executor/task_executor.py#L1031-L1039

TODO:

- [ ] Still missing `allow_extras`
- [ ] DRY?
