### PR TITLE
iptables chain creation does not populate with a rule

### DIFF
--- a/changelogs/fragments/80257-iptables-chain-creation-does-not-populate-a-rule.yml
+++ b/changelogs/fragments/80257-iptables-chain-creation-does-not-populate-a-rule.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - iptables - fix iptables chain creation so it behaves like the command line utility (https://github.com/ansible/ansible/issues/80256).

--- a/changelogs/fragments/80257-iptables-chain-creation-does-not-populate-a-rule.yml
+++ b/changelogs/fragments/80257-iptables-chain-creation-does-not-populate-a-rule.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - iptables - fix iptables chain creation so it behaves like the command line utility (https://github.com/ansible/ansible/issues/80256).
+  - iptables - remove default rule creation when creating iptables chain to be more similar to the command line utility (https://github.com/ansible/ansible/issues/80256).

--- a/test/integration/targets/iptables/tasks/chain_management.yml
+++ b/test/integration/targets/iptables/tasks/chain_management.yml
@@ -45,12 +45,6 @@
       - result is not failed
       - '"FOOBAR-CHAIN" in result.stdout'
 
-- name: flush the foobar chain
-  become: true
-  iptables:
-    chain: FOOBAR-CHAIN
-    flush: true
-
 - name: delete the foobar chain
   become: true
   iptables:

--- a/test/integration/targets/iptables/tasks/chain_management.yml
+++ b/test/integration/targets/iptables/tasks/chain_management.yml
@@ -56,7 +56,7 @@
 
 - name: get the state of the iptable rules after rule is added to foobar chain
   become: true
-  shell: "/usr/sbin/iptables -L"
+  shell: "{{ iptables_bin }} -L"
   register: result
 
 - name: assert rule is present in foobar chain

--- a/test/integration/targets/iptables/tasks/chain_management.yml
+++ b/test/integration/targets/iptables/tasks/chain_management.yml
@@ -45,6 +45,31 @@
       - result is not failed
       - '"FOOBAR-CHAIN" in result.stdout'
 
+- name: add rule to foobar chain
+  become: true
+  iptables:
+    chain: FOOBAR-CHAIN
+    source: 0.0.0.0
+    destination: 0.0.0.0
+    jump: DROP
+
+- name: get the state of the iptable rules after rule is added to foobar chain
+  become: true
+  shell: "/usr/sbin/iptables -L"
+  register: result
+
+- name: assert rule is present in foobar chain
+  assert:
+    that:
+      - result is not failed
+      - '"DROP       all  --  0.0.0.0              0.0.0.0" in result.stdout'
+
+- name: flush the foobar chain
+  become: true
+  iptables:
+    chain: FOOBAR-CHAIN
+    flush: true
+
 - name: delete the foobar chain
   become: true
   iptables:

--- a/test/integration/targets/iptables/tasks/chain_management.yml
+++ b/test/integration/targets/iptables/tasks/chain_management.yml
@@ -52,6 +52,7 @@
     source: 0.0.0.0
     destination: 0.0.0.0
     jump: DROP
+    comment: "FOOBAR-CHAIN RULE"
 
 - name: get the state of the iptable rules after rule is added to foobar chain
   become: true
@@ -62,7 +63,7 @@
   assert:
     that:
       - result is not failed
-      - '"DROP       all  --  0.0.0.0              0.0.0.0" in result.stdout'
+      - '"FOOBAR-CHAIN RULE" in result.stdout'
 
 - name: flush the foobar chain
   become: true
@@ -87,4 +88,3 @@
     that:
       - result is not failed
       - '"FOOBAR-CHAIN" not in result.stdout'
-      - '"FOOBAR-RULE" not in result.stdout'

--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -181,7 +181,7 @@ class TestIptables(ModuleTestCase):
                 iptables.main()
                 self.assertTrue(result.exception.args[0]['changed'])
 
-        self.assertEqual(run_command.call_count, 2)
+        self.assertEqual(run_command.call_count, 1)
         self.assertEqual(run_command.call_args_list[0][0][0], [
             '/sbin/iptables',
             '-t',
@@ -208,7 +208,6 @@ class TestIptables(ModuleTestCase):
 
         commands_results = [
             (1, '', ''),  # check_rule_present
-            (0, '', ''),  # check_chain_present
             (0, '', ''),
         ]
 
@@ -218,7 +217,7 @@ class TestIptables(ModuleTestCase):
                 iptables.main()
                 self.assertTrue(result.exception.args[0]['changed'])
 
-        self.assertEqual(run_command.call_count, 3)
+        self.assertEqual(run_command.call_count, 2)
         self.assertEqual(run_command.call_args_list[0][0][0], [
             '/sbin/iptables',
             '-t',
@@ -232,7 +231,7 @@ class TestIptables(ModuleTestCase):
             '-j',
             'ACCEPT'
         ])
-        self.assertEqual(run_command.call_args_list[2][0][0], [
+        self.assertEqual(run_command.call_args_list[1][0][0], [
             '/sbin/iptables',
             '-t',
             'filter',
@@ -272,7 +271,7 @@ class TestIptables(ModuleTestCase):
                 iptables.main()
                 self.assertTrue(result.exception.args[0]['changed'])
 
-        self.assertEqual(run_command.call_count, 2)
+        self.assertEqual(run_command.call_count, 1)
         self.assertEqual(run_command.call_args_list[0][0][0], [
             '/sbin/iptables',
             '-t',
@@ -321,7 +320,7 @@ class TestIptables(ModuleTestCase):
                 iptables.main()
                 self.assertTrue(result.exception.args[0]['changed'])
 
-        self.assertEqual(run_command.call_count, 3)
+        self.assertEqual(run_command.call_count, 2)
         self.assertEqual(run_command.call_args_list[0][0][0], [
             '/sbin/iptables',
             '-t',
@@ -343,7 +342,7 @@ class TestIptables(ModuleTestCase):
             '--to-ports',
             '8600'
         ])
-        self.assertEqual(run_command.call_args_list[2][0][0], [
+        self.assertEqual(run_command.call_args_list[1][0][0], [
             '/sbin/iptables',
             '-t',
             'nat',
@@ -1019,10 +1018,8 @@ class TestIptables(ModuleTestCase):
         })
 
         commands_results = [
-            (1, '', ''),  # check_rule_present
             (1, '', ''),  # check_chain_present
             (0, '', ''),  # create_chain
-            (0, '', ''),  # append_rule
         ]
 
         with patch.object(basic.AnsibleModule, 'run_command') as run_command:
@@ -1031,30 +1028,18 @@ class TestIptables(ModuleTestCase):
                 iptables.main()
                 self.assertTrue(result.exception.args[0]['changed'])
 
-        self.assertEqual(run_command.call_count, 4)
+        self.assertEqual(run_command.call_count, 2)
 
         self.assertEqual(run_command.call_args_list[0][0][0], [
-            '/sbin/iptables',
-            '-t', 'filter',
-            '-C', 'FOOBAR',
-        ])
-
-        self.assertEqual(run_command.call_args_list[1][0][0], [
             '/sbin/iptables',
             '-t', 'filter',
             '-L', 'FOOBAR',
         ])
 
-        self.assertEqual(run_command.call_args_list[2][0][0], [
+        self.assertEqual(run_command.call_args_list[1][0][0], [
             '/sbin/iptables',
             '-t', 'filter',
             '-N', 'FOOBAR',
-        ])
-
-        self.assertEqual(run_command.call_args_list[3][0][0], [
-            '/sbin/iptables',
-            '-t', 'filter',
-            '-A', 'FOOBAR',
         ])
 
         commands_results = [
@@ -1078,7 +1063,6 @@ class TestIptables(ModuleTestCase):
 
         commands_results = [
             (1, '', ''),  # check_rule_present
-            (1, '', ''),  # check_chain_present
         ]
 
         with patch.object(basic.AnsibleModule, 'run_command') as run_command:
@@ -1087,15 +1071,9 @@ class TestIptables(ModuleTestCase):
                 iptables.main()
                 self.assertTrue(result.exception.args[0]['changed'])
 
-        self.assertEqual(run_command.call_count, 2)
+        self.assertEqual(run_command.call_count, 1)
 
         self.assertEqual(run_command.call_args_list[0][0][0], [
-            '/sbin/iptables',
-            '-t', 'filter',
-            '-C', 'FOOBAR',
-        ])
-
-        self.assertEqual(run_command.call_args_list[1][0][0], [
             '/sbin/iptables',
             '-t', 'filter',
             '-L', 'FOOBAR',


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
iptables chain creation does not populate with a rule by default. Behaves more like the iptables command line tool.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
fixes #80256

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iptables

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before

Control host:
$ ansible-playbook -i hosts create-chain.yml 
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development.
This is a rapidly changing source of code and can become unstable at any point.

PLAY [alma9] *********************************************************************************************************************************************************************************

TASK [Create new chain] **********************************************************************************************************************************************************************
changed: [alma9]

PLAY RECAP ***********************************************************************************************************************************************************************************
alma9                      : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

iptables command on target host:

# iptables -nL 
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         

Chain TESTCHAIN (0 references)
target     prot opt source               destination         
           all  --  0.0.0.0/0            0.0.0.0/0  


After

Control host:
$ ansible-playbook -i hosts createchain.yml 
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development.
This is a rapidly changing source of code and can become unstable at any point.

PLAY [alma9] *********************************************************************************************************************************************************************************

TASK [Create new chain] **********************************************************************************************************************************************************************
changed: [alma9]

PLAY RECAP ***********************************************************************************************************************************************************************************
alma9                      : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


iptables command on target host:

# iptables -nL 
Chain INPUT (policy ACCEPT)
target     prot opt source               destination         

Chain FORWARD (policy ACCEPT)
target     prot opt source               destination         

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         

Chain TESTCHAIN (0 references)
target     prot opt source               destination         

```
