### PR TITLE
Remove docs references to obsolete test plugins

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
@@ -157,9 +157,7 @@ Some of the available aliases are:
 - ``cloud/azure``
 - ``cloud/cs``
 - ``cloud/digitalocean``
-- ``cloud/foreman``
 - ``cloud/openshift``
-- ``cloud/tower``
 - ``cloud/vcenter``
 
 Untested


### PR DESCRIPTION
##### SUMMARY

Remove docs references to obsolete test plugins.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst