### PR TITLE
🐛 Make integration tests compatible w/ modern Git

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/setup_recursive_scm_dependency.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/setup_recursive_scm_dependency.yml
@@ -22,7 +22,12 @@
   lineinfile:
     path: '{{ scm_path }}/namespace_2/collection_2/galaxy.yml'
     regexp: '^dependencies'
-    line: "dependencies: {'git+file://{{ scm_path }}/namespace_1/.git#collection_1/': 'master'}"
+    # NOTE: The committish is set to `HEAD` here because Git's default has
+    # NOTE: changed to `main` and it behaves differently in
+    # NOTE: different envs with different Git versions.
+    line: >-
+      dependencies:
+      {'git+file://{{ scm_path }}/namespace_1/.git#collection_1/': 'HEAD'}
 
 - name: Commit the changes
   shell: git add ./; git commit -m 'add collection'

--- a/test/integration/targets/ansible-galaxy/runme.sh
+++ b/test/integration/targets/ansible-galaxy/runme.sh
@@ -61,10 +61,13 @@ f_ansible_galaxy_create_role_repo_post()
             git add .
             git commit -m "local testing ansible galaxy role"
 
+            # NOTE: `HEAD` is used because the newer Git versions create
+            # NOTE: `main` by default and the older ones differ. We
+            # NOTE: want to avoid hardcoding them.
             git archive \
                 --format=tar \
                 --prefix="${repo_name}/" \
-                master > "${repo_tar}"
+                HEAD > "${repo_tar}"
             # Configure basic (insecure) HTTPS-accessible repository
             galaxy_local_test_role_http_repo="${galaxy_webserver_root}/${galaxy_local_test_role}.git"
             if [[ ! -d "${galaxy_local_test_role_http_repo}" ]]; then
@@ -354,7 +357,7 @@ pushd "${galaxy_testdir}"
 popd # ${galaxy_testdir}
 
 f_ansible_galaxy_status \
-    "role info non-existant role"
+    "role info non-existent role"
 
 mkdir -p "${role_testdir}"
 pushd "${role_testdir}"

--- a/test/integration/targets/git/aliases
+++ b/test/integration/targets/git/aliases
@@ -1,2 +1,1 @@
-destructive
 shippable/posix/group1

--- a/test/integration/targets/git/aliases
+++ b/test/integration/targets/git/aliases
@@ -1,1 +1,2 @@
+destructive
 shippable/posix/group1

--- a/test/integration/targets/git/tasks/depth.yml
+++ b/test/integration/targets/git/tasks/depth.yml
@@ -95,14 +95,16 @@
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
     depth: 1
-    version: master
+    version: >-
+      {{ git_default_branch }}
 
 - name: DEPTH | run a second time (now fetch, not clone)
   git:
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
     depth: 1
-    version: master
+    version: >-
+      {{ git_default_branch }}
   register: git_fetch
 
 - name: DEPTH | ensure the fetch succeeded
@@ -120,7 +122,8 @@
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
     depth: 1
-    version: master
+    version: >-
+      {{ git_default_branch }}
 
 - name: DEPTH | switch to older branch with depth=1 (uses fetch)
   git:

--- a/test/integration/targets/git/tasks/forcefully-fetch-tag.yml
+++ b/test/integration/targets/git/tasks/forcefully-fetch-tag.yml
@@ -11,7 +11,7 @@
     git add leet;
     git commit -m uh-oh;
     git tag -f herewego;
-    git push --tags origin master
+    git push --tags origin '{{ git_default_branch }}'
   args:
     chdir: "{{ repo_dir }}/tag_force_push_clone1"
 
@@ -26,7 +26,7 @@
     git add leet;
     git commit -m uh-oh;
     git tag -f herewego;
-    git push -f --tags origin master
+    git push -f --tags origin '{{ git_default_branch }}'
   args:
     chdir: "{{ repo_dir }}/tag_force_push_clone1"
 

