### PR TITLE
[stable-2.12] ansible-test - Fix pylint error with old home dir (#80151)

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-home.yml
+++ b/changelogs/fragments/ansible-test-pylint-home.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Set ``PYLINTHOME`` for the ``pylint`` sanity test to prevent failures due to ``pylint`` checking for the existence of an obsolete home directory.

--- a/test/lib/ansible_test/_internal/commands/sanity/pylint.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/pylint.py
@@ -40,6 +40,7 @@ from ...ansible_util import (
     get_collection_detail,
     CollectionDetail,
     CollectionDetailError,
+    ResultType,
 )
 
 from ...config import (
@@ -245,6 +246,10 @@ class PylintTest(SanitySingleVersion):
 
         # expose plugin paths for use in custom plugins
         env.update(dict(('ANSIBLE_TEST_%s_PATH' % k.upper(), os.path.abspath(v) + os.path.sep) for k, v in data_context().content.plugin_paths.items()))
+
+        # Set PYLINTHOME to prevent pylint from checking for an obsolete directory, which can result in a test failure due to stderr output.
+        # See: https://github.com/PyCQA/pylint/blob/e6c6bf5dfd61511d64779f54264b27a368c43100/pylint/constants.py#L148
+        env.update(PYLINTHOME=os.path.join(ResultType.TMP.path, 'pylint'))
 
         if paths:
             display.info('Checking %d file(s) in context "%s" with config: %s' % (len(paths), context, rcfile), verbosity=1)

--- a/test/lib/ansible_test/_internal/commands/sanity/pylint.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/pylint.py
@@ -17,6 +17,10 @@ from . import (
     SANITY_ROOT,
 )
 
+from ...io import (
+    make_dirs,
+)
+
 from ...test import (
     TestResult,
 )
@@ -249,7 +253,9 @@ class PylintTest(SanitySingleVersion):
 
         # Set PYLINTHOME to prevent pylint from checking for an obsolete directory, which can result in a test failure due to stderr output.
         # See: https://github.com/PyCQA/pylint/blob/e6c6bf5dfd61511d64779f54264b27a368c43100/pylint/constants.py#L148
-        env.update(PYLINTHOME=os.path.join(ResultType.TMP.path, 'pylint'))
+        pylint_home = os.path.join(ResultType.TMP.path, 'pylint')
+        make_dirs(pylint_home)
+        env.update(PYLINTHOME=pylint_home)
 
         if paths:
             display.info('Checking %d file(s) in context "%s" with config: %s' % (len(paths), context, rcfile), verbosity=1)


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/80151
Backport of https://github.com/ansible/ansible/pull/80155

(cherry picked from commit 27287b40c0605e583145538ac072260095c139d7)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
