### PR TITLE
The split filter was added in ansible-core 2.11

### DIFF
--- a/lib/ansible/plugins/filter/split.yml
+++ b/lib/ansible/plugins/filter/split.yml
@@ -1,6 +1,6 @@
 DOCUMENTATION:
   name: split
-  version_added: "historical"
+  version_added: 2.11
   short_description: split a string into a list
   description:
     - Using Python's text object method C(split) we turn strings into lists via a 'splitting character'.


### PR DESCRIPTION
##### SUMMARY
Currently `version_added` for the `split` filter says `historical`, which usually means "a long time ago" (probably before 2.0). But in fact that filter was only added in ansible-core 2.11, as I noticed when using it in an integration test that failed on Ansible 2.9 :)

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
split filter docs
