### PR TITLE
Fix missing " in ansible_tips_tricks.rst for vaulted variables

### DIFF
--- a/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
+++ b/docs/docsite/rst/tips_tricks/ansible_tips_tricks.rst
@@ -97,7 +97,7 @@ To circumvent this, you can encrypt the variables individually using ``ansible-v
 #. Inside this subdirectory, create two files named ``vars`` and ``vault``.
 #. In the ``vars`` file, define all of the variables needed, including any sensitive ones.
 #. Copy all of the sensitive variables over to the ``vault`` file and prefix these variables with ``vault_``.
-#. Adjust the variables in the ``vars`` file to point to the matching ``vault_`` variables using jinja2 syntax: ``db_password: {{ vault_db_password }}``.
+#. Adjust the variables in the ``vars`` file to point to the matching ``vault_`` variables using jinja2 syntax: ``db_password: "{{ vault_db_password }}"``.
 #. Encrypt the ``vault`` file to protect its contents.
 #. Use the variable name from the ``vars`` file in your playbooks.
 


### PR DESCRIPTION
##### SUMMARY
When applying  the section "Keep vaulted variables safely visible", I got the error that the quotation marks for "{{ vault_db_password }}" in ``db_password: {{ vault_db_password }}`` are missing. After adding them, everything worked fine. Therefore, I would propose to add them. But maybe I made another related mistake.

##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
