### PR TITLE
[stable-2.12] ansible-test - local change detection without --fork-point

### DIFF
--- a/changelogs/fragments/79734-ansible-test-change-detection.yml
+++ b/changelogs/fragments/79734-ansible-test-change-detection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ansible-test local change detection - use ``git merge-base <branch> HEAD`` instead of ``git merge-base --fork-point <branch>`` (https://github.com/ansible/ansible/pull/79734)."

--- a/test/lib/ansible_test/_internal/git.py
+++ b/test/lib/ansible_test/_internal/git.py
@@ -76,7 +76,7 @@ class Git:
 
     def get_branch_fork_point(self, branch):  # type: (str) -> str
         """Return a reference to the point at which the given branch was forked."""
-        cmd = ['merge-base', '--fork-point', branch]
+        cmd = ['merge-base', branch, 'HEAD']
         return self.run_git(cmd).strip()
 
     def is_valid_ref(self, ref):  # type: (str) -> bool


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/79734

(cherry picked from commit a5bb4c7deea0561a947702483355a90000f7980b)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
