### PR TITLE
📝 Document macOS user deletion over SSH

### DIFF
--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -245,8 +245,8 @@ need to install them into the virtualenv. There are two methods:
       $ cp -v /usr/lib64/python3.*/site-packages/*selinux*.so ./py3-ansible/lib64/python3.*/site-packages/
 
 
-Running on macOS
-----------------
+Running on macOS as a controller
+--------------------------------
 
 When executing Ansible on a system with macOS as a controller machine one might encounter the following error:
 
@@ -259,6 +259,23 @@ In general the recommended workaround is to set the following environment variab
   .. code-block:: shell
 
         $ export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+
+
+.. _macos_as_a_target_faq:
+
+Running on macOS as a target
+----------------------------
+
+When executing Ansible against a system with macOS Monteray 12, macOS Ventura
+13 or above, as a target machine, one might encounter the following error:
+
+  .. error::
+        "eDSPermissionError" DS Error: -14120 (eDSPermissionError)
+
+.. seealso::
+
+   For more details, check out `the official Apple user guide article
+   <https://support.apple.com/guide/mac-help/mchlp1066/mac#mchlp1b6a98a>`_.
 
 
 Running on BSD

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -266,11 +266,13 @@ In general the recommended workaround is to set the following environment variab
 Running on macOS as a target
 ----------------------------
 
-When executing Ansible against a system with macOS Monteray 12, macOS Ventura
-13 or above, as a target machine, one might encounter the following error:
+When managing a system with macOS Monterey 12, macOS Ventura
+13 or above over SSH, one might encounter the following error:
 
   .. error::
         "eDSPermissionError" DS Error: -14120 (eDSPermissionError)
+
+This is a good indication that *Allow full disk access for remote users* has not been enabled.
 
 .. seealso::
 

--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -267,7 +267,7 @@ Running on macOS as a target
 ----------------------------
 
 When managing a system with macOS Monterey 12, macOS Ventura
-13 or above over SSH, one might encounter the following error:
+13 or above over SSH, the following error can occur:
 
   .. error::
         "eDSPermissionError" DS Error: -14120 (eDSPermissionError)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -98,7 +98,7 @@ options:
         description:
             - Whether the account should exist or not, taking action if the state is different from what is stated.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#running-on-macos-as-a-target)
-              for details on allowing to remove users on remote macOS systems.
+              for details on additional requirements when removing users on macOS systems.
         type: str
         choices: [ absent, present ]
         default: present

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -97,6 +97,8 @@ options:
     state:
         description:
             - Whether the account should exist or not, taking action if the state is different from what is stated.
+            - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#running-on-macos-as-a-target)
+              for details on allowing to remove users on remote macOS systems.
         type: str
         choices: [ absent, present ]
         default: present

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -97,8 +97,8 @@ options:
     state:
         description:
             - Whether the account should exist or not, taking action if the state is different from what is stated.
-            - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#running-on-macos-as-a-target)
-              for details on additional requirements when removing users on macOS systems.
+            - See this L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#running-on-macos-as-a-target)
+              for additional requirements when removing users on macOS systems.
         type: str
         choices: [ absent, present ]
         default: present


### PR DESCRIPTION
This change adds notes to the FAQ and the `user` module docs, explaining the requirement to enable `Full Disk Access` for SSH-connected user sessions manually, if one needs to run a user deletion against a modern macOS system as a target, using Ansible.

Ref: https://support.apple.com/guide/mac-help/mchlp1066/mac#mchlp1b6a98a

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`user` module and macOS FAQ section

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A