### PR TITLE
Deprecate plural collections_paths option

### DIFF
--- a/changelogs/fragments/collections_paths-deprecation.yml
+++ b/changelogs/fragments/collections_paths-deprecation.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+- Deprecated the env var ``ANSIBLE_COLLECTIONS_PATHS``, use the singular form ``ANSIBLE_COLLECTIONS_PATH`` instead
+- Deprecated ini config option ``collections_paths``, use the singular form ``collections_path`` instead

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -200,12 +200,18 @@ COLLECTIONS_PATHS:
   default: '{{ ANSIBLE_HOME ~ "/collections:/usr/share/ansible/collections" }}'
   type: pathspec
   env:
-  - name: ANSIBLE_COLLECTIONS_PATHS  # TODO: Deprecate this and ini once PATH has been in a few releases.
+  - name: ANSIBLE_COLLECTIONS_PATHS
+    deprecated:
+      why: does not fit var naming standard, use the singular form ANSIBLE_COLLECTIONS_PATH instead
+      version: "2.19"
   - name: ANSIBLE_COLLECTIONS_PATH
     version_added: '2.10'
   ini:
   - key: collections_paths
     section: defaults
+    deprecated:
+      why: does not fit var naming standard, use the singular form collections_path instead
+      version: "2.19"
   - key: collections_path
     section: defaults
     version_added: '2.10'

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Test installing collections from git repositories
   environment:
-    ANSIBLE_COLLECTIONS_PATHS: "{{ galaxy_dir }}/collections"
+    ANSIBLE_COLLECTIONS_PATH: "{{ galaxy_dir }}/collections"
   vars:
     cleanup: True
     galaxy_dir: "{{ galaxy_dir }}"

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -737,7 +737,7 @@
 - name: install collection with symlink - {{ test_id }}
   command: ansible-galaxy collection install symlink.symlink -s '{{ test_name }}' {{ galaxy_verbosity }}
   environment:
-    ANSIBLE_COLLECTIONS_PATHS: '{{ galaxy_dir }}/ansible_collections'
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
   register: install_symlink
 
 - find:
@@ -799,7 +799,7 @@
     - name: install symlink_dirs collection from source
       command: ansible-galaxy collection install {{ galaxy_dir }}/scratch/symlink_dirs/symlink_dirs/
       environment:
-        ANSIBLE_COLLECTIONS_PATHS: '{{ galaxy_dir }}/ansible_collections'
+        ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
       register: install_symlink_dirs
 
     - name: get result of install collection with symlink_dirs - {{ test_id }}
@@ -833,7 +833,7 @@
 - name: install collection and dep compatible with multiple requirements - {{ test_id }}
   command: ansible-galaxy collection install parent_dep.parent_collection parent_dep2.parent_collection
   environment:
-    ANSIBLE_COLLECTIONS_PATHS: '{{ galaxy_dir }}/ansible_collections'
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
   register: install_req
 
 - name: assert install collections with ansible-galaxy install - {{ test_id }}
@@ -855,7 +855,7 @@
     - name: install a collection to the same installation directory - {{ test_id }}
       command: ansible-galaxy collection install namespace1.name1
       environment:
-        ANSIBLE_COLLECTIONS_PATHS: '{{ galaxy_dir }}/ansible_collections'
+        ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
       register: install_req
 
     - name: assert installed collections with ansible-galaxy install - {{ test_id }}
@@ -1062,7 +1062,7 @@
   args:
     chdir: '{{ galaxy_dir }}/scratch'
   environment:
-    ANSIBLE_COLLECTIONS_PATHS: '{{ galaxy_dir }}/ansible_collections'
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
   register: install_concrete_pre
 
 - name: get result of install collections with concrete pre-release dep - {{ test_id }}

--- a/test/integration/targets/ansible/ansible-testé.cfg
+++ b/test/integration/targets/ansible/ansible-testé.cfg
@@ -1,3 +1,3 @@
 [defaults]
 remote_user = admin
-collections_paths = /tmp/collections
+collections_path = /tmp/collections

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -16,7 +16,7 @@ ansible-config list | grep 'DEFAULT_REMOTE_USER'
 # Collection
 ansible-config view -c ./ansible-testé.cfg | grep 'collections_paths = /tmp/collections'
 ansible-config dump -c ./ansible-testé.cfg | grep 'COLLECTIONS_PATHS([^)]*) ='
-ANSIBLE_COLLECTIONS_PATHS=/tmp/collections ansible-config dump| grep 'COLLECTIONS_PATHS([^)]*) ='
+ANSIBLE_COLLECTIONS_PATH=/tmp/collections ansible-config dump| grep 'COLLECTIONS_PATHS([^)]*) ='
 ansible-config list | grep 'COLLECTIONS_PATHS'
 
 # 'view' command must fail when config file is missing or has an invalid file extension

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -14,7 +14,7 @@ ANSIBLE_REMOTE_USER=administrator ansible-config dump| grep 'DEFAULT_REMOTE_USER
 ansible-config list | grep 'DEFAULT_REMOTE_USER'
 
 # Collection
-ansible-config view -c ./ansible-testé.cfg | grep 'collections_paths = /tmp/collections'
+ansible-config view -c ./ansible-testé.cfg | grep 'collections_path = /tmp/collections'
 ansible-config dump -c ./ansible-testé.cfg | grep 'COLLECTIONS_PATHS([^)]*) ='
 ANSIBLE_COLLECTIONS_PATH=/tmp/collections ansible-config dump| grep 'COLLECTIONS_PATHS([^)]*) ='
 ansible-config list | grep 'COLLECTIONS_PATHS'


### PR DESCRIPTION
##### SUMMARY
Deprecates the plural options for specifying the collections path `ANSIBLE_COLLECTIONS_PATHS` (env) and `collections_paths` (ini). These were the original options but didn't match the config naming standard and in Ansible 2.10 the singular form were added for these options. As all the currently supported* Ansible versions have been able to use the singular form the plural versions are now marked as deprecated.

Fixes: https://github.com/ansible/ansible/issues/79588

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
config