### PR TITLE
add a description to the entrypoints example of the argument spec

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_reuse_roles.rst
@@ -350,6 +350,8 @@ Sample specification
    # roles/myapp/tasks/main.yml entry point
    main:
      short_description: The main entry point for the myapp role.
+     description:
+       - Does int and str things with myapp.
      options:
        myapp_int:
          type: "int"
@@ -365,6 +367,8 @@ Sample specification
    # roles/myapp/tasks/alternate.yml entry point
    alternate:
      short_description: The alternate entry point for the myapp role.
+     description:
+       - Does only int things with myapp.
      options:
        myapp_int:
          type: "int"


### PR DESCRIPTION
##### SUMMARY

it's not said anywhere that `description` is an optional field and without it other tools (like antsibull-docs) reject the example as invalid




##### ISSUE TYPE
- Docs Pull Request

+label: docsite_pr

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
