### PR TITLE
Enforce that `Display.display` requires a `str`

### DIFF
--- a/changelogs/fragments/display-display-str-only.yml
+++ b/changelogs/fragments/display-display-str-only.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Perform type check on data passed to Display.display to enforce the requirement of being given a python3 unicode string

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -326,6 +326,9 @@ class Display(metaclass=Singleton):
         Note: msg *must* be a unicode string to prevent UnicodeError tracebacks.
         """
 
+        if not isinstance(msg, str):
+            raise TypeError(f'Display message must be str, not: {msg.__class__.__name__}')
+
         if self._final_q:
             # If _final_q is set, that means we are in a WorkerProcess
             # and instead of displaying messages directly from the fork


### PR DESCRIPTION
##### SUMMARY
Perform type check on data passed to `Display.display` to enforce the requirement of being given a python3 unicode string

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/display.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
