### PR TITLE
ansible-doc tests: fix URL processing

### DIFF
--- a/test/integration/targets/ansible-doc/fix-urls.py
+++ b/test/integration/targets/ansible-doc/fix-urls.py
@@ -1,0 +1,15 @@
+"""Unwrap URLs to docs.ansible.com and remove version"""
+
+import re
+import sys
+
+
+def main():
+    data = sys.stdin.read()
+    data = re.sub('(https://docs\\.ansible\\.com/[^ ]+)\n +([^ ]+)\n', '\\1\\2\n', data, flags=re.MULTILINE)
+    data = re.sub('https://docs\\.ansible\\.com/ansible(|-core)/(?:[^/]+)/', 'https://docs.ansible.com/ansible\\1/devel/', data)
+    sys.stdout.write(data)
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansible-doc/randommodule-text.output
+++ b/test/integration/targets/ansible-doc/randommodule-text.output
@@ -72,12 +72,10 @@ SEE ALSO:
       * Module ansible.builtin.ping
            The official documentation on the
            ansible.builtin.ping module.
-           https://docs.ansible.com/ansible-core/devel/collectio
-        ns/ansible/builtin/ping_module.html
+           https://docs.ansible.com/ansible-core/devel/collections/ansible/builtin/ping_module.html
       * Module ansible.builtin.uri
            Use this to fetch an URI
-           https://docs.ansible.com/ansible-core/devel/collectio
-        ns/ansible/builtin/uri_module.html
+           https://docs.ansible.com/ansible-core/devel/collections/ansible/builtin/uri_module.html
       * Module testns.testcol.test
       * Module testns.testcol.fakemodule
            A fake module
@@ -86,8 +84,7 @@ SEE ALSO:
            https://docs.ansible.com
       * Ansible documentation [foo_bar]
            Some foo bar.
-           https://docs.ansible.com/ansible-
-           core/devel/#stq=foo_bar&stp=1
+           https://docs.ansible.com/ansible-core/devel/#stq=foo_bar&stp=1
 
 
 AUTHOR: Ansible Core Team

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -43,14 +43,14 @@ expected_out="$(sed '1 s/\(^> TESTNS\.TESTCOL\.FAKEMODULE\).*(.*)$/\1/' fakemodu
 test "$current_out" == "$expected_out"
 
 echo "test randommodule docs from collection"
-# we use sed to strip the plugin path from the first line, and remove versions from URLs when this is run from stable-X branches
-current_out="$(ansible-doc --playbook-dir ./ testns.testcol.randommodule | sed '1 s/\(^> TESTNS\.TESTCOL\.RANDOMMODULE\).*(.*)$/\1/' | sed 's/https:\/\/docs.ansible.com\/ansible-core\/[^\/]+\//https:\/\/docs.ansible.com\/ansible-core\/devel\//g')"
+# we use sed to strip the plugin path from the first line, and fix-urls.py to unbreak and replace URLs from stable-X branches
+current_out="$(ansible-doc --playbook-dir ./ testns.testcol.randommodule | sed '1 s/\(^> TESTNS\.TESTCOL\.RANDOMMODULE\).*(.*)$/\1/' | python fix-urls.py)"
 expected_out="$(sed '1 s/\(^> TESTNS\.TESTCOL\.RANDOMMODULE\).*(.*)$/\1/' randommodule-text.output)"
 test "$current_out" == "$expected_out"
 
 echo "test yolo filter docs from collection"
-# we use sed to strip the plugin path from the first line
-current_out="$(ansible-doc --playbook-dir ./ testns.testcol.yolo --type test | sed '1 s/\(^> TESTNS\.TESTCOL\.YOLO\).*(.*)$/\1/' | sed 's/https:\/\/docs.ansible.com\/ansible-core\/[^\/]+\//https:\/\/docs.ansible.com\/ansible-core\/devel\//g')"
+# we use sed to strip the plugin path from the first line, and fix-urls.py to unbreak and replace URLs from stable-X branches
+current_out="$(ansible-doc --playbook-dir ./ testns.testcol.yolo --type test | sed '1 s/\(^> TESTNS\.TESTCOL\.YOLO\).*(.*)$/\1/' | python fix-urls.py)"
 expected_out="$(sed '1 s/\(^> TESTNS\.TESTCOL\.YOLO\).*(.*)$/\1/' yolo-text.output)"
 test "$current_out" == "$expected_out"
 

--- a/test/integration/targets/ansible-doc/yolo-text.output
+++ b/test/integration/targets/ansible-doc/yolo-text.output
@@ -13,8 +13,7 @@ SEE ALSO:
       * Module ansible.builtin.test
            The official documentation on the
            ansible.builtin.test module.
-           https://docs.ansible.com/ansible-core/devel/collectio
-        ns/ansible/builtin/test_module.html
+           https://docs.ansible.com/ansible-core/devel/collections/ansible/builtin/test_module.html
       * Module testns.testcol.fakemodule
            A fake module
       * Lookup plugin testns.testcol.noop
@@ -23,19 +22,16 @@ SEE ALSO:
       * Filter plugin ansible.builtin.combine
            The official documentation on the
            ansible.builtin.combine filter plugin.
-           https://docs.ansible.com/ansible-core/devel/collectio
-        ns/ansible/builtin/combine_filter.html
+           https://docs.ansible.com/ansible-core/devel/collections/ansible/builtin/combine_filter.html
       * Lookup plugin ansible.builtin.file
            Read a file on the controller.
-           https://docs.ansible.com/ansible-core/devel/collectio
-        ns/ansible/builtin/file_lookup.html
+           https://docs.ansible.com/ansible-core/devel/collections/ansible/builtin/file_lookup.html
       * Ansible docsite
            See also the Ansible docsite.
            https://docs.ansible.com
       * Ansible documentation [foo_bar]
            Some foo bar.
-           https://docs.ansible.com/ansible-
-           core/devel/#stq=foo_bar&stp=1
+           https://docs.ansible.com/ansible-core/devel/#stq=foo_bar&stp=1
 
 
 NAME: yolo


### PR DESCRIPTION
##### SUMMARY
When trying to backport #80280 the backports (#80285, #80286) showed that the tests as added in #80280 and #80212 will start failing in a stable branch.

The problem is that in the ansible-doc text output the URLs are wrapped to fit in a certain line width, and replacing `https://docs.ansible.com/ansible-doc/<version>/` by `https://docs.ansible.com/ansible-doc/devel/` will not change that the line break is happening somewhere else.

This adds a script that unbreaks the docs.ansible.com URLs and replaces the version with `devel`. I first tried to do this with sed, but sed in multiline only works for GNU sed, thus failing on some platforms. (#80285 has a test commit for that, you can see that it fails.) Then I used a Python script to do the processing (see the last commit in #80285). That's what I used in this PR as well. Once this is merged, I will update the backports to use the commit resulting from this PR.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
ansible-doc integration tests
