### PR TITLE
[stable-2.15] ansible-test - Fix traceback when mixing sources (#80801)

### DIFF
--- a/changelogs/fragments/ansible-test-source-detection.yml
+++ b/changelogs/fragments/ansible-test-source-detection.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test - Fix a traceback that occurs when attempting to test Ansible source using a different ansible-test.
+                   A clear error message is now given when this scenario occurs.

--- a/test/lib/ansible_test/_internal/data.py
+++ b/test/lib/ansible_test/_internal/data.py
@@ -10,7 +10,6 @@ from .util import (
     ApplicationError,
     import_plugins,
     is_subdir,
-    is_valid_identifier,
     ANSIBLE_LIB_ROOT,
     ANSIBLE_TEST_ROOT,
     ANSIBLE_SOURCE_ROOT,
@@ -219,12 +218,8 @@ class DataContext:
         elif 'ansible_collections' not in cwd.split(os.path.sep):
             blocks.append('No "ansible_collections" parent directory was found.')
 
-        if self.content.collection:
-            if not is_valid_identifier(self.content.collection.namespace):
-                blocks.append(f'The namespace "{self.content.collection.namespace}" is an invalid identifier or a reserved keyword.')
-
-            if not is_valid_identifier(self.content.collection.name):
-                blocks.append(f'The name "{self.content.collection.name}" is an invalid identifier or a reserved keyword.')
+        if isinstance(self.content.unsupported, list):
+            blocks.extend(self.content.unsupported)
 
         message = '\n'.join(blocks)
 

--- a/test/lib/ansible_test/_internal/provider/layout/__init__.py
+++ b/test/lib/ansible_test/_internal/provider/layout/__init__.py
@@ -95,7 +95,7 @@ class ContentLayout(Layout):
         unit_module_path: str,
         unit_module_utils_path: str,
         unit_messages: t.Optional[LayoutMessages],
-        unsupported: bool = False,
+        unsupported: bool | list[str] = False,
     ) -> None:
         super().__init__(root, paths)
 

--- a/test/lib/ansible_test/_internal/provider/layout/ansible.py
+++ b/test/lib/ansible_test/_internal/provider/layout/ansible.py
@@ -8,6 +8,11 @@ from . import (
     LayoutProvider,
 )
 
+from ...util import (
+    ANSIBLE_SOURCE_ROOT,
+    ANSIBLE_TEST_ROOT,
+)
+
 
 class AnsibleLayout(LayoutProvider):
     """Layout provider for Ansible source."""
@@ -26,6 +31,15 @@ class AnsibleLayout(LayoutProvider):
             module_utils='lib/ansible/module_utils',
         )
 
+        errors: list[str] = []
+
+        if root != ANSIBLE_SOURCE_ROOT:
+            errors.extend((
+                f'Cannot test "{root}" with ansible-test from "{ANSIBLE_TEST_ROOT}".',
+                '',
+                f'Did you intend to run "{root}/bin/ansible-test" instead?',
+            ))
+
         return ContentLayout(
             root,
             paths,
@@ -43,4 +57,5 @@ class AnsibleLayout(LayoutProvider):
             unit_module_path='test/units/modules',
             unit_module_utils_path='test/units/module_utils',
             unit_messages=None,
+            unsupported=errors,
         )

--- a/test/lib/ansible_test/_internal/provider/layout/collection.py
+++ b/test/lib/ansible_test/_internal/provider/layout/collection.py
@@ -53,6 +53,14 @@ class CollectionLayout(LayoutProvider):
         integration_targets_path = self.__check_integration_path(paths, integration_messages)
         self.__check_unit_path(paths, unit_messages)
 
+        errors: list[str] = []
+
+        if not is_valid_identifier(collection_namespace):
+            errors.append(f'The namespace "{collection_namespace}" is an invalid identifier or a reserved keyword.')
+
+        if not is_valid_identifier(collection_name):
+            errors.append(f'The name "{collection_name}" is an invalid identifier or a reserved keyword.')
+
         return ContentLayout(
             root,
             paths,
@@ -74,7 +82,7 @@ class CollectionLayout(LayoutProvider):
             unit_module_path='tests/unit/plugins/modules',
             unit_module_utils_path='tests/unit/plugins/module_utils',
             unit_messages=unit_messages,
-            unsupported=not (is_valid_identifier(collection_namespace) and is_valid_identifier(collection_name)),
+            unsupported=errors,
         )
 
     @staticmethod


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/80801

* ansible-test - Fix traceback when mixing sources
* ansible-test - Refactor layout error handling
 
(cherry picked from commit b16041f1a91bb74b7adbf2ad1f1af25603151cb3)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
