### PR TITLE
Add "Introduction to Ansible" content to getting started

### DIFF
--- a/docs/docsite/rst/2.10_index.rst
+++ b/docs/docsite/rst/2.10_index.rst
@@ -3,22 +3,22 @@
 Ansible Documentation
 =====================
 
-About Ansible
-`````````````
+.. About Ansible
+.. `````````````
 
-Ansible is an IT automation tool.  It can configure systems, deploy software, and orchestrate more advanced IT tasks such as continuous deployments or zero downtime rolling updates.
+.. Ansible is an IT automation tool.  It can configure systems, deploy software, and orchestrate more advanced IT tasks such as continuous deployments or zero downtime rolling updates.
 
-Ansible's main goals are simplicity and ease-of-use. It also has a strong focus on security and reliability, featuring a minimum of moving parts, usage of OpenSSH for transport (with other transports and pull modes as alternatives), and a language that is designed around auditability by humans--even those not familiar with the program.
+.. Ansible's main goals are simplicity and ease-of-use. It also has a strong focus on security and reliability, featuring a minimum of moving parts, usage of OpenSSH for transport (with other transports and pull modes as alternatives), and a language that is designed around auditability by humans--even those not familiar with the program.
 
-We believe simplicity is relevant to all sizes of environments, so we design for busy users of all types: developers, sysadmins, release engineers, IT managers, and everyone in between. Ansible is appropriate for managing all environments, from small setups with a handful of instances to enterprise environments with many thousands of instances.
+.. We believe simplicity is relevant to all sizes of environments, so we design for busy users of all types: developers, sysadmins, release engineers, IT managers, and everyone in between. Ansible is appropriate for managing all environments, from small setups with a handful of instances to enterprise environments with many thousands of instances.
 
-You can learn more at `AnsibleFest <https://www.ansible.com/ansiblefest>`_, the annual event for all Ansible contributors, users, and customers hosted by Red Hat. AnsibleFest is the place to connect with others, learn new skills, and find a new friend to automate with.
+.. You can learn more at `AnsibleFest <https://www.ansible.com/ansiblefest>`_, the annual event for all Ansible contributors, users, and customers hosted by Red Hat. AnsibleFest is the place to connect with others, learn new skills, and find a new friend to automate with.
 
-Ansible manages machines in an agent-less manner. There is never a question of how to upgrade remote daemons or the problem of not being able to manage systems because daemons are uninstalled.  Because OpenSSH is one of the most peer-reviewed open source components, security exposure is greatly reduced. Ansible is decentralized--it relies on your existing OS credentials to control access to remote machines. If needed, Ansible can easily connect with Kerberos, LDAP, and other centralized authentication management systems.
+.. Ansible manages machines in an agent-less manner. There is never a question of how to upgrade remote daemons or the problem of not being able to manage systems because daemons are uninstalled.  Because OpenSSH is one of the most peer-reviewed open source components, security exposure is greatly reduced. Ansible is decentralized--it relies on your existing OS credentials to control access to remote machines. If needed, Ansible can easily connect with Kerberos, LDAP, and other centralized authentication management systems.
 
-This documentation covers the version of Ansible noted in the upper left corner of this page. We maintain multiple versions of Ansible and of the documentation, so please be sure you are using the version of the documentation that covers the version of Ansible you're using. For recent features, we note the version of Ansible where the feature was added.
+.. This documentation covers the version of Ansible noted in the upper left corner of this page. We maintain multiple versions of Ansible and of the documentation, so please be sure you are using the version of the documentation that covers the version of Ansible you're using. For recent features, we note the version of Ansible where the feature was added.
 
-Ansible releases a new major release approximately twice a year. The core application evolves somewhat conservatively, valuing simplicity in language design and setup. Contributors develop and change modules and plugins, hosted in collections since version 2.10, much more quickly.
+.. Ansible releases a new major release approximately twice a year. The core application evolves somewhat conservatively, valuing simplicity in language design and setup. Contributors develop and change modules and plugins, hosted in collections since version 2.10, much more quickly.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/docsite/rst/ansible_index.rst
+++ b/docs/docsite/rst/ansible_index.rst
@@ -5,25 +5,6 @@
 Ansible Documentation
 =====================
 
