### PR TITLE
update ansible-galaxy testserver to use SSLContext.load_cert_chain

### DIFF
--- a/test/integration/targets/ansible-galaxy/files/testserver.py
+++ b/test/integration/targets/ansible-galaxy/files/testserver.py
@@ -3,21 +3,14 @@ __metaclass__ = type
 
 import sys
 import ssl
+import http.server
+import socketserver
 
 if __name__ == '__main__':
-    if sys.version_info[0] >= 3:
-        import http.server
-        import socketserver
-        Handler = http.server.SimpleHTTPRequestHandler
-        context = ssl.SSLContext()
-        context.load_cert_chain(certfile='./cert.pem', keyfile='./key.pem')
-        httpd = socketserver.TCPServer(("", 4443), Handler)
-        httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
-    else:
-        import BaseHTTPServer
-        import SimpleHTTPServer
-        Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
-        httpd = BaseHTTPServer.HTTPServer(("", 4443), Handler)
-        httpd.socket = ssl.wrap_socket(httpd.socket, certfile='./cert.pem', keyfile='./key.pem', server_side=True)
+    Handler = http.server.SimpleHTTPRequestHandler
+    context = ssl.SSLContext()
+    context.load_cert_chain(certfile='./cert.pem', keyfile='./key.pem')
+    httpd = socketserver.TCPServer(("", 4443), Handler)
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
 
     httpd.serve_forever()

--- a/test/integration/targets/ansible-galaxy/files/testserver.py
+++ b/test/integration/targets/ansible-galaxy/files/testserver.py
@@ -9,12 +9,15 @@ if __name__ == '__main__':
         import http.server
         import socketserver
         Handler = http.server.SimpleHTTPRequestHandler
+        context = ssl.SSLContext()
+        context.load_cert_chain(certfile='./cert.pem', keyfile='./key.pem')
         httpd = socketserver.TCPServer(("", 4443), Handler)
+        httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
     else:
         import BaseHTTPServer
         import SimpleHTTPServer
         Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
         httpd = BaseHTTPServer.HTTPServer(("", 4443), Handler)
+        httpd.socket = ssl.wrap_socket(httpd.socket, certfile='./cert.pem', keyfile='./key.pem', server_side=True)
 
-    httpd.socket = ssl.wrap_socket(httpd.socket, certfile='./cert.pem', keyfile='./key.pem', server_side=True)
     httpd.serve_forever()

--- a/test/integration/targets/ansible-galaxy/files/testserver.py
+++ b/test/integration/targets/ansible-galaxy/files/testserver.py
@@ -1,10 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
-import ssl
 import http.server
 import socketserver
+import ssl
 
 if __name__ == '__main__':
     Handler = http.server.SimpleHTTPRequestHandler


### PR DESCRIPTION
##### SUMMARY
Update another case of #80490 so the test will be compatible with Python 3.12.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
