### PR TITLE
Emphasise `variable_start_string`/`variable_end_string` affects templated vars

### DIFF
--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -79,6 +79,17 @@ EXAMPLES = r'''
     group: wheel
     mode: u=rw,g=r,o=r
 
+- name: Template a file using different marker strings
+  ansible.builtin.template:
+    src: globals.yml.j2
+    dest: /etc/kolla/globals.yml
+    block_start_string: "<%"
+    block_end_string: "%>"
+    variable_start_string: "<<"
+    variable_end_string: ">>"
+  vars:
+    vip_address: "<< hostvars['controller-00']['ansible_host'] >>"
+
 - name: Copy a version of named.conf that is dependent on the OS. setype obtained by doing ls -Z /etc/named.conf on original file
   ansible.builtin.template:
     src: named.conf_{{ ansible_os_family }}.j2

--- a/lib/ansible/plugins/doc_fragments/template_common.py
+++ b/lib/ansible/plugins/doc_fragments/template_common.py
@@ -48,35 +48,41 @@ options:
   block_start_string:
     description:
     - The string marking the beginning of a block.
+    - This will affect evaluation of templated variables in the same step.
     type: str
     default: '{%'
     version_added: '2.4'
   block_end_string:
     description:
     - The string marking the end of a block.
+    - This will affect evaluation of templated variables in the same step.
     type: str
     default: '%}'
     version_added: '2.4'
   variable_start_string:
     description:
     - The string marking the beginning of a print statement.
+    - This will affect evaluation of templated variables in the same step.
     type: str
     default: '{{'
     version_added: '2.4'
   variable_end_string:
     description:
     - The string marking the end of a print statement.
+    - This will affect evaluation of templated variables in the same step.
     type: str
     default: '}}'
     version_added: '2.4'
   comment_start_string:
     description:
     - The string marking the beginning of a comment statement.
+    - This will affect evaluation of templated variables in the same step.
     type: str
     version_added: '2.12'
   comment_end_string:
     description:
     - The string marking the end of a comment statement.
+    - This will affect evaluation of templated variables in the same step.
     type: str
     version_added: '2.12'
   trim_blocks:

--- a/lib/ansible/plugins/doc_fragments/template_common.py
+++ b/lib/ansible/plugins/doc_fragments/template_common.py
@@ -77,12 +77,14 @@ options:
     description:
     - The string marking the beginning of a comment statement.
     - This will affect evaluation of templated variables in the same step.
+    default: '{#'
     type: str
     version_added: '2.12'
   comment_end_string:
     description:
     - The string marking the end of a comment statement.
     - This will affect evaluation of templated variables in the same step.
+    default: '#}'
     type: str
     version_added: '2.12'
   trim_blocks:

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -54,12 +54,14 @@ DOCUMENTATION = """
         description:
           - The string marking the beginning of a comment statement.
           - This will affect evaluation of templated variables in the same step.
+        default: '{#'
         version_added: '2.12'
         type: str
       comment_end_string:
         description:
           - The string marking the end of a comment statement.
           - This will affect evaluation of templated variables in the same step.
+        default: '#}'
         version_added: '2.12'
         type: str
     seealso:

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -18,26 +18,30 @@ DOCUMENTATION = """
       convert_data:
         type: bool
         description:
-            - Whether to convert YAML into data. If False, strings that are YAML will be left untouched.
-            - Mutually exclusive with the jinja2_native option.
+          - Whether to convert YAML into data. If False, strings that are YAML will be left untouched.
+          - Mutually exclusive with the jinja2_native option.
         default: true
       variable_start_string:
-        description: The string marking the beginning of a print statement.
+        description:
+          - The string marking the beginning of a print statement.
+          - This will affect evaluation of templated variables in the same step.
         default: '{{'
         version_added: '2.8'
         type: str
       variable_end_string:
-        description: The string marking the end of a print statement.
+        description:
+          - The string marking the end of a print statement.
+          - This will affect evaluation of templated variables in the same step.
         default: '}}'
         version_added: '2.8'
         type: str
       jinja2_native:
         description:
-            - Controls whether to use Jinja2 native types.
-            - It is off by default even if global jinja2_native is True.
-            - Has no effect if global jinja2_native is False.
-            - This offers more flexibility than the template module which does not use Jinja2 native types at all.
-            - Mutually exclusive with the convert_data option.
+          - Controls whether to use Jinja2 native types.
+          - It is off by default even if global jinja2_native is True.
+          - Has no effect if global jinja2_native is False.
+          - This offers more flexibility than the template module which does not use Jinja2 native types at all.
+          - Mutually exclusive with the convert_data option.
         default: False
         version_added: '2.11'
         type: bool
@@ -47,11 +51,15 @@ DOCUMENTATION = """
         version_added: '2.3'
         type: dict
       comment_start_string:
-        description: The string marking the beginning of a comment statement.
+        description:
+          - The string marking the beginning of a comment statement.
+          - This will affect evaluation of templated variables in the same step.
         version_added: '2.12'
         type: str
       comment_end_string:
-        description: The string marking the end of a comment statement.
+        description:
+          - The string marking the end of a comment statement.
+          - This will affect evaluation of templated variables in the same step.
         version_added: '2.12'
         type: str
     seealso:


### PR DESCRIPTION
##### SUMMARY

Fixes #80996

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- `lib/ansible/modules/template.py`

##### ADDITIONAL INFORMATION

None.
