### PR TITLE
Add multirepo tip to doc issue report

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -64,7 +64,7 @@ body:
           <em>Why?</em>
         </summary>
 
-        We would do it by ourselves but unfortunatelly, the curent
+        We would do it by ourselves but unfortunately, the current
         edition of GitHub Issue Forms Alpha does not support this yet 🤷
 
 
@@ -86,18 +86,23 @@ body:
       feature below, *use your best guess if unsure*.
 
 
-      **Tip:** Be advised that the source for some parts of the
-      documentation are hosted outside of this repository. If the page
-      you are reporting describes modules/plugins/etc that are not
-      officially supported by the Ansible Core Engineering team, there
-      is a good chance that it is coming from one of the [Ansible
-      Collections maintained by the community][collections org]. If this
-      is the case, please make sure to file an issue under the
-      appropriate project there instead.
+      **Tip:** Source files for Ansible community documentation is
+      hosted in different repositories. Please make sure to file an
+      issue in the correct project.
+      Documentation for modules/plugins/etc that are officially
+      supported by the Ansible Core Engineering team is available
+      in this (`ansible/ansible`) repository.
+      User documentation pages such as the Playbook Guide,
+      Developer Guide, and so on is available in the
+      [`ansible/ansible-documentation`][ansible-documentation] repository.
+      Documentation for other modules/plugins/etc is likely to be
+      available in one of the [Ansible Collections maintained by
+      the community][collections org].
 
 
+      [ansible-documentation]: https://github.com/ansible/ansible-documentation/issues
       [collections org]: /ansible-collections
-    placeholder: docs/docsite/rst/dev_guide/debugging.rst
+    placeholder: lib/ansible/modules/copy.py
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -93,7 +93,7 @@ body:
       supported by the Ansible Core Engineering team is available
       in this (`ansible/ansible`) repository.
       Documentation guides such as the Playbook Guide,
-      Developer Guide, and so on is available in the
+      Developer Guide, and so on are available in the
       [`ansible/ansible-documentation`][ansible-documentation] repository.
       Documentation for other modules/plugins/etc is likely to be
       available in one of the [Ansible Collections maintained by

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -102,7 +102,7 @@ body:
       community collection.
 
 
-      [ansible-documentation]: https://github.com/ansible/ansible-documentation/issues
+      [`ansible/ansible-documentation`]: /ansible/ansible-documentation
       [collections org]: /ansible-collections
     placeholder: lib/ansible/modules/copy.py
   validations:

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -91,7 +91,7 @@ body:
       in this (`ansible/ansible`) repository.
       The Installation Guide, Playbook Guide, Developer Guide,
       and other documentation is available in the
-      [`ansible/ansible-documentation`][ansible-documentation] repository.
+      [`ansible/ansible-documentation`] repository.
       Documentation for other modules/plugins/etc is likely to be
       available in one of the [Ansible Collections maintained by
       the community][collections org]. Select the **Issue Tracker** button

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -93,14 +93,12 @@ body:
       and other documentation is available in the
       [`ansible/ansible-documentation`] repository.
       Documentation for other modules/plugins/etc is likely to be
-      available in one of the [Ansible Collections maintained by
-      the community][collections org]. Select the **Issue Tracker** button
-      in the documentation to go directly to the GitHub issues for a
-      community collection.
-
+      available in one of the [Ansible Collections][collections-index].
+      If available in the collection documentation, select the
+      *Issue Tracker** button to go directly to the GitHub issues.
 
       [`ansible/ansible-documentation`]: /ansible/ansible-documentation
-      [collections org]: /ansible-collections
+      [collections-index]: https://docs.ansible.com/ansible/latest/collections/index.html
     placeholder: lib/ansible/modules/copy.py
   validations:
     required: true

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -92,7 +92,7 @@ body:
       Documentation for modules/plugins/etc that are officially
       supported by the Ansible Core Engineering team is available
       in this (`ansible/ansible`) repository.
-      User documentation pages such as the Playbook Guide,
+      Documentation guides such as the Playbook Guide,
       Developer Guide, and so on is available in the
       [`ansible/ansible-documentation`][ansible-documentation] repository.
       Documentation for other modules/plugins/etc is likely to be

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -92,12 +92,14 @@ body:
       Documentation for modules/plugins/etc that are officially
       supported by the Ansible Core Engineering team is available
       in this (`ansible/ansible`) repository.
-      Documentation guides such as the Playbook Guide,
-      Developer Guide, and so on are available in the
+      The Installation Guide, Playbook Guide, Developer Guide,
+      and other documentation is available in the
       [`ansible/ansible-documentation`][ansible-documentation] repository.
       Documentation for other modules/plugins/etc is likely to be
       available in one of the [Ansible Collections maintained by
-      the community][collections org].
+      the community][collections org]. Select the **Issue Tracker** button
+      in the documentation to go directly to the GitHub issues for a
+      community collection.
 
 
       [ansible-documentation]: https://github.com/ansible/ansible-documentation/issues

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -86,7 +86,7 @@ body:
       feature below, *use your best guess if unsure*.
 
 
-      **Tip:** Source files for Ansible community documentation is
+      **Tip:** Source files for Ansible community documentation are
       hosted in different repositories. Please make sure to file an
       issue in the correct project.
       Documentation for modules/plugins/etc that are officially

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -64,9 +64,6 @@ body:
           <em>Why?</em>
         </summary>
 
-        We would do it by ourselves but unfortunately, the current
-        edition of GitHub Issue Forms Alpha does not support this yet 🤷
-
 
         _We will make it easier in the future, once GitHub
         supports dropdown defaults. Promise!_


### PR DESCRIPTION
##### SUMMARY
Updates the doc issue report template to direct users to the `ansible-documentation` repo.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`.github/ISSUE_TEMPLATE/documentation_report.yml`

##### ADDITIONAL INFORMATION
N/A
