### PR TITLE
[stable-2.15] ansible-test - Update pylint to 2.17.3 (#80632)

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-update.yml
+++ b/changelogs/fragments/ansible-test-pylint-update.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - ansible-test - Update ``pylint`` to 2.17.2 to resolve several possible false positives.
+  - ansible-test - Update ``pylint`` to 2.17.3 to resolve several possible false positives.

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
@@ -1,11 +1,11 @@
 # edit "sanity.pylint.in" and generate with: hacking/update-sanity-requirements.py --test pylint
-astroid==2.15.3
+astroid==2.15.4
 dill==0.3.6
 isort==5.12.0
 lazy-object-proxy==1.9.0
 mccabe==0.7.0
-platformdirs==3.2.0
-pylint==2.17.2
+platformdirs==3.3.0
+pylint==2.17.3
 PyYAML==6.0
 tomli==2.0.1
 tomlkit==0.11.7


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/80632

(cherry picked from commit 372fc99686c1f5a701d37e7c09e89c1fad3c0e29)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test