### PR TITLE
Fixing bit shift, extra comma, reformatting "copy" test.

### DIFF
--- a/test/units/modules/test_copy.py
+++ b/test/units/modules/test_copy.py
@@ -128,16 +128,19 @@ def test_split_pre_existing_dir_working_dir_exists(directory, expected, mocker):
 #
 # Info helpful for making new test cases:
 #
-# base_mode = {'dir no perms': 0o040000,
-# 'file no perms': 0o100000,
-# 'dir all perms': 0o400000 | 0o777,
-# 'file all perms': 0o100000, | 0o777}
+# base_mode = {
+# 'dir no perms':   0o040000,
+# 'file no perms':  0o100000,
+# 'dir all perms':  0o040000 | 0o777,
+# 'file all perms': 0o100000 | 0o777}
 #
-# perm_bits = {'x': 0b001,
+# perm_bits = {
+# 'x': 0b001,
 # 'w': 0b010,
 # 'r': 0b100}
 #
-# role_shift = {'u': 6,
+# role_shift = {
+# 'u': 6,
 # 'g': 3,
 # 'o': 0}
 


### PR DESCRIPTION
##### SUMMARY
The "test_copy.py" module had one of the doc comments with a bit shifted.  Made
harder to realize since the first example was way shifted to the right.  I spent an hour
on code review because of this when my test wasn't working as expected.

Reformatted and fixed bit shift, there was also an extra comma in one example.

Fixes #80457

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
test/units/modules/test_copy.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Diff should be self-explanitory.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
N/A
```
