### PR TITLE
dnf5: enable now implemented cacheonly functionality

### DIFF
--- a/changelogs/fragments/dnf5-cacheonly.yml
+++ b/changelogs/fragments/dnf5-cacheonly.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - dnf5 - enable now implemented ``cacheonly`` functionality

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -215,7 +215,6 @@ options:
     default: "no"
   cacheonly:
     description:
-      - This is currently no-op as dnf5 does not implement the feature.
       - Tells dnf to run entirely from system cache; does not download or update metadata.
     type: bool
     default: "no"

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -512,7 +512,7 @@ class Dnf5Module(YumDnf):
         conf.clean_requirements_on_remove = self.autoremove
         conf.installroot = self.installroot
         conf.use_host_config = True  # needed for installroot
-        conf.cacheonly = self.cacheonly
+        conf.cacheonly = "all" if self.cacheonly else "none"
         if self.download_dir:
             conf.destdir = self.download_dir
 

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -74,4 +74,3 @@
   when:
     - (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('23', '>=')) or
       (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
-    - not dnf5|default('false')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Note that this also fixes a traceback caused by backwards incompatible change in dnf5 where cacheonly was changed from bool to string: https://github.com/rpm-software-management/dnf5/pull/665/files#diff-ab65249ff7fccadfb2864b6826f6559f7f16fad43fd3bf2da0b4fe8db790d59aR179

The above change is only present in the nightly builds that our CI uses. Once the change is released we need to backport this into 2.15.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
dnf5