### PR TITLE
[stable-2.15] Extend ansible-doc test with more classic markup. (#80407)

### DIFF
--- a/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/modules/randommodule.py
+++ b/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/modules/randommodule.py
@@ -10,6 +10,10 @@ short_description: A random module
 description:
     - A random module.
     - See O(foo.bar.baz#role:main:foo=bar) for how this is used in the P(foo.bar.baz#role)'s C(main) entrypoint.
+    - See L(the docsite,https://docs.ansible.com/ansible-core/devel/) for more information on ansible-core.
+    - This module is not related to the M(ansible.builtin.copy) module. HORIZONTALLINE You might also be interested
+      in R(ansible_python_interpreter, ansible_python_interpreter).
+    - Sometimes you have M(broken markup) that will result in error messages.
 author:
     - Ansible Core Team
 version_added: 1.0.0

--- a/test/integration/targets/ansible-doc/randommodule-text.output
+++ b/test/integration/targets/ansible-doc/randommodule-text.output
@@ -2,7 +2,12 @@
 
         A random module. See `foo=bar' (of role foo.bar.baz, main
         entrypoint) for how this is used in the [foo.bar.baz]'s `main'
-        entrypoint.
+        entrypoint. See the docsite <https://docs.ansible.com/ansible-
+        core/devel/> for more information on ansible-core. This module
+        is not related to the [ansible.builtin.copy] module.
+        -------------  You might also be interested in
+        ansible_python_interpreter. Sometimes you have [broken markup]
+        that will result in error messages.
 
 ADDED IN: version 1.0.0 of testns.testcol
 

--- a/test/integration/targets/ansible-doc/randommodule.output
+++ b/test/integration/targets/ansible-doc/randommodule.output
@@ -13,7 +13,10 @@
             },
             "description": [
                 "A random module.",
-                "See O(foo.bar.baz#role:main:foo=bar) for how this is used in the P(foo.bar.baz#role)'s C(main) entrypoint."
+                "See O(foo.bar.baz#role:main:foo=bar) for how this is used in the P(foo.bar.baz#role)'s C(main) entrypoint.",
+                "See L(the docsite,https://docs.ansible.com/ansible-core/devel/) for more information on ansible-core.",
+                "This module is not related to the M(ansible.builtin.copy) module. HORIZONTALLINE You might also be interested in R(ansible_python_interpreter, ansible_python_interpreter).",
+                "Sometimes you have M(broken markup) that will result in error messages."
             ],
             "filename": "./collections/ansible_collections/testns/testcol/plugins/modules/randommodule.py",
             "has_action": false,


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/80407

(cherry picked from commit 96f7fd5539f6124004fecef8f7110d4965686872)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

ansible-doc integration test