-About Ansible
-`````````````
-
-Ansible is an IT automation tool.  It can configure systems, deploy software, and orchestrate more advanced IT tasks such as continuous deployments or zero downtime rolling updates.
-
-Ansible's main goals are simplicity and ease-of-use. It also has a strong focus on security and reliability, featuring a minimum of moving parts, usage of OpenSSH for transport (with other transports and pull modes as alternatives), and a language that is designed around auditability by humans--even those not familiar with the program.
-
-We believe simplicity is relevant to all sizes of environments, so we design for busy users of all types: developers, sysadmins, release engineers, IT managers, and everyone in between. Ansible is appropriate for managing all environments, from small setups with a handful of instances to enterprise environments with many thousands of instances.
-
-You can learn more at `AnsibleFest <https://www.ansible.com/ansiblefest>`_, the annual event for all Ansible contributors, users, and customers hosted by Red Hat. AnsibleFest is the place to connect with others, learn new skills, and find a new friend to automate with.
-
-Ansible manages machines in an agent-less manner. There is never a question of how to upgrade remote daemons or the problem of not being able to manage systems because daemons are uninstalled. Also, security exposure is greatly reduced because Ansible uses OpenSSH — the open source connectivity tool for remote login with the SSH (Secure Shell) protocol.
-
-Ansible is decentralized--it relies on your existing OS credentials to control access to remote machines. And if needed, Ansible can easily connect with Kerberos, LDAP, and other centralized authentication management systems.
-
-This documentation covers the version of Ansible noted in the upper left corner of this page. We maintain multiple versions of Ansible and the Ansible documentation, so please be sure you are using the documentation version that covers the version of Ansible you are using. For recent features, we note the version of Ansible where the feature was added.
-
-Ansible releases a new major release approximately twice a year. The core application evolves somewhat conservatively, valuing simplicity in language design and setup. Contributors develop and change modules and plugins hosted in collections since version 2.10 much more quickly.
-
 .. toctree::
    :maxdepth: 2
    :caption: Ansible getting started

--- a/docs/docsite/rst/core_index.rst
+++ b/docs/docsite/rst/core_index.rst
@@ -7,29 +7,29 @@
 Ansible Core Documentation
 **************************
 
-About ansible-core
-===================
+.. About ansible-core
+.. ===================
 
-Ansible is an IT automation tool.  It can configure systems, deploy software, and orchestrate more advanced IT tasks such as continuous deployments or zero downtime rolling updates.
+.. Ansible is an IT automation tool.  It can configure systems, deploy software, and orchestrate more advanced IT tasks such as continuous deployments or zero downtime rolling updates.
 
-Ansible core, or ``ansible-core`` is the main building block and architecture for Ansible, and includes:
+.. Ansible core, or ``ansible-core`` is the main building block and architecture for Ansible, and includes:
 
-* CLI tools such as ``ansible-playbook``, ``ansible-doc``. and others for driving and interacting with automation.
-* The Ansible language that uses YAML to create a set of rules for developing Ansible Playbooks and includes functions such as conditionals, blocks, includes, loops, and other Ansible imperatives.
-* An architectural framework that allows extensions through Ansible collections.
+.. * CLI tools such as ``ansible-playbook``, ``ansible-doc``. and others for driving and interacting with automation.
+.. * The Ansible language that uses YAML to create a set of rules for developing Ansible Playbooks and includes functions such as conditionals, blocks, includes, loops, and other Ansible imperatives.
+.. * An architectural framework that allows extensions through Ansible collections.
 
-Ansible's main goals are simplicity and ease-of-use. It also has a strong focus on security and reliability, featuring a minimum of moving parts, usage of OpenSSH for transport (with other transports and pull modes as alternatives), and a language that is designed around auditability by humans--even those not familiar with the program.
+.. Ansible's main goals are simplicity and ease-of-use. It also has a strong focus on security and reliability, featuring a minimum of moving parts, usage of OpenSSH for transport (with other transports and pull modes as alternatives), and a language that is designed around auditability by humans--even those not familiar with the program.
 
