### PR TITLE
Update wait_for_connection to not reference configure script

### DIFF
--- a/lib/ansible/modules/wait_for_connection.py
+++ b/lib/ansible/modules/wait_for_connection.py
@@ -101,7 +101,7 @@ EXAMPLES = r'''
       customization:
         hostname: '{{ vm_shortname }}'
         runonce:
-        - powershell.exe -ExecutionPolicy Unrestricted -File C:\Windows\Temp\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert -EnableCredSSP
+        - cmd.exe /c winrm.cmd quickconfig -quiet -force
     delegate_to: localhost
 
   - name: Wait for system to become reachable over WinRM


### PR DESCRIPTION
##### SUMMARY
The `ConfigureRemotingForAnsible.ps1` script is now removed from the repo, use a builtin command instead in this example.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
wait_for_connection