### PR TITLE
[Docs] communication.rst: Add a hint about adding Matrix shields to READMEs

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -61,7 +61,7 @@ If there is no appropriate room for your community, please create it.
 
 For more information, see the community-hosted `Matrix FAQ <https://hackmd.io/@ansible-community/community-matrix-faq>`_.
 
-You can add Matrix shields to your repository's ``README.md`` using the shield in the `community-topics repository <https://github.com/ansible-community/community-topics#community-topics>`_ as a template.
+You can add Matrix shields to your repository's ``README.md`` using the shield in the `community-topics <https://github.com/ansible-community/community-topics#community-topics>`_ repository as a template.
 
 Ansible community on IRC
 ------------------------

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -61,6 +61,8 @@ If there is no appropriate room for your community, please create it.
 
 For more information, see the community-hosted `Matrix FAQ <https://hackmd.io/@ansible-community/community-matrix-faq>`_.
 
+You can add Matrix shields to your repository's ``README.md`` using the shield in the `community-topics repository <https://github.com/ansible-community/community-topics#community-topics>`_ as a template.
+
 Ansible community on IRC
 ------------------------
 


### PR DESCRIPTION
##### SUMMARY
communication.rst: Add a hint about adding Matrix shields to READMEs

Fixes https://github.com/ansible-community/community-topics/issues/190

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/community/communication.rst