### PR TITLE
replace: handle exception while parsing escape char

### DIFF
--- a/changelogs/fragments/79364_replace.yml
+++ b/changelogs/fragments/79364_replace.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- replace - handle exception when bad escape character is provided in replace (https://github.com/ansible/ansible/issues/79364).

--- a/lib/ansible/modules/replace.py
+++ b/lib/ansible/modules/replace.py
@@ -285,7 +285,11 @@ def main():
         section = contents
 
     mre = re.compile(params['regexp'], re.MULTILINE)
-    result = re.subn(mre, params['replace'], section, 0)
+    try:
+        result = re.subn(mre, params['replace'], section, 0)
+    except re.error as e:
+        module.fail_json(msg="Unable to process replace due to error: %s" % to_text(e),
+                         exception=format_exc())
 
     if result[1] > 0 and section != result[0]:
         if pattern:

--- a/test/integration/targets/replace/tasks/main.yml
+++ b/test/integration/targets/replace/tasks/main.yml
@@ -264,7 +264,7 @@
       - replace_cat8.stdout_lines[7] == "0.0.0.0"
       - replace_cat8.stdout_lines[13] == "0.0.0.0"
 
-# https://github.com/ansible/ansible/issues/79364
+# For Python 3.6 or greater - https://github.com/ansible/ansible/issues/79364
 - name: Handle bad escape character in regular expression
   replace:
     path: /dev/null
@@ -274,9 +274,11 @@
     replace: '\D'
   ignore_errors: true
   register: replace_test9
+  when: ansible_python.version.major == 3 and ansible_python.version.minor > 6
 
 - name: Validate the failure
   assert:
     that:
       - replace_test9 is failure
       - replace_test9.msg.startswith("Unable to process replace")
+  when: ansible_python.version.major == 3 and ansible_python.version.minor > 6

--- a/test/integration/targets/replace/tasks/main.yml
+++ b/test/integration/targets/replace/tasks/main.yml
@@ -263,3 +263,20 @@
       - replace_cat8.stdout_lines[1] == "9.9.9.9"
       - replace_cat8.stdout_lines[7] == "0.0.0.0"
       - replace_cat8.stdout_lines[13] == "0.0.0.0"
+
+# https://github.com/ansible/ansible/issues/79364
+- name: Handle bad escape character in regular expression
+  replace:
+    path: /dev/null
+    after: ^
+    before: $
+    regexp: \.
+    replace: '\D'
+  ignore_errors: true
+  register: replace_test9
+
+- name: Validate the failure
+  assert:
+    that:
+      - replace_test9 is failure
+      - replace_test9.msg.startswith("Unable to process replace")


### PR DESCRIPTION
##### SUMMARY

* Fail early when bad escape character is provided in replace module

Fixes: #79364

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/79364_replace.yml
lib/ansible/modules/replace.py
test/integration/targets/replace/tasks/main.yml

