### PR TITLE
Add explicit encoding to subprocess.Popen() calls.

### DIFF
--- a/hacking/test-module.py
+++ b/hacking/test-module.py
@@ -31,6 +31,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import locale
 import glob
 import optparse
 import os
@@ -187,7 +188,7 @@ def ansiballz_setup(modfile, modname, interpreters):
         command = []
     command.extend([modfile, 'explode'])
 
-    cmd = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cmd = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding=locale.getlocale()[1])
     out, err = cmd.communicate()
     out, err = to_text(out, errors='surrogate_or_strict'), to_text(err)
     lines = out.splitlines()
@@ -230,7 +231,7 @@ def runtest(modfile, argspath, modname, module_style, interpreters):
     if argspath is not None:
         invoke = "%s %s" % (invoke, argspath)
 
-    cmd = subprocess.Popen(invoke, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cmd = subprocess.Popen(invoke, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding=locale.getlocale()[1])
     (out, err) = cmd.communicate()
     out, err = to_text(out), to_text(err)
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -41,29 +41,18 @@ def check_blocking_io():
 
 check_blocking_io()
 
-
 def initialize_locale():
     """Set the locale to the users default setting and ensure
     the locale and filesystem encoding are UTF-8.
     """
     try:
         locale.setlocale(locale.LC_ALL, '')
-        dummy, encoding = locale.getlocale()
     except (locale.Error, ValueError) as e:
         raise SystemExit(
             'ERROR: Ansible could not initialize the preferred locale: %s' % e
         )
 
-    if not encoding or encoding.lower() not in ('utf-8', 'utf8'):
-        raise SystemExit('ERROR: Ansible requires the locale encoding to be UTF-8; Detected %s.' % encoding)
-
-    fs_enc = sys.getfilesystemencoding()
-    if fs_enc.lower() != 'utf-8':
-        raise SystemExit('ERROR: Ansible requires the filesystem encoding to be UTF-8; Detected %s.' % fs_enc)
-
-
 initialize_locale()
-
 
 from importlib.metadata import version
 from ansible.module_utils.compat.version import LooseVersion
@@ -508,7 +497,7 @@ class CLI(ABC):
             else:
                 CLI.pager_pipe(text)
         else:
-            p = subprocess.Popen('less --version', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p = subprocess.Popen('less --version', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding=locale.getlocale()[1])
             p.communicate()
             if p.returncode == 0:
                 CLI.pager_pipe(text, 'less')
@@ -521,7 +510,7 @@ class CLI(ABC):
         if 'less' in CLI.PAGER:
             os.environ['LESS'] = CLI.LESS_OPTS
         try:
-            cmd = subprocess.Popen(CLI.PAGER, shell=True, stdin=subprocess.PIPE, stdout=sys.stdout)
+            cmd = subprocess.Popen(CLI.PAGER, shell=True, stdin=subprocess.PIPE, stdout=sys.stdout, encoding=locale.getlocale()[1])
             cmd.communicate(input=to_bytes(text))
         except IOError:
             pass
@@ -604,7 +593,7 @@ class CLI(ABC):
             cmd = [b_pwd_file]
 
             try:
-                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding=locale.getlocale()[1])
             except OSError as e:
                 raise AnsibleError("Problem occured when trying to run the password script %s (%s)."
                                    " If this is not a script, remove the executable bit from the file." % (pwd_file, e))

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -4,6 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import locale
 import os
 import pty
 import time
@@ -1220,7 +1221,7 @@ def start_connection(play_context, options, task_uuid):
     master, slave = pty.openpty()
     p = subprocess.Popen(
         [python, ansible_connection, *verbosity, to_text(os.getppid()), to_text(task_uuid)],
-        stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+        stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, encoding = locale.getlocale()[1]
     )
     os.close(slave)
 

--- a/lib/ansible/galaxy/collection/gpg.py
+++ b/lib/ansible/galaxy/collection/gpg.py
@@ -7,6 +7,7 @@ from ansible.errors import AnsibleError
 from ansible.galaxy.user_agent import user_agent
 from ansible.module_utils.urls import open_url
 
+import locale
 import contextlib
 import os
 import subprocess
@@ -76,7 +77,7 @@ def run_gpg_verify(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             pass_fds=(status_fd_write,),
-            encoding='utf8',
+            encoding=locale.getlocale()[1]
         )
     except (FileNotFoundError, subprocess.SubprocessError) as err:
         raise AnsibleError(

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2019,7 +2019,7 @@ class AnsibleModule(object):
         try:
             if self._debug:
                 self.log('Executing: ' + self._clean_args(args))
-            cmd = subprocess.Popen(args, **kwargs)
+            cmd = subprocess.Popen(args, encoding=locale.getlocale()[1], **kwargs)
             if before_communicate_callback:
                 before_communicate_callback(cmd)
 

--- a/lib/ansible/module_utils/service.py
+++ b/lib/ansible/module_utils/service.py
@@ -29,6 +29,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import locale
 import glob
 import os
 import pickle
@@ -204,7 +205,8 @@ def daemonize(module, cmd):
             run_cmd.append(to_bytes(c, errors=errors))
 
         # execute the command in forked process
-        p = subprocess.Popen(run_cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, preexec_fn=lambda: os.close(pipe[1]))
+        p = subprocess.Popen(run_cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, preexec_fn=lambda: os.close(pipe[1]),
+            encoding=locale.getlocale()[1])
         fds = [p.stdout, p.stderr]
 
         # loop reading output till it is done

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
+import locale
 import errno
 import json
 import shlex
@@ -169,7 +170,7 @@ def _run_module(wrapped_cmd, jid):
         interpreter = _get_interpreter(cmd[0])
         if interpreter:
             cmd = interpreter + cmd
-        script = subprocess.Popen(cmd, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+        script = subprocess.Popen(cmd, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE, encoding=locale.getlocale()[1],
                                   stderr=subprocess.PIPE)
 
         (outdata, stderr) = script.communicate()

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -158,6 +158,7 @@ EXAMPLES = r'''
 
 RETURN = r'''#'''
 
+import locale
 import glob
 import json
 import os
@@ -298,7 +299,8 @@ class Service(object):
 
             # chkconfig localizes messages and we're screen scraping so make
             # sure we use the C locale
-            p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=lang_env, preexec_fn=lambda: os.close(pipe[1]))
+            p = subprocess.Popen(cmd, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=lang_env, preexec_fn=lambda: os.close(pipe[1]),
+                encoding=locale.getlocale()[1])
             stdout = b("")
             stderr = b("")
             fds = [p.stdout, p.stderr]

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -457,6 +457,7 @@ uid:
 '''
 
 
+import locale
 import ctypes.util
 import grp
 import calendar
@@ -1205,6 +1206,7 @@ class User(object):
             env['LC_ALL'] = get_best_parsable_locale(self.module)
             try:
                 p = subprocess.Popen([to_bytes(c) for c in cmd],
+                                     encoding=locale.getlocale()[1],
                                      stdin=slave_in_fd,
                                      stdout=slave_out_fd,
                                      stderr=slave_err_fd,

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -19,6 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import locale
 import errno
 import fcntl
 import os
@@ -447,7 +448,7 @@ class ScriptVaultSecret(FileVaultSecret):
     def _run(self, command):
         try:
             # STDERR not captured to make it easier for users to prompt for input in their scripts
-            p = subprocess.Popen(command, stdout=subprocess.PIPE)
+            p = subprocess.Popen(command, stdout=subprocess.PIPE, encoding=locale.getlocale()[1])
         except OSError as e:
             msg_format = "Problem running vault password script %s (%s)." \
                 " If this is not a script, remove the executable bit from the file."
@@ -479,7 +480,7 @@ class ClientScriptVaultSecret(ScriptVaultSecret):
 
     def _run(self, command):
         try:
-            p = subprocess.Popen(command,
+            p = subprocess.Popen(command, encoding=locale.getlocale()[1],
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
         except OSError as e:

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -18,6 +18,7 @@ DOCUMENTATION = '''
         - The remote user is ignored, the user with which the ansible CLI was executed is used instead.
 '''
 
+import locale
 import fcntl
 import getpass
 import os
@@ -102,6 +103,7 @@ class Connection(ConnectionBase):
         p = subprocess.Popen(
             cmd,
             shell=isinstance(cmd, (text_type, binary_type)),
+            encoding=locale.getlocale()[1],
             executable=executable,
             cwd=self.cwd,
             stdin=stdin,

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -161,6 +161,7 @@ DOCUMENTATION = """
         type: int
 """
 
+import locale
 import base64
 import logging
 import os
@@ -410,7 +411,7 @@ class Connection(ConnectionBase):
             display.vvvv("calling kinit with subprocess for principal %s"
                          % principal)
             try:
-                p = subprocess.Popen(kinit_cmdline, stdin=subprocess.PIPE,
+                p = subprocess.Popen(kinit_cmdline, stdin=subprocess.PIPE, encoding=locale.getlocale()[1],
                                      stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
                                      env=krb5env)

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -32,6 +32,7 @@ DOCUMENTATION = '''
         - To find the scripts that used to be part of the code release, go to U(https://github.com/ansible-community/contrib-scripts/).
 '''
 
+import locale
 import os
 import subprocess
 
@@ -90,7 +91,7 @@ class InventoryModule(BaseInventoryPlugin):
 
         try:
             try:
-                sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding=locale.getlocale()[1])
             except OSError as e:
                 raise AnsibleParserError("problem running %s (%s)" % (' '.join(cmd), to_native(e)))
             (stdout, stderr) = sp.communicate()
@@ -186,7 +187,7 @@ class InventoryModule(BaseInventoryPlugin):
 
         cmd = [path, "--host", host]
         try:
-            sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding=locale.getlocale()[1])
         except OSError as e:
             raise AnsibleError("problem running %s (%s)" % (' '.join(cmd), e))
         (out, stderr) = sp.communicate()

--- a/lib/ansible/plugins/lookup/lines.py
+++ b/lib/ansible/plugins/lookup/lines.py
@@ -42,6 +42,7 @@ RETURN = """
     elements: str
 """
 
+import locale
 import subprocess
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
@@ -54,7 +55,7 @@ class LookupModule(LookupBase):
 
         ret = []
         for term in terms:
-            p = subprocess.Popen(term, cwd=self._loader.get_basedir(), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+            p = subprocess.Popen(term, cwd=self._loader.get_basedir(), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, encoding=locale.getlocale()[1])
             (stdout, stderr) = p.communicate()
             if p.returncode == 0:
                 ret.extend([to_text(l) for l in stdout.splitlines()])

--- a/lib/ansible/plugins/lookup/pipe.py
+++ b/lib/ansible/plugins/lookup/pipe.py
@@ -45,6 +45,7 @@ RETURN = r"""
     elements: str
 """
 
+import locale
 import subprocess
 
 from ansible.errors import AnsibleError
@@ -66,7 +67,7 @@ class LookupModule(LookupBase):
             # https://github.com/ansible/ansible/issues/6550
             term = str(term)
 
-            p = subprocess.Popen(term, cwd=self._loader.get_basedir(), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+            p = subprocess.Popen(term, cwd=self._loader.get_basedir(), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, encoding=locale.getlocale()[1])
             (stdout, stderr) = p.communicate()
             if p.returncode == 0:
                 ret.append(stdout.decode("utf-8").rstrip())

--- a/lib/ansible/utils/cmd_functions.py
+++ b/lib/ansible/utils/cmd_functions.py
@@ -18,6 +18,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import locale
 import os
 import select
 import shlex
@@ -33,7 +34,7 @@ def run_cmd(cmd, live=False, readsize=10):
     # subprocess should be passed byte strings.
     cmdargs = [to_bytes(a, errors='surrogate_or_strict') for a in cmdargs]
 
-    p = subprocess.Popen(cmdargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(cmdargs, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding=locale.getlocale()[1])
 
     stdout = b''
     stderr = b''

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -26,6 +26,7 @@ else:
     # this will be set to False if curses.setupterm() fails
     HAS_CURSES = True
 
+import locale
 import codecs
 import ctypes.util
 import fcntl
@@ -292,7 +293,7 @@ class Display(metaclass=Singleton):
 
         if self.b_cowsay:
             try:
-                cmd = subprocess.Popen([self.b_cowsay, "-l"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                cmd = subprocess.Popen([self.b_cowsay, "-l"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding=locale.getlocale()[1])
                 (out, err) = cmd.communicate()
                 if cmd.returncode:
                     raise Exception
@@ -554,7 +555,7 @@ class Display(metaclass=Singleton):
             runcmd.append(b'-f')
             runcmd.append(to_bytes(thecow))
         runcmd.append(to_bytes(msg))
-        cmd = subprocess.Popen(runcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cmd = subprocess.Popen(runcmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding=locale.getlocale()[1])
         (out, err) = cmd.communicate()
         self.display(u"%s\n" % to_text(out), color=color)
 

--- a/lib/ansible/utils/ssh_functions.py
+++ b/lib/ansible/utils/ssh_functions.py
@@ -20,6 +20,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import locale
 import subprocess
 
 from ansible import constants as C
@@ -43,7 +44,7 @@ def check_for_controlpersist(ssh_executable):
     b_ssh_exec = to_bytes(ssh_executable, errors='surrogate_or_strict')
     has_cp = True
     try:
-        cmd = subprocess.Popen([b_ssh_exec, '-o', 'ControlPersist'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cmd = subprocess.Popen([b_ssh_exec, '-o', 'ControlPersist'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding=locale.getlocale()[1])
         (out, err) = cmd.communicate()
         if b"Bad configuration option" in err or b"Usage:" in err:
             has_cp = False

--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -77,6 +77,7 @@ RETURN = '''
 #
 '''
 
+import locale
 import datetime
 import os
 import subprocess
@@ -205,7 +206,7 @@ def sign_manifest(signature_path, manifest_path, module, collection_setup_result
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             pass_fds=(status_fd_write,),
-            encoding='utf8',
+            encoding=locale.getlocale()[1]
         )
     except (FileNotFoundError, subprocess.SubprocessError) as err:
         collection_setup_result['gpg_detach_sign']['error'] = "Failed during GnuPG verification with command '{gpg_cmd}': {err}".format(

--- a/test/integration/targets/ansible-test-container/runme.py
+++ b/test/integration/targets/ansible-test-container/runme.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import locale
 import abc
 import dataclasses
 import datetime
@@ -748,7 +749,7 @@ def run_command(
     display.subsection(f'Run command: {shlex.join(command)}')
 
     try:
-        with subprocess.Popen(args=command, stdin=stdin, stdout=stdout, stderr=stderr, env=env, text=True) as process:
+        with subprocess.Popen(args=command, stdin=stdin, stdout=stdout, stderr=stderr, env=env, text=True, encoding=locale.getlocale()[1]) as process:
             process_stdout, process_stderr = process.communicate(data)
             process_status = process.returncode
     except FileNotFoundError:

--- a/test/integration/targets/preflight_encoding/tasks/main.yml
+++ b/test/integration/targets/preflight_encoding/tasks/main.yml
@@ -41,22 +41,3 @@
 
 - meta: end_host
   when: non_utf8 is falsy
-
-- name: Test unsuccessful encodings
-  shell: '{{ item }} ansible --version'
-  args:
-    executable: '{{ bash.stdout_lines|first }}'
-  loop:
-    - LC_ALL={{ non_utf8 }}
-    - LC_ALL= LC_CTYPE={{ non_utf8 }}
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - result is failed
-      - result.results | select('failed') | length == 2
-      - >-
-        'ERROR: Ansible requires the locale encoding to be UTF-8' in result.results[0].stderr
-      - >-
-        'ERROR: Ansible requires the locale encoding to be UTF-8' in result.results[1].stderr

--- a/test/integration/targets/prepare_http_tests/library/httptester_kinit.py
+++ b/test/integration/targets/prepare_http_tests/library/httptester_kinit.py
@@ -31,6 +31,7 @@ RETURN = r'''
 #
 '''
 
+import locale
 import contextlib
 import errno
 import os
@@ -104,7 +105,7 @@ def main():
 
     # Debugging purposes, get the Kerberos version. On platforms like OpenSUSE this may not be on the PATH.
     try:
-        process = subprocess.Popen(['%skrb5-config' % prefix, '--version'], stdout=subprocess.PIPE)
+        process = subprocess.Popen(['%skrb5-config' % prefix, '--version'], stdout=subprocess.PIPE, encoding=locale.getlocale()[1])
         stdout, stderr = process.communicate()
         version = to_text(stdout)
     except OSError as e:
@@ -126,7 +127,7 @@ def main():
         kinit_env = os.environ.copy()
         kinit_env['KRB5_TRACE'] = '/dev/stdout'
 
-        process = subprocess.Popen(kinit_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        process = subprocess.Popen(kinit_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding=locale.getlocale()[1],
                                    env=kinit_env)
         stdout, stderr = process.communicate(to_bytes(module.params['password'], errors='surrogate_or_strict') + b'\n')
         rc = process.returncode

--- a/test/integration/targets/var_precedence/ansible-var-precedence-check.py
+++ b/test/integration/targets/var_precedence/ansible-var-precedence-check.py
@@ -6,6 +6,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import locale
 import json
 import os
 import sys
@@ -24,6 +25,7 @@ TESTDIR = tempfile.mkdtemp()
 def run_command(args, cwd=None):
     p = subprocess.Popen(
         args,
+        encoding=locale.getlocale()[1],
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE,
         shell=True,

--- a/test/lib/ansible_test/_internal/ssh.py
+++ b/test/lib/ansible_test/_internal/ssh.py
@@ -1,6 +1,7 @@
 """High level functions for working with SSH."""
 from __future__ import annotations
 
+import locale
 import dataclasses
 import itertools
 import json
@@ -229,6 +230,7 @@ def run_ssh_command(
         process = SshProcess(None)
     else:
         process = SshProcess(subprocess.Popen(cmd_bytes, env=env_bytes, bufsize=-1,  # pylint: disable=consider-using-with
+                                              encoding=locale.getlocale()[1],
                                               stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE))
 
     return process

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -1,6 +1,7 @@
 """Miscellaneous utility functions and classes."""
 from __future__ import annotations
 
+import locale
 import abc
 import collections.abc as c
 import enum
@@ -476,7 +477,7 @@ def raw_command(
         try:
             cmd_bytes = [to_bytes(arg) for arg in cmd]
             env_bytes = dict((to_bytes(k), to_bytes(v)) for k, v in env.items())
-            process = subprocess.Popen(cmd_bytes, env=env_bytes, stdin=stdin, stdout=stdout, stderr=stderr, cwd=cwd)  # pylint: disable=consider-using-with
+            process = subprocess.Popen(cmd_bytes, env=env_bytes, stdin=stdin, stdout=stdout, stderr=stderr, cwd=cwd, encoding=locale.getlocale()[1])  # pylint: disable=consider-using-with
         except FileNotFoundError as ex:
             raise ApplicationError('Required program "%s" not found.' % cmd[0]) from ex
 

--- a/test/lib/ansible_test/_util/target/sanity/import/importer.py
+++ b/test/lib/ansible_test/_util/target/sanity/import/importer.py
@@ -98,6 +98,7 @@ def main():
             try:
                 cmd = [external_python, yaml_to_json_path]
                 proc = subprocess.Popen([to_bytes(c) for c in cmd],  # pylint: disable=consider-using-with
+                                        encoding=locale.getlocale()[1],
                                         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 stdout_bytes, stderr_bytes = proc.communicate(to_bytes(yaml))
 

--- a/test/lib/ansible_test/_util/target/setup/requirements.py
+++ b/test/lib/ansible_test/_util/target/setup/requirements.py
@@ -4,6 +4,7 @@ __metaclass__ = type
 
 # pylint: disable=wrong-import-position
 
+import locale
 import resource
 
 # Setting a low soft RLIMIT_NOFILE value will improve the performance of subprocess.Popen on Python 2.x when close_fds=True.
@@ -318,7 +319,7 @@ def execute_command(cmd, cwd=None, capture=False, env=None):  # type: (t.List[st
         stderr = None
 
     cwd_bytes = to_optional_bytes(cwd)
-    process = subprocess.Popen(cmd_bytes, cwd=cwd_bytes, stdin=devnull(), stdout=stdout, stderr=stderr, env=env)  # pylint: disable=consider-using-with
+    process = subprocess.Popen(cmd_bytes, cwd=cwd_bytes, stdin=devnull(), stdout=stdout, stderr=stderr, env=env, encoding=locale.getlocale()[1])  # pylint: disable=consider-using-with
     stdout_bytes, stderr_bytes = process.communicate()
     stdout_text = to_optional_text(stdout_bytes) or u''
     stderr_text = to_optional_text(stderr_bytes) or u''


### PR DESCRIPTION
Remove checks for UTF8-only -- that's an unnecessary limitation. The work is probably incomplete, but `ssh.py` can now handle non-UTF8 encodings.

will now print the date's output in whatever locale (assuming the local and remote locales match, of course).

##### SUMMARY

Instead of insisting on UTF8, add locale to all calls to `subprocess.Popen()`

Fixes:	#55157

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

The below command now prints the output in proper Ukrainian (my `LANG` is set to `uk_UA.KOI8-U`):

```paste below
	ansible -ilocalhost, -a date all
	localhost | CHANGED | rc=0 >>
	Пн  7 серп. 2023 01:16:13 EDT
```
whereas before -- with all current versions of Ansible -- the output would be garbled: `пп╣яп©. 2023 01:16:59 EDT`.

I'm sure, the work is not complete -- and I'm hoping, automated regression tests will point out the omissions to me.