### PR TITLE
ssh: Add IdentitiesOnly option

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -250,6 +250,21 @@ DOCUMENTATION = '''
           cli:
             - name: private_key_file
               option: '--private-key'
+      identites_only:
+          description:
+            - Use only the provided key when private_key_file is set
+          ini:
+            - section: defaults
+              key: identities_only
+          env:
+            - name: ANSIBLE_SSH_IDENTITIES_ONLY
+          vars:
+            - name: ansible_ssh_identities_only
+              version_added: '2.16'
+          cli:
+            - name: identities_only
+              option: '--identities-only'
+          default: 0
 
       control_path:
         description:
@@ -732,6 +747,9 @@ class Connection(ConnectionBase):
         if key:
             b_args = (b"-o", b'IdentityFile="' + to_bytes(os.path.expanduser(key), errors='surrogate_or_strict') + b'"')
             self._add_args(b_command, b_args, u"ANSIBLE_PRIVATE_KEY_FILE/private_key_file/ansible_ssh_private_key_file set")
+            if self.get_option('identities_only'):
+                b_args = (b"-o", b"IdentitiesOnly=yes")
+                self._add_args(b_command, b_args, u"ssh option IdentitesOnly set")
 
         if not conn_password:
             self._add_args(


### PR DESCRIPTION
##### SUMMARY
'IdentitiesOnly' option prevents to load keys from default locations and tries only the key provided as a CLI option.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
connection/ssh.py

##### ADDITIONAL INFORMATION
SSH fails on authorization when the authorization limit of public keys was met. This can happen if the default location has more than `limit` number of keys therefore the key provided as a CLI option will not be tried.

Reproduction:
- Fill `~/.ssh`  with keys until the ssh limit is met
- Try making a connection
