### PR TITLE
🎨 Convert RST to manpage in-memory @ PEP 517

### DIFF
--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -20,6 +20,10 @@ __all__ = (  # noqa: WPS317, WPS410
 )
 
 
+BUILD_MANPAGES_CONFIG_SETTING = '--build-manpages'
+"""Config setting name toggle that is used to request manpage in sdists."""
+
+
 def _make_in_tree_ansible_importable() -> None:
     """Add the library directory to module lookup paths."""
     lib_path = str(Path.cwd() / 'lib/')
@@ -82,7 +86,7 @@ def build_sdist(  # noqa: WPS210, WPS430
          sdist_directory: os.PathLike,
          config_settings: dict[str, str] | None = None,
 ) -> str:
-    build_manpages_requested = '--build-manpages' in (
+    build_manpages_requested = BUILD_MANPAGES_CONFIG_SETTING in (
         config_settings or {}
     )
     if build_manpages_requested:
@@ -101,10 +105,15 @@ def build_sdist(  # noqa: WPS210, WPS430
 def get_requires_for_build_sdist(
         config_settings: dict[str, str] | None = None,
 ) -> list[str]:
-    return _setuptools_get_requires_for_build_sdist(
-        config_settings=config_settings,
-    ) + [
+    build_manpages_requested = BUILD_MANPAGES_CONFIG_SETTING in (
+        config_settings or {}
+    )
+    manpage_build_deps = [
         'docutils',  # provides `rst2man`
         'jinja2',  # used in `hacking/build-ansible.py generate-man`
         'pyyaml',  # needed for importing in-tree `ansible-core` from `lib/`
-    ]
+    ] if build_manpages_requested else []
+
+    return _setuptools_get_requires_for_build_sdist(
+        config_settings=config_settings,
+    ) + manpage_build_deps

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import typing as t
 from configparser import ConfigParser
 from importlib.metadata import import_module
 from pathlib import Path
@@ -42,7 +43,7 @@ def _get_package_distribution_version() -> str:
     return getattr(import_module(version_mod_str), version_var_str)
 
 
-def _generate_rst_in_templates() -> Path:
+def _generate_rst_in_templates() -> t.Iterable[Path]:
     """Create ``*.1.rst.in`` files out of CLI Python modules."""
     generate_man_cmd = (
         sys.executable,

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -53,7 +53,10 @@ def _generate_rst_in_templates() -> Path:
     return Path('docs/man/man1/').glob('*.1.rst.in')
 
 
-def _convert_rst_in_template_to_manpage(rst_in, version_number) -> None:
+def _convert_rst_in_template_to_manpage(
+        rst_in: Path,
+        version_number: str,
+) -> None:
     """Render pre-made ``*.1.rst.in`` templates into manpages.
 
     This includes pasting the hardcoded version into the resulting files.

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -116,6 +116,8 @@ def get_requires_for_build_sdist(
     build_manpages_requested = BUILD_MANPAGES_CONFIG_SETTING in (
         config_settings or {}
     )
+    build_manpages_requested = True  # FIXME: Once pypa/build#559 is addressed.
+
     manpage_build_deps = [
         'docutils',  # provides `rst2man`
         'jinja2',  # used in `hacking/build-ansible.py generate-man`


### PR DESCRIPTION
Previously, the automation was writing a temporary templated RST on
disk and calling a helper CLI script on that. But with this change, it
happens with less unnecessary I/O.

Co-Authored-By: Matt Davis <6775756+nitzmahone@users.noreply.github.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Packaging Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`packaging/pep517_backend/`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

N/A
