### PR TITLE
Fetch signatures from galaxy after the dependency resolver runs

### DIFF
--- a/changelogs/fragments/80334-reduce-ansible-galaxy-api-calls.yml
+++ b/changelogs/fragments/80334-reduce-ansible-galaxy-api-calls.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - reduce API calls to servers by fetching signatures only for final candidates.

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -926,8 +926,7 @@ class GalaxyAPI:
         try:
             signatures = data["signatures"]
         except KeyError:
-            # Noisy since this is used by the dep resolver, so require more verbosity than Galaxy calls
-            display.vvvvvv(f"Server {self.api_server} has not signed {namespace}.{name}:{version}")
+            display.vvvv(f"Server {self.api_server} has not signed {namespace}.{name}:{version}")
             return []
         else:
             return [signature_info["signature"] for signature_info in signatures]

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -743,7 +743,8 @@ def install_collections(
 
     keyring_exists = artifacts_manager.keyring is not None
     with _display_progress("Starting collection install process"):
-        for fqcn, concrete_coll_pin in dependency_map.items():
+        for fqcn in dependency_map.keys():
+            concrete_coll_pin = dependency_map[fqcn]
             if concrete_coll_pin.is_virtual:
                 display.vvvv(
                     "'{coll!s}' is virtual, skipping.".
@@ -767,6 +768,19 @@ def install_collections(
                     "Configure a keyring for ansible-galaxy to use "
                     "or disable signature verification. "
                     "Skipping signature verification."
+                )
+
+            if concrete_coll_pin.type == 'galaxy':
+                signatures = concrete_coll_pin.src.get_collection_signatures(
+                    concrete_coll_pin.namespace, concrete_coll_pin.name, concrete_coll_pin.ver
+                )
+
+                concrete_coll_pin = Candidate(
+                    concrete_coll_pin.fqcn,
+                    concrete_coll_pin.ver,
+                    concrete_coll_pin.src,
+                    concrete_coll_pin.type,
+                    frozenset([*concrete_coll_pin.signatures, *signatures])
                 )
 
             try:

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -770,17 +770,7 @@ def install_collections(
                 )
 
             if concrete_coll_pin.type == 'galaxy':
-                signatures = concrete_coll_pin.src.get_collection_signatures(
-                    concrete_coll_pin.namespace, concrete_coll_pin.name, concrete_coll_pin.ver
-                )
-
-                concrete_coll_pin = Candidate(
-                    concrete_coll_pin.fqcn,
-                    concrete_coll_pin.ver,
-                    concrete_coll_pin.src,
-                    concrete_coll_pin.type,
-                    frozenset([*concrete_coll_pin.signatures, *signatures])
-                )
+                concrete_coll_pin = concrete_coll_pin.with_signatures_repopulated(concrete_coll_pin)
 
             try:
                 install(concrete_coll_pin, output_path, artifacts_manager)

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -770,7 +770,7 @@ def install_collections(
                 )
 
             if concrete_coll_pin.type == 'galaxy':
-                concrete_coll_pin = concrete_coll_pin.with_signatures_repopulated(concrete_coll_pin)
+                concrete_coll_pin = concrete_coll_pin.with_signatures_repopulated()
 
             try:
                 install(concrete_coll_pin, output_path, artifacts_manager)

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -743,8 +743,7 @@ def install_collections(
 
     keyring_exists = artifacts_manager.keyring is not None
     with _display_progress("Starting collection install process"):
-        for fqcn in dependency_map.keys():
-            concrete_coll_pin = dependency_map[fqcn]
+        for fqcn, concrete_coll_pin in dependency_map.items():
             if concrete_coll_pin.is_virtual:
                 display.vvvv(
                     "'{coll!s}' is virtual, skipping.".

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -27,7 +27,7 @@ if t.TYPE_CHECKING:
     )
 
 
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.collection import HAS_PACKAGING, PkgReq
 from ansible.module_utils._text import to_bytes, to_native, to_text
@@ -590,7 +590,7 @@ class Candidate(
         :raises AssertionError: If the supplied candidate is not sourced from a Galaxy-like index.
         """
         if self.type != 'galaxy':
-            raise AssertionError(f"Invalid collection type for {self}: unable to get signatures from a galaxy server.")
+            raise AnsibleAssertionError(f"Invalid collection type for {self!r}: unable to get signatures from a galaxy server.")
 
         signatures = self.src.get_collection_signatures(self.namespace, self.name, self.ver)
         return self.__class__(self.fqcn, self.ver, self.src, self.type, frozenset([*self.signatures, *signatures]))

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -585,14 +585,12 @@ class Candidate(
     def __init__(self, *args, **kwargs):
         super(Candidate, self).__init__()
 
-    @classmethod
-    def with_signatures_repopulated(cls, collection):
-        # type: (t.Type[Candidate], Candidate) -> Candidate
-        if collection.type != 'galaxy':
-            raise ValueError(
-                f"Invalid collection type for {collection}: unable to get signatures from a galaxy server."
-            )
-        signatures = collection.src.get_collection_signatures(
-            collection.namespace, collection.name, collection.ver
-        )
-        return cls(collection.fqcn, collection.ver, collection.src, collection.type, frozenset([*collection.signatures, *signatures]))
+    def with_signatures_repopulated(self):  # type: (Candidate) -> Candidate
+        """Populate a new Candidate instance with Galaxy signatures.
+        :raises AssertionError: If the supplied candidate is not sourced from a Galaxy-like index.
+        """
+        if self.type != 'galaxy':
+            raise AssertionError(f"Invalid collection type for {self}: unable to get signatures from a galaxy server.")
+
+        signatures = self.src.get_collection_signatures(self.namespace, self.name, self.ver)
+        return self.__class__(self.fqcn, self.ver, self.src, self.type, frozenset([*self.signatures, *signatures]))

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -587,7 +587,7 @@ class Candidate(
 
     @classmethod
     def with_signatures_repopulated(cls, collection):
-        # type: (t.Type[Collection], Collection) -> Collection
+        # type: (t.Type[Candidate], Candidate) -> Candidate
         if collection.type != 'galaxy':
             raise ValueError(
                 f"Invalid collection type for {collection}: unable to get signatures from a galaxy server."

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -587,7 +587,7 @@ class Candidate(
 
     def with_signatures_repopulated(self):  # type: (Candidate) -> Candidate
         """Populate a new Candidate instance with Galaxy signatures.
-        :raises AssertionError: If the supplied candidate is not sourced from a Galaxy-like index.
+        :raises AnsibleAssertionError: If the supplied candidate is not sourced from a Galaxy-like index.
         """
         if self.type != 'galaxy':
             raise AnsibleAssertionError(f"Invalid collection type for {self!r}: unable to get signatures from a galaxy server.")

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -584,3 +584,15 @@ class Candidate(
 
     def __init__(self, *args, **kwargs):
         super(Candidate, self).__init__()
+
+    @classmethod
+    def with_signatures_repopulated(cls, collection):
+        # type: (t.Type[Collection], Collection) -> Collection
+        if collection.type != 'galaxy':
+            raise ValueError(
+                f"Invalid collection type for {collection}: unable to get signatures from a galaxy server."
+            )
+        signatures = collection.src.get_collection_signatures(
+            collection.namespace, collection.name, collection.ver
+        )
+        return cls(collection.fqcn, collection.ver, collection.src, collection.type, frozenset([*collection.signatures, *signatures]))

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -392,7 +392,6 @@ class CollectionDependencyProviderBase(AbstractProvider):
 
             if not unsatisfied:
                 if self._include_signatures:
-                    signatures = src_server.get_collection_signatures(first_req.namespace, first_req.name, version)
                     for extra_source in extra_signature_sources:
                         signatures.append(get_signature_from_source(extra_source))
                 latest_matches.append(

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -5,7 +5,7 @@
     state: directory
 
 - name: install simple collection from first accessible server
-  command: ansible-galaxy collection install namespace1.name1 {{ galaxy_verbosity }}
+  command: ansible-galaxy collection install namespace1.name1 -vvvv
   environment:
     ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
   register: from_first_good_server
@@ -30,6 +30,7 @@
     - install_normal_files.files[1].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md']
     - install_normal_files.files[2].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md']
     - (install_normal_manifest.content | b64decode | from_json).collection_info.version == '1.0.9'
+    - 'from_first_good_server.stdout|regex_findall("has not signed namespace1\.name1")|length == 1'
 
 - name: Remove the collection
   file:


### PR DESCRIPTION
##### SUMMARY
Fetch signatures for type 'galaxy' candidates after the dependency resolver runs so it runs only for the final matches

`find_matches` has access to the corresponding requirements for a match, so it's populating the user-requested signatures. The outer scope recreates the Candidate with the complete list before validating+installing.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy