### PR TITLE
(module) rpm_key: Add URL request timeout

### DIFF
--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -48,6 +48,7 @@ options:
         - Timeout in seconds for URL requests
         type: int
         default: 10
+        version_added: 2.16
 extends_documentation_fragment:
     - action_common_attributes
 attributes:


### PR DESCRIPTION
##### SUMMARY

Added the option to specify the timeout when fetching the key from an URL. The default timeout from `fetch_url` is sometimes to low. This happened to me when using a proxy which is really slow. Since the module does support fetching from an URL, I believe the timeout setting is something that might also provide value to others than me.
To workaround not being able to specify the timeout today, two separate tasks are needed where one downloading the key and the next one imports the key.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

Before (workaround)

```yaml
---
- name: Import Docker GPG key
  hosts: test
  tasks:
    - name: Download key
      environment:
        http_proxy: 'http://my-slow-proxy:3128'
        https_proxy: "{{ http_proxy }}"
      ansible.builtin.get_url:
        url: https://download.docker.com/linux/centos/gpg
        dest: /tmp/docker.gpg
        timeout: 45

    - name: Import key
      become: true
      ansible.builtin.rpm_key:
        key: /tmp/docker.gpg
        state: present
```

After

```yaml
---
- name: Import Docker GPG key
  hosts: test
  tasks:
    - name: Import key
      become: true
      environment:
        http_proxy: 'http://my-slow-proxy:3128'
        https_proxy: "{{ http_proxy }}"
      ansible.builtin.rpm_key:
        key: /tmp/docker.gpg
        timeout: 45
        state: present
```