### PR TITLE
unarchive - respect symlinks in archives

### DIFF
--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -271,6 +271,7 @@ MOD_TIME_DIFF_RE = re.compile(r': Mod time differs$')
 # NEWER_DIFF_RE = re.compile(r' is newer or same age.$')
 EMPTY_FILE_RE = re.compile(r': : Warning: Cannot stat: No such file or directory$')
 MISSING_FILE_RE = re.compile(r': Warning: Cannot stat: No such file or directory$')
+MISSING_LINK_RE = re.compile(r': Warning: Cannot readlink: No such file or directory$')
 ZIP_FILE_MODE_RE = re.compile(r'([r-][w-][SsTtx-]){3}')
 INVALID_OWNER_RE = re.compile(r': Invalid owner')
 INVALID_GROUP_RE = re.compile(r': Invalid group')
@@ -896,7 +897,7 @@ class TgzArchive(object):
             differ_regexes = [
                 MOD_TIME_DIFF_RE, MISSING_FILE_RE, INVALID_OWNER_RE,
                 INVALID_GROUP_RE, SYMLINK_DIFF_RE, CONTENT_DIFF_RE,
-                SIZE_DIFF_RE
+                SIZE_DIFF_RE, MISSING_LINK_RE,
             ]
             for regex in differ_regexes:
                 if regex.search(line):


### PR DESCRIPTION
this patch fixes the extraction if symlinks are present in an archive but the symlinks don't exist in the target filesystem.

tar reports this with:
```console
/bin/tar: $filename: Warning: Cannot readlink: No such file or directory
```

previously, this was not matched against, hence the re-extraction was not triggered, although needed.

additionally, setting permissions on that file later fails, leading to errors like: Unexpected error when accessing exploded file: `[Errno 2] No such file or directory: b'/path/to/$filename'`

```python-traceback
  File "payload.zip/ansible/modules/unarchive.py", line 901, in main
  File "payload.zip/ansible/module_utils/basic.py", line 1417, in set_fs_attributes_if_different
    file_args['path'], file_args['owner'], changed, diff, expand
  File "payload.zip/ansible/module_utils/basic.py", line 1058, in set_owner_if_different
    orig_uid, orig_gid = self.user_and_group(b_path, expand)
  File "payload.zip/ansible/module_utils/basic.py", line 952, in user_and_group
    st = os.lstat(b_path)
```

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`unarchive` module