### PR TITLE
Error messages are written in the stderr

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_error_handling.rst
@@ -116,13 +116,13 @@ You can also combine multiple conditions for failure. This task will fail if bot
       register: result
       failed_when:
         - result.rc == 0
-        - '"No such" not in result.stdout'
+        - '"No such" not in result.stderr'
 
 If you want the task to fail when only one condition is satisfied, change the ``failed_when`` definition to
 
 .. code-block:: yaml
 
-      failed_when: result.rc == 0 or "No such" not in result.stdout
+      failed_when: result.rc == 0 or "No such" not in result.stderr
 
 If you have too many conditions to fit neatly into one line, you can split it into a multi-line YAML value with ``>``.
 
@@ -132,7 +132,7 @@ If you have too many conditions to fit neatly into one line, you can split it in
       ansible.builtin.shell: "./myBinary"
       register: ret
       failed_when: >
-        ("No such file or directory" in ret.stdout) or
+        ("No such file or directory" in ret.stderr) or
         (ret.stderr != '') or
         (ret.rc == 10)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Some examples of error handling documentation are written as '"No such" not in result.stdout', 
but the output is written in the standard error. The right expression is '"No such" not in result.stderr'.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
