### PR TITLE
Improve ansible.builtin.copy directory_mode parameter docs

### DIFF
--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -79,10 +79,9 @@ options:
       See CVE-2020-1736 for further details.
   directory_mode:
     description:
-    - Set the access permissions of recursively copied directories to the given mode.
-      See C(mode) for the syntax of accepted values.
-    - Only newly created directories have their mode set.
-      Permissions on existing directories are not changed.
+    - Set the access permissions of newly created directories to the given mode.
+      Permissions on existing directories do not change.
+    - See C(mode) for the syntax of accepted values.
     - The system defaults are used when this parameter is not set.
     type: raw
     version_added: '1.5'

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -79,9 +79,11 @@ options:
       See CVE-2020-1736 for further details.
   directory_mode:
     description:
-    - When doing a recursive copy set the mode for the directories.
-    - If this is not set we will use the system defaults.
-    - The mode is only set on directories which are newly created, and will not affect those that already existed.
+    - Set the access permissions of recursively copied directories to the given mode.
+      See C(mode) for the syntax of accepted values.
+    - Only newly created directories have their mode set.
+      Permissions on existing directories are not changed.
+    - The system defaults are used when this parameter is not set.
     type: raw
     version_added: '1.5'
   remote_src:

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -82,7 +82,7 @@ options:
     - Set the access permissions of newly created directories to the given mode.
       Permissions on existing directories do not change.
     - See C(mode) for the syntax of accepted values.
-    - The system defaults are used when this parameter is not set.
+    - The target system's defaults determine permissions when this parameter is not set.
     type: raw
     version_added: '1.5'
   remote_src:


### PR DESCRIPTION
##### SUMMARY
The docs of the ansiblble.builting.copy directory_mode parameter are vague.  Specifically, the current text does not explicitly state that the parameter takes a mode.  It can be read to take a boolean, the mode used then being the value supplied to the mode parameter.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.builtin.copy

##### ADDITIONAL INFORMATION
Alter the directory_mode docs to be specific about the value supplied, simplify sentences, remove extra words, rephrase, and generally clarify.