### PR TITLE
modules/user: Fix returned groups issue

### DIFF
--- a/changelogs/fragments/81164-fix-user-module-groups-output-issue.yml
+++ b/changelogs/fragments/81164-fix-user-module-groups-output-issue.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - - The `user` module now outputs the exhaustive list of groups a user belongs to. Previously, only specified groups to which the user is to be added were displayed. ([#80669](https://github.com/ansible/ansible/issues/80669)) 

--- a/changelogs/fragments/81164-fix-user-module-groups-output-issue.yml
+++ b/changelogs/fragments/81164-fix-user-module-groups-output-issue.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - The `user` module now outputs the exhaustive list of groups a user belongs to. Previously, only specified groups to which the user is to be added were displayed. ([#80669](https://github.com/ansible/ansible/issues/80669)) 
+  - The ``user`` module now outputs the exhaustive list of groups a user belongs to. Previously, only specified groups to which the user is to be added were displayed (https://github.com/ansible/ansible/issues/80669).

--- a/changelogs/fragments/81164-fix-user-module-groups-output-issue.yml
+++ b/changelogs/fragments/81164-fix-user-module-groups-output-issue.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - - The `user` module now outputs the exhaustive list of groups a user belongs to. Previously, only specified groups to which the user is to be added were displayed. ([#80669](https://github.com/ansible/ansible/issues/80669)) 
+  - The `user` module now outputs the exhaustive list of groups a user belongs to. Previously, only specified groups to which the user is to be added were displayed. ([#80669](https://github.com/ansible/ansible/issues/80669)) 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3220,8 +3220,9 @@ def main():
         result['comment'] = info[4]
         result['home'] = info[5]
         result['shell'] = info[6]
-        if user.groups is not None:
-            result['groups'] = user.groups
+
+        # Get the list of groups the user is a member of
+        result['groups'] = ','.join(sorted(user.user_group_membership(exclude_primary=False)))
 
         # handle missing homedirs
         info = user.user_info()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Get the list of the groups the user belongs to by leveraging the **_user_group_membership_** function

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #80669 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
user
