### PR TITLE
Add simpleinit_msb fact for service_mgr

### DIFF
--- a/changelogs/fragments/service_facts_simpleinit_msb.yml
+++ b/changelogs/fragments/service_facts_simpleinit_msb.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Update ``ansible_service_mgr`` fact to include init system for SMGL OS family

--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -131,6 +131,8 @@ class ServiceMgrFactCollector(BaseFactCollector):
             service_mgr_name = 'smf'
         elif collected_facts.get('ansible_distribution') == 'OpenWrt':
             service_mgr_name = 'openwrt_init'
+        elif collected_facts.get('ansible_distribution') == 'SMGL':
+            service_mgr_name = 'simpleinit_msb'
         elif collected_facts.get('ansible_system') == 'Linux':
             # FIXME: mv is_systemd_managed
             if self.is_systemd_managed(module=module):


### PR DESCRIPTION
##### SUMMARY

This adds fact part from #19231 that has been backported recently in https://github.com/ansible-collections/community.general/pull/6618.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

`ansible_service_mgr` fact

##### ADDITIONAL INFORMATION

N/A