### PR TITLE
Added a suggest to the error.

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -681,7 +681,7 @@ class VaultLib:
         b_plaintext = None
 
         if not self.secrets:
-            raise AnsibleVaultError('Attempting to decrypt but no vault secrets found')
+            raise AnsibleVaultError('Attempting to decrypt but no vault secrets found, try adding --ask-vault-pass')
 
         # WARNING: Currently, the vault id is not required to match the vault id in the vault blob to
         #          decrypt a vault properly. The vault id in the vault blob is not part of the encrypted


### PR DESCRIPTION
##### SUMMARY

After reading the stackoverflow post:
https://stackoverflow.com/questions/64261899/ansible-error-attempting-to-decrypt-but-no-vault-secrets-found-but-im-not-de

This made the option much clearer. I added this to the RaisedError so someone could try to fix the error.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`ansible-vault`
