### PR TITLE
Avoid deprecated importlib.abc.TraversableResources

### DIFF
--- a/changelogs/fragments/81082-deprecated-importlib-abc.yml
+++ b/changelogs/fragments/81082-deprecated-importlib-abc.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Use ``importlib.resources.abc.TraversableResources`` instead of deprecated
+    ``importlib.abc.TraversableResources`` where available
+    (https:/github.com/ansible/ansible/pull/81082).

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -49,7 +49,7 @@ try:
         # Used with Python 3.9 and 3.10 only
         # This member is still available as an alias up until Python 3.14 but
         # is deprecated as of Python 3.12.
-        from importlib.abc import TraversableResources
+        from importlib.abc import TraversableResources  # deprecated: description='TraversableResources move' python_version='3.10'
 except ImportError:
     # Python < 3.9
     TraversableResources = object  # type: ignore[assignment,misc]

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -52,6 +52,7 @@ try:
         from importlib.abc import TraversableResources  # deprecated: description='TraversableResources move' python_version='3.10'
 except ImportError:
     # Python < 3.9
+    # deprecated: description='TraversableResources fallback' python_version='3.8'
     TraversableResources = object  # type: ignore[assignment,misc]
 
 try:

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -40,8 +40,18 @@ except ImportError:
     reload_module = reload  # type: ignore[name-defined]  # pylint:disable=undefined-variable
 
 try:
-    from importlib.abc import TraversableResources
+    try:
+        # Available on Python >= 3.11
+        # We ignore the import error that will trigger when running mypy with
+        # older Python versions.
+        from importlib.resources.abc import TraversableResources  # type: ignore[import]
+    except ImportError:
+        # Used with Python 3.9 and 3.10 only
+        # This member is still available as an alias up until Python 3.14 but
+        # is deprecated as of Python 3.12.
+        from importlib.abc import TraversableResources
 except ImportError:
+    # Python < 3.9
     TraversableResources = object  # type: ignore[assignment,misc]
 
 try:


### PR DESCRIPTION
##### SUMMARY

Avoid usage of deprecated importlib.abc.TraversableResources. This fixes ansible-compat test failures with Python 3.12, as they enforce `-Werror`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/utils/collection_loader/_collection_finder.py


##### ADDITIONAL INFORMATION

It would be possible to remove the `ignore[import]` if we changed the code to conditionalize imports based on `sys.version_info` instead of using `try-except`s and updated the mypy sanity test requirements to include a newer mypy version whose bundled typeshed includes https://github.com/python/typeshed/commit/75ecd7e2298a23bb92a5034c2f4552208a04861b, but I considered that out of scope for this PR.