### PR TITLE
psrp - fix up script chdir setting

### DIFF
--- a/changelogs/fragments/psrp-script-chdir.yml
+++ b/changelogs/fragments/psrp-script-chdir.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- psrp script - Support setting ``chdir`` with ``script`` when using the ``psrp`` connection plugin - https://github.com/ansible/ansible/issues/81277

--- a/test/integration/targets/connection_psrp/files/cd_script.ps1
+++ b/test/integration/targets/connection_psrp/files/cd_script.ps1
@@ -1,0 +1,1 @@
+$pwd.Path

--- a/test/integration/targets/connection_psrp/tests.yml
+++ b/test/integration/targets/connection_psrp/tests.yml
@@ -134,3 +134,37 @@
         path: /tmp/empty.txt
         state: absent
       delegate_to: localhost
+
+
+  # https://github.com/ansible/ansible/issues/81277
+  # First few tests ensure the cd checking doesn't impact raw commands and only
+  # ones added by _low_level_execute_command
+  - name: run raw command with cd command without normal command separator
+    raw: cd C:\Windows; $pwd.Path
+    register: raw_cd1
+
+  - name: run raw command with cd command with normal command separator
+    raw: cd c:\Windows ; $pwd.Path
+    register: raw_cd2
+
+  - name: run raw command with common PowerShell encoded command wrapper
+    raw: cd c:\Windows ; PowerShell -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand {{ '$pwd.Path' | b64encode(encoding='utf-16-le') }}
+    register: raw_cd3
+
+  - name: assert raw cd commands worked
+    assert:
+      that:
+      - raw_cd1.stdout == 'C:\\Windows'
+      - raw_cd2.stdout == 'C:\\Windows'
+      - raw_cd3.stdout == 'C:\\Windows'
+
+  - name: run script with chdir
+    script: cd_script.ps1
+    args:
+      chdir: C:\Windows
+    register: script_cd
+
+  - name: assert script chdir output
+    assert:
+      that:
+      - script_cd.stdout


### PR DESCRIPTION
##### SUMMARY
The `psrp` connection plugin runs commands in a unique way due to the nature of the underlying protocol it uses. When `_low_level_execute_command` is called with a custom `chdir` value it simply just prepends `cd {path} ; {cmd}`. This PR updates the login in `psrp` to take this into account and to try and set the value properly if it's running with the standard module payload command that script would use.

Fixes: https://github.com/ansible/ansible/issues/81277

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
psrp