### PR TITLE
[stable-2.13] Fix url lookup test to use test container (#80284)

### DIFF
--- a/test/integration/targets/lookup_url/tasks/main.yml
+++ b/test/integration/targets/lookup_url/tasks/main.yml
@@ -1,11 +1,11 @@
 - name: Test that retrieving a url works
   set_fact:
-    web_data: "{{ lookup('url', 'https://gist.githubusercontent.com/abadger/9858c22712f62a8effff/raw/43dd47ea691c90a5fa7827892c70241913351963/test') }}"
+    web_data: "{{ lookup('url', 'https://{{ httpbin_host }}/get?one') }}"
 
 - name: Assert that the url was retrieved
   assert:
     that:
-      - "'one' in web_data"
+      - "'one' in web_data.args"
 
 - name: Test that retrieving a url with invalid cert fails
   set_fact:


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/80284

(cherry picked from commit 054aa9215857f376ee4d387339e6b82bcc14b437)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

integration tests