### PR TITLE
Add test for symbolic to octal when others is omitted

### DIFF
--- a/test/units/module_utils/basic/test__symbolic_mode_to_octal.py
+++ b/test/units/module_utils/basic/test__symbolic_mode_to_octal.py
@@ -63,8 +63,8 @@ DATA = (  # Going from no permissions to setting all for user, group, and/or oth
     # Multiple permissions
     (0o040000, u'u=rw-x+X,g=r-x+X,o=r-x+X', 0o0755),
     (0o100000, u'u=rw-x+X,g=r-x+X,o=r-x+X', 0o0644),
-    (0o040777, u'u=rx,g=rx', 0o0550),
-    (0o100777, u'u=rx,g=rx', 0o0550),
+    (0o040777, u'ug=rx,o=', 0o0550),
+    (0o100777, u'ug=rx,o=', 0o0550),
 )
 
 UMASK_DATA = (

--- a/test/units/module_utils/basic/test__symbolic_mode_to_octal.py
+++ b/test/units/module_utils/basic/test__symbolic_mode_to_octal.py
@@ -63,8 +63,14 @@ DATA = (  # Going from no permissions to setting all for user, group, and/or oth
     # Multiple permissions
     (0o040000, u'u=rw-x+X,g=r-x+X,o=r-x+X', 0o0755),
     (0o100000, u'u=rw-x+X,g=r-x+X,o=r-x+X', 0o0644),
+    (0o040000, u'ug=rx,o=', 0o0550),
+    (0o100000, u'ug=rx,o=', 0o0550),
+    (0o040000, u'u=rx,g=r', 0o0540),
+    (0o100000, u'u=rx,g=r', 0o0540),
     (0o040777, u'ug=rx,o=', 0o0550),
     (0o100777, u'ug=rx,o=', 0o0550),
+    (0o040777, u'u=rx,g=r', 0o0547),
+    (0o100777, u'u=rx,g=r', 0o0547),
 )
 
 UMASK_DATA = (

--- a/test/units/module_utils/basic/test__symbolic_mode_to_octal.py
+++ b/test/units/module_utils/basic/test__symbolic_mode_to_octal.py
@@ -63,6 +63,8 @@ DATA = (  # Going from no permissions to setting all for user, group, and/or oth
     # Multiple permissions
     (0o040000, u'u=rw-x+X,g=r-x+X,o=r-x+X', 0o0755),
     (0o100000, u'u=rw-x+X,g=r-x+X,o=r-x+X', 0o0644),
+    (0o040777, u'u=rx,g=rx', 0o0550),
+    (0o100777, u'u=rx,g=rx', 0o0550),
 )
 
 UMASK_DATA = (


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In our project ansible-lint complained about implicit octal values:
```
yaml[octal-values]: Forbidden implicit octal value "0550"
```
Instead of converting these values to a string we wanted to increase the readability, by using symbolic notation.

However, the ansible documentation is not very clear on how to reproduce the `0550` permissions in symbolic notation. Should we give it all permissions `u=rx,g=rx,o=` or is `u=rx,g=rx` enough? Or could we even do `ug=rx`.

Add case when there should be no permissions for other. And specific permissions for owner and group.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
basic

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Only a new test to check if it works as expected, if it does, may update documentation to add such examples.
<!--- Paste verbatim command output below, e.g. before and after your change -->