-We believe simplicity is relevant to all sizes of environments, so we design for busy users of all types: developers, sysadmins, release engineers, IT managers, and everyone in between. Ansible is appropriate for managing all environments, from small setups with a handful of instances to enterprise environments with many thousands of instances.
+.. We believe simplicity is relevant to all sizes of environments, so we design for busy users of all types: developers, sysadmins, release engineers, IT managers, and everyone in between. Ansible is appropriate for managing all environments, from small setups with a handful of instances to enterprise environments with many thousands of instances.
 
-You can learn more at `AnsibleFest <https://www.ansible.com/ansiblefest>`_, the annual event for all Ansible contributors, users, and customers hosted by Red Hat. AnsibleFest is the place to connect with others, learn new skills, and find a new friend to automate with.
+.. You can learn more at `AnsibleFest <https://www.ansible.com/ansiblefest>`_, the annual event for all Ansible contributors, users, and customers hosted by Red Hat. AnsibleFest is the place to connect with others, learn new skills, and find a new friend to automate with.
 
-Ansible manages machines in an agent-less manner. There is never a question of how to upgrade remote daemons or the problem of not being able to manage systems because daemons are uninstalled.  Because OpenSSH is one of the most peer-reviewed open source components, security exposure is greatly reduced. Ansible is decentralized--it relies on your existing OS credentials to control access to remote machines. If needed, Ansible can easily connect with Kerberos, LDAP, and other centralized authentication management systems.
+.. Ansible manages machines in an agent-less manner. There is never a question of how to upgrade remote daemons or the problem of not being able to manage systems because daemons are uninstalled.  Because OpenSSH is one of the most peer-reviewed open source components, security exposure is greatly reduced. Ansible is decentralized--it relies on your existing OS credentials to control access to remote machines. If needed, Ansible can easily connect with Kerberos, LDAP, and other centralized authentication management systems.
 
-This documentation covers the version of ``ansible-core`` noted in the upper left corner of this page. We maintain multiple versions of ``ansible-core`` and of the documentation, so please be sure you are using the version of the documentation that covers the version of Ansible you're using. For recent features, we note the version of Ansible where the feature was added.
+.. This documentation covers the version of ``ansible-core`` noted in the upper left corner of this page. We maintain multiple versions of ``ansible-core`` and of the documentation, so please be sure you are using the version of the documentation that covers the version of Ansible you're using. For recent features, we note the version of Ansible where the feature was added.
 
 
-``ansible-core`` releases a new major release approximately twice a year. The core application evolves somewhat conservatively, valuing simplicity in language design and setup. Contributors develop and change modules and plugins, hosted in collections since version 2.10, much more quickly.
+.. ``ansible-core`` releases a new major release approximately twice a year. The core application evolves somewhat conservatively, valuing simplicity in language design and setup. Contributors develop and change modules and plugins, hosted in collections since version 2.10, much more quickly.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/docsite/rst/getting_started/index.rst
+++ b/docs/docsite/rst/getting_started/index.rst
@@ -1,99 +1,127 @@
-.. _getting_started_index:
+Getting Started with Ansible in a Self-Contained Project Structure
+==================================================================
 
-############################
-Getting started with Ansible
-############################
+Introduction to Ansible
+-----------------------
 
