### PR TITLE
add coverage 6.5.0 for Python 3.12

### DIFF
--- a/test/lib/ansible_test/_data/requirements/ansible-test.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible-test.txt
@@ -1,4 +1,4 @@
 # The test-constraints sanity test verifies this file, but changes must be made manually to keep it in up-to-date.
 virtualenv == 16.7.12 ; python_version < '3'
-coverage == 6.5.0 ; python_version >= '3.7' and python_version <= '3.11'
+coverage == 6.5.0 ; python_version >= '3.7' and python_version <= '3.12'
 coverage == 4.5.4 ; python_version >= '2.6' and python_version <= '3.6'

--- a/test/lib/ansible_test/_internal/coverage_util.py
+++ b/test/lib/ansible_test/_internal/coverage_util.py
@@ -69,7 +69,7 @@ class CoverageVersion:
 
 COVERAGE_VERSIONS = (
     # IMPORTANT: Keep this in sync with the ansible-test.txt requirements file.
-    CoverageVersion('6.5.0', 7, (3, 7), (3, 11)),
+    CoverageVersion('6.5.0', 7, (3, 7), (3, 12)),
     CoverageVersion('4.5.4', 0, (2, 6), (3, 6)),
 )
 """


### PR DESCRIPTION
##### SUMMARY
temporary measure until #81077 in order to add Python 3.12 to the default containers without skipping coverage

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
