### PR TITLE
Handle unreachable errors in fetch properly

### DIFF
--- a/changelogs/fragments/27816-fetch-unreachable.yml
+++ b/changelogs/fragments/27816-fetch-unreachable.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- fetch - Handle unreachable errors properly (https://github.com/ansible/ansible/issues/27816)

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -19,7 +19,7 @@ __metaclass__ = type
 
 import os
 import base64
-from ansible.errors import AnsibleError, AnsibleActionFail, AnsibleActionSkip
+from ansible.errors import AnsibleConnectionFailure, AnsibleError, AnsibleActionFail, AnsibleActionSkip
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.six import string_types
 from ansible.module_utils.parsing.convert_bool import boolean
@@ -75,6 +75,8 @@ class ActionModule(ActionBase):
                 # Follow symlinks because fetch always follows symlinks
                 try:
                     remote_stat = self._execute_remote_stat(source, all_vars=task_vars, follow=True)
+                except AnsibleConnectionFailure:
+                    raise
                 except AnsibleError as ae:
                     result['changed'] = False
                     result['file'] = source

--- a/test/integration/targets/fetch/roles/fetch_tests/tasks/failures.yml
+++ b/test/integration/targets/fetch/roles/fetch_tests/tasks/failures.yml
@@ -28,6 +28,15 @@
   register: failed_fetch_dest_dir
   ignore_errors: true
 
+- name: Test unreachable
+  fetch:
+    src: "{{ remote_tmp_dir }}/orig"
+    dest: "{{ output_dir }}"
+  register: unreachable_fetch
+  ignore_unreachable: true
+  vars:
+    ansible_user: wrong
+
 - name: Ensure fetch failed
   assert:
     that:
@@ -39,3 +48,4 @@
       - failed_fetch_no_access.msg is search('file is not readable')
       - failed_fetch_dest_dir is failed
       - failed_fetch_dest_dir.msg is search('dest is an existing directory')
+      - unreachable_fetch is unreachable


### PR DESCRIPTION
##### SUMMARY
Handle unreachable errors in fetch properly. Fixes #27816

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/fetch.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
