### PR TITLE
[stable-2.14] Replace FreeBSD 12.3 w/ 12.4 in CI & ansible-test

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -91,8 +91,8 @@ stages:
               test: rhel/8.6@3.9
             - name: RHEL 9.0
               test: rhel/9.0
-            - name: FreeBSD 12.3
-              test: freebsd/12.3
+            - name: FreeBSD 12.4
+              test: freebsd/12.4
             - name: FreeBSD 13.1
               test: freebsd/13.1
           groups:

--- a/changelogs/fragments/freebsd-12.3-replacement.yml
+++ b/changelogs/fragments/freebsd-12.3-replacement.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >-
+    ansible-test — Replaced `freebsd/12.3` remote with `freebsd/12.4`.
+    The former is no longer functional.

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -2,7 +2,7 @@ alpine/3.16 python=3.10 become=doas_sudo provider=aws arch=x86_64
 alpine become=doas_sudo provider=aws arch=x86_64
 fedora/36 python=3.10 become=sudo provider=aws arch=x86_64
 fedora become=sudo provider=aws arch=x86_64
-freebsd/12.3 python=3.8 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
+freebsd/12.4 python=3.9 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd/13.1 python=3.8,3.7,3.9,3.10 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 macos/12.0 python=3.10 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -163,6 +163,8 @@ bootstrap_remote_freebsd()
         # Declare platform/python version combinations which do not have supporting OS packages available.
         # For these combinations ansible-test will use pip to install the requirements instead.
         case "${platform_version}/${python_version}" in
+            "12.4/3.9")
+                ;;
             *)
                 jinja2_pkg=""  # not available
                 cryptography_pkg=""  # not available


### PR DESCRIPTION
FreeBSD 12.3 bootstrap packages stopped being available.

##### SUMMARY

$sbj.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Maintenance Pull Request

##### ADDITIONAL INFORMATION

https://dev.azure.com/ansible/ansible/_build/results?buildId=86583&view=logs&j=bc90f28e-6c73-5456-28fb-da28a84a0104&t=fdb4130b-5f96-5b02-ddf4-dc10bc9dd2d4&l=509