### PR TITLE
Update reboot module to include message option

### DIFF
--- a/lib/ansible/modules/reboot.py
+++ b/lib/ansible/modules/reboot.py
@@ -121,6 +121,10 @@ EXAMPLES = r'''
     reboot_command: launchctl reboot userspace
     boot_time_command: uptime | cut -d ' ' -f 5
 
+- name: Reboot machine and send a message
+  ansible.builtin.reboot:
+    msg: "Rebooting machine in 5 seconds"
+
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
updated an examples which includes how to use reboot module to include a message 


##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME

Ansible built in reboot module 

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

This pull request is in regards to how to display a message on servers before rebooting using built in ansible reboot module
```
