### PR TITLE
Add space to make linter happy

### DIFF
--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -35,7 +35,7 @@ DOCUMENTATION = """
 
 EXAMPLES = """
 - ansible.builtin.debug:
-    msg: "the value of foo.txt is {{lookup('ansible.builtin.file', '/etc/foo.txt') }}"
+    msg: "the value of foo.txt is {{ lookup('ansible.builtin.file', '/etc/foo.txt') }}"
 
 - name: display multiple file contents
   ansible.builtin.debug: var=item


### PR DESCRIPTION
##### SUMMARY
Adding a space so the example conforms with linter

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
`ansible.builtin.file`
