### PR TITLE
installation_distros: update Fedora section

### DIFF
--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -10,7 +10,7 @@ The following instructions will guide you through installing the ``ansible`` pac
 .. contents::
   :local:
 
-Installing Ansible on Fedora or Enterprise Linux
+Installing Ansible on Fedora Linux
 -------------------------------------------------
 
 To install the batteries included ``ansible`` package on Fedora run
@@ -37,17 +37,22 @@ See the `Fedora Packages index <https://packages.fedoraproject.org/search?query=
 for a full list of Ansible collections packaged in Fedora.
 
 
-Users of Enterprise Linux distributions,
-including CentOS Stream, Almalinux, and Rocky Linux,
+Please `file a bug <https://bugzilla.redhat.com/enter_bug.cgi>`_ against the
+``Fedora`` product in Red Hat Bugzilla to reach the package maintainers.
+
+Installing Ansible from EPEL
+----------------------------------
+
+Users of CentOS Stream, Almalinux, Rocky Linux, and related distributions
 can install ``ansible`` or Ansible collections from the community maintained
 `EPEL <https://docs.fedoraproject.org/en-US/epel/>`_
 (Extra Packages for Enterprise Linux) repository.
 
 After `enabling the EPEL repository <https://docs.fedoraproject.org/en-US/epel/#_quickstart>`_,
-users can use the same ``dnf`` commands as for Fedora.
+users can use the same ``dnf`` commands as for Fedora Linux.
 
-Please `file a bug <https://bugzilla.redhat.com/enter_bug.cgi>`_
-in Red Hat Bugzilla to reach the package maintainers.
+Please `file a bug <https://bugzilla.redhat.com/enter_bug.cgi>`_ against the
+``Fedora EPEL`` product in Red Hat Bugzilla to reach the package maintainers.
 
 
 Installing Ansible on OpenSUSE Tumbleweed/Leap

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -38,7 +38,7 @@ for a full list of Ansible collections packaged in Fedora.
 
 
 Users of Enterprise Linux distributions,
-including CentOS Stream, RHEL, Almalinux, and Rocky Linux,
+including CentOS Stream, Almalinux, and Rocky Linux,
 can install ``ansible`` or Ansible collections from the community maintained
 `EPEL <https://docs.fedoraproject.org/en-US/epel/>`_
 (Extra Packages for Enterprise Linux) repository.

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -10,23 +10,45 @@ The following instructions will guide you through installing the ``ansible`` pac
 .. contents::
   :local:
 
-Installing Ansible on Fedora or CentOS 
---------------------------------------
+Installing Ansible on Fedora or Enterprise Linux
+-------------------------------------------------
 
-On Fedora:
+To install the batteries included ``ansible`` package on Fedora run
 
 .. code-block:: bash
 
     $ sudo dnf install ansible
 
-On CentOS:
+If you prefer to install the minimal ``ansible-core`` package run
 
 .. code-block:: bash
 
-    $ sudo yum install epel-release
-    $ sudo yum install ansible
+    $ sudo dnf install ansible-core
 
-RPMs for currently supported versions of CentOS are also available from `EPEL <https://fedoraproject.org/wiki/EPEL>`_.
+Several Ansible collections are also available from the Fedora repositories as
+standalone packages that users can install alongside ``ansible-core``.
+For example, to install the ``community.general`` collection run
+
+.. code-block:: bash
+
+   $ sudo dnf install ansible-collection-community-general
+
+See the `Fedora Packages index <https://packages.fedoraproject.org/search?query=ansible-collection>`_
+for a full list of Ansible collections packaged in Fedora.
+
+
+Users of Enterprise Linux distributions,
+including CentOS Stream, RHEL, Almalinux, and Rocky Linux,
+can install ``ansible`` or Ansible collections from the community supported
+`EPEL <https://docs.fedoraproject.org/en-US/epel/>`_
+(Extra Packages for Enterprise Linux) repository.
+
+After `enabling the EPEL repository <https://docs.fedoraproject.org/en-US/epel/#_quickstart>`_,
+users can use the same ``dnf`` commands as for Fedora.
+
+Please `file a bug <https://bugzilla.redhat.com/enter_bug.cgi>`_
+in Red Hat Bugzilla to reach the package maintainers.
+
 
 Installing Ansible on OpenSUSE Tumbleweed/Leap
 ----------------------------------------------

--- a/docs/docsite/rst/installation_guide/installation_distros.rst
+++ b/docs/docsite/rst/installation_guide/installation_distros.rst
@@ -39,7 +39,7 @@ for a full list of Ansible collections packaged in Fedora.
 
 Users of Enterprise Linux distributions,
 including CentOS Stream, RHEL, Almalinux, and Rocky Linux,
-can install ``ansible`` or Ansible collections from the community supported
+can install ``ansible`` or Ansible collections from the community maintained
 `EPEL <https://docs.fedoraproject.org/en-US/epel/>`_
 (Extra Packages for Enterprise Linux) repository.
 


### PR DESCRIPTION
##### SUMMARY

- Mention the ansible-core and ansible-collections-* packages as well
- Replace CentOS references with Enterprise Linux. EPEL is for more than just CentOS.
- Correct links to the EPEL project documentation. We no longer use the wiki.
- Point to the official documentation for enabling the EPEL repository instead of duplicating here.
- Include maintainer contact information.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
docs

##### ADDITIONAL INFORMATION
Relates: https://github.com/ansible/ansible/pull/80389
