### PR TITLE
Make PEP 517 mutation tests use pinned old setuptools

### DIFF
--- a/test/integration/targets/canonical-pep517-self-packaging/runme_test.py
+++ b/test/integration/targets/canonical-pep517-self-packaging/runme_test.py
@@ -207,6 +207,12 @@ def test_installing_sdist_build_with_modern_deps_to_old_env(
         with TarFile.gzopen(tmp_path_sdist_w_modern_tools) as sdist_fd:
             sdist_fd.extractall(path=tmp_dir_unpacked_sdist_root)
 
+        pip_install(
+            venv_python_exe, 'setuptools',
+            env_vars={
+                'PIP_CONSTRAINT': str(LOWEST_SUPPORTED_BUILD_DEPS_FILE),
+            },
+        )
         with _chdir_cm(tmp_dir_unpacked_sdist_path):
             run_with_venv_python(
                 venv_python_exe, 'setup.py', 'sdist',
@@ -219,6 +225,9 @@ def test_installing_sdist_build_with_modern_deps_to_old_env(
     else:
         pip_install(
             venv_python_exe, str(tmp_path_sdist_w_modern_tools), '--no-deps',
+            env_vars={
+                'PIP_CONSTRAINT': str(LOWEST_SUPPORTED_BUILD_DEPS_FILE),
+            },
         )
 
     # Smoke test — installing an sdist with pip that does not support invoking

--- a/test/integration/targets/canonical-pep517-self-packaging/runme_test.py
+++ b/test/integration/targets/canonical-pep517-self-packaging/runme_test.py
@@ -218,10 +218,6 @@ def test_installing_sdist_build_with_modern_deps_to_old_env(
                 venv_python_exe, 'setup.py', 'sdist',
                 env_vars={'PATH': environ['PATH']},
             )
-            run_with_venv_python(
-                venv_python_exe, 'setup.py', 'install',
-                env_vars={'PATH': environ['PATH']},
-            )
     else:
         pip_install(
             venv_python_exe, str(tmp_path_sdist_w_modern_tools), '--no-deps',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This patch removes calling `setup.py install` from `test_installing_sdist_build_with_modern_deps_to_old_env` because this `pip install` fallback corner case step is not what we care about testing. Only `setup.py sdist` is important. Moreover, this change pins `setuptools` to the same old version that other tests do.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Packaging Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`canonical-pep517-self-packaging` integration test

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This was caught while making the following backport PR: #80261.