### PR TITLE
modules/dnf: Substitute variables in DNF cache path

### DIFF
--- a/changelogs/fragments/dnf_cache_path.yml
+++ b/changelogs/fragments/dnf_cache_path.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - dnf - Substitute variables in DNF cache path (https://github.com/ansible/ansible/pull/80094).

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -403,6 +403,7 @@ from ansible.module_utils.yumdnf import YumDnf, yumdnf_argument_spec
 # to set proper locale before importing dnf to be able to scrape
 # the output in some cases (FIXME?).
 dnf = None
+libdnf = None
 
 
 class DnfModule(YumDnf):
@@ -483,6 +484,7 @@ class DnfModule(YumDnf):
         os.environ['LANGUAGE'] = os.environ['LANG'] = locale
 
         global dnf
+        global libdnf
         try:
             import dnf
             import dnf.const
@@ -490,6 +492,7 @@ class DnfModule(YumDnf):
             import dnf.package
             import dnf.subject
             import dnf.util
+            import libdnf
             HAS_DNF = True
         except ImportError:
             HAS_DNF = False
@@ -556,6 +559,9 @@ class DnfModule(YumDnf):
 
         # Load substitutions from the filesystem
         conf.substitutions.update_from_etc(installroot)
+
+        # Substitute variables in cachedir path
+        conf.cachedir = libdnf.conf.ConfigParser.substitute(conf.cachedir, conf.substitutions)
 
         # Handle different DNF versions immutable mutable datatypes and
         # dnf v1/v2/v3

--- a/test/lib/ansible_test/_util/controller/sanity/mypy/ansible-core.ini
+++ b/test/lib/ansible_test/_util/controller/sanity/mypy/ansible-core.ini
@@ -58,6 +58,9 @@ ignore_missing_imports = True
 [mypy-dnf.*]
 ignore_missing_imports = True
 
+[mypy-libdnf.*]
+ignore_missing_imports = True
+
 [mypy-apt.*]
 ignore_missing_imports = True
 

--- a/test/lib/ansible_test/_util/controller/sanity/mypy/modules.ini
+++ b/test/lib/ansible_test/_util/controller/sanity/mypy/modules.ini
@@ -25,6 +25,9 @@ ignore_missing_imports = True
 [mypy-dnf.*]
 ignore_missing_imports = True
 
+[mypy-libdnf.*]
+ignore_missing_imports = True
+
 [mypy-apt.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The cache directory can be specified with variables that are expanded by DNF, e.g.

```
cachedir=/var/cache/yum/$basearch/$releasever
```

But the `dnf` module would use that path literally, instead of replacing `$basearch` and `$releasever` with their values.

This commit ensures that variables in `cachedir` are properly substituted.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`dnf`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

To reproduce the issue, set

```ini
[main]
cachedir=/var/cache/yum/$basearch/$releasever
```

in `/etc/dnf/dnf.conf` and use the `dnf` module to install a package. On the target system, Ansible will create a directory called `/var/cache/yum/$basearch/$releasever`, instead of `/var/cache/yum/x86_64/8` for instance.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
