### PR TITLE
uri: improve force_basic_auth documentation

### DIFF
--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -94,9 +94,16 @@ options:
   force_basic_auth:
     description:
       - Force the sending of the Basic authentication header upon initial request.
-      - The library used by the uri module only sends authentication information when a webservice
-        responds to an initial request with a 401 status. Since some basic auth services do not properly
-        send a 401, logins will fail.
+      - When this setting is C(false), this module will first try an unauthenticated request, and when the server replies
+        with an C(HTTP 401) error, it will submit the Basic authentication header.
+      - When this setting is C(true), this module will immediately send a Basic authentication header on the first
+        request.
+      - "Use this setting in any of the following scenarios:"
+      - You know the webservice endpoint always requires HTTP Basic authentication, and you want to speed up your
+        requests by eliminating the first roundtrip.
+      - The web service does not properly send an HTTP 401 error to your client, so Ansible's HTTP library will not
+        properly respond with HTTP credentials, and logins will fail.
+      - The webservice bans or rate-limits clients that cause any HTTP 401 errors.
     type: bool
     default: no
   follow_redirects:


### PR DESCRIPTION
##### SUMMARY
Add more details about what `true` and `false` mean for the `force_basic_auth` setting.

Give example scenarios when clients may want to use this setting.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
uri

##### ADDITIONAL INFORMATION
Recently web service administrators enabled `fail2ban` on a web service that saw a high rate of `HTTP 401` errors. Turns out these are due to many web clients simply trying the unauthenticated request first, hitting the `401` error, and then re-trying.

Update the documentation to make it clearer that `force_basic_auth` is faster for clients and easier for rate-limiting server admins.