### PR TITLE
Expand pylint deprecated plugin to catch ansible.module_utils.common.warnings uses

### DIFF
--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py
@@ -95,7 +95,7 @@ ANSIBLE_VERSION = LooseVersion('.'.join(ansible_version_raw.split('.')[:3]))
 
 
 def _get_expr_name(node):
-    """Funciton to get either ``attrname`` or ``name`` from ``node.func.expr``
+    """Function to get either ``attrname`` or ``name`` from ``node.func.expr``
 
     Created specifically for the case of ``display.deprecated`` or ``self._display.deprecated``
     """
@@ -104,6 +104,17 @@ def _get_expr_name(node):
     except AttributeError:
         # If this fails too, we'll let it raise, the caller should catch it
         return node.func.expr.name
+
+
+def _get_func_name(node):
+    """Function to get either ``attrname`` or ``name`` from ``node.func``
+
+    Created specifically for the case of ``from ansible.module_utils.common.warnings import deprecate``
+    """
+    try:
+        return node.func.attrname
+    except AttributeError:
+        return node.func.name
 
 
 def parse_isodate(value):
@@ -218,8 +229,9 @@ class AnsibleDeprecatedChecker(BaseChecker):
         date = None
         collection_name = None
         try:
-            if (node.func.attrname == 'deprecated' and 'display' in _get_expr_name(node) or
-                    node.func.attrname == 'deprecate' and _get_expr_name(node)):
+            funcname = _get_func_name(node)
+            if (funcname == 'deprecated' and 'display' in _get_expr_name(node) or
+                    funcname == 'deprecate'):
                 if node.keywords:
                     for keyword in node.keywords:
                         if len(node.keywords) == 1 and keyword.arg is None:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -224,6 +224,8 @@ test/units/modules/test_apt.py pylint:disallowed-name
 test/units/module_utils/basic/test_deprecate_warn.py pylint:ansible-deprecated-no-version
 test/units/module_utils/basic/test_deprecate_warn.py pylint:ansible-deprecated-version
 test/units/module_utils/basic/test_run_command.py pylint:disallowed-name
+test/units/module_utils/common/warnings/test_deprecate.py pylint:ansible-deprecated-no-version  # testing Display.deprecated call without a version or date
+test/units/module_utils/common/warnings/test_deprecate.py pylint:ansible-deprecated-version  # testing Deprecated version found in call to Display.deprecated or AnsibleModule.deprecate
 test/units/module_utils/urls/fixtures/multipart.txt line-endings  # Fixture for HTTP tests that use CRLF
 test/units/module_utils/urls/test_fetch_url.py replace-urlopen
 test/units/module_utils/urls/test_gzip.py replace-urlopen
@@ -245,3 +247,4 @@ lib/ansible/playbook/helpers.py pylint:ansible-deprecated-version
 lib/ansible/playbook/included_file.py pylint:ansible-deprecated-version
 lib/ansible/plugins/action/__init__.py pylint:ansible-deprecated-version
 lib/ansible/template/__init__.py pylint:ansible-deprecated-version
+lib/ansible/module_utils/common/file.py pylint:ansible-deprecated-version


### PR DESCRIPTION
##### SUMMARY
Expand pylint deprecated plugin to catch `ansible.module_utils.common.warnings` uses

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
