### PR TITLE
Disable cron integration test on Alpine

### DIFF
--- a/test/integration/targets/setup_cron/tasks/main.yml
+++ b/test/integration/targets/setup_cron/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: Alpine is not supported due to lack of libfaketime
+  meta: end_host
+  when: ansible_distribution == 'Alpine'
+
 - name: Include distribution specific variables
   include_vars: "{{ lookup('first_found', search) }}"
   vars:


### PR DESCRIPTION
##### SUMMARY

The tests are now failing due to the lack of `libfaketime` in the Alpine repos.

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

cron integration test