### PR TITLE
[stable-2.14] fix ansible_pkg_mgr is not available on kylin linux

### DIFF
--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -95,6 +95,18 @@ class PkgMgrFactCollector(BaseFactCollector):
                         pkg_mgr_name = 'dnf'
             except ValueError:
                 pkg_mgr_name = 'dnf'
+        elif collected_facts['ansible_distribution'] == 'Kylin Linux Advanced Server':
+            try:
+                major_version = collected_facts['ansible_distribution_major_version']
+                major_version = major_version[1:] if major_version[0] == 'V' else major_version
+                if int(major_version) < 10:
+                    if self._pkg_mgr_exists('yum'):
+                        pkg_mgr_name = 'yum'
+                else:
+                    if self._pkg_mgr_exists('dnf'):
+                        pkg_mgr_name = 'dnf'
+            except ValueError:
+                pkg_mgr_name = 'dnf'
         else:
             # If it's not one of the above and it's Red Hat family of distros, assume
             # RHEL or a clone. For versions of RHEL < 8 that Ansible supports, the


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
![image](https://github.com/ansible/ansible/assets/10629406/606fcade-90d8-4e01-9c65-b374faa6eedc)

The value of the `ansible_distribution_major_version variable` in the [`Kylin Linux`](https://www.kylinos.cn/scheme/server.html) is `V10`, which means that it cannot be converted directly by the int() function, so special handling of this value is required.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
`module_utils/facts/system/pkg_mgr`
