### PR TITLE
[stable-2.13] Revert "define code owners to support branch-protection rules on docs (#81041)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-/docs/ @ansible/ansible-release-managers
-/examples/ @ansible/ansible-release-managers
-/hacking/ @ansible/ansible-release-managers


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81228

This reverts commit 91177623581490af0455307f6c8e26312b04b4a0.

(cherry picked from commit 7c6564ad0ecfe5075005788aab3f112ea6759a90)

##### ISSUE TYPE

Feature Pull Request
