### PR TITLE
yum_repository: deprecate keepcache parameter

### DIFF
--- a/changelogs/fragments/yum_repository_keepcache.yml
+++ b/changelogs/fragments/yum_repository_keepcache.yml
@@ -1,0 +1,4 @@
+---
+deprecated_features:
+- yum_repository - deprecated parameter 'keepcache' (https://github.com/ansible/ansible/issues/78693).
+

--- a/changelogs/fragments/yum_repository_keepcache.yml
+++ b/changelogs/fragments/yum_repository_keepcache.yml
@@ -1,4 +1,3 @@
 ---
 deprecated_features:
 - yum_repository - deprecated parameter 'keepcache' (https://github.com/ansible/ansible/issues/78693).
-

--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -169,6 +169,7 @@ options:
     description:
       - Either V(1) or V(0). Determines whether or not yum keeps the cache of
         headers and packages after successful installation.
+      - This parameter is deprecated and will be removed in version 2.20.
     choices: ['0', '1']
     type: str
   metadata_expire:
@@ -527,6 +528,11 @@ class YumRepo(object):
 
             # Set the value only if it was defined (default is None)
             if value is not None and key in self.allowed_params:
+                if key == 'keepcache':
+                    self.module.deprecate(
+                        "'keepcache' parameter is deprecated.",
+                        version='2.20'
+                    )
                 self.repofile.set(self.section, key, value)
 
     def save(self):


### PR DESCRIPTION
##### SUMMARY

* keepcache parameter can not be set in repository file
  instead it goes in yum.conf or dnf.conf

Fixes: #78693

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/yum_repository_keepcache.yml
lib/ansible/modules/yum_repository.py

