### PR TITLE
ansible.builtin inferred by collection_name == None

### DIFF
--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py
@@ -160,6 +160,8 @@ class AnsibleDeprecatedChecker(BaseChecker):
             self.add_message('ansible-deprecated-date', node=node, args=(date,))
 
     def _check_version(self, node, version, collection_name):
+        if collection_name is None:
+            collection_name = 'ansible.builtin'
         if not isinstance(version, (str, float)):
             if collection_name == 'ansible.builtin':
                 symbol = 'ansible-invalid-deprecated-version'

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -240,7 +240,6 @@ test/units/utils/collection_loader/fixtures/collections_masked/ansible_collectio
 test/units/utils/collection_loader/test_collection_loader.py pylint:undefined-variable  # magic runtime local var splatting
 lib/ansible/executor/module_common.py pylint:ansible-deprecated-version
 lib/ansible/executor/play_iterator.py pylint:ansible-deprecated-version
-lib/ansible/executor/play_iterator.py pylint:ansible-deprecated-version
 lib/ansible/module_utils/urls.py pylint:ansible-deprecated-version
 lib/ansible/playbook/helpers.py pylint:ansible-deprecated-version
 lib/ansible/playbook/included_file.py pylint:ansible-deprecated-version

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -238,3 +238,11 @@ test/units/utils/collection_loader/fixtures/collections_masked/ansible_collectio
 test/units/utils/collection_loader/fixtures/collections_masked/ansible_collections/testns/__init__.py empty-init  # testing that collections don't need inits
 test/units/utils/collection_loader/fixtures/collections_masked/ansible_collections/testns/testcoll/__init__.py empty-init  # testing that collections don't need inits
 test/units/utils/collection_loader/test_collection_loader.py pylint:undefined-variable  # magic runtime local var splatting
+lib/ansible/executor/module_common.py pylint:ansible-deprecated-version
+lib/ansible/executor/play_iterator.py pylint:ansible-deprecated-version
+lib/ansible/executor/play_iterator.py pylint:ansible-deprecated-version
+lib/ansible/module_utils/urls.py pylint:ansible-deprecated-version
+lib/ansible/playbook/helpers.py pylint:ansible-deprecated-version
+lib/ansible/playbook/included_file.py pylint:ansible-deprecated-version
+lib/ansible/plugins/action/__init__.py pylint:ansible-deprecated-version
+lib/ansible/template/__init__.py pylint:ansible-deprecated-version


### PR DESCRIPTION
##### SUMMARY
In the deprecated pylint plugin, if we make it to `_check_version` with `collection_name` being `None`, we should infer that `collection_name` is actually `ansible.builtin`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
