### PR TITLE
Trim down 2.12 test matrix

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -12,15 +12,6 @@ pr:
       - devel
       - stable-*
 
-schedules:
-  - cron: 0 7 * * *
-    displayName: Nightly
-    always: true
-    branches:
-      include:
-        - devel
-        - stable-*
-
 variables:
   - name: checkoutPath
     value: ansible

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -12,6 +12,15 @@ pr:
       - devel
       - stable-*
 
+schedules:
+  - cron: 0 7 * * *
+    displayName: Nightly
+    always: true
+    branches:
+      include:
+        - devel
+        - stable-*
+
 variables:
   - name: checkoutPath
     value: ansible

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -65,35 +65,18 @@ stages:
             - test: 3.8
             - test: 3.9
             - test: '3.10'
-  - stage: Windows
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Server {0}
-          testFormat: windows/{0}/1
-          targets:
-            - test: 2012
-            - test: 2012-R2
-            - test: 2016
-            - test: 2019
-            - test: 2022
   - stage: Remote
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
         parameters:
           targets:
-            - name: macOS 11.1
-              test: macos/11.1
             - name: RHEL 7.9
               test: rhel/7.9
             - name: RHEL 8.4 py36
               test: rhel/8.4@3.6
             - name: RHEL 8.4 py38
               test: rhel/8.4@3.8
-            - name: FreeBSD 13.0
-              test: freebsd/13.0
           groups:
             - 1
             - 2
@@ -103,10 +86,6 @@ stages:
       - template: templates/matrix.yml  # context/controller (ansible-test container management)
         parameters:
           targets:
-            - name: Alpine 3.16
-              test: alpine/3.16
-            - name: Fedora 36
-              test: fedora/36
             - name: RHEL 8.4
               test: rhel/8.4
             - name: RHEL 9.0
@@ -124,24 +103,10 @@ stages:
         parameters:
           testFormat: linux/{0}
           targets:
-            - name: Alpine 3
-              test: alpine3
             - name: CentOS 6
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: Fedora 33
-              test: fedora33
-            - name: Fedora 34
-              test: fedora34
-            - name: openSUSE 15 py2
-              test: opensuse15py2
-            - name: openSUSE 15 py3
-              test: opensuse15
-            - name: Ubuntu 18.04
-              test: ubuntu1804
-            - name: Ubuntu 20.04
-              test: ubuntu2004
           groups:
             - 1
             - 2
@@ -178,16 +143,12 @@ stages:
         parameters:
           testFormat: i/{0}
           targets:
-            - name: macOS 11.1
-              test: macos/11.1
             - name: RHEL 7.9
               test: rhel/7.9
             - name: RHEL 8.4 py36
               test: rhel/8.4@3.6
             - name: RHEL 8.4 py38
               test: rhel/8.4@3.8
-            - name: FreeBSD 13.0
-              test: freebsd/13.0
   - stage: Incidental_Docker
     displayName: Incidental Docker
     dependsOn: []
@@ -200,62 +161,16 @@ stages:
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: Fedora 33
-              test: fedora33
-            - name: Fedora 34
-              test: fedora34
-            - name: openSUSE 15 py2
-              test: opensuse15py2
-            - name: openSUSE 15 py3
-              test: opensuse15
-            - name: Ubuntu 18.04
-              test: ubuntu1804
-            - name: Ubuntu 20.04
-              test: ubuntu2004
-  - stage: Incidental_Windows
-    displayName: Incidental Windows
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: Server {0}
-          testFormat: i/windows/{0}
-          targets:
-            - test: 2012
-            - test: 2012-R2
-            - test: 2016
-            - test: 2019
-            - test: 2022
-  - stage: Incidental
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: i/{0}/1
-          targets:
-            - name: IOS Python
-              test: ios/csr1000v/
-            - name: VyOS Python
-              test: vyos/1.1.8/
-            - name: AWS Python 2.7
-              test: aws/2.7
-            - name: AWS Python 3.6
-              test: aws/3.6
-            - name: Cloud Python
-              test: cloud/
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
       - Sanity
       - Units
-      - Windows
       - Remote
       - Docker
       - Galaxy
       - Generic
       - Incidental_Remote
       - Incidental_Docker
-      - Incidental_Windows
-      - Incidental
     jobs:
       - template: templates/coverage.yml

--- a/test/lib/ansible_test/_internal/commands/sanity/integration_aliases.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/integration_aliases.py
@@ -224,7 +224,6 @@ class IntegrationAliasesTest(SanitySingleVersion):
         messages = []
 
         messages += self.check_posix_targets(args)
-        messages += self.check_windows_targets()
 
         if messages:
             return SanityFailure(self.name, messages=messages)


### PR DESCRIPTION
##### SUMMARY

The ansible-core 2.12 release reaches EOL on May 22nd, 2023 -- one week after the release of ansible-core 2.15.0.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

.azure-pipelines/azure-pipelines.yml