### PR TITLE
ansible-test - Narrow the scope of some sanity tests

### DIFF
--- a/changelogs/fragments/ansible-test-sanity-scope.yml
+++ b/changelogs/fragments/ansible-test-sanity-scope.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - The ``replace-urlopen`` sanity test is now limited to plugins in collections.
+                   Previously any Python file in a collection was checked for ``urlopen`` usage.

--- a/changelogs/fragments/ansible-test-sanity-scope.yml
+++ b/changelogs/fragments/ansible-test-sanity-scope.yml
@@ -3,3 +3,5 @@ minor_changes:
                    Previously any Python file in a collection was checked for ``urlopen`` usage.
   - ansible-test - The ``use-compat-six`` sanity test is now limited to plugins in collections.
                    Previously any Python file in a collection was checked for ``six`` usage.
+  - ansible-test - The ``no-get-exception`` sanity test is now limited to plugins in collections.
+                   Previously any Python file in a collection was checked for ``get_exception`` usage.

--- a/changelogs/fragments/ansible-test-sanity-scope.yml
+++ b/changelogs/fragments/ansible-test-sanity-scope.yml
@@ -1,3 +1,5 @@
 minor_changes:
   - ansible-test - The ``replace-urlopen`` sanity test is now limited to plugins in collections.
                    Previously any Python file in a collection was checked for ``urlopen`` usage.
+  - ansible-test - The ``use-compat-six`` sanity test is now limited to plugins in collections.
+                   Previously any Python file in a collection was checked for ``six`` usage.

--- a/test/integration/targets/ansible-test-sanity-no-get-exception/aliases
+++ b/test/integration/targets/ansible-test-sanity-no-get-exception/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group3  # runs in the distro test containers
+shippable/generic/group1  # runs in the default test container
+context/controller
+needs/target/collection

--- a/test/integration/targets/ansible-test-sanity-no-get-exception/ansible_collections/ns/col/do-not-check-me.py
+++ b/test/integration/targets/ansible-test-sanity-no-get-exception/ansible_collections/ns/col/do-not-check-me.py
@@ -1,0 +1,5 @@
+from ansible.module_utils.pycompat24 import get_exception
+
+
+def do_stuff():
+    get_exception()

--- a/test/integration/targets/ansible-test-sanity-no-get-exception/ansible_collections/ns/col/plugins/modules/check-me.py
+++ b/test/integration/targets/ansible-test-sanity-no-get-exception/ansible_collections/ns/col/plugins/modules/check-me.py
@@ -1,0 +1,5 @@
+from ansible.module_utils.pycompat24 import get_exception
+
+
+def do_stuff():
+    get_exception()

--- a/test/integration/targets/ansible-test-sanity-no-get-exception/expected.txt
+++ b/test/integration/targets/ansible-test-sanity-no-get-exception/expected.txt
@@ -1,0 +1,2 @@
+plugins/modules/check-me.py:1:44: do not use `get_exception`
+plugins/modules/check-me.py:5:4: do not use `get_exception`

--- a/test/integration/targets/ansible-test-sanity-no-get-exception/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-no-get-exception/runme.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu
+
+source ../collection/setup.sh
+
+set -x
+
+ansible-test sanity --test no-get-exception --color --lint --failure-ok "${@}" > actual.txt
+
+diff -u "${TEST_DIR}/expected.txt" actual.txt
+diff -u do-not-check-me.py plugins/modules/check-me.py

--- a/test/integration/targets/ansible-test-sanity-replace-urlopen/aliases
+++ b/test/integration/targets/ansible-test-sanity-replace-urlopen/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group3  # runs in the distro test containers
+shippable/generic/group1  # runs in the default test container
+context/controller
+needs/target/collection

--- a/test/integration/targets/ansible-test-sanity-replace-urlopen/ansible_collections/ns/col/do-not-check-me.py
+++ b/test/integration/targets/ansible-test-sanity-replace-urlopen/ansible_collections/ns/col/do-not-check-me.py
@@ -1,0 +1,5 @@
+import urllib.request
+
+
+def do_stuff():
+    urllib.request.urlopen('https://www.ansible.com/')

--- a/test/integration/targets/ansible-test-sanity-replace-urlopen/ansible_collections/ns/col/plugins/modules/check-me.py
+++ b/test/integration/targets/ansible-test-sanity-replace-urlopen/ansible_collections/ns/col/plugins/modules/check-me.py
@@ -1,0 +1,5 @@
+import urllib.request
+
+
+def do_stuff():
+    urllib.request.urlopen('https://www.ansible.com/')

--- a/test/integration/targets/ansible-test-sanity-replace-urlopen/expected.txt
+++ b/test/integration/targets/ansible-test-sanity-replace-urlopen/expected.txt
@@ -1,0 +1,1 @@
+plugins/modules/check-me.py:5:20: use `ansible.module_utils.urls.open_url` instead of `urlopen`

--- a/test/integration/targets/ansible-test-sanity-replace-urlopen/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-replace-urlopen/runme.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu
+
+source ../collection/setup.sh
+
+set -x
+
+ansible-test sanity --test replace-urlopen --color --lint --failure-ok "${@}" > actual.txt
+
+diff -u "${TEST_DIR}/expected.txt" actual.txt
+diff -u do-not-check-me.py plugins/modules/check-me.py

