### PR TITLE
ansible-test - Fix packaging change classification

### DIFF
--- a/test/integration/targets/canonical-pep517-self-packaging/aliases
+++ b/test/integration/targets/canonical-pep517-self-packaging/aliases
@@ -1,2 +1,3 @@
 shippable/posix/group3
 context/controller
+packaging

--- a/test/integration/targets/entry_points/aliases
+++ b/test/integration/targets/entry_points/aliases
@@ -1,2 +1,3 @@
 context/controller
 shippable/posix/group4
+packaging

--- a/test/lib/ansible_test/_internal/classification/__init__.py
+++ b/test/lib/ansible_test/_internal/classification/__init__.py
@@ -668,6 +668,10 @@ class PathMapper:
 
         minimal: dict[str, str] = {}
 
+        packaging = {
+            'integration': 'packaging/',
+        }
+
         # Early classification that needs to occur before common classification belongs here.
 
         if path.startswith('test/units/compat/'):
@@ -749,6 +753,9 @@ class PathMapper:
             return minimal
 
         if path.startswith('packaging/'):
+            if path.startswith('packaging/pep517_backend/'):
+                return packaging
+
             return minimal
 
         if path.startswith('test/ansible_test/'):
@@ -836,16 +843,17 @@ class PathMapper:
                 return minimal
 
             if path in (
-                    'setup.py',
+                'MANIFEST.in',
+                'pyproject.toml',
+                'requirements.txt',
+                'setup.cfg',
+                'setup.py',
             ):
-                return all_tests(self.args)  # broad impact, run all tests
+                return packaging
 
             if ext in (
-                '.in',
                 '.md',
                 '.rst',
-                '.toml',
-                '.txt',
             ):
                 return minimal
 


### PR DESCRIPTION
##### SUMMARY

ansible-test - Fix packaging change classification.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

ansible-test

##### ADDITIONAL INFORMATION

Any new integration tests for ansible-core which depend on packaging related files will need the `packaging` alias, to indicate the dependency. Currently `ansible-test` has no way of detecting this dependency or enforcing that the alias is present.