### PR TITLE
[2.15] Validate task attributes with first finalized attrs after loop (#80476)

### DIFF
--- a/changelogs/fragments/80476-fix-loop-task-post-validation.yml
+++ b/changelogs/fragments/80476-fix-loop-task-post-validation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix post-validating looped task fields so the strategy uses the correct values after task execution.

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -137,6 +137,12 @@ class TaskExecutor:
                                 self._task.ignore_errors = item_ignore
                             elif self._task.ignore_errors and not item_ignore:
                                 self._task.ignore_errors = item_ignore
+                        if 'unreachable' in item and item['unreachable']:
+                            item_ignore_unreachable = item.pop('_ansible_ignore_unreachable')
+                            if not res.get('unreachable'):
+                                self._task.ignore_unreachable = item_ignore_unreachable
+                            elif self._task.ignore_unreachable and not item_ignore_unreachable:
+                                self._task.ignore_unreachable = item_ignore_unreachable
 
                         # ensure to accumulate these
                         for array in ['warnings', 'deprecations']:
@@ -277,6 +283,7 @@ class TaskExecutor:
                             u" to something else to avoid variable collisions and unexpected behavior." % (self._task, loop_var))
 
         ran_once = False
+        task_fields = None
         no_log = False
         items_len = len(items)
         results = []
@@ -348,6 +355,7 @@ class TaskExecutor:
 
             res['_ansible_item_result'] = True
             res['_ansible_ignore_errors'] = task_fields.get('ignore_errors')
+            res['_ansible_ignore_unreachable'] = task_fields.get('ignore_unreachable')
 
             # gets templated here unlike rest of loop_control fields, depends on loop_var above
             try:
@@ -392,6 +400,10 @@ class TaskExecutor:
                             del task_vars[var]
 
         self._task.no_log = no_log
+        # NOTE: run_once cannot contain loop vars because it's templated earlier also
+        # This is saving the post-validated field from the last loop so the strategy can use the templated value post task execution
+        self._task.run_once = task_fields.get('run_once')
+        self._task.action = task_fields.get('action')
 
         return results
 

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -35,7 +35,6 @@ from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleAssertionError, AnsibleParserError
 from ansible.executor.play_iterator import IteratingStates, FailedStates
 from ansible.module_utils._text import to_text
-from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.playbook.handler import Handler
 from ansible.playbook.included_file import IncludedFile
 from ansible.playbook.task import Task
@@ -214,10 +213,7 @@ class StrategyModule(StrategyBase):
                                 skip_rest = True
                                 break
 
-                        if templar.is_template(task.run_once):
-                            setattr(task, 'run_once', boolean(templar.template(task.run_once), strict=True))
-
-                        run_once = task.run_once or action and getattr(action, 'BYPASS_HOST_LOOP', False)
+                        run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
 
                         if (task.any_errors_fatal or run_once) and not task.ignore_errors:
                             any_errors_fatal = True


### PR DESCRIPTION
##### SUMMARY
Backport for #80476

* Validate task attributes `run_once` and `action` with finalized attrs after individual loop results

* Validate task attribute `ignore_unreachable` using individual loop results

Once there's a way to post validate only certain fields, we can use self._task.post_validate() instead

This replaces the fix introduced in https://github.com/ansible/ansible/pull/80051.

(cherry picked from commit bd6feeb6e7b334d5da572cbb5add7594be7fc61e)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
