### PR TITLE
ansible-test - Relax pylint config for backports

### DIFF
--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test.cfg
@@ -39,7 +39,7 @@ good-names=
     Run,
 
 class-attribute-rgx=[A-Za-z_][A-Za-z0-9_]{1,40}$
-attr-rgx=[a-z_][a-z0-9_]{1,40}$
+attr-rgx=[A-Za-z_][A-Za-z0-9_]{1,40}$
 method-rgx=[a-z_][a-z0-9_]{1,40}$
 function-rgx=[a-z_][a-z0-9_]{1,40}$
 


### PR DESCRIPTION
##### SUMMARY

ansible-test - Relax pylint config for backports.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test