### PR TITLE
[stable-2.13] pep517 backend - Use correct import_module import (#80480)

### DIFF
--- a/changelogs/fragments/pep517-backend-import-fix.yml
+++ b/changelogs/fragments/pep517-backend-import-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pep517 build backend - Use the documented ``import_module`` import from ``importlib``.

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -9,7 +9,7 @@ import sys
 import typing as t
 from configparser import ConfigParser
 from contextlib import contextmanager, suppress
-from importlib.metadata import import_module
+from importlib import import_module
 from io import StringIO
 from pathlib import Path
 from shutil import copytree


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/80480

(cherry picked from commit e87802cf2c75c5f2578e58ed2edb3e033623cc78)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

packaging/pep517_backend/_backend.py