### PR TITLE
Removed unused `get_md5` parameter from stat module

### DIFF
--- a/changelogs/fragments/remove_md5.yml
+++ b/changelogs/fragments/remove_md5.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - stat - removed unused `get_md5` parameter.

--- a/lib/ansible/modules/stat.py
+++ b/lib/ansible/modules/stat.py
@@ -307,13 +307,6 @@ stat:
             type: str
             sample: ../foobar/21102015-1445431274-908472971
             version_added: 2.4
-        md5:
-            description: md5 hash of the file; this will be removed in Ansible 2.9 in
-                favor of the checksum return value
-            returned: success, path exists and user can read stats and path
-                supports hashing and md5 is supported
-            type: str
-            sample: f88fa92d8cf2eeecf4c0a50ccc96d0c0
         checksum:
             description: hash of the file
             returned: success, path exists, user can read stats, path supports
@@ -454,7 +447,6 @@ def main():
         argument_spec=dict(
             path=dict(type='path', required=True, aliases=['dest', 'name']),
             follow=dict(type='bool', default=False),
-            get_md5=dict(type='bool', default=False),
             get_checksum=dict(type='bool', default=True),
             get_mime=dict(type='bool', default=True, aliases=['mime', 'mime_type', 'mime-type']),
             get_attributes=dict(type='bool', default=True, aliases=['attr', 'attributes']),
@@ -472,10 +464,6 @@ def main():
     get_attr = module.params.get('get_attributes')
     get_checksum = module.params.get('get_checksum')
     checksum_algorithm = module.params.get('checksum_algorithm')
-
-    # NOTE: undocumented option since 2.9 to be removed at a later date if possible (3.0+)
-    # no real reason for keeping other than fear we may break older content.
-    get_md5 = module.params.get('get_md5')
 
     # main stat data
     try:
@@ -516,15 +504,6 @@ def main():
 
     # checksums
     if output.get('isreg') and output.get('readable'):
-
-        # NOTE: see above about get_md5
-        if get_md5:
-            # Will fail on FIPS-140 compliant systems
-            try:
-                output['md5'] = module.md5(b_path)
-            except ValueError:
-                output['md5'] = None
-
         if get_checksum:
             output['checksum'] = module.digest_from_file(b_path, checksum_algorithm)
 

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -49,10 +49,7 @@ lib/ansible/modules/package_facts.py validate-modules:doc-choices-do-not-match-s
 lib/ansible/modules/replace.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/service.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/service.py validate-modules:use-run-command-not-popen
-lib/ansible/modules/stat.py validate-modules:doc-default-does-not-match-spec  # get_md5 is undocumented
 lib/ansible/modules/stat.py validate-modules:parameter-invalid
-lib/ansible/modules/stat.py validate-modules:parameter-type-not-in-doc
-lib/ansible/modules/stat.py validate-modules:undocumented-parameter
 lib/ansible/modules/systemd_service.py validate-modules:parameter-invalid
 lib/ansible/modules/systemd_service.py validate-modules:return-syntax-error
 lib/ansible/modules/sysvinit.py validate-modules:return-syntax-error


### PR DESCRIPTION
##### SUMMARY
* removed unused, undocumented `get_md5` parameter from stat module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/remove_md5.yml
lib/ansible/modules/stat.py
test/sanity/ignore.txt
