### PR TITLE
[stable-2.15] ansible-test: cloudstack: bump test container version

### DIFF
--- a/changelogs/fragments/81319-cloudstack-test-container-bump-version.yml
+++ b/changelogs/fragments/81319-cloudstack-test-container-bump-version.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Updated the CloudStack test container to version 1.6.1.

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/cs.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/cs.py
@@ -41,7 +41,7 @@ class CsCloudProvider(CloudProvider):
     def __init__(self, args: IntegrationConfig) -> None:
         super().__init__(args)
 
-        self.image = os.environ.get('ANSIBLE_CLOUDSTACK_CONTAINER', 'quay.io/ansible/cloudstack-test-container:1.6.0')
+        self.image = os.environ.get('ANSIBLE_CLOUDSTACK_CONTAINER', 'quay.io/ansible/cloudstack-test-container:1.6.1')
         self.host = ''
         self.port = 0
 


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81319

(cherry picked from commit 99eeaf7da8fc96ab927c767a29e351efc23360fb)

##### ISSUE TYPE

Test Pull Request

##### COMPONENT NAME

ansible-test