### PR TITLE
catch GalaxyError instead of its base class to ensure attr exists

### DIFF
--- a/changelogs/fragments/a-g-role-fix-catching-exception.yml
+++ b/changelogs/fragments/a-g-role-fix-catching-exception.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy role info - fix unhandled AttributeError by catching the correct exception.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -28,7 +28,7 @@ from ansible import context
 from ansible.cli.arguments import option_helpers as opt_help
 from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.galaxy import Galaxy, get_collections_galaxy_meta_info
-from ansible.galaxy.api import GalaxyAPI
+from ansible.galaxy.api import GalaxyAPI, GalaxyError
 from ansible.galaxy.collection import (
     build_collection,
     download_collections,
@@ -1220,7 +1220,7 @@ class GalaxyCLI(CLI):
                 remote_data = None
                 try:
                     remote_data = self.api.lookup_role_by_name(role, False)
-                except AnsibleError as e:
+                except GalaxyError as e:
                     if e.http_code == 400 and 'Bad Request' in e.message:
                         # Role does not exist in Ansible Galaxy
                         data = u"- the role %s was not found" % role


### PR DESCRIPTION
##### SUMMARY
Spotted by @mattclay here https://dev.azure.com/ansible/ansible/_build/results?buildId=70658&view=logs&j=02dadd93-89a3-596f-96af-bb98c44d93c0&t=8eb8a0c8-a819-57ed-b7c9-ca65999a5199&l=947.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
