### PR TITLE
[stable-2.15] ansible-test - Use FreeBSD packaged setuptools (#80615)

### DIFF
--- a/changelogs/fragments/ansible-test-freebsd-bootstrap-setuptools.yml
+++ b/changelogs/fragments/ansible-test-freebsd-bootstrap-setuptools.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - When bootstrapping remote FreeBSD instances, use the OS packaged ``setuptools`` instead of installing the latest version from PyPI.

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -148,6 +148,7 @@ bootstrap_remote_freebsd()
     packages="
         python${python_package_version}
         py${python_package_version}-sqlite3
+        py${python_package_version}-setuptools
         bash
         curl
         gtar


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/80615

This will avoid issues during bootstrapping caused by breaking changes in setuptools.

(cherry picked from commit abc58c026b2e91af4a2bb57f7bfe21c609bd3de9)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test