### PR TITLE
[stable-2.13] ansible-test - Avoid use of deprecated utcnow (#80750)

### DIFF
--- a/changelogs/fragments/ansible-test-utcnow.yml
+++ b/changelogs/fragments/ansible-test-utcnow.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Use ``datetime.datetime.now`` with ``tz`` specified instead of ``datetime.datetime.utcnow``.

--- a/lib/ansible/utils/_junit_xml.py
+++ b/lib/ansible/utils/_junit_xml.py
@@ -138,6 +138,10 @@ class TestSuite:
     system_out: str | None = None
     system_err: str | None = None
 
+    def __post_init__(self):
+        if self.timestamp and self.timestamp.tzinfo != datetime.timezone.utc:
+            raise ValueError(f'timestamp.tzinfo must be {datetime.timezone.utc!r}')
+
     @property
     def disabled(self) -> int:
         """The number of disabled test cases."""
@@ -181,7 +185,7 @@ class TestSuite:
             skipped=self.skipped,
             tests=self.tests,
             time=self.time,
-            timestamp=self.timestamp.isoformat(timespec='seconds') if self.timestamp else None,
+            timestamp=self.timestamp.replace(tzinfo=None).isoformat(timespec='seconds') if self.timestamp else None,
         )
 
     def get_xml_element(self) -> ET.Element:

--- a/test/lib/ansible_test/_internal/commands/env/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/env/__init__.py
@@ -85,7 +85,7 @@ def show_dump_env(args):  # type: (EnvConfig) -> None
         ),
         git=get_ci_provider().get_git_details(args),
         platform=dict(
-            datetime=datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
+            datetime=datetime.datetime.now(tz=datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
             platform=platform.platform(),
             uname=platform.uname(),
         ),

--- a/test/lib/ansible_test/_internal/commands/integration/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/integration/__init__.py
@@ -565,7 +565,7 @@ def command_integration_filtered(
             coverage_manager.teardown()
 
             result_name = '%s-%s.json' % (
-                args.command, re.sub(r'[^0-9]', '-', str(datetime.datetime.utcnow().replace(microsecond=0))))
+                args.command, re.sub(r'[^0-9]', '-', str(datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0, tzinfo=None))))
 
             data = dict(
                 targets=results,

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/__init__.py
@@ -170,7 +170,7 @@ def cloud_init(args, targets):  # type: (IntegrationConfig, t.Tuple[IntegrationT
 
     if not args.explain and results:
         result_name = '%s-%s.json' % (
-            args.command, re.sub(r'[^0-9]', '-', str(datetime.datetime.utcnow().replace(microsecond=0))))
+            args.command, re.sub(r'[^0-9]', '-', str(datetime.datetime.now(tz=datetime.timezone.utc).replace(microsecond=0, tzinfo=None))))
 
         data = dict(
             clouds=results,

--- a/test/lib/ansible_test/_internal/commands/sanity/pylint.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/pylint.py
@@ -153,19 +153,19 @@ class PylintTest(SanitySingleVersion):
             except CollectionDetailError as ex:
                 display.warning('Skipping pylint collection version checks since collection detail loading failed: %s' % ex.reason)
 
-        test_start = datetime.datetime.utcnow()
+        test_start = datetime.datetime.now(tz=datetime.timezone.utc)
 
         for context, context_paths in sorted(contexts):
             if not context_paths:
                 continue
 
-            context_start = datetime.datetime.utcnow()
+            context_start = datetime.datetime.now(tz=datetime.timezone.utc)
             messages += self.pylint(args, context, context_paths, plugin_dir, plugin_names, python, collection_detail)
-            context_end = datetime.datetime.utcnow()
+            context_end = datetime.datetime.now(tz=datetime.timezone.utc)
 
             context_times.append('%s: %d (%s)' % (context, len(context_paths), context_end - context_start))
 
-        test_end = datetime.datetime.utcnow()
+        test_end = datetime.datetime.now(tz=datetime.timezone.utc)
 
         for context_time in context_times:
             display.info(context_time, verbosity=4)

--- a/test/lib/ansible_test/_internal/test.py
+++ b/test/lib/ansible_test/_internal/test.py
@@ -112,7 +112,7 @@ class TestResult:
                 junit_xml.TestSuite(
                     name='ansible-test',
                     cases=[test_case],
-                    timestamp=datetime.datetime.utcnow(),
+                    timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
                 ),
             ],
         )
@@ -150,13 +150,11 @@ One or more of the following situations may be responsible:
 
         output += '\n\nConsult the console log for additional details on where the timeout occurred.'
 
-        timestamp = datetime.datetime.utcnow()
-
         suites = junit_xml.TestSuites(
             suites=[
                 junit_xml.TestSuite(
                     name='ansible-test',
-                    timestamp=timestamp,
+                    timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
                     cases=[
                         junit_xml.TestCase(
                             name='timeout',


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/80750

(cherry picked from commit fd341265d001d4e6545ffb2b7d154340cb1f1931)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test