### PR TITLE
[2.15] Docs backport to update the changelogs for Ansible 8

### DIFF
--- a/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
+++ b/docs/docsite/rst/reference_appendices/release_and_maintenance.rst
@@ -81,15 +81,17 @@ This table links to the changelogs for each major Ansible release. These changel
 ==================================      ==============================================      =========================
 Ansible Community Package Release       Status                                              Core version dependency
 ==================================      ==============================================      =========================
-8.0.0                                   In development (unreleased)                         2.15
-`7.x Changelogs`_                       Current                                             2.14
-`6.x Changelogs`_                       Unmaintained (end of life) after Ansible 6.7.0      2.13
+9.0.0                                   In development (unreleased)                         2.16
+`8.x Changelogs`_                       Current                                             2.15
+`7.x Changelogs`_                       Unmaintained (end of life) after Ansible 7.7.0      2.14
+`6.x Changelogs`_                       Unmaintained (end of life)                          2.13
 `5.x Changelogs`_                       Unmaintained (end of life)                          2.12
 `4.x Changelogs`_                       Unmaintained (end of life)                          2.11
 `3.x Changelogs`_                       Unmaintained (end of life)                          2.10
 `2.10 Changelogs`_                      Unmaintained (end of life)                          2.10
 ==================================      ==============================================      =========================
 
+.. _8.x Changelogs: https://github.com/ansible-community/ansible-build-data/blob/main/8/CHANGELOG-v8.rst
 .. _7.x Changelogs: https://github.com/ansible-community/ansible-build-data/blob/main/7/CHANGELOG-v7.rst
 .. _6.x Changelogs: https://github.com/ansible-community/ansible-build-data/blob/main/6/CHANGELOG-v6.rst
 .. _5.x Changelogs: https://github.com/ansible-community/ansible-build-data/blob/main/5/CHANGELOG-v5.rst


### PR DESCRIPTION
##### SUMMARY
Backport for https://github.com/ansible/ansible/pull/80886

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/reference_appendices/release_and_maintenance.rst

##### ADDITIONAL INFORMATION
N/A
