### PR TITLE
Better parse virtualenv_command option for pip

### DIFF
--- a/changelogs/fragments/76372-fix-pip-virtualenv-command-parsing.yml
+++ b/changelogs/fragments/76372-fix-pip-virtualenv-command-parsing.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Fixed `pip` module failure in case of usage quotes for
+    `virtualenv_command` option for the venv command.
+    (https://github.com/ansible/ansible/issues/76372)

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -568,6 +568,28 @@
         that:
           - "version13 is success"
 
+- name: Test virtualenv command with venv formatting
+  when: ansible_python.version.major > 2
+  block:
+    - name: Clean up the virtualenv
+      file:
+        state: absent
+        name: "{{ remote_tmp_dir }}/pipenv"
+
+    # ref: https://github.com/ansible/ansible/issues/76372
+    - name: install using different venv formatting
+      pip:
+        name: "{{ pip_test_package }}"
+        virtualenv: "{{ remote_tmp_dir }}/pipenv"
+        virtualenv_command: "{{ ansible_python_interpreter ~ ' -mvenv' }}"
+        state: present
+      register: version14
+
+    - name: ensure install using virtualenv_command with venv formatting
+      assert:
+        that:
+          - "version14 is changed"
+
 ### test virtualenv_command end ###
 
 # https://github.com/ansible/ansible/issues/68592


### PR DESCRIPTION
##### SUMMARY
At the moment if a users wants to protect  virtualenv_command by using
quotes around 'venv', module will fail out as literal parsing is used
at the moment. In order to imrpove things, argparse is leveraged to
parse out passed value to the virtualenv_command

Fixes: #76372

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pip
