### PR TITLE
replace deprecated ast.value.s with ast.value.value

### DIFF
--- a/changelogs/fragments/80968-replace-deprecated-ast-attr.yml
+++ b/changelogs/fragments/80968-replace-deprecated-ast-attr.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix ``ast`` deprecation warnings for ``Str`` and ``value.s`` when using Python 3.12.

--- a/lib/ansible/parsing/plugin_docs.py
+++ b/lib/ansible/parsing/plugin_docs.py
@@ -151,10 +151,10 @@ def read_docstring_from_python_file(filename, verbose=True, ignore_errors=True):
                             if theid == 'EXAMPLES':
                                 # examples 'can' be yaml, but even if so, we dont want to parse as such here
                                 # as it can create undesired 'objects' that don't display well as docs.
-                                data[varkey] = to_text(child.value.s)
+                                data[varkey] = to_text(child.value.value)
                             else:
                                 # string should be yaml if already not a dict
-                                data[varkey] = AnsibleLoader(child.value.s, file_name=filename).get_single_data()
+                                data[varkey] = AnsibleLoader(child.value.value, file_name=filename).get_single_data()
 
                         display.debug('Documentation assigned: %s' % varkey)
 

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -26,7 +26,7 @@ from jinja2.compiler import generate
 from jinja2.exceptions import UndefinedError
 
 from ansible.errors import AnsibleError, AnsibleUndefinedVariable
-from ansible.module_utils.six import text_type
+from ansible.module_utils.six import text_type, string_types
 from ansible.module_utils.common.text.converters import to_native
 from ansible.playbook.attribute import FieldAttribute
 from ansible.template import Templar
@@ -144,7 +144,7 @@ class Conditional:
                         inside_call = True
                     elif isinstance(node, ast.Yield):
                         inside_yield = True
-                    elif isinstance(node, ast.Constant):
+                    elif isinstance(node, ast.Constant) and isinstance(node.value, string_types):
                         if disable_lookups:
                             if inside_call and node.value.startswith("__"):
                                 # calling things with a dunder is generally bad at this point...

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -146,7 +146,7 @@ class Conditional:
                         inside_yield = True
                     elif isinstance(node, ast.Str):
                         if disable_lookups:
-                            if inside_call and node.s.startswith("__"):
+                            if inside_call and node.value.startswith("__"):
                                 # calling things with a dunder is generally bad at this point...
                                 raise AnsibleError(
                                     "Invalid access found in the conditional: '%s'" % conditional
@@ -154,7 +154,7 @@ class Conditional:
                             elif inside_yield:
                                 # we're inside a yield, so recursively parse and traverse the AST
                                 # of the result to catch forbidden syntax from executing
-                                parsed = ast.parse(node.s, mode='exec')
+                                parsed = ast.parse(node.value, mode='exec')
                                 cnv = CleansingNodeVisitor()
                                 cnv.visit(parsed)
                     # iterate over all child nodes

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -26,7 +26,7 @@ from jinja2.compiler import generate
 from jinja2.exceptions import UndefinedError
 
 from ansible.errors import AnsibleError, AnsibleUndefinedVariable
-from ansible.module_utils.six import text_type, string_types
+from ansible.module_utils.six import text_type
 from ansible.module_utils.common.text.converters import to_native
 from ansible.playbook.attribute import FieldAttribute
 from ansible.template import Templar
@@ -144,7 +144,7 @@ class Conditional:
                         inside_call = True
                     elif isinstance(node, ast.Yield):
                         inside_yield = True
-                    elif isinstance(node, ast.Constant) and isinstance(node.value, string_types):
+                    elif isinstance(node, ast.Constant) and isinstance(node.value, text_type):
                         if disable_lookups:
                             if inside_call and node.value.startswith("__"):
                                 # calling things with a dunder is generally bad at this point...

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -144,7 +144,7 @@ class Conditional:
                         inside_call = True
                     elif isinstance(node, ast.Yield):
                         inside_yield = True
-                    elif isinstance(node, ast.Str):
+                    elif isinstance(node, ast.Constant):
                         if disable_lookups:
                             if inside_call and node.value.startswith("__"):
                                 # calling things with a dunder is generally bad at this point...

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -808,22 +808,22 @@ class ModuleValidator(Validator):
                         continue
 
                     if grandchild.id == 'DOCUMENTATION':
-                        docs['DOCUMENTATION']['value'] = child.value.s
+                        docs['DOCUMENTATION']['value'] = child.value.value
                         docs['DOCUMENTATION']['lineno'] = child.lineno
                         docs['DOCUMENTATION']['end_lineno'] = (
-                            child.lineno + len(child.value.s.splitlines())
+                            child.lineno + len(child.value.value.splitlines())
                         )
                     elif grandchild.id == 'EXAMPLES':
-                        docs['EXAMPLES']['value'] = child.value.s
+                        docs['EXAMPLES']['value'] = child.value.value
                         docs['EXAMPLES']['lineno'] = child.lineno
                         docs['EXAMPLES']['end_lineno'] = (
-                            child.lineno + len(child.value.s.splitlines())
+                            child.lineno + len(child.value.value.splitlines())
                         )
                     elif grandchild.id == 'RETURN':
-                        docs['RETURN']['value'] = child.value.s
+                        docs['RETURN']['value'] = child.value.value
                         docs['RETURN']['lineno'] = child.lineno
                         docs['RETURN']['end_lineno'] = (
-                            child.lineno + len(child.value.s.splitlines())
+                            child.lineno + len(child.value.value.splitlines())
                         )
 
         return docs

--- a/test/lib/ansible_test/_util/controller/sanity/yamllint/yamllinter.py
+++ b/test/lib/ansible_test/_util/controller/sanity/yamllint/yamllinter.py
@@ -181,15 +181,15 @@ class YamlChecker:
                 if doc_types and target.id not in doc_types:
                     continue
 
-                fmt_match = fmt_re.match(statement.value.s.lstrip())
+                fmt_match = fmt_re.match(statement.value.value.lstrip())
                 fmt = 'yaml'
                 if fmt_match:
                     fmt = fmt_match.group(1)
 
                 docs[target.id] = dict(
-                    yaml=statement.value.s,
+                    yaml=statement.value.value,
                     lineno=statement.lineno,
-                    end_lineno=statement.lineno + len(statement.value.s.splitlines()),
+                    end_lineno=statement.lineno + len(statement.value.value.splitlines()),
                     fmt=fmt.lower(),
                 )
 


### PR DESCRIPTION
##### SUMMARY
the s attribute is deprecated since Python 3.8 and [emits a warning in 3.12](https://github.com/python/cpython/commit/376137f6ec73e0800e49cec6100e401f6154b693) causing some test failures

also related: https://github.com/pytest-dev/pytest/issues/10977

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
