### PR TITLE
[stable-2.12] ansible-test - Show Python version before install (#80022)

### DIFF
--- a/changelogs/fragments/ansible-test-requirements-message.yml
+++ b/changelogs/fragments/ansible-test-requirements-message.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test - Always indicate the Python version being used before installing requirements.
+                   Resolves issue https://github.com/ansible/ansible/issues/72855

--- a/test/lib/ansible_test/_internal/python_requirements.py
+++ b/test/lib/ansible_test/_internal/python_requirements.py
@@ -52,6 +52,7 @@ from .data import (
 from .host_configs import (
     PosixConfig,
     PythonConfig,
+    VirtualPythonConfig,
 )
 
 from .connections import (
@@ -259,6 +260,20 @@ def run_pip(
     """Run the specified pip commands for the given Python, and optionally the specified host."""
     connection = connection or LocalConnection(args)
     script = prepare_pip_script(commands)
+
+    if isinstance(args, IntegrationConfig):
+        # Integration tests can involve two hosts (controller and target).
+        # The connection type can be used to disambiguate between the two.
+        context = " (controller)" if isinstance(connection, LocalConnection) else " (target)"
+    else:
+        context = ""
+
+    if isinstance(python, VirtualPythonConfig):
+        context += " [venv]"
+
+    # The interpreter path is not included below.
+    # It can be seen by running ansible-test with increased verbosity (showing all commands executed).
+    display.info(f'Installing requirements for Python {python.version}{context}')
 
     if not args.explain:
         try:


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/80022

Always indicate the Python version being used before installing requirements.

(cherry picked from commit 5e3db6e44169aa88cd027f469eea96f1f17fea95)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
