### PR TITLE
[bp/2.15] deb822_repository: use http-agent with open_url

### DIFF
--- a/changelogs/fragments/deb822_open_url.yml
+++ b/changelogs/fragments/deb822_open_url.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- deb822_repository - use http-agent for receiving content (https://github.com/ansible/ansible/issues/80809).

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -325,7 +325,7 @@ def write_signed_by_key(module, v, slug):
     parts = generic_urlparse(urlparse(v))
     if parts.scheme:
         try:
-            r = open_url(v)
+            r = open_url(v, http_agent='ansible-httpget')
         except Exception as exc:
             raise_from(RuntimeError(to_native(exc)), exc)
         else:

--- a/test/integration/targets/deb822_repository/tasks/test.yml
+++ b/test/integration/targets/deb822_repository/tasks/test.yml
@@ -9,7 +9,7 @@
       - main
       - restricted
   register: deb822_check_mode_1
-  check_mode: yes
+  check_mode: true
 
 - name: Create deb822 repo
   deb822_repository:
@@ -211,3 +211,19 @@
     that:
       - ansible_test_repo_remove is changed
       - ansible_test_repo_stats.results|map(attribute='stat')|selectattr('exists') == []
+
+- name: Check if http-agent works when using cloudflare repo - check_mode
+  deb822_repository:
+    name: cloudflared
+    types: deb
+    uris: https://pkg.cloudflare.com/cloudflared
+    suites: "bullseye"
+    components: main
+    signed_by: https://pkg.cloudflare.com/cloudflare-main.gpg
+    state: present
+  check_mode: true
+  register: ansible_test_http_agent
+
+- assert:
+    that:
+      - ansible_test_http_agent is changed


### PR DESCRIPTION
##### SUMMARY
* Use http-agent in open_url API while getting cloudflare content

Fixes: #80809

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/deb822_open_url.yml
lib/ansible/modules/deb822_repository.py
test/integration/targets/deb822_repository/tasks/test.yml