### PR TITLE
[stable-2.15] ansible-test - Fix sanity traceback with `-e` opt (#81271)

### DIFF
--- a/changelogs/fragments/ansible-test-explain-traceback.yml
+++ b/changelogs/fragments/ansible-test-explain-traceback.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test - Fix several possible tracebacks when using the ``-e`` option with sanity tests.
+  - ansible-test - Remove redundant warning about missing programs before attempting to execute them.

--- a/test/integration/targets/ansible-test-sanity/runme.sh
+++ b/test/integration/targets/ansible-test-sanity/runme.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+set -eux
+
+ansible-test sanity --color --allow-disabled -e "${@}"
+
+set +x
+
 source ../collection/setup.sh
 
 set -x

--- a/test/lib/ansible_test/_internal/commands/sanity/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/__init__.py
@@ -263,7 +263,7 @@ def command_sanity(args: SanityConfig) -> None:
                         virtualenv_python = create_sanity_virtualenv(args, test_profile.python, test.name)
 
                         if virtualenv_python:
-                            virtualenv_yaml = check_sanity_virtualenv_yaml(virtualenv_python)
+                            virtualenv_yaml = args.explain or check_sanity_virtualenv_yaml(virtualenv_python)
 
                             if test.require_libyaml and not virtualenv_yaml:
                                 result = SanitySkipped(test.name)
@@ -1169,20 +1169,23 @@ def create_sanity_virtualenv(
 
         run_pip(args, virtualenv_python, commands, None)  # create_sanity_virtualenv()
 
-        write_text_file(meta_install, virtualenv_install)
+        if not args.explain:
+            write_text_file(meta_install, virtualenv_install)
 
         # false positive: pylint: disable=no-member
         if any(isinstance(command, PipInstall) and command.has_package('pyyaml') for command in commands):
-            virtualenv_yaml = yamlcheck(virtualenv_python)
+            virtualenv_yaml = yamlcheck(virtualenv_python, args.explain)
         else:
             virtualenv_yaml = None
 
-        write_json_file(meta_yaml, virtualenv_yaml)
+        if not args.explain:
+            write_json_file(meta_yaml, virtualenv_yaml)
 
         created_venvs.append(f'{label}-{python.version}')
 
-    # touch the marker to keep track of when the virtualenv was last used
-    pathlib.Path(virtualenv_marker).touch()
+    if not args.explain:
+        # touch the marker to keep track of when the virtualenv was last used
+        pathlib.Path(virtualenv_marker).touch()
 
     return virtualenv_python
 

--- a/test/lib/ansible_test/_internal/commands/sanity/ansible_doc.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/ansible_doc.py
@@ -113,6 +113,9 @@ class AnsibleDocTest(SanitySingleVersion):
                     summary = 'Output on stderr from ansible-doc is considered an error.\n\n%s' % SubprocessError(cmd, stderr=stderr)
                     return SanityFailure(self.name, summary=summary)
 
+                if args.explain:
+                    continue
+
                 plugin_list_json = json.loads(stdout)
                 doc_targets[doc_type] = []
                 for plugin_name, plugin_value in sorted(plugin_list_json.items()):

--- a/test/lib/ansible_test/_internal/commands/sanity/import.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/import.py
@@ -140,7 +140,7 @@ class ImportTest(SanityMultipleVersion):
                 display.warning(f'Skipping sanity test "{self.name}" on Python {python.version} due to missing virtual environment support.')
                 return SanitySkipped(self.name, python.version)
 
-            virtualenv_yaml = check_sanity_virtualenv_yaml(virtualenv_python)
+            virtualenv_yaml = args.explain or check_sanity_virtualenv_yaml(virtualenv_python)
 
             if virtualenv_yaml is False:
                 display.warning(f'Sanity test "{self.name}" ({import_type}) on Python {python.version} may be slow due to missing libyaml support in PyYAML.')

--- a/test/lib/ansible_test/_internal/commands/sanity/mypy.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/mypy.py
@@ -168,6 +168,9 @@ class MypyTest(SanityMultipleVersion):
         # However, it will also report issues on those files, which is not the desired behavior.
         messages = [message for message in messages if message.path in paths_set]
 
+        if args.explain:
+            return SanitySuccess(self.name, python_version=python.version)
+
         results = settings.process_errors(messages, paths)
 
         if results:
@@ -250,7 +253,7 @@ class MypyTest(SanityMultipleVersion):
 
         pattern = r'^(?P<path>[^:]*):(?P<line>[0-9]+):((?P<column>[0-9]+):)? (?P<level>[^:]+): (?P<message>.*)$'
 
-        parsed = parse_to_list_of_dict(pattern, stdout)
+        parsed = parse_to_list_of_dict(pattern, stdout or '')
 
         messages = [SanityMessage(
             level=r['level'],

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -438,7 +438,7 @@ def raw_command(
     display.info(f'{description}: {escaped_cmd}', verbosity=cmd_verbosity, truncate=True)
     display.info('Working directory: %s' % cwd, verbosity=2)
 
-    program = find_executable(cmd[0], cwd=cwd, path=env['PATH'], required='warning')
+    program = find_executable(cmd[0], cwd=cwd, path=env['PATH'], required=False)
 
     if program:
         display.info('Program found: %s' % program, verbosity=2)

--- a/test/lib/ansible_test/_internal/util_common.py
+++ b/test/lib/ansible_test/_internal/util_common.py
@@ -498,9 +498,14 @@ def run_command(
     )
 
 
-def yamlcheck(python: PythonConfig) -> t.Optional[bool]:
+def yamlcheck(python: PythonConfig, explain: bool = False) -> t.Optional[bool]:
     """Return True if PyYAML has libyaml support, False if it does not and None if it was not found."""
-    result = json.loads(raw_command([python.path, os.path.join(ANSIBLE_TEST_TARGET_TOOLS_ROOT, 'yamlcheck.py')], capture=True)[0])
+    stdout = raw_command([python.path, os.path.join(ANSIBLE_TEST_TARGET_TOOLS_ROOT, 'yamlcheck.py')], capture=True, explain=explain)[0]
+
+    if explain:
+        return None
+
+    result = json.loads(stdout)
 
     if not result['yaml']:
         return None


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81271

Also remove redundant warning about missing programs.

Includes integration tests to verify `-e` does not traceback.

(cherry picked from commit 3f7bf0bcd41776300b504f9effaabf84ad5ff39e)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