--- a/test/integration/targets/ansible-test-sanity-use-compat-six/aliases
+++ b/test/integration/targets/ansible-test-sanity-use-compat-six/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group3  # runs in the distro test containers
+shippable/generic/group1  # runs in the default test container
+context/controller
+needs/target/collection

--- a/test/integration/targets/ansible-test-sanity-use-compat-six/ansible_collections/ns/col/do-not-check-me.py
+++ b/test/integration/targets/ansible-test-sanity-use-compat-six/ansible_collections/ns/col/do-not-check-me.py
@@ -1,0 +1,5 @@
+import six
+
+
+def do_stuff():
+    assert six.text_type

--- a/test/integration/targets/ansible-test-sanity-use-compat-six/ansible_collections/ns/col/plugins/modules/check-me.py
+++ b/test/integration/targets/ansible-test-sanity-use-compat-six/ansible_collections/ns/col/plugins/modules/check-me.py
@@ -1,0 +1,5 @@
+import six
+
+
+def do_stuff():
+    assert six.text_type

--- a/test/integration/targets/ansible-test-sanity-use-compat-six/expected.txt
+++ b/test/integration/targets/ansible-test-sanity-use-compat-six/expected.txt
@@ -1,0 +1,1 @@
+plugins/modules/check-me.py:1:1: use `ansible.module_utils.six` instead of `six`

--- a/test/integration/targets/ansible-test-sanity-use-compat-six/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-use-compat-six/runme.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu
+
+source ../collection/setup.sh
+
+set -x
+
+ansible-test sanity --test use-compat-six --color --lint --failure-ok "${@}" > actual.txt
+
+diff -u "${TEST_DIR}/expected.txt" actual.txt
+diff -u do-not-check-me.py plugins/modules/check-me.py

--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/no-get-exception.json
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/no-get-exception.json
@@ -2,6 +2,10 @@
     "extensions": [
         ".py"
     ],
+    "prefixes": [
+        "lib/ansible/",
+        "plugins/"
+    ],
     "ignore_self": true,
     "output": "path-line-column-message"
 }

--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/replace-urlopen.json
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/replace-urlopen.json
@@ -2,6 +2,10 @@
     "extensions": [
         ".py"
     ],
+    "prefixes": [
+        "lib/ansible/",
+        "plugins/"
+    ],
     "ignore_self": true,
     "output": "path-line-column-message"
 }

--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/use-compat-six.json
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/use-compat-six.json
@@ -2,5 +2,9 @@
     "extensions": [
         ".py"
     ],
+    "prefixes": [
+        "lib/ansible/",
+        "plugins/"
+    ],
     "output": "path-line-column-message"
 }

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -1,4 +1,3 @@
-.azure-pipelines/scripts/publish-codecov.py replace-urlopen
 lib/ansible/cli/scripts/ansible_connection_cli_stub.py shebang
 lib/ansible/config/base.yml no-unwanted-files
 lib/ansible/executor/powershell/async_watchdog.ps1 pslint:PSCustomUseLiteralPath
@@ -138,7 +137,6 @@ test/integration/targets/win_script/files/test_script_removes_file.ps1 pslint:PS
 test/integration/targets/win_script/files/test_script_with_args.ps1 pslint:PSAvoidUsingWriteHost # Keep
 test/integration/targets/win_script/files/test_script_with_splatting.ps1 pslint:PSAvoidUsingWriteHost # Keep
 test/lib/ansible_test/_data/requirements/sanity.pslint.ps1 pslint:PSCustomUseLiteralPath # Uses wildcards on purpose
-test/lib/ansible_test/_util/target/setup/requirements.py replace-urlopen
 test/support/network-integration/collections/ansible_collections/ansible/netcommon/plugins/module_utils/compat/ipaddress.py no-unicode-literals
 test/support/network-integration/collections/ansible_collections/cisco/ios/plugins/cliconf/ios.py pylint:arguments-renamed
 test/support/network-integration/collections/ansible_collections/vyos/vyos/plugins/cliconf/vyos.py pylint:arguments-renamed
@@ -167,9 +165,6 @@ test/units/module_utils/basic/test_deprecate_warn.py pylint:ansible-deprecated-v
 test/units/module_utils/common/warnings/test_deprecate.py pylint:ansible-deprecated-no-version  # testing Display.deprecated call without a version or date
 test/units/module_utils/common/warnings/test_deprecate.py pylint:ansible-deprecated-version  # testing Deprecated version found in call to Display.deprecated or AnsibleModule.deprecate
 test/units/module_utils/urls/fixtures/multipart.txt line-endings  # Fixture for HTTP tests that use CRLF
-test/units/module_utils/urls/test_fetch_url.py replace-urlopen
-test/units/module_utils/urls/test_gzip.py replace-urlopen
-test/units/module_utils/urls/test_Request.py replace-urlopen
 test/units/utils/collection_loader/fixtures/collections/ansible_collections/testns/testcoll/plugins/action/my_action.py pylint:relative-beyond-top-level
 test/units/utils/collection_loader/fixtures/collections/ansible_collections/testns/testcoll/plugins/modules/__init__.py empty-init  # testing that collections don't need inits
 test/units/utils/collection_loader/fixtures/collections_masked/ansible_collections/ansible/__init__.py empty-init  # testing that collections don't need inits


### PR DESCRIPTION
##### SUMMARY

Narrow the scope of some sanity tests:

  - replace-urlopen
  - use-compat-six
  - no-get-exception

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test