### PR TITLE
Remove terminal viewing docs

### DIFF
--- a/docs/docsite/rst/plugins/terminal.rst
+++ b/docs/docsite/rst/plugins/terminal.rst
@@ -29,13 +29,6 @@ Terminal plugins operate without configuration. All options to control the termi
 
 Plugins are self-documenting. Each plugin should document its configuration options.
 
-.. _terminal_plugin_list:
-
-Viewing terminal plugins
-------------------------
-
-These plugins have migrated to collections on `Ansible Galaxy <https://galaxy.ansible.com>`_. If you installed Ansible version 2.10 or later using ``pip``, you have access to several terminal plugins. To list all available terminal plugins on your control node, type ``ansible-doc -t terminal -l``. To view plugin-specific documentation and examples, use ``ansible-doc -t terminal``.
-
 
 .. seealso::
 


### PR DESCRIPTION

##### SUMMARY
* ansible-doc command can not handle terminal plugins since they are not documentable and configurable. Removing documentation section to list them.

Fixes: #80140

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/plugins/terminal.rst

