### PR TITLE
Add support for password in private key in paramiko { cli, variable }

### DIFF
--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -256,7 +256,7 @@ def add_connect_options(parser):
 
     connect_group.add_argument('--private-key', '--key-file', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',
                                help='use this file to authenticate the connection', type=unfrack_path())
-    connect_group.add_argument('--private-key-file-passphrase', '--key-file-passphrase', default=C.DEFAULT_PRIVATE_KEY_FILE_PASSPHRASE, 
+    connect_group.add_argument('--private-key-file-passphrase', '--key-file-passphrase', default=C.DEFAULT_PRIVATE_KEY_FILE_PASSPHRASE,
                                dest='private_key_file_passphrase', help='use passphrase on private-key to authenticate the connection')
     connect_group.add_argument('-u', '--user', default=C.DEFAULT_REMOTE_USER, dest='remote_user',
                                help='connect as this user (default=%s)' % C.DEFAULT_REMOTE_USER)

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -256,6 +256,8 @@ def add_connect_options(parser):
 
     connect_group.add_argument('--private-key', '--key-file', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',
                                help='use this file to authenticate the connection', type=unfrack_path())
+    connect_group.add_argument('--private-key-file-passphrase', '--key-file-passphrase', default=C.DEFAULT_PRIVATE_KEY_FILE_PASSPHRASE, dest='private_key_file_passphrase',
+                               help='use passphrase on private-key to authenticate the connection')
     connect_group.add_argument('-u', '--user', default=C.DEFAULT_REMOTE_USER, dest='remote_user',
                                help='connect as this user (default=%s)' % C.DEFAULT_REMOTE_USER)
     connect_group.add_argument('-c', '--connection', dest='connection', default=C.DEFAULT_TRANSPORT,

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -256,8 +256,8 @@ def add_connect_options(parser):
 
     connect_group.add_argument('--private-key', '--key-file', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',
                                help='use this file to authenticate the connection', type=unfrack_path())
-    connect_group.add_argument('--private-key-file-passphrase', '--key-file-passphrase', default=C.DEFAULT_PRIVATE_KEY_FILE_PASSPHRASE, dest='private_key_file_passphrase',
-                               help='use passphrase on private-key to authenticate the connection')
+    connect_group.add_argument('--private-key-file-passphrase', '--key-file-passphrase', default=C.DEFAULT_PRIVATE_KEY_FILE_PASSPHRASE, 
+                               dest='private_key_file_passphrase', help='use passphrase on private-key to authenticate the connection')
     connect_group.add_argument('-u', '--user', default=C.DEFAULT_REMOTE_USER, dest='remote_user',
                                help='connect as this user (default=%s)' % C.DEFAULT_REMOTE_USER)
     connect_group.add_argument('-c', '--connection', dest='connection', default=C.DEFAULT_TRANSPORT,

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -930,6 +930,15 @@ DEFAULT_PRIVATE_KEY_FILE:
   ini:
   - {key: private_key_file, section: defaults}
   type: path
+DEFAULT_PRIVATE_KEY_FILE_PASSPHRASE:
+  name: Private key file passphrase
+  default: ~
+  description:
+    - Private key file passphrase
+  env: [{name: ANSIBLE_PRIVATE_KEY_FILE_PASSPHRASE}]
+  ini:
+  - {key: private_key_file_passphrase, section: defaults}
+  type: string
 DEFAULT_PRIVATE_ROLE_VARS:
   name: Private role variables
   default: False

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -60,6 +60,7 @@ RESET_VARS = (
     'ansible_ssh_port',
     'ansible_ssh_user',
     'ansible_ssh_private_key_file',
+    'ansible_ssh_private_key_file_passphrase',
     'ansible_ssh_pipelining',
     'ansible_ssh_executable',
 )
@@ -85,6 +86,7 @@ class PlayContext(Base):
     timeout = FieldAttribute(isa='int', default=C.DEFAULT_TIMEOUT)
     connection_user = FieldAttribute(isa='string')
     private_key_file = FieldAttribute(isa='string', default=C.DEFAULT_PRIVATE_KEY_FILE)
+    private_key_file_passphrase = FieldAttribute(isa='string', default=C.DEFAULT_PRIVATE_KEY_FILE_PASSPHRASE)
     pipelining = FieldAttribute(isa='bool', default=C.ANSIBLE_PIPELINING)
 
     # networking modules
@@ -187,6 +189,7 @@ class PlayContext(Base):
         # From the command line.  These should probably be used directly by plugins instead
         # For now, they are likely to be moved to FieldAttribute defaults
         self.private_key_file = context.CLIARGS.get('private_key_file')  # Else default
+        self.private_key_file_passphrase = context.CLIARGS.get('private_key_file_passphrase') # Else default
         self._internal_verbosity = context.CLIARGS.get('verbosity')  # Else default
 
         # Not every cli that uses PlayContext has these command line args so have a default

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -189,7 +189,7 @@ class PlayContext(Base):
         # From the command line.  These should probably be used directly by plugins instead
         # For now, they are likely to be moved to FieldAttribute defaults
         self.private_key_file = context.CLIARGS.get('private_key_file')  # Else default
-        self.private_key_file_passphrase = context.CLIARGS.get('private_key_file_passphrase') # Else default
+        self.private_key_file_passphrase = context.CLIARGS.get('private_key_file_passphrase')  # Else default
         self._internal_verbosity = context.CLIARGS.get('verbosity')  # Else default
 
         # Not every cli that uses PlayContext has these command line args so have a default

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -306,7 +306,7 @@ DOCUMENTATION = """
               version_added: '2.16'
           cli:
             - name: private_key_file_passphrase
-              option: '--private-key-passphrase'    
+              option: '--private-key-passphrase'
 """
 
 import os

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -285,6 +285,29 @@ DOCUMENTATION = """
           cli:
             - name: private_key_file
               option: '--private-key'
+      private_key_file_passphrase:
+          description:
+              - Private key passphrase
+          type: string
+          ini:
+            - section: defaults
+              key: private_key_file_passphrase
+            - section: paramiko_connection
+              key: private_key_file_passphrase
+              version_added: '2.15'
+          env:
+            - name: ANSIBLE_PRIVATE_KEY_FILE_PASSPHRASE
+            - name: ANSIBLE_PARAMIKO_PRIVATE_KEY_FILE_PASSPHRASE
+              version_added: '2.15'
+          vars:
+            - name: ansible_private_key_file_passphrase
+            - name: ansible_ssh_private_key_file_passphrase
+            - name: ansible_paramiko_private_key_file_passphrase
+              version_added: '2.15'
+          cli:
+            - name: private_key_file_passphrase
+              option: '--private-key-passphrase'
+              
 """
 
 import os
@@ -509,12 +532,16 @@ class Connection(ConnectionBase):
             if LooseVersion(paramiko.__version__) >= LooseVersion('1.15.0'):
                 ssh_connect_kwargs['banner_timeout'] = self.get_option('banner_timeout')
 
+            passphrase = None
+            if self.get_option('private_key_file_passphrase'):
+                passphrase = self.get_option('private_key_file_passphrase')
             ssh.connect(
                 self.get_option('remote_addr').lower(),
                 username=self.get_option('remote_user'),
                 allow_agent=allow_agent,
                 look_for_keys=self.get_option('look_for_keys'),
                 key_filename=key_filename,
+                passphrase=passphrase,
                 password=conn_password,
                 timeout=self.get_option('timeout'),
                 port=port,

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -294,16 +294,16 @@ DOCUMENTATION = """
               key: private_key_file_passphrase
             - section: paramiko_connection
               key: private_key_file_passphrase
-              version_added: '1.0'
+              version_added: '2.16'
           env:
             - name: ANSIBLE_PRIVATE_KEY_FILE_PASSPHRASE
             - name: ANSIBLE_PARAMIKO_PRIVATE_KEY_FILE_PASSPHRASE
-              version_added: '1.0'
+              version_added: '2.16'
           vars:
             - name: ansible_private_key_file_passphrase
             - name: ansible_ssh_private_key_file_passphrase
             - name: ansible_paramiko_private_key_file_passphrase
-              version_added: '1.0'
+              version_added: '2.16'
           cli:
             - name: private_key_file_passphrase
               option: '--private-key-passphrase'    

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -531,9 +531,7 @@ class Connection(ConnectionBase):
             if LooseVersion(paramiko.__version__) >= LooseVersion('1.15.0'):
                 ssh_connect_kwargs['banner_timeout'] = self.get_option('banner_timeout')
 
-            passphrase = None
-            if self.get_option('private_key_file_passphrase'):
-                passphrase = self.get_option('private_key_file_passphrase')
+            passphrase = self.get_option('private_key_file_passphrase') or None
             ssh.connect(
                 self.get_option('remote_addr').lower(),
                 username=self.get_option('remote_user'),

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -294,20 +294,16 @@ DOCUMENTATION = """
               key: private_key_file_passphrase
             - section: paramiko_connection
               key: private_key_file_passphrase
-              version_added: '2.15'
           env:
             - name: ANSIBLE_PRIVATE_KEY_FILE_PASSPHRASE
             - name: ANSIBLE_PARAMIKO_PRIVATE_KEY_FILE_PASSPHRASE
-              version_added: '2.15'
           vars:
             - name: ansible_private_key_file_passphrase
             - name: ansible_ssh_private_key_file_passphrase
             - name: ansible_paramiko_private_key_file_passphrase
-              version_added: '2.15'
           cli:
             - name: private_key_file_passphrase
-              option: '--private-key-passphrase'
-              
+              option: '--private-key-passphrase'    
 """
 
 import os

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -294,13 +294,16 @@ DOCUMENTATION = """
               key: private_key_file_passphrase
             - section: paramiko_connection
               key: private_key_file_passphrase
+              version_added: '1.0'
           env:
             - name: ANSIBLE_PRIVATE_KEY_FILE_PASSPHRASE
             - name: ANSIBLE_PARAMIKO_PRIVATE_KEY_FILE_PASSPHRASE
+              version_added: '1.0'
           vars:
             - name: ansible_private_key_file_passphrase
             - name: ansible_ssh_private_key_file_passphrase
             - name: ansible_paramiko_private_key_file_passphrase
+              version_added: '1.0'
           cli:
             - name: private_key_file_passphrase
               option: '--private-key-passphrase'    


### PR DESCRIPTION
Added support for password in private key on cli, variable, ansible.cfg

##### SUMMARY

Added support for password in private key in paramiko { cli, variable }

##### ISSUE TYPE

Added support for password in private key in paramiko { cli, variable } 

- Feature Pull Request

##### COMPONENT NAME

`lib/ansible/plugins/connection/paramiko_ssh.py`

##### ADDITIONAL INFORMATION

Added support for password in private key in paramiko { cli, variable }