### PR TITLE
filters vault/unvault fix vault_id parameter usage (#81422)

### DIFF
--- a/changelogs/fragments/vault_unvault_id_fix.yml
+++ b/changelogs/fragments/vault_unvault_id_fix.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - vault and unvault filters now properly take ``vault_id`` parameter.
+deprecated_features:
+  - vault and unfault filters - the undocumented ``vaultid`` parameter is deprecated and will be removed in ansible-core 2.20. Use ``vault_id`` instead.

--- a/lib/ansible/plugins/filter/encryption.py
+++ b/lib/ansible/plugins/filter/encryption.py
@@ -17,7 +17,7 @@ from ansible.utils.display import Display
 display = Display()
 
 
-def do_vault(data, secret, salt=None, vaultid='filter_default', wrap_object=False):
+def do_vault(data, secret, salt=None, vault_id='filter_default', wrap_object=False, vaultid=None):
 
     if not isinstance(secret, (string_types, binary_type, Undefined)):
         raise AnsibleFilterTypeError("Secret passed is required to be a string, instead we got: %s" % type(secret))
@@ -25,11 +25,18 @@ def do_vault(data, secret, salt=None, vaultid='filter_default', wrap_object=Fals
     if not isinstance(data, (string_types, binary_type, Undefined)):
         raise AnsibleFilterTypeError("Can only vault strings, instead we got: %s" % type(data))
 
+    if vaultid is not None:
+        display.deprecated("Use of undocumented 'vaultid', use 'vault_id' instead", version='2.20')
+        if vault_id == 'filter_default':
+            vault_id = vaultid
+        else:
+            display.warning("Ignoring vaultid as vault_id is already set.")
+
     vault = ''
     vs = VaultSecret(to_bytes(secret))
     vl = VaultLib()
     try:
-        vault = vl.encrypt(to_bytes(data), vs, vaultid, salt)
+        vault = vl.encrypt(to_bytes(data), vs, vault_id, salt)
     except UndefinedError:
         raise
     except Exception as e:
@@ -43,7 +50,7 @@ def do_vault(data, secret, salt=None, vaultid='filter_default', wrap_object=Fals
     return vault
 
 
-def do_unvault(vault, secret, vaultid='filter_default'):
+def do_unvault(vault, secret, vault_id='filter_default', vaultid=None):
 
     if not isinstance(secret, (string_types, binary_type, Undefined)):
         raise AnsibleFilterTypeError("Secret passed is required to be as string, instead we got: %s" % type(secret))
@@ -51,9 +58,16 @@ def do_unvault(vault, secret, vaultid='filter_default'):
     if not isinstance(vault, (string_types, binary_type, AnsibleVaultEncryptedUnicode, Undefined)):
         raise AnsibleFilterTypeError("Vault should be in the form of a string, instead we got: %s" % type(vault))
 
+    if vaultid is not None:
+        display.deprecated("Use of undocumented 'vaultid', use 'vault_id' instead", version='2.20')
+        if vault_id == 'filter_default':
+            vault_id = vaultid
+        else:
+            display.warning("Ignoring vaultid as vault_id is already set.")
+
     data = ''
     vs = VaultSecret(to_bytes(secret))
-    vl = VaultLib([(vaultid, vs)])
+    vl = VaultLib([(vault_id, vs)])
     if isinstance(vault, AnsibleVaultEncryptedUnicode):
         vault.vault = vl
         data = vault.data

--- a/test/integration/targets/filter_encryption/base.yml
+++ b/test/integration/targets/filter_encryption/base.yml
@@ -2,6 +2,7 @@
   gather_facts: true
   vars:
     data: secret
+    data2: 'foo: bar\n'
     dvault: '{{ "secret"|vault("test")}}'
     password: test
     s_32: '{{(2**31-1)}}'
@@ -21,6 +22,15 @@
     is_64: '{{ "64" in ansible_facts["architecture"] }}'
     salt: '{{ is_64|bool|ternary(s_64, s_32)|random(seed=inventory_hostname)}}'
     vaultedstring: '{{ is_64|bool|ternary(vaultedstring_64, vaultedstring_32) }}'
+    # command line vaulted data2
+    vaulted_id: !vault |
+                $ANSIBLE_VAULT;1.2;AES256;test1
+                36383733336533656264393332663131613335333332346439356164383935656234663631356430
+                3533353537343834333538356366376233326364613362640a623832636339363966336238393039
+                35316562626335306534356162623030613566306235623863373036626531346364626166656134
+                3063376436656635330a363636376131663362633731313964353061663661376638326461393736
+                3863
+    vaulted_to_id: "{{data2|vault('test1@secret', vault_id='test1')}}"
 
   tasks:
     - name: check vaulting
@@ -35,3 +45,5 @@
         that:
           - vaultedstring|unvault(password) == data
           - vault|unvault(password) == data
+          - vaulted_id|unvault('test1@secret', vault_id='test1')
+          - vaulted_to_id|unvault('test1@secret', vault_id='test1')

--- a/test/integration/targets/unvault/main.yml
+++ b/test/integration/targets/unvault/main.yml
@@ -1,4 +1,5 @@
 - hosts: localhost
+  gather_facts: false
   tasks:
     - set_fact:
         unvaulted: "{{ lookup('unvault', 'vault') }}"

--- a/test/integration/targets/unvault/runme.sh
+++ b/test/integration/targets/unvault/runme.sh
@@ -2,5 +2,5 @@
 
 set -eux
 
-
+# simple run
 ansible-playbook --vault-password-file password main.yml


### PR DESCRIPTION
* vault/unvault filters, fixed id field to match documented.

fixes #81420

Co-authored-by: Felix Fontein <felix@fontein.de>
(cherry picked from commit f3a15a4a95d011741885942cad7187f1f7c572fe)

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