--- a/test/integration/targets/git/tasks/gpg-verification.yml
+++ b/test/integration/targets/git/tasks/gpg-verification.yml
@@ -36,9 +36,14 @@
 - name: GPG-VERIFICATION | Generate local GnuPG signed repository
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
+  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
+  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
-    set -e
+    set -eEu
+
     git init
+    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
+
     touch an_empty_file
     git add an_empty_file
     git commit --no-gpg-sign --message "Commit, and don't sign"
@@ -48,11 +53,11 @@
     git tag --annotate --message "This is not a signed tag" unsigned_annotated_tag HEAD
     git commit --allow-empty --gpg-sign --message "Commit, and sign"
     git tag --sign --message "This is a signed tag" signed_annotated_tag HEAD
-    git checkout -b some_branch/signed_tip master
+    git checkout -b some_branch/signed_tip '{{ git_default_branch }}'
     git commit --allow-empty --gpg-sign --message "Commit, and sign"
-    git checkout -b another_branch/unsigned_tip master
+    git checkout -b another_branch/unsigned_tip '{{ git_default_branch }}'
     git commit --allow-empty --no-gpg-sign --message "Commit, and don't sign"
-    git checkout master
+    git checkout '{{ git_default_branch }}'
   args:
     chdir: "{{ git_gpg_source }}"
 

--- a/test/integration/targets/git/tasks/gpg-verification.yml
+++ b/test/integration/targets/git/tasks/gpg-verification.yml
@@ -36,13 +36,10 @@
 - name: GPG-VERIFICATION | Generate local GnuPG signed repository
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
-  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
-  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
     set -eEu
 
     git init
-    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
 
     touch an_empty_file
     git add an_empty_file

--- a/test/integration/targets/git/tasks/localmods.yml
+++ b/test/integration/targets/git/tasks/localmods.yml
@@ -1,6 +1,20 @@
 # test for https://github.com/ansible/ansible-modules-core/pull/5505
 - name: LOCALMODS | prepare old git repo
-  shell: rm -rf localmods; mkdir localmods; cd localmods; git init; echo "1" > a; git add a; git commit -m "1"
+  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
+  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
+  shell: |
+    set -eEu
+
+    rm -rf localmods
+    mkdir localmods
+    cd localmods
+
+    git init
+    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
+
+    echo "1" > a
+    git add a
+    git commit -m "1"
   args:
     chdir: "{{repo_dir}}"
 
@@ -55,7 +69,21 @@
 
 # localmods and shallow clone
 - name: LOCALMODS | prepare old git repo
-  shell: rm -rf localmods; mkdir localmods; cd localmods; git init; echo "1" > a; git add a; git commit -m "1"
+  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
+  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
+  shell: |
+    set -eEu
+
+    rm -rf localmods
+    mkdir localmods
+    cd localmods
+
+    git init
+    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
+
+    echo "1" > a
+    git add a
+    git commit -m "1"
   args:
     chdir: "{{repo_dir}}"
 

--- a/test/integration/targets/git/tasks/localmods.yml
+++ b/test/integration/targets/git/tasks/localmods.yml
@@ -1,7 +1,5 @@
 # test for https://github.com/ansible/ansible-modules-core/pull/5505
 - name: LOCALMODS | prepare old git repo
-  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
-  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
     set -eEu
 
@@ -10,7 +8,6 @@
     cd localmods
 
     git init
-    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
 
     echo "1" > a
     git add a
@@ -69,8 +66,6 @@
 
 # localmods and shallow clone
 - name: LOCALMODS | prepare old git repo
-  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
-  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
     set -eEu
 
@@ -79,7 +74,6 @@
     cd localmods
 
     git init
-    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
 
     echo "1" > a
     git add a

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -16,27 +16,37 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- import_tasks: setup.yml
-- import_tasks: setup-local-repos.yml
+# NOTE: Moving `$HOME` to tmp dir allows this integration test be
+# NOTE: non-destructive. There is no other way to instruct Git use a custom
+# NOTE: config path. There are new `$GIT_CONFIG_KEY_{COUNT,KEY,VALUE}` vars
+# NOTE: for setting specific configuration values but those are only available
+# NOTE: since Git v2.31 which is why we cannot rely on them yet.
 
