### PR TITLE
Improve Ansible.Basic.cs tempdir uniqueness

### DIFF
--- a/changelogs/fragments/ansible-basic-tmpdir-uniqueness.yml
+++ b/changelogs/fragments/ansible-basic-tmpdir-uniqueness.yml
@@ -1,0 +1,2 @@
+bugifxes:
+- Windows - Ensure the module temp directory contains more unique values to avoid conflicts with concurrent runs - https://github.com/ansible/ansible/issues/80294

--- a/changelogs/fragments/ansible-basic-tmpdir-uniqueness.yml
+++ b/changelogs/fragments/ansible-basic-tmpdir-uniqueness.yml
@@ -1,2 +1,2 @@
-bugifxes:
+bugfixes:
 - Windows - Ensure the module temp directory contains more unique values to avoid conflicts with concurrent runs - https://github.com/ansible/ansible/issues/80294

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -178,7 +178,7 @@ namespace Ansible.Basic
                     }
 
                     string dateTime = DateTime.Now.ToFileTime().ToString();
-                    string dirName = String.Format("ansible-moduletmp-{0}-{1}-{2}", dateTime, Process.GetCurrentProcess().Id,
+                    string dirName = String.Format("ansible-moduletmp-{0}-{1}-{2}", dateTime, System.Diagnostics.Process.GetCurrentProcess().Id,
                         new Random().Next(0, int.MaxValue));
                     string newTmpdir = Path.Combine(baseDir, dirName);
 #if CORECLR

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -178,7 +178,8 @@ namespace Ansible.Basic
                     }
 
                     string dateTime = DateTime.Now.ToFileTime().ToString();
-                    string dirName = String.Format("ansible-moduletmp-{0}-{1}", dateTime, new Random().Next(0, int.MaxValue));
+                    string dirName = String.Format("ansible-moduletmp-{0}-{1}-{2}", dateTime, Process.GetCurrentProcess().Id,
+                        new Random().Next(0, int.MaxValue));
                     string newTmpdir = Path.Combine(baseDir, dirName);
 #if CORECLR
                     DirectoryInfo tmpdirInfo = Directory.CreateDirectory(newTmpdir);


### PR DESCRIPTION
##### SUMMARY
The current tempdir naming scheme can result in the same name if the remote worker starts at the same time as another. By using the process id it should add enough uniqueness to avoid this situation.

Fixes: https://github.com/ansible/ansible/issues/80294

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Ansible.Basic.cs