### PR TITLE
Fix typo docs in playbooks_tags.rst

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_tags.rst
@@ -257,7 +257,7 @@ If you want tag inheritance, you probably want to use imports. However, using bo
 
 .. code-block:: yaml
 
-   - name: Apply the db tag to the include and to all tasks in db.yaml
+   - name: Apply the db tag to the include and to all tasks in db.yml
      include_tasks:
        file: db.yml
        # adds 'db' tag to tasks within db.yml


### PR DESCRIPTION
##### SUMMARY

Fixes typo in file name.
It seems it refers to `db.yml` not `db.yaml`.

ISSUE TYPE

Docs Pull Request