### PR TITLE
Extend OpenBSDStrategy to also update current hostname.

### DIFF
--- a/changelogs/fragments/80520-fix-current-hostname-openbsd.yml
+++ b/changelogs/fragments/80520-fix-current-hostname-openbsd.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - The `hostname` module now also updates both current and permanent hostname on OpenBSD. Before it only updated the permanent hostname (https://github.com/ansible/ansible/issues/80520).

--- a/changelogs/fragments/80520-fix-current-hostname-openbsd.yml
+++ b/changelogs/fragments/80520-fix-current-hostname-openbsd.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - The `hostname` module now also updates both current and permanent hostname on OpenBSD. Before it only updated the permanent hostname (https://github.com/ansible/ansible/issues/80520).
+  - The ``hostname`` module now also updates both current and permanent hostname on OpenBSD. Before it only updated the permanent hostname (https://github.com/ansible/ansible/issues/80520).

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -387,10 +387,29 @@ class OpenRCStrategy(BaseStrategy):
 class OpenBSDStrategy(FileStrategy):
     """
     This is a OpenBSD family Hostname manipulation strategy class - it edits
-    the /etc/myname file.
+    the /etc/myname file for the permanent hostname and executes hostname
+    command for the current hostname.
     """
 
     FILE = '/etc/myname'
+    COMMAND = "hostname"
+
+    def __init__(self, module):
+        super(OpenBSDStrategy, self).__init__(module)
+        self.hostname_cmd = self.module.get_bin_path(self.COMMAND, True)
+
+    def get_current_hostname(self):
+        cmd = [self.hostname_cmd]
+        rc, out, err = self.module.run_command(cmd)
+        if rc != 0:
+            self.module.fail_json(msg="Command failed rc=%d, out=%s, err=%s" % (rc, out, err))
+        return to_native(out).strip()
+
+    def set_current_hostname(self, name):
+        cmd = [self.hostname_cmd, name]
+        rc, out, err = self.module.run_command(cmd)
+        if rc != 0:
+            self.module.fail_json(msg="Command failed rc=%d, out=%s, err=%s" % (rc, out, err))
 
 
 class SolarisStrategy(BaseStrategy):


### PR DESCRIPTION
##### SUMMARY
Extend the `OpenBSDStrategy` with a `hostname` command that gets/updates the current system hostname as well as editing `/etc/myname`.

Fixes #80520 for me in test runs.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
hostname

##### ADDITIONAL INFORMATION
See issue #80520.