### PR TITLE
fix redis cache setup

### DIFF
--- a/test/integration/targets/old_style_cache_plugins/setup_redis_cache.yml
+++ b/test/integration/targets/old_style_cache_plugins/setup_redis_cache.yml
@@ -20,8 +20,9 @@
 
     - name: get the latest stable redis server release
       get_url:
-        url: http://download.redis.io/redis-stable.tar.gz
+        url: https://download.redis.io/redis-stable.tar.gz
         dest: ./
+        timeout: 60
 
     - name: unzip download
       unarchive:


### PR DESCRIPTION
##### SUMMARY

Tweak problematic redis cache setup in `old_style_cache_plugins` integration tests. 

* use https repo
* increase default download timeout of 10s for slow/lagged connections
* needs to just not use redis ;)

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME

old_style_cache_plugins integration test
##### ADDITIONAL INFORMATION
