### PR TITLE
[stable-2.15] fix networking path (#81295)

### DIFF
--- a/changelogs/fragments/forced_local+fix+.yml
+++ b/changelogs/fragments/forced_local+fix+.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - core will now also look at the connection plugin to force 'local' interpreter for networking path compatibility as just ansible_network_os could be misleading.

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -609,9 +609,8 @@ class TaskExecutor:
             display.vvvv('local domain socket path is %s' % socket_path, host=self._play_context.remote_addr)
             setattr(self._connection, '_socket_path', socket_path)
 
-        # TODO: eventually remove this block as this should be a 'consequence' of 'forced_local' modules
         # special handling for python interpreter for network_os, default to ansible python unless overridden
-        if 'ansible_network_os' in cvars and 'ansible_python_interpreter' not in cvars:
+        if 'ansible_python_interpreter' not in cvars and 'ansible_network_os' in cvars and getattr(self._connection, '_remote_is_local', False):
             # this also avoids 'python discovery'
             cvars['ansible_python_interpreter'] = sys.executable
 


### PR DESCRIPTION
* now uses class property instead of only relying on network_os variable

---------

Co-authored-by: Martin Krizek <martin.krizek@gmail.com>
(cherry picked from commit 6db006a5fa18b710e5ad0bc90e5ea5494a6b68c2)


##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### COMPONENT NAME
core