### PR TITLE
Add OpenSUSE to the distro's installation guide

### DIFF
--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -28,6 +28,12 @@ On CentOS:
 
 RPMs for currently supported versions of CentOS are also available from `EPEL <https://fedoraproject.org/wiki/EPEL>`_.
 
+Installing Ansible on OpenSUSE Tumbleweed/Leap
+----------------------------------------------
+
+.. code-block:: bash
+
+    $ sudo zypper install ansible
 
 .. _from_apt:
 

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -34,6 +34,8 @@ Installing Ansible on OpenSUSE Tumbleweed/Leap
 .. code-block:: bash
 
     $ sudo zypper install ansible
+    
+See `OpenSUSE Support Portal <https://en.opensuse.org/Portal:Support>` for additional help with Ansible on OpenSUSE.
 
 .. _from_apt:
 


### PR DESCRIPTION
##### SUMMARY
Similar to the rest of the distros, OpenSUSE distributes ansible and it was missing.

##### ISSUE TYPE
- Docs Pull Request
