### PR TITLE
Update urls unit test to support latest cryptography release

### DIFF
--- a/changelogs/fragments/urls-unit-test-latest-cryptography.yml
+++ b/changelogs/fragments/urls-unit-test-latest-cryptography.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Update module_utils.urls unit test to work with cryptography >= 41.0.0.

--- a/test/units/module_utils/urls/test_channel_binding.py
+++ b/test/units/module_utils/urls/test_channel_binding.py
@@ -9,7 +9,31 @@ import base64
 import os.path
 import pytest
 
+from ansible.module_utils.compat.version import LooseVersion
 from ansible.module_utils import urls
+
+
+# cryptography < 41.0.0 does not associate the algorithm with the cert,
+# so module_utils falls back to cryptography.hazmat.primitives.hashes.SHA256
+rsa_pss_sha512 = (
+    b'\x85\x85\x19\xB9\xE1\x0F\x23\xE2'
+    b'\x1D\x2C\xE9\xD5\x47\x2A\xAB\xCE'
+    b'\x42\x0F\xD1\x00\x75\x9C\x53\xA1'
+    b'\x7B\xB9\x79\x86\xB2\x59\x61\x27'
+)
+
+if urls.HAS_CRYPTOGRAPHY:
+    import cryptography
+
+    if LooseVersion(cryptography.__version__) >= LooseVersion('41.0.0'):
+        rsa_pss_sha512 = (
+            b"K\x8c\xa5\xf5y\x89A\xa0\xaf'\xeb"
+            b"\x00\xeb\xccUz6z\xe0l\x035\xa3h"
+            b"\xfc\xa6 k\xda]\xba\x88\xf8m\xf3"
+            b"\x98\xd2\xd2wW\x87w\xa4\x0e\x14"
+            b"\t\xd4]\xb9\xa29\xe2h\x1b\x9f"
+            b"\xe6\x04\x00\xec\x7fc\x83\xd7b"
+        )
 
 
 @pytest.mark.skipif(not urls.HAS_CRYPTOGRAPHY, reason='Requires cryptography to be installed')
@@ -44,10 +68,7 @@ from ansible.module_utils import urls
                            b'\xC2\xDC\xBB\x89\x8D\x84\x47\x4E'
                            b'\x58\x9C\xD7\xC2\x7A\xDB\xEF\x8B'
                            b'\xD9\xC0\xC0\x68\xAF\x9C\x36\x6D'),
-    ('rsa-pss_sha512.pem', b'\x85\x85\x19\xB9\xE1\x0F\x23\xE2'
-                           b'\x1D\x2C\xE9\xD5\x47\x2A\xAB\xCE'
-                           b'\x42\x0F\xD1\x00\x75\x9C\x53\xA1'
-                           b'\x7B\xB9\x79\x86\xB2\x59\x61\x27'),
+    ('rsa-pss_sha512.pem', rsa_pss_sha512),
     ('ecdsa_sha256.pem', b'\xFE\xCF\x1B\x25\x85\x44\x99\x90'
                          b'\xD9\xE3\xB2\xC9\x2D\x3F\x59\x7E'
                          b'\xC8\x35\x4E\x12\x4E\xDA\x75\x1D'


### PR DESCRIPTION
##### SUMMARY
This is necessary for this unit test to pass against the latest version of our default test container.

bisected when I ran into this:

https://github.com/pyca/cryptography/commit/b436fafa7cf43c96f66d50162ac495c99ade1f39 <- initial change which made our test case an error
https://github.com/pyca/cryptography/commit/93c96b777acffd6b1fab17077397e5c5a73c4c71 <- added support for the algorithm so now module_utils uses SHA512 instead of the fallback

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME

<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
