### PR TITLE
Remove FreeBSD 12.2 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -92,8 +92,6 @@ stages:
               test: rhel/8.4@3.6
             - name: RHEL 8.4 py38
               test: rhel/8.4@3.8
-            - name: FreeBSD 12.2
-              test: freebsd/12.2
             - name: FreeBSD 13.0
               test: freebsd/13.0
           groups:
@@ -188,8 +186,6 @@ stages:
               test: rhel/8.4@3.6
             - name: RHEL 8.4 py38
               test: rhel/8.4@3.8
-            - name: FreeBSD 12.2
-              test: freebsd/12.2
             - name: FreeBSD 13.0
               test: freebsd/13.0
   - stage: Incidental_Docker


### PR DESCRIPTION
##### SUMMARY

The package repositories are no longer available:

```
Bootstrapping pkg from pkg+http://pkg.FreeBSD.org/FreeBSD:12:amd64/release_2, please wait...
pkg: Error fetching http://pkg.FreeBSD.org/FreeBSD:12:amd64/release_2/Latest/pkg.txz: Not Found
```

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

.azure-pipelines/azure-pipelines.yml