### PR TITLE
[stable-2.9] Skip apt_repository test on Ubuntu 18.04

### DIFF
--- a/test/integration/targets/apt_repository/tasks/main.yml
+++ b/test/integration/targets/apt_repository/tasks/main.yml
@@ -16,6 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: Skip tests on Ubuntu 18.04 due to intermittent failures from attempted use of IPv6 addresses
+  meta: end_play
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04'
+
 - include: 'apt.yml'
   when: ansible_distribution in ('Ubuntu')
 


### PR DESCRIPTION
##### SUMMARY

Skip apt_repository test on Ubuntu 18.04.

##### ISSUE TYPE

Test Pull Request
