### PR TITLE
handle run_once with omit keyword on linear strategy

### DIFF
--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -215,7 +215,12 @@ class StrategyModule(StrategyBase):
                                 break
 
                         if templar.is_template(task.run_once):
-                            setattr(task, 'run_once', boolean(templar.template(task.run_once), strict=True))
+                            templated_run_once = templar.template(task.run_once)
+                            omit_value = templar.available_variables.get('omit')
+                            if omit_value is not None and templated_run_once == omit_value:
+                                task.set_to_context("run_once")
+                            else:
+                                setattr(task, 'run_once', boolean(templated_run_once, strict=True))
 
                         run_once = task.run_once or action and getattr(action, 'BYPASS_HOST_LOOP', False)
 

--- a/test/integration/targets/strategy_linear/task_templated_run_once.yml
+++ b/test/integration/targets/strategy_linear/task_templated_run_once.yml
@@ -3,18 +3,58 @@
   vars:
     run_once_flag: false
   tasks:
-    - debug:
-        msg: "I am {{ item }}"
-      run_once: "{{ run_once_flag }}"
-      register: reg1
-      loop:
-        - "{{ inventory_hostname }}"
+    - name: Use normal template
+      block: 
+      - debug:
+          msg: "I am {{ item }}"
+        run_once: "{{ run_once_flag }}"
+        register: reg1
+        loop:
+          - "{{ inventory_hostname }}"
 
-    - assert:
-        that:
-          - "reg1.results[0].msg == 'I am testhost'"
-      when: inventory_hostname == 'testhost'
-    - assert:
-        that:
-          - "reg1.results[0].msg == 'I am testhost2'"
-      when: inventory_hostname == 'testhost2'
+      - assert:
+          that:
+            - "reg1.results[0].msg == 'I am testhost'"
+        when: inventory_hostname == 'testhost'
+      - assert:
+          that:
+            - "reg1.results[0].msg == 'I am testhost2'"
+        when: inventory_hostname == 'testhost2'
+
+    
+    - name: Use omit
+      block:
+        - debug:
+            msg: "I am {{ item }}"
+          run_once: "{{ omit }}"
+          register: reg2
+          loop:
+            - "{{ inventory_hostname }}"
+
+        - assert:
+            that:
+              - "reg2.results[0].msg == 'I am testhost'"
+          when: inventory_hostname == 'testhost'
+        - assert:
+            that:
+              - "reg2.results[0].msg == 'I am testhost2'"
+          when: inventory_hostname == 'testhost2'
+
+
+    - name: Use compound template expression with omit
+      block:
+        - debug:
+            msg: "I am {{ item }}"
+          run_once: "{{ run_once_flag or omit }}"
+          register: reg3
+          loop:
+            - "{{ inventory_hostname }}"
+
+        - assert:
+            that:
+              - "reg3.results[0].msg == 'I am testhost'"
+          when: inventory_hostname == 'testhost'
+        - assert:
+            that:
+              - "reg3.results[0].msg == 'I am testhost2'"
+          when: inventory_hostname == 'testhost2'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
According to https://github.com/ansible/ansible/pull/80051#issuecomment-1493091749. And after my verification, `run_once` template expression with `omit` keyword will cause failure indeed. Now fix it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
linear strategy plugin

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
