### PR TITLE
ansible-test - Fix pylint error with old home dir

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-home.yml
+++ b/changelogs/fragments/ansible-test-pylint-home.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Set ``PYLINTHOME`` for the ``pylint`` sanity test to prevent failures due to ``pylint`` checking for the existence of an obsolete home directory.

--- a/test/lib/ansible_test/_internal/commands/sanity/pylint.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/pylint.py
@@ -41,6 +41,7 @@ from ...ansible_util import (
     get_collection_detail,
     CollectionDetail,
     CollectionDetailError,
+    ResultType,
 )
 
 from ...config import (
@@ -247,6 +248,10 @@ class PylintTest(SanitySingleVersion):
 
         # expose plugin paths for use in custom plugins
         env.update(dict(('ANSIBLE_TEST_%s_PATH' % k.upper(), os.path.abspath(v) + os.path.sep) for k, v in data_context().content.plugin_paths.items()))
+
+        # Set PYLINTHOME to prevent pylint from checking for an obsolete directory, which can result in a test failure due to stderr output.
+        # See: https://github.com/PyCQA/pylint/blob/e6c6bf5dfd61511d64779f54264b27a368c43100/pylint/constants.py#L148
+        env.update(PYLINTHOME=os.path.join(ResultType.TMP.path, 'pylint'))
 
         if paths:
             display.info('Checking %d file(s) in context "%s" with config: %s' % (len(paths), context, rcfile), verbosity=1)


### PR DESCRIPTION
##### SUMMARY

ansible-test - Fix pylint error with old home dir.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
