### PR TITLE
New feature - Add filter dict2product

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -571,6 +571,33 @@ def list_of_dict_key_value_elements_to_dict(mylist, key_name='key', value_name='
         raise AnsibleFilterTypeError("items2dict requires a list of dictionaries, got %s instead." % mylist)
 
 
+def dict_to_product(mydict, key1, key2, skip_missing=False):
+    ''' takes a dict make a product of two list of subelements, equivalent to
+        product(mydict[key1], mydict[key2]) '''
+
+    try:
+        if isinstance(mydict[key1], list):
+            list1 = mydict[key1]
+        else:
+            list1 = [mydict[key1]]
+
+        if isinstance(mydict[key2], list):
+            list2 = mydict[key2]
+        else:
+            list2 = [mydict[key2]]
+
+        return [(x, y) for x in list1 for y in list2]
+
+    except KeyError as e:
+        if skip_missing:
+            return []
+
+        raise AnsibleFilterTypeError(
+            "dict2product requires dictionary to contain the keys '%s' and '%s', but %s is missing."
+            % (key1, key2, e)
+        )
+
+
 def path_join(paths):
     ''' takes a sequence or a string, and return a concatenation
         of the different members '''
@@ -687,6 +714,7 @@ class FilterModule(object):
             'flatten': flatten,
             'dict2items': dict_to_list_of_dict_key_value_elements,
             'items2dict': list_of_dict_key_value_elements_to_dict,
+            'dict2product': dict_to_product,
             'subelements': subelements,
             'split': partial(unicode_wrap, text_type.split),
         }

--- a/lib/ansible/plugins/filter/dict2product.yml
+++ b/lib/ansible/plugins/filter/dict2product.yml
@@ -39,7 +39,7 @@ EXAMPLES: |
 
   # Note: Keys that are not list, are made into list before processing,
   #       like "ip" in that example.
-  # dns => [["1.2.3.4", "example1.domain.tld"], ["1.2.3.4", "example2.domain.tld"]]
+  # dns => [("1.2.3.4", "example1.domain.tld"), ("1.2.3.4", "example2.domain.tld")]
   vars:
     network:
       ip: 1.2.3.4

--- a/lib/ansible/plugins/filter/dict2product.yml
+++ b/lib/ansible/plugins/filter/dict2product.yml
@@ -1,0 +1,69 @@
+DOCUMENTATION:
+  name: dict2product
+  author: Aurélien Rouëné
+  version_added: "2.15"
+  short_description: Convert a dictionary into a product of two if it's key's values.
+  positional: _input, key1_name, key2_name
+  description:
+    - Takes a dictionary and returns a list of the products of two lists found at the keys
+      C(key1) and C(key2) of the dictionary.
+  options:
+    _input:
+      description:
+        - The dictionary to transform
+      type: dict
+      required: true
+    key1_name:
+      description: The name of the first key to get the list from.
+      type: str
+      default: key
+      version_added: "2.15"
+    key2_name:
+      description: The name of the second key to get the list from.
+      type: str
+      default: value
+      version_added: "2.15"
+    skip_missing:
+      description: If True, does not raise an error when one of the keys is missing in the dictionary.
+      type: bool
+      default: False
+      version_added: "2.15"
+  seealso:
+    - plugin_type: filter
+      plugin: ansible.builtin.dict2items
+
+EXAMPLES: |
+
+  # items => [[1, 3], [1, 4], [2, 3], [2, 4]]
+  items: "{{ {'a': [1, 2], 'b': [3, 4]} | dict2product('a', 'b') }}"
+
+  # Note: Keys that are not list, are made into list before processing,
+  #       like "ip" in that example.
+  # dns => [["1.2.3.4", "example1.domain.tld"], ["1.2.3.4", "example2.domain.tld"]]
+  vars:
+    network:
+      ip: 1.2.3.4
+      names:
+        - example1.domain.tld
+        - example2.domain.tld
+    dns: "{{ network | dict2product('ip', 'names') }}"
+
+  # dns => [[["1.2.3.4", "example1"], ["1.2.3.4", "example2"]],
+  #        [["4.3.2.1", "example3"], ["4.3.2.1", "example4"]]]
+  vars:
+    networks:
+      - ip: 1.2.3.4
+        names:
+          - example1
+          - example2
+      - ip: 4.3.2.1
+        names:
+          - example3
+          - example4
+    dns: "{{ networks | map('dict2product', 'ip', 'names') }}"
+
+RETURN:
+  _value:
+    description: A list of list.
+    type: list
+    elements: dict

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -710,7 +710,7 @@
       - dict2product_fail_key1 is failed
       - dict2product_fail_key2 is failed
       - '{"foo": "bar"} | dict2product("foo", "bar", skip_missing=True) == []'
