### PR TITLE
Avoid redundant unsafe wrapping in ansible_eval_concat

### DIFF
--- a/changelogs/fragments/ansible_eval_concat-remove-redundant-unsafe-wrap.yml
+++ b/changelogs/fragments/ansible_eval_concat-remove-redundant-unsafe-wrap.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "``ansible_eval_concat`` - avoid redundant unsafe wrapping of templated strings converted to Python types"

--- a/lib/ansible/template/native_helpers.py
+++ b/lib/ansible/template/native_helpers.py
@@ -14,7 +14,6 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.six import string_types
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 from ansible.utils.native_jinja import NativeJinjaText
-from ansible.utils.unsafe_proxy import wrap_var
 
 
 _JSON_MAP = {
@@ -60,7 +59,6 @@ def ansible_eval_concat(nodes):
 
     # if this looks like a dictionary, list or bool, convert it to such
     if out.startswith(('{', '[')) or out in ('True', 'False'):
-        unsafe = hasattr(out, '__UNSAFE__')
         try:
             out = ast.literal_eval(
                 ast.fix_missing_locations(
@@ -71,9 +69,6 @@ def ansible_eval_concat(nodes):
             )
         except (ValueError, SyntaxError, MemoryError):
             pass
-        else:
-            if unsafe:
-                out = wrap_var(out)
 
     return out
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The wrap_var is done in do_template for all concat functions after their return.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/template/native_helpers.py`