### PR TITLE
Extend setup_collections timeout to 3 minutes

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -91,7 +91,7 @@ from multiprocessing import dummy as threading
 from multiprocessing import TimeoutError
 
 
-COLLECTIONS_BUILD_AND_PUBLISH_TIMEOUT = 120
+COLLECTIONS_BUILD_AND_PUBLISH_TIMEOUT = 180
 
 
 def publish_collection(module, collection):


### PR DESCRIPTION
##### SUMMARY

We are hitting around 1m35s on a good run, and seems we are timing out every so often.  This PR extends the timeout to 3 minutes from 2 minutes to hopefully alleviate transient issues in a longer publishing time.

##### ISSUE TYPE

- Test Pull Request

##### COMPONENT NAME

test/integration/targets/ansible-galaxy-collection/library/setup_collections.py

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