-Ansible automates the management of remote systems and controls their desired state.
-A basic Ansible environment has three main components:
+Ansible is an open-source automation platform that allows IT professionals to automate various areas of their domain, for example:
+
+* repetitive tasks
+* system configuration
+* software deployments
+* continuous deployments
+* zero downtime rolling updates
+
+Users can write simple, human-readable automation scripts called playbooks. Those playbooks utilize a declarative approach to describe the desired state of a remote or local system (a managed host) that Ansible should ensure.
+
+Ansible is decentralized is a sense that it relies on your existing OS credentials to control access to remote machines. And if needed, Ansible can easily connect with Kerberos, LDAP, and other centralized authentication management systems.
+
+The following are some of the key strengths of Ansible:
+
+* agent-less architecture: no need for agents or additional software to be installed on managed hosts. This reduces maintenance overhead.
+
+* simplicity: Ansible features a minimum of moving parts, uses YAML syntax for its playbooks and leverages SSH/WinRM protocols to establish secure connections to execute tasks remotely.
+
+* scalability and flexibility: modular design enables users to quickly and easily scale from one managed host to many. Support for wide range of operating systems, cloud platforms and network devices make Ansible also a very flexible automation platform.
+
+* idempotence and predictability: when the managed host is in the correct state, running the same playbook multiple times does no changes.
+
+Ansible releases a new major release approximately twice a year. The core application (`ansible-core`) evolves somewhat conservatively, valuing simplicity in language design and setup. Contributors develop and change modules and plugins hosted in collections since version 2.10 more quickly.
 
 
-Control node
-   A system on which Ansible is installed.
-   You run Ansible commands such as ``ansible`` or ``ansible-inventory`` on a control node.
+.. note::
 
-Managed node
-   A remote system, or host, that Ansible controls.
+   This documentation covers the version of Ansible noted in the upper left corner of this page. The community maintains multiple versions of Ansible and of the documentation. Be sure you use the documentation that matches the version of software that you need. For recent features, we note the time of addition.
 
-Inventory
-   A list of managed nodes that are logically organized.
-   You create an inventory on the control node to describe host deployments to Ansible.
 
-.. image:: ../images/ansible_basic.svg
-   :width: 400px
-   :align: center
-   :height: 200px
-   :alt: Basic components of an Ansible environment include a control node, an inventory of managed nodes, and a module copied to each managed node.
+Setting up Ansible project
+--------------------------
+This guide will walk you through setting up a self-contained project structure for working with Ansible. The goal is to create a single directory that can easily be committed to a GitHub repository and used with utilities like AWX and Navigator. Additionally, we will integrate Visual Studio Code (VSCode) and Ansible Lint for an improved development experience.
 
-Ready to start using Ansible?
-Complete the following steps to get up and running:
+Step 1: Create a project directory
+----------------------------------
+Start by creating a new directory in your home directory. This will serve as the root directory for your Ansible project.
 
-#. Install Ansible. Visit the :ref:`installation guide<installation_guide>` for complete details.
-   
-   .. code-block:: bash 
-      
-      python3 -m pip install --user ansible
+.. code-block:: shell
 
-#. Create an inventory by adding the IP address or fully qualified domain name (FQDN) of one or more remote systems to ``/etc/ansible/hosts``.
-   The following example adds the IP addresses of three virtual machines in KVM:
+   $ mkdir ansible-project
+   $ cd ansible-project
 
-   .. code-block:: ini
+Step 2: Create the host inventory
+---------------------------------
+Next, let's create the inventory file for your Ansible project. This file will contain the list of hosts or groups of hosts that Ansible will manage. Create a file named ``inventory`` in the project directory.
 
-      [myvirtualmachines]
-      192.0.2.50
-      192.0.2.51
-      192.0.2.52
+.. code-block:: shell
 
-#. Verify the hosts in your inventory.
-   
-   .. code-block:: bash 
+   $ touch inventory
 
-      ansible all --list-hosts
+You can now add the necessary hosts and groups to the ``inventory`` file using your preferred text editor. Make sure to follow the correct INI file format.
 
-   .. code-block:: ansible-output
+Step 3: Organize playbooks
+--------------------------
+Now, let's create a directory to store your Ansible playbooks and place them adjacent to the inventory file. This will keep all your playbooks in one place, making it easier to manage and version control.
 
-      hosts (1):
-        192.0.2.50
-        192.0.2.51
-        192.0.2.52
+.. code-block:: shell
 
-#. Set up SSH connections so Ansible can connect to the managed nodes.
+   $ mkdir playbooks
 
