### PR TITLE
[stable-2.13] Overhaul package-data sanity test (#81427)

### DIFF
--- a/test/lib/ansible_test/_internal/python_requirements.py
+++ b/test/lib/ansible_test/_internal/python_requirements.py
@@ -245,6 +245,13 @@ def collect_requirements(
             # installed packages may have run-time dependencies on setuptools
             uninstall_packages.remove('setuptools')
 
+        # hack to allow the package-data sanity test to keep wheel in the venv
+        install_commands = [command for command in commands if isinstance(command, PipInstall)]
+        install_wheel = any(install.has_package('wheel') for install in install_commands)
+
+        if install_wheel:
+            uninstall_packages.remove('wheel')
+
         commands.extend(collect_uninstall(packages=uninstall_packages))
 
     return commands

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -1,342 +1,184 @@
+"""Verify the contents of the built sdist and wheel."""
 from __future__ import annotations
 
 import contextlib
 import fnmatch
-import glob
 import os
 import pathlib
-import re
 import shutil
 import subprocess
 import sys
 import tarfile
 import tempfile
-
-import packaging.version
+import typing as t
+import zipfile
 
 from ansible.release import __version__
 
 
-def assemble_files_to_ship(complete_file_list):
-    """
-    This looks for all files which should be shipped in the sdist
-    """
-    # All files which are in the repository except these:
+def collect_sdist_files(complete_file_list: list[str]) -> list[str]:
+    """Return a list of files which should be present in the sdist."""
     ignore_patterns = (
-        # Developer-only tools
         '.azure-pipelines/*',
-        '.github/*',
-        '.github/*/*',
-        'changelogs/fragments/*',
-        'hacking/*',
-        'hacking/*/*',
-        'test/results/.tmp/*',
-        'test/results/.tmp/*/*',
-        'test/results/.tmp/*/*/*',
-        'test/results/.tmp/*/*/*/*',
-        'test/results/.tmp/*/*/*/*/*',
+        '.cherry_picker.toml',
         '.git*',
-    )
-    ignore_files = frozenset((
-        # Developer-only tools
+        '.mailmap',
         'changelogs/README.md',
         'changelogs/config.yaml',
-        '.cherry_picker.toml',
-        '.mailmap',
-    ))
-
-    # These files are generated and then intentionally added to the sdist
-
-    # Manpages
-    ignore_script = ('ansible-connection', 'ansible-test')
-    script_names = [os.path.basename(path) for path in complete_file_list if path.startswith('bin/')]
-
-    # Misc
-    misc_generated_files = [
-        'PKG-INFO',
-    ]
-
-    shipped_files = misc_generated_files
-
-    for path in complete_file_list:
-        if path not in ignore_files:
-            for ignore in ignore_patterns:
-                if fnmatch.fnmatch(path, ignore):
-                    break
-            else:
-                shipped_files.append(path)
-
-    return shipped_files
-
-
-def assemble_files_to_install(complete_file_list):
-    """
-    This looks for all of the files which should show up in an installation of ansible
-    """
-    ignore_patterns = (
-        # Tests excluded from sdist
+        'changelogs/fragments/*',
+        'hacking/*',
     )
 
-    pkg_data_files = []
-    for path in complete_file_list:
+    sdist_files = [path for path in complete_file_list if not any(fnmatch.fnmatch(path, ignore) for ignore in ignore_patterns)]
 
-        if path.startswith("lib/ansible"):
+    egg_info = (
+        'PKG-INFO',
+        'SOURCES.txt',
+        'dependency_links.txt',
+        'entry_points.txt',
+        'not-zip-safe',
+        'requires.txt',
+        'top_level.txt',
+    )
+
+    sdist_files.append('PKG-INFO')
+    sdist_files.extend(f'lib/ansible_core.egg-info/{name}' for name in egg_info)
+
+    return sdist_files
+
+
+def collect_wheel_files(complete_file_list: list[str]) -> list[str]:
+    """Return a list of files which should be present in the wheel."""
+    wheel_files = []
+
+    for path in complete_file_list:
+        if path.startswith('lib/ansible/'):
             prefix = 'lib'
-        elif path.startswith("test/lib/ansible_test"):
+        elif path.startswith('test/lib/ansible_test/'):
             prefix = 'test/lib'
         else:
             continue
 
-        for ignore in ignore_patterns:
-            if fnmatch.fnmatch(path, ignore):
-                break
-        else:
-            pkg_data_files.append(os.path.relpath(path, prefix))
+        wheel_files.append(os.path.relpath(path, prefix))
 
-    return pkg_data_files
+    dist_info = (
+        'COPYING',
+        'METADATA',
+        'RECORD',
+        'WHEEL',
+        'entry_points.txt',
+        'top_level.txt',
+    )
+
+    wheel_files.append(f'ansible_core-{__version__}.data/scripts/ansible-test')
+    wheel_files.extend(f'ansible_core-{__version__}.dist-info/{name}' for name in dist_info)
+
+    return wheel_files
 
 
 @contextlib.contextmanager
-def clean_repository(file_list):
-    """Copy the repository to clean it of artifacts"""
-    # Create a tempdir that will be the clean repo
-    with tempfile.TemporaryDirectory() as repo_root:
-        directories = {repo_root + os.path.sep}
+def clean_repository(complete_file_list: list[str]) -> t.Generator[str, None, None]:
+    """Copy the files to a temporary directory and yield the path."""
+    directories = sorted(set(os.path.dirname(path) for path in complete_file_list))
+    directories.remove('')
 
-        for filename in file_list:
-            # Determine if we need to create the directory
-            directory = os.path.dirname(filename)
-            dest_dir = os.path.join(repo_root, directory)
-            if dest_dir not in directories:
-                os.makedirs(dest_dir)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        for directory in directories:
+            os.makedirs(os.path.join(temp_dir, directory))
 
-                # Keep track of all the directories that now exist
-                path_components = directory.split(os.path.sep)
-                path = repo_root
-                for component in path_components:
-                    path = os.path.join(path, component)
-                    if path not in directories:
-                        directories.add(path)
+        for path in complete_file_list:
+            shutil.copy2(path, os.path.join(temp_dir, path), follow_symlinks=False)
 
-            # Copy the file
-            shutil.copy2(filename, dest_dir, follow_symlinks=False)
-
-        yield repo_root
+        yield temp_dir
 
 
-def create_sdist(tmp_dir):
-    """Create an sdist in the repository"""
-    # Make sure a changelog exists for this version when testing from devel.
-    # When testing from a stable branch the changelog will already exist.
-    version = packaging.version.Version(__version__)
-    pathlib.Path(f'changelogs/CHANGELOG-v{version.major}.{version.minor}.rst').touch()
-
+def build(source_dir: str, tmp_dir: str) -> tuple[pathlib.Path, pathlib.Path]:
+    """Create a sdist and wheel."""
     create = subprocess.run(
-        [sys.executable, '-m', 'build', '--sdist', '--no-isolation', '--outdir', tmp_dir],
+        [sys.executable, '-m', 'build', '--no-isolation', '--outdir', tmp_dir],
         stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         check=False,
+        cwd=source_dir,
     )
-
-    stderr = create.stderr
-    stdout = create.stdout
 
     if create.returncode != 0:
-        raise Exception('make snapshot failed:\n%s' % stderr + '\n' + stdout)
+        raise RuntimeError(f'build failed:\n{create.stderr}\n{create.stdout}')
 
-    # Determine path to sdist
-    tmp_dir_files = os.listdir(tmp_dir)
+    tmp_dir_files = list(pathlib.Path(tmp_dir).iterdir())
 
-    if not tmp_dir_files:
-        raise Exception('sdist was not created in the temp dir')
-    elif len(tmp_dir_files) > 1:
-        raise Exception('Unexpected extra files in the temp dir')
+    if len(tmp_dir_files) != 2:
+        raise RuntimeError(f'build resulted in {len(tmp_dir_files)} items instead of 2')
 
-    return os.path.join(tmp_dir, tmp_dir_files[0])
+    sdist_path = [path for path in tmp_dir_files if path.suffix == '.gz'][0]
+    wheel_path = [path for path in tmp_dir_files if path.suffix == '.whl'][0]
 
-
-def extract_sdist(sdist_path, tmp_dir):
-    """Untar the sdist"""
-    # Untar the sdist from the tmp_dir
-    with tarfile.open(os.path.join(tmp_dir, sdist_path), 'r|*') as sdist:
-        sdist.extractall(path=tmp_dir)
-
-    # Determine the sdist directory name
-    sdist_filename = os.path.basename(sdist_path)
-    tmp_dir_files = os.listdir(tmp_dir)
-    try:
-        tmp_dir_files.remove(sdist_filename)
-    except ValueError:
-        # Unexpected could not find original sdist in temp dir
-        raise
-
-    if len(tmp_dir_files) > 1:
-        raise Exception('Unexpected extra files in the temp dir')
-    elif len(tmp_dir_files) < 1:
-        raise Exception('sdist extraction did not occur i nthe temp dir')
-
-    return os.path.join(tmp_dir, tmp_dir_files[0])
+    return sdist_path, wheel_path
 
 
-def install_sdist(tmp_dir, sdist_dir):
-    """Install the extracted sdist into the temporary directory"""
-    install = subprocess.run(
-        ['python', 'setup.py', 'install', '--root=%s' % tmp_dir],
-        stdin=subprocess.DEVNULL,
-        capture_output=True,
-        text=True,
-        cwd=os.path.join(tmp_dir, sdist_dir),
-        check=False,
+def list_sdist(path: pathlib.Path) -> list[str]:
+    """Return a list of the files in the sdist."""
+    item: tarfile.TarInfo
+
+    with tarfile.open(path) as sdist:
+        paths = ['/'.join(pathlib.Path(item.path).parts[1:]) for item in sdist.getmembers() if not item.isdir()]
+
+    return paths
+
+
+def list_wheel(path: pathlib.Path) -> list[str]:
+    """Return a list of the files in the wheel."""
+    with zipfile.ZipFile(path) as wheel:
+        paths = [item.filename for item in wheel.filelist if not item.is_dir()]
+
+    return paths
+
+
+def check_files(source: str, expected: list[str], actual: list[str]) -> list[str]:
+    """Verify the expected files exist and no extra files exist."""
+    missing = sorted(set(expected) - set(actual))
+    extra = sorted(set(actual) - set(expected))
+
+    errors = (
+        [f'{path}: missing from {source}' for path in missing] +
+        [f'{path}: unexpected in {source}' for path in extra]
     )
 
-    stdout, stderr = install.stdout, install.stderr
-
-    if install.returncode != 0:
-        raise Exception('sdist install failed:\n%s' % stderr)
-
-    # Determine the prefix for the installed files
-    match = re.search('^copying .* -> (%s/.*?/(?:site|dist)-packages)/ansible$' %
-                      tmp_dir, stdout, flags=re.M)
-
-    return match.group(1)
+    return errors
 
 
-def check_sdist_contains_expected(sdist_dir, to_ship_files):
-    """Check that the files we expect to ship are present in the sdist"""
-    results = []
-    for filename in to_ship_files:
-        path = os.path.join(sdist_dir, filename)
-        if not os.path.exists(path):
-            results.append('%s: File was not added to sdist' % filename)
-
-    # Also changelog
-    changelog_files = glob.glob(os.path.join(sdist_dir, 'changelogs/CHANGELOG-v2.[0-9]*.rst'))
-    if not changelog_files:
-        results.append('changelogs/CHANGELOG-v2.*.rst: Changelog file was not added to the sdist')
-    elif len(changelog_files) > 1:
-        results.append('changelogs/CHANGELOG-v2.*.rst: Too many changelog files: %s'
-                       % changelog_files)
-
-    return results
-
-
-def check_sdist_files_are_wanted(sdist_dir, to_ship_files):
-    """Check that all files in the sdist are desired"""
-    results = []
-    for dirname, dummy, files in os.walk(sdist_dir):
-        dirname = os.path.relpath(dirname, start=sdist_dir)
-        if dirname == '.':
-            dirname = ''
-
-        for filename in files:
-            if filename == 'setup.cfg':
-                continue
-
-            path = os.path.join(dirname, filename)
-            if path not in to_ship_files:
-
-                if fnmatch.fnmatch(path, 'changelogs/CHANGELOG-v2.[0-9]*.rst'):
-                    # changelog files are expected
-                    continue
-
-                if fnmatch.fnmatch(path, 'lib/ansible_core.egg-info/*'):
-                    continue
-
-                # FIXME: ansible-test doesn't pass the paths of symlinks to us so we aren't
-                # checking those
-                if not os.path.islink(os.path.join(sdist_dir, path)):
-                    results.append('%s: File in sdist was not in the repository' % path)
-
-    return results
-
-
-def check_installed_contains_expected(install_dir, to_install_files):
-    """Check that all the files we expect to be installed are"""
-    results = []
-    for filename in to_install_files:
-        path = os.path.join(install_dir, filename)
-        if not os.path.exists(path):
-            results.append('%s: File not installed' % os.path.join('lib', filename))
-
-    return results
-
-
-EGG_RE = re.compile('ansible[^/]+\\.egg-info/(PKG-INFO|SOURCES.txt|'
-                    'dependency_links.txt|not-zip-safe|requires.txt|top_level.txt|entry_points.txt)$')
-
-
-def check_installed_files_are_wanted(install_dir, to_install_files):
-    """Check that all installed files were desired"""
-    results = []
-
-    for dirname, dummy, files in os.walk(install_dir):
-        dirname = os.path.relpath(dirname, start=install_dir)
-        if dirname == '.':
-            dirname = ''
-
-        for filename in files:
-            # If this is a byte code cache, look for the python file's name
-            directory = dirname
-            if filename.endswith('.pyc') or filename.endswith('.pyo'):
-                # Remove the trailing "o" or c"
-                filename = filename[:-1]
-
-                if directory.endswith('%s__pycache__' % os.path.sep):
-                    # Python3 byte code cache, look for the basename of
-                    # __pycache__/__init__.cpython-36.py
-                    segments = filename.rsplit('.', 2)
-                    if len(segments) >= 3:
-                        filename = '.'.join((segments[0], segments[2]))
-                        directory = os.path.dirname(directory)
-
-            path = os.path.join(directory, filename)
-
-            # Test that the file was listed for installation
-            if path not in to_install_files:
-                # FIXME: ansible-test doesn't pass the paths of symlinks to us so we
-                # aren't checking those
-                if not os.path.islink(os.path.join(install_dir, path)):
-                    if not EGG_RE.match(path):
-                        results.append('%s: File was installed but was not supposed to be' % path)
-
-    return results
-
-
-def main():
-    """All of the files in the repository"""
+def main() -> None:
+    """Main program entry point."""
     complete_file_list = sys.argv[1:] or sys.stdin.read().splitlines()
+
+    errors = []
 
     # Limit visible files to those reported by ansible-test.
     # This avoids including files which are not committed to git.
     with clean_repository(complete_file_list) as clean_repo_dir:
-        os.chdir(clean_repo_dir)
+        if __version__.endswith('.dev0'):
+            # Make sure a changelog exists for this version when testing from devel.
+            # When testing from a stable branch the changelog will already exist.
+            major_minor_version = '.'.join(__version__.split('.')[:2])
+            changelog_path = f'changelogs/CHANGELOG-v{major_minor_version}.rst'
+            pathlib.Path(clean_repo_dir, changelog_path).touch()
+            complete_file_list.append(changelog_path)
 
-        to_ship_files = assemble_files_to_ship(complete_file_list)
-        to_install_files = assemble_files_to_install(complete_file_list)
+        expected_sdist_files = collect_sdist_files(complete_file_list)
+        expected_wheel_files = collect_wheel_files(complete_file_list)
 
-        results = []
         with tempfile.TemporaryDirectory() as tmp_dir:
-            sdist_path = create_sdist(tmp_dir)
-            sdist_dir = extract_sdist(sdist_path, tmp_dir)
+            sdist_path, wheel_path = build(clean_repo_dir, tmp_dir)
 
-            # Check that the files that are supposed to be in the sdist are there
-            results.extend(check_sdist_contains_expected(sdist_dir, to_ship_files))
+            actual_sdist_files = list_sdist(sdist_path)
+            actual_wheel_files = list_wheel(wheel_path)
 
-            # Check that the files that are in the sdist are in the repository
-            results.extend(check_sdist_files_are_wanted(sdist_dir, to_ship_files))
+            errors.extend(check_files('sdist', expected_sdist_files, actual_sdist_files))
+            errors.extend(check_files('wheel', expected_wheel_files, actual_wheel_files))
 
-            # install the sdist
-            install_dir = install_sdist(tmp_dir, sdist_dir)
-
-            # Check that the files that are supposed to be installed are there
-            results.extend(check_installed_contains_expected(install_dir, to_install_files))
-
-            # Check that the files that are installed are supposed to be installed
-            results.extend(check_installed_files_are_wanted(install_dir, to_install_files))
-
-        for message in results:
-            print(message)
+    for error in errors:
+        print(error)
 
 
 if __name__ == '__main__':

--- a/test/sanity/code-smell/package-data.requirements.in
+++ b/test/sanity/code-smell/package-data.requirements.in
@@ -1,4 +1,5 @@
-build
+build  # required to build sdist
+wheel  # required to build wheel
 jinja2
 pyyaml  # ansible-core requirement
 resolvelib < 0.9.0

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -15,3 +15,4 @@ rstcheck==3.3.1
 semantic-version==2.8.5
 setuptools==45.2.0
 tomli==2.0.1
+wheel==0.41.0


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81427

The sanity test now only inspects the sdist and wheel instead of trying to install the sdist using setup.py.

(cherry picked from commit f894ce89b4db25a5bd50da2d48ab77ace3491487)

##### ISSUE TYPE

Test Pull Request
