### PR TITLE
[stable-2.14] ansible-test - Fix handling of long timeouts (#80769)

### DIFF
--- a/changelogs/fragments/ansible-test-long-timeout-fix.yml
+++ b/changelogs/fragments/ansible-test-long-timeout-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix handling of timeouts exceeding one day.

--- a/test/lib/ansible_test/_internal/timeout.py
+++ b/test/lib/ansible_test/_internal/timeout.py
@@ -125,6 +125,6 @@ def configure_test_timeout(args: TestConfig) -> None:
 
     signal.signal(signal.SIGUSR1, timeout_handler)
 
-    instance = WrappedThread(functools.partial(timeout_waiter, timeout_remaining.seconds))
+    instance = WrappedThread(functools.partial(timeout_waiter, timeout_remaining.total_seconds()))
     instance.daemon = True
     instance.start()


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/80769

(cherry picked from commit aacab0633a963e7a89fc1e6ac71cdf06553f96ab)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