-   a. Add your public SSH key to the ``authorized_keys`` file on each remote system.
-   b. Test the SSH connections, for example:
+You can now start adding your Ansible playbooks to the ``playbooks`` directory. For example, you could create a playbook named ``setup.yml``:
 
-   .. code-block:: bash
+.. code-block:: shell
 
-      ssh username@192.0.2.50
-    
-   If the username on the control node is different on the host, you need to pass the ``-u`` option with the ``ansible`` command.
+   $ touch playbooks/setup.yml
 
-#. Ping the managed nodes.
+Step 4: Manage collections
+--------------------------
+To manage Ansible collections used in your project, create a directory called ``collections`` within the project directory.
 
-   .. code-block:: bash 
+.. code-block:: shell
 
-      ansible all -m ping
+   $ mkdir collections
 
-   .. literalinclude:: ansible_output/ping_output.txt
-      :language: text
+You can now add the necessary collections to a ``requirements.yml`` file inside the ``collections`` directory. This file will serve as a manifest for the collections your project depends on.
 
-Congratulations! You are now using Ansible.
-Continue by :ref:`learning how to build an inventory<get_started_inventory>`.
+.. code-block:: shell
 
-.. seealso::
+   $ touch collections/requirements.yml
 
-   `Ansible Demos <https://github.com/ansible/product-demos>`_
-       Demonstrations of different Ansible usecases
-   `Ansible Labs <https://www.ansible.com/products/ansible-training>`_
-       Labs to provide further knowledge on different topics
-   `Mailing List <https://groups.google.com/group/ansible-project>`_
-       Questions? Help? Ideas?  Stop by the list on Google Groups
-   :ref:`communication_irc`
-       How to join Ansible chat channels
+Inside the ``requirements.yml`` file, list the collections you need, specifying the name and version. For example:
 
-.. toctree::
-   :maxdepth: 1
+.. code-block:: yaml
 
-   get_started_inventory
-   get_started_playbook
-   basic_concepts
+   ---
+   collections:
+     - name: ansible.posix
+       version: 1.3.0
+     - name: community.general
+       version: 3.8.0
+
+Step 5: Configure VSCode and Lint
+---------------------------------
+To enhance your development experience, we will set up Visual Studio Code (VSCode) as your development environment and incorporate linting for Ansible.
+
+1. Install the "Ansible" extension for VSCode.
+2. Open the project directory in VSCode: ``$ code .``
+3. Install the "ansible-lint" Python package globally or in a virtual environment: ``$ pip install ansible-lint``
+
+VSCode should now provide syntax highlighting, linting, and other useful features for Ansible development.
+
+Step 6: Commit to GitHub
+------------------------
+You now have a self-contained Ansible project structure that can be easily committed to a GitHub repository. Initialize a new Git repository and add all the files:
+
+.. code-block:: shell
+
+   $ git init
+   $ git add .
+   $ git commit -m "Initial commit"
+
+You can now push your project to GitHub or any other version control system of your choice.
+
+Conclusion
+----------
+By following this guide, you have successfully set up a self-contained Ansible project structure. Your project directory now includes an organized inventory file, playbooks directory, and collections directory. This structure allows for easy management, version control, and integration with utilities like AWX and Navigator.
+
+Additionally, you have configured Visual Studio Code (VSCode) as your development environment and incorporated Ansible Lint for an improved development experience. With syntax highlighting, linting, and other features provided by VSCode, you can write and manage your Ansible code more efficiently.
+
+You are now ready to commit your project to a GitHub repository or any other version control system of your choice. Enjoy working on your Ansible projects with this streamlined and self-contained project structure!


### PR DESCRIPTION
##### SUMMARY
Refreshes + moves the "About Ansible" content from https://docs.ansible.com/ansible/latest/index.html  and puts it as a high-level subsection right under the  "Getting started with Ansible" heading here https://docs.ansible.com/ansible/latest/getting_started/index.html

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
docs.ansible.com

##### ADDITIONAL INFORMATION
Closes issue #78459
