### PR TITLE
Remove deprecated default.fact_caching_prefix ini config option

### DIFF
--- a/changelogs/fragments/inventory_cache-remove-deprecated-default-section.yml
+++ b/changelogs/fragments/inventory_cache-remove-deprecated-default-section.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - inventory_cache - remove deprecated ``default.fact_caching_prefix`` ini configuration option, use ``defaults.fact_caching_prefix`` instead.

--- a/lib/ansible/plugins/doc_fragments/inventory_cache.py
+++ b/lib/ansible/plugins/doc_fragments/inventory_cache.py
@@ -67,12 +67,6 @@ options:
       - name: ANSIBLE_CACHE_PLUGIN_PREFIX
       - name: ANSIBLE_INVENTORY_CACHE_PLUGIN_PREFIX
     ini:
-      - section: default
-        key: fact_caching_prefix
-        deprecated:
-          alternatives: Use the 'defaults' section instead
-          why: Fixes typing error in INI section name
-          version: '2.16'
       - section: defaults
         key: fact_caching_prefix
       - section: inventory


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`lib/ansible/plugins/doc_fragments/inventory_cache.py`