### PR TITLE
Add ability to filter find on mode

### DIFF
--- a/changelogs/fragments/find-mode.yml
+++ b/changelogs/fragments/find-mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- find module - Add ability to filter based on modes

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -116,11 +116,14 @@ options:
             - Choose objects matching a specified permission. This value is
               restricted to modes that can be applied using the python
               C(os.chmod) function.
+            - The mode can be provided as an octal such as V("0o0644") or
+              as symbolic such as V(u=rw,g=r,o=r)
         type: raw
         version_added: '2.16'
     exact_mode:
         description:
-            - Restrict mode matching to exact matches only.
+            - Restrict mode matching to exact matches only, and not as a
+              minimum set of permissions to match.
         type: bool
         default: true
         version_added: '2.16'

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -564,8 +564,8 @@ def main():
 
                     elif stat.S_ISLNK(st.st_mode) and params['file_type'] == 'link':
                         if (pfilter(fsobj, params['patterns'], params['excludes'], params['use_regex']) and
-                            agefilter(st, now, age, params['age_stamp']) and
-                            mode_filter(st, params['mode'], params['exact_mode'], module)):
+                                agefilter(st, now, age, params['age_stamp']) and
+                                mode_filter(st, params['mode'], params['exact_mode'], module)):
 
                             r.update(statinfo(st))
                             filelist.append(r)

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -373,11 +373,10 @@ def mode_filter(st, mode, exact, module):
 
     st_mode = stat.S_IMODE(st.st_mode)
 
-    if not isinstance(mode, int):
-        try:
-            mode = int(mode, 8)
-        except ValueError:
-            mode = module._symbolic_mode_to_octal(_Object(st_mode=0), mode)
+    try:
+        mode = int(mode, 8)
+    except ValueError:
+        mode = module._symbolic_mode_to_octal(_Object(st_mode=0), mode)
 
     mode = stat.S_IMODE(mode)
 

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -117,11 +117,13 @@ options:
               restricted to modes that can be applied using the python
               C(os.chmod) function.
         type: raw
+        version_added: '2.16'
     exact_mode:
         description:
             - Restrict mode matching to exact matches only.
         type: bool
         default: true
+        version_added: '2.16'
     follow:
         description:
             - Set this to V(true) to follow symlinks in path for systems with python 2.6+.

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -268,6 +268,7 @@ import time
 
 from ansible.module_utils.common.text.converters import to_text, to_native
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import string_types
 
 
 class _Object:
@@ -463,6 +464,11 @@ def main():
     )
 
     params = module.params
+
+    if params['mode'] and not isinstance(params['mode'], string_types):
+        module.fail_json(
+            msg="argument 'mode' is not a string and conversion is not allowed, value is of type %s" % params['mode'].__class__.__name__
+        )
 
     # Set the default match pattern to either a match-all glob or
     # regex depending on use_regex being set.  This makes sure if you

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -113,11 +113,13 @@ options:
         default: no
     mode:
         description:
-            - Choose objects matching a specified permission
+            - Choose objects matching a specified permission. This value is
+              restricted to modes that can be applied using the python
+              C(os.chmod) function.
         type: raw
     exact_mode:
         description:
-            - Restrict mode matching to exact matches only
+            - Restrict mode matching to exact matches only.
         type: bool
         default: true
     follow:

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -116,7 +116,7 @@ options:
             - Choose objects matching a specified permission. This value is
               restricted to modes that can be applied using the python
               C(os.chmod) function.
-            - The mode can be provided as an octal such as V("0o0644") or
+            - The mode can be provided as an octal such as V("0644") or
               as symbolic such as V(u=rw,g=r,o=r)
         type: raw
         version_added: '2.16'

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -374,3 +374,6 @@
       - '"{{ remote_tmp_dir_test }}/astest/old.txt" in astest_list'
       - '"{{ remote_tmp_dir_test }}/astest/.hidden.txt" in astest_list'
       - '"checksum" in result.files[0]'
+
+- name: Run mode tests
+  import_tasks: mode.yml

--- a/test/integration/targets/find/tasks/mode.yml
+++ b/test/integration/targets/find/tasks/mode.yml
@@ -1,0 +1,68 @@
+- name: create test files for mode matching
+  file:
+    path: '{{ remote_tmp_dir_test }}/mode_{{ item }}'
+    state: touch
+    mode: '{{ item }}'
+  loop:
+    - '0644'
+    - '0444'
+    - '0400'
+    - '0700'
+    - '0666'
+
+- name: exact mode octal
+  find:
+    path: '{{ remote_tmp_dir_test }}'
+    pattern: 'mode_*'
+    mode: '0644'
+    exact_mode: true
+  register: exact_mode_0644
+
+- name: exact mode symbolic
+  find:
+    path: '{{ remote_tmp_dir_test }}'
+    pattern: 'mode_*'
+    mode: 'u=rw,g=r,o=r'
+    exact_mode: true
+  register: exact_mode_0644_symbolic
+
+- name: find all user readable files octal
+  find:
+    path: '{{ remote_tmp_dir_test }}'
+    pattern: 'mode_*'
+    mode: '0400'
+    exact_mode: false
+  register: user_readable_octal
+
+- name: find all user readable files symbolic
+  find:
+    path: '{{ remote_tmp_dir_test }}'
+    pattern: 'mode_*'
+    mode: 'u=r'
+    exact_mode: false
+  register: user_readable_symbolic
+
+- name: all other readable files octal
+  find:
+    path: '{{ remote_tmp_dir_test }}'
+    pattern: 'mode_*'
+    mode: '0004'
+    exact_mode: false
+  register: other_readable_octal
+
+- name: all other readable files symbolic
+  find:
+    path: '{{ remote_tmp_dir_test }}'
+    pattern: 'mode_*'
+    mode: 'o=r'
+    exact_mode: false
+  register: other_readable_symbolic
+
+- assert:
+    that:
+      - exact_mode_0644.files == exact_mode_0644_symbolic.files
+      - exact_mode_0644.files[0].path == '{{ remote_tmp_dir_test }}/mode_0644'
+      - user_readable_octal.files == user_readable_symbolic.files
+      - user_readable_octal.files|map(attribute='path')|map('basename')|sort == ['mode_0400', 'mode_0444', 'mode_0644', 'mode_0666', 'mode_0700']
+      - other_readable_octal.files == other_readable_symbolic.files
+      - other_readable_octal.files|map(attribute='path')|map('basename')|sort == ['mode_0444', 'mode_0644', 'mode_0666']


### PR DESCRIPTION
##### SUMMARY

Add ability to filter find on mode

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

AAPRFE-32

<details>
<summary>Examples...</summary>
<p>

```yaml
    - name: find executables with octal
      find:
        path: '{{ playbook_dir }}'
        mode: '0o111'
        exact_mode: no

    - name: find executable with symbolic
      find:
        path: '{{ playbook_dir }}'
        mode: 'a+x'
        exact_mode: no

    - name: find readable files with octal
      find:
        path: '{{ playbook_dir }}'
        mode: '0o444'
        exact_mode: no

    - name: find readable files with symbolic
      find:
        path: '{{ playbook_dir }}'
        mode: 'a+r'
        exact_mode: no

    - name: find files with at least 644 octal perms
      find:
        path: '{{ playbook_dir }}'
        mode: '0o644'
        exact_mode: no

    - name: find files with exactly 644 octal perms
      find:
        path: '{{ playbook_dir }}'
        mode: '0o644'
        exact_mode: yes
```

</p>
</details>