### PR TITLE
correct docs/comments for type casing in config manager

### DIFF
--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -63,7 +63,7 @@ def ensure_type(value, value_type, origin=None):
         :temppath: Same as 'tmppath'
         :tmp: Same as 'tmppath'
         :pathlist: Treat the value as a typical PATH string.  (On POSIX, this
-            means colon separated strings.)  Split the value and then expand
+            means comma separated strings.)  Split the value and then expand
             each part for environment variables and tildes.
         :pathspec: Treat the value as a PATH string. Expands any environment variables
             tildes's in the value.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change the "colon" in line 66 of manager.py to "comma"

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes Issue #80907

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
The ```ensure_type``` function in lib/ansible/config/manager.py