### PR TITLE
Add notes for DNF module about caveats when ensuring presence of groups

### DIFF
--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -280,7 +280,8 @@ notes:
     upstream dnf's API doesn't properly mark groups as installed, therefore upon
     removal the module is unable to detect that the group is installed
     (https://bugzilla.redhat.com/show_bug.cgi?id=1620324)
-  - When using the C(state: present) option with package groups, be aware that
+  - >-
+    When using the C(state: present) option with package groups, be aware that
     the underlying DNF API may upgrade packages within the group to ensure they
     align with the group's current metadata definitions. If you aim to merely
     check for the presence of a group without potentially upgrading its

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -280,6 +280,11 @@ notes:
     upstream dnf's API doesn't properly mark groups as installed, therefore upon
     removal the module is unable to detect that the group is installed
     (https://bugzilla.redhat.com/show_bug.cgi?id=1620324)
+  - When using the C(state: present) option with package groups, be aware that
+    the underlying DNF API may upgrade packages within the group to ensure they
+    align with the group's current metadata definitions. If you aim to merely
+    check for the presence of a group without potentially upgrading its
+    packages, additional considerations, or checks might be necessary.
 requirements:
   - "python >= 2.6"
   - python-dnf


### PR DESCRIPTION
##### SUMMARY

Add additional notes to the `dnf` module/documentation about the behavior of the `dnf` API's handling of groups.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

When using `state: present` in conjunction with a package group (EX: `@Core`), it is possible that a package in the group can be updated regardless of the `state: present`, causing breaking or unexpected results.

**test-dnf-module.yml**

```yaml
---
- name: Test dnf module
  hosts: localhost
  tasks:
    - name: Test group present/update
      ansible.builtin.dnf:
        name: "@Core"
        state: present
```

```bash
[root@c ~]# rpm -q curl
curl-7.76.1-23.el9_2.1.x86_64
```

```bash
TASK [Test group present/update] ***********************************************************************
task path: /root/update-test.yml:6
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir "` echo /root/.ansible/tmp/ansible-tmp-1691356716.832642-1563126-24396014678510 `" && echo ansible-tmp-1691356716.832642-1563126-24396014678510="` echo /root/.ansible/tmp/ansible-tmp-1691356716.832642-1563126-24396014678510 `" ) && sleep 0'
Using module file /usr/lib/python3.11/site-packages/ansible/modules/dnf.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-1563122tenqqjke/tmph7vr0kpm TO /root/.ansible/tmp/ansible-tmp-1691356716.832642-1563126-24396014678510/AnsiballZ_dnf.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1691356716.832642-1563126-24396014678510/ /root/.ansible/tmp/ansible-tmp-1691356716.832642-1563126-24396014678510/AnsiballZ_dnf.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3.11 /root/.ansible/tmp/ansible-tmp-1691356716.832642-1563126-24396014678510/AnsiballZ_dnf.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1691356716.832642-1563126-24396014678510/ > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "allow_downgrade": false,
            "allowerasing": false,
            "autoremove": false,
            "bugfix": false,
            "cacheonly": false,
            "conf_file": null,
            "disable_excludes": null,
            "disable_gpg_check": false,
            "disable_plugin": [],
            "disablerepo": [],
            "download_dir": null,
            "download_only": false,
            "enable_plugin": [],
            "enablerepo": [],
            "exclude": [],
            "install_repoquery": true,
            "install_weak_deps": true,
            "installroot": "/",
            "list": null,
            "lock_timeout": 30,
            "name": [
                "@Core"
            ],
            "nobest": false,
            "releasever": null,
            "security": false,
            "skip_broken": false,
            "sslverify": true,
            "state": "present",
            "update_cache": false,
            "update_only": false,
            "validate_certs": true
        }
    },
    "msg": "",
    "rc": 0,
    "results": [
        "Group core installed.",
        "Installed: curl-7.76.1-23.el9_2.2.x86_64",
        "Removed: curl-7.76.1-23.el9_2.1.x86_64"
    ]
}

PLAY RECAP *********************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

```bash
[root@c ~]# rpm -q curl
curl-7.76.1-23.el9_2.2.x86_64
```