### PR TITLE
[stable-2.13] Bump azure-pipelines-test-container to v4.0.1 @ CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -31,7 +31,7 @@ variables:
   - name: fetchDepth
     value: 500
   - name: defaultContainer
-    value: quay.io/ansible/azure-pipelines-test-container:3.0.0
+    value: quay.io/ansible/azure-pipelines-test-container:4.0.1
 
 pool: Standard
 


### PR DESCRIPTION
This patch updates the test container used in CI to the new v4 that defaults to using Python 3.10 and is based on Ubuntu 22.04 Jammy[[1]].

[1]: https://github.com/ansible/azure-pipelines-test-container/pull/17

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
CI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Refs:
* https://github.com/ansible/ansible/issues/80424
* https://github.com/ansible/azure-pipelines-test-container/pull/17
* https://github.com/ansible/ansible/pull/80916