### PR TITLE
deb822_repository: use http-agent with open_url

### DIFF
--- a/changelogs/fragments/deb822_open_url.yml
+++ b/changelogs/fragments/deb822_open_url.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- deb822_repository - use http-agent for receiving content (https://github.com/ansible/ansible/issues/80809).

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1884,7 +1884,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
 
     username = module.params.get('url_username', '')
     password = module.params.get('url_password', '')
-    http_agent = module.params.get('http_agent', 'ansible-httpget')
+    http_agent = module.params.get('http_agent', get_user_agent())
     force_basic_auth = module.params.get('force_basic_auth', '')
 
     follow_redirects = module.params.get('follow_redirects', 'urllib2')
@@ -2068,3 +2068,8 @@ def fetch_file(module, url, data=None, headers=None, method=None,
     except Exception as e:
         module.fail_json(msg="Failure downloading %s, %s" % (url, to_native(e)))
     return fetch_temp_file.name
+
+
+def get_user_agent():
+    """Returns a user agent used by open_url"""
+    return u"ansible-httpget"

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -242,6 +242,7 @@ from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six import raise_from  # type: ignore[attr-defined]
 from ansible.module_utils.urls import generic_urlparse
 from ansible.module_utils.urls import open_url
+from ansible.module_utils.urls import get_user_agent
 from ansible.module_utils.urls import urlparse
 
 HAS_DEBIAN = True
@@ -325,7 +326,7 @@ def write_signed_by_key(module, v, slug):
     parts = generic_urlparse(urlparse(v))
     if parts.scheme:
         try:
-            r = open_url(v)
+            r = open_url(v, http_agent=get_user_agent())
         except Exception as exc:
             raise_from(RuntimeError(to_native(exc)), exc)
         else:

--- a/test/integration/targets/deb822_repository/tasks/test.yml
+++ b/test/integration/targets/deb822_repository/tasks/test.yml
@@ -9,7 +9,7 @@
       - main
       - restricted
   register: deb822_check_mode_1
-  check_mode: yes
+  check_mode: true
 
 - name: Create deb822 repo
   deb822_repository:
@@ -211,3 +211,19 @@
     that:
       - ansible_test_repo_remove is changed
       - ansible_test_repo_stats.results|map(attribute='stat')|selectattr('exists') == []
+
+- name: Check if http-agent works when using cloudflare repo - check_mode
+  deb822_repository:
+    name: cloudflared
+    types: deb
+    uris: https://pkg.cloudflare.com/cloudflared
+    suites: "bullseye"
+    components: main
+    signed_by: https://pkg.cloudflare.com/cloudflare-main.gpg
+    state: present
+  check_mode: true
+  register: ansible_test_http_agent
+
+- assert:
+    that:
+      - ansible_test_http_agent is changed


### PR DESCRIPTION
##### SUMMARY
* Use http-agent in open_url API while getting content from URL

Fixes: #80809

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/deb822_open_url.yml
lib/ansible/module_utils/urls.py
lib/ansible/modules/deb822_repository.py
test/integration/targets/deb822_repository/tasks/test.yml
