### PR TITLE
ansible-galaxy - support `resolvelib >= 0.5.3, < 1.1.0`

### DIFF
--- a/changelogs/fragments/80196-resolvelib_lt_1_1_0.yml
+++ b/changelogs/fragments/80196-resolvelib_lt_1_1_0.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-galaxy - support ``resolvelib >= 0.5.3, < 1.1.0``.

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -42,7 +42,7 @@ except ImportError:
 
 # TODO: add python requirements to ansible-test's ansible-core distribution info and remove the hardcoded lowerbound/upperbound fallback
 RESOLVELIB_LOWERBOUND = SemanticVersion("0.5.3")
-RESOLVELIB_UPPERBOUND = SemanticVersion("0.10.0")
+RESOLVELIB_UPPERBOUND = SemanticVersion("1.1.0")
 RESOLVELIB_VERSION = SemanticVersion.from_loose_version(LooseVersion(resolvelib_version))
 
 
@@ -220,7 +220,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
             Mapping of identifier, list of named tuple pairs.
             The named tuples have the entries ``requirement`` and ``parent``.
 
-        resolvelib >=0.8.0, <= 0.9.0
+        resolvelib >=0.8.0, <= 1.0.1
 
         :param identifier: The value returned by ``identify()``.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ importlib_resources >= 5.0, < 5.1; python_version < '3.10'
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, < 1.1.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, == 1.0.1  # dependency resolver used by ansible-galaxy

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ importlib_resources >= 5.0, < 5.1; python_version < '3.10'
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, < 0.10.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, < 1.1.0  # dependency resolver used by ansible-galaxy

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ importlib_resources >= 5.0, < 5.1; python_version < '3.10'
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, == 1.0.1  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, < 1.1.0  # dependency resolver used by ansible-galaxy

--- a/test/integration/targets/ansible-galaxy-collection/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/vars/main.yml
@@ -9,6 +9,8 @@ supported_resolvelib_versions:
   - "0.6.0"
   - "0.7.0"
   - "0.8.0"
+  - "0.9.0"
+  - "1.0.1"
 
 unsupported_resolvelib_versions:
   - "0.2.0"  # Fails on import

--- a/test/lib/ansible_test/_data/requirements/ansible.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible.txt
@@ -15,4 +15,4 @@ importlib_resources >= 5.0, < 5.1; python_version < '3.10'
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, < 1.1.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, == 1.0.1  # dependency resolver used by ansible-galaxy

--- a/test/lib/ansible_test/_data/requirements/ansible.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible.txt
@@ -15,4 +15,4 @@ importlib_resources >= 5.0, < 5.1; python_version < '3.10'
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, < 0.10.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, < 1.1.0  # dependency resolver used by ansible-galaxy

--- a/test/lib/ansible_test/_data/requirements/ansible.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible.txt
@@ -15,4 +15,4 @@ importlib_resources >= 5.0, < 5.1; python_version < '3.10'
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, == 1.0.1  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, < 1.1.0  # dependency resolver used by ansible-galaxy

--- a/test/sanity/code-smell/docs-build.requirements.in
+++ b/test/sanity/code-smell/docs-build.requirements.in
@@ -1,6 +1,6 @@
 jinja2
 pyyaml
-resolvelib < 0.10.0
+resolvelib < 1.1.0
 sphinx == 5.3.0
 sphinx-notfound-page
 sphinx-ansible-theme

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -27,7 +27,7 @@ Pygments==2.14.0
 pytz==2022.7.1
 PyYAML==6.0
 requests==2.28.2
-resolvelib==0.9.0
+resolvelib==1.0.1
 rstcheck==5.0.0
 semantic-version==2.10.0
 sh==1.14.3

--- a/test/sanity/code-smell/package-data.requirements.in
+++ b/test/sanity/code-smell/package-data.requirements.in
@@ -1,6 +1,6 @@
 docutils < 0.18  # match version required by sphinx in the docs-build sanity test
 jinja2
 pyyaml  # ansible-core requirement
-resolvelib < 0.10.0
+resolvelib < 1.1.0
 rstcheck < 6  # match version used in other sanity tests
 antsibull-changelog

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -5,7 +5,7 @@ Jinja2==3.1.2
 MarkupSafe==2.1.2
 packaging==23.0
 PyYAML==6.0
-resolvelib==0.9.0
+resolvelib==1.0.1
 rstcheck==5.0.0
 semantic-version==2.10.0
 types-docutils==0.18.3


### PR DESCRIPTION
##### SUMMARY
<https://pypi.org/project/resolvelib/1.0.1> released on 2023-03-09:

-   <https://github.com/sarugaku/resolvelib/blob/main/CHANGELOG.rst#101-2023-03-09>
-   <https://github.com/sarugaku/resolvelib/releases/tag/1.0.1>
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
API guarantees discussions:
* https://github.com/sarugaku/resolvelib/issues/97
* https://github.com/sarugaku/resolvelib/pull/125