### PR TITLE
Remove duplicated and unused FILE_ATTRIBUTES constant

### DIFF
--- a/changelogs/fragments/81494-remove-duplicated-file-attribute-constant.yml
+++ b/changelogs/fragments/81494-remove-duplicated-file-attribute-constant.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Remove duplicated and unused FILE_ATTRIBUTES constant in module_utils/basic.py file."

--- a/changelogs/fragments/81494-remove-duplicated-file-attribute-constant.yml
+++ b/changelogs/fragments/81494-remove-duplicated-file-attribute-constant.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "Remove duplicated and unused FILE_ATTRIBUTES constant in module_utils/basic.py file."
+  - Import ``FILE_ATTRIBUTES`` from ``ansible.module_utils.common.file`` in ``ansible.module_utils.basic`` instead of defining it twice.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -20,29 +20,6 @@ if not _PY_MIN:
     )
     sys.exit(1)
 
-FILE_ATTRIBUTES = {
-    'A': 'noatime',
-    'a': 'append',
-    'c': 'compressed',
-    'C': 'nocow',
-    'd': 'nodump',
-    'D': 'dirsync',
-    'e': 'extents',
-    'E': 'encrypted',
-    'h': 'blocksize',
-    'i': 'immutable',
-    'I': 'indexed',
-    'j': 'journalled',
-    'N': 'inline',
-    's': 'zero',
-    'S': 'synchronous',
-    't': 'notail',
-    'T': 'blockroot',
-    'u': 'undelete',
-    'X': 'compressedraw',
-    'Z': 'compresseddirty',
-}
-
 # Ansible modules can be written in any language.
 # The functions available here can be used to do many common tasks,
 # to simplify development of Python modules.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -149,6 +149,7 @@ from ansible.module_utils.common.file import (
     is_executable,
     format_attributes,
     get_flags_from_attributes,
+    FILE_ATTRIBUTES,
 )
 from ansible.module_utils.common.sys_info import (
     get_distribution,


### PR DESCRIPTION
##### SUMMARY
There is a duplicated and unused `FILE_ATTRIBUTE` constant in the `module_utils/basic.py` file. It is better to remove such a duplicate constant before someone uses it in the code and there is unnecessary confusion down the line.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
Simple lint, cleanup change.