### PR TITLE
Support role extension for semantic markup

### DIFF
--- a/changelogs/fragments/80305-ansible-doc-role-semantic-markup.yml
+++ b/changelogs/fragments/80305-ansible-doc-role-semantic-markup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ansible-doc - support role extension for semantic markup spec so that ``O()`` and ``RV()`` referring to role entrypoints are rendered more readable (https://github.com/ansible/ansible/pull/80305)."

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -411,10 +411,17 @@ class DocCLI(CLI, RoleMixin):
             plugin_fqcn = plugin_type = ''
         else:
             plugin_fqcn = plugin_type = ''
+        entrypoint = None
+        if ':' in text:
+            entrypoint, text = text.split(':', 1)
         if value is not None:
             text = f"{text}={value}"
         if plugin_fqcn and plugin_type:
-            return f"`{text}' (of {plugin_type} {plugin_fqcn})"
+            plugin_suffix = '' if plugin_type in ('role', 'module', 'playbook') else ' plugin'
+            plugin = f"{plugin_type}{plugin_suffix} {plugin_fqcn}"
+            if plugin_type == 'role' and entrypoint is not None:
+                plugin = f"{plugin}, {entrypoint} entrypoint"
+            return f"`{text}' (of {plugin})"
         return f"`{text}'"
 
     @classmethod

--- a/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/modules/randommodule.py
+++ b/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/modules/randommodule.py
@@ -9,6 +9,7 @@ module: randommodule
 short_description: A random module
 description:
     - A random module.
+    - See O(foo.bar.baz#role:main:foo=bar) for how this is used in the P(foo.bar.baz#role)'s C(main) entrypoint.
 author:
     - Ansible Core Team
 version_added: 1.0.0

--- a/test/integration/targets/ansible-doc/randommodule-text.output
+++ b/test/integration/targets/ansible-doc/randommodule-text.output
@@ -1,6 +1,8 @@
 > TESTNS.TESTCOL.RANDOMMODULE    (./collections/ansible_collections/testns/testcol/plugins/modules/randommodule.py)
 
-        A random module.
+        A random module. See `foo=bar' (of role foo.bar.baz, main
+        entrypoint) for how this is used in the [foo.bar.baz]'s `main'
+        entrypoint.
 
 ADDED IN: version 1.0.0 of testns.testcol
 
@@ -107,7 +109,7 @@ RETURN VALUES:
         This should be in the middle.
         Has some more data.
         Check out `m_middle.suboption' and compare it to `a_first=foo'
-        and `value' (of lookup community.general.foo).
+        and `value' (of lookup plugin community.general.foo).
         returned: success and 1st of month
         type: dict
 

--- a/test/integration/targets/ansible-doc/randommodule.output
+++ b/test/integration/targets/ansible-doc/randommodule.output
@@ -12,7 +12,8 @@
                 "why": "Test deprecation"
             },
             "description": [
-                "A random module."
+                "A random module.",
+                "See O(foo.bar.baz#role:main:foo=bar) for how this is used in the P(foo.bar.baz#role)'s C(main) entrypoint."
             ],
             "filename": "./collections/ansible_collections/testns/testcol/plugins/modules/randommodule.py",
             "has_action": false,


### PR DESCRIPTION
##### SUMMARY
Right now the semantic markup spec does not really support roles: these have entrypoints, which are not reflected in the `O()` and `RV()` syntaxes.

This implements support of a proposal for fixing this laid out (and implemented for antsibull-docs) in https://github.com/ansible-community/antsibull-docs/pull/113.

The main change here is to also remove the entrypoint and show it in a nice way. Without this PR, `O(foo.bar.baz#role:main:foo=bar)` from the test would result in `main:foo=bar (of role foo.bar.baz)`. The PR changes it to`foo=bar' (of role foo.bar.baz, main entrypoint)`.

(The PR also adds `plugin` after the plugin type for plugin types that are not modue, role, and playbook. This makes it a bit nicer to read: 'of lookup plugin foo.bar.baz' instead of 'of lookup foo.bar.baz').

Keeping this as a draft until the proposal in https://github.com/ansible-community/antsibull-docs/pull/113 has been decided on.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-doc
