### PR TITLE
setup module, retry facter to handle --puppet errors

### DIFF
--- a/changelogs/fragments/setup_facter_fix.yml
+++ b/changelogs/fragments/setup_facter_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup module (fact gathering) will now try to be smarter about different versions of facter emitting error when --puppet flag is used w/o puppet.

--- a/lib/ansible/module_utils/facts/other/facter.py
+++ b/lib/ansible/module_utils/facts/other/facter.py
@@ -6,6 +6,8 @@ __metaclass__ = type
 
 import json
 
+import ansible.module_utils.compat.typing as t
+
 from ansible.module_utils.facts.namespace import PrefixFactNamespace
 from ansible.module_utils.facts.collector import BaseFactCollector
 

--- a/lib/ansible/module_utils/facts/other/facter.py
+++ b/lib/ansible/module_utils/facts/other/facter.py
@@ -1,27 +1,12 @@
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright (c) 2023 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import json
 
-import ansible.module_utils.compat.typing as t
-
 from ansible.module_utils.facts.namespace import PrefixFactNamespace
-
 from ansible.module_utils.facts.collector import BaseFactCollector
 
 
@@ -49,6 +34,12 @@ class FacterFactCollector(BaseFactCollector):
         # if facter is installed, and we can use --json because
         # ruby-json is ALSO installed, include facter data in the JSON
         rc, out, err = module.run_command(facter_path + " --puppet --json")
+
+        # for some versions of facter, --puppet returns an error if puppet is not present,
+        # try again w/o it, other errors should still appear and be sent back
+        if rc != 0:
+            rc, out, err = module.run_command(facter_path + " --json")
+
         return rc, out, err
 
     def get_facter_output(self, module):


### PR DESCRIPTION
facter versions have changed how they deal with the --puppet flag when puppet is not present, most versions will just ignore it and not error, but initial versions of facter 4 changed the behaviour (later reverted).

fixes #80496

note: should start deprecating builtin factor class in favor of facter_facts module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
modules/setup
