### PR TITLE
[sanity-mypy] Ignore re-import warning

### DIFF
--- a/lib/ansible/module_utils/compat/typing.py
+++ b/lib/ansible/module_utils/compat/typing.py
@@ -13,7 +13,7 @@ except Exception:  # pylint: disable=broad-except
     pass
 
 try:
-    from typing import *  # type: ignore[assignment]
+    from typing import *  # type: ignore[assignment,no-redef]
 except Exception:  # pylint: disable=broad-except
     pass
 


### PR DESCRIPTION
##### SUMMARY
* get_origin is already imported warning can be ignored safely.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/compat/typing.py

