### PR TITLE
Fix missing command descriptions in manpages/docs

### DIFF
--- a/changelogs/fragments/add-missing-cli-docs.yml
+++ b/changelogs/fragments/add-missing-cli-docs.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - The ``ansible-config init`` command now has a documentation description.
+  - The ``ansible-galaxy collection download`` command now has a documentation description.
+  - The ``ansible-galaxy collection verify`` command now has a documentation description.
+  - The ``ansible-inventory`` command command now has a documentation description (previously used as the epilog).
+  - The ``ansible-galaxy collection install`` command documentation is now visible (previously hidden by a decorator).
+  - The ``ansible-galaxy role install`` command documentation is now visible (previously hidden by a decorator).
+  - Fix ``ansible-config init`` man page option indentation.

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -362,6 +362,7 @@ class ConfigCLI(CLI):
         return sections
 
     def execute_init(self):
+        """Create initial configuration"""
 
         data = []
         config_entries = self._list_entries_from_args()

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -11,6 +11,7 @@ __metaclass__ = type
 from ansible.cli import CLI
 
 import argparse
+import functools
 import json
 import os.path
 import pathlib
@@ -94,6 +95,7 @@ def with_collection_artifacts_manager(wrapped_method):
     the related temporary directory auto-cleanup around the target
     method invocation.
     """
+    @functools.wraps(wrapped_method)
     def method_wrapper(*args, **kwargs):
         if 'artifacts_manager' in kwargs:
             return wrapped_method(*args, **kwargs)
@@ -1039,6 +1041,7 @@ class GalaxyCLI(CLI):
 
     @with_collection_artifacts_manager
     def execute_download(self, artifacts_manager=None):
+        """Download collections and their dependencies as a tarball for an offline install."""
         collections = context.CLIARGS['args']
         no_deps = context.CLIARGS['no_deps']
         download_path = context.CLIARGS['download_path']
@@ -1270,6 +1273,7 @@ class GalaxyCLI(CLI):
 
     @with_collection_artifacts_manager
     def execute_verify(self, artifacts_manager=None):
+        """Compare checksums with the collection(s) found on the server and the installed copy. This does not verify dependencies."""
 
         collections = context.CLIARGS['args']
         search_paths = AnsibleCollectionConfig.collection_paths
@@ -1307,8 +1311,6 @@ class GalaxyCLI(CLI):
         You can pass in a list (roles or collections) or use the file
         option listed below (these are mutually exclusive). If you pass in a list, it
         can be a name (which will be downloaded via the galaxy API and github), or it can be a local tar archive file.
-
-        :param artifacts_manager: Artifacts manager.
         """
         install_items = context.CLIARGS['args']
         requirements_file = context.CLIARGS['requirements']

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -64,7 +64,7 @@ class InventoryCLI(CLI):
     def init_parser(self):
         super(InventoryCLI, self).init_parser(
             usage='usage: %prog [options] [host|group]',
-            epilog='Show Ansible inventory information, by default it uses the inventory script JSON format')
+            desc='Show Ansible inventory information, by default it uses the inventory script JSON format')
 
         opt_help.add_inventory_options(self.parser)
         opt_help.add_vault_options(self.parser)


### PR DESCRIPTION
##### SUMMARY

Fix missing command descriptions in manpages/docs.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

lib/ansible/cli/config.py
lib/ansible/cli/galaxy.py
lib/ansible/cli/inventory.py