### PR TITLE
Update password.py documentation

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -46,7 +46,7 @@ DOCUMENTATION = """
         description:
           - A list of names that compose a custom character set in the generated passwords.
           - Note that this parameter dictates the possible character sets in the resulting password, not the required character sets.
-            If you want to require certain chacter sets, consider using the C(community.general.random_string lookup) plugin - 
+            If you want to require certain chacter sets, consider using the C(community.general.random_string lookup) plugin -
             U(https://docs.ansible.com/ansible/latest/collections/community/general/random_string_lookup.html).
           - 'By default generated passwords contain a random mix of upper and lowercase ASCII letters, the numbers 0-9, and punctuation (". , : - _").'
           - "They can be either parts of Python's string module attributes or represented literally ( :, -)."

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -45,6 +45,9 @@ DOCUMENTATION = """
         version_added: "1.4"
         description:
           - A list of names that compose a custom character set in the generated passwords.
+          - Note that this parameter dictates the possible characters in the resulting password, not the required characters.
+            If you want to require certain chacters, consider using the C(community.general.random_string lookup) plugin - 
+            U(https://docs.ansible.com/ansible/latest/collections/community/general/random_string_lookup.html).
           - 'By default generated passwords contain a random mix of upper and lowercase ASCII letters, the numbers 0-9, and punctuation (". , : - _").'
           - "They can be either parts of Python's string module attributes or represented literally ( :, -)."
           - "Though string modules can vary by Python version, valid values for both major releases include:

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -45,8 +45,8 @@ DOCUMENTATION = """
         version_added: "1.4"
         description:
           - A list of names that compose a custom character set in the generated passwords.
-          - Note that this parameter dictates the possible character sets in the resulting password, not the required character sets.
-            If you want to require certain chacter sets, consider using the C(community.general.random_string lookup) plugin -
+          - This parameter defines the possible character sets in the resulting password, not the required character sets.
+            If you want to require certain character sets for passwords, you can use the C(community.general.random_string lookup) plugin -
             U(https://docs.ansible.com/ansible/latest/collections/community/general/random_string_lookup.html).
           - 'By default generated passwords contain a random mix of upper and lowercase ASCII letters, the numbers 0-9, and punctuation (". , : - _").'
           - "They can be either parts of Python's string module attributes or represented literally ( :, -)."

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -45,8 +45,8 @@ DOCUMENTATION = """
         version_added: "1.4"
         description:
           - A list of names that compose a custom character set in the generated passwords.
-          - Note that this parameter dictates the possible characters in the resulting password, not the required characters.
-            If you want to require certain chacters, consider using the C(community.general.random_string lookup) plugin - 
+          - Note that this parameter dictates the possible character sets in the resulting password, not the required character sets.
+            If you want to require certain chacter sets, consider using the C(community.general.random_string lookup) plugin - 
             U(https://docs.ansible.com/ansible/latest/collections/community/general/random_string_lookup.html).
           - 'By default generated passwords contain a random mix of upper and lowercase ASCII letters, the numbers 0-9, and punctuation (". , : - _").'
           - "They can be either parts of Python's string module attributes or represented literally ( :, -)."

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -47,7 +47,7 @@ DOCUMENTATION = """
           - A list of names that compose a custom character set in the generated passwords.
           - This parameter defines the possible character sets in the resulting password, not the required character sets.
             If you want to require certain character sets for passwords, you can use the C(community.general.random_string lookup) plugin -
-            U(https://docs.ansible.com/ansible/latest/collections/community/general/random_string_lookup.html).
+            M(community.general.random_string).
           - 'By default generated passwords contain a random mix of upper and lowercase ASCII letters, the numbers 0-9, and punctuation (". , : - _").'
           - "They can be either parts of Python's string module attributes or represented literally ( :, -)."
           - "Though string modules can vary by Python version, valid values for both major releases include:

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -47,7 +47,7 @@ DOCUMENTATION = """
           - A list of names that compose a custom character set in the generated passwords.
           - This parameter defines the possible character sets in the resulting password, not the required character sets.
             If you want to require certain character sets for passwords, you can use the C(community.general.random_string lookup) plugin -
-            M(community.general.random_string).
+            P(community.general.random_string#lookup).
           - 'By default generated passwords contain a random mix of upper and lowercase ASCII letters, the numbers 0-9, and punctuation (". , : - _").'
           - "They can be either parts of Python's string module attributes or represented literally ( :, -)."
           - "Though string modules can vary by Python version, valid values for both major releases include:


### PR DESCRIPTION
##### SUMMARY
Update documentation to clarify that the chars parameter does not require characters it only allows characters.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
password.py Ansible password lookup plugin

##### ADDITIONAL INFORMATION
We have found that ansible password lookup does not force specific character sets based on the `chars` argument. The `chars` argument just gives a list of possible character sets, but rather does not require characters from each character set defined. For example, if you set `chars=ascii_letters,digits` you may end up generating a password with upper and lower case letters but no numbers. We often require multiple character sets for minimum password complexity. We sometimes avoid certain characters.

To fix this issue and force characters from particular character sets we should suggest using the random_string lookup plugin.
