### PR TITLE
[stable-2.15] --syntax-check is only applicable to ansible-playbook. Fixes #80506 (#80507)

### DIFF
--- a/changelogs/fragments/80506-syntax-check-playbook-only.yml
+++ b/changelogs/fragments/80506-syntax-check-playbook-only.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- syntax check - Limit ``--syntax-check`` to ``ansible-playbook`` only, as that is the only CLI affected by this argument
+  (https://github.com/ansible/ansible/issues/80506)

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -235,8 +235,6 @@ def add_check_options(parser):
     """Add options for commands which can run with diagnostic information of tasks"""
     parser.add_argument("-C", "--check", default=False, dest='check', action='store_true',
                         help="don't make any changes; instead, try to predict some of the changes that may occur")
-    parser.add_argument('--syntax-check', dest='syntax', action='store_true',
-                        help="perform a syntax check on the playbook, but do not execute it")
     parser.add_argument("-D", "--diff", default=C.DIFF_ALWAYS, dest='diff', action='store_true',
                         help="when changing (small) files and templates, show the differences in those"
                              " files; works great with --check")

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -54,6 +54,8 @@ class PlaybookCLI(CLI):
         opt_help.add_module_options(self.parser)
 
         # ansible playbook specific opts
+        self.parser.add_argument('--syntax-check', dest='syntax', action='store_true',
+                                 help="perform a syntax check on the playbook, but do not execute it")
         self.parser.add_argument('--list-tasks', dest='listtasks', action='store_true',
                                  help="list all tasks that would be executed")
         self.parser.add_argument('--list-tags', dest='listtags', action='store_true',


### PR DESCRIPTION
(cherry picked from commit f3774ae)


Co-authored-by: Matt Martz <matt@sivel.net>