### PR TITLE
Documentation : update of the split filter example

### DIFF
--- a/lib/ansible/plugins/filter/split.yml
+++ b/lib/ansible/plugins/filter/split.yml
@@ -23,7 +23,7 @@ EXAMPLES: |
     listjojo: "{{ 'jojo is a' | split }}"
 
     # listjojocomma => [ "jojo is", "a" ]
-    listjojocomma: "{{ 'jojo is, a' | split(',') }}"
+    listjojocomma: "{{ 'jojo is, a' | split(',' ) }}"
 
 RETURN:
   _value:


### PR DESCRIPTION
##### SUMMARY
The "listjojocomma" example is wrong : it's missing the last parenthesis.



##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
split

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Go to : https://docs.ansible.com/ansible/latest/collections/ansible/builtin/split_filter.html#id5

