### PR TITLE
modules/find: param contains: Describe matching behavior

### DIFF
--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -56,6 +56,8 @@ options:
     contains:
         description:
             - A regular expression or pattern which should be matched against the file content.
+            - Depending on I(read_whole_file), the regular expression or pattern MUST either match the
+              ENTIRE file content or an ENTIRE line, not just parts of it.
             - Works only when I(file_type) is C(file).
         type: str
     read_whole_file:

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -56,8 +56,9 @@ options:
     contains:
         description:
             - A regular expression or pattern which should be matched against the file content.
-            - Depending on I(read_whole_file), the regular expression or pattern MUST either match the
-              ENTIRE file content or an ENTIRE line, not just parts of it.
+            - If I(read_whole_file) is C(true) it matches against the beginning of the line (uses
+              C(re.match())). If I(read_whole_file) is C(false), it searches anywhere for that pattern
+              (uses C(re.search())).
             - Works only when I(file_type) is C(file).
         type: str
     read_whole_file:


### PR DESCRIPTION


##### SUMMARY
Add similiar description to the `contains` parameter like the `patterns` parameter has already.
Also implicitly refer to `read_whole_file`, which changes the behavior or `contains`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
find

##### ADDITIONAL INFORMATION
Took me too long to debug the bug. Because I first didn't saw `read_whole_file` but read the description of `patterns`, I expected that the default would be to automatically require matching only parts of the file as the whole file would be too huge to load in memory for that comparison.