-- import_tasks: formats.yml
-- import_tasks: missing_hostkey.yml
-- import_tasks: missing_hostkey_acceptnew.yml
-- import_tasks: no-destination.yml
-- import_tasks: specific-revision.yml
-- import_tasks: submodules.yml
-- import_tasks: change-repo-url.yml
-- import_tasks: depth.yml
-- import_tasks: single-branch.yml
-- import_tasks: checkout-new-tag.yml
-- include_tasks: gpg-verification.yml
-  when:
+- block:
+  - import_tasks: setup.yml
+  - import_tasks: setup-local-repos.yml
+
+  - import_tasks: formats.yml
+  - import_tasks: missing_hostkey.yml
+  - import_tasks: missing_hostkey_acceptnew.yml
+  - import_tasks: no-destination.yml
+  - import_tasks: specific-revision.yml
+  - import_tasks: submodules.yml
+  - import_tasks: change-repo-url.yml
+  - import_tasks: depth.yml
+  - import_tasks: single-branch.yml
+  - import_tasks: checkout-new-tag.yml
+  - include_tasks: gpg-verification.yml
+    when:
     - not gpg_version.stderr
     - gpg_version.stdout
     - not (ansible_os_family == 'RedHat' and ansible_distribution_major_version is version('7', '<'))
-- import_tasks: localmods.yml
-- import_tasks: reset-origin.yml
-- import_tasks: ambiguous-ref.yml
-- import_tasks: archive.yml
-- import_tasks: separate-git-dir.yml
-- import_tasks: forcefully-fetch-tag.yml
+  - import_tasks: localmods.yml
+  - import_tasks: reset-origin.yml
+  - import_tasks: ambiguous-ref.yml
+  - import_tasks: archive.yml
+  - import_tasks: separate-git-dir.yml
+  - import_tasks: forcefully-fetch-tag.yml
+  environment:
+    HOME: >-
+      {{ remote_tmp_dir }}

--- a/test/integration/targets/git/tasks/missing_hostkey.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey.yml
@@ -35,7 +35,8 @@
   git:
     repo: '{{ repo_format3 }}'
     dest: '{{ checkout_dir }}'
-    version: 'master'
+    version: >-
+      {{ git_default_branch }}
     accept_hostkey: false # should already have been accepted
     key_file: '{{ github_ssh_private_key }}'
     ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'

--- a/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey_acceptnew.yml
@@ -55,7 +55,8 @@
       git:
         repo: '{{ repo_format3 }}'
         dest: '{{ checkout_dir }}'
-        version: 'master'
+        version: >-
+          {{ git_default_branch }}
         accept_newhostkey: false # should already have been accepted
         key_file: '{{ github_ssh_private_key }}'
         ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'

--- a/test/integration/targets/git/tasks/reset-origin.yml
+++ b/test/integration/targets/git/tasks/reset-origin.yml
@@ -12,13 +12,10 @@
     state: directory
 
 - name: RESET-ORIGIN | Initialise the repo with a file named origin,see github.com/ansible/ansible/pull/22502
-  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
-  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
     set -eEu
 
     git init
-    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
 
     echo "PR 22502" > origin
     git add origin

--- a/test/integration/targets/git/tasks/reset-origin.yml
+++ b/test/integration/targets/git/tasks/reset-origin.yml
@@ -12,7 +12,17 @@
     state: directory
 
 - name: RESET-ORIGIN | Initialise the repo with a file named origin,see github.com/ansible/ansible/pull/22502
-  shell: git init; echo "PR 22502" > origin; git add origin; git commit -m "PR 22502"
+  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
+  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
+  shell: |
+    set -eEu
+
+    git init
+    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
+
+    echo "PR 22502" > origin
+    git add origin
+    git commit -m "PR 22502"
   args:
     chdir: "{{ repo_dir }}/origin"
 

