### PR TITLE
handle more collection CLI options with ansible-galaxy install

### DIFF
--- a/changelogs/fragments/a-g-improve-unified-install.yml
+++ b/changelogs/fragments/a-g-improve-unified-install.yml
@@ -1,7 +1,6 @@
 minor_changes:
 - >-
-  ``ansible-galaxy install`` - when installing roles and collections from a ``-r``/``--role-file``,
-  allow all collection command line options except ``--requirements-file``.
+  ``ansible-galaxy install`` - allow all collection command line options when installing roles and collections from a requirements file.
 deprecated_features:
 - >-
   ``ansible-galaxy install`` - deprecate the ``--roles-path`` alias ``-p`` since the path type may be ambiguous.

--- a/changelogs/fragments/a-g-improve-unified-install.yml
+++ b/changelogs/fragments/a-g-improve-unified-install.yml
@@ -1,0 +1,8 @@
+minor_changes:
+- >-
+  ``ansible-galaxy install`` - when installing roles and collections from a ``-r``/``--role-file``,
+  allow all collection command line options except ``--requirements-file``.
+deprecated_features:
+- >-
+  ``ansible-galaxy install`` - deprecate the ``--roles-path`` alias ``-p`` since the path type may be ambiguous.
+  The shorthand can still be used in non-ambiguous contexts, for example ``ansible-galaxy role install``.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -519,8 +519,11 @@ class GalaxyCLI(CLI):
 
         install_collections_with_roles = False
         if galaxy_type != 'collection':
-            install_parser.add_argument('-r', '--role-file', dest='requirements',
-                                        help='A file containing a list of roles to be installed.')
+            if self._implicit_role:
+                req_help = 'A file containing a list of collections or roles (or both) to be installed.'
+            else:
+                req_help = 'A file containing a list of roles to be installed.'
+            install_parser.add_argument('-r', '--role-file', '--requirements-file', dest='requirements', help=req_help)
 
             r_re = re.compile(r'^(?<!-)-[a-zA-Z]*r[a-zA-Z]*')  # -r, -fr
             contains_r = bool([a for a in self._raw_args if r_re.match(a)])
@@ -544,7 +547,7 @@ class GalaxyCLI(CLI):
         if galaxy_type == 'collection' or install_collections_with_roles:
             context = ''
             if install_collections_with_roles:
-                context = '(collections only) '
+                context = '(collection option) '
             install_parser.add_argument(*collection_path_args, dest='collections_path',
                                         default=self._get_default_collection_path(),
                                         help='The path to the directory containing your collections.')

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -551,7 +551,7 @@ class GalaxyCLI(CLI):
                 context = '(collection option) '
             install_parser.add_argument(*collection_path_args, dest='collections_path',
                                         default=self._get_default_collection_path(),
-                                        help='The path to the directory containing your collections.')
+                                        help=f'{context}The path to the directory containing your collections.')
             install_parser.add_argument('--pre', dest='allow_pre_release', action='store_true',
                                         help=f'{context}Include pre-release versions. Semantic versioning pre-releases are ignored by default')
             install_parser.add_argument('-U', '--upgrade', dest='upgrade', action='store_true', default=False,

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -494,7 +494,8 @@ class GalaxyCLI(CLI):
         install_description = 'Install {0}(s) from file(s), URL(s) or Ansible Galaxy'.format(galaxy_type)
         if self._implicit_role:
             install_description += (
-                '. Roles and collections can be installed together using a --role-file.'
+                '. Roles and collections can be installed together using a --role-file. '
+                'See collection specific options with "ansible-galaxy install -r requirements.yml --help".'
             )
         install_parser = parser.add_parser('install', parents=parents, description=install_description)
         install_parser.set_defaults(func=self.execute_install)


### PR DESCRIPTION
##### SUMMARY
related #81159

* support more collection options when installing roles and collections together using --role-file. `--roles-path` and `--collections-path` can be provided together.
* deprecate the `-p` option with `ansible-galaxy install` in favor of `ansible-galaxy role install -p`. We'll be able to remove the two-type warning once it's removed.

##### ISSUE TYPE
- Feature Pull Request
