### PR TITLE
packaging: add ANSIBLE_PEP517_BUILD_MANPAGES envvar

### DIFF
--- a/changelogs/fragments/pep-doc-env.yaml
+++ b/changelogs/fragments/pep-doc-env.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Add ``ANSIBLE_PEP517_BUILD_MANPAGES`` envvar to internal pyproject build
+    backend to control whether or not to build manpages
+    (https://github.com/ansible/ansible/pull/80363).

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -44,12 +44,10 @@ __all__ = (  # noqa: WPS317, WPS410
 )
 
 
-BUILD_MANPAGES_CONFIG_SETTING = '--build-manpages'
-"""Config setting name toggle that is used to request manpage in sdists."""
-
-BUILD_MANPAGES_CONFIG_ENVVAR = (
-    os.environ.get("ANSIBLE_PEP517_BUILD_MANPAGES", "0").lower() in ("1", "true")
+BUILD_MANPAGES = (
+    os.environ.get('ANSIBLE_PEP517_BUILD_MANPAGES', '0').lower() in ('1', 'true')
 )
+"""Environment variable toggle that is used to request manpage in sdists."""
 
 
 @contextmanager
@@ -116,18 +114,13 @@ def build_sdist(  # noqa: WPS210, WPS430
          sdist_directory: os.PathLike,
          config_settings: dict[str, str] | None = None,
 ) -> str:
-    config_settings = config_settings or {}
-    build_manpages_requested = (
-        BUILD_MANPAGES_CONFIG_SETTING in config_settings or
-        BUILD_MANPAGES_CONFIG_ENVVAR
-    )
     original_src_dir = Path.cwd().resolve()
     with _run_in_temporary_directory() as tmp_dir:
         tmp_src_dir = Path(tmp_dir) / 'src'
         copytree(original_src_dir, tmp_src_dir)
         os.chdir(tmp_src_dir)
 
-        if build_manpages_requested:
+        if BUILD_MANPAGES:
             Path('docs/man/man1/').mkdir(exist_ok=True, parents=True)
             version_number = _get_package_distribution_version()
             for rst_in in _generate_rst_in_templates():
@@ -162,17 +155,11 @@ def build_sdist(  # noqa: WPS210, WPS430
 def get_requires_for_build_sdist(
         config_settings: dict[str, str] | None = None,
 ) -> list[str]:
-    config_settings = config_settings or {}
-    build_manpages_requested = (
-        BUILD_MANPAGES_CONFIG_SETTING in config_settings or
-        BUILD_MANPAGES_CONFIG_ENVVAR
-    )
-
     manpage_build_deps = [
         'docutils',  # provides `rst2man`
         'jinja2',  # used in `hacking/build-ansible.py generate-man`
         'pyyaml',  # needed for importing in-tree `ansible-core` from `lib/`
-    ] if build_manpages_requested else []
+    ] if BUILD_MANPAGES else []
 
     return _setuptools_get_requires_for_build_sdist(
         config_settings=config_settings,

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -47,6 +47,10 @@ __all__ = (  # noqa: WPS317, WPS410
 BUILD_MANPAGES_CONFIG_SETTING = '--build-manpages'
 """Config setting name toggle that is used to request manpage in sdists."""
 
+BUILD_MANPAGES_CONFIG_ENVVAR = (
+    os.environ.get("ANSIBLE_PEP517_BUILD_MANPAGES", "0").lower() in ("1", "true")
+)
+
 
 @contextmanager
 def _run_in_temporary_directory() -> t.Iterator[Path]:
@@ -112,8 +116,10 @@ def build_sdist(  # noqa: WPS210, WPS430
          sdist_directory: os.PathLike,
          config_settings: dict[str, str] | None = None,
 ) -> str:
-    build_manpages_requested = BUILD_MANPAGES_CONFIG_SETTING in (
-        config_settings or {}
+    config_settings = config_settings or {}
+    build_manpages_requested = (
+        BUILD_MANPAGES_CONFIG_SETTING in config_settings or
+        BUILD_MANPAGES_CONFIG_ENVVAR
     )
     original_src_dir = Path.cwd().resolve()
     with _run_in_temporary_directory() as tmp_dir:
@@ -156,10 +162,11 @@ def build_sdist(  # noqa: WPS210, WPS430
 def get_requires_for_build_sdist(
         config_settings: dict[str, str] | None = None,
 ) -> list[str]:
-    build_manpages_requested = BUILD_MANPAGES_CONFIG_SETTING in (
-        config_settings or {}
+    config_settings = config_settings or {}
+    build_manpages_requested = (
+        BUILD_MANPAGES_CONFIG_SETTING in config_settings or
+        BUILD_MANPAGES_CONFIG_ENVVAR
     )
-    build_manpages_requested = True  # FIXME: Once pypa/build#559 is addressed.
 
     manpage_build_deps = [
         'docutils',  # provides `rst2man`

--- a/packaging/release.py
+++ b/packaging/release.py
@@ -1231,7 +1231,7 @@ def build(allow_dirty: bool = False) -> None:
         git("worktree", "add", "-d", temp_dir)
 
         try:
-            run("python", "-m", "build", "--config-setting=--build-manpages", env=env, cwd=temp_dir)
+            run("python", "-m", "build", env=env | dict(ANSIBLE_PEP517_BUILD_MANPAGES=1), cwd=temp_dir)
 
             get_sdist_path(version, dist_dir).rename(sdist_file)
             get_wheel_path(version, dist_dir).rename(wheel_file)

--- a/test/integration/targets/canonical-pep517-self-packaging/runme_test.py
+++ b/test/integration/targets/canonical-pep517-self-packaging/runme_test.py
@@ -170,11 +170,11 @@ def test_installing_sdist_build_with_modern_deps_to_old_env(
     tmp_dir_sdist_w_modern_tools = tmp_path / 'sdist-w-modern-tools'
     build_dists(
         venv_python_exe, '--sdist',
-        '--config-setting=--build-manpages',
         f'--outdir={tmp_dir_sdist_w_modern_tools!s}',
         str(SRC_ROOT_DIR),
         env_vars={
             'PIP_CONSTRAINT': str(MODERNISH_BUILD_DEPS_FILE),
+            'ANSIBLE_PEP517_BUILD_MANPAGES': '1',
         },
     )
     tmp_path_sdist_w_modern_tools = (
@@ -284,11 +284,11 @@ def test_dist_rebuilds_with_manpages_premutations(
     tmp_dir_sdist_with_manpages = tmp_path / 'sdist-with-manpages'
     build_dists(
         venv_python_exe, '--sdist',
-        '--config-setting=--build-manpages',
         f'--outdir={tmp_dir_sdist_with_manpages!s}',
         str(SRC_ROOT_DIR),
         env_vars={
             'PIP_CONSTRAINT': str(LOWEST_SUPPORTED_BUILD_DEPS_FILE),
+            'ANSIBLE_PEP517_BUILD_MANPAGES': '1',
         },
     )
     tmp_path_sdist_with_manpages = (
@@ -306,11 +306,11 @@ def test_dist_rebuilds_with_manpages_premutations(
     tmp_dir_rebuilt_sdist = tmp_path / 'rebuilt-sdist'
     build_dists(
         venv_python_exe, '--sdist',
-        '--config-setting=--build-manpages',
         f'--outdir={tmp_dir_rebuilt_sdist!s}',
         str(sdist_without_manpages_path),
         env_vars={
             'PIP_CONSTRAINT': str(MODERNISH_BUILD_DEPS_FILE),
+            'ANSIBLE_PEP517_BUILD_MANPAGES': '1',
         },
     )
     tmp_path_rebuilt_sdist = tmp_dir_rebuilt_sdist / EXPECTED_SDIST_NAME

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -180,11 +180,12 @@ def create_sdist(tmp_dir):
     pathlib.Path(f'changelogs/CHANGELOG-v{version.major}.{version.minor}.rst').touch()
 
     create = subprocess.run(
-        [sys.executable, '-m', 'build', '--sdist', '--config-setting=--build-manpages', '--outdir', tmp_dir],
+        [sys.executable, '-m', 'build', '--sdist', '--outdir', tmp_dir],
         stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         check=False,
+        env={"ANSIBLE_PEP517_BUILD_MANPAGES": '1'}
     )
 
     stderr = create.stderr


### PR DESCRIPTION
##### Summary

Add ``ANSIBLE_PEP517_BUILD_MANPAGES`` envvar to internal pyproject build backend to control whether or not to build manpages

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
packaging

##### ADDITIONAL INFORMATION

`build` does not pass config_settings to `get_requires_build_sdist()`, and some tooling (e.g. Fedora's pyproject-rpm-macros) doesn't support passing config_settings down to `build_sdist()` either.

This commit adds a fallback to $ANSIBLE_PEP517_BUILD_MANPAGES when the `--build-manpages` config setting isn't passed to the backend. It also removes the workaround that unconditionally enables building manpages.

/cc @webknjaz