### PR TITLE
Correct bypass_host_loop attribute for group_by

### DIFF
--- a/lib/ansible/modules/group_by.py
+++ b/lib/ansible/modules/group_by.py
@@ -40,7 +40,7 @@ attributes:
     become:
       support: none
     bypass_host_loop:
-      support: full
+      support: none
     bypass_task_loop:
       support: none
     check_mode:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This action originally bypassed the host loop, but that was changed in 1fa975d81a80d101c54919453bed9b2d1e5f3ed4 and it does not currently.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
group_by

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
