### PR TITLE
Remove puppet dependency from facter #80496

### DIFF
--- a/changelogs/fragments/80496-remove-puppet-dependency-from-facter.yml
+++ b/changelogs/fragments/80496-remove-puppet-dependency-from-facter.yml
@@ -1,4 +1,2 @@
 bugfixes:
-  father_facts - Remove the default --puppet flag from facter in gather facts since it has a none zero return value in version 4.3.0 in the 
-  absense of puppet.
-  (https://github.com/ansible/ansible/issues/80496)
+  - father_facts - Remove the default --puppet flag from facter in gather facts since it has a none zero return value in version 4.3.0 in the absense of puppet. (https://github.com/ansible/ansible/issues/80496)

--- a/changelogs/fragments/80496-remove-puppet-dependency-from-facter.yml
+++ b/changelogs/fragments/80496-remove-puppet-dependency-from-facter.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  father_facts - Remove --puppet flag from facter in gather facts since it has a none zero return value in version 4.3.0
+  (https://github.com/ansible/ansible/issues/80496)

--- a/changelogs/fragments/80496-remove-puppet-dependency-from-facter.yml
+++ b/changelogs/fragments/80496-remove-puppet-dependency-from-facter.yml
@@ -1,3 +1,4 @@
 bugfixes:
-  father_facts - Remove --puppet flag from facter in gather facts since it has a none zero return value in version 4.3.0
+  father_facts - Remove the default --puppet flag from facter in gather facts since it has a none zero return value in version 4.3.0 in the 
+  absense of puppet.
   (https://github.com/ansible/ansible/issues/80496)

--- a/lib/ansible/module_utils/facts/other/facter.py
+++ b/lib/ansible/module_utils/facts/other/facter.py
@@ -70,7 +70,6 @@ class FacterFactCollector(BaseFactCollector):
 
         rc, out, err = self.run_facter(module, facter_path, options)
 
-
         if rc != 0:
             return None
 

--- a/lib/ansible/module_utils/facts/other/facter.py
+++ b/lib/ansible/module_utils/facts/other/facter.py
@@ -45,10 +45,17 @@ class FacterFactCollector(BaseFactCollector):
 
         return facter_path
 
-    def run_facter(self, module, facter_path):
+    def find_puppet(self, module):
+        puppet_path = module.get_bin_path('puppet', opt_dirs=['/opt/puppetlabs/bin'])
+
+        return puppet_path
+
+    def run_facter(self, module, facter_path, options):
         # if facter is installed, and we can use --json because
         # ruby-json is ALSO installed, include facter data in the JSON
-        rc, out, err = module.run_command(facter_path + " --json")
+
+        rc, out, err = module.run_command(facter_path + options)
+
         return rc, out, err
 
     def get_facter_output(self, module):
@@ -56,7 +63,13 @@ class FacterFactCollector(BaseFactCollector):
         if not facter_path:
             return None
 
-        rc, out, err = self.run_facter(module, facter_path)
+        options = " --json"
+
+        if self.find_puppet(module):
+            options += " --puppet"
+
+        rc, out, err = self.run_facter(module, facter_path, options)
+
 
         if rc != 0:
             return None

--- a/lib/ansible/module_utils/facts/other/facter.py
+++ b/lib/ansible/module_utils/facts/other/facter.py
@@ -48,7 +48,7 @@ class FacterFactCollector(BaseFactCollector):
     def run_facter(self, module, facter_path):
         # if facter is installed, and we can use --json because
         # ruby-json is ALSO installed, include facter data in the JSON
-        rc, out, err = module.run_command(facter_path + " --puppet --json")
+        rc, out, err = module.run_command(facter_path + " --json")
         return rc, out, err
 
     def get_facter_output(self, module):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove puppet dependency from facter since `facter --puppet` has a none-zero return code from version >4.3

Fixes #80496

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/module_utils/facts/

