### PR TITLE
Don't include a default for cli as it overrides config with lesser pr…

### DIFF
--- a/changelogs/fragments/timeout_config_fix.yml
+++ b/changelogs/fragments/timeout_config_fix.yml
@@ -1,2 +1,4 @@
 bugfixes:
   - connection timeouts defined in ansible.cfg will now be properly used, the --timeout cli option was obscuring them by always being set.
+breaking_changes:
+  - Any plugin using the config system and the `cli` entry to use the `timeout` from the command line, will see the value change if the use had configured it in any of the lower precedence methods.

--- a/changelogs/fragments/timeout_config_fix.yml
+++ b/changelogs/fragments/timeout_config_fix.yml
@@ -2,3 +2,4 @@ bugfixes:
   - connection timeouts defined in ansible.cfg will now be properly used, the --timeout cli option was obscuring them by always being set.
 breaking_changes:
   - Any plugin using the config system and the `cli` entry to use the `timeout` from the command line, will see the value change if the use had configured it in any of the lower precedence methods.
+    If relying on this behaviour to consume the global/generic timeout from the DEFAULT_TIMEOUT constant, please consult the documentation on plugin configuration to add the overlaping entries.

--- a/changelogs/fragments/timeout_config_fix.yml
+++ b/changelogs/fragments/timeout_config_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - connection timeouts defined in ansible.cfg will now be properly used, the --timeout cli option was obscuring them by always being set.

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -250,8 +250,8 @@ def add_connect_options(parser):
                                help='connect as this user (default=%s)' % C.DEFAULT_REMOTE_USER)
     connect_group.add_argument('-c', '--connection', dest='connection', default=C.DEFAULT_TRANSPORT,
                                help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
-    connect_group.add_argument('-T', '--timeout', default=C.DEFAULT_TIMEOUT, type=int, dest='timeout',
-                               help="override the connection timeout in seconds (default=%s)" % C.DEFAULT_TIMEOUT)
+    connect_group.add_argument('-T', '--timeout', default=None, type=int, dest='timeout',
+                               help="override the connection timeout in seconds (default depends on connection)")
 
     # ssh only
     connect_group.add_argument('--ssh-common-args', default=None, dest='ssh_common_args',

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -84,6 +84,13 @@ class AnsiblePlugin(ABC):
             options[option] = self.get_option(option, hostvars=hostvars)
         return options
 
+    def get_option_and_origin(self, option, hostvars=None):
+        try:
+            option_value, origin = C.config.get_config_value_and_origin(option, plugin_type=self.plugin_type, plugin_name=self._load_name, variables=hostvars)
+        except AnsibleError as e:
+            raise KeyError(to_native(e))
+        return option_value, origin
+
     def set_option(self, option, value):
         self._options[option] = value
 

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -84,13 +84,6 @@ class AnsiblePlugin(ABC):
             options[option] = self.get_option(option, hostvars=hostvars)
         return options
 
-    def get_option_and_origin(self, option, hostvars=None):
-        try:
-            option_value, origin = C.config.get_config_value_and_origin(option, plugin_type=self.plugin_type, plugin_name=self._load_name, variables=hostvars)
-        except AnsibleError as e:
-            raise KeyError(to_native(e))
-        return option_value, origin
-
     def set_option(self, option, value):
         self._options[option] = value
 


### PR DESCRIPTION
…ecedence

  connection plugins should already use the same config entries (and more)
  than DEFAULT_TIMEOUT.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
config