### PR TITLE
Removed testing support for Server 2012 and 2012 R2

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -73,8 +73,6 @@ stages:
           nameFormat: Server {0}
           testFormat: windows/{0}/1
           targets:
-            - test: 2012
-            - test: 2012-R2
             - test: 2016
             - test: 2019
             - test: 2022
@@ -204,8 +202,6 @@ stages:
           nameFormat: Server {0}
           testFormat: i/windows/{0}
           targets:
-            - test: 2012
-            - test: 2012-R2
             - test: 2016
             - test: 2019
             - test: 2022

--- a/.azure-pipelines/commands/incidental/windows.sh
+++ b/.azure-pipelines/commands/incidental/windows.sh
@@ -16,7 +16,7 @@ provider="${P:-default}"
 python_default="$(PYTHONPATH="${PWD}/test/lib" python -c 'from ansible_test._internal import constants; print(constants.CONTROLLER_MIN_PYTHON_VERSION)')"
 
 # version to test when only testing a single version
-single_version=2012-R2
+single_version=2022
 
 # shellcheck disable=SC2086
 ansible-test windows-integration --list-targets -v ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} > /tmp/explain.txt 2>&1 || { cat /tmp/explain.txt && false; }

--- a/.azure-pipelines/commands/windows.sh
+++ b/.azure-pipelines/commands/windows.sh
@@ -21,7 +21,7 @@ IFS=' ' read -r -a python_versions <<< \
 python_default="$(PYTHONPATH="${PWD}/test/lib" python -c 'from ansible_test._internal import constants; print(constants.CONTROLLER_MIN_PYTHON_VERSION)')"
 
 # version to test when only testing a single version
-single_version=2012-R2
+single_version=2022
 
 # shellcheck disable=SC2086
 ansible-test windows-integration --list-targets -v ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} > /tmp/explain.txt 2>&1 || { cat /tmp/explain.txt && false; }

--- a/changelogs/fragments/server2012-deprecation.yml
+++ b/changelogs/fragments/server2012-deprecation.yml
@@ -1,0 +1,8 @@
+deprecated_features:
+- >-
+  Support for Windows Server 2012 and 2012 R2 has been removed as the support end of life from Microsoft is October
+  10th 2023. These versions of Windows will no longer be tested in this Ansible release and it cannot be guaranteed
+  that they will continue to work going forward.
+
+removed_features:
+- ansible-test - Removed support for the remote Windows targets 2012 and 2012-R2

--- a/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
@@ -171,7 +171,7 @@ When creating a new module there are a few things to keep in mind:
 - Look for common functions in ``./lib/ansible/module_utils/powershell/`` and use the code there instead of duplicating work. These can be imported by adding the line ``#Requires -Module *`` where * is the filename to import, and will be automatically included with the module code sent to the Windows target when run through Ansible
 - As well as PowerShell module utils, C# module utils are stored in ``./lib/ansible/module_utils/csharp/`` and are automatically imported in a module execution if the line ``#AnsibleRequires -CSharpUtil *`` is present
 - C# and PowerShell module utils achieve the same goal but C# allows a developer to implement low level tasks, such as calling the Win32 API, and can be faster in some cases
-- Ensure the code runs under Powershell v3 and higher on Windows Server 2012 and higher; if higher minimum Powershell or OS versions are required, ensure the documentation reflects this clearly
+- Ensure the code runs under Powershell v5.1 and higher on Windows Server 2016 and higher; if higher minimum Powershell or OS versions are required, ensure the documentation reflects this clearly
 - Ansible runs modules under strictmode version 2.0. Be sure to test with that enabled by putting ``Set-StrictMode -Version 2.0`` at the top of your dev script
 - Favor native Powershell cmdlets over executable calls if possible
 - Use the full cmdlet name instead of aliases, for example ``Remove-Item`` over ``rm``

--- a/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/integration-aliases.rst
@@ -74,8 +74,9 @@ Platform versions, as specified using the ``--remote`` option with ``/`` removed
 
 Windows versions, as specified using the ``--windows`` option can also be skipped:
 
-- ``skip/windows/2012`` - Skip tests on Windows Server 2012.
-- ``skip/windows/2012-R2`` - Skip tests on Windows Server 2012 R2.
+- ``skip/windows/2016`` - Skip tests on Windows Server 2016.
+- ``skip/windows/2019`` - Skip tests on Windows Server 2019.
+- ``skip/windows/2022`` - Skip tests on Windows Server 2022.
 
 Aliases can be used to skip Python major versions using one of the following:
 

