### PR TITLE
ansible-test - add proxy support to pip

### DIFF
--- a/changelogs/fragments/81117-add-proxy-to-pip.yaml
+++ b/changelogs/fragments/81117-add-proxy-to-pip.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Allow pip in ansible-test to install modules via proxy (https://github.com/ansible/ansible/pull/81117).
+    The proxy is selected via the os environment vars - first existing var in the order of 'HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy' is used.

--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -338,7 +338,7 @@ Environment variables
 
 When using environment variables to manipulate tests there some limitations to keep in mind. Environment variables are:
 
-* Not propagated from the host to the test environment when using the ``--docker`` or ``--remote`` options.
+* Not propagated from the host to the test environment when using the ``--docker`` or ``--remote`` options. However, when using the ``--docker`` option, the ``PROXY_ENVIRONMENT_VARS`` from ``test/lib/ansible_test/_internal/constants.py`` are propagated.
 * Not exposed to the test environment unless enabled in ``test/lib/ansible_test/_internal/util.py`` in the ``common_environment`` function.
 
     Example: ``ANSIBLE_KEEP_REMOTE_FILES=1`` can be set when running ``ansible-test integration --venv``. However, using the ``--docker`` option would

--- a/test/lib/ansible_test/_internal/constants.py
+++ b/test/lib/ansible_test/_internal/constants.py
@@ -46,3 +46,12 @@ ANSIBLE_BIN_SYMLINK_MAP = {
     'ansible-test': '../test/lib/ansible_test/_util/target/cli/ansible_test_cli_stub.py',
     'ansible-vault': '../lib/ansible/cli/vault.py',
 }
+
+PROXY_ENVIRONMENT_VARS = (
+    'http_proxy',
+    'https_proxy',
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'no_proxy',
+    'NO_PROXY',
+)

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -31,6 +31,10 @@ from .config import (
     CommonConfig,
 )
 
+from .constants import (
+    PROXY_ENVIRONMENT_VARS
+)
+
 from .thread import (
     mutex,
     named_lock,
@@ -974,6 +978,11 @@ def docker_exec(
 
     if data or stdin or stdout:
         options.append('-i')
+
+    env = docker_environment()
+    for var in PROXY_ENVIRONMENT_VARS:
+        if var in env and env[var] is not None:
+            options.extend(['--env', '{0}={1}'.format(var, env[var])])
 
     return docker_command(
         args,

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -59,6 +59,7 @@ from .thread import (
 
 from .constants import (
     SUPPORTED_PYTHON_VERSIONS,
+    PROXY_ENVIRONMENT_VARS
 )
 
 C = t.TypeVar('C')
@@ -659,13 +660,7 @@ def common_environment() -> dict[str, str]:
         # export  CFLAGS="-I$(brew --prefix openssl)/include/ -I$(brew --prefix libyaml)/include/"
         'LDFLAGS',
         'CFLAGS',
-        'http_proxy',
-        'https_proxy',
-        'HTTP_PROXY',
-        'HTTPS_PROXY',
-        'no_proxy',
-        'NO_PROXY',
-    )
+    ) + PROXY_ENVIRONMENT_VARS
 
     # FreeBSD Compatibility
     # This is required to include libyaml support in PyYAML.

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -659,6 +659,12 @@ def common_environment() -> dict[str, str]:
         # export  CFLAGS="-I$(brew --prefix openssl)/include/ -I$(brew --prefix libyaml)/include/"
         'LDFLAGS',
         'CFLAGS',
+        'http_proxy',
+        'https_proxy',
+        'HTTP_PROXY',
+        'HTTPS_PROXY',
+        'no_proxy',
+        'NO_PROXY',
     )
 
     # FreeBSD Compatibility

--- a/test/lib/ansible_test/_util/target/setup/requirements.py
+++ b/test/lib/ansible_test/_util/target/setup/requirements.py
@@ -190,12 +190,12 @@ def common_pip_environment():  # type: () -> t.Dict[str, str]
     return env
 
 
-def common_pip_options(isInstall=False):  # type: () -> t.List[str]
+def common_pip_options(is_install=False):  # type: () -> t.List[str]
     """Return a list of common pip options."""
     opt = [
         '--disable-pip-version-check',
     ]
-    if not isInstall:
+    if not is_install:
         return opt
     for var in ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy']:
         if var in os.environ and os.environ[var] is not None:

--- a/test/lib/ansible_test/_util/target/setup/requirements.py
+++ b/test/lib/ansible_test/_util/target/setup/requirements.py
@@ -130,7 +130,7 @@ def install(pip, options):  # type: (str, t.Dict[str, t.Any]) -> None
     tempdir = tempfile.mkdtemp(prefix='ansible-test-', suffix='-requirements')
 
     try:
-        options = common_pip_options()
+        options = common_pip_options(True)
         options.extend(packages)
 
         for path, content in requirements:
@@ -190,11 +190,19 @@ def common_pip_environment():  # type: () -> t.Dict[str, str]
     return env
 
 
-def common_pip_options():  # type: () -> t.List[str]
+def common_pip_options(isInstall=False):  # type: () -> t.List[str]
     """Return a list of common pip options."""
-    return [
+    opt = [
         '--disable-pip-version-check',
     ]
+    if not isInstall:
+        return opt
+    for var in ['HTTPS_PROXY', 'https_proxy', 'HTTP_PROXY', 'http_proxy']:
+        if var in os.environ and os.environ[var] is not None:
+            opt.append('--proxy')
+            opt.append(os.environ[var])
+            break
+    return opt
 
 
 def devnull():  # type: () -> t.IO[bytes]


### PR DESCRIPTION
# Add proxy support to pip

##### SUMMARY
With this commit the --proxy parameter is added to pip the pip options if the command is install.
The value is sourced from the os environment. As only one proxy can be used by pip the first matching environment variable that exists will be used. Nowadys most sources are transfered vis https so proxies with HTTPS are prefered. As there is no convention weather the variables are lower or upper case - both are checked.

The _no_proxy_ vars are already accepted as pip currently prepares to support a no_proxy option (pypa/pip#5378) 

fixes #77304 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test (sanity)
