### PR TITLE
PowerShell - remove uneeded dotnet code for future compatibility

### DIFF
--- a/changelogs/fragments/dotnet-preparation.yml
+++ b/changelogs/fragments/dotnet-preparation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- PowerShell - Remove some code which is no longer valid for dotnet 5+

--- a/lib/ansible/module_utils/csharp/Ansible.AccessToken.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.AccessToken.cs
@@ -2,7 +2,6 @@ using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Text;
@@ -123,7 +122,6 @@ namespace Ansible.AccessToken
             base.SetHandle(handle);
         }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             Marshal.FreeHGlobal(handle);
@@ -247,7 +245,6 @@ namespace Ansible.AccessToken
         public SafeNativeHandle() : base(true) { }
         public SafeNativeHandle(IntPtr handle) : base(true) { this.handle = handle; }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             return NativeMethods.CloseHandle(handle);

--- a/lib/ansible/module_utils/csharp/Ansible.Become.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Become.cs
@@ -4,7 +4,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Security.AccessControl;
 using System.Security.Principal;
@@ -175,7 +174,6 @@ namespace Ansible.Become
     {
         public SafeLsaHandle() : base(true) { }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             UInt32 res = NativeMethods.LsaDeregisterLogonProcess(handle);
@@ -187,7 +185,6 @@ namespace Ansible.Become
     {
         public SafeLsaMemoryBuffer() : base(true) { }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             UInt32 res = NativeMethods.LsaFreeReturnBuffer(handle);
@@ -200,7 +197,6 @@ namespace Ansible.Become
         public NoopSafeHandle() : base(IntPtr.Zero, false) { }
         public override bool IsInvalid { get { return false; } }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle() { return true; }
     }
 

--- a/lib/ansible/module_utils/csharp/Ansible.Privilege.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Privilege.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Text;
@@ -92,7 +91,6 @@ namespace Ansible.Privilege
         {
             base.SetHandle(handle);
         }
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             Marshal.FreeHGlobal(handle);
@@ -104,7 +102,7 @@ namespace Ansible.Privilege
     {
         public SafeNativeHandle() : base(true) { }
         public SafeNativeHandle(IntPtr handle) : base(true) { this.handle = handle; }
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+
         protected override bool ReleaseHandle()
         {
             return NativeMethods.CloseHandle(handle);

--- a/lib/ansible/module_utils/csharp/Ansible.Process.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Process.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections;
 using System.IO;
 using System.Linq;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
@@ -176,7 +175,6 @@ namespace Ansible.Process
             base.SetHandle(handle);
         }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             Marshal.FreeHGlobal(handle);

--- a/test/integration/targets/module_utils_Ansible.Become/library/ansible_become_tests.ps1
+++ b/test/integration/targets/module_utils_Ansible.Become/library/ansible_become_tests.ps1
@@ -48,7 +48,6 @@ $test_whoami = {
     Add-Type -TypeDefinition @'
 using Microsoft.Win32.SafeHandles;
 using System;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Text;
@@ -212,7 +211,6 @@ namespace Ansible
     {
         public SafeLsaMemoryBuffer() : base(true) { }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             UInt32 res = NativeMethods.LsaFreeReturnBuffer(handle);
@@ -232,7 +230,6 @@ namespace Ansible
             base.SetHandle(handle);
         }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             Marshal.FreeHGlobal(handle);
@@ -245,7 +242,6 @@ namespace Ansible
         public SafeNativeHandle() : base(true) { }
         public SafeNativeHandle(IntPtr handle) : base(true) { this.handle = handle; }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             return NativeMethods.CloseHandle(handle);

--- a/test/support/windows-integration/plugins/module_utils/Ansible.Service.cs
+++ b/test/support/windows-integration/plugins/module_utils/Ansible.Service.cs
@@ -2,7 +2,6 @@ using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Text;
@@ -274,7 +273,6 @@ namespace Ansible.Service
             base.SetHandle(handle);
         }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             Marshal.FreeHGlobal(handle);
@@ -287,7 +285,6 @@ namespace Ansible.Service
         public SafeServiceHandle() : base(true) { }
         public SafeServiceHandle(IntPtr handle) : base(true) { this.handle = handle; }
 
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         protected override bool ReleaseHandle()
         {
             return NativeMethods.CloseServiceHandle(handle);


### PR DESCRIPTION
##### SUMMARY
The `ReliabilityContract` is an obsolete attribute and will cause the C# code that use it to fail to compile on newer versions of dotnet. While we don't officially support it yet there is no need to continue including this attribute.

Related: https://github.com/ansible-collections/ansible.windows/issues/537

##### ISSUE TYPE
- Bugfix Pull Request