### PR TITLE
Revert logic to use Popen.communicate

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1852,8 +1852,6 @@ class AnsibleModule(object):
             try:
                 selector.register(pipe, selectors.EVENT_READ)
             except KeyError:
-                # The pipe has already been registered, this would only happen
-                # on our last pass attempt to read the pipe
                 pass
 
     def run_command(self, args, check_rc=False, close_fds=True, executable=None, data=None, binary_data=False, path_prefix=None, cwd=None,

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1852,6 +1852,8 @@ class AnsibleModule(object):
             try:
                 selector.register(pipe, selectors.EVENT_READ)
             except KeyError:
+                # The pipe has already been registered, this would only happen
+                # on our last pass attempt to read the pipe
                 pass
 
     def run_command(self, args, check_rc=False, close_fds=True, executable=None, data=None, binary_data=False, path_prefix=None, cwd=None,

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1857,7 +1857,7 @@ class AnsibleModule(object):
         that of CPython subprocess.Popen.communicate, in that this method will
         stop reading once the spawned command has exited and stdout and stderr
         have been consumed, as opposed to waiting until stdout/stderr are
-        closed. This can be an important destinction, when taken into account
+        closed. This can be an important distinction, when taken into account
         that a forked or backgrounded process may hold stdout or stderr open
         for longer than the spawned command.
 
@@ -1914,7 +1914,7 @@ class AnsibleModule(object):
         :kw handle_exceptions: This flag indicates whether an exception will
             be handled inline and issue a failed_json or if the caller should
             handle it.
-        :kw bufsize: This corresponding argument to the open() function when
+        :kw bufsize: The buffer size passed to the open() function when
             creating the stdin/stdout/stderr pipe file objects.
         :returns: A 3-tuple of return code (integer), stdout (native string),
             and stderr (native string).  On python2, stdout and stderr are both

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2084,7 +2084,7 @@ class AnsibleModule(object):
 
                 # if we're checking for prompts, do it now, but only if stdout
                 # actually changed since the last loop
-                if stdout_changed and prompt_re and prompt_re.search(stdout) and not data:
+                if prompt_re and stdout_changed and prompt_re.search(stdout) and not data:
                     if encoding:
                         stdout = to_native(stdout, encoding=encoding, errors=errors)
                     return (257, stdout, "A prompt was encountered while running a command, but no input data was specified")

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1848,8 +1848,7 @@ class AnsibleModule(object):
 
     def run_command(self, args, check_rc=False, close_fds=True, executable=None, data=None, binary_data=False, path_prefix=None, cwd=None,
                     use_unsafe_shell=False, prompt_regex=None, environ_update=None, umask=None, encoding='utf-8', errors='surrogate_or_strict',
-                    expand_user_and_vars=True, pass_fds=None, before_communicate_callback=None, ignore_invalid_cwd=True, handle_exceptions=True,
-                    bufsize=-1):
+                    expand_user_and_vars=True, pass_fds=None, before_communicate_callback=None, ignore_invalid_cwd=True, handle_exceptions=True):
         '''
         Execute a command, returns rc, stdout, and stderr.
 
@@ -1914,8 +1913,6 @@ class AnsibleModule(object):
         :kw handle_exceptions: This flag indicates whether an exception will
             be handled inline and issue a failed_json or if the caller should
             handle it.
-        :kw bufsize: The buffer size passed to the open() function when
-            creating the stdin/stdout/stderr pipe file objects.
         :returns: A 3-tuple of return code (integer), stdout (native string),
             and stderr (native string).  On python2, stdout and stderr are both
             byte strings.  On python3, stdout and stderr are text strings converted
@@ -2013,7 +2010,6 @@ class AnsibleModule(object):
                 os.umask(umask)
 
         kwargs = dict(
-            bufsize=bufsize,
             executable=executable,
             shell=shell,
             close_fds=close_fds,

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1853,9 +1853,13 @@ class AnsibleModule(object):
         '''
         Execute a command, returns rc, stdout, and stderr.
 
-        The mechanism of this method for reading stdout and stderr differs from that of CPython
-        subprocess.Popen.communicate, in that this method will stop reading once the spawned command
-        has exited, as opposed to waiting until stdout/stderr are closed.
+        The mechanism of this method for reading stdout and stderr differs from
+        that of CPython subprocess.Popen.communicate, in that this method will
+        stop reading once the spawned command has exited and stdout and stderr
+        have been consumed, as opposed to waiting until stdout/stderr are
+        closed. This can be an important destinction, when taken into account
+        that a forked or backgrounded process may hold stdout or stderr open
+        for longer than the spawned command.
 
         :arg args: is the command to run
             * If args is a list, the command will be run with shell=False.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1846,6 +1846,14 @@ class AnsibleModule(object):
         if PY2 and sys.platform != 'win32':
             signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
+    @staticmethod
+    def _register_event_read_pipes(selector, cmd):
+        for pipe in (cmd.stdout, cmd.stderr):
+            try:
+                selector.register(pipe, selectors.EVENT_READ)
+            except KeyError:
+                pass
+
     def run_command(self, args, check_rc=False, close_fds=True, executable=None, data=None, binary_data=False, path_prefix=None, cwd=None,
                     use_unsafe_shell=False, prompt_regex=None, environ_update=None, umask=None, encoding='utf-8', errors='surrogate_or_strict',
                     expand_user_and_vars=True, pass_fds=None, before_communicate_callback=None, ignore_invalid_cwd=True, handle_exceptions=True,
@@ -2058,8 +2066,7 @@ class AnsibleModule(object):
                 if isinstance(data, text_type):
                     data = to_bytes(data)
 
-            selector.register(cmd.stdout, selectors.EVENT_READ)
-            selector.register(cmd.stderr, selectors.EVENT_READ)
+            self._register_event_read_pipes(selector, cmd)
 
             if os.name == 'posix':
                 fcntl.fcntl(cmd.stdout.fileno(), fcntl.F_SETFL, fcntl.fcntl(cmd.stdout.fileno(), fcntl.F_GETFL) | os.O_NONBLOCK)
@@ -2069,6 +2076,7 @@ class AnsibleModule(object):
                 cmd.stdin.write(data)
                 cmd.stdin.close()
 
+            process_exited = False
             while True:
                 # A timeout of 1 is both a little short and a little long.
                 # With None we could deadlock, with a lower value we would
@@ -2086,6 +2094,14 @@ class AnsibleModule(object):
                     elif key.fileobj == cmd.stderr:
                         stderr += b_chunk
 
+                if process_exited:
+                    # Below we've already determined there is nothing to read,
+                    # and that the process has exited from a previous loop
+                    # iteration. At this point, we've now attempted a final
+                    # read to attempt fetching anything else that may be
+                    # sitting in stdout/stderr
+                    break
+
                 # if we're checking for prompts, do it now, but only if stdout
                 # actually changed since the last loop
                 if prompt_re and stdout_changed and prompt_re.search(stdout) and not data:
@@ -2096,16 +2112,22 @@ class AnsibleModule(object):
                 # break out if no pipes are left to read or the pipes are completely read
                 # and the process is terminated
                 if (not events or not selector.get_map()) and cmd.poll() is not None:
-                    break
+                    # We'll go through the loop one more time to ensure nothing
+                    # is waiting to be read
+                    self._register_event_read_pipes(selector, cmd)
+                    process_exited = True
+                    continue
 
                 # No pipes are left to read but process is not yet terminated
                 # Only then it is safe to wait for the process to be finished
                 # NOTE: Actually cmd.poll() is always None here if no selectors are left
                 elif not selector.get_map() and cmd.poll() is None:
                     cmd.wait()
-                    # The process is terminated. Since no pipes to read from are
-                    # left, there is no need to call select() again.
-                    break
+                    # We'll go through the loop one more time to ensure nothing
+                    # is waiting to be read
+                    self._register_event_read_pipes(selector, cmd)
+                    process_exited = True
+                    continue
 
             cmd.stdout.close()
             cmd.stderr.close()

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2046,7 +2046,10 @@ class AnsibleModule(object):
             stdout = b''
             stderr = b''
 
-            # Mirror the CPython subprocess logic and preference for the selector to use
+            # Mirror the CPython subprocess logic and preference for the selector to use.
+            # poll/select have the advantage of not requiring any extra file
+            # descriptor, contrarily to epoll/kqueue (also, they require a single
+            # syscall).
             if hasattr(selectors, 'PollSelector'):
                 selector = selectors.PollSelector()
             else:

--- a/test/integration/targets/command_shell/scripts/yoink.sh
+++ b/test/integration/targets/command_shell/scripts/yoink.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sleep 10

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -583,3 +583,8 @@
     that:
       - shell_expand_failure is failed
       - "shell_expand_failure.msg == 'Unsupported parameters for (shell) module: expand_argument_vars'"
+
+- name: Run command that backgrounds, to ensure no hang
+  shell: '{{ role_path }}/scripts/yoink.sh &'
+  delegate_to: localhost
+  timeout: 5

--- a/test/units/module_utils/basic/test_run_command.py
+++ b/test/units/module_utils/basic/test_run_command.py
@@ -109,7 +109,7 @@ def mock_subprocess(mocker):
             super(MockSelector, self).close()
             self._file_objs = []
 
-    selectors.DefaultSelector = MockSelector
+    selectors.PollSelector = MockSelector
 
     subprocess = mocker.patch('ansible.module_utils.basic.subprocess')
     subprocess._output = {mocker.sentinel.stdout: SpecialBytesIO(b'', fh=mocker.sentinel.stdout),
@@ -147,7 +147,7 @@ class TestRunCommandArgs:
                               for (arg, cmd_lst, cmd_str), sh in product(ARGS_DATA, (True, False))),
                              indirect=['stdin'])
     def test_args(self, cmd, expected, shell, rc_am):
-        rc_am.run_command(cmd, use_unsafe_shell=shell, prompt_regex='i_dont_exist')
+        rc_am.run_command(cmd, use_unsafe_shell=shell)
         assert rc_am._subprocess.Popen.called
         args, kwargs = rc_am._subprocess.Popen.call_args
         assert args == (expected, )
@@ -163,17 +163,17 @@ class TestRunCommandArgs:
 class TestRunCommandCwd:
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
     def test_cwd(self, mocker, rc_am):
-        rc_am.run_command('/bin/ls', cwd='/new', prompt_regex='i_dont_exist')
+        rc_am.run_command('/bin/ls', cwd='/new')
         assert rc_am._subprocess.Popen.mock_calls[0][2]['cwd'] == b'/new'
 
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
     def test_cwd_relative_path(self, mocker, rc_am):
-        rc_am.run_command('/bin/ls', cwd='sub-dir', prompt_regex='i_dont_exist')
+        rc_am.run_command('/bin/ls', cwd='sub-dir')
         assert rc_am._subprocess.Popen.mock_calls[0][2]['cwd'] == b'/home/foo/sub-dir'
 
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
     def test_cwd_not_a_dir(self, mocker, rc_am):
-        rc_am.run_command('/bin/ls', cwd='/not-a-dir', prompt_regex='i_dont_exist')
+        rc_am.run_command('/bin/ls', cwd='/not-a-dir')
         assert rc_am._subprocess.Popen.mock_calls[0][2]['cwd'] == b'/not-a-dir'
 
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
@@ -212,14 +212,14 @@ class TestRunCommandRc:
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
     def test_check_rc_false(self, rc_am):
         rc_am._subprocess.Popen.return_value.returncode = 1
-        (rc, stdout, stderr) = rc_am.run_command('/bin/false', check_rc=False, prompt_regex='i_dont_exist')
+        (rc, stdout, stderr) = rc_am.run_command('/bin/false', check_rc=False)
         assert rc == 1
 
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
     def test_check_rc_true(self, rc_am):
         rc_am._subprocess.Popen.return_value.returncode = 1
         with pytest.raises(SystemExit):
-            rc_am.run_command('/bin/false', check_rc=True, prompt_regex='i_dont_exist')
+            rc_am.run_command('/bin/false', check_rc=True)
         assert rc_am.fail_json.called
         args, kwargs = rc_am.fail_json.call_args
         assert kwargs['rc'] == 1
@@ -228,7 +228,7 @@ class TestRunCommandRc:
 class TestRunCommandOutput:
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
     def test_text_stdin(self, rc_am):
-        (rc, stdout, stderr) = rc_am.run_command('/bin/foo', data='hello world', prompt_regex='i_dont_exist')
+        (rc, stdout, stderr) = rc_am.run_command('/bin/foo', data='hello world')
         assert rc_am._subprocess.Popen.return_value.stdin.getvalue() == b'hello world\n'
 
     @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
@@ -237,7 +237,7 @@ class TestRunCommandOutput:
                                      SpecialBytesIO(b'hello', fh=mocker.sentinel.stdout),
                                      mocker.sentinel.stderr:
                                      SpecialBytesIO(b'', fh=mocker.sentinel.stderr)}
