### PR TITLE
added lock timeout to apt dpkg_options (#78658)

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1318,13 +1318,13 @@ def main():
     allow_unauthenticated = p['allow_unauthenticated']
     allow_downgrade = p['allow_downgrade']
     allow_change_held_packages = p['allow_change_held_packages']
-    dpkg_options = expand_dpkg_options(p['dpkg_options'])
     autoremove = p['autoremove']
     fail_on_autoremove = p['fail_on_autoremove']
     autoclean = p['autoclean']
 
     # max times we'll retry
     deadline = time.time() + p['lock_timeout']
+    dpkg_options = '%s -o DPkg::Lock::Timeout=%s' % (expand_dpkg_options(p['dpkg_options']), p['lock_timeout'])
 
     # keep running on lock issues unless timeout or resolution is hit.
     while True:


### PR DESCRIPTION
##### SUMMARY

Fixes #78658

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt

##### ADDITIONAL INFORMATION
Using the `lock_timeout` option available in the `apt` module still results in apt lock clashes. This is easily reproducible by running an apt install externally to ansible at the same time as ansible apt module is installing a package.

This change adds the `DPkg::Lock::Timeout` option to the apt command with the (existing) user specified `lock_timeout` value.

```diff
diff --git a/lib/ansible/modules/apt.py b/lib/ansible/modules/apt.py
index 2a214392c2..14d95acf97 100644
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1318,13 +1318,13 @@ def main():
     allow_unauthenticated = p['allow_unauthenticated']
     allow_downgrade = p['allow_downgrade']
     allow_change_held_packages = p['allow_change_held_packages']
-    dpkg_options = expand_dpkg_options(p['dpkg_options'])
     autoremove = p['autoremove']
     fail_on_autoremove = p['fail_on_autoremove']
     autoclean = p['autoclean']
 
     # max times we'll retry
     deadline = time.time() + p['lock_timeout']
+    dpkg_options = '%s -o DPkg::Lock::Timeout=%s' % (expand_dpkg_options(p['dpkg_options']), p['lock_timeout'])
 
     # keep running on lock issues unless timeout or resolution is hit.
     while True:
```
