### PR TITLE
Handle backwards compat for dnf older than 5.0.12

### DIFF
--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -676,6 +676,7 @@ class Dnf5Module(YumDnf):
         else:
             download_args = []
             if libdnf5_version < (5, 0, 12):
+                # 5.0.12 moved specifying the download dir to conf.destdir
                 download_args.append(self.download_dir or "")
             transaction.download(*download_args)
             if not self.download_only:

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -669,7 +669,10 @@ class Dnf5Module(YumDnf):
             if results:
                 msg = "Check mode: No changes made, but would have if not in check mode"
         else:
-            transaction.download()
+            try:
+                transaction.download(self.download_dir or "")
+            except TypeError:
+                transaction.download()
             if not self.download_only:
                 if not self.disable_gpg_check and not transaction.check_gpg_signatures():
                     self.module.fail_json(


### PR DESCRIPTION
##### SUMMARY
Handle backwards compat for dnf older than 5.0.12

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/dnf5.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
