### PR TITLE
ansible-test - remove Fedora 37 container and remote support

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -120,8 +120,6 @@ stages:
               test: alpine/3.17
             - name: Alpine 3.18
               test: alpine/3.18
-            - name: Fedora 37
-              test: fedora/37
             - name: Fedora 38
               test: fedora/38
             - name: RHEL 8.8
@@ -143,8 +141,6 @@ stages:
               test: alpine3
             - name: CentOS 7
               test: centos7
-            - name: Fedora 37
-              test: fedora37
             - name: Fedora 38
               test: fedora38
             - name: openSUSE 15
@@ -162,8 +158,6 @@ stages:
           targets:
             - name: Alpine 3
               test: alpine3
-            - name: Fedora 37
-              test: fedora37
             - name: Fedora 38
               test: fedora38
             - name: Ubuntu 22.04

--- a/changelogs/fragments/ansible-test-fedora-37.yml
+++ b/changelogs/fragments/ansible-test-fedora-37.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - Remove Fedora 37 remote support.
+  - ansible-test - Remove Fedora 37 test container.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -3,7 +3,6 @@ default image=quay.io/ansible/default-test-container:8.2.0 python=3.11,2.7,3.6,3
 default image=quay.io/ansible/ansible-core-test-container:8.2.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10 context=ansible-core
 alpine3 image=quay.io/ansible/alpine3-test-container:5.0.0 python=3.10 cgroup=none audit=none
 centos7 image=quay.io/ansible/centos7-test-container:5.0.0 python=2.7 cgroup=v1-only
-fedora37 image=quay.io/ansible/fedora37-test-container:5.0.0 python=3.11
 fedora38 image=quay.io/ansible/fedora38-test-container:6.1.0 python=3.11
 opensuse15 image=quay.io/ansible/opensuse15-test-container:6.0.0 python=3.6
 ubuntu2004 image=quay.io/ansible/ubuntu2004-test-container:5.0.0 python=3.8

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -1,7 +1,6 @@
 alpine/3.17 python=3.10 become=doas_sudo provider=aws arch=x86_64
 alpine/3.18 python=3.11 become=doas_sudo provider=aws arch=x86_64
 alpine become=doas_sudo provider=aws arch=x86_64
-fedora/37 python=3.11 become=sudo provider=aws arch=x86_64
 fedora/38 python=3.11 become=sudo provider=aws arch=x86_64
 fedora become=sudo provider=aws arch=x86_64
 freebsd/12.4 python=3.9 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64


### PR DESCRIPTION
##### SUMMARY
2-week transition period will be over on July 10th.

Removed from distro-test-containers: https://github.com/ansible/distro-test-containers/pull/105

Closes #80415

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test
