### PR TITLE
Fix typo in plugin synopsis, split.yml

### DIFF
--- a/lib/ansible/plugins/filter/split.yml
+++ b/lib/ansible/plugins/filter/split.yml
@@ -3,7 +3,7 @@ DOCUMENTATION:
   version_added: "historical"
   short_description: split a string into a list
   description:
-    - Using Python's text object method C(split) we turn strings into lists via a 'spliting character'.
+    - Using Python's text object method C(split) we turn strings into lists via a 'splitting character'.
   notes:
     - This is a passthrough to Python's C(str.split).
   positional: _input, _split_string


### PR DESCRIPTION
typo in description

##### SUMMARY

minor correction to a typo in the filter plugin synopsis 

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

ansible.builtin.split

##### ADDITIONAL INFORMATION

direct link: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/split_filter.html#synopsis

