### PR TITLE
Do not re-template delegate_to, act off of pre-cached data

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -156,7 +156,7 @@ class TaskExecutor:
                     res = dict(changed=False, skipped=True, skipped_reason='No items in the list', results=[])
             else:
                 # We aren't in a loop, so to make delegate_to predictable, use ansible_delegated_vars
-                # To shortcut re-templating delegate_to
+                # to shortcut re-templating delegate_to
                 delegated_vars = self._job_vars.get('ansible_delegated_vars', {})
                 if self._task.delegate_to and len(delegated_vars) == 1:
                     self._task.delegate_to = next(iter(delegated_vars))

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -304,6 +304,8 @@ class TaskExecutor:
                 cached_delegate_to = item.delegate_to
                 item = item.item
             else:
+                # If there was no delegate_to, we won't have pre-calculated and cached
+                # the loop info from VariableManager._get_delegated_vars
                 cached_delegate_to = None
 
             task_vars['ansible_loop_var'] = loop_var

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -158,16 +158,8 @@ class TaskExecutor:
                 # We aren't in a loop, so to make delegate_to predictable, use ansible_delegated_vars
                 # To shortcut re-templating delegate_to
                 delegated_vars = self._job_vars.get('ansible_delegated_vars', {})
-                try:
-                    if len(delegated_vars) > 1:
-                        raise StopIteration(
-                            'This is unexpected, in a non-loop context this should never have more than a single host'
-                        )
-                    cached_delegate_to = next(iter(delegated_vars))
-                except StopIteration:
-                    pass
-                else:
-                    self._task.delegate_to = cached_delegate_to
+                if self._task.delegate_to and len(delegated_vars) == 1:
+                    self._task.delegate_to = next(iter(delegated_vars))
 
                 display.debug("calling self._execute()")
                 res = self._execute()

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -76,3 +76,7 @@ ansible-playbook test_delegate_to_lookup_context.yml -i inventory -v "$@"
 ansible-playbook delegate_local_from_root.yml -i inventory -v "$@" -e 'ansible_user=root'
 ansible-playbook delegate_with_fact_from_delegate_host.yml "$@"
 ansible-playbook delegate_facts_loop.yml -i inventory -v "$@"
+ansible-playbook test_random_delegate_to_with_loop.yml -i inventory -v "$@"
+
+# Run playbook multiple times to ensure there are no false-negatives
+for i in $(seq 0 10); do ansible-playbook test_random_delegate_to_without_loop.yml -i inventory -v "$@"; done;

--- a/test/integration/targets/delegate_to/test_random_delegate_to_with_loop.yml
+++ b/test/integration/targets/delegate_to/test_random_delegate_to_with_loop.yml
@@ -1,0 +1,26 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - add_host:
+        name: 'host{{ item }}'
+        groups:
+          - test
+      loop: '{{ range(10) }}'
+
+    # This task may fail, if it does, it means the same thing as if the assert below fails
+    - set_fact:
+        dv: '{{ ansible_delegated_vars[ansible_host]["ansible_host"] }}'
+      delegate_to: '{{ groups.test|random }}'
+      delegate_facts: true
+      # Purposefully smaller loop than group count
+      loop: '{{ range(5) }}'
+
+- hosts: test
+  gather_facts: false
+  tasks:
+    - assert:
+        that:
+          - dv == inventory_hostname
+      # The small loop above means we won't set this var for every host
+      # and a smaller loop is faster, and may catch the error in the above task
+      when: dv is defined

--- a/test/integration/targets/delegate_to/test_random_delegate_to_without_loop.yml
+++ b/test/integration/targets/delegate_to/test_random_delegate_to_without_loop.yml
@@ -1,0 +1,13 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - add_host:
+        name: 'host{{ item }}'
+        groups:
+          - test
+      loop: '{{ range(10) }}'
+
+    - set_fact:
+        dv: '{{ ansible_delegated_vars[ansible_host]["ansible_host"] }}'
+      delegate_to: '{{ groups.test|random }}'
+      delegate_facts: true


### PR DESCRIPTION
##### SUMMARY
Do not re-template `delegate_to`, act off of pre-cached data

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/task_executor.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
