### PR TITLE
[stable-2.14] Disable cron integration test on Alpine (#81301)

### DIFF
--- a/test/integration/targets/setup_cron/tasks/main.yml
+++ b/test/integration/targets/setup_cron/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: Alpine is not supported due to lack of libfaketime
+  meta: end_host
+  when: ansible_distribution == 'Alpine'
+
 - name: Include distribution specific variables
   include_vars: "{{ lookup('first_found', search) }}"
   vars:


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81301

The tests are now failing due to the lack of `libfaketime` in the Alpine repos.

(cherry picked from commit 261a12b8a95533547a7cad966543f904940ac056)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

cron integration test
