### PR TITLE
🧪 Switch macOS 13.2 to 12.0 in CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -87,8 +87,8 @@ stages:
       - template: templates/matrix.yml  # context/target
         parameters:
           targets:
-            - name: macOS 13.2
-              test: macos/13.2
+            - name: macOS 12.0
+              test: macos/12.0
             - name: RHEL 7.9
               test: rhel/7.9
             - name: RHEL 8.7 py36
@@ -107,8 +107,8 @@ stages:
       - template: templates/matrix.yml  # context/controller
         parameters:
           targets:
-            - name: macOS 13.2
-              test: macos/13.2
+            - name: macOS 12.0
+              test: macos/12.0
             - name: RHEL 8.7
               test: rhel/8.7
             - name: RHEL 9.1

--- a/test/integration/targets/lookup_url/aliases
+++ b/test/integration/targets/lookup_url/aliases
@@ -1,7 +1,7 @@
 destructive
 shippable/posix/group3
 needs/httptester
-skip/macos/13.2  # This test crashes Python due to https://wefearchange.org/2018/11/forkmacos.rst.html
+skip/macos/12.0  # This test crashes Python due to https://wefearchange.org/2018/11/forkmacos.rst.html
 # Example failure:
 #
 # TASK [lookup_url : Test that retrieving a url works] ***************************


### PR DESCRIPTION
The former revealed unexpected flakiness while the latter is the previous value that was used to be stable. This is a temporary revert.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The initial VM swap: https://github.com/ansible/ansible/pull/79508