### PR TITLE
Documentation changes for #80367 and #80270

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -67,6 +67,8 @@ Selecting an Ansible package and version to install
 
 Ansible's community packages are distributed in two ways: a minimalist language and runtime package called ``ansible-core``, and a much larger "batteries included" package called ``ansible``, which adds a community-curated selection of :ref:`Ansible Collections <collections>` for automating a wide variety of devices. Choose the package that fits your needs; The following instructions  use ``ansible``, but  you can substitute ``ansible-core``  if you prefer to start with a more minimal package and separately install only the Ansible Collections you require. The ``ansible`` or ``ansible-core`` packages may be available in your operating systems package manager, and you are free to install these packages with your preferred method. These installation instructions only cover the officially supported means of installing the python package with ``pip``.
 
+See the :ref:`Ansible package release status table<ansible_changelogs>` for the ``ansible-core`` version included in the package.
+
 Installing and upgrading Ansible
 ================================
 

--- a/docs/docsite/rst/playbook_guide/playbooks_blocks.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_blocks.rst
@@ -154,7 +154,7 @@ You can use blocks with ``flush_handlers`` in a rescue task to ensure that all h
           ansible.builtin.debug:
             msg: 'I execute normally'
           changed_when: true
-          notify: run me even after an error
+          notify: Run me even after an error
 
         - name: Force a failure
           ansible.builtin.command: /bin/false

--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -71,6 +71,7 @@ Work in Collections is tracked within the individual Collection repositories.
 
 You can refer to the :ref:`Ansible package porting guides<porting_guides>` for tips on updating your playbooks to run on newer versions of Ansible. For Ansible 2.10 and later releases, you can install the Ansible package with ``pip``. See :ref:`intro_installation_guide` for details. You can download older Ansible releases from `<https://releases.ansible.com/ansible/>`_.
 
+.. _ansible_changelogs:
 
 Ansible community changelogs
 ----------------------------


### PR DESCRIPTION
##### SUMMARY
Made the document changes outlines in #80367 and #80270

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Ansible Documentation

##### ADDITIONAL INFORMATION
For #80270, the handler name has been fixed <img width="1122" alt="Screenshot 2023-04-04 at 10 22 26 am" src="https://user-images.githubusercontent.com/86450936/229656203-f6757942-8e45-4e2e-98fb-1b0a11561fa0.png">

For #80367, have added the links to the changelog table

<img width="1131" alt="Screenshot 2023-04-04 at 10 25 49 am" src="https://user-images.githubusercontent.com/86450936/229656327-6c480e9c-b87b-445a-a096-b75207444aec.png">

<img width="1076" alt="Screenshot 2023-04-04 at 10 26 13 am" src="https://user-images.githubusercontent.com/86450936/229656332-cf1d7a87-f87e-47dc-adc8-aaa8d60ec35b.png">
