### PR TITLE
docsite build: upgrade sphinx-ansible-theme and antsibull-core

### DIFF
--- a/docs/docsite/requirements.txt
+++ b/docs/docsite/requirements.txt
@@ -12,6 +12,6 @@ pyyaml
 rstcheck
 sphinx-notfound-page >= 0.6
 sphinx-intl
-sphinx-ansible-theme >= 0.9.1
+sphinx-ansible-theme >= 0.10.2
 sphinx
 resolvelib

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -4,7 +4,7 @@ aiohttp==3.8.4
 aiosignal==1.3.1
 alabaster==0.7.13
 ansible-pygments==0.1.1
-antsibull-core==1.5.1
+antsibull-core==1.6.0
 antsibull-docs==1.11.0
 async-timeout==4.0.2
 asyncio-pool==0.6.0

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -33,7 +33,7 @@ sh==1.14.3
 six==1.16.0
 snowballstemmer==2.2.0
 Sphinx==5.3.0
-sphinx-ansible-theme==0.10.1
+sphinx-ansible-theme==0.10.2
 sphinx-notfound-page==0.8.3
 sphinx-rtd-theme==1.2.0
 sphinxcontrib-applehelp==1.0.4


### PR DESCRIPTION
##### SUMMARY
This PR is mainly for backporting to stable-2.15; for devel, antsibull-docs and antsibull-core should be upgraded to 2.0.0 (as soon as antsibull-docs 2.0.0 is out).

- The sphinx-ansible-theme upgrade fixes a CSS bug (https://github.com/ansible-community/sphinx_ansible_theme/issues/56).
- The antsibull-core upgrade allows the Ansible docsite build to download collections once Ansible Community Galaxy is replaced with the new codebase. This isn't urgent, but could well happen before Ansible 8 (whose docsite is built from the stable-2.15 branch) is EOL.

CC @oraNod @samccann

##### ISSUE TYPE
- Docs Pull Request
- Test Pull Request

##### COMPONENT NAME
docsite build
