### PR TITLE
Use --no-isolation for package-data sanity test

### DIFF
--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -180,7 +180,7 @@ def create_sdist(tmp_dir):
     pathlib.Path(f'changelogs/CHANGELOG-v{version.major}.{version.minor}.rst').touch()
 
     create = subprocess.run(
-        [sys.executable, '-m', 'build', '--sdist', '--config-setting=--build-manpages', '--outdir', tmp_dir],
+        [sys.executable, '-m', 'build', '--sdist', '--no-isolation', '--config-setting=--build-manpages', '--outdir', tmp_dir],
         stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,


### PR DESCRIPTION
##### SUMMARY

The dependencies are already in the sanity test venv. This avoids use of unpinned dependencies and a dependency on a network connection.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

package-data sanity test