### PR TITLE
validate-modules: support plugin see-also

### DIFF
--- a/changelogs/fragments/80244-validate-modules-seealso.yml
+++ b/changelogs/fragments/80244-validate-modules-seealso.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "validate-modules sanity test - support the ``plugin`` see-also part of the semantic markup specification (https://github.com/ansible/ansible/pull/80244)."

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/sidecar.yaml
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/sidecar.yaml
@@ -19,7 +19,7 @@ DOCUMENTATION:
   - Ansible Core Team
   seealso:
   - plugin: ns.col.import_order_lookup
-    plugin_type: looup
+    plugin_type: lookup
 
 EXAMPLES: |
   - name: example for sidecar

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/sidecar.yaml
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/sidecar.yaml
@@ -17,6 +17,9 @@ DOCUMENTATION:
       default: foo
   author:
   - Ansible Core Team
+  seealso:
+  - plugin: ns.col.import_order_lookup
+    plugin_type: looup
 
 EXAMPLES: |
   - name: example for sidecar

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -12,6 +12,7 @@ from functools import partial
 from urllib.parse import urlparse
 
 from voluptuous import ALLOW_EXTRA, PREVENT_EXTRA, All, Any, Invalid, Length, Required, Schema, Self, ValueInvalid, Exclusive
+from ansible.constants import DOCUMENTABLE_PLUGINS
 from ansible.module_utils.six import string_types
 from ansible.module_utils.common.collections import is_iterable
 from ansible.module_utils.parsing.convert_bool import boolean
@@ -170,6 +171,11 @@ seealso_schema = Schema(
         Any(
             {
                 Required('module'): Any(*string_types),
+                'description': doc_string,
+            },
+            {
+                Required('plugin'): Any(*string_types),
+                Required('plugin_type'): Any(*DOCUMENTABLE_PLUGINS),
                 'description': doc_string,
             },
             {


### PR DESCRIPTION
##### SUMMARY
Subset of #80243 resp. #74937. Extends the `seealso` schema to support plugin see-alsos. (See also #80212, which shows them in ansible-doc.)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
validate-modules
