### PR TITLE
URI Module find json sub type

### DIFF
--- a/changelogs/fragments/update-maybe-json-uri.yml
+++ b/changelogs/fragments/update-maybe-json-uri.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- uri - fix search for JSON type to include complex strings containing '+'

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -707,7 +707,15 @@ def main():
         sub_type = 'octet-stream'
         content_encoding = 'utf-8'
 
-    maybe_json = content_type and sub_type.lower() in JSON_CANDIDATES
+    if sub_type and '+' in sub_type:
+        # https://www.rfc-editor.org/rfc/rfc6839#section-3.1
+        sub_type_suffix = sub_type.partition('+')[2]
+        maybe_json = content_type and sub_type_suffix.lower() in JSON_CANDIDATES
+    elif sub_type:
+        maybe_json = content_type and sub_type.lower() in JSON_CANDIDATES
+    else:
+        maybe_json = False
+
     maybe_output = maybe_json or return_content or info['status'] not in status_code
 
     if maybe_output:

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -696,6 +696,18 @@
     that:
       - result.json.json[0] == 'JSON Test Pattern pass1'
 
+- name: Test find JSON as subtype
+  uri:
+    url: "https://{{ httpbin_host }}/response-headers?content-type=application/ld%2Bjson"
+    method: POST
+    return_content: true
+  register: result
+
+- name: Validate JSON as subtype
+  assert:
+    that:
+      - result.json is defined
+
 - name: Make request that includes password in JSON keys
   uri:
     url: "https://{{ httpbin_host}}/get?key-password=value-password"


### PR DESCRIPTION
uri: fixed search for json types to include strings in the format xxx/yyy+json

##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/80709

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
uri module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
JSON was not being found as a valid type because the name included extra characters generally in the format xxx/yyy+json. The string was not found as a valid type because of this complex string. 

