### PR TITLE
🐛📝 Undouble trailing colon @ `faq.rst`

### DIFF
--- a/docs/docsite/rst/reference_appendices/faq.rst
+++ b/docs/docsite/rst/reference_appendices/faq.rst
@@ -319,7 +319,7 @@ There are a few common errors that one might run into when trying to execute Ans
   .. error::
       /usr/bin/python: EDC5129I No such file or directory
 
-  To fix this set the path to the python installation in your inventory like so::
+  To fix this set the path to the python installation in your inventory like so:
 
   .. code-block:: ini
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It is causing parsing/representation problems of the following explicit RST code block.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`faq.rst`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
In RST, the code blocks that are marked with an explicit directive, don't expect a double trailing colon on the line above.