### PR TITLE
Added an example of mixed format argv in command module

### DIFF
--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -161,6 +161,17 @@ EXAMPLES = r'''
       - dbname with whitespace
     creates: /path/to/database
 
+- name: Run command using argv with mixed argument formats
+  ansible.builtin.command:
+    argv:
+      - /path/to/binary
+      - -v
+      - --debug
+      - --longopt
+      - value for longopt
+      - --other-longopt=value for other longopt
+      - positional
+
 - name: Safely use templated variable to run command. Always use the quote filter to avoid injection issues
   ansible.builtin.command: cat {{ myfile|quote }}
   register: myoutput


### PR DESCRIPTION
##### SUMMARY

Fixes: #80126

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/modules/command.py

