### PR TITLE
Use _remote_is_local in plugins.connection.local

### DIFF
--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -42,6 +42,7 @@ class Connection(ConnectionBase):
 
     transport = 'local'
     has_pipelining = True
+    _remote_is_local = True
 
     def __init__(self, *args, **kwargs):
 


### PR DESCRIPTION

##### SUMMARY

During interpreter discovery, this flag ensures that `connection: local` tasks do not persist the discovered interpreter in the ansible facts.

This avoids an issue where mixing `connection: local` and `connection: ssh` tasks on the same host doesn't work if they don't use the same interpreter (e.g. the local host only has /usr/bin/python3 available, and the remote host only has /usr/bin/python available).

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`ansible.plugins.connection.local`

##### ADDITIONAL INFORMATION

Consider the following scenario:

1. Local host has `/usr/bin/python3` as an interpreter (`/usr/bin/python` does not exist)
2. Remote host has `/usr/bin/python` and `/usr/bin/python2.7` as interpreters (`/usr/bin/python3` does not exist)
3. First task uses `connection: local`
  * Without this proposed change, after raising `InterpreterDiscoveryRequiredError`, we [set the discovered_interpreter_python fact](https://github.com/ansible/ansible/blob/1055803c3a812189a1133297f7f5468579283f86/lib/ansible/plugins/action/__init__.py#L305)
  * With this proposed change, `InterpreterDiscoveryRequiredError` is not raised because we call `modify_module` with `remote_is_local` which immediately [re-uses the current interpreter](https://github.com/ansible/ansible/blob/1055803c3a812189a1133297f7f5468579283f86/lib/ansible/executor/module_common.py#L603) (which makes sense on `connection: local` IMHO)
4. Second task uses `connection: ssh`
  * With the current behavior, `discovered_interpreter_python` was set during interpreter discovery on the local connection so we reuse `/usr/bin/python3`. Alas! It's not available on the remote host. The connection fails.
  * With this proposed change, `discovered_interpreter_python` was not set on the local connection, so we go through the discovery as usual and find `/usr/bin/python` as a suitable interpreter
5. Third task uses `connection: local` again
  * No issue because `modify_module` [returns the current interpreter](https://github.com/ansible/ansible/blob/1055803c3a812189a1133297f7f5468579283f86/lib/ansible/executor/module_common.py#L603), so it's not a problem that `discovered_interpreter_python` was set on the remote machine.