--- a/test/integration/targets/git/tasks/setup-local-repos.yml
+++ b/test/integration/targets/git/tasks/setup-local-repos.yml
@@ -9,15 +9,38 @@
     - "{{ repo_dir }}/tag_force_push"
 
 - name: SETUP-LOCAL-REPOS | prepare minimal git repo
-  shell: git init; echo "1" > a; git add a; git commit -m "1"
+  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
+  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
+  shell: |
+    set -eEu
+
+    git init
+    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
+
+    echo "1" > a
+    git add a
+    git commit -m "1"
   args:
     chdir: "{{ repo_dir }}/minimal"
 
 - name: SETUP-LOCAL-REPOS | prepare git repo for shallow clone
+  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
+  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
-    git init;
-    echo "1" > a; git add a; git commit -m "1"; git tag earlytag; git branch earlybranch;
-    echo "2" > a; git add a; git commit -m "2";
+    set -eEu
+
+    git init
+    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
+
+    echo "1" > a
+    git add a
+    git commit -m "1"
+    git tag earlytag
+    git branch earlybranch
+
+    echo "2" > a
+    git add a
+    git commit -m "2"
   args:
     chdir: "{{ repo_dir }}/shallow"
 
@@ -28,8 +51,14 @@
     chdir: "{{ repo_dir }}/shallow"
 
 - name: SETUP-LOCAL-REPOS | prepare tmp git repo with two branches
+  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
+  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
+    set -eEu
+
     git init
+    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
+
     echo "1" > a; git add a; git commit -m "1"
     git checkout -b test_branch; echo "2" > a; git commit -m "2 on branch" a
     git checkout -b new_branch; echo "3" > a; git commit -m "3 on new branch" a
@@ -40,6 +69,12 @@
 # We make the repo here for consistency with the other repos,
 # but we finish setting it up in forcefully-fetch-tag.yml.
 - name: SETUP-LOCAL-REPOS | prepare tag_force_push git repo
-  shell: git init --bare
+  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
+  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
+  shell: |
+    set -eEu
+
+    git init --bare
+    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
   args:
     chdir: "{{ repo_dir }}/tag_force_push"

--- a/test/integration/targets/git/tasks/setup-local-repos.yml
+++ b/test/integration/targets/git/tasks/setup-local-repos.yml
@@ -9,13 +9,10 @@
     - "{{ repo_dir }}/tag_force_push"
 
 - name: SETUP-LOCAL-REPOS | prepare minimal git repo
-  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
-  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
     set -eEu
 
     git init
-    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
 
     echo "1" > a
     git add a
@@ -24,13 +21,10 @@
     chdir: "{{ repo_dir }}/minimal"
 
 - name: SETUP-LOCAL-REPOS | prepare git repo for shallow clone
-  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
-  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
     set -eEu
 
     git init
-    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
 
     echo "1" > a
     git add a
@@ -51,13 +45,10 @@
     chdir: "{{ repo_dir }}/shallow"
 
 - name: SETUP-LOCAL-REPOS | prepare tmp git repo with two branches
-  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
-  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
     set -eEu
 
     git init
-    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
 
     echo "1" > a; git add a; git commit -m "1"
     git checkout -b test_branch; echo "2" > a; git commit -m "2 on branch" a
@@ -69,12 +60,9 @@
 # We make the repo here for consistency with the other repos,
 # but we finish setting it up in forcefully-fetch-tag.yml.
 - name: SETUP-LOCAL-REPOS | prepare tag_force_push git repo
-  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
-  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
     set -eEu
 
     git init --bare
-    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
   args:
     chdir: "{{ repo_dir }}/tag_force_push"

--- a/test/integration/targets/git/tasks/setup.yml
+++ b/test/integration/targets/git/tasks/setup.yml
@@ -28,13 +28,14 @@
   register: gpg_version
 
 - name: SETUP | set git global user.email if not already set