--- a/docs/docsite/rst/os_guide/windows_faq.rst
+++ b/docs/docsite/rst/os_guide/windows_faq.rst
@@ -14,26 +14,18 @@ Does Ansible work with Windows XP or Server 2003?
 ``````````````````````````````````````````````````
 Ansible does not work with Windows XP or Server 2003 hosts. Ansible does work with these Windows operating system versions:
 
-* Windows Server 2008 :sup:`1`
-* Windows Server 2008 R2 :sup:`1`
-* Windows Server 2012
-* Windows Server 2012 R2
 * Windows Server 2016
 * Windows Server 2019
-* Windows 7 :sup:`1`
-* Windows 8.1
+* Windows Server 2022
 * Windows 10
+* Windows 11
 
-1 - See the :ref:`Server 2008 FAQ <windows_faq_server2008>` entry for more details.
+Support for Windows Server 2008, 2008 R2, and Windows 7 ended in the 2.10
+release. Support for Windows Server 2012, 2012 R2, Windows 8, and 8.1 ended in
+the 2.16 release.
 
 Ansible also has minimum PowerShell version requirements - please see
 :ref:`windows_setup` for the latest information.
-
-.. _windows_faq_server2008:
-
-Are Server 2008, 2008 R2 and Windows 7 supported?
-`````````````````````````````````````````````````
-Microsoft ended Extended Support for these versions of Windows on January 14th, 2020, and Ansible deprecated official support in the 2.10 release. No new feature development will occur targeting these operating systems, and automated testing has ceased. However, existing modules and features will likely continue to work, and simple pull requests to resolve issues with these Windows versions may be accepted.
 
 Can I manage Windows Nano Server with Ansible?
 ``````````````````````````````````````````````

--- a/docs/docsite/rst/os_guide/windows_setup.rst
+++ b/docs/docsite/rst/os_guide/windows_setup.rst
@@ -12,9 +12,9 @@ Host Requirements
 For Ansible to communicate to a Windows host and use Windows modules, the
 Windows host must meet these base requirements for connectivity:
 
-* With Ansible you can generally manage Windows versions under the current and extended support from Microsoft. You can also manage desktop OSs including Windows 8.1, and 10, and server OSs including Windows Server 2012, 2012 R2, 2016, 2019, and 2022.
+* With Ansible you can generally manage Windows versions under the current and extended support from Microsoft. You can also manage desktop OSs including Windows 10 and 11, and server OSs including Windows Server 2016, 2019, and 2022.
 
-* You need to install PowerShell 3.0 or newer and at least .NET 4.0 on the Windows host.
+* You need to install PowerShell 5.1 or newer and at least .NET 4.0 on the Windows host.
 
 * You need to create and activate a WinRM listener. More details, see `WinRM Setup <https://docs.ansible.com/ansible/latest//user_guide/windows_setup.html#winrm-listener>`_.
 
@@ -22,7 +22,7 @@ Windows host must meet these base requirements for connectivity:
 
 Upgrading PowerShell and .NET Framework
 ---------------------------------------
-Ansible requires PowerShell version 3.0 and .NET Framework 4.0 or newer to function on older operating systems like Server 2008 and Windows 7. The base image does not meet this
+Ansible requires PowerShell version 5.1 and .NET Framework 4.6 or newer to function. The base image for older unsupported OS' do not meet these
 requirement. You can use the `Upgrade-PowerShell.ps1 <https://github.com/jborean93/ansible-windows/blob/master/scripts/Upgrade-PowerShell.ps1>`_ script to update these.
 
 This is an example of how to run this script from PowerShell:

--- a/test/lib/ansible_test/_data/completion/windows.txt
+++ b/test/lib/ansible_test/_data/completion/windows.txt
@@ -1,5 +1,3 @@
-windows/2012 provider=aws arch=x86_64
-windows/2012-R2 provider=aws arch=x86_64
 windows/2016 provider=aws arch=x86_64
 windows/2019 provider=aws arch=x86_64
 windows/2022 provider=aws arch=x86_64


### PR DESCRIPTION
##### SUMMARY
Removes testing support for Windows Server 2012 and 2012 R2 from `ansible-test`. These versions will hit the end of life during the lifecycle of Ansible 2.16 and we can no longer support them. Also updates a few references in the docs to mention 2016/Windows 10 as the new baseline alongside PowerShell 5.1 and dotnet frameowrk 4.6 which were shipped with those versions.

Fixes: https://github.com/ansible/ansible/issues/80421
Fixes: https://github.com/ansible/ansible/issues/80422

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
core