### PR TITLE
ansible-test: cloudstack: bump test container version

### DIFF
--- a/changelogs/fragments/81319-cloudstack-test-container-bump-version.yml
+++ b/changelogs/fragments/81319-cloudstack-test-container-bump-version.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Updated the CloudStack test container to version 1.6.1.

--- a/changelogs/fragments/81319-cloudstack-test-container-bump-version.yml
+++ b/changelogs/fragments/81319-cloudstack-test-container-bump-version.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - Updated the CloudStack test container to version 1.6.1.
+  - ansible-test - Updated the CloudStack test container to version 1.6.1.

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/cs.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/cs.py
@@ -38,7 +38,7 @@ class CsCloudProvider(CloudProvider):
     def __init__(self, args: IntegrationConfig) -> None:
         super().__init__(args)
 
-        self.image = os.environ.get('ANSIBLE_CLOUDSTACK_CONTAINER', 'quay.io/ansible/cloudstack-test-container:1.6.0')
+        self.image = os.environ.get('ANSIBLE_CLOUDSTACK_CONTAINER', 'quay.io/ansible/cloudstack-test-container:1.6.1')
         self.host = ''
         self.port = 0
 


### PR DESCRIPTION
##### SUMMARY

Bump cloudstack test container version fixes an issue with accessing admin keys in a json file export.

/cc @mattclay as requested

##### ISSUE TYPE

- Test Pull Request

##### COMPONENT NAME

cloudstack

##### ADDITIONAL INFORMATION

Also see https://github.com/ansible/cloudstack-test-container/pull/18