### PR TITLE
[stable-2.15] Exclude internal options from man pages and docs (#81360)

### DIFF
--- a/changelogs/fragments/suppressed-options.yml
+++ b/changelogs/fragments/suppressed-options.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Exclude internal options from man pages and docs.

--- a/packaging/pep517_backend/_generate_man.py
+++ b/packaging/pep517_backend/_generate_man.py
@@ -50,6 +50,8 @@ def get_options(optlist):
 
     opts = []
     for opt in optlist:
+        if opt.help == argparse.SUPPRESS:
+            continue
         res = {
             'desc': opt.help,
             'options': opt.option_strings


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81360

(cherry picked from commit fead6546715beb2ef61c6a42cc91375d9d7914ab)

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

packaging/pep517_backend/_generate_man.py