### PR TITLE
fix incorrect dnf and dnf5 package discovery

### DIFF
--- a/changelogs/fragments/80546-dnf5-discovery.yaml
+++ b/changelogs/fragments/80546-dnf5-discovery.yaml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - Fix ``dnf`` and ``dnf5`` package module discovery on Fedora Linux. Now,
+    ansible prefers ``dnf`` on Fedora < 39 and prefers ``dnf5`` on Fedora >= 39
+    but falls back if the default is not available
+    (https://github.com/ansible/ansible/pull/80546).

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -18,6 +18,7 @@ from ansible.module_utils.facts.collector import BaseFactCollector
 PKG_MGRS = [{'path': '/usr/bin/rpm-ostree', 'name': 'atomic_container'},
             {'path': '/usr/bin/yum', 'name': 'yum'},
             {'path': '/usr/bin/dnf', 'name': 'dnf'},
+            {'path': '/usr/bin/dnf5', 'name': 'dnf5'},
             {'path': '/usr/bin/apt-get', 'name': 'apt'},
             {'path': '/usr/bin/zypper', 'name': 'zypper'},
             {'path': '/usr/sbin/urpmi', 'name': 'urpmi'},
@@ -77,11 +78,10 @@ class PkgMgrFactCollector(BaseFactCollector):
                 if int(collected_facts['ansible_distribution_major_version']) < 23:
                     if self._pkg_mgr_exists('yum'):
                         pkg_mgr_name = 'yum'
-                elif int(collected_facts['ansible_distribution_major_version']) >= 39:
-                    # /usr/bin/dnf is planned to be a symlink to /usr/bin/dnf5
-                    if self._pkg_mgr_exists('dnf'):
-                        pkg_mgr_name = 'dnf5'
-                else:
+                elif int(collected_facts['ansible_distribution_major_version']) < 39:
+                    # Always use dnf if it's available.
+                    # dnf5 or yum may be installed on Fedora < 39,
+                    # but the system default should be prefered.
                     if self._pkg_mgr_exists('dnf'):
                         pkg_mgr_name = 'dnf'
             except ValueError:

--- a/test/integration/targets/dnf5/playbook.yml
+++ b/test/integration/targets/dnf5/playbook.yml
@@ -3,7 +3,7 @@
     - block:
         - command: "dnf install -y 'dnf-command(copr)'"
         - command: dnf copr enable -y rpmsoftwaremanagement/dnf5-unstable
-        - command: dnf install -y python3-libdnf5
+        - command: dnf install -y python3-libdnf5 dnf5
 
         - include_role:
             name: dnf
@@ -11,6 +11,41 @@
             dnf5: true
             dnf_log_files:
               - /var/log/dnf5.log
+
+        - name: Ensure python3-dnf is absent
+          command: "dnf remove -y python3-dnf --setopt=protected_packages="
+
+        - name: Re-gather facts
+          setup:
+            gather_subset:
+              - "!all"
+              - "!min"
+              - "pkg_mgr"
+        - debug: var=ansible_pkg_mgr
+
+        - name: Ensure that dnf5 is used when dnf is absent
+          assert:
+            that: "ansible_pkg_mgr == 'dnf5'"
+
+        - name: Install python3-dnf
+          dnf5:
+            name:
+              - python3-dnf
+              - /usr/bin/dnf
+
+        - name: Re-gather facts
+          setup:
+            gather_subset:
+              - "!all"
+              - "!min"
+              - "pkg_mgr"
+        - debug: var=ansible_pkg_mgr
+
+        - name: Check the distribution default package manager
+          vars:
+            _expected: "{{ 'dnf' if ansible_distribution_major_version | int < 39 else 'dnf5' }}"
+          assert:
+            that: ansible_pkg_mgr == _expected
       when:
         - ansible_distribution == 'Fedora'
         - ansible_distribution_major_version is version('37', '>=')


### PR DESCRIPTION
##### SUMMARY

Ansible should _prefer_ dnf on Fedora < 39 and _prefer_ dnf5 on Fedora >= 39, but ansible should fall back if the default is not available.
This also adds dnf5 to the PKG_MGRS array instead of relying on Fedora special-casing, so this will work properly when other distributions adopt dnf5.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/facts/system/pkg_mgr.py

##### ADDITIONAL INFORMATION

Fixes: https://github.com/ansible/ansible/issues/80376