### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-/docs/ @ansible/ansible-release-managers
-/examples/ @ansible/ansible-release-managers
-/hacking/ @ansible/ansible-release-managers


### PR DESCRIPTION
##### SUMMARY

The `CODEOWNERS` file is no longer needed to protect directories now that the docs migration is over.

This reverts commit 91177623581490af0455307f6c8e26312b04b4a0.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

.github/CODEOWNERS