### PR TITLE
fix #80523 - adding short option for --ask-vault-pass

### DIFF
--- a/changelogs/fragments/80523_-_adding_short_option_for_--ask-vault-pass.yml
+++ b/changelogs/fragments/80523_-_adding_short_option_for_--ask-vault-pass.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - cli - Added short option '-J' for asking for vault password (https://github.com/ansible/ansible/issues/80523).

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -393,7 +393,7 @@ def add_vault_options(parser):
     parser.add_argument('--vault-id', default=[], dest='vault_ids', action='append', type=str,
                         help='the vault identity to use')
     base_group = parser.add_mutually_exclusive_group()
-    base_group.add_argument('--ask-vault-password', '--ask-vault-pass', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
+    base_group.add_argument('-J', '--ask-vault-pass', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
                             help='ask for vault password')
     base_group.add_argument('--vault-password-file', '--vault-pass-file', default=[], dest='vault_password_files',
                             help="vault password file", type=unfrack_path(follow=False), action='append')

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -393,7 +393,7 @@ def add_vault_options(parser):
     parser.add_argument('--vault-id', default=[], dest='vault_ids', action='append', type=str,
                         help='the vault identity to use')
     base_group = parser.add_mutually_exclusive_group()
-    base_group.add_argument('-J', '--ask-vault-pass', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
+    base_group.add_argument('-J', '--ask-vault-password', '--ask-vault-pass', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
                             help='ask for vault password')
     base_group.add_argument('--vault-password-file', '--vault-pass-file', default=[], dest='vault_password_files',
                             help="vault password file", type=unfrack_path(follow=False), action='append')


### PR DESCRIPTION
##### SUMMARY
This PR contains a fix for #80523 and introduce a short option `-J` for Ask vault password

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Command Line Options 

`./lib/ansible/cli/arguments/option_helpers.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The ansible command option `--ask-vault-password` got replaced by `-J` and will now be possible beside the most common used `--ask-vault-pass`

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
// BEFORE //
$ ansible-playbook --help | grep ask-vault -A1
  --ask-vault-password, --ask-vault-pass
                        ask for vault password

// AFTER //
$ ansible-playbook --help | grep ask-vault -A1
  -J, --ask-vault-pass  ask for vault password
  -K, --ask-become-pass
```
