### PR TITLE
[2.14] copy - fix check mode with remote_src=True (#78624)

### DIFF
--- a/changelogs/fragments/78624-copy-remote-src-check-mode.yml
+++ b/changelogs/fragments/78624-copy-remote-src-check-mode.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - copy - fix reporting changes to file attributes in check mode with remote_src=True (https://github.com/ansible/ansible/issues/77957).
+  - copy - fix creating the dest directory in check mode with remote_src=True (https://github.com/ansible/ansible/issues/78611).

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -616,6 +616,8 @@ def main():
                 e.result['msg'] += ' Could not copy to {0}'.format(dest)
                 module.fail_json(**e.results)
 
+            if module.check_mode:
+                module.exit_json(msg='dest directory %s would be created' % dirname, changed=True, src=src)
             os.makedirs(b_dirname)
             directory_args = module.load_file_common_arguments(module.params)
             directory_mode = module.params["directory_mode"]
@@ -814,9 +816,8 @@ def main():
     if backup_file:
         res_args['backup_file'] = backup_file
 
-    if not module.check_mode:
-        file_args = module.load_file_common_arguments(module.params, path=dest)
-        res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'])
+    file_args = module.load_file_common_arguments(module.params, path=dest)
+    res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'])
 
     module.exit_json(**res_args)
 

--- a/test/integration/targets/copy/tasks/check_mode.yml
+++ b/test/integration/targets/copy/tasks/check_mode.yml
@@ -113,8 +113,7 @@
       - check_mode_subdir_first is changed
 
       - check_mode_trailing_slash_first is changed
-      # TODO: This is a legitimate bug
-      #- not check_mode_trailing_slash_first_stat.stat.exists
+      - not check_mode_trailing_slash_first_stat.stat.exists
       - check_mode_trailing_slash_real is changed
       - check_mode_trailing_slash_real_stat.stat.exists
       - check_mode_trailing_slash_second is not changed
@@ -124,3 +123,41 @@
       - check_mode_foo_real is changed
       - check_mode_foo_real_stat.stat.exists
       - check_mode_foo_second is not changed
+
+  - name: check_mode - Do a basic copy to setup next test (without check mode)
+    copy:
+      src: foo.txt
+      dest: "{{ remote_dir }}/foo-check_mode.txt"
+      mode: 0444
+
+  - name: check_mode - Copy the same src with a different mode (check mode)
+    copy:
+      src: foo.txt
+      dest: "{{ remote_dir }}/foo-check_mode.txt"
+      mode: 0666
+    check_mode: True
+    register: check_mode_file_attribute
+
+  - name: stat the file to make sure the mode was not updated in check mode
+    stat:
+      path: "{{ remote_dir }}/foo-check_mode.txt"
+    register: check_mode_file_attribute_stat
+
+  - name: check_mode - Copy the same src with a different mode (without check mode)
+    copy:
+      src: foo.txt
+      dest: "{{ remote_dir }}/foo-check_mode.txt"
+      mode: 0666
+    register: real_file_attribute
+
+  - name: stat the file to make sure the mode was updated without check mode
+    stat:
+      path: "{{ remote_dir }}/foo-check_mode.txt"
+    register: real_file_attribute_stat
+
+  - assert:
+      that:
+        - check_mode_file_attribute is changed
+        - real_file_attribute is changed
+        - "check_mode_file_attribute_stat.stat.mode == '0444'"
+        - "real_file_attribute_stat.stat.mode == '0666'"


### PR DESCRIPTION
##### SUMMARY
Backport for #78624

* Don't create dest directory in check mode

uncomment existing test

Fix checking for file attribute changes in check mode and add a test

(cherry picked from commit b7a0e0d79278906c57c6dfc637d0e0b09b45db34)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
copy