### PR TITLE
edited line 265 on uri.py to fail when there is an http status 200 or…

### DIFF
--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -260,9 +260,9 @@ EXAMPLES = r'''
 - name: Check that a page returns a status 200 and fail if the word AWESOME is not in the page contents
   ansible.builtin.uri:
     url: http://www.example.com
-    return_content: true
+    return_content: trueple.com
   register: this
-  failed_when: "'AWESOME' not in this.content"
+  failed_when: "this is failed or 'AWESOME' not in this.content"
 
 - name: Create a JIRA issue
   ansible.builtin.uri:


### PR DESCRIPTION
… the word 'AWESOME' in the page.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
     Edited to send failure message when the page has status 200 or when the word 'AWESOME' is not contained within it.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #80386 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lib\ansible\modules\uri.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Edited line 265 in the uri.py , to send failure when there is a status 200 on a page, or when the word 'AWESOME' is not within it.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
 failed_when: "'AWESOME' not in this.content"

```
  failed_when: "this is failed or 'AWESOME' not in this.content"


