### PR TITLE
2.15: dnf5: fix module/pkg names in the failed respawn msg (#80402)

### DIFF
--- a/changelogs/fragments/dnf5-fix-interpreter-fail-msg.yml
+++ b/changelogs/fragments/dnf5-fix-interpreter-fail-msg.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf5 - fix module and package names in the message following failed module respawn attempt

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -445,8 +445,8 @@ class Dnf5Module(YumDnf):
 
         # done all we can do, something is just broken (auto-install isn't useful anymore with respawn, so it was removed)
         self.module.fail_json(
-            msg="Could not import the dnf python module using {0} ({1}). "
-            "Please install `python3-dnf` or `python2-dnf` package or ensure you have specified the "
+            msg="Could not import the libdnf5 python module using {0} ({1}). "
+            "Please install python3-libdnf5 package or ensure you have specified the "
             "correct ansible_python_interpreter. (attempted {2})".format(
                 sys.executable, sys.version.replace("\n", ""), system_interpreters
             ),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #80402
(cherry picked from commit 12ce7d2e4e27dd209ad9a3027b36ff3b4d6f0c10)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnf5