### PR TITLE
Add source_ports parameter to the iptables module

### DIFF
--- a/changelogs/fragments/80595-add-source-ports-to-iptables-module.yml
+++ b/changelogs/fragments/80595-add-source-ports-to-iptables-module.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - iptables - add source_ports parameter to the module.

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -241,6 +241,7 @@ options:
     type: list
     elements: str
     default: []
+    version_added: "2.16"
   to_ports:
     description:
       - This specifies a destination port or range of ports to use, without

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -234,6 +234,13 @@ options:
     elements: str
     default: []
     version_added: "2.11"
+  source_ports:
+    description:
+      - This specifies multiple source port numbers or port ranges to match in the multiport module.
+      - It can only be used in conjunction with the protocols tcp, udp, udplite, dccp and sctp.
+    type: list
+    elements: str
+    default: []
   to_ports:
     description:
       - This specifies a destination port or range of ports to use, without
@@ -626,6 +633,8 @@ def construct_rule(params):
     append_param(rule, params['to_destination'], '--to-destination', False)
     append_match(rule, params['destination_ports'], 'multiport')
     append_csv(rule, params['destination_ports'], '--dports')
+    append_match(rule, params['source_ports'], 'multiport')
+    append_csv(rule, params['source_ports'], '--sports')
     append_param(rule, params['to_source'], '--to-source', False)
     append_param(rule, params['goto'], '-g', False)
     append_param(rule, params['in_interface'], '-i', False)
@@ -801,6 +810,7 @@ def main():
             fragment=dict(type='str'),
             set_counters=dict(type='str'),
             source_port=dict(type='str'),
+            source_ports=dict(type='list', elements='str', default=[]),
             destination_port=dict(type='str'),
             destination_ports=dict(type='list', elements='str', default=[]),
             to_ports=dict(type='str'),

--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -912,7 +912,7 @@ class TestIptables(ModuleTestCase):
         self.assertEqual(run_command.call_args[0][0][14], 'this is a comment')
 
     def test_destination_ports(self):
-        """ Test multiport module usage with multiple ports """
+        """ Test multiport module usage with multiple destination ports """
         set_module_args({
             'chain': 'INPUT',
             'protocol': 'tcp',
@@ -942,6 +942,42 @@ class TestIptables(ModuleTestCase):
             '-j', 'ACCEPT',
             '-m', 'multiport',
             '--dports', '80,443,8081:8085',
+            '-i', 'eth0',
+            '-m', 'comment',
+            '--comment', 'this is a comment'
+        ])
+
+    def test_source_ports(self):
+        """ Test multiport module usage with multiple source ports """
+        set_module_args({
+            'chain': 'INPUT',
+            'protocol': 'tcp',
+            'in_interface': 'eth0',
+            'source': '192.168.0.1/32',
+            'source_ports': ['80', '443', '8081:8085'],
+            'jump': 'ACCEPT',
+            'comment': 'this is a comment',
+        })
+        commands_results = [
+            (0, '', ''),
+        ]
+
+        with patch.object(basic.AnsibleModule, 'run_command') as run_command:
+            run_command.side_effect = commands_results
+            with self.assertRaises(AnsibleExitJson) as result:
+                iptables.main()
+                self.assertTrue(result.exception.args[0]['changed'])
+
+        self.assertEqual(run_command.call_count, 1)
+        self.assertEqual(run_command.call_args_list[0][0][0], [
+            '/sbin/iptables',
+            '-t', 'filter',
+            '-C', 'INPUT',
+            '-p', 'tcp',
+            '-s', '192.168.0.1/32',
+            '-j', 'ACCEPT',
+            '-m', 'multiport',
+            '--sports', '80,443,8081:8085',
             '-i', 'eth0',
             '-m', 'comment',
             '--comment', 'this is a comment'


### PR DESCRIPTION
##### SUMMARY
The `source_ports` parameter has been added to the iptables module. This parameter allows users to define more than one source port, like the existing `destination_ports` parameter which is allowing them to define multiple destination ports.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`iptables` module