### PR TITLE
jinja in tags fix

### DIFF
--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -363,18 +363,18 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
         except KeyError:
             pass
 
-        if attr=='tags':
-            all_vars=self._variable_manager.get_vars(play=self.play,task=self)
-            templar=Templar(loader=self._loader,variables=all_vars)
+        if attr == 'tags':
+            all_vars = self._variable_manager.get_vars(play=self.play, task=self)
+            templar = Templar(loader=self._loader, variables=all_vars)
             value = templar.template(value)
             _temp_tags = set()
-            if isinstance(value,list):
+            if isinstance(value, list):
                 for tag in value:
                     if isinstance(tag, list):
                         _temp_tags.update(tag)
                     else:
                         _temp_tags.add(tag)
-                value=list(_temp_tags)
+                value = list(_temp_tags)
 
         return value
 

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -31,6 +31,7 @@ from ansible.playbook.notifiable import Notifiable
 from ansible.playbook.role import Role
 from ansible.playbook.taggable import Taggable
 from ansible.utils.sentinel import Sentinel
+from ansible.template import Templar
 
 
 class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatable):
@@ -361,6 +362,19 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
                     pass
         except KeyError:
             pass
+
+        if attr=='tags':
+            all_vars=self._variable_manager.get_vars(play=self.play,task=self)
+            templar=Templar(loader=self._loader,variables=all_vars)
+            value = templar.template(value)
+            _temp_tags = set()
+            if isinstance(value,list):
+                for tag in value:
+                    if isinstance(tag, list):
+                        _temp_tags.update(tag)
+                    else:
+                        _temp_tags.add(tag)
+                value=list(_temp_tags)
 
         return value
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -495,18 +495,18 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
         except KeyError:
             pass
 
-        if attr=='tags':
-            all_vars=self._variable_manager.get_vars(play=self.play,task=self)
-            templar=Templar(loader=self._loader,variables=all_vars)
+        if attr == 'tags':
+            all_vars = self._variable_manager.get_vars(play=self.play, task=self)
+            templar = Templar(loader=self._loader, variables=all_vars)
             value = templar.template(value)
             _temp_tags = set()
-            if isinstance(value,list):
+            if isinstance(value, list):
                 for tag in value:
                     if isinstance(tag, list):
                         _temp_tags.update(tag)
                     else:
                         _temp_tags.add(tag)
-                value=list(_temp_tags)
+                value = list(_temp_tags)
 
         return value
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -39,6 +39,7 @@ from ansible.playbook.taggable import Taggable
 from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.display import Display
 from ansible.utils.sentinel import Sentinel
+from ansible.template import Templar
 
 __all__ = ['Task']
 
@@ -493,6 +494,19 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
                         value = parent_value
         except KeyError:
             pass
+
+        if attr=='tags':
+            all_vars=self._variable_manager.get_vars(play=self.play,task=self)
+            templar=Templar(loader=self._loader,variables=all_vars)
+            value = templar.template(value)
+            _temp_tags = set()
+            if isinstance(value,list):
+                for tag in value:
+                    if isinstance(tag, list):
+                        _temp_tags.update(tag)
+                    else:
+                        _temp_tags.add(tag)
+                value=list(_temp_tags)
 
         return value
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The ansible program is currently using a recursive getter in the context of tags. This caused an issue when someone tried to use jinja list templates in `include_tasks` apply parameter.  The function `evaluate_tags` can not set the new evaluated tags at the parents where the tags are inherited from which is causing the jinja template to stay in the tags parameter and get resolved again later in the pipeline.
The issue is fixed when the jinja template resolve happens at the end of the getter instead of when the `evaluate_tags` function is called.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- `block.py`
- `task.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The following task generates an error "list of (class string or class int) is expected as tags but got class list.
This error indicates the jinja template gets evaulated but not unpacked.
```- name: "include generic task"
  include_tasks:
    file: generic.yml
    apply:
      tags: "{{ cfg }}"
  vars:
    cfg:
      - tagA
      - tagB
  tags:
    - always
 ```

After the getter fix the above code runs fine.
