### PR TITLE
ansible-test - Remove old pytest-forked constraint

### DIFF
--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -5,7 +5,6 @@ pywinrm >= 0.3.0 ; python_version < '3.11' # message encryption support
 pywinrm >= 0.4.3 ; python_version >= '3.11' # support for Python 3.11
 pytest < 5.0.0, >= 4.5.0 ; python_version == '2.7' # pytest 5.0.0 and later will no longer support python 2.7
 pytest >= 4.5.0 ; python_version > '2.7' # pytest 4.5.0 added support for --strict-markers
-pytest-forked >= 1.0.2 # pytest-forked before 1.0.2 does not work with pytest 4.2.0+
 ntlm-auth >= 1.3.0 # message encryption support using cryptography
 requests-ntlm >= 1.1.0 # message encryption support
 requests-credssp >= 0.1.0 # message encryption support


### PR DESCRIPTION
##### SUMMARY

This is a follow-up to https://github.com/ansible/ansible/pull/80525/, where the constraint was made obsolete.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test