### PR TITLE
📦 Drop unnecessary wheel PEP 517 build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
-requires = ["setuptools >= 39.2.0", "wheel"]
+requires = ["setuptools >= 39.2.0"]
 backend-path = ["packaging"]  # requires 'Pip>=20' or 'pep517>=0.6.0'
 build-backend = "pep517_backend.hooks"  # wraps `setuptools.build_meta`


### PR DESCRIPTION
Code snippets advertising the `wheel` dependency in the `pyproject.toml`'s `[build-system].requires` setting were a historical mistake. This has been corrected in
https://github.com/pypa/setuptools/commit/f7d30a95 but many pyprojects still have `wheel` in their configs.

It is not needed for building sdists and the corresponding setuptools' PEP 517 hook that provides requirements for building wheels already esposes this dependency automatically.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Packaging Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`pyproject.toml`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
https://github.com/pypa/setuptools/pull/3056