### PR TITLE
define code owners to support branch-protection rules on docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/docs/ @ansible/ansible-release-managers
+/examples/ @ansible/ansible-release-managers
+/hacking/ @ansible/ansible-release-managers


### PR DESCRIPTION
##### SUMMARY
* during interim docs/ (and related dirs) split to separate repo, prevent merges that might require a rebase of the target repo


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

