### PR TITLE
apt key and repository example security patch

### DIFF
--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -86,11 +86,11 @@ EXAMPLES = '''
     - name: somerepo |no apt key
       ansible.builtin.get_url:
         url: https://download.example.com/linux/ubuntu/gpg
-        dest: /etc/apt/trusted.gpg.d/somerepo.asc
+        dest: /usr/share/keyrings/somerepo.asc
 
     - name: somerepo | apt source
       ansible.builtin.apt_repository:
-        repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/myrepo.asc] https://download.example.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/myrepo.asc] https://download.example.com/linux/ubuntu {{ ansible_distribution_release }} stable"
         state: present
 
 - name: Add an apt key by id from a keyserver

--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -86,11 +86,11 @@ EXAMPLES = '''
     - name: somerepo |no apt key
       ansible.builtin.get_url:
         url: https://download.example.com/linux/ubuntu/gpg
-        dest: /usr/share/keyrings/somerepo.asc
+        dest: /etc/apt/keyrings/somerepo.asc
 
     - name: somerepo | apt source
       ansible.builtin.apt_repository:
-        repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/myrepo.asc] https://download.example.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/myrepo.asc] https://download.example.com/linux/ubuntu {{ ansible_distribution_release }} stable"
         state: present
 
 - name: Add an apt key by id from a keyserver

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -138,11 +138,11 @@ EXAMPLES = '''
     - name: somerepo |no apt key
       ansible.builtin.get_url:
         url: https://download.example.com/linux/ubuntu/gpg
-        dest: /etc/apt/trusted.gpg.d/somerepo.asc
+        dest: /usr/share/keyrings/somerepo.asc
 
     - name: somerepo | apt source
       ansible.builtin.apt_repository:
-        repo: "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/myrepo.asc] https://download.example.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/myrepo.asc] https://download.example.com/linux/ubuntu {{ ansible_distribution_release }} stable"
         state: present
 '''
 

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -138,11 +138,11 @@ EXAMPLES = '''
     - name: somerepo |no apt key
       ansible.builtin.get_url:
         url: https://download.example.com/linux/ubuntu/gpg
-        dest: /usr/share/keyrings/somerepo.asc
+        dest: /etc/apt/keyrings/somerepo.asc
 
     - name: somerepo | apt source
       ansible.builtin.apt_repository:
-        repo: "deb [arch=amd64 signed-by=/usr/share/keyrings/myrepo.asc] https://download.example.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/myrepo.asc] https://download.example.com/linux/ubuntu {{ ansible_distribution_release }} stable"
         state: present
 '''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The documented example in the already merged changes in #78206 if implemented would possibly weaken security of a host system.
This change mitigates it by changing adding a trusted key to a folder location /etc/apt/keyrings which is handled safely by apt.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Improves example of #78206

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
apt-key, apt-repository

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Saving trusted keys to /etc/apt/trusted.gpg.d/ is considered dangerous: https://blog.cloudflare.com/dont-use-apt-key/


<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
As changed in the commits as documented here:
https://blog.cloudflare.com/dont-use-apt-key/#a-better-way

>    Make sure the key isn’t in /etc/apt/trusted.gpg or /etc/apt/trusted.gpg.d/ anymore. If the key is its own file, the easiest way to do this is to move it to /usr/share/keyrings/. Make sure the file is owned by root, and only root can write to it. This step is important, because it prevents apt from using this key to check all repositories in the sources list.
    Modify the sources file in /etc/apt/sources.list.d/ telling apt that this particular repository can be “signed by” a specific key. When you’re done, the line should look like this: 

> `deb [signed-by=/usr/share/keyrings/cloudflare-client.gpg] https://pkg.cloudflareclient.com/ bullseye main`


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
