### PR TITLE
Add ssh_key_derivation_rounds KDF parameter for Ed25519 SSH key generation in user module

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3144,7 +3144,7 @@ def main():
             # following are specific to ssh key generation
             generate_ssh_key=dict(type='bool'),
             ssh_key_bits=dict(type='int', default=ssh_defaults['bits']),
-            ssh_key_derivation_rounds=dict(type='int', default=ssh_defaults['rounds']),
+            ssh_key_derivation_rounds=dict(type='int', default=ssh_defaults['rounds'], no_log=False),
             ssh_key_type=dict(type='str', default=ssh_defaults['type']),
             ssh_key_file=dict(type='path'),
             ssh_key_comment=dict(type='str', default=ssh_defaults['comment']),

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -157,7 +157,7 @@ options:
             - Optionally specify the number of KDF (Key Derivation Function) rounds for key generation.
             - The default value depends on ssh-keygen.
         type: int
-        version_added: "next"
+        version_added: "2.16"
     ssh_key_type:
         description:
             - Optionally specify the type of SSH key to generate.


### PR DESCRIPTION
### Ed25519 SSH key generation in user module

##### SUMMARY

This pull request adds support for the `ssh_key_derivation_rounds` parameter in the user module's Ed25519 SSH key generation. It allows users to specify the number of Key Derivation Function (KDF) rounds to be used during key generation, providing enhanced security and flexibility.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

user

##### ADDITIONAL INFORMATION