-      - '{"foo": "bar", "buz": ["one", "two"]} | dict2product("foo", "buz") == [["bar", "one"], ["bar", "two"]]'
+      - '{"foo": "bar", "buz": ["one", "two"]} | dict2product("foo", "buz") == [("bar", "one"), ("bar", "two")]'
 
 - name: Verify path_join throws on non-string and non-sequence
   set_fact:

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -609,7 +609,6 @@
       - 'subelements_demo|subelements("groups") == [({"name": "alice", "groups": ["wheel"], "authorized": ["/tmp/alice/onekey.pub"]}, "wheel")]'
       - 'subelements_demo|subelements(["groups"]) == [({"name": "alice", "groups": ["wheel"], "authorized": ["/tmp/alice/onekey.pub"]}, "wheel")]'
 
-
 - name: Verify dict2items throws on non-Mapping
   set_fact:
     foo: '{{True|dict2items}}'
@@ -679,6 +678,39 @@
       - error in items2dict_fail.msg
   vars:
     error: "items2dict requires each dictionary in the list to contain the keys 'key' and 'value'"
+
+- name: Verify dict2product throws on non dict
+  set_fact:
+    foo: '{{ True | dict2product }}'
+  ignore_errors: yes
+  register: dict2product_fail
+
+- name: Verify dict2product throws on key1 absent
+  set_fact:
+    foo: '{{ foo_dict | dict2product("foo", "bar") }}'
+  vars:
+    foo_dict:
+      bar: "foo"
+  ignore_errors: yes
+  register: dict2product_fail_key1
+
+- name: Verify dict2product throws on key2 absent
+  set_fact:
+    foo: '{{ foo_dict | dict2product("bar", "foo") }}'
+  vars:
+    foo_dict:
+      bar: "foo"
+  ignore_errors: yes
+  register: dict2product_fail_key2
+
+- name: Verify dict2product
+  assert:
+    that:
+      - dict2product_fail is failed
+      - dict2product_fail_key1 is failed
+      - dict2product_fail_key2 is failed
+      - '{"foo": "bar"} | dict2product("foo", "bar", skip_missing=True) == []'
+      - '{"foo": "bar", "buz": ["one", "two"]} | dict2product("foo", "buz") == [["bar", "one"], ["bar", "two"]]'
 
 - name: Verify path_join throws on non-string and non-sequence
   set_fact:


### PR DESCRIPTION
##### SUMMARY

Add filter **dict2product** to be able to use a product filter on a dict, using keys names as arguments instead of having to use a list, which is not always practical.

With the current **product** filter, we have to pass a list as first and second argument like that `{{ list | product(list) }}`, which means we have to get the two list from two variables. Dict2product can use two list embedded in a dict for the same result.

To be easy to use, single elements in the dict will automatically be converted to a list, in the example below the ip in a list and the ip not in a list gives the same result.

Here is a practical example with a loop : 

```
vars:
  networks:
    - ip: ["1.2.3.4"]
      name: ["example1.domain.tld"]
    - ip: "4.3.2.1"
      name:
        - example2.domain.tld
        - example3.domain.tld
```

```
- name: Create dns entry
  community.windows.win_dns_record:
    name: "{{ item.1 }}"
    type: "A"
    value: "{{ item.0 }}"
    zone: "{{ domain_name }}"
    state: present
  delegate_to: "{{ dns_server }}"
  loop: "{{ networks | map('dict2product', 'ip', 'name') | flatten(1) }}"
```

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/filter/core.py

##### ADDITIONAL INFORMATION

