### PR TITLE
[2.14] ansible-galaxy: fix installing signed collections (#80661)

### DIFF
--- a/changelogs/fragments/80648-fix-ansible-galaxy-cache-signatures-bug.yml
+++ b/changelogs/fragments/80648-fix-ansible-galaxy-cache-signatures-bug.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-galaxy - fix installing signed collections (https://github.com/ansible/ansible/issues/80648).
+  - ansible-galaxy collection verify - fix verifying signed collections when the keyring is not configured.

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -914,7 +914,7 @@ def verify_collections(
                         # NOTE: If there are no Galaxy server signatures, only user-provided signature URLs,
                         # NOTE: those alone validate the MANIFEST.json and the remote collection is not downloaded.
                         # NOTE: The remote MANIFEST.json is only used in verification if there are no signatures.
-                        if not signatures and not collection.signature_sources:
+                        if artifacts_manager.keyring is None or not signatures:
                             api_proxy.get_collection_version_metadata(
                                 remote_collection,
                             )

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -166,6 +166,7 @@ def _is_concrete_artifact_pointer(tested_str):
 
 
 class _ComputedReqKindsMixin:
+    UNIQUE_ATTRS = ('fqcn', 'ver', 'src', 'type')
 
     def __init__(self, *args, **kwargs):
         if not self.may_have_offline_galaxy_info:
@@ -179,6 +180,12 @@ class _ComputedReqKindsMixin:
                 self.name,
                 self.ver
             )
+
+    def __hash__(self):
+        return hash(tuple(getattr(self, attr) for attr in _ComputedReqKindsMixin.UNIQUE_ATTRS))
+
+    def __eq__(self, candidate):
+        return hash(self) == hash(candidate)
 
     @classmethod
     def from_dir_path_as_unknown(  # type: ignore[misc]


### PR DESCRIPTION
##### SUMMARY
Backporting #80661

* Fix installing signed collections by using the fqcn, version, source, and type as a unique identifier.

Define __hash__ and __eq__ methods to handle Candidate/Requirement comparison excluding signatures which aren't fully populated until install time.

* Remove PinnedCandidateRequests since it is redundant now.

* Fix verifying against a signed remote when the keyring isn't configured

(cherry picked from commit d5e2e7a0a8ca9017a091922648430374539f878b)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy