### PR TITLE
fix ansible_pkg_mgr is unknown in Kylin Linux

### DIFF
--- a/changelogs/fragments/81332-fix-pkg-mgr-in-kylin.yml
+++ b/changelogs/fragments/81332-fix-pkg-mgr-in-kylin.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pkg_mgr.py - Fix `ansible_pkg_mgr` is unknown in Kylin Linux (https://github.com/ansible/ansible/issues/81332)

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -85,13 +85,17 @@ class PkgMgrFactCollector(BaseFactCollector):
                 break
 
         try:
-            distro_major_ver = int(collected_facts['ansible_distribution_major_version'])
+            major_version = collected_facts['ansible_distribution_major_version']
+            if collected_facts['ansible_distribution'] == 'Kylin Linux Advanced Server':
+                major_version = major_version.lstrip('V')
+            distro_major_ver = int(major_version)
         except ValueError:
             # a non integer magical future version
             return self._default_unknown_pkg_mgr
 
         if (
             (collected_facts['ansible_distribution'] == 'Fedora' and distro_major_ver < 23)
+            or (collected_facts['ansible_distribution'] == 'Kylin Linux Advanced Server' and distro_major_ver < 10)
             or (collected_facts['ansible_distribution'] == 'Amazon' and distro_major_ver < 2022)
             or distro_major_ver < 8  # assume RHEL or a clone
         ) and any(pm for pm in PKG_MGRS if pm['name'] == 'yum' and os.path.exists(pm['path'])):

--- a/test/units/module_utils/facts/system/test_pkg_mgr.py
+++ b/test/units/module_utils/facts/system/test_pkg_mgr.py
@@ -14,7 +14,19 @@ _FEDORA_FACTS = {
     "ansible_os_family": "RedHat"
 }
 
+_KYLIN_FACTS = {
+    "ansible_distribution": "Kylin Linux Advanced Server",
+    "ansible_distribution_major_version": "V10",
+    "ansible_os_family": "RedHat"
+}
+
 # NOTE pkg_mgr == "dnf" means the dnf module for the dnf 4 or below
+
+
+def test_default_dnf_version_detection_kylin_dnf4(mocker):
+    mocker.patch("os.path.exists", lambda p: p in ("/usr/bin/dnf", "/usr/bin/dnf-3"))
+    mocker.patch("os.path.realpath", lambda p: {"/usr/bin/dnf": "/usr/bin/dnf-3"}.get(p, p))
+    assert PkgMgrFactCollector().collect(collected_facts=_KYLIN_FACTS).get("pkg_mgr") == "dnf"
 
 
 def test_default_dnf_version_detection_fedora_dnf4(mocker):


### PR DESCRIPTION
##### SUMMARY

The value of the `ansible_distribution_major_version` variable in the [`Kylin Linux`](https://www.kylinos.cn/scheme/server.html) is `V10`, which means that it cannot be converted directly by the [`int()`](https://github.com/ansible/ansible/blob/v2.15.2/lib/ansible/module_utils/facts/system/pkg_mgr.py#L88) function, so special handling of this value is required.

Fixes #81332 

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### COMPONENT NAME

`module_utils/facts/system/pkg_mgr`

