### PR TITLE
Do not use hardcoded httpbin.org in uri tests

### DIFF
--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -305,7 +305,7 @@
   environment:
     https_proxy: 'https://localhost:3456'
   uri:
-    url: 'https://httpbin.org/get'
+    url: 'https://{{ httpbin_host }}/get'
   register: result
   ignore_errors: true
 
@@ -318,7 +318,7 @@
   environment:
     https_proxy: 'https://localhost:3456'
   uri:
-    url: 'https://httpbin.org/get'
+    url: 'https://{{ httpbin_host }}/get'
     use_proxy: no
 
 # Ubuntu12.04 doesn't have python-urllib3, this makes handling required dependencies a pain across all variations


### PR DESCRIPTION
##### SUMMARY
Do not use hardcoded httpbin.org in uri tests

##### ISSUE TYPE

- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
