### PR TITLE
[stable-2.14] Reorganize CI sanity test matrix (#81004)

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -47,8 +47,6 @@ stages:
             - test: 1
             - test: 2
             - test: 3
-            - test: 4
-            - test: 5
   - stage: Units
     dependsOn: []
     jobs:

--- a/.azure-pipelines/commands/sanity.sh
+++ b/.azure-pipelines/commands/sanity.sh
@@ -7,12 +7,43 @@ IFS='/:' read -ra args <<< "$1"
 
 group="${args[1]}"
 
+group2_include=(
+    ansible-doc
+    changelog
+    package-data
+    pep8
+    pylint
+    validate-modules
+)
+
+group3_include=(
+    docs-build
+    sanity-docs
+)
+
+group1_exclude=(
+    "${group2_include[@]}"
+    "${group3_include[@]}"
+)
+
+options=()
+
 case "${group}" in
-    1) options=(--skip-test pylint --skip-test ansible-doc --skip-test docs-build --skip-test package-data --skip-test changelog --skip-test validate-modules) ;;
-    2) options=(                   --test      ansible-doc --test      docs-build --test      package-data --test      changelog) ;;
-    3) options=(--test pylint --exclude test/units/ --exclude lib/ansible/module_utils/) ;;
-    4) options=(--test pylint           test/units/           lib/ansible/module_utils/) ;;
-    5) options=(                                                                                                                 --test validate-modules) ;;
+    1)
+        for name in "${group1_exclude[@]}"; do
+            options+=(--skip-test "${name}")
+        done
+        ;;
+    2)
+        for name in "${group2_include[@]}"; do
+            options+=(--test "${name}")
+        done
+        ;;
+    3)
+        for name in "${group3_include[@]}"; do
+            options+=(--test "${name}")
+        done
+        ;;
 esac
 
 # shellcheck disable=SC2086


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81004

(cherry picked from commit ff359fa8e11c7b84a67e286e95c606c06b02152f)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

.azure-pipelines/azure-pipelines.yml