### PR TITLE
Fix MANIFEST.in includes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -29,7 +29,7 @@ recursive-include lib/ansible/modules *.yml
 recursive-include lib/ansible/plugins/test *.yml
 recursive-include lib/ansible/plugins/filter *.yml
 recursive-include licenses *.txt
-recursive-include packaging *
+recursive-include packaging Makefile *.py
 recursive-include test/ansible_test *.py Makefile
 recursive-include test/integration *
 recursive-include test/lib/ansible_test/config *.yml *.template
@@ -37,7 +37,7 @@ recursive-include test/lib/ansible_test/_data *.cfg *.in *.ini *.ps1 *.txt *.yml
 recursive-include test/lib/ansible_test/_util *.cfg *.ini *.json *.ps1 *.psd1 *.py *.sh *.txt *.yml
 recursive-include test/lib/ansible_test/_util/controller/sanity/validate-modules validate-modules
 recursive-include test/sanity *.in *.json *.py *.txt
-recursive-include test/support *.py *.ps1 *.psm1 *.cs
+recursive-include test/support *.py *.ps1 *.psm1 *.cs *.md
 exclude test/sanity/code-smell/botmeta.*
 exclude test/sanity/code-smell/release-names.*
 exclude test/lib/ansible_test/_internal/commands/sanity/bin_symlinks.py

--- a/changelogs/fragments/fix-manifest.yml
+++ b/changelogs/fragments/fix-manifest.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix ``MANIFEST.in`` to exclude unwanted files in the ``packaging/`` directory.
+  - Fix ``MANIFEST.in`` to include ``*.md`` files in the ``test/support/`` directory.

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -51,7 +51,6 @@ def assemble_files_to_ship(complete_file_list):
         'hacking/report.py',
         'hacking/return_skeleton_generator.py',
         'hacking/test-module',
-        'test/support/README.md',
         'test/lib/ansible_test/_internal/commands/sanity/bin_symlinks.py',
         'test/lib/ansible_test/_internal/commands/sanity/integration_aliases.py',
         '.cherry_picker.toml',


### PR DESCRIPTION
##### SUMMARY

  - Fix ``MANIFEST.in`` to exclude unwanted files in the ``packaging/`` directory.
  - Fix ``MANIFEST.in`` to include ``*.md`` files in the ``test/support/`` directory.
  
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

MANIFEST.in
