### PR TITLE
ansible-galaxy - add general config timeout

### DIFF
--- a/changelogs/fragments/ansible-galaxy-server-timeout.yml
+++ b/changelogs/fragments/ansible-galaxy-server-timeout.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add a general ``GALAXY_SERVER_TIMEOUT`` config option for distribution servers (https://github.com/ansible/ansible/issues/79833).

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1336,6 +1336,15 @@ GALAXY_IGNORE_CERTS:
   ini:
   - {key: ignore_certs, section: galaxy}
   type: boolean
+GALAXY_SERVER_TIMEOUT:
+  name: Default timeout to use for API calls
+  description:
+    - The default timeout for Galaxy API calls. Galaxy servers that don't configure a specific timeout will fall back to this value.
+  env: [{name: ANSIBLE_GALAXY_SERVER_TIMEOUT}]
+  default: 60
+  ini:
+  - {key: server_timeout, section: galaxy}
+  type: int
 GALAXY_ROLE_SKELETON:
   name: Galaxy role skeleton directory
   description: Role skeleton directory to use as a template for the ``init`` action in ``ansible-galaxy``/``ansible-galaxy role``, same as ``--role-skeleton``.


### PR DESCRIPTION
##### SUMMARY
Add a general config option for the Galaxy API timeout. Now servers without a config (like the default server) have options other than `--timeout`.

Fixes non-docs portion of #79833. It should still be documented that `timeout` can be configured per-server (this is the only missing public field).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-galaxy