### PR TITLE
Fix order of CLI arguments on FreeBSD

### DIFF
--- a/changelogs/fragments/freebsd_service.yml
+++ b/changelogs/fragments/freebsd_service.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - service - fix order of CLI arguments on FreeBSD (https://github.com/ansible/ansible/pull/81377).

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -1012,7 +1012,7 @@ class FreeBsdService(Service):
         self.sysrc_cmd = self.module.get_bin_path('sysrc')
 
     def get_service_status(self):
-        rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, 'onestatus', self.arguments))
+        rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.arguments, self.name, 'onestatus'))
         if self.name == "pf":
             self.running = "Enabled" in stdout
         else:
@@ -1032,7 +1032,7 @@ class FreeBsdService(Service):
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile
 
-        rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, 'rcvar', self.arguments))
+        rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.arguments, self.name, 'rcvar'))
         try:
             rcvars = shlex.split(stdout, comments=True)
         except Exception:
@@ -1097,7 +1097,7 @@ class FreeBsdService(Service):
         if self.action == "reload":
             self.action = "onereload"
 
-        ret = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, self.action, self.arguments))
+        ret = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.arguments, self.name, self.action))
 
         if self.sleep:
             time.sleep(self.sleep)


### PR DESCRIPTION
##### SUMMARY

When passing arguments on FreeBSD to service command the order is important, otherwise the service command will ignore the arguments.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### COMPONENT NAME

Module: ansible.builtin.service

<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

service command with different order of argument `-v`:
```
# service ntpd status -v
ntpd is running as pid 9232.

# service -v ntpd status
ntpd is located in /etc/rc.d
ntpd is running as pid 9232
```

This is more important when passing '-j <jail name or id>' because it will error.
```
# service nginx status -j <jail>
nginx does not exist in /etc/rc.d or the local startup
directories (/usr/local/etc/rc.d), or is not executable

# service -j <jail> nginx status
nginx is runing on pid 3501.
```
