### PR TITLE
Update user.py

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -52,7 +52,7 @@ options:
         type: str
     groups:
         description:
-            - List of groups user will be added to.
+            - A list of supplementary groups which the user is also a member of.
             - By default, the user is removed from all other groups. Configure C(append) to modify this.
             - When set to an empty string C(''),
               the user is removed from all groups except the primary group.


### PR DESCRIPTION
changed the documentation of 'groups' in modules/user.py to 'A list of supplementary groups which the user is also a member of'.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
changed the documentation of 'groups' in modules/user.py to 'A list of supplementary groups which the user is also a member of'.

Fixes #81102 

##### ISSUE TYPE
- Docs Pull Request
- 
##### COMPONENT NAME
lib/ansible/modules/user.py

