### PR TITLE
Symbolic modes with X or =[ugo] always use original mode

### DIFF
--- a/changelogs/fragments/80128-symbolic-modes-X-use-computed.yml
+++ b/changelogs/fragments/80128-symbolic-modes-X-use-computed.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - file modules - Make symbolic modes with X use the computed permission, not original file (https://github.com/ansible/ansible/issues/80128)
+  - copy unit tests - Fixing "dir all perms" documentation and formatting for easier reading.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1074,7 +1074,7 @@ class AnsibleModule(object):
                     raise ValueError("bad symbolic permission for mode: %s" % mode)
 
                 for user in users:
-                    mode_to_apply = cls._get_octal_mode_from_symbolic_perms(path_stat, user, perms, use_umask)
+                    mode_to_apply = cls._get_octal_mode_from_symbolic_perms(path_stat, new_mode, user, perms, use_umask)
                     new_mode = cls._apply_operation_to_mode(user, opers[idx], mode_to_apply, new_mode)
 
         return new_mode
@@ -1099,9 +1099,7 @@ class AnsibleModule(object):
         return new_mode
 
     @staticmethod
-    def _get_octal_mode_from_symbolic_perms(path_stat, user, perms, use_umask):
-        prev_mode = stat.S_IMODE(path_stat.st_mode)
-
+    def _get_octal_mode_from_symbolic_perms(path_stat, prev_mode, user, perms, use_umask):
         is_directory = stat.S_ISDIR(path_stat.st_mode)
         has_x_permissions = (prev_mode & EXEC_PERM_BITS) > 0
         apply_X_permission = is_directory or has_x_permissions

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1074,7 +1074,7 @@ class AnsibleModule(object):
                     raise ValueError("bad symbolic permission for mode: %s" % mode)
 
                 for user in users:
-                    mode_to_apply = cls._get_octal_mode_from_symbolic_perms(path_stat, new_mode, user, perms, use_umask)
+                    mode_to_apply = cls._get_octal_mode_from_symbolic_perms(path_stat, user, perms, use_umask, new_mode)
                     new_mode = cls._apply_operation_to_mode(user, opers[idx], mode_to_apply, new_mode)
 
         return new_mode
@@ -1099,7 +1099,9 @@ class AnsibleModule(object):
         return new_mode
 
     @staticmethod
-    def _get_octal_mode_from_symbolic_perms(path_stat, prev_mode, user, perms, use_umask):
+    def _get_octal_mode_from_symbolic_perms(path_stat, user, perms, use_umask, prev_mode=None):
+        if prev_mode is None:
+            prev_mode = stat.S_IMODE(path_stat.st_mode)
         is_directory = stat.S_ISDIR(path_stat.st_mode)
         has_x_permissions = (prev_mode & EXEC_PERM_BITS) > 0
         apply_X_permission = is_directory or has_x_permissions

--- a/test/units/modules/test_copy.py
+++ b/test/units/modules/test_copy.py
@@ -128,16 +128,19 @@ def test_split_pre_existing_dir_working_dir_exists(directory, expected, mocker):
 #
 # Info helpful for making new test cases:
 #
-# base_mode = {'dir no perms': 0o040000,
-# 'file no perms': 0o100000,
-# 'dir all perms': 0o400000 | 0o777,
-# 'file all perms': 0o100000, | 0o777}
+# base_mode = {
+# 'dir no perms':   0o040000,
+# 'file no perms':  0o100000,
+# 'dir all perms':  0o040000 | 0o777,
+# 'file all perms': 0o100000 | 0o777}
 #
-# perm_bits = {'x': 0b001,
+# perm_bits = {
+# 'x': 0b001,
 # 'w': 0b010,
 # 'r': 0b100}
 #
-# role_shift = {'u': 6,
+# role_shift = {
+# 'u': 6,
 # 'g': 3,
 # 'o': 0}
 
@@ -171,6 +174,10 @@ DATA = (  # Going from no permissions to setting all for user, group, and/or oth
     # Same as chmod but is it a bug?
     # chmod a-X statfile <== removes execute from statfile
     (0o100777, u'a-X', 0o0666),
+
+    # Verify X uses computed not original mode
+    (0o100777, u'a=,u=rX', 0o0400),
+    (0o040777, u'a=,u=rX', 0o0500),
 
     # Multiple permissions
     (0o040000, u'u=rw-x+X,g=r-x+X,o=r-x+X', 0o0755),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes #80128 

The setting of file module symbolic permissions differs between the file module and the system "chmod"  (only tested on Ubuntu 22.04), but also defies common sense (IMHO :-).  The issue applies to "dynamic" permissions like "X" ("a=X") and permissions with "ugo" in the right hand side ("g=u"), but only if they come after a permission which has already modified the value in question.  This is particularly a problem with recursive permissions changes for files and directories.  An example of problematic permissions are: "a=,u=rX" and "u=rx,g=u".  chmod treats these changes as cumulative, where the ansible "file" module always uses the original file permissions to determine "X" or "=[ugo]".

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
file

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

All of this is covered in #80128 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
