### PR TITLE
[stable-2.14] Overhaul package-data sanity test (#81427)

### DIFF
--- a/test/lib/ansible_test/_internal/python_requirements.py
+++ b/test/lib/ansible_test/_internal/python_requirements.py
@@ -251,6 +251,13 @@ def collect_requirements(
             # installed packages may have run-time dependencies on setuptools
             uninstall_packages.remove('setuptools')
 
+        # hack to allow the package-data sanity test to keep wheel in the venv
+        install_commands = [command for command in commands if isinstance(command, PipInstall)]
+        install_wheel = any(install.has_package('wheel') for install in install_commands)
+
+        if install_wheel:
+            uninstall_packages.remove('wheel')
+
         commands.extend(collect_uninstall(packages=uninstall_packages))
 
     return commands

--- a/test/sanity/code-smell/package-data.requirements.in
+++ b/test/sanity/code-smell/package-data.requirements.in
@@ -1,4 +1,5 @@
-build
+build  # required to build sdist
+wheel  # required to build wheel
 jinja2
 pyyaml  # ansible-core requirement
 resolvelib < 0.9.0

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -15,3 +15,4 @@ rstcheck==3.5.0
 semantic-version==2.10.0
 setuptools==45.2.0
 tomli==2.0.1
+wheel==0.41.0


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81427

The sanity test now only inspects the sdist and wheel instead of trying to install the sdist using setup.py.

(cherry picked from commit f894ce89b4db25a5bd50da2d48ab77ace3491487)

##### ISSUE TYPE

Test Pull Request
