### PR TITLE
[stable-2.12] ansible-test - Pre-build PyYAML wheels (#81300)

### DIFF
--- a/changelogs/fragments/ansible-test-pyyaml-build.yml
+++ b/changelogs/fragments/ansible-test-pyyaml-build.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Pre-build a PyYAML wheel before installing requirements to avoid a potential Cython build failure.

--- a/test/lib/ansible_test/_data/requirements/sanity.ansible-doc.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.ansible-doc.txt
@@ -1,3 +1,5 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 jinja2 == 3.0.1  # ansible-core requirement
 pyyaml == 5.4.1  # ansible-core requirement
 packaging == 21.0  # ansible-doc requirement

--- a/test/lib/ansible_test/_data/requirements/sanity.changelog.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.changelog.txt
@@ -1,3 +1,5 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 antsibull-changelog == 0.9.0
 
 # dependencies

--- a/test/lib/ansible_test/_data/requirements/sanity.import.plugin.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.import.plugin.txt
@@ -1,3 +1,5 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 jinja2 == 3.0.1
 PyYAML == 5.4.1
 cryptography == 3.3.2

--- a/test/lib/ansible_test/_data/requirements/sanity.import.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.import.txt
@@ -1,1 +1,3 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 pyyaml == 5.4.1  # needed for yaml_to_json.py

--- a/test/lib/ansible_test/_data/requirements/sanity.integration-aliases.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.integration-aliases.txt
@@ -1,1 +1,3 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 pyyaml == 5.4.1

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
@@ -1,3 +1,5 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 pylint == 2.9.3
 pyyaml == 5.4.1  # needed for collection_detail.py
 

--- a/test/lib/ansible_test/_data/requirements/sanity.runtime-metadata.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.runtime-metadata.txt
@@ -1,2 +1,4 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 pyyaml == 5.4.1
 voluptuous == 0.12.1

--- a/test/lib/ansible_test/_data/requirements/sanity.validate-modules.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.validate-modules.txt
@@ -1,3 +1,5 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 jinja2 == 3.0.1 # ansible-core requirement
 pyyaml == 5.4.1  # needed for collection_detail.py
 voluptuous == 0.12.1

--- a/test/lib/ansible_test/_data/requirements/sanity.yamllint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.yamllint.txt
@@ -1,3 +1,5 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 yamllint == 1.26.0
 
 # dependencies

--- a/test/lib/ansible_test/_internal/commands/sanity/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/__init__.py
@@ -70,6 +70,7 @@ from ...executor import (
 )
 
 from ...python_requirements import (
+    PipCommand,
     PipInstall,
     collect_requirements,
     run_pip,
@@ -1118,7 +1119,7 @@ def create_sanity_virtualenv(
     # The path to the virtual environment must be kept short to avoid the 127 character shebang length limit on Linux.
     # If the limit is exceeded, generated entry point scripts from pip installed packages will fail with syntax errors.
     virtualenv_install = json.dumps([command.serialize() for command in commands], indent=4)
-    virtualenv_hash = hashlib.sha256(to_bytes(virtualenv_install)).hexdigest()[:8]
+    virtualenv_hash = hash_pip_commands(commands)
     virtualenv_cache = os.path.join(os.path.expanduser('~/.ansible/test/venv'))
     virtualenv_path = os.path.join(virtualenv_cache, label, f'{python.version}', virtualenv_hash)
     virtualenv_marker = os.path.join(virtualenv_path, 'marker.txt')
@@ -1156,6 +1157,39 @@ def create_sanity_virtualenv(
     pathlib.Path(virtualenv_marker).touch()
 
     return virtualenv_python
+
+
+def hash_pip_commands(commands: list[PipCommand]) -> str:
+    """Return a short hash unique to the given list of pip commands, suitable for identifying the resulting sanity test environment."""
+    serialized_commands = json.dumps([make_pip_command_hashable(command) for command in commands], indent=4)
+
+    return hashlib.sha256(to_bytes(serialized_commands)).hexdigest()[:8]
+
+
+def make_pip_command_hashable(command: PipCommand) -> tuple[str, dict[str, t.Any]]:
+    """Return a serialized version of the given pip command that is suitable for hashing."""
+    if isinstance(command, PipInstall):
+        # The pre-build instructions for pip installs must be omitted, so they do not affect the hash.
+        # This is allows the pre-build commands to be added without breaking sanity venv caching.
+        # It is safe to omit these from the hash since they only affect packages used during builds, not what is installed in the venv.
+        command = PipInstall(
+            requirements=[omit_pre_build_from_requirement(*req) for req in command.requirements],
+            constraints=list(command.constraints),
+            packages=list(command.packages),
+        )
+
+    return command.serialize()
+
+
+def omit_pre_build_from_requirement(path: str, requirements: str) -> tuple[str, str]:
+    """Return the given requirements with pre-build instructions omitted."""
+    lines = requirements.splitlines(keepends=True)
+
+    # CAUTION: This code must be kept in sync with the code which processes pre-build instructions in:
+    #          test/lib/ansible_test/_util/target/setup/requirements.py
+    lines = [line for line in lines if not line.startswith('# pre-build ')]
+
+    return path, ''.join(lines)
 
 
 def check_sanity_virtualenv_yaml(python):  # type: (VirtualPythonConfig) -> t.Optional[bool]

--- a/test/lib/ansible_test/_util/target/setup/requirements.py
+++ b/test/lib/ansible_test/_util/target/setup/requirements.py
@@ -134,6 +134,14 @@ def install(pip, options):  # type: (str, t.Dict[str, t.Any]) -> None
         options.extend(packages)
 
         for path, content in requirements:
+            if path.split(os.sep)[0] in ('test', 'requirements'):
+                # Support for pre-build is currently limited to requirements embedded in ansible-test and those used by ansible-core.
+                # Requirements from ansible-core can be found in the 'test' and 'requirements' directories.
+                # This feature will probably be extended to support collections after further testing.
+                # Requirements from collections can be found in the 'tests' directory.
+                for pre_build in parse_pre_build_instructions(content):
+                    pre_build.execute(pip)
+
             write_text_file(os.path.join(tempdir, path), content, True)
             options.extend(['-r', path])
 
@@ -148,6 +156,61 @@ def install(pip, options):  # type: (str, t.Dict[str, t.Any]) -> None
         execute_command(command, env=env, cwd=tempdir)
     finally:
         remove_tree(tempdir)
+
+
+class PreBuild:
+    """Parsed pre-build instructions."""
+
+    def __init__(self, requirement):  # type: (str) -> None
+        self.requirement = requirement
+        self.constraints = []  # type: list[str]
+
+    def execute(self, pip):  # type: (str) -> None
+        """Execute these pre-build instructions."""
+        tempdir = tempfile.mkdtemp(prefix='ansible-test-', suffix='-pre-build')
+
+        try:
+            options = common_pip_options()
+            options.append(self.requirement)
+
+            constraints = '\n'.join(self.constraints) + '\n'
+            constraints_path = os.path.join(tempdir, 'constraints.txt')
+
+            write_text_file(constraints_path, constraints, True)
+
+            env = common_pip_environment()
+            env.update(PIP_CONSTRAINT=constraints_path)
+
+            command = [sys.executable, pip, 'wheel'] + options
+
+            execute_command(command, env=env, cwd=tempdir)
+        finally:
+            remove_tree(tempdir)
+
+
+def parse_pre_build_instructions(requirements):  # type: (str) -> list[PreBuild]
+    """Parse the given pip requirements and return a list of extracted pre-build instructions."""
+    # CAUTION: This code must be kept in sync with the sanity test hashing code in:
+    #          test/lib/ansible_test/_internal/commands/sanity/__init__.py
+
+    pre_build_prefix = '# pre-build '
+    pre_build_requirement_prefix = pre_build_prefix + 'requirement: '
+    pre_build_constraint_prefix = pre_build_prefix + 'constraint: '
+
+    lines = requirements.splitlines()
+    pre_build_lines = [line for line in lines if line.startswith(pre_build_prefix)]
+
+    instructions = []  # type: list[PreBuild]
+
+    for line in pre_build_lines:
+        if line.startswith(pre_build_requirement_prefix):
+            instructions.append(PreBuild(line[len(pre_build_requirement_prefix):]))
+        elif line.startswith(pre_build_constraint_prefix):
+            instructions[-1].constraints.append(line[len(pre_build_constraint_prefix):])
+        else:
+            raise RuntimeError('Unsupported pre-build comment: ' + line)
+
+    return instructions
 
 
 def uninstall(pip, options):  # type: (str, t.Dict[str, t.Any]) -> None

--- a/test/sanity/code-smell/botmeta.requirements.txt
+++ b/test/sanity/code-smell/botmeta.requirements.txt
@@ -1,2 +1,4 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 pyyaml == 5.4.1
 voluptuous == 0.12.1

--- a/test/sanity/code-smell/deprecated-config.requirements.txt
+++ b/test/sanity/code-smell/deprecated-config.requirements.txt
@@ -1,3 +1,5 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 jinja2 == 3.0.1 # ansible-core requirement
 pyyaml == 5.4.1
 

--- a/test/sanity/code-smell/docs-build.requirements.txt
+++ b/test/sanity/code-smell/docs-build.requirements.txt
@@ -1,3 +1,5 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 jinja2 == 3.0.1
 pyyaml == 5.4.1
 resolvelib == 0.5.4

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -1,3 +1,5 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 docutils == 0.17.1
 jinja2 == 3.0.1
 packaging == 21.0

--- a/test/sanity/code-smell/release-names.requirements.txt
+++ b/test/sanity/code-smell/release-names.requirements.txt
@@ -1,1 +1,3 @@
+# pre-build requirement: pyyaml == 5.4.1
+# pre-build constraint: Cython < 3.0
 pyyaml == 5.4.1


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81300

This works around Cython failures when attempting to install PyYAML >= 5.4 <= 6.0.

(cherry picked from commit e964078a83af240b103e34eafca9162deff0e16f)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test
