### PR TITLE
Fix Source Mage family mapping

### DIFF
--- a/changelogs/fragments/80985-fix-smgl-family-mapping.yml
+++ b/changelogs/fragments/80985-fix-smgl-family-mapping.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - distribution facts - fix Source Mage family mapping

--- a/docs/docsite/rst/playbook_guide/playbooks_conditionals.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_conditionals.rst
@@ -569,7 +569,7 @@ Possible values (sample, not complete list):
     HP-UX
     Mandrake
     RedHat
-    SGML
+    SMGL
     Slackware
     Solaris
     Suse

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -524,7 +524,7 @@ class Distribution(object):
                      'Solaris': ['Solaris', 'Nexenta', 'OmniOS', 'OpenIndiana', 'SmartOS'],
                      'Slackware': ['Slackware'],
                      'Altlinux': ['Altlinux'],
-                     'SGML': ['SGML'],
+                     'SMGL': ['SMGL'],
                      'Gentoo': ['Gentoo', 'Funtoo'],
                      'Alpine': ['Alpine'],
                      'AIX': ['AIX'],


### PR DESCRIPTION
##### SUMMARY

This fixes Source Mage family mapping (`SMGL` == `Source Mage GNU/Linux`) bug introduced in #23012.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

Distribution fact

##### ADDITIONAL INFORMATION

First introduced in #19671.