### PR TITLE
[stable-2.15] Add missing skip entries for selinux module_util (#81305)

### DIFF
--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -80,6 +80,8 @@ lib/ansible/module_utils/compat/selinux.py import-3.6!skip # pass/fail depends o
 lib/ansible/module_utils/compat/selinux.py import-3.7!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.8!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.9!skip # pass/fail depends on presence of libselinux.so
+lib/ansible/module_utils/compat/selinux.py import-3.10!skip # pass/fail depends on presence of libselinux.so
+lib/ansible/module_utils/compat/selinux.py import-3.11!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/distro/_distro.py future-import-boilerplate # ignore bundled
 lib/ansible/module_utils/distro/_distro.py metaclass-boilerplate # ignore bundled
 lib/ansible/module_utils/distro/_distro.py no-assert


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81305

(cherry picked from commit 18cbfc688b0bc78f96d8776fe476ec47b319a8b2)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

sanity tests