### PR TITLE
Bump `coverage.py` to v7.3.0 in `ansible-test`

### DIFF
--- a/changelogs/fragments/ansible-test-coverage-update.yml
+++ b/changelogs/fragments/ansible-test-coverage-update.yml
@@ -1,6 +1,6 @@
 ---
 
-bugfixes:
+minor_changes:
 - ansible-test — Python 3.8–3.12 will use ``coverage`` v7.3.0.
 - ansible-test — ``coverage`` v6.5.0 is to be used only under Python 3.7.
 

--- a/changelogs/fragments/ansible-test-coverage-update.yml
+++ b/changelogs/fragments/ansible-test-coverage-update.yml
@@ -1,0 +1,7 @@
+---
+
+bugfixes:
+- ansible-test — Python 3.8–3.12 will use ``coverage`` v7.3.0.
+- ansible-test — ``coverage`` v6.5.0 is to be used only under Python 3.7.
+
+...

--- a/test/lib/ansible_test/_data/requirements/ansible-test.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible-test.txt
@@ -1,4 +1,5 @@
 # The test-constraints sanity test verifies this file, but changes must be made manually to keep it in up-to-date.
 virtualenv == 16.7.12 ; python_version < '3'
-coverage == 6.5.0 ; python_version >= '3.7' and python_version <= '3.12'
+coverage == 7.3.0 ; python_version >= '3.8' and python_version <= '3.12'
+coverage == 6.5.0 ; python_version >= '3.7' and python_version <= '3.7'
 coverage == 4.5.4 ; python_version >= '2.6' and python_version <= '3.6'

--- a/test/lib/ansible_test/_internal/coverage_util.py
+++ b/test/lib/ansible_test/_internal/coverage_util.py
@@ -69,7 +69,8 @@ class CoverageVersion:
 
 COVERAGE_VERSIONS = (
     # IMPORTANT: Keep this in sync with the ansible-test.txt requirements file.
-    CoverageVersion('6.5.0', 7, (3, 7), (3, 12)),
+    CoverageVersion('7.3.0', 7, (3, 8), (3, 12)),
+    CoverageVersion('6.5.0', 7, (3, 7), (3, 7)),
     CoverageVersion('4.5.4', 0, (2, 6), (3, 6)),
 )
 """


### PR DESCRIPTION
This patch upgrades the `coverage.py` version used under Python 3.8 through 3.12.
It also upgrades the path patterns in the generated configs according to the changes
in v7.0.0b1 of said library as it replaced the matching method from `fnmatch` to `glob`[[1]][[2]].

Resolves #80427

[1]: https://coverage.readthedocs.io/en/7.2.7/migrating.html#migrating-to-coverage-py-7-x
[2]: https://github.com/nedbat/coveragepy/commit/ec6205a8de972af6a09453235d02a7ebea6aea8e

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
^ $sbj ^

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ansible-test`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A
