### PR TITLE
Moved now variable to before zipfile creation as recommended by on (a…

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1148,6 +1148,8 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
                 display.debug('ANSIBALLZ: Lock acquired: %s' % id(lock))
                 # Check that no other process has created this while we were
                 # waiting for the lock
+                #moved from 1246
+                now = datetime.datetime.utcnow()
                 if not os.path.exists(cached_module_filename):
                     display.debug('ANSIBALLZ: Creating module')
                     # Create the module zip data
@@ -1241,7 +1243,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         else:
             coverage = ''
 
-        now = datetime.datetime.utcnow()
+        # now = datetime.datetime.utcnow()
         output.write(to_bytes(ACTIVE_ANSIBALLZ_TEMPLATE % dict(
             zipdata=zipdata,
             ansible_module=module_name,


### PR DESCRIPTION
…nsible#80089)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We moved the now datetime initialization before the zipfile creation. Fixes (ansible#80089). Note: I am new to open source so this might not be helpful. Also sorry for pulling this twice.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
executor/module_common.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
This was done for a college class so again we are new to this.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