-  shell: git config --global user.email || git config --global user.email "noreply@example.com"
+  shell: git config --global user.email 'noreply@example.com'
 
 - name: SETUP | set git global user.name if not already set
-  shell: git config --global user.name  || git config --global user.name  "Ansible Test Runner"
+  shell: git config --global user.name  'Ansible Test Runner'
 
 - name: SETUP | set git global init.defaultBranch
-  shell: git config --global init.defaultBranch '{{ git_default_branch }}'
+  shell: >-
+    git config --global init.defaultBranch '{{ git_default_branch }}'
 
 - name: SETUP | set git global init.templateDir
   # NOTE: This custom Git repository template emulates the `init.defaultBranch`
@@ -45,8 +46,13 @@
   # NOTE: out to have mysterious side effects that break the tests in surprising
   # NOTE: ways.
   shell: |
-    git config --global init.templateDir '~/Templates/git.git'
-    mkdir -pv ~/Templates
+    set -eEu
+
+    git config --global \
+      init.templateDir '{{ remote_tmp_dir }}/git-templates/git.git'
+
+    mkdir -pv '{{ remote_tmp_dir }}/git-templates'
+    set +e
     GIT_TEMPLATES_DIR=$(\
       2>/dev/null \
         ls -1d \
@@ -54,8 +60,12 @@
           '/usr/local/share/git-core/templates' \
           '/usr/share/git-core/templates' \
     )
-    cp -r "${GIT_TEMPLATES_DIR}" ~/Templates/git.git
-    echo 'ref: refs/heads/{{ git_default_branch }}' > ~/Templates/git.git/HEAD
+    set -e
+    >&2 echo "Found Git's default templates directory: ${GIT_TEMPLATES_DIR}"
+    cp -r "${GIT_TEMPLATES_DIR}" '{{ remote_tmp_dir }}/git-templates/git.git'
+
+    echo 'ref: refs/heads/{{ git_default_branch }}' \
+      > '{{ remote_tmp_dir }}/git-templates/git.git/HEAD'
 
 - name: SETUP | create repo_dir
   file:

--- a/test/integration/targets/git/tasks/setup.yml
+++ b/test/integration/targets/git/tasks/setup.yml
@@ -36,6 +36,27 @@
 - name: SETUP | set git global init.defaultBranch
   shell: git config --global init.defaultBranch '{{ git_default_branch }}'
 
+- name: SETUP | set git global init.templateDir
+  # NOTE: This custom Git repository template emulates the `init.defaultBranch`
+  # NOTE: setting on Git versions below 2.28.
+  # NOTE: Ref: https://superuser.com/a/1559582.
+  # NOTE: Other workarounds mentioned there, like invoking
+  # NOTE: `git symbolic-ref HEAD refs/heads/main` after each `git init` turned
+  # NOTE: out to have mysterious side effects that break the tests in surprising
+  # NOTE: ways.
+  shell: |
+    git config --global init.templateDir '~/Templates/git.git'
+    mkdir -pv ~/Templates
+    GIT_TEMPLATES_DIR=$(\
+      2>/dev/null \
+        ls -1d \
+          '/Library/Developer/CommandLineTools/usr/share/git-core/templates' \
+          '/usr/local/share/git-core/templates' \
+          '/usr/share/git-core/templates' \
+    )
+    cp -r "${GIT_TEMPLATES_DIR}" ~/Templates/git.git
+    echo 'ref: refs/heads/{{ git_default_branch }}' > ~/Templates/git.git/HEAD
+
 - name: SETUP | create repo_dir
   file:
     path: "{{ repo_dir }}"

--- a/test/integration/targets/git/tasks/setup.yml
+++ b/test/integration/targets/git/tasks/setup.yml
@@ -33,6 +33,9 @@
 - name: SETUP | set git global user.name if not already set
   shell: git config --global user.name  || git config --global user.name  "Ansible Test Runner"
 
