### PR TITLE
Templar: do not add dict to globals

### DIFF
--- a/changelogs/fragments/templar-globals-dict.yml
+++ b/changelogs/fragments/templar-globals-dict.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "``Templar`` - do not add the ``dict`` constructor to ``globals`` as all required Jinja2 versions already do so"

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -45,7 +45,7 @@ from ansible.errors import (
     AnsibleOptionsError,
     AnsibleUndefinedVariable,
 )
-from ansible.module_utils.six import string_types, text_type
+from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native, to_text, to_bytes
 from ansible.module_utils.common.collections import is_sequence
 from ansible.plugins.loader import filter_loader, lookup_loader, test_loader
@@ -565,9 +565,6 @@ class Templar:
             loader=FileSystemLoader(loader.get_basedir() if loader else '.'),
         )
         self.environment.template_class.environment_class = environment_class
-
-        # jinja2 global is inconsistent across versions, this normalizes them
-        self.environment.globals['dict'] = dict
 
         # Custom globals
         self.environment.globals['lookup'] = self._lookup


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
All required Jinja2 versions (>=3.0) already do this, see https://github.com/pallets/jinja/commit/f9d804ead73de76b29bb5a793e6d4335c5649e56
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/template/__init__.py`