### PR TITLE
apt module, fix issue with packages not installing when pinned and cached

### DIFF
--- a/changelogs/fragments/80813-fixed-apt-cache-version-pinning-issue.yml
+++ b/changelogs/fragments/80813-fixed-apt-cache-version-pinning-issue.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "``ansible.modules.apt`` - fixed apt-cache version pinning issue in ``package_best_match()``"

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -496,14 +496,19 @@ def package_best_match(pkgname, version_cmp, version, release, cache):
     policy.read_pinfile(apt_pkg.config.find_file("Dir::Etc::preferences"))
     policy.read_pindir(apt_pkg.config.find_file("Dir::Etc::preferencesparts"))
 
+    pkg = cache[pkgname]
     if release:
         # 990 is the priority used in `apt-get -t`
         policy.create_pin('Release', pkgname, release, 990)
     if version_cmp == "=":
         # Installing a specific version from command line overrides all pinning
         # We don't mimmic this exactly, but instead set a priority which is higher than all APT built-in pin priorities.
+        try:
+            pkgver = next(v1 for v1 in pkg.version_list if v1.ver_str == version)
+            policy.set_priority(pkgver, 0)
+        except StopIteration:
+            pass
         policy.create_pin('Version', pkgname, version, 1001)
-    pkg = cache[pkgname]
     pkgver = policy.get_candidate_ver(pkg)
     if not pkgver:
         return None

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -505,9 +505,10 @@ def package_best_match(pkgname, version_cmp, version, release, cache):
         # We don't mimmic this exactly, but instead set a priority which is higher than all APT built-in pin priorities.
         try:
             pkgver = next(v1 for v1 in pkg.version_list if v1.ver_str == version)
-            policy.set_priority(pkgver, 0)
         except StopIteration:
             pass
+        else:
+            policy.set_priority(pkgver, 0)
         policy.create_pin('Version', pkgname, version, 1001)
     pkgver = policy.get_candidate_ver(pkg)
     if not pkgver:

--- a/test/integration/targets/apt/defaults/main.yml
+++ b/test/integration/targets/apt/defaults/main.yml
@@ -1,2 +1,8 @@
 apt_foreign_arch: i386
 hello_old_version: 2.6-1
+foobar:
+  package_name: foobar
+  versions:
+    - 1.0.1
+    - 1.0.2
+    - 1.0.0

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -395,6 +395,33 @@
     that:
       - apt_result is not changed
 
+# https://github.com/ansible/ansible/issues/80813
+- name: Install a specific package version - "{{ foobar.package_name }}={{ foobar.versions[0] }}"
+  apt:
+    name: "{{ foobar.package_name }}={{ item }}"
+    state: present
+    allow_downgrade: yes
+  with_items: "{{ foobar.versions[0] }}"
+
+- name: Install a specific package version - "{{ foobar.package_name }}={{ foobar.versions[1] }}"
+  apt:
+    name: "{{ foobar.package_name }}={{ item }}"
+    state: present
+    allow_downgrade: yes
+  with_items: "{{ foobar.versions[1] }}"
+
+- name: Install a specific package version - "{{ foobar.package_name }}={{ foobar.versions[2] }}"
+  apt:
+    name: "{{ foobar.package_name }}={{ item }}"
+    state: present
+    allow_downgrade: yes
+  with_items: "{{ foobar.versions[2] }}"
+
+- name: remove package foobar
+  apt:
+    name: foobar
+    state: absent
+
 # check policy_rc_d parameter
 
 - name: Install unscd but forbid service start

--- a/test/integration/targets/setup_deb_repo/files/package_specs/stable/foobar-1.0.2
+++ b/test/integration/targets/setup_deb_repo/files/package_specs/stable/foobar-1.0.2
@@ -1,0 +1,10 @@
+Section: misc
+Priority: optional
+Standards-Version: 2.3.3
+
+Package: foobar
+Version: 1.0.2
+Section: system
+Maintainer: John Doe <john@doe.com>
+Architecture: all
+Description: Dummy package


### PR DESCRIPTION
##### SUMMARY
Currently when apt cache holds multiple versions of the same package, including newer versions and older versions, a specific installation of the package version (other than the latest version) fails with an error message:
```
no available installation candidate for pkgname=x.y.z
```
However, the command line such as
```
$ apt install pkgname=x.y.z
```
works just fine, the reason being some issue in apt_cache.Policy which fails to override the default priority. 

When `set_priority()` is called before create_pin then it works as expected.


fixes #80813


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
modules/apt


