### PR TITLE
Clarify galaxy CLI --help about install locations

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -496,7 +496,7 @@ class GalaxyCLI(CLI):
             description_text = (
                 'Install {0}(s) from file(s), URL(s) or Ansible '
                 'Galaxy to the first entry in the config {1}S_PATH '
-                'unless overriden by --{0}s-path'.format(galaxy_type, galaxy_type.upper())
+                'unless overridden by --{0}s-path'.format(galaxy_type, galaxy_type.upper())
             )
         install_parser = parser.add_parser('install', parents=parents,
                                            help='Install {0}(s) from file(s), URL(s) or Ansible '

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -277,7 +277,7 @@ class GalaxyCLI(CLI):
         collections_path = opt_help.ArgumentParser(add_help=False)
         collections_path.add_argument('-p', '--collections-path', dest='collections_path', type=opt_help.unfrack_path(pathsep=True),
                                       action=opt_help.PrependListAction,
-                                      help="One or more directories to search for collections in addition "
+                                      help="One or more directories to search for collections (or install to) in addition "
                                       "to the default COLLECTIONS_PATHS. Separate multiple paths "
                                       "with '{0}'.".format(os.path.pathsep))
 
@@ -485,9 +485,23 @@ class GalaxyCLI(CLI):
             args_kwargs['help'] = 'Role name, URL or tar file'
             ignore_errors_help = 'Ignore errors and continue with the next specified role.'
 
+        if self._implicit_role:
+            # installing both roles and collections
+            description_text = (
+                'Install roles and collections from file(s), URL(s) or Ansible '
+                'Galaxy to the first entry in the config COLLECTIONS_PATH for collections '
+                'and first entry in the config ROLES_PATH for roles.'
+            )
+        else:
+            description_text = (
+                'Install {0}(s) from file(s), URL(s) or Ansible '
+                'Galaxy to the first entry in the config {1}S_PATH '
+                'unless overriden by --{0}s-path'.format(galaxy_type, galaxy_type.upper())
+            )
         install_parser = parser.add_parser('install', parents=parents,
                                            help='Install {0}(s) from file(s), URL(s) or Ansible '
-                                                'Galaxy'.format(galaxy_type))
+                                                'Galaxy'.format(galaxy_type),
+                                           description=description_text)
         install_parser.set_defaults(func=self.execute_install)
 
         install_parser.add_argument('args', metavar='{0}_name'.format(galaxy_type), nargs='*', **args_kwargs)


### PR DESCRIPTION
##### SUMMARY
I asked a lot of questions to @john-westcott-iv on https://github.com/ansible/awx/pull/14081 which we discovered really came down to docs of the `ansible-galaxy` commands themselves.

In https://github.com/ansible/ansible/pull/67843 a new `ansible-galaxy install` command was introduced which could install _both_ roles and collections. The options are well-documented, but the _effect_ of the command is actually unclear. To explain why this the case, consider:

```
ansible-galaxy role install --help
```

What does this command do? The help text should show this in the _main body_ of the text. It doesn't quite do that, but it does have that information buried in an option.

```
  -p ROLES_PATH, --roles-path ROLES_PATH
                        The path to the directory containing your roles. The default is the first writable one
                        configured via DEFAULT_ROLES_PATH: {{ ANSIBLE_HOME ~
                        "/roles:/usr/share/ansible/roles:/etc/ansible/roles" }} . This argument may be specified
                        multiple times.
```

Yes, it is obvious _that it installs roles_ but _where does it install them?_ This help text answers that.

Surprisingly, this question is _not answered at all_ for either
 - `ansible-galaxy install --help` or
 - `ansible-galaxy collection install --help`

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/cli/galaxy.py

##### ADDITIONAL INFORMATION
With this change, we get:

```
$ ansible-galaxy role install --help
usage: ansible-galaxy role install [-h] [-s API_SERVER] [--token API_KEY] [-c] [--timeout TIMEOUT] [-v] [-f]
                                   [-p ROLES_PATH] [-i] [-n | --force-with-deps] [-r REQUIREMENTS] [-g]
                                   [role_name ...]

Install role(s) from file(s), URL(s) or Ansible Galaxy to the first entry in the config ROLES_PATH unless overriden
by --roles-path
```


```
$ ansible-galaxy collection install --help
usage: ansible-galaxy collection install [-h] [-s API_SERVER] [--token API_KEY] [-c] [--timeout TIMEOUT] [-v] [-f]
                                         [--clear-response-cache] [--no-cache] [-i] [-n | --force-with-deps]
                                         [-p COLLECTIONS_PATH] [-r REQUIREMENTS] [--pre] [-U] [--keyring KEYRING]
                                         [--disable-gpg-verify] [--signature SIGNATURES]
                                         [--required-valid-signature-count REQUIRED_VALID_SIGNATURE_COUNT]
                                         [--ignore-signature-status-code {EXPSIG,EXPKEYSIG,REVKEYSIG,BADSIG,ERRSIG,NO_PUBKEY,MISSING_PASSPHRASE,BAD_PASSPHRASE,NODATA,UNEXPECTED,ERROR,FAILURE,BADARMOR,KEYEXPIRED,KEYREVOKED,NO_SECKEY}]
                                         [--offline]
                                         [collection_name ...]

Install collection(s) from file(s), URL(s) or Ansible Galaxy to the first entry in the config COLLECTIONS_PATH
unless overriden by --collections-path
```

and

```
$ ansible-galaxy install --help
usage: ansible-galaxy role install [-h] [-s API_SERVER] [--token API_KEY] [-c] [--timeout TIMEOUT] [-v] [-f]
                                   [-p ROLES_PATH] [-i] [-n | --force-with-deps] [-r REQUIREMENTS] [-g]
                                   [role_name ...]

Install roles and collections from file(s), URL(s) or Ansible Galaxy to the first entry in the config
COLLECTIONS_PATH for collections and first entry in the config ROLES_PATH for roles.
```

To me, this answers the question of "what does this do?" for each command.

There are still some other shortcomings that I did _not_ address with this, but I want to mention anyway:
 - the `ansible-galaxy install` command has a `--roles-path` CLI option, but no collections path option
 - the `install` subcommand isn't listed in `ansible-galaxy --help`

For now, I wanted to stop at a purely docs patch, as this should change the help text rendering, but not change anything about the behavior.