### PR TITLE
junit-xml - Remove outdated type ignore hint

### DIFF
--- a/lib/ansible/utils/_junit_xml.py
+++ b/lib/ansible/utils/_junit_xml.py
@@ -15,7 +15,7 @@ from xml.dom import minidom
 from xml.etree import ElementTree as ET
 
 
-@dataclasses.dataclass  # type: ignore[misc]  # https://github.com/python/mypy/issues/5374
+@dataclasses.dataclass
 class TestResult(metaclass=abc.ABCMeta):
     """Base class for the result of a test case."""
 


### PR DESCRIPTION
##### SUMMARY

junit-xml - Remove outdated type ignore hint.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/utils/_junit_xml.py