### PR TITLE
Use `skip/macos` instead of `skip/macos/13.2`

### DIFF
--- a/test/integration/targets/lookup_url/aliases
+++ b/test/integration/targets/lookup_url/aliases
@@ -1,7 +1,7 @@
 destructive
 shippable/posix/group3
 needs/httptester
-skip/macos/13.2  # This test crashes Python due to https://wefearchange.org/2018/11/forkmacos.rst.html
+skip/macos  # This test crashes Python due to https://wefearchange.org/2018/11/forkmacos.rst.html
 # Example failure:
 #
 # TASK [lookup_url : Test that retrieving a url works] ***************************


### PR DESCRIPTION
##### SUMMARY

The reason for the skip won't be going away with future versions of macOS.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

integration tests