-        (rc, stdout, stderr) = rc_am.run_command('/bin/cat hello.txt', prompt_regex='i_dont_exist')
+        (rc, stdout, stderr) = rc_am.run_command('/bin/cat hello.txt')
         assert rc == 0
         # module_utils function.  On py3 it returns text and py2 it returns
         # bytes because it's returning native strings
@@ -251,7 +251,7 @@ class TestRunCommandOutput:
                                      mocker.sentinel.stderr:
                                      SpecialBytesIO(u'لرئيسية'.encode('utf-8'),
                                                     fh=mocker.sentinel.stderr)}
-        (rc, stdout, stderr) = rc_am.run_command('/bin/something_ugly', prompt_regex='i_dont_exist')
+        (rc, stdout, stderr) = rc_am.run_command('/bin/something_ugly')
         assert rc == 0
         # module_utils function.  On py3 it returns text and py2 it returns
         # bytes because it's returning native strings


### PR DESCRIPTION
##### SUMMARY
Revert logic to use Popen.communicate. Fixes #80863

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ADDITIONAL INFORMATION

This PR:

1. Reverts change to prefer `Popen.communicate`
2. Adds a lot more comments to explain why things are the way they are
3. Aligns selectors logic more closely to `Popen.communicate`, such as a read size that was shown to reduce CPU usage, and use the subprocess preference for the selector implementation.
4. ~Adds a new `bufsize` argument Fixes #80379~

During investigation, I think we've determined that there are cases where a process on some platforms could exit, and stdout/stderr haven't been flushed, and _may_ have data still in them, not quite ready to read from.  I added a commit `loopty loop` that would go back through the loop 1 more time in an attempt to read the pipes after the command had exited, but this added another 2s onto the execution time, so I've reverted it. The specific report where I believe this was the case, had also indicated that increasing the buffer size handled this.

~A backport will need to remove the new `bufsize` argument.~