### PR TITLE
_symbolic_mode_to_octal- fix raising ValueError for invalid symbolic modes

### DIFF
--- a/changelogs/fragments/80449-fix-symbolic-mode-error-msg.yml
+++ b/changelogs/fragments/80449-fix-symbolic-mode-error-msg.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - file modules - fix validating invalid symbolic modes.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -265,8 +265,8 @@ PASSWD_ARG_RE = re.compile(r'^[-]{0,2}pass[-]?(word|wd)?')
 
 # Used for parsing symbolic file perms
 MODE_OPERATOR_RE = re.compile(r'[+=-]')
-USERS_RE = re.compile(r'[^ugo]')
-PERMS_RE = re.compile(r'[^rwxXstugo]')
+USERS_RE = re.compile(r'[ugo]+')
+PERMS_RE = re.compile(r'[rwxXstugo]*')
 
 
 #
@@ -1063,14 +1063,14 @@ class AnsibleModule(object):
 
             # Check if there are illegal characters in the user list
             # They can end up in 'users' because they are not split
-            if USERS_RE.match(users):
+            if not USERS_RE.fullmatch(users):
                 raise ValueError("bad symbolic permission for mode: %s" % mode)
 
             # Now we have two list of equal length, one contains the requested
             # permissions and one with the corresponding operators.
             for idx, perms in enumerate(permlist):
                 # Check if there are illegal characters in the permissions
-                if PERMS_RE.match(perms):
+                if not PERMS_RE.fullmatch(perms):
                     raise ValueError("bad symbolic permission for mode: %s" % mode)
 
                 for user in users:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -265,8 +265,8 @@ PASSWD_ARG_RE = re.compile(r'^[-]{0,2}pass[-]?(word|wd)?')
 
 # Used for parsing symbolic file perms
 MODE_OPERATOR_RE = re.compile(r'[+=-]')
-USERS_RE = re.compile(r'[ugo]+')
-PERMS_RE = re.compile(r'[rwxXstugo]*')
+USERS_RE = re.compile(r'^[ugo]+$')
+PERMS_RE = re.compile(r'^[rwxXstugo]*$')
 
 
 #
@@ -1063,14 +1063,14 @@ class AnsibleModule(object):
 
             # Check if there are illegal characters in the user list
             # They can end up in 'users' because they are not split
-            if not USERS_RE.fullmatch(users):
+            if not USERS_RE.match(users):
                 raise ValueError("bad symbolic permission for mode: %s" % mode)
 
             # Now we have two list of equal length, one contains the requested
             # permissions and one with the corresponding operators.
             for idx, perms in enumerate(permlist):
                 # Check if there are illegal characters in the permissions
-                if not PERMS_RE.fullmatch(perms):
+                if not PERMS_RE.match(perms):
                     raise ValueError("bad symbolic permission for mode: %s" % mode)
 
                 for user in users:

--- a/test/integration/targets/unarchive/tasks/test_mode.yml
+++ b/test/integration/targets/unarchive/tasks/test_mode.yml
@@ -3,6 +3,29 @@
     path: '{{remote_tmp_dir}}/test-unarchive-tar-gz'
     state: directory
 
+- name: test invalid modes
+  unarchive:
+    src: "{{ remote_tmp_dir }}/test-unarchive.tar.gz"
+    dest: "{{ remote_tmp_dir }}/test-unarchive-tar-gz"
+    remote_src: yes
+    mode: "{{ item }}"
+    list_files: True
+  register: unarchive_mode_errors
+  ignore_errors: yes
+  loop:
+    - u=foo
+    - foo=r
+    - ufoo=r
+    - abc=r
+    - ao=r
+    - oa=r
+
+- assert:
+    that:
+      - item.failed
+      - "'bad symbolic permission for mode: ' + item.item == item.details"
+  loop: "{{ unarchive_mode_errors.results }}"
+
 - name: unarchive and set mode to 0600, directories 0700
   unarchive:
     src: "{{ remote_tmp_dir }}/test-unarchive.tar.gz"

--- a/test/units/modules/test_copy.py
+++ b/test/units/modules/test_copy.py
@@ -185,6 +185,10 @@ UMASK_DATA = (
 INVALID_DATA = (
     (0o040000, u'a=foo', "bad symbolic permission for mode: a=foo"),
     (0o040000, u'f=rwx', "bad symbolic permission for mode: f=rwx"),
+    (0o100777, u'of=r', "bad symbolic permission for mode: of=r"),
+
+    (0o100777, u'ao=r', "bad symbolic permission for mode: ao=r"),
+    (0o100777, u'oa=r', "bad symbolic permission for mode: oa=r"),
 )
 
 


### PR DESCRIPTION
##### SUMMARY
Use fullmatch to ensure the whole `users` and `perms` strings contain only valid characters.

We were only validating the initial users/perms character, so invalid characters could cause a KeyError in
```
        def or_reduce(mode, perm):
            return mode | user_perms_to_modes[user][perm]
```
by following a valid one. This improves the result.details for this error cornercase.

I noticed this issue while looking at #80443. Since the current behavior seems to meet the expectation in https://github.com/ansible/ansible/pull/80443#pullrequestreview-1375441173, I added test cases using `a` in conjunction with other users.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
unarchive