### PR TITLE
Remove unnecessary test case in vault editor

### DIFF
--- a/test/units/parsing/vault/test_vault_editor.py
+++ b/test/units/parsing/vault/test_vault_editor.py
@@ -498,21 +498,9 @@ class TestVaultEditor(unittest.TestCase):
         res = ve._real_path(filename)
         self.assertEqual(res, '-')
 
-    def test_real_path_dev_null(self):
+    def test_real_path_not_dash(self):
         filename = '/dev/null'
         ve = self._vault_editor()
 
         res = ve._real_path(filename)
-        self.assertEqual(res, '/dev/null')
-
-    def test_real_path_symlink(self):
-        self._test_dir = os.path.realpath(self._create_test_dir())
-        file_path = self._create_file(self._test_dir, 'test_file', content=b'this is a test file')
-        file_link_path = os.path.join(self._test_dir, 'a_link_to_test_file')
-
-        os.symlink(file_path, file_link_path)
-
-        ve = self._vault_editor()
-
-        res = ve._real_path(file_link_path)
-        self.assertEqual(res, file_path)
+        self.assertNotEqual(res, '-')


### PR DESCRIPTION

##### SUMMARY
* Remove test_real_path_symlink test case
* Check if we do not get `-` return when some value other `-` is passed

Fixes: #80444

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
parsing/vault/test_vault_editor.py