### PR TITLE
Document how to run all tasks, even the ones with the never tag

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_tags.rst
@@ -351,6 +351,12 @@ To run all tasks except those tagged ``packages``:
 
    ansible-playbook example.yml --skip-tags "packages"
 
+To run all tasks, even those excluded because are tagged ``never``:
+
+.. code-block:: bash
+
+   ansible-playbook example.yml --skip-tags "all,never"
+
 Previewing the results of using tags
 ------------------------------------
 

--- a/docs/docsite/rst/playbook_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_tags.rst
@@ -355,7 +355,7 @@ To run all tasks, even those excluded because are tagged ``never``:
 
 .. code-block:: bash
 
-   ansible-playbook example.yml --skip-tags "all,never"
+   ansible-playbook example.yml --tags "all,never"
 
 Previewing the results of using tags
 ------------------------------------


### PR DESCRIPTION
##### SUMMARY
Example on how to run all tasks without excluding the never tag.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It's difficult to know how to run all tasks without excluding the never tag. 
Just added it to the the docs.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tags

##### ADDITIONAL INFORMATION

Reading the example 

``` yml
tasks:
  - name: Run the rarely-used debug task
    ansible.builtin.debug:
     msg: '{{ showmevar }}'
    tags: [ never, debug ]
```

I thought that it is really useful and I want to use it so I can execute my code with and without debugs using tags.  
But whithout knowing the incantation, I can't:
``` sh
ansible-playbook example.yml --skip-tags "all,never"
```
If I had the trouble surely someone more will have it.