### PR TITLE
Define processor topology on s390x

### DIFF
--- a/changelogs/fragments/19755-ansible_processor-s390x-topology.yml
+++ b/changelogs/fragments/19755-ansible_processor-s390x-topology.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible_facts.hardware - Define processor topology on s390x (https://github.com/ansible/ansible/issues/19755)

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -170,6 +170,8 @@ class LinuxHardware(Hardware):
         cores = {}
         zp = 0
         zmt = 0
+        bookid = 0
+        drawerid = 0
 
         xen = False
         xen_paravirt = False
@@ -225,11 +227,11 @@ class LinuxHardware(Hardware):
                 i += 1
             elif key == 'physical id':
                 physid = val
-                if physid not in sockets:
+                if zp == 0 and physid not in sockets:
                     sockets[physid] = 1
             elif key == 'core id':
                 coreid = val
-                if coreid not in sockets:
+                if zp == 0 and coreid not in cores:
                     cores[coreid] = 1
             elif key == 'cpu cores':
                 sockets[physid] = int(val)
@@ -240,6 +242,17 @@ class LinuxHardware(Hardware):
                 zp = int(val)
             elif key == 'max thread id':
                 zmt = int(val) + 1
+            # S390x 5.7+ kernel with CONFIG_SCHED_TOPOLOGY
+            elif key == 'book id':
+                bookid = val
+            elif key == 'drawer id':
+                drawerid = val
+                physid = "%s.%s.%s" % (drawerid, bookid, physid)
+                coreid = "%s.%s.%s.%s" % (drawerid, bookid, physid, coreid)
+                if physid not in sockets:
+                    sockets[physid] = 1
+                if coreid not in cores:
+                    cores[coreid] = 1
             # SPARC
             elif key == 'ncpus active':
                 i = int(val)
@@ -257,8 +270,10 @@ class LinuxHardware(Hardware):
             i = processor_occurrence
 
         if collected_facts.get('ansible_architecture') == 's390x':
-            # getting sockets would require 5.7+ with CONFIG_SCHED_TOPOLOGY
-            cpu_facts['processor_count'] = 1
+            if sockets:
+                cpu_facts['processor_count'] = len(sockets)
+            else:
+                cpu_facts['processor_count'] = 1
             cpu_facts['processor_cores'] = round(zp / zmt)
             cpu_facts['processor_threads_per_core'] = zmt
             cpu_facts['processor_vcpus'] = zp

--- a/test/units/module_utils/facts/hardware/linux_data.py
+++ b/test/units/module_utils/facts/hardware/linux_data.py
@@ -633,7 +633,7 @@ CPU_INFO_TEST_SCENARIOS = [
                 'IBM/S390',
             ],
             'processor_cores': 32,
-            'processor_count': 1,
+            'processor_count': 5,
             'processor_nproc': 64,
             'processor_threads_per_core': 2,
             'processor_vcpus': 64


### PR DESCRIPTION
##### SUMMARY

This is a continuation of #79806, using processor topology on s390x hosts where available (5.7+ kernel with `CONFIG_SCHED_TOPOLOGY`) to define a more accurate `processor_count` value ("sockets", like on x86 hosts).

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

facts

##### ADDITIONAL INFORMATION

The modified test case shows the effect of this patch.

/cc @nitzmahone 
