### PR TITLE
Update dnf5 module to handle API change for setting the download directory

### DIFF
--- a/changelogs/fragments/80887-dnf5-api-change.yml
+++ b/changelogs/fragments/80887-dnf5-api-change.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- dnf5 - Update dnf5 module to handle API change for setting the download directory
+  (https://github.com/ansible/ansible/issues/80887)

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -513,6 +513,8 @@ class Dnf5Module(YumDnf):
         conf.installroot = self.installroot
         conf.use_host_config = True  # needed for installroot
         conf.cacheonly = self.cacheonly
+        if self.download_dir:
+            conf.destdir = self.download_dir
 
         base.setup()
 
@@ -667,7 +669,7 @@ class Dnf5Module(YumDnf):
             if results:
                 msg = "Check mode: No changes made, but would have if not in check mode"
         else:
-            transaction.download(self.download_dir or "")
+            transaction.download()
             if not self.download_only:
                 if not self.disable_gpg_check and not transaction.check_gpg_signatures():
                     self.module.fail_json(


### PR DESCRIPTION
##### SUMMARY
Update dnf5 module to handle API change for setting the download directory. Fixes #80887

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/dnf5.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
