### PR TITLE
Make sure that values that should be strings are actually strings

### DIFF
--- a/changelogs/fragments/81029-connection-types.yml
+++ b/changelogs/fragments/81029-connection-types.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "paramiko_ssh, psrp, and ssh connection plugins - ensure that all values for options that should be strings are actually converted to strings (https://github.com/ansible/ansible/pull/81029)."

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -22,6 +22,7 @@ DOCUMENTATION = """
         description:
             - Address of the remote target
         default: inventory_hostname
+        type: string
         vars:
             - name: inventory_hostname
             - name: ansible_host
@@ -52,6 +53,7 @@ DOCUMENTATION = """
         description:
             - User to login/authenticate as
             - Can be set from the CLI via the C(--user) or C(-u) options.
+        type: string
         vars:
             - name: ansible_user
             - name: ansible_ssh_user
@@ -72,6 +74,7 @@ DOCUMENTATION = """
         description:
           - Secret used to either login the ssh server or as a passphrase for ssh keys that require it
           - Can be set from the CLI via the C(--ask-pass) option.
+        type: string
         vars:
             - name: ansible_password
             - name: ansible_ssh_pass
@@ -111,6 +114,7 @@ DOCUMENTATION = """
         description:
             - Proxy information for running the connection via a jumphost
             - Also this plugin will scan 'ssh_args', 'ssh_extra_args' and 'ssh_common_args' from the 'ssh' plugin settings for proxy information if set.
+        type: string
         env: [{name: ANSIBLE_PARAMIKO_PROXY_COMMAND}]
         ini:
           - {key: proxy_command, section: paramiko_connection}
@@ -120,6 +124,7 @@ DOCUMENTATION = """
       ssh_args:
           description: Only used in parsing ProxyCommand for use in this plugin.
           default: ''
+          type: string
           ini:
               - section: 'ssh_connection'
                 key: 'ssh_args'
@@ -134,6 +139,7 @@ DOCUMENTATION = """
               alternatives: proxy_command
       ssh_common_args:
           description: Only used in parsing ProxyCommand for use in this plugin.
+          type: string
           ini:
               - section: 'ssh_connection'
                 key: 'ssh_common_args'
@@ -152,6 +158,7 @@ DOCUMENTATION = """
               alternatives: proxy_command
       ssh_extra_args:
           description: Only used in parsing ProxyCommand for use in this plugin.
+          type: string
           vars:
               - name: ansible_ssh_extra_args
           env:
@@ -259,6 +266,7 @@ DOCUMENTATION = """
       private_key_file:
           description:
               - Path to private key file to use for authentication.
+          type: string
           ini:
             - section: defaults
               key: private_key_file

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -188,7 +188,7 @@ options:
     vars:
     - name: ansible_psrp_ignore_proxy
     type: bool
-    default: 'no'
+    default: false
 
   # auth options
   certificate_key_pem:
@@ -221,7 +221,7 @@ options:
     - Disables the use of TLSv1.2 on the CredSSP authentication channel.
     - This should not be set to C(yes) unless dealing with a host that does not
       have TLSv1.2.
-    default: no
+    default: false
     type: bool
     vars:
     - name: ansible_psrp_credssp_disable_tlsv1_2
@@ -262,7 +262,7 @@ options:
     - CBT is used to provide extra protection against Man in the Middle C(MitM)
       attacks by binding the outer transport channel to the auth channel.
     - CBT is not used when using just C(HTTP), only C(HTTPS).
-    default: yes
+    default: true
     type: bool
     vars:
     - name: ansible_psrp_negotiate_send_cbt

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -28,6 +28,7 @@ DOCUMENTATION = '''
       host:
           description: Hostname/IP to connect to.
           default: inventory_hostname
+          type: string
           vars:
                - name: inventory_hostname
                - name: ansible_host
@@ -55,6 +56,7 @@ DOCUMENTATION = '''
                 version_added: '2.5'
       password:
           description: Authentication password for the C(remote_user). Can be supplied as CLI option.
+          type: string
           vars:
               - name: ansible_password
               - name: ansible_ssh_pass
@@ -64,6 +66,7 @@ DOCUMENTATION = '''
               - Password prompt that sshpass should search for. Supported by sshpass 1.06 and up.
               - Defaults to C(Enter PIN for) when pkcs11_provider is set.
           default: ''
+          type: string
           ini:
               - section: 'ssh_connection'
                 key: 'sshpass_prompt'
@@ -75,6 +78,7 @@ DOCUMENTATION = '''
       ssh_args:
           description: Arguments to pass to all SSH CLI tools.
           default: '-C -o ControlMaster=auto -o ControlPersist=60s'
+          type: string
           ini:
               - section: 'ssh_connection'
                 key: 'ssh_args'
@@ -85,6 +89,7 @@ DOCUMENTATION = '''
                 version_added: '2.7'
       ssh_common_args:
           description: Common extra args for all SSH CLI tools.
+          type: string
           ini:
               - section: 'ssh_connection'
                 key: 'ssh_common_args'
@@ -103,6 +108,7 @@ DOCUMENTATION = '''
             - This defines the location of the SSH binary. It defaults to C(ssh) which will use the first SSH binary available in $PATH.
             - This option is usually not required, it might be useful when access to system SSH is restricted,
               or when using SSH wrappers to connect to remote hosts.
+          type: string
           env: [{name: ANSIBLE_SSH_EXECUTABLE}]
           ini:
           - {key: ssh_executable, section: ssh_connection}
