### PR TITLE
user: Remove superfluous user not found warning

### DIFF
--- a/changelogs/fragments/80267-ansible_builtin_user-remove-user-not-found-warning.yml
+++ b/changelogs/fragments/80267-ansible_builtin_user-remove-user-not-found-warning.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible.builtin.user - Remove user not found warning (https://github.com/ansible/ansible/issues/80267)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1070,12 +1070,6 @@ class User(object):
                         exists = True
                         break
 
-            if not exists:
-                self.module.warn(
-                    "'local: true' specified and user '{name}' was not found in {file}. "
-                    "The local user account may already exist if the local account database exists "
-                    "somewhere other than {file}.".format(file=self.PASSWORDFILE, name=self.name))
-
             return exists
 
         else:

--- a/test/integration/targets/user/tasks/test_local.yml
+++ b/test/integration/targets/user/tasks/test_local.yml
@@ -224,8 +224,6 @@
 - name: Ensure warnings were displayed properly
   assert:
     that:
-      - local_user_test_1['warnings'] | length > 0
-      - local_user_test_1['warnings'] | first is search('The local user account may already exist')
       - local_user_test_5['warnings'] is search("'append' is set, but no 'groups' are specified. Use 'groups'")
       - local_existing['warnings'] is not defined
   when: ansible_facts.system in ['Linux']


### PR DESCRIPTION
##### SUMMARY

Removes the warning, when `local: true` and the user could not be found.

A note about this warning already exists in the documentation.

Fixes #80267

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ansible.builtin.user

##### ADDITIONAL INFORMATION

See #80267.