### PR TITLE
Raise the minimum setuptools version to 66.1.0

### DIFF
--- a/changelogs/fragments/ansible-test-minimum-setuptools.yml
+++ b/changelogs/fragments/ansible-test-minimum-setuptools.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - The minimum required ``setuptools`` version is now 45.2.0, as it is the oldest version to support Python 3.10.
+  - The minimum required ``setuptools`` version is now 66.1.0, as it is the oldest version to support Python 3.12.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
-requires = ["setuptools >= 45.2.0"]
+requires = ["setuptools >= 66.1.0"]  # minimum setuptools version supporting Python 3.12
 backend-path = ["packaging"]  # requires 'Pip>=20' or 'pep517>=0.6.0'
 build-backend = "pep517_backend.hooks"  # wraps `setuptools.build_meta`

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-# Minimum target setuptools 45.2.0
+# Minimum target setuptools 66.1.0
 
 [metadata]
 name = ansible-core

--- a/test/integration/targets/canonical-pep517-self-packaging/minimum-build-constraints.txt
+++ b/test/integration/targets/canonical-pep517-self-packaging/minimum-build-constraints.txt
@@ -1,8 +1,4 @@
-# Lowest supporting Python 3.10:
-setuptools == 57.0.0; python_version == "3.10"
-
-# Lowest supporting Python 3.11:
-setuptools == 60.0.0; python_version >= "3.11"
+setuptools == 66.1.0  # minimum requirement in pyproject.toml
 
 
 # An arbitrary old version that was released before Python 3.10.0:

--- a/test/integration/targets/canonical-pep517-self-packaging/modernish-build-constraints.txt
+++ b/test/integration/targets/canonical-pep517-self-packaging/modernish-build-constraints.txt
@@ -1,4 +1,4 @@
-setuptools == 67.4.0
+setuptools == 68.0.0  # latest release as of this commit
 
 # Wheel-only build dependency
 wheel == 0.38.4

--- a/test/integration/targets/canonical-pep517-self-packaging/runme_test.py
+++ b/test/integration/targets/canonical-pep517-self-packaging/runme_test.py
@@ -96,32 +96,6 @@ def assert_dirs_equal(*dir_paths: t.List[Path]) -> None:
     assert not dir_comparison.funny_files
 
 
-def normalize_unpacked_rebuilt_sdist(sdist_path: Path) -> None:
-    top_pkg_info_path = sdist_path / 'PKG-INFO'
-    nested_pkg_info_path = (
-        sdist_path / 'lib' / f'{DIST_NAME}.egg-info' / 'PKG-INFO'
-    )
-    entry_points_path = nested_pkg_info_path.parent / 'entry_points.txt'
-
-    # setuptools v39 write out two trailing empty lines and an unknown platform
-    # while the recent don't
-    top_pkg_info_path.write_text(
-        top_pkg_info_path.read_text().replace(
-            'Classifier: Development Status :: 5',
-            'Platform: UNKNOWN\nClassifier: Development Status :: 5',
-        ) + '\n\n'
-    )
-    nested_pkg_info_path.write_text(
-        nested_pkg_info_path.read_text().replace(
-            'Classifier: Development Status :: 5',
-            'Platform: UNKNOWN\nClassifier: Development Status :: 5',
-        ) + '\n\n'
-    )
-
-    # setuptools v39 write out one trailing empty line while the recent don't
-    entry_points_path.write_text(entry_points_path.read_text() + '\n')
-
-
 @pytest.fixture
 def venv_python_exe(tmp_path: Path) -> t.Iterator[Path]:
     venv_path = tmp_path / 'pytest-managed-venv'
@@ -336,7 +310,6 @@ def test_dist_rebuilds_with_manpages_premutations(
     )
     assert rebuilt_sdist_path.exists()
     assert rebuilt_sdist_path.is_dir()
-    normalize_unpacked_rebuilt_sdist(rebuilt_sdist_path)
     # Ensure the man page directory exists to ease diff comparison.
     for dir_path in (rebuilt_sdist_path, sdist_with_manpages_path):
         (dir_path / 'docs/man/man1').mkdir(parents=True, exist_ok=True)

--- a/test/sanity/code-smell/package-data.requirements.in
+++ b/test/sanity/code-smell/package-data.requirements.in
@@ -5,4 +5,4 @@ pyyaml
 resolvelib < 1.1.0
 rstcheck < 6  # newer versions have too many dependencies
 antsibull-changelog
-setuptools == 45.2.0  # minimum supported setuptools
+setuptools == 66.1.0  # minimum supported setuptools

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -12,7 +12,7 @@ PyYAML==6.0
 resolvelib==1.0.1
 rstcheck==5.0.0
 semantic-version==2.10.0
-setuptools==45.2.0
+setuptools==66.1.0
 tomli==2.0.1
 types-docutils==0.18.3
 typing_extensions==4.5.0


### PR DESCRIPTION
##### SUMMARY

This is the first version to support Python 3.12.

While Python 3.10 and 3.11 could use an older version, a consistent minimum is easier to work with and test against.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

pyproject.toml

##### ADDITIONAL INFORMATION
