### PR TITLE
Option to override host and port when using `uri` and `get_url` modules

### DIFF
--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -397,7 +397,7 @@ EXAMPLES = r'''
     ciphers: '@SECLEVEL=2:ECDH+AESGCM:ECDH+CHACHA20:ECDH+AES:DHE+AES:!aNULL:!eNULL:!aDSS:!SHA1:!AESCCM'
 
 - name: Provide custom address resolution rules.
-  ansible.builtin.get_url:
+  ansible.builtin.uri:
     url: https://example.org
     resolve:
       example.org: 127.0.0.1:8443
@@ -636,7 +636,7 @@ def main():
         decompress=dict(type='bool', default=True),
         ciphers=dict(type='list', elements='str'),
         use_netrc=dict(type='bool', default=True),
-        resolve=dict(type='dict', default={}),
+        resolve=dict(type='dict'),
     )
 
     module = AnsibleModule(

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -674,3 +674,6 @@
 
 - name: Test use_netrc=False
   import_tasks: use_netrc.yml
+
+- name: Test resolve
+  import_tasks: resolve.yml

--- a/test/integration/targets/get_url/tasks/resolve.yml
+++ b/test/integration/targets/get_url/tasks/resolve.yml
@@ -1,23 +1,23 @@
 - name: create src file
   copy:
-    dest: '{{ files_dir }}/resolved.txt'
-    content: 'ptux'
+    dest: "{{ files_dir }}/resolved.txt"
+    content: "ptux"
 
 - name: download resolved.txt from another host
   get_url:
-    url: 'http://hostname/resolved.txt'
-    dest: '{{ remote_tmp_dir }}/resolved_host.txt'
+    url: "http://hostname/resolved.txt"
+    dest: "{{ remote_tmp_dir }}/resolved_host.txt"
     resolve:
-      hostname: '127.0.0.1:{{ http_port }}'
+      hostname: "127.0.0.1:{{ http_port }}"
   register: result_resolve_host
 
 - name: download resolved.txt from matched host and port
   get_url:
-    url: 'http://hostname:12345/resolved.txt'
-    dest: '{{ remote_tmp_dir }}/resolved_host_and_port.txt'
+    url: "http://hostname:12345/resolved.txt"
+    dest: "{{ remote_tmp_dir }}/resolved_host_and_port.txt"
     resolve:
-      'hostname': '127.0.0.1:666'
-      'hostname:12345': '127.0.0.1:{{ http_port }}'
+      "hostname": "127.0.0.1:666"
+      "hostname:12345": "127.0.0.1:{{ http_port }}"
   register: result_resolve_host_and_port
 
 - name: Assert that the file was downloaded from the resolved host

--- a/test/integration/targets/get_url/tasks/resolve.yml
+++ b/test/integration/targets/get_url/tasks/resolve.yml
@@ -1,0 +1,29 @@
+- name: create src file
+  copy:
+    dest: '{{ files_dir }}/resolved.txt'
+    content: 'ptux'
+
+- name: download resolved.txt from another host
+  get_url:
+    url: 'http://hostname/resolved.txt'
+    dest: '{{ remote_tmp_dir }}/resolved_host.txt'
+    resolve:
+      hostname: '127.0.0.1:{{ http_port }}'
+  register: result_resolve_host
+
+- name: download resolved.txt from matched host and port
+  get_url:
+    url: 'http://hostname:12345/resolved.txt'
+    dest: '{{ remote_tmp_dir }}/resolved_host_and_port.txt'
+    resolve:
+      'hostname': '127.0.0.1:666'
+      'hostname:12345': '127.0.0.1:{{ http_port }}'
+  register: result_resolve_host_and_port
+
+- name: Assert that the file was downloaded from the resolved host
+  assert:
+    that:
+      - result_resolve_host is changed
+      - result_resolve_host.url =='http://hostname/resolved.txt'
+      - result_resolve_host_and_port is changed
+      - result_resolve_host_and_port.url == 'http://hostname:12345/resolved.txt'

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -798,3 +798,6 @@
 
 - name: Test use_netrc.yml
   import_tasks: use_netrc.yml
+
+- name: Test resolve
+  import_tasks: resolve.yml

--- a/test/integration/targets/uri/tasks/resolve.yml
+++ b/test/integration/targets/uri/tasks/resolve.yml
@@ -1,0 +1,18 @@
+- name: create src file
+  copy:
+    dest: '{{ files_dir }}/uri-resolved.txt'
+    content: 'ptux'
+
+- name: Fetch file from
+  ansible.builtin.uri:
+    url: http://hostname/uri-resolved.txt
+    return_content: yes
+    resolve:
+      hostname: 127.0.0.1:{{ http_port }}
+  register: result_uri_resolved_host
+
+- name: Assert that the content was fetched from the resolved host
+  assert:
+    that:
+      - result_uri_resolved_host.content == 'ptux'
+      - result_uri_resolved_host.url =='http://hostname/uri-resolved.txt'

--- a/test/integration/targets/uri/tasks/resolve.yml
+++ b/test/integration/targets/uri/tasks/resolve.yml
@@ -1,7 +1,7 @@
 - name: create src file
   copy:
-    dest: '{{ files_dir }}/uri-resolved.txt'
-    content: 'ptux'
+    dest: "{{ files_dir }}/uri-resolved.txt"
+    content: "ptux"
 
 - name: Fetch file from
   ansible.builtin.uri:

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -69,7 +69,7 @@ def test_fetch_url(open_url_mock, fake_ansible_module):
                                           follow_redirects='urllib2', force=False, force_basic_auth='', headers=None,
                                           http_agent='ansible-httpget', last_mod_time=None, method=None, timeout=10, url_password='', url_username='',
                                           use_proxy=True, validate_certs=True, use_gssapi=False, unix_socket=None, ca_path=None, unredirected_headers=None,
-                                          decompress=True, ciphers=None, use_netrc=True)
+                                          decompress=True, ciphers=None, use_netrc=True, resolve=None)
 
 
 def test_fetch_url_params(open_url_mock, fake_ansible_module):
@@ -92,7 +92,7 @@ def test_fetch_url_params(open_url_mock, fake_ansible_module):
                                           follow_redirects='all', force=False, force_basic_auth=True, headers=None,
                                           http_agent='ansible-test', last_mod_time=None, method=None, timeout=10, url_password='passwd', url_username='user',
                                           use_proxy=True, validate_certs=False, use_gssapi=False, unix_socket=None, ca_path=None, unredirected_headers=None,
-                                          decompress=True, ciphers=None, use_netrc=True)
+                                          decompress=True, ciphers=None, use_netrc=True, resolve=None)
 
 
 def test_fetch_url_cookies(mocker, fake_ansible_module):

--- a/test/units/module_utils/urls/test_urls.py
+++ b/test/units/module_utils/urls/test_urls.py
@@ -107,3 +107,22 @@ def test_unix_socket_patch_httpconnection_connect(mocker):
     with urls.unix_socket_patch_httpconnection_connect():
         conn.connect()
     assert unix_conn.call_count == 1
+
+
+@pytest.mark.parametrize(
+    ('rules', 'address', 'expected'),
+    [
+        [{"host": "newhost"}, ('host', None), ('newhost', None)],
+        [{"host:123": "newhost"}, ('host', None), ('host', None)],
+        [{"host:123": "newhost"}, ('host', 123), ('newhost', 123)],
+        [{"host": "newhost:123"}, ('host', None), ('newhost', '123')],
+        [{"host": "newhost:123"}, ('host', 80), ('newhost', '123')],
+    ]
+)
+def test_address_mapper(rules, address, expected):
+    host, port = address
+    mapper = urls.AddressMapper(rules)
+
+    new_address = mapper.translate(host, port)
+
+    assert new_address == expected


### PR DESCRIPTION
##### SUMMARY
An option to explicitly set the address to be used by the `uri` and `get_url` modules when making a request.

Use cases: 
- to hit a particular endpoint in case a given domain resolves to multiple IP addresses (Fixes #70707).
- for use in smoke checks on the target host in case the HTTPS server uses SNI which prevents us from pointing to the target site by providing the "Host" HTTP header.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- ansible.builtin.uri
- ansible.builtin.get_url

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The implementation temporary overrides socket.getaddrinfo function while making a request. Although it looks a little hacky, this method has been around in the Python world for years.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: Provide custom address resolution rules.
  ansible.builtin.uri:
    url: https://example.org
    resolve:
      example.org: 127.0.0.1:8443
```

```yaml
- name: Provide custom address resolution rules.
  ansible.builtin.get_url:
    url: http://example.org/index.html
    resolve:
      example.org: localhost
```