@@ -115,6 +121,7 @@ DOCUMENTATION = '''
           default: sftp
           description:
             - This defines the location of the sftp binary. It defaults to C(sftp) which will use the first binary available in $PATH.
+          type: string
           env: [{name: ANSIBLE_SFTP_EXECUTABLE}]
           ini:
           - {key: sftp_executable, section: ssh_connection}
@@ -126,6 +133,7 @@ DOCUMENTATION = '''
           default: scp
           description:
             - This defines the location of the scp binary. It defaults to C(scp) which will use the first binary available in $PATH.
+          type: string
           env: [{name: ANSIBLE_SCP_EXECUTABLE}]
           ini:
           - {key: scp_executable, section: ssh_connection}
@@ -135,6 +143,7 @@ DOCUMENTATION = '''
                 version_added: '2.7'
       scp_extra_args:
           description: Extra exclusive to the C(scp) CLI
+          type: string
           vars:
               - name: ansible_scp_extra_args
           env:
@@ -149,6 +158,7 @@ DOCUMENTATION = '''
           default: ''
       sftp_extra_args:
           description: Extra exclusive to the C(sftp) CLI
+          type: string
           vars:
               - name: ansible_sftp_extra_args
           env:
@@ -163,6 +173,7 @@ DOCUMENTATION = '''
           default: ''
       ssh_extra_args:
           description: Extra exclusive to the SSH CLI.
+          type: string
           vars:
               - name: ansible_ssh_extra_args
           env:
@@ -209,6 +220,7 @@ DOCUMENTATION = '''
           description:
               - User name with which to login to the remote server, normally set by the remote_user keyword.
               - If no user is supplied, Ansible will let the SSH client binary choose the user as it normally.
+          type: string
           ini:
             - section: defaults
               key: remote_user
@@ -239,6 +251,7 @@ DOCUMENTATION = '''
       private_key_file:
           description:
               - Path to private key file to use for authentication.
+          type: string
           ini:
             - section: defaults
               key: private_key_file
@@ -257,6 +270,7 @@ DOCUMENTATION = '''
           - Since 2.3, if null (default), ansible will generate a unique hash. Use ``%(directory)s`` to indicate where to use the control dir path setting.
           - Before 2.3 it defaulted to ``control_path=%(directory)s/ansible-ssh-%%h-%%p-%%r``.
           - Be aware that this setting is ignored if C(-o ControlPath) is set in ssh args.
+        type: string
         env:
           - name: ANSIBLE_SSH_CONTROL_PATH
         ini:
@@ -270,6 +284,7 @@ DOCUMENTATION = '''
         description:
           - This sets the directory to use for ssh control path if the control path setting is null.
           - Also, provides the ``%(directory)s`` variable for the control path setting.
+        type: string
         env:
           - name: ANSIBLE_SSH_CONTROL_PATH_DIR
         ini:
@@ -279,7 +294,7 @@ DOCUMENTATION = '''
           - name: ansible_control_path_dir
             version_added: '2.7'
       sftp_batch_mode:
-        default: 'yes'
+        default: true
         description: 'TODO: write it'
         env: [{name: ANSIBLE_SFTP_BATCH_MODE}]
         ini:
@@ -295,6 +310,7 @@ DOCUMENTATION = '''
             - For OpenSSH >=9.0 you must add an additional option to enable scp (scp_extra_args="-O")
             - Using 'piped' creates an ssh pipe with C(dd) on either side to copy the data
         choices: ['sftp', 'scp', 'piped', 'smart']
+        type: string
         env: [{name: ANSIBLE_SSH_TRANSFER_METHOD}]
         ini:
             - {key: transfer_method, section: ssh_connection}
@@ -321,7 +337,7 @@ DOCUMENTATION = '''
             version_added: '2.7'
       use_tty:
         version_added: '2.5'
-        default: 'yes'
+        default: true
         description: add -tt to ssh commands to force tty allocation.
         env: [{name: ANSIBLE_SSH_USETTY}]
         ini:
@@ -354,6 +370,7 @@ DOCUMENTATION = '''
       pkcs11_provider:
         version_added: '2.12'
         default: ""
+        type: string
         description:
           - "PKCS11 SmartCard provider such as opensc, example: /usr/local/lib/opensc-pkcs11.so"
           - Requires sshpass version 1.06+, sshpass must support the -P option.


### PR DESCRIPTION
##### SUMMARY
The plugin config manager doesn't use `string` as a default for `type` (as opposed to the module argument spec). Therefore if there is no explicit `type: string`, values are not automatically converted to strings.

This caused a problem with the community.routeros collection when some users tried to their routers whose password looked like an integer and was specified in the inventory - the password ended up being parsed as an integer, and was passed on to libssh and paramiko as an integer. The ansible.netcommon.libssh connetion plugin and the paramiko connection plugin used (might be ansible.builtin.paramiko_ssh, I'm not sure sure) didn't convert the passwords to strings either and just passed them on - which resulted in strange errors, which unfortunately came without a stack trace (due to network_cli passing the errors on via JSON RPC without a stack trace).

In any case, adding `type: string` to the `password` field of ansible.netcommon.libssh fixed the problem for my local reproducer (I didn't manage to get paramiko working so I cannot reproduce it with paramiko), but then I also added `type: string` to all other fields that should be strings (the result is https://github.com/ansible-collections/ansible.netcommon/pull/549). Now some connetion plugins in ansible-core have the same problem, they do not use `type: string` for options that should be strings.

This PR adds `type: string` to all options in connection plugins that are missing them (and cleans up some `yes`/`no` values I found while looking for missing `type`s).

Ref: https://github.com/ansible-collections/community.routeros/issues/175

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connection/paramiko_ssh.py
lib/ansible/plugins/connection/psrp.py
lib/ansible/plugins/connection/ssh.py
