### PR TITLE
Fix `ansible_pkg_mgr` incorrect in TencentOS Server Linux

### DIFF
--- a/changelogs/fragments/fix-pkg-mgr-in-TencentOS.yml
+++ b/changelogs/fragments/fix-pkg-mgr-in-TencentOS.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pkg_mgr.py - Fix `ansible_pkg_mgr` incorrect in TencentOS Server Linux

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -93,6 +93,7 @@ class PkgMgrFactCollector(BaseFactCollector):
         if (
             (collected_facts['ansible_distribution'] == 'Fedora' and distro_major_ver < 23)
             or (collected_facts['ansible_distribution'] == 'Amazon' and distro_major_ver < 2022)
+            or (collected_facts['ansible_distribution'] == 'TencentOS' and distro_major_ver < 3)
             or distro_major_ver < 8  # assume RHEL or a clone
         ) and any(pm for pm in PKG_MGRS if pm['name'] == 'yum' and os.path.exists(pm['path'])):
             pkg_mgr_name = 'yum'


### PR DESCRIPTION
##### SUMMARY

TencentOS is a rhel based distribution but their rule of major version are different. It use yum as default pkg_mgr in TencentOS Server 2 and before, while in TencentOS Server 3 the default pkg_mgr is dnf. Therefore, the pkg_mgr determination logic in current code is not suitable for TencentOS Server.

##### ISSUE TYPE

Bugfix Pull Request


##### COMPONENT NAME

module_utils/facts/system/pkg_mgr
