### PR TITLE
2.15: Properly disable modularity tests for dnf5 only (#81195)

### DIFF
--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -62,7 +62,7 @@
     - astream_name is defined
     - (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('29', '>=')) or
       (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
-    - not dnf5|default('false')
+    - not dnf5|default(false)
   tags:
     - dnf_modularity
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Backport of #81195 

(cherry picked from commit eb19692f484b2b58ac3697950eaa4e48b8320db5)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
`test/integration/targets/dnf/tasks/main.yml`
