### PR TITLE
CLI/vault: harmonize `stderr` capturing behavior across executable password file variants

### DIFF
--- a/docs/docsite/rst/vault_guide/vault_managing_passwords.rst
+++ b/docs/docsite/rst/vault_guide/vault_managing_passwords.rst
@@ -87,7 +87,7 @@ To create a vault password client script:
   * Within the script itself:
       * Print the passwords to standard output
       * Accept a ``--vault-id`` option
-      * If the script prompts for data (for example, a database password), display the prompts to the TTY.
+      * To prompt for data (for example, a database password), you can write to standard error or write to the TTY directly.
 
 When you run a playbook that uses vault passwords stored in a third-party tool, specify the script as the source within the ``--vault-id`` flag. For example:
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -604,14 +604,16 @@ class CLI(ABC):
             cmd = [b_pwd_file]
 
             try:
-                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                # STDERR not captured to make it easier for users to prompt for input in their scripts
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
             except OSError as e:
                 raise AnsibleError("Problem occured when trying to run the password script %s (%s)."
                                    " If this is not a script, remove the executable bit from the file." % (pwd_file, e))
 
             stdout, stderr = p.communicate()
             if p.returncode != 0:
-                raise AnsibleError("The password script %s returned an error (rc=%s): %s" % (pwd_file, p.returncode, stderr))
+                err_suffix = ": %s" % stderr if stderr else "."
+                raise AnsibleError("The password script %s returned an error (rc=%s)%s" % (pwd_file, p.returncode, err_suffix))
             secret = stdout
 
         else:

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -460,8 +460,9 @@ class ScriptVaultSecret(FileVaultSecret):
 
     def _check_results(self, stdout, stderr, popen):
         if popen.returncode != 0:
-            raise AnsibleError("Vault password script %s returned non-zero (%s): %s" %
-                               (self.filename, popen.returncode, stderr))
+            err_suffix = ": %s" % stderr if stderr else "."
+            raise AnsibleError("Vault password script %s returned an error (rc=%s)%s" %
+                               (self.filename, popen.returncode, err_suffix))
 
     def _build_command(self):
         return [self.filename]


### PR DESCRIPTION
##### SUMMARY
Currently, if a `vault_password_file` is executed, `stderr` is passed on, but if a `become_password_file` or `connection_password_file` is executed, `stderr` is captured.

Therefore, this PR proposes: 

- Better align `become_password_file` and `connection_password_file` with `vault_password_file`, reducing surprises and facilitating prompting for input (e.g. from a password manager) the same way it is already possible with `vault_password_file`.

- Harmonize the exception messages returned in the case of a non-zero exit status, and do not show `None` if nothing was captured from stderr.

- Add/adapt the pertinent unit test cases.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CLI, vault

##### ADDITIONAL INFORMATION
`become_password_file` and `connection_password_file` seem to have no unit test coverage yet. I added one test to cover the proposed change - this is not sufficient, but writing more tests to properly cover the adjacent areas in the code is currently out of scope for me.
