### PR TITLE
ansible-doc - output additional `version_added` information from `main/argument_specs.yml`

### DIFF
--- a/changelogs/fragments/docs_argument_specs_version_added.yml
+++ b/changelogs/fragments/docs_argument_specs_version_added.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - ansible-doc will now output additional ``version_added`` information from role argument specification information at the entrypoint
+    level, like antsibull-docs has been doing since role support was added (https://github.com/ansible/ansible/pull/80625).

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1144,6 +1144,11 @@ class DocCLI(CLI, RoleMixin):
                 text.append("%s\n" % textwrap.fill(DocCLI.tty_ify(desc),
                                                    limit, initial_indent=opt_indent,
                                                    subsequent_indent=opt_indent))
+            if doc.get('version_added'):
+                version_added = doc.pop('version_added')
+                version_added_collection = doc.pop('version_added_collection', None)
+                text.append("ADDED IN: %s\n" % DocCLI._format_version_added(version_added, version_added_collection))
+
             if doc.get('options'):
                 text.append("OPTIONS (= is mandatory):\n")
                 DocCLI.add_fields(text, doc.pop('options'), limit, opt_indent)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The command `ansible-doc -t role -l` did not output the `version_added` from the role argument specification information at the entrypoint level, but antsibull-docs has been supporting it since role support was added. The behavior between the two tools is now aligned.

Relates to: #79994

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- ansible-doc

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

n/a