### PR TITLE
Implement try-restart state for systemd module

### DIFF
--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -27,7 +27,7 @@ options:
         description:
             - V(started)/V(stopped) are idempotent actions that will not run commands unless necessary.
               V(restarted) will always bounce the unit. V(reloaded) will always reload.
-              V(tried-restart) will restart the unit if it is running and do nothing if the unit is not running. 
+              V(tried-restart) will restart the unit if it is running and do nothing if the unit is not running.
         type: str
         choices: [ reloaded, restarted, started, stopped, tried-restart ]
     enabled:


### PR DESCRIPTION
##### SUMMARY

Adds the state `tried-restart` to the systemd module.

Currently the systemd module only supports the states `started`, `stopped`, `reloaded` and `restarted`. A common use case is to restart a service only if it is already running, which systemd [officially supports](https://www.freedesktop.org/software/systemd/man/systemctl.html) through the command `try-restart`. While this is already possible with ansible through a combination of fetching the state and a conditional restart, supporting it directly as a target state would make things much easier.

The name of the state `tried-restart` was the best I could come up with to stay in line with the naming convention of existing states, while staying close to the `try-restart` used by systemd.


<!--- Describe the change below, including rationale and design decisions -->



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes https://github.com/ansible/ansible/issues/61763

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME

<!--- Write the short name of the module, plugin, task or feature below -->

systemd

##### ADDITIONAL INFORMATION

