### PR TITLE
Fix stealth exceptions and blocking select() in daemonize()

### DIFF
--- a/changelogs/fragments/81064-daemonize-fixes.yml
+++ b/changelogs/fragments/81064-daemonize-fixes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "``ansible.module_utils.service`` - fix inter-process communication in ``daemonize()``"

--- a/lib/ansible/module_utils/service.py
+++ b/lib/ansible/module_utils/service.py
@@ -207,17 +207,19 @@ def daemonize(module, cmd):
         p = subprocess.Popen(run_cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, preexec_fn=lambda: os.close(pipe[1]))
         fds = [p.stdout, p.stderr]
 
-        # loop reading output till its done
+        # loop reading output till it is done
         output = {p.stdout: b(""), p.stderr: b("")}
         while fds:
             rfd, wfd, efd = select.select(fds, [], fds, 1)
-            if (rfd + wfd + efd) or p.poll():
+            if (rfd + wfd + efd) or p.poll() is None:
                 for out in list(fds):
                     if out in rfd:
                         data = os.read(out.fileno(), chunk)
                         if not data:
                             fds.remove(out)
-                    output[out] += b(data)
+                        output[out] += data
+            else:
+                break
 
         # even after fds close, we might want to wait for pid to die
         p.wait()
@@ -246,7 +248,7 @@ def daemonize(module, cmd):
                 data = os.read(pipe[0], chunk)
                 if not data:
                     break
-                return_data += b(data)
+                return_data += data
 
         # Note: no need to specify encoding on py3 as this module sends the
         # pickle to itself (thus same python interpreter so we aren't mixing


### PR DESCRIPTION
##### SUMMARY

This came out of the debugging session from https://github.com/ansible-collections/community.general/pull/6618 where a module must use `daemonize()` to work.

`daemonize()` was ported to `module_utils.service` in #21256 with a couple of issues that are not reproducible with the code from the now-deprecated `service` module. I couldn't find use of it alone in both ansible and community.general collection repos, so it seems it wasn't tested thoroughly afterwards.

This PR fixes a few things:

1. Padding bug on L220: `local variable 'data' referenced before assignment`
2. Type bugs on L220 and L251: `'bytes' object has no attribute 'encode'`
3. The biggest logical one on L214 is two-fold:
    1. `p.poll()` should be replaced with `p.poll() is None` as it was in the deprecated `service` module since as per [#subprocess.Popen.poll](https://docs.python.org/3/library/subprocess.html#subprocess.Popen.poll) it can return `0`, `1`, `2`, etc. (any return code) as well as `None` while the process hasn't terminated.
    2. Missing `else: break` that's also present in the deprecated `service` module: because we have a 2-process communication (parent, child) the condition on L214 is never satisfied, and the parent's `select()` blocks indefinitely waiting for the child on L246 ([#select.select](https://docs.python.org/3/library/select.html#select.select)). By adding `else: break` we exit the loop when the process started by the child exits.

cc @bcoca 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`module_utils.service`

##### ADDITIONAL INFORMATION

Relevant code from `modules.service`: [service.py#L301-L335](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/service.py#L301-L335)