### PR TITLE
Fix symlink handling when reinstalling collections and cleaning up

### DIFF
--- a/changelogs/fragments/fix-reinstalling-collections-symlink.yml
+++ b/changelogs/fragments/fix-reinstalling-collections-symlink.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - unlink namespace and collection directories if they are symlinks when reinstalling collections or cleaning up after a failed install (https://github.com/ansible/ansible/issues/81350).

--- a/changelogs/fragments/fix-reinstalling-collections-symlink.yml
+++ b/changelogs/fragments/fix-reinstalling-collections-symlink.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ansible-galaxy - unlink namespace and collection directories if they are symlinks when reinstalling collections or cleaning up after a failed install (https://github.com/ansible/ansible/issues/81350).
+  - ansible-galaxy - fix handling symlink/non-directory namespaces and collections when installing collections or cleaning up after a failed install. Symlinks will be unlinked, and files removed. (https://github.com/ansible/ansible/issues/81350).

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -778,6 +778,46 @@
     - install_symlink_actual.results[5].stat.islnk
     - install_symlink_actual.results[5].stat.lnk_target == '../REÅDMÈ.md'
 
+- name: remove installed collection previous test
+  file:
+    state: absent
+    path: '{{ galaxy_dir }}/ansible_collections/symlink/symlink'
+
+- name: test reinstalling a collection that is a symlink
+  vars:
+    symlink_src: "{{ galaxy_dir }}/symlink_src"
+    collections_path: "{{ galaxy_dir }}/linked_collections"
+    extra_args: "-s {{ test_name }} {{ galaxy_verbosity }}"
+  block:
+    - name: setup - install collection to use for creating a symlink
+      command: "ansible-galaxy collection install symlink.symlink -p {{ symlink_src }} {{ extra_args }}"
+
+    - name: setup - create directory for symlink
+      file:
+        path: "{{ collections_path }}/ansible_collections/symlink"
+        state: directory
+
+    - name: setup - create symlink to the collection
+      command: ln -s {{ symlink_src }}/ansible_collections/symlink/symlink symlink
+      become: yes
+      args:
+        chdir: '{{ collections_path }}/ansible_collections/symlink'
+
+    - name: test the collection can be reinstalled
+      command: "ansible-galaxy collection install symlink.symlink -p {{ collections_path }} --force {{ extra_args }}"
+      register: reinstalled_collection
+
+    - assert:
+        that:
+          - '"symlink.symlink:1.0.0 was installed successfully" in reinstalled_collection.stdout'
+  always:
+    - name: clean up test directories from previous test
+      file:
+        state: absent
+        path: "{{ item }}"
+      loop:
+        - "{{ symlink_src }}"
+        - "{{ collections_path }}"
 
 # Testing an install from source to check that symlinks to directories
 # are preserved (see issue https://github.com/ansible/ansible/issues/78442)

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -86,6 +86,27 @@
     that:
     - '"Installing ''namespace1.name1:1.0.9'' to" in install_existing_force.stdout'
 
+- name: test installing the collection with something in the way (no --force needed)
+  block:
+    - name: setup - put non-collection at the destination path - {{ test_id }}
+      file:
+        state: '{{ item }}'
+        path: '{{ galaxy_dir }}/ansible_collections/namespace1/name1'
+      loop:
+        - absent
+        - touch
+
+    - name: test install with a conflicting a file - {{ test_id }}
+      command: ansible-galaxy collection install namespace1.name1 -s '{{ test_name }}' {{ galaxy_verbosity }}
+      environment:
+        ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
+      register: install_existing_force
+
+    - name: assert collection was installed - {{ test_id }}
+      assert:
+        that:
+        - '"Installing ''namespace1.name1:1.0.9'' to" in install_existing_force.stdout'
+
 - name: remove test installed collection - {{ test_id }}
   file:
     path: '{{ galaxy_dir }}/ansible_collections/namespace1'


### PR DESCRIPTION
##### SUMMARY

Unlink symlink collections before reinstalling and when cleaning up after a failed install

Fixes #81350

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
