### PR TITLE
regex_replace: correct Python function in docs

### DIFF
--- a/lib/ansible/plugins/filter/regex_replace.yml
+++ b/lib/ansible/plugins/filter/regex_replace.yml
@@ -5,7 +5,7 @@ DOCUMENTATION:
   description:
     - Replace a substring defined by a regular expression with another defined by another regular expression based on the first match.
   notes:
-    - Maps to Python's C(re.replace).
+    - Maps to Python's C(re.sub).
   positional: _input, _regex_match, _regex_replace
   options:
     _input:


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
`regex_replace` calls `re.sub()`: https://github.com/ansible/ansible/blob/59a791ee3be41d00f65fe47c20dd93489dd7222b/lib/ansible/plugins/filter/core.py#L124-L135

I don't think `re.replace()` has ever existed, this was probably just accidental conflation with the non-regex string `replace()` method.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME

<!--- Write the short name of the module, plugin, task or feature below -->
regex_replace

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
