### PR TITLE
Vars Plugin Documentation Improvement

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -544,7 +544,7 @@ Include the ``vars_plugin_staging`` documentation fragment to allow users to det
           - vars_plugin_staging
     '''
 
-At times a value provided by a vars plugin will contain unsafe values. The utility function `wrap_var` provided by `ansible.utils.unsafe_proxy` should be used to ensure that Ansible handles the variable and value correctly. The use cases for unsafe data is covered in `unsafe strings section of the playbook guide <https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings>`_.
+At times a value provided by a vars plugin will contain unsafe values. The utility function `wrap_var` provided by `ansible.utils.unsafe_proxy` should be used to ensure that Ansible handles the variable and value correctly. The use cases for unsafe data is covered in :ref:`unsafe_strings`.
 
 .. code-block:: python
 

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -544,6 +544,19 @@ Include the ``vars_plugin_staging`` documentation fragment to allow users to det
           - vars_plugin_staging
     '''
 
+At times a value provided by a vars plugin will contain unsafe values. The utility function `wrap_var` provided by `ansible.utils.unsafe_proxy` should be used to ensure that Ansible handles the variable and value correctly. The use cases for unsafe data is covered in :ref:`playbooks_advanced_syntax.unsafe_strings`
+
+.. code-block:: python
+
+    from ansible.plugins.vars import BaseVarsPlugin
+    import ansible.utils.unsafe_proxy
+
+    class VarsPlugin(BaseVarsPlugin):
+        def get_vars(self, loader, path, entities):
+            return dict(
+                something_unsafe=ansible.utils.unsafe_proxy.wrap_var("{{ SOMETHING_UNSAFE }}")
+            )
+
 For example vars plugins, see the source code for the `vars plugins included with Ansible Core
 <https://github.com/ansible/ansible/tree/devel/lib/ansible/plugins/vars>`_.
 

--- a/docs/docsite/rst/dev_guide/developing_plugins.rst
+++ b/docs/docsite/rst/dev_guide/developing_plugins.rst
@@ -544,17 +544,17 @@ Include the ``vars_plugin_staging`` documentation fragment to allow users to det
           - vars_plugin_staging
     '''
 
-At times a value provided by a vars plugin will contain unsafe values. The utility function `wrap_var` provided by `ansible.utils.unsafe_proxy` should be used to ensure that Ansible handles the variable and value correctly. The use cases for unsafe data is covered in :ref:`playbooks_advanced_syntax.unsafe_strings`
+At times a value provided by a vars plugin will contain unsafe values. The utility function `wrap_var` provided by `ansible.utils.unsafe_proxy` should be used to ensure that Ansible handles the variable and value correctly. The use cases for unsafe data is covered in `unsafe strings section of the playbook guide <https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_advanced_syntax.html#unsafe-or-raw-strings>`_.
 
 .. code-block:: python
 
     from ansible.plugins.vars import BaseVarsPlugin
-    import ansible.utils.unsafe_proxy
+    from ansible.utils.unsafe_proxy import wrap_var
 
     class VarsPlugin(BaseVarsPlugin):
         def get_vars(self, loader, path, entities):
             return dict(
-                something_unsafe=ansible.utils.unsafe_proxy.wrap_var("{{ SOMETHING_UNSAFE }}")
+                something_unsafe=wrap_var("{{ SOMETHING_UNSAFE }}")
             )
 
 For example vars plugins, see the source code for the `vars plugins included with Ansible Core


### PR DESCRIPTION
##### SUMMARY
* I ran into an issue developing a vars plugin that had to load unsafe data and Ansible Devel helped me find the `wrap_var` function in `ansible.utils.unsafe_proxy` so I thought I'd write up a tweak to the documentation page to cover it.
* It likely has uses outside of vars plugins specifically but I could see others needing it here (as I encountered it) so I figured I'd start here.
* I'm not sure if the link back to the playbook guide is correct so please help me out if it is not.
* Any style or tone improvements are welcome as well

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
The development guide for plugins, specifically vars plugins.

##### ADDITIONAL INFORMATION
I encountered an issue with handling unsafe data in a vars plugin I was writing. After some back and forth the Ansible Devel channel was able to sort me out. Hopefully this PR will help others find the same answer faster in the future.