### PR TITLE
Sanity Fixes:

### DIFF
--- a/lib/ansible/modules/async_status.py
+++ b/lib/ansible/modules/async_status.py
@@ -124,8 +124,7 @@ def main():
     async_dir = module.params['_async_dir']
 
     # setup logging directory
-    logdir = os.path.expanduser(async_dir)
-    log_path = os.path.join(logdir, jid)
+    log_path = os.path.join(async_dir, jid)
 
     if not os.path.exists(log_path):
         module.fail_json(msg="could not find job", ansible_job_id=jid, started=1, finished=1)

--- a/lib/ansible/playbook/playbook_include.py
+++ b/lib/ansible/playbook/playbook_include.py
@@ -48,7 +48,7 @@ class PlaybookInclude(Base, Conditional, Taggable):
     def load(data, basedir, variable_manager=None, loader=None):
         return PlaybookInclude().load_data(ds=data, basedir=basedir, variable_manager=variable_manager, loader=loader)
 
-    def load_data(self, ds, basedir, variable_manager=None, loader=None):
+    def load_data(self, ds, variable_manager=None, loader=None, basedir=None):
         '''
         Overrides the base load_data(), as we're actually going to return a new
         Playbook() object rather than a PlaybookInclude object

--- a/lib/ansible/plugins/lookup/random_choice.py
+++ b/lib/ansible/plugins/lookup/random_choice.py
@@ -41,7 +41,7 @@ from ansible.plugins.lookup import LookupBase
 
 class LookupModule(LookupBase):
 
-    def run(self, terms, inject=None, **kwargs):
+    def run(self, terms, variables=None, **kwargs):
 
         ret = terms
         if terms:

--- a/lib/ansible/plugins/shell/cmd.py
+++ b/lib/ansible/plugins/shell/cmd.py
@@ -34,24 +34,24 @@ class ShellModule(PSShellModule):
     # Used by various parts of Ansible to do Windows specific changes
     _IS_WINDOWS = True
 
-    def quote(self, s):
+    def quote(self, cmd):
         # cmd does not support single quotes that the shlex_quote uses. We need to override the quoting behaviour to
         # better match cmd.exe.
         # https://blogs.msdn.microsoft.com/twistylittlepassagesallalike/2011/04/23/everyone-quotes-command-line-arguments-the-wrong-way/
 
         # Return an empty argument
-        if not s:
+        if not cmd:
             return '""'
 
-        if _find_unsafe(s) is None:
-            return s
+        if _find_unsafe(cmd) is None:
+            return cmd
 
         # Escape the metachars as we are quoting the string to stop cmd from interpreting that metachar. For example
         # 'file &whoami.exe' would result in 'file $(whoami.exe)' instead of the literal string
         # https://stackoverflow.com/questions/3411771/multiple-character-replace-with-python
         for c in '^()%!"<>&|':  # '^' must be the first char that we scan and replace
-            if c in s:
+            if c in cmd:
                 # I can't find any docs that explicitly say this but to escape ", it needs to be prefixed with \^.
-                s = s.replace(c, ("\\^" if c == '"' else "^") + c)
+                cmd = cmd.replace(c, ("\\^" if c == '"' else "^") + c)
 
-        return '^"' + s + '^"'
+        return '^"' + cmd + '^"'

--- a/lib/ansible/plugins/test/match.yml
+++ b/lib/ansible/plugins/test/match.yml
@@ -19,7 +19,7 @@ DOCUMENTATION:
       type: boolean
       default: False
     multiline:
-      description: Match against mulitple lines in string.
+      description: Match against multiple lines in string.
       type: boolean
       default: False
 EXAMPLES: |

--- a/lib/ansible/plugins/test/search.yml
+++ b/lib/ansible/plugins/test/search.yml
@@ -18,7 +18,7 @@ DOCUMENTATION:
       type: boolean
       default: False
     multiline:
-      description: Match against mulitple lines in string.
+      description: Match against multiple lines in string.
       type: boolean
       default: False
 

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -22,7 +22,6 @@ lib/ansible/keyword_desc.yml no-unwanted-files
 lib/ansible/modules/apt.py validate-modules:parameter-invalid
 lib/ansible/modules/apt_repository.py validate-modules:parameter-invalid
 lib/ansible/modules/assemble.py validate-modules:nonexistent-parameter-documented
-lib/ansible/modules/async_status.py use-argspec-type-path
 lib/ansible/modules/async_status.py validate-modules!skip
 lib/ansible/modules/async_wrapper.py ansible-doc!skip  # not an actual module
 lib/ansible/modules/async_wrapper.py pylint:ansible-bad-function # ignore, required
@@ -93,19 +92,15 @@ lib/ansible/module_utils/six/__init__.py no-dict-itervalues
 lib/ansible/module_utils/six/__init__.py pylint:self-assigning-variable
 lib/ansible/module_utils/six/__init__.py pylint:trailing-comma-tuple
 lib/ansible/module_utils/six/__init__.py replace-urlopen
-lib/ansible/module_utils/urls.py pylint:arguments-renamed
 lib/ansible/module_utils/urls.py replace-urlopen
 lib/ansible/parsing/yaml/objects.py pylint:arguments-renamed
 lib/ansible/playbook/collectionsearch.py required-and-default-attributes  # https://github.com/ansible/ansible/issues/61460
-lib/ansible/playbook/playbook_include.py pylint:arguments-renamed
 lib/ansible/playbook/role/include.py pylint:arguments-renamed
 lib/ansible/plugins/action/normal.py action-plugin-docs # default action plugin for modules without a dedicated action plugin
 lib/ansible/plugins/cache/base.py ansible-doc!skip  # not a plugin, but a stub for backwards compatibility
 lib/ansible/plugins/callback/__init__.py pylint:arguments-renamed
 lib/ansible/plugins/inventory/advanced_host_list.py pylint:arguments-renamed
 lib/ansible/plugins/inventory/host_list.py pylint:arguments-renamed
-lib/ansible/plugins/lookup/random_choice.py pylint:arguments-renamed
-lib/ansible/plugins/shell/cmd.py pylint:arguments-renamed
 lib/ansible/utils/collection_loader/_collection_finder.py pylint:deprecated-class
 lib/ansible/utils/collection_loader/_collection_meta.py pylint:deprecated-class
 test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/integration/targets/hello/files/bad.py pylint:ansible-bad-function # ignore, required for testing
@@ -157,11 +152,8 @@ test/lib/ansible_test/_data/requirements/sanity.pslint.ps1 pslint:PSCustomUseLit
 test/lib/ansible_test/_util/target/setup/ConfigureRemotingForAnsible.ps1 pslint:PSCustomUseLiteralPath
 test/lib/ansible_test/_util/target/setup/requirements.py replace-urlopen
 test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/module_utils/compat/ipaddress.py no-unicode-literals
-test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/utils.py pylint:use-a-generator
 test/support/network-integration/collections/ansible_collections/cisco/ios/plugins/cliconf/ios.py pylint:arguments-renamed
-test/support/network-integration/collections/ansible_collections/cisco/ios/plugins/modules/ios_config.py pep8:E501
 test/support/network-integration/collections/ansible_collections/vyos/vyos/plugins/cliconf/vyos.py pylint:arguments-renamed
-test/support/network-integration/collections/ansible_collections/vyos/vyos/plugins/modules/vyos_command.py pep8:E231
 test/support/windows-integration/collections/ansible_collections/ansible/windows/plugins/module_utils/WebRequest.psm1 pslint!skip
 test/support/windows-integration/collections/ansible_collections/ansible/windows/plugins/modules/win_uri.ps1 pslint!skip
 test/support/windows-integration/plugins/modules/async_status.ps1 pslint!skip

--- a/test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/utils.py
+++ b/test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/utils.py
@@ -593,7 +593,7 @@ def remove_empties(cfg_dict):
         elif (
             isinstance(val, list)
             and val
-            and all([isinstance(x, dict) for x in val])
+            and all(isinstance(x, dict) for x in val)
         ):
             child_val = [remove_empties(x) for x in val]
             if child_val:

--- a/test/support/network-integration/collections/ansible_collections/cisco/ios/plugins/modules/ios_config.py
+++ b/test/support/network-integration/collections/ansible_collections/cisco/ios/plugins/modules/ios_config.py
@@ -34,7 +34,8 @@ extends_documentation_fragment:
 - cisco.ios.ios
 notes:
 - Tested against IOS 15.6
-- Abbreviated commands are NOT idempotent, see L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
+- Abbreviated commands are NOT idempotent,
+  see L(Network FAQ,../network/user_guide/faq.html#why-do-the-config-modules-always-return-changed-true-with-abbreviated-commands).
 options:
   lines:
     description:

--- a/test/support/network-integration/collections/ansible_collections/vyos/vyos/plugins/modules/vyos_command.py
+++ b/test/support/network-integration/collections/ansible_collections/vyos/vyos/plugins/modules/vyos_command.py
@@ -213,7 +213,7 @@ def main():
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
     result.update(
-        {"stdout": responses, "stdout_lines": list(to_lines(responses)),}
+        {"stdout": responses, "stdout_lines": list(to_lines(responses)), }
     )
 
     module.exit_json(**result)


### PR DESCRIPTION
##### SUMMARY

* Typo fixes
* arguments-renamed
* pep8:E501
* pylint:use-a-generator
* pep8:E231
* use-argspec-type-path

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/module_utils/urls.py
lib/ansible/modules/async_status.py
lib/ansible/playbook/playbook_include.py
lib/ansible/plugins/lookup/random_choice.py
lib/ansible/plugins/shell/cmd.py
lib/ansible/plugins/test/match.yml
lib/ansible/plugins/test/search.yml
test/sanity/ignore.txt
test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/module_utils/network/common/utils.py
test/support/network-integration/collections/ansible_collections/cisco/ios/plugins/modules/ios_config.py
test/support/network-integration/collections/ansible_collections/vyos/vyos/plugins/modules/vyos_command.py

