### PR TITLE
Pylint deprecated comment checker

### DIFF
--- a/changelogs/fragments/pylint-deprecated-comment-checker.yml
+++ b/changelogs/fragments/pylint-deprecated-comment-checker.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ansible-test - Add new pylint checker for new ``# deprecated:`` comments within code to trigger errors when time to remove code
+  that has no user facing deprecation message

--- a/test/lib/ansible_test/_internal/commands/sanity/pylint.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/pylint.py
@@ -18,6 +18,11 @@ from . import (
     SANITY_ROOT,
 )
 
+from ...constants import (
+    CONTROLLER_PYTHON_VERSIONS,
+    REMOTE_ONLY_PYTHON_VERSIONS,
+)
+
 from ...io import (
     make_dirs,
 )
@@ -234,6 +239,8 @@ class PylintTest(SanitySingleVersion):
             '--rcfile', rcfile,
             '--output-format', 'json',
             '--load-plugins', ','.join(sorted(load_plugins)),
+            '--min-controller-python', CONTROLLER_PYTHON_VERSIONS[0],
+            '--min-target-python', REMOTE_ONLY_PYTHON_VERSIONS[0],
         ] + paths  # fmt: skip
 
         if data_context().content.collection:

--- a/test/lib/ansible_test/_internal/commands/sanity/pylint.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/pylint.py
@@ -43,6 +43,7 @@ from ...util import (
 
 from ...util_common import (
     run_command,
+    process_scoped_temporary_file,
 )
 
 from ...ansible_util import (
@@ -86,6 +87,8 @@ class PylintTest(SanitySingleVersion):
         return [target for target in targets if os.path.splitext(target.path)[1] == '.py' or is_subdir(target.path, 'bin')]
 
     def test(self, args: SanityConfig, targets: SanityTargets, python: PythonConfig) -> TestResult:
+        min_python_version_db_path = self.create_min_python_db(args, targets.targets)
+
         plugin_dir = os.path.join(SANITY_ROOT, 'pylint', 'plugins')
         plugin_names = sorted(p[0] for p in [
             os.path.splitext(p) for p in os.listdir(plugin_dir)] if p[1] == '.py' and p[0] != '__init__')
@@ -168,7 +171,7 @@ class PylintTest(SanitySingleVersion):
                 continue
 
             context_start = datetime.datetime.now(tz=datetime.timezone.utc)
-            messages += self.pylint(args, context, context_paths, plugin_dir, plugin_names, python, collection_detail)
+            messages += self.pylint(args, context, context_paths, plugin_dir, plugin_names, python, collection_detail, min_python_version_db_path)
             context_end = datetime.datetime.now(tz=datetime.timezone.utc)
 
             context_times.append('%s: %d (%s)' % (context, len(context_paths), context_end - context_start))
@@ -199,6 +202,22 @@ class PylintTest(SanitySingleVersion):
 
         return SanitySuccess(self.name)
 
+    def create_min_python_db(self, args: SanityConfig, targets: t.Iterable[TestTarget]) -> str:
+        """Create a database of target file paths and their minimum required Python version, returning the path to the database."""
+        target_paths = set(target.path for target in self.filter_remote_targets(list(targets)))
+        controller_min_version = CONTROLLER_PYTHON_VERSIONS[0]
+        target_min_version = REMOTE_ONLY_PYTHON_VERSIONS[0]
+        min_python_versions = {
+            os.path.abspath(target.path): target_min_version if target.path in target_paths else controller_min_version for target in targets
+        }
+
+        min_python_version_db_path = process_scoped_temporary_file(args)
+
+        with open(min_python_version_db_path, 'w') as database_file:
+            json.dump(min_python_versions, database_file)
+
+        return min_python_version_db_path
+
     @staticmethod
     def pylint(
         args: SanityConfig,
@@ -208,6 +227,7 @@ class PylintTest(SanitySingleVersion):
         plugin_names: list[str],
         python: PythonConfig,
         collection_detail: CollectionDetail,
+        min_python_version_db_path: str,
     ) -> list[dict[str, str]]:
         """Run pylint using the config specified by the context on the specified paths."""
         rcfile = os.path.join(SANITY_ROOT, 'pylint', 'config', context.split('/')[0] + '.cfg')
@@ -239,8 +259,7 @@ class PylintTest(SanitySingleVersion):
             '--rcfile', rcfile,
             '--output-format', 'json',
             '--load-plugins', ','.join(sorted(load_plugins)),
-            '--min-controller-python', CONTROLLER_PYTHON_VERSIONS[0],
-            '--min-target-python', REMOTE_ONLY_PYTHON_VERSIONS[0],
+            '--min-python-version-db', min_python_version_db_path,
         ] + paths  # fmt: skip
 
         if data_context().content.collection:


### PR DESCRIPTION
##### SUMMARY
This PR adds a new pylint checker for a new `# deprecated:` comment, that will allow an error to occur once the deprecated code can be removed, when no user facing deprecation will be displayed.

Format:

```
some_thing()  # deprecated: description='some description' core_version='2.18' python_version='3.11'
```

##### ISSUE TYPE
- Feature Pull Request
- Test Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
