### PR TITLE
Update comment to match correct form parameter

### DIFF
--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -69,7 +69,7 @@ class KeycloakToken(object):
 
         # - build a request to POST to auth_url
         #  - body is form encoded
-        #    - 'request_token' is the offline token stored in ansible.cfg
+        #    - 'refresh_token' is the offline token stored in ansible.cfg
         #    - 'grant_type' is 'refresh_token'
         #    - 'client_id' is 'cloud-services'
         #       - should probably be based on the contents of the


### PR DESCRIPTION
Updated `refresh_token` to match value in the form payload from line 63.

##### SUMMARY

The variable name in this comment is incorrect and does not match the actual value from the form.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

Galaxy token.

##### ADDITIONAL INFORMATION

Simple comment fix to match the correct form value for those testing the token refresh process.
