### PR TITLE
ansible-galaxy list output format to create requirements.yml

### DIFF
--- a/changelogs/fragments/galaxy-output-for-requirements-yml.yml
+++ b/changelogs/fragments/galaxy-output-for-requirements-yml.yml
@@ -1,0 +1,7 @@
+minor_changes:
+- >-
+  Roles can now be listed with ``ansible-galaxy list`` using the ``--format`` option
+  (https://github.com/ansible/ansible/issues/15916).
+- >-
+  Collections and roles can be listed in a format compatible for a ``requirements.yml``
+  file using ``ansible-galaxy [collection|role] list --format requirements``.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -131,7 +131,7 @@ def _format_header(path, h1, h2, w1=10, w2=7):
 
 
 def _format_collection(collection, cwidth=10, vwidth=7, min_cwidth=10, min_vwidth=7):
-    return('{fqcn:{cwidth}} {version:{vwidth}}\n'.format(
+    return ('{fqcn:{cwidth}} {version:{vwidth}}\n'.format(
         fqcn=to_text(collection.fqcn),
         version=collection.ver,
         cwidth=max(cwidth, min_cwidth),  # Make sure the width isn't smaller than the header

--- a/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
@@ -123,6 +123,24 @@
   with_dict: "{{ list_result_json.stdout | from_json }}"
   when: "'dev' in item.key"
 
+- name: list collections in requirements format
+  command: ansible-galaxy collection list --format requirements
+  register: list_result_requirements
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ galaxy_dir }}/dev:{{ galaxy_dir }}/prod"
+
+- debug: msg="{{ list_result_requirements }}"
+- assert:
+    that:
+      - "list_result_requirements.stdout_lines[0] == 'collections:'"
+      - "'\n- name: dev.collection1\n  version: ' + latest in list_result_requirements.stdout"
+      - "'\n- name: dev.collection2\n  version: placeholder' in list_result_requirements.stdout"
+      - "'\n- name: dev.collection3\n  version: ' + latest in list_result_requirements.stdout"
+      - "'\n- name: dev.collection5\n  version: ' + latest in list_result_requirements.stdout"
+      - "'\n- name: dev.collection6\n  version: ' + latest in list_result_requirements.stdout"
+  vars:
+    latest: "'*'"
+
 - name: list single collection in json format
   command: "ansible-galaxy collection list {{ item.key }} --format json"
   register: list_single_result_json
@@ -146,6 +164,15 @@
     that:
       - "(item.stdout | from_yaml)[galaxy_dir + '/dev/ansible_collections'][item.item.key].version == item.item.value"
   with_items: "{{ list_single_result_json.results }}"
+
+- name: list single collection in requirements format
+  command: "ansible-galaxy collection list dev.collection2 --format requirements"
+  register: list_single_result_requirements
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: "{{ galaxy_dir }}/dev"
+
+- assert:
+    that: "'collections:\n- name: dev.collection2\n  version: placeholder' == list_single_result_requirements.stdout"
 
 - name: test that no json is emitted when no collection paths are usable
   command: "ansible-galaxy collection list --format json"

--- a/test/units/cli/galaxy/test_display_collection.py
+++ b/test/units/cli/galaxy/test_display_collection.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 import pytest
 
-from ansible.cli.galaxy import _display_collection
+from ansible.cli.galaxy import _format_collection
 from ansible.galaxy.dependency_resolution.dataclasses import Requirement
 
 
@@ -19,28 +19,20 @@ def collection_object():
 
 
 def test_display_collection(capsys, collection_object):
-    _display_collection(collection_object())
-    out, err = capsys.readouterr()
-
+    out = _format_collection(collection_object())
     assert out == 'sandwiches.ham 1.5.0  \n'
 
 
 def test_display_collections_small_max_widths(capsys, collection_object):
-    _display_collection(collection_object(), 1, 1)
-    out, err = capsys.readouterr()
-
+    out = _format_collection(collection_object(), 1, 1)
     assert out == 'sandwiches.ham 1.5.0  \n'
 
 
 def test_display_collections_large_max_widths(capsys, collection_object):
-    _display_collection(collection_object(), 20, 20)
-    out, err = capsys.readouterr()
-
+    out = _format_collection(collection_object(), 20, 20)
     assert out == 'sandwiches.ham       1.5.0               \n'
 
 
 def test_display_collection_small_minimum_widths(capsys, collection_object):
-    _display_collection(collection_object('a.b'), min_cwidth=0, min_vwidth=0)
-    out, err = capsys.readouterr()
-
+    out = _format_collection(collection_object('a.b'), min_cwidth=0, min_vwidth=0)
     assert out == 'a.b        1.5.0  \n'

--- a/test/units/cli/galaxy/test_display_header.py
+++ b/test/units/cli/galaxy/test_display_header.py
@@ -5,37 +5,31 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ansible.cli.galaxy import _display_header
+from ansible.cli.galaxy import _format_header
 
 
 def test_display_header_default(capsys):
-    _display_header('/collections/path', 'h1', 'h2')
-    out, err = capsys.readouterr()
-    out_lines = out.splitlines()
-
-    assert out_lines[0] == ''
-    assert out_lines[1] == '# /collections/path'
-    assert out_lines[2] == 'h1         h2     '
-    assert out_lines[3] == '---------- -------'
+    assert _format_header('/collections/path', 'h1', 'h2') == (
+        '\n'
+        '# /collections/path\n'
+        'h1         h2     \n'
+        '---------- -------\n'
+    )
 
 
 def test_display_header_widths(capsys):
-    _display_header('/collections/path', 'Collection', 'Version', 18, 18)
-    out, err = capsys.readouterr()
-    out_lines = out.splitlines()
-
-    assert out_lines[0] == ''
-    assert out_lines[1] == '# /collections/path'
-    assert out_lines[2] == 'Collection         Version           '
-    assert out_lines[3] == '------------------ ------------------'
+    assert _format_header('/collections/path', 'Collection', 'Version', 18, 18) == (
+        '\n'
+        '# /collections/path\n'
+        'Collection         Version           \n'
+        '------------------ ------------------\n'
+    )
 
 
 def test_display_header_small_widths(capsys):
-    _display_header('/collections/path', 'Col', 'Ver', 1, 1)
-    out, err = capsys.readouterr()
-    out_lines = out.splitlines()
-
-    assert out_lines[0] == ''
-    assert out_lines[1] == '# /collections/path'
-    assert out_lines[2] == 'Col Ver'
-    assert out_lines[3] == '--- ---'
+    assert _format_header('/collections/path', 'Col', 'Ver', 1, 1) == (
+        '\n'
+        '# /collections/path\n'
+        'Col Ver\n'
+        '--- ---\n'
+    )

--- a/test/units/cli/galaxy/test_display_role.py
+++ b/test/units/cli/galaxy/test_display_role.py
@@ -5,24 +5,22 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from ansible.cli.galaxy import _display_role
+from ansible.cli.galaxy import _dump_roles_as_human
 
 
 def test_display_role(mocker, capsys):
-    mocked_galaxy_role = mocker.Mock(install_info=None)
-    mocked_galaxy_role.name = 'testrole'
-    _display_role(mocked_galaxy_role)
-    out, err = capsys.readouterr()
-    out_lines = out.splitlines()
-
-    assert out_lines[0] == '- testrole, (unknown version)'
+    marshalled_role = {'name': 'testrole', 'version': None}
+    result = _dump_roles_as_human({'roles': [marshalled_role]})
+    assert result == (
+        "# roles\n"
+        "- testrole, (unknown version)"
+    )
 
 
 def test_display_role_known_version(mocker, capsys):
-    mocked_galaxy_role = mocker.Mock(install_info={'version': '1.0.0'})
-    mocked_galaxy_role.name = 'testrole'
-    _display_role(mocked_galaxy_role)
-    out, err = capsys.readouterr()
-    out_lines = out.splitlines()
-
-    assert out_lines[0] == '- testrole, 1.0.0'
+    marshalled_role = {'name': 'testrole', 'version': '1.0.0'}
+    result = _dump_roles_as_human({'roles': [marshalled_role]})
+    assert result == (
+        "# roles\n"
+        "- testrole, 1.0.0"
+    )


### PR DESCRIPTION
##### SUMMARY
Refreshed version of #77020

Allows roles to be listed with `--format`, and adds a new format type `requirements` to list collections/roles in a format compatible with requirements.yml.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy [collection|role] list --format