### PR TITLE
Exclude internal options from man pages and docs

### DIFF
--- a/changelogs/fragments/suppressed-options.yml
+++ b/changelogs/fragments/suppressed-options.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Exclude internal options from man pages and docs.

--- a/packaging/pep517_backend/_generate_man.py
+++ b/packaging/pep517_backend/_generate_man.py
@@ -51,6 +51,8 @@ def get_options(optlist):
 
     opts = []
     for opt in optlist:
+        if opt.help == argparse.SUPPRESS:
+            continue
         res = {
             'desc': opt.help,
             'options': opt.option_strings


### PR DESCRIPTION
##### SUMMARY

Exclude internal options from man pages and docs.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

packaging/pep517_backend/_generate_man.py