### PR TITLE
Validate task attributes with first finalized attrs after loop

### DIFF
--- a/changelogs/fragments/80476-fix-loop-task-post-validation.yml
+++ b/changelogs/fragments/80476-fix-loop-task-post-validation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix post-validating looped task fields so the strategy uses the correct values after task execution.

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -277,6 +277,7 @@ class TaskExecutor:
                             u" to something else to avoid variable collisions and unexpected behavior." % (self._task, loop_var))
 
         ran_once = False
+        initial_attrs = None
         no_log = False
         items_len = len(items)
         results = []
@@ -330,6 +331,8 @@ class TaskExecutor:
             (self._play_context, tmp_play_context) = (tmp_play_context, self._play_context)
             res = self._execute(variables=task_vars)
             task_fields = self._task.dump_attrs()
+            if item_index == 0:
+                initial_attrs = task_fields
             (self._task, tmp_task) = (tmp_task, self._task)
             (self._play_context, tmp_play_context) = (tmp_play_context, self._play_context)
 
@@ -391,6 +394,8 @@ class TaskExecutor:
                         if var in task_vars and var not in self._job_vars:
                             del task_vars[var]
 
+        if initial_attrs is not None:
+            self._task.from_attrs(initial_attrs)
         self._task.no_log = no_log
 
         return results

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -403,6 +403,7 @@ class TaskExecutor:
         # NOTE: run_once cannot contain loop vars because it's templated earlier also
         # This is saving the post-validated field from the last loop so the strategy can use the templated value post task execution
         self._task.run_once = task_fields.get('run_once')
+        self._task.action = task_fields.get('action')
 
         return results
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -277,7 +277,7 @@ class TaskExecutor:
                             u" to something else to avoid variable collisions and unexpected behavior." % (self._task, loop_var))
 
         ran_once = False
-        initial_attrs = None
+        task_fields = None
         no_log = False
         items_len = len(items)
         results = []
@@ -331,8 +331,6 @@ class TaskExecutor:
             (self._play_context, tmp_play_context) = (tmp_play_context, self._play_context)
             res = self._execute(variables=task_vars)
             task_fields = self._task.dump_attrs()
-            if item_index == 0:
-                initial_attrs = task_fields
             (self._task, tmp_task) = (tmp_task, self._task)
             (self._play_context, tmp_play_context) = (tmp_play_context, self._play_context)
 
@@ -394,8 +392,8 @@ class TaskExecutor:
                         if var in task_vars and var not in self._job_vars:
                             del task_vars[var]
 
-        if initial_attrs is not None:
-            self._task.from_attrs(initial_attrs)
+        if task_fields is not None:
+            self._task.from_attrs(task_fields)
         self._task.no_log = no_log
 
         return results

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -35,7 +35,6 @@ from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleAssertionError, AnsibleParserError
 from ansible.executor.play_iterator import IteratingStates, FailedStates
 from ansible.module_utils._text import to_text
-from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.playbook.handler import Handler
 from ansible.playbook.included_file import IncludedFile
 from ansible.playbook.task import Task
@@ -214,10 +213,7 @@ class StrategyModule(StrategyBase):
                                 skip_rest = True
                                 break
 
-                        if templar.is_template(task.run_once):
-                            setattr(task, 'run_once', boolean(templar.template(task.run_once), strict=True))
-
-                        run_once = task.run_once or action and getattr(action, 'BYPASS_HOST_LOOP', False)
+                        run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
 
                         if (task.any_errors_fatal or run_once) and not task.ignore_errors:
                             any_errors_fatal = True


### PR DESCRIPTION
##### SUMMARY
Fixing post validating the task itself when getting loop results. Previously we validated a copy of the task per loop item, but never finalized the overall task the strategy uses later.

This is an alternative to the fix in #80051, without breaking inheritance. Omit still does not work as intended, as with many FA  (it's a truthy string), but this is a more general problem we should address.

Supersedes #80382 as a stop-gap before #80394 to unbreak inheritance.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
TE