### PR TITLE
[2.15] ansible-galaxy - fix installing dir sources with a trailing path separator

### DIFF
--- a/changelogs/fragments/a-g-col-install-directory-with-trailing-sep.yml
+++ b/changelogs/fragments/a-g-col-install-directory-with-trailing-sep.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - fix installing collections from directories that have a trailing path separator (https://github.com/ansible/ansible/issues/77803).

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -211,6 +211,8 @@ class _ComputedReqKindsMixin:
     @classmethod
     def from_dir_path(cls, dir_path, art_mgr):
         """Make collection from an directory with metadata."""
+        if dir_path.endswith(to_bytes(os.path.sep)):
+            dir_path = dir_path.rstrip(to_bytes(os.path.sep))
         b_dir_path = to_bytes(dir_path, errors='surrogate_or_strict')
         if not _is_collection_dir(b_dir_path):
             display.warning(
@@ -261,6 +263,8 @@ class _ComputedReqKindsMixin:
         regardless of whether any of known metadata files are present.
         """
         # There is no metadata, but it isn't required for a functional collection. Determine the namespace.name from the path.
+        if dir_path.endswith(to_bytes(os.path.sep)):
+            dir_path = dir_path.rstrip(to_bytes(os.path.sep))
         u_dir_path = to_text(dir_path, errors='surrogate_or_strict')
         path_list = u_dir_path.split(os.path.sep)
         req_name = '.'.join(path_list[-2:])
@@ -419,6 +423,9 @@ class _ComputedReqKindsMixin:
                 'is not an HTTP URL.'.
                 format(not_url=req_source.api_server),
             )
+
+        if req_type == 'dir' and req_source.endswith(os.path.sep):
+            req_source = req_source.rstrip(os.path.sep)
 
         tmp_inst_req = cls(req_name, req_version, req_source, req_type, req_signature_sources)
 

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -794,7 +794,7 @@
         force: yes
 
     - name: install symlink_dirs collection from source
-      command: ansible-galaxy collection install {{ galaxy_dir }}/scratch/symlink_dirs/
+      command: ansible-galaxy collection install {{ galaxy_dir }}/scratch/symlink_dirs/symlink_dirs/
       environment:
         ANSIBLE_COLLECTIONS_PATHS: '{{ galaxy_dir }}/ansible_collections'
       register: install_symlink_dirs


### PR DESCRIPTION
##### SUMMARY
Backport for #79110

* strip trailing path separator from type=dir sources

(cherry picked from commit 964e678a7fa3b0745f9302e7a3682851089d09d2)
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy collection install