### PR TITLE
[stable-2.14] Reconfigure stdout/stderr to replace invalid UTF-8 characters

### DIFF
--- a/changelogs/fragments/80258-defensive-display-non-utf8.yml
+++ b/changelogs/fragments/80258-defensive-display-non-utf8.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Display - Defensively configure writing to stdout and stderr with the replace encoding error handler that will replace invalid characters
+  (https://github.com/ansible/ansible/issues/80258)

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -228,6 +228,12 @@ class Display(metaclass=Singleton):
         except Exception as ex:
             self.warning(f"failed to patch stdout/stderr for fork-safety: {ex}")
 
+        try:
+            sys.stdout.reconfigure(errors='replace')
+            sys.stderr.reconfigure(errors='replace')
+        except Exception as ex:
+            self.warning(f"failed to reconfigure stdout/stderr with the replace error handler: {ex}")
+
     def set_queue(self, queue):
         """Set the _final_q on Display, so that we know to proxy display over the queue
         instead of directly writing to stdout/stderr from forks


### PR DESCRIPTION
##### SUMMARY
Reconfigure stdout/stderr to replace invalid UTF-8 characters. Fixes #80258

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/display.py

##### ADDITIONAL INFORMATION
Minimal backport of https://github.com/ansible/ansible/pull/80370 for 2.14.