### PR TITLE
[stable-2.13] Fix command doc lookup in man page generation (#81365)

### DIFF
--- a/changelogs/fragments/missing-doc-func.yml
+++ b/changelogs/fragments/missing-doc-func.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - When generating man pages, use ``func`` to find the command function instead of looking it up by the command name.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -271,6 +271,7 @@ class GalaxyCLI(CLI):
 
         # Add sub parser for the Galaxy collection actions
         collection = type_parser.add_parser('collection', help='Manage an Ansible Galaxy collection.')
+        collection.set_defaults(func=self.execute_collection)  # to satisfy doc build
         collection_parser = collection.add_subparsers(metavar='COLLECTION_ACTION', dest='action')
         collection_parser.required = True
         self.add_download_options(collection_parser, parents=[common, cache_options])
@@ -283,6 +284,7 @@ class GalaxyCLI(CLI):
 
         # Add sub parser for the Galaxy role actions
         role = type_parser.add_parser('role', help='Manage an Ansible Galaxy role.')
+        role.set_defaults(func=self.execute_role)  # to satisfy doc build
         role_parser = role.add_subparsers(metavar='ROLE_ACTION', dest='action')
         role_parser.required = True
         self.add_init_options(role_parser, parents=[common, force, offline])

--- a/packaging/pep517_backend/_generate_man.py
+++ b/packaging/pep517_backend/_generate_man.py
@@ -172,7 +172,7 @@ def opts_docs(cli_class_name, cli_module_name):
             # docs['actions'][action] = {}
             # docs['actions'][action]['name'] = action
             action_info['name'] = action
-            action_info['desc'] = trim_docstring(getattr(cli, 'execute_%s' % action).__doc__)
+            action_info['desc'] = trim_docstring(parser.get_default("func").__doc__)
 
             # docs['actions'][action]['desc'] = getattr(cli, 'execute_%s' % action).__doc__.strip()
             action_doc_list = opt_doc_list(parser)


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81365

(cherry picked from commit f9d674fcfd178bc2f9fb6f466b9e891290d2e53f)

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

packaging/pep517_backend/_generate_man.py