### PR TITLE
Use package_data instead of include_package_data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,23 +17,9 @@ include examples/hosts
 include examples/ansible.cfg
 include examples/scripts/ConfigureRemotingForAnsible.ps1
 include examples/scripts/upgrade_to_ps3.ps1
-include lib/ansible/keyword_desc.yml
-recursive-include lib/ansible/executor/powershell *.ps1
-recursive-include lib/ansible/module_utils/csharp *.cs
-recursive-include lib/ansible/module_utils/powershell *.psm1
-recursive-include lib/ansible/modules/windows *.ps1
-recursive-include lib/ansible/galaxy/data *.yml *.j2 README.md ansible.cfg inventory .git_keep
-recursive-include lib/ansible/config *.yml
-recursive-include lib/ansible/modules *.yml
-recursive-include lib/ansible/plugins/test *.yml
-recursive-include lib/ansible/plugins/filter *.yml
 recursive-include licenses *.txt
 recursive-include packaging *.py
 recursive-include test/integration *
-recursive-include test/lib/ansible_test/config *.yml *.template
-recursive-include test/lib/ansible_test/_data *.cfg *.in *.ini *.ps1 *.txt *.yml coveragerc
-recursive-include test/lib/ansible_test/_util *.cfg *.ini *.json *.ps1 *.psd1 *.py *.sh *.txt *.yml
-recursive-include test/lib/ansible_test/_util/controller/sanity/validate-modules validate-modules
 recursive-include test/sanity *.in *.json *.py *.txt
 recursive-include test/support *.py *.ps1 *.psm1 *.cs *.md
 exclude test/sanity/code-smell/botmeta.*

--- a/changelogs/fragments/fix-setuptools-warnings.yml
+++ b/changelogs/fragments/fix-setuptools-warnings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Use ``package_data`` instead of ``include_package_data`` for ``setup.cfg`` to avoid ``setuptools`` warnings.

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,12 +38,55 @@ classifiers =
 [options]
 zip_safe = False
 python_requires = >=3.9
-include_package_data = True
 # keep ansible-test as a verbatim script to work with editable installs, since it needs to do its
 # own package redirection magic that's beyond the scope of the normal `ansible` path redirection
 # done by setuptools `develop`
 scripts =
     bin/ansible-test
+
+[options.package_data]
+ansible =
+    config/*.yml
+    executor/powershell/*.ps1
+    galaxy/data/*.yml
+    galaxy/data/*/*.j2
+    galaxy/data/*/*.md
+    galaxy/data/*/*/*.cfg
+    galaxy/data/*/*/*.j2
+    galaxy/data/*/*/*.md
+    galaxy/data/*/*/*/*.j2
+    galaxy/data/*/*/*/*.yml
+    galaxy/data/*/*/*/.git_keep
+    galaxy/data/*/*/*/inventory
+    galaxy/data/*/*/.git_keep
+    galaxy/data/*/*/inventory
+    keyword_desc.yml
+    module_utils/csharp/*.cs
+    module_utils/powershell/*.psm1
+    plugins/*/*.yml
+ansible_test =
+    _data/*/*.in
+    _data/*/*.ps1
+    _data/*/*.txt
+    _data/*/*.yml
+    _data/*/*/*.ini
+    _data/ansible.cfg
+    _data/coveragerc
+    _util/*/*/*.ps1
+    _util/*/*/*.py
+    _util/*/*/*.sh
+    _util/*/*/*/*.ini
+    _util/*/*/*/*.json
+    _util/*/*/*/*.ps1
+    _util/*/*/*/*.psd1
+    _util/*/*/*/*.py
+    _util/*/*/*/*.txt
+    _util/*/*/*/*/*.cfg
+    _util/*/*/*/*/*.ps1
+    _util/*/*/*/*/*.py
+    _util/*/*/*/*/*.yml
+    config/*.template
+    config/*.yml
 
 # setuptools 51.0.0
 # [options.entry_points]


### PR DESCRIPTION
##### SUMMARY

This resolves warnings generated by setuptools such as the following:

_Warning: Package 'ansible.galaxy.data' is absent from the `packages` configuration.

Once setuptools 62.3.0 becomes our minimum we'll be able to simplify the globs by making them recursive.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

setup.cfg