### PR TITLE
Fix spelling and grammar in subelements filter doc

### DIFF
--- a/lib/ansible/plugins/filter/subelements.yml
+++ b/lib/ansible/plugins/filter/subelements.yml
@@ -1,7 +1,7 @@
 DOCUMENTATION:
   name: subelements
   version_added: "2.7"
-  short_description: retuns a product of a list and it's elements
+  short_description: returns a product of a list and its elements
   positional: _input, _subelement, skip_missing
   description:
     - This produces a product of an object and the subelement values of that object, similar to the subelements lookup. This lets you specify individual subelements to use in a template I(_input).


### PR DESCRIPTION
##### SUMMARY
Fixes a spelling and grammar issue on the short description for the subelements filter.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs.ansible.com