### PR TITLE
pep517 backend - Copy symlinks when copying source

### DIFF
--- a/changelogs/fragments/pep517-backend-traceback-fix.yml
+++ b/changelogs/fragments/pep517-backend-traceback-fix.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - pep517 build backend - Copy symlinks when copying the source tree.
+    This avoids tracebacks in various scenarios, such as when a venv is present in the source tree.

--- a/packaging/pep517_backend/_backend.py
+++ b/packaging/pep517_backend/_backend.py
@@ -118,7 +118,7 @@ def build_sdist(  # noqa: WPS210, WPS430
     original_src_dir = Path.cwd().resolve()
     with _run_in_temporary_directory() as tmp_dir:
         tmp_src_dir = Path(tmp_dir) / 'src'
-        copytree(original_src_dir, tmp_src_dir)
+        copytree(original_src_dir, tmp_src_dir, symlinks=True)
         os.chdir(tmp_src_dir)
 
         if build_manpages_requested:


### PR DESCRIPTION
##### SUMMARY

pep517 backend - Copy symlinks when copying source.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

packaging/pep517_backend/_backend.py

##### ADDITIONAL INFORMATION

Example traceback:

```
Traceback (most recent call last):
  File "/home/mclay/.ansible/test/venv/sanity.package-data/3.10/2e6d7684/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
    main()
  File "/home/mclay/.ansible/test/venv/sanity.package-data/3.10/2e6d7684/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 335, in main
    json_out['return_val'] = hook(**hook_input['kwargs'])
  File "/home/mclay/.ansible/test/venv/sanity.package-data/3.10/2e6d7684/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 304, in build_sdist
    return backend.build_sdist(sdist_directory, config_settings)
  File "/tmp/tmp15hv0nte/packaging/pep517_backend/_backend.py", line 121, in build_sdist
    copytree(original_src_dir, tmp_src_dir, symlinks=False)
  File "/usr/lib/python3.10/shutil.py", line 558, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
  File "/usr/lib/python3.10/shutil.py", line 512, in _copytree
    raise Error(errors)
shutil.Error: [('/tmp/tmp15hv0nte/test/results/.tmp/delegation/python2.7/bin/python2', '/tmp/.tmp-ansible-pep517-zdcv_iwp/src/test/results/.tmp/delegation/python2.7/bin/python2', "[Errno 2] No such file or directory: '/tmp/tmp15hv0nte/test/results/.tmp/delegation/python2.7/bin/python2'"), ('/tmp/tmp15hv0nte/test/results/.tmp/delegation/python2.7/bin/python', '/tmp/.tmp-ansible-pep517-zdcv_iwp/src/test/results/.tmp/delegation/python2.7/bin/python', "[Errno 2] No such file or directory: '/tmp/tmp15hv0nte/test/results/.tmp/delegation/python2.7/bin/python'")]
```