### PR TITLE
adhoc: add option to disable hosts count with --list

### DIFF
--- a/changelogs/fragments/adhoc-add-no-hosts-count-option.yml
+++ b/changelogs/fragments/adhoc-add-no-hosts-count-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible adhoc - add ``--no-hosts-count`` (``-n``) option to disable hosts count with ``--list``

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -58,6 +58,9 @@ class AdHocCLI(CLI):
         self.parser.add_argument('-m', '--module-name', dest='module_name',
                                  help="Name of the action to execute (default=%s)" % C.DEFAULT_MODULE_NAME,
                                  default=C.DEFAULT_MODULE_NAME)
+        self.parser.add_argument('-n', '--no-hosts-count', dest='hosts_count',
+                                 action='store_false',
+                                 help="Don't print number of hosts with --list")
         self.parser.add_argument('args', metavar='pattern', help='host pattern')
 
     def post_process_args(self, options):
@@ -128,7 +131,8 @@ class AdHocCLI(CLI):
 
         # just listing hosts?
         if context.CLIARGS['listhosts']:
-            display.display('  hosts (%d):' % len(hosts))
+            if context.CLIARGS['hosts_count']:
+                display.display('  hosts (%d):' % len(hosts))
             for host in hosts:
                 display.display('    %s' % host)
             return 0


### PR DESCRIPTION
##### SUMMARY
The "Hosts (N):" output is not always desired.  Allow it to be disabled with `--no-hosts-count` (`-n`).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
adhoc cli