### PR TITLE
[stable-2.13] Add changelog fragment for docs/examples removal (#81410)

### DIFF
--- a/changelogs/fragments/remove-docs-examples.yml
+++ b/changelogs/fragments/remove-docs-examples.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - The ``docs`` and ``examples`` directories are no longer included in the ``ansible-core`` sdist.
+    These directories have been moved to the https://github.com/ansible/ansible-documentation repository.


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81410

(cherry picked from commit 0c03a6bcf6ecd235de7b4407e4ab7c51faacc980)

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

changelogs/fragments/remove-docs-examples.yml