### PR TITLE
dpkg_selections: Check if package exists before selection operation

### DIFF
--- a/changelogs/fragments/dpkg_selections.yml
+++ b/changelogs/fragments/dpkg_selections.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- dpkg_selections - check if the package exists before preforming the selection operation (https://github.com/ansible/ansible/issues/81404).

--- a/changelogs/fragments/dpkg_selections.yml
+++ b/changelogs/fragments/dpkg_selections.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- dpkg_selections - check if the package exists before preforming the selection operation (https://github.com/ansible/ansible/issues/81404).
+- dpkg_selections - check if the package exists before performing the selection operation (https://github.com/ansible/ansible/issues/81404).

--- a/lib/ansible/modules/dpkg_selections.py
+++ b/lib/ansible/modules/dpkg_selections.py
@@ -54,6 +54,7 @@ EXAMPLES = '''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.locale import get_best_parsable_locale
 
 
 def main():
@@ -67,12 +68,18 @@ def main():
 
     dpkg = module.get_bin_path('dpkg', True)
 
+    locale = get_best_parsable_locale(module)
+    DPKG_ENV = dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale, LC_CTYPE=locale)
+    module.run_command_environ_update = DPKG_ENV
+
     name = module.params['name']
     selection = module.params['selection']
 
     # Get current settings.
     rc, out, err = module.run_command([dpkg, '--get-selections', name], check_rc=True)
-    if not out:
+    if 'no packages found matching' in err:
+        module.fail_json(msg="Failed to find package '%s' to perform selection '%s'." % (name, selection))
+    elif not out:
         current = 'not present'
     else:
         current = out.split()[1]

--- a/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
+++ b/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
@@ -98,4 +98,4 @@
 - name: Check that module fails for non-existent package
   assert:
     that:
-      - "'Failed to find package' in result.stdout"
+      - "'Failed to find package' in result.msg"

--- a/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
+++ b/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
@@ -87,3 +87,15 @@
   apt:
     name: hello
     state: absent
+
+- name: Try to select non-existent package
+  dpkg_selections:
+    name: kernel
+    selection: hold
+  ignore_errors: yes
+  register: result
+
+- name: Check that module fails for non-existent package
+  assert:
+    that:
+      - "'Failed to find package' in result.stdout"


### PR DESCRIPTION
##### SUMMARY

Fixes: #81404

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/dpkg_selections.yml
lib/ansible/modules/dpkg_selections.py
test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml

