### PR TITLE
fix using templated values for include/import role FA

### DIFF
--- a/changelogs/fragments/fix-templating-private-role-FA.yml
+++ b/changelogs/fragments/fix-templating-private-role-FA.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - roles - Fix templating ``public``, ``allow_duplicates`` and ``rolespec_validate`` (https://github.com/ansible/ansible/issues/80304).

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -307,6 +307,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     # template the role name now, if needed
                     all_vars = variable_manager.get_vars(play=play, task=ir)
                     templar = Templar(loader=loader, variables=all_vars)
+                    ir.post_validate(templar=templar)
                     ir._role_name = templar.template(ir._role_name)
 
                     # uses compiled list from object

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -187,6 +187,7 @@ class IncludedFile:
                             role_name = templar.template(role_name)
 
                         new_task = original_task.copy()
+                        new_task.post_validate(templar=templar)
                         new_task._role_name = role_name
                         for from_arg in new_task.FROM_ARGS:
                             if from_arg in include_args:

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -86,6 +86,9 @@ class IncludeRole(TaskInclude):
         templar = Templar(loader=loader, variables=available_variables)
         from_files = templar.template(self._from_files)
 
+        for attr in (self.OTHER_ARGS - {'apply'}):
+            setattr(self, attr, templar.template(getattr(self, attr)))
+
         # build role
         actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=from_files,
                                 from_include=True, validate=self.rolespec_validate, public=self.public)

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -85,16 +85,15 @@ class IncludeRole(TaskInclude):
             available_variables = {}
         templar = Templar(loader=loader, variables=available_variables)
         from_files = templar.template(self._from_files)
-
-        for attr in (self.OTHER_ARGS - {'apply'}):
-            setattr(self, attr, templar.template(getattr(self, attr)))
+        public = templar.template(getattr(self, 'public'))
+        rolespec_validate = templar.template(getattr(self, 'rolespec_validate'))
 
         # build role
         actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=from_files,
-                                from_include=True, validate=self.rolespec_validate, public=self.public)
-        actual_role._metadata.allow_duplicates = self.allow_duplicates
+                                from_include=True, validate=rolespec_validate, public=public)
+        actual_role._metadata.allow_duplicates = templar.template(getattr(self, 'allow_duplicates'))
 
-        if self.statically_loaded or self.public:
+        if self.statically_loaded or public:
             myplay.roles.append(actual_role)
 
         # save this for later use

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -51,9 +51,9 @@ class IncludeRole(TaskInclude):
     # ATTRIBUTES
 
     # private as this is a 'module options' vs a task property
-    allow_duplicates = NonInheritableFieldAttribute(isa='bool', default=True, private=True)
-    public = NonInheritableFieldAttribute(isa='bool', default=False, private=True)
-    rolespec_validate = NonInheritableFieldAttribute(isa='bool', default=True)
+    allow_duplicates = NonInheritableFieldAttribute(isa='bool', default=True, private=True, always_post_validate=True)
+    public = NonInheritableFieldAttribute(isa='bool', default=False, private=True, always_post_validate=True)
+    rolespec_validate = NonInheritableFieldAttribute(isa='bool', default=True, private=True, always_post_validate=True)
 
     def __init__(self, block=None, role=None, task_include=None):
 
@@ -85,15 +85,13 @@ class IncludeRole(TaskInclude):
             available_variables = {}
         templar = Templar(loader=loader, variables=available_variables)
         from_files = templar.template(self._from_files)
-        public = templar.template(getattr(self, 'public'))
-        rolespec_validate = templar.template(getattr(self, 'rolespec_validate'))
 
         # build role
         actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=from_files,
-                                from_include=True, validate=rolespec_validate, public=public)
-        actual_role._metadata.allow_duplicates = templar.template(getattr(self, 'allow_duplicates'))
+                                from_include=True, validate=self.rolespec_validate, public=self.public)
+        actual_role._metadata.allow_duplicates = self.allow_duplicates
 
-        if self.statically_loaded or public:
+        if self.statically_loaded or self.public:
             myplay.roles.append(actual_role)
 
         # save this for later use

--- a/test/integration/targets/include_import/roles/role_with_argspec/meta/argument_specs.yml
+++ b/test/integration/targets/include_import/roles/role_with_argspec/meta/argument_specs.yml
@@ -1,0 +1,7 @@
+argument_specs:
+  main:
+    short_description: The main entry point for dup_allowed_role
+    options:
+      optional_int:
+        type: int
+        description: An integer value

--- a/test/integration/targets/include_import/roles/role_with_argspec/tasks/main.yml
+++ b/test/integration/targets/include_import/roles/role_with_argspec/tasks/main.yml
@@ -1,0 +1,1 @@
+- debug: msg='Running role_with_argspec'

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -121,6 +121,11 @@ ansible-playbook valid_include_keywords/playbook.yml "$@"
 ansible-playbook tasks/test_allow_single_role_dup.yml 2>&1 | tee test_allow_single_role_dup.out
 test "$(grep -c 'ok=3' test_allow_single_role_dup.out)" = 1
 
+# test templating public, allow_duplicates, and rolespec_validate
+ansible-playbook tasks/test_templating_IncludeRole_FA.yml 2>&1 | tee IncludeRole_FA_template.out
+test "$(grep -c 'ok=4' IncludeRole_FA_template.out)" = 1
+test "$(grep -c 'failed=0' IncludeRole_FA_template.out)" = 1
+
 # https://github.com/ansible/ansible/issues/66764
 ANSIBLE_HOST_PATTERN_MISMATCH=error ansible-playbook empty_group_warning/playbook.yml
 

--- a/test/integration/targets/include_import/tasks/test_templating_IncludeRole_FA.yml
+++ b/test/integration/targets/include_import/tasks/test_templating_IncludeRole_FA.yml
@@ -1,0 +1,28 @@
+---
+- name: test templating allow_duplicates, public, and rolespec_validate
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: prevent duplicate roles with a templated value
+      block:
+        - import_role:
+            name: dup_allowed_role
+            allow_duplicates: "{{ False | bool }}"
+        - import_role:
+            name: dup_allowed_role
+            allow_duplicates: "{{ False | bool }}"
+
+    - name: prevent leaky vars with a templated value
+      include_role:
+        name: role1
+        public: "{{ False | bool }}"
+    - assert:
+        that:
+          - where_am_i_defined is undefined
+
+    - name: skip role argspec validation with a templated value
+      include_role:
+        name: role_with_argspec
+        rolespec_validate: "{{ False | bool }}"
+      vars:
+        optional_int: wrong_type


### PR DESCRIPTION
##### SUMMARY
Fixes bug portion of #80304

I wasn't sure where these should be templated, but added it in `get_block_list` since `self._from_files` is templated here already, and defined by the user at the same level.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
roles

