### PR TITLE
Fix remote_tmp tests so that they actually use the remote_tmp

### DIFF
--- a/test/integration/targets/remote_tmp/playbook.yml
+++ b/test/integration/targets/remote_tmp/playbook.yml
@@ -40,20 +40,28 @@
         name: ../setup_remote_tmp_dir
 
     - file:
-        state: touch
-        path: "{{ remote_tmp_dir }}/65393"
+        state: directory
+        path: "{{ remote_tmp_dir }}/remote_tmp"
 
-    - copy:
-        src: "{{ remote_tmp_dir }}/65393"
-        dest: "{{ remote_tmp_dir }}/65393.2"
-        remote_src: true
+    - vars:
+        # Isolate the remote_tmp used by these tests
+        ansible_remote_tmp: "{{ remote_tmp_dir }}/remote_tmp"
+      block:
+        - file:
+            state: touch
+            path: "{{ remote_tmp_dir }}/65393"
 
-    - find:
-        path: "~/.ansible/tmp"
-        use_regex: yes
-        patterns: 'AnsiballZ_.+\.py'
-        recurse: true
-      register: result
+        - copy:
+            src: "{{ remote_tmp_dir }}/65393"
+            dest: "{{ remote_tmp_dir }}/65393.2"
+            remote_src: true
+
+        - find:
+            path: "{{ remote_tmp_dir }}/remote_tmp"
+            use_regex: yes
+            patterns: 'AnsiballZ_.+\.py'
+            recurse: true
+          register: result
 
     - debug:
         var: result

--- a/test/integration/targets/remote_tmp/playbook.yml
+++ b/test/integration/targets/remote_tmp/playbook.yml
@@ -35,13 +35,12 @@
     # ensuring remote_tmp is cleaned up. Pipelining is enabled in the test
     # inventory
     ansible_pipelining: false
+    # Ensure that the remote_tmp_dir we create allows the unpriv connection user
+    # to create the remote_tmp
+    ansible_become: false
   tasks:
     - import_role:
         name: ../setup_remote_tmp_dir
-
-    - file:
-        state: directory
-        path: "{{ remote_tmp_dir }}/remote_tmp"
 
     - vars:
         # Isolate the remote_tmp used by these tests
@@ -57,7 +56,7 @@
             remote_src: true
 
         - find:
-            path: "{{ remote_tmp_dir }}/remote_tmp"
+            path: "{{ ansible_remote_tmp }}"
             use_regex: yes
             patterns: 'AnsiballZ_.+\.py'
             recurse: true

--- a/test/integration/targets/remote_tmp/playbook.yml
+++ b/test/integration/targets/remote_tmp/playbook.yml
@@ -30,6 +30,11 @@
 - name: Test tempdir is removed
   hosts: testhost
   gather_facts: false
+  vars:
+    # These tests cannot be run with pipelining as it defeats the purpose of
+    # ensuring remote_tmp is cleaned up. Pipelining is enabled in the test
+    # inventory
+    ansible_pipelining: false
   tasks:
     - import_role:
         name: ../setup_remote_tmp_dir
@@ -55,5 +60,6 @@
 
     - assert:
         that:
-          # Should find nothing since pipelining is used
-          - result.files|length == 0
+          # Should only be AnsiballZ_find.py because find is actively running
+          - result.files|length == 1
+          - result.files[0].path.endswith('/AnsiballZ_find.py')


### PR DESCRIPTION
##### SUMMARY
Fix remote_tmp tests so that they actually use the remote_tmp

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/integration/targets/remote_tmp/playbook.yml

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
