### PR TITLE
docsite: bump antsibull-docs version to 1.10.0 to support semantic markup

### DIFF
--- a/test/sanity/code-smell/docs-build.requirements.in
+++ b/test/sanity/code-smell/docs-build.requirements.in
@@ -5,4 +5,4 @@ sphinx == 5.3.0
 sphinx-notfound-page
 sphinx-ansible-theme
 rstcheck < 6  # rstcheck 6.x has problem with rstcheck.core triggered by include files w/ sphinx directives https://github.com/rstcheck/rstcheck-core/issues/3
-antsibull-docs == 1.9.0  # currently approved version
+antsibull-docs == 1.10.0  # currently approved version

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -5,7 +5,7 @@ aiosignal==1.3.1
 alabaster==0.7.13
 ansible-pygments==0.1.1
 antsibull-core==1.5.1
-antsibull-docs==1.9.0
+antsibull-docs==1.10.0
 async-timeout==4.0.2
 asyncio-pool==0.6.0
 attrs==22.2.0


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-community/community-topics/issues/53
Changelog: https://github.com/ansible-community/antsibull-docs/blob/1.10.0/CHANGELOG.rst#v1-10-0

The main new feature is semantic markup.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
docsite
docs build sanity test
