### PR TITLE
password_hash - fix bcrypt algorithm when passlib is not installed 

### DIFF
--- a/changelogs/fragments/password_hash-fix-crypt-salt-bcrypt.yml
+++ b/changelogs/fragments/password_hash-fix-crypt-salt-bcrypt.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - password_hash - fix salt format for ``crypt`` fallback (deprecated, and only used if ``passlib`` is not installed) for ``bcrypt`` algorithm.
+  - password_hash - fix salt format for ``crypt``  (only used if ``passlib`` is not installed) for the ``bcrypt`` algorithm.

--- a/changelogs/fragments/password_hash-fix-crypt-salt-bcrypt.yml
+++ b/changelogs/fragments/password_hash-fix-crypt-salt-bcrypt.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - password_hash - fix salt format for ``crypt`` fallback (deprecated, and only used if ``passlib`` is not installed) for ``bcrypt`` algorithm.

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -128,9 +128,10 @@ class CryptHash(BaseHash):
         return ret
 
     def _rounds(self, rounds):
-        if rounds == self.algo_data.implicit_rounds:
+        if rounds == self.algo_data.implicit_rounds and self.algorithm != 'bcrypt':
             # Passlib does not include the rounds if it is the same as implicit_rounds.
             # Make crypt lib behave the same, by not explicitly specifying the rounds in that case.
+            # Exclude bcrypt, which requires 2 digits for the salt.
             return None
         else:
             return rounds
@@ -148,7 +149,10 @@ class CryptHash(BaseHash):
             saltstring = "$%s" % ident
 
         if rounds:
-            saltstring += "$rounds=%d" % rounds
+            if self.algorithm == 'bcrypt':
+                saltstring += "$%d" % rounds
+            else:
+                saltstring += "$rounds=%d" % rounds
 
         saltstring += "$%s" % salt
 

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -183,6 +183,7 @@ class PasslibHash(BaseHash):
 
         if not PASSLIB_AVAILABLE:
             raise AnsibleError("passlib must be installed and usable to hash with '%s'" % algorithm, orig_exc=PASSLIB_E)
+        display.vv("Using passlib to hash input with '%s'" % algorithm)
 
         try:
             self.crypt_algo = getattr(passlib.hash, algorithm)

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -128,10 +128,12 @@ class CryptHash(BaseHash):
         return ret
 
     def _rounds(self, rounds):
-        if rounds == self.algo_data.implicit_rounds and self.algorithm != 'bcrypt':
+        if self.algorithm == 'bcrypt':
+            # crypt requires 2 digits for rounds
+            return rounds or self.algo_data.implicit_rounds
+        elif rounds == self.algo_data.implicit_rounds:
             # Passlib does not include the rounds if it is the same as implicit_rounds.
             # Make crypt lib behave the same, by not explicitly specifying the rounds in that case.
-            # Exclude bcrypt, which requires 2 digits for the salt.
             return None
         else:
             return rounds

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -478,7 +478,7 @@
   vars:
     msg: "msdcc is not in the list of supported passlib algorithms: md5, blowfish, sha256, sha512"
 
-- name: try to use bcrypt
+- name: test password_hash can work with bcrypt without passlib installed
   debug:
     msg: "{{ 'somestring'|password_hash('bcrypt') }}"
   register: crypt_bcrypt

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -478,6 +478,13 @@
   vars:
     msg: "msdcc is not in the list of supported passlib algorithms: md5, blowfish, sha256, sha512"
 
+- name: try to use bcrypt
+  debug:
+    msg: "{{ 'somestring'|password_hash('bcrypt') }}"
+  register: crypt_bcrypt
+  # Some implementations of crypt do not fail outright and return some short value.
+  failed_when: crypt_bcrypt is failed or (crypt_bcrypt.msg|length|int) != 60
+
 - name: Verify to_uuid throws on weird namespace
   set_fact:
     foo: '{{"hey"|to_uuid(namespace=22)}}'

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -484,6 +484,7 @@
   register: crypt_bcrypt
   # Some implementations of crypt do not fail outright and return some short value.
   failed_when: crypt_bcrypt is failed or (crypt_bcrypt.msg|length|int) != 60
+  when: ansible_facts.os_family in ['RedHat', 'Debian']
 
 - name: Verify to_uuid throws on weird namespace
   set_fact:


### PR DESCRIPTION
##### SUMMARY
Fix `bcrypt` algorithm with the `crypt` fallback when `passlib` isn't installed. This is deprecated since 2.14, but I thought it was potentially worth backporting. The encoding syntax should be `\$2a\$[0-9]{2}\$[./A-Za-z0-9]{53}` according to https://www.openwall.com/crypt/openwall-crypt.3.pdf.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

password_hash