### PR TITLE
Update user module documentation to include MacOS password change behavior

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -93,6 +93,8 @@ options:
             - To create an account with a locked/disabled password on Linux systems, set this to C('!') or C('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to C('*************').
             - B(OS X/macOS:) Enter the cleartext password as the value. Be sure to take relevant security precautions.
+            - On macOS, when using the `user` module, the password specified in the `password` option will always be set, regardless of whether the user account already exists or not.
+            - When the password is set or changed, the `user` module will always return `changed: true` for macOS systems.
         type: str
     state:
         description:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -93,8 +93,9 @@ options:
             - To create an account with a locked/disabled password on Linux systems, set this to C('!') or C('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to C('*************').
             - B(OS X/macOS:) Enter the cleartext password as the value. Be sure to take relevant security precautions.
-            - On macOS, when using the `user` module, the password specified in the `password` option will always be set, regardless of whether the user account already exists or not.
-            - When the password is set or changed, the `user` module will always return `changed: true` for macOS systems.
+            - On macOS, the password specified in the C(password) option will always be set, regardless of whether the user account already exists or not.
+            - When the password is passed as an argument, the C(user) module will always return changed to C(true) for macOS systems.
+              Since macOS no longer provides access to the hashed passwords directly.
         type: str
     state:
         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
[User Module] Include MacOS password change behaviour in documentation

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes https://github.com/ansible/ansible/issues/80884
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
User module 
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

This pull request adds information to the user module documentation regarding the behavior of password changes on MacOS. Specifically, it highlights the fact that MacOS will always enforce the setting of a password, regardless of the input provided. Even if an empty or null password is specified, MacOS will automatically assign a password and return a status of changed: true.

This addition is important to ensure that users are aware of the specific behavior when using the user module on MacOS, as it may differ from other operating systems.

This Pull request fixes the issue mentioned in #80884 

Please review and consider merging this pull request to provide comprehensive and accurate documentation for users working with the user module on MacOS.



```
