### PR TITLE
filter: add documentation for msg parameter

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -327,8 +327,7 @@ def mandatory(a, msg=None):
 
         if msg is not None:
             raise AnsibleFilterError(to_native(msg))
-        else:
-            raise AnsibleFilterError("Mandatory variable %s not defined." % name)
+        raise AnsibleFilterError("Mandatory variable %s not defined." % name)
 
     return a
 

--- a/lib/ansible/plugins/filter/mandatory.yml
+++ b/lib/ansible/plugins/filter/mandatory.yml
@@ -10,10 +10,17 @@ DOCUMENTATION:
       description: Mandatory expression.
       type: raw
       required: true
+    msg:
+      description: The customized message that is printed when the given variable is not defined.
+      type: str
+      required: false
 EXAMPLES: |
 
     # results in a Filter Error
     {{ notdefined | mandatory }}
+
+    # print a custom error message
+    {{ notdefined | mandatory(msg='This variable is required.') }}
 
 RETURN:
   _value:


### PR DESCRIPTION
##### SUMMARY

* mandatory filter provides `msg` parameter. Document the same.

Fixes: #81105

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE

- Docs Pull Request



##### COMPONENT NAME
lib/ansible/plugins/filter/core.py
lib/ansible/plugins/filter/mandatory.yml

