### PR TITLE
unarchive - ensure src is an absolute path before picking handler

### DIFF
--- a/changelogs/fragments/80738-abs-unarachive-src.yml
+++ b/changelogs/fragments/80738-abs-unarachive-src.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unarchive - fix unarchiving sources that are copied to the remote node using a relative temporory directory path (https://github.com/ansible/ansible/issues/80710).

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -1054,6 +1054,9 @@ def main():
     if not os.access(src, os.R_OK):
         module.fail_json(msg="Source '%s' not readable" % src)
 
+    # ensure src is an absolute path before picking handlers
+    src = os.path.abspath(src)
+
     # skip working with 0 size archives
     try:
         if os.path.getsize(src) == 0:

--- a/test/integration/targets/unarchive/runme.sh
+++ b/test/integration/targets/unarchive/runme.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible-playbook -i ../../inventory runme.yml -v "$@"
+
+# https://github.com/ansible/ansible/issues/80710
+ANSIBLE_REMOTE_TMP=./ansible ansible-playbook -i ../../inventory test_relative_tmp_dir.yml -v "$@"

--- a/test/integration/targets/unarchive/runme.yml
+++ b/test/integration/targets/unarchive/runme.yml
@@ -1,0 +1,4 @@
+- hosts: all
+  gather_facts: no
+  roles:
+    - { role: ../unarchive }

--- a/test/integration/targets/unarchive/test_relative_tmp_dir.yml
+++ b/test/integration/targets/unarchive/test_relative_tmp_dir.yml
@@ -1,0 +1,10 @@
+- hosts: all
+  gather_facts: no
+  tasks:
+    - include_role:
+        name: ../setup_remote_tmp_dir
+    - include_role:
+        name: ../setup_gnutar
+    - include_tasks: tasks/prepare_tests.yml
+    
+    - include_tasks: tasks/test_tar.yml


### PR DESCRIPTION
##### SUMMARY
Fixes #80710 by ensuring src is an absolute path before a handler tries to use it

Also adds a test case using a relative remote tmp dir

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
unarchive