+- name: SETUP | set git global init.defaultBranch
+  shell: git config --global init.defaultBranch '{{ git_default_branch }}'
+
 - name: SETUP | create repo_dir
   file:
     path: "{{ repo_dir }}"

--- a/test/integration/targets/git/tasks/single-branch.yml
+++ b/test/integration/targets/git/tasks/single-branch.yml
@@ -52,7 +52,8 @@
     repo: 'file://{{ repo_dir|expanduser }}/shallow_branches'
     dest: '{{ checkout_dir }}'
     single_branch: yes
-    version: master
+    version: >-
+      {{ git_default_branch }}
   register: single_branch_3
 
 - name: SINGLE_BRANCH | Clone example git repo using single_branch with version again
@@ -60,7 +61,8 @@
     repo: 'file://{{ repo_dir|expanduser }}/shallow_branches'
     dest: '{{ checkout_dir }}'
     single_branch: yes
-    version: master
+    version: >-
+      {{ git_default_branch }}
   register: single_branch_4
 
 - name: SINGLE_BRANCH | List revisions

--- a/test/integration/targets/git/tasks/specific-revision.yml
+++ b/test/integration/targets/git/tasks/specific-revision.yml
@@ -162,7 +162,17 @@
     path: "{{ checkout_dir }}"
 
 - name: SPECIFIC-REVISION | prepare origina repo
-  shell: git init; echo "1" > a; git add a; git commit -m "1"
+  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
+  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
+  shell: |
+    set -eEu
+
+    git init
+    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
+
+    echo "1" > a
+    git add a
+    git commit -m "1"
   args:
     chdir: "{{ checkout_dir }}"
 
@@ -191,7 +201,17 @@
     force: yes
 
 - name: SPECIFIC-REVISION | create new commit in original
-  shell: git init; echo "2" > b; git add b; git commit -m "2"
+  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
+  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
+  shell: |
+    set -eEu
+
+    git init
+    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
+
+    echo "2" > b
+    git add b
+    git commit -m "2"
   args:
     chdir: "{{ checkout_dir }}"
 

--- a/test/integration/targets/git/tasks/specific-revision.yml
+++ b/test/integration/targets/git/tasks/specific-revision.yml
@@ -162,13 +162,10 @@
     path: "{{ checkout_dir }}"
 
 - name: SPECIFIC-REVISION | prepare origina repo
-  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
-  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
     set -eEu
 
     git init
-    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
 
     echo "1" > a
     git add a
@@ -201,13 +198,10 @@
     force: yes
 
 - name: SPECIFIC-REVISION | create new commit in original
-  # NOTE: `git symbolic-ref` command emulates the `init.defaultBranch` setting
-  # NOTE: on Git versions lower than 2.28. Ref: https://superuser.com/a/1419674
   shell: |
     set -eEu
 
     git init
-    git symbolic-ref HEAD refs/heads/{{ git_default_branch }}
 
     echo "2" > b
     git add b

--- a/test/integration/targets/git/vars/main.yml
+++ b/test/integration/targets/git/vars/main.yml
@@ -41,6 +41,7 @@ repo_update_url_2: 'https://github.com/ansible-test-robinro/git-test-new'
 known_host_files:
   - "{{ lookup('env','HOME') }}/.ssh/known_hosts"
   - '/etc/ssh/ssh_known_hosts'
+git_default_branch: main
 git_version_supporting_depth: 1.9.1
 git_version_supporting_ls_remote: 1.7.5
 git_version_supporting_single_branch: 1.7.10


### PR DESCRIPTION
This patch makes use of the `init.defaultBranch` setting to unify the test across new and old Git versions since one defaults to `master` and the other uses `main` for the default branch.

Where possible, it uses the `HEAD` committish to avoid having to normalize the branch name.

The change fixes the following integration tests:

  * `ansible-galaxy`

  * `ansible-galaxy-collection-scm` (recursive collection)

  * `git`

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests/integration/

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Extracted from #79508
