### PR TITLE
[stable-2.15] Resolve issues on python pre-3.10.6 with collection dirs longer than 100 characters (#81061)

### DIFF
--- a/changelogs/fragments/long-collection-paths-fix.yml
+++ b/changelogs/fragments/long-collection-paths-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy - Fix issue installing collections containing directories with more than 100 characters on python versions before 3.10.6

--- a/test/units/cli/galaxy/test_collection_extract_tar.py
+++ b/test/units/cli/galaxy/test_collection_extract_tar.py
@@ -14,6 +14,7 @@ from ansible.galaxy.collection import _extract_tar_dir
 @pytest.fixture
 def fake_tar_obj(mocker):
     m_tarfile = mocker.Mock()
+    m_tarfile._ansible_normalized_cache = {'/some/dir': mocker.Mock()}
     m_tarfile.type = mocker.Mock(return_value=b'99')
     m_tarfile.SYMTYPE = mocker.Mock(return_value=b'22')
 
@@ -22,22 +23,10 @@ def fake_tar_obj(mocker):
 
 def test_extract_tar_member_trailing_sep(mocker):
     m_tarfile = mocker.Mock()
-    m_tarfile.getmember = mocker.Mock(side_effect=KeyError)
+    m_tarfile._ansible_normalized_cache = {}
 
     with pytest.raises(AnsibleError, match='Unable to extract'):
         _extract_tar_dir(m_tarfile, '/some/dir/', b'/some/dest')
-
-    assert m_tarfile.getmember.call_count == 1
-
-
-def test_extract_tar_member_no_trailing_sep(mocker):
-    m_tarfile = mocker.Mock()
-    m_tarfile.getmember = mocker.Mock(side_effect=KeyError)
-
-    with pytest.raises(AnsibleError, match='Unable to extract'):
-        _extract_tar_dir(m_tarfile, '/some/dir', b'/some/dest')
-
-    assert m_tarfile.getmember.call_count == 2
 
 
 def test_extract_tar_dir_exists(mocker, fake_tar_obj):


### PR DESCRIPTION
(cherry picked from commit 56b67cc)


Co-authored-by: Matt Martz <matt@sivel.net>