### PR TITLE
Fix yaml syntax in csvfile_lookup example

### DIFF
--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -57,7 +57,7 @@ EXAMPLES = """
     neighbor_as: "{{ csvline[5] }}"
     neigh_int_ip: "{{ csvline[6] }}"
   vars:
-    csvline = "{{ lookup('ansible.builtin.csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',') }}"
+    csvline: "{{ lookup('ansible.builtin.csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',') }}"
   delegate_to: localhost
 """
 


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fix yaml syntax in csvfile_lookup example

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME

ansible.builtin.csvfile lookup

##### ADDITIONAL INFORMATION

Testing this example gives a parse error.
The correct syntax needs a colon for assignment, not equal sign

```paste below
ERROR! Vars in a Task must be specified as a dictionary

The error appears to be in .... line 22, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  vars:
    csvline = "{{ lookup('ansible.builtin.csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',') }}"
    ^ here
We could be wrong, but this one looks like it might be an issue with
missing quotes. Always quote template expression brackets when they
start a value. For instance:

    with_items:
      - {{ foo }}

Should be written as:

    with_items:
      - "{{ foo }}"

```
