### PR TITLE
Pre-calculate date early and use it for all zipfile writes

### DIFF
--- a/changelogs/fragments/80089-prevent-module-build-date-issue.yml
+++ b/changelogs/fragments/80089-prevent-module-build-date-issue.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- ansiballz - Prevent issue where the time on the control host could
+  change part way through building the ansiballz file, potentially causing
+  a pre-1980 date to be used during ansiballz unpacking leading to a zip
+  file error (https://github.com/ansible/ansible/issues/80089)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -881,7 +881,7 @@ def _make_zinfo(filename, date_time, zf=None):
     return zinfo
 
 
-def recursive_finder(name, module_fqn, module_data, zf, date_time):
+def recursive_finder(name, module_fqn, module_data, zf, date_time=None):
     """
     Using ModuleDepFinder, make sure we have all of the module_utils files that
     the module and its module_utils files needs. (no longer actually recursive)
@@ -891,6 +891,8 @@ def recursive_finder(name, module_fqn, module_data, zf, date_time):
     :arg zf: An open :python:class:`zipfile.ZipFile` object that holds the Ansible module payload
         which we're assembling
     """
+    if date_time is None:
+        date_time = time.gmtime()[:6]
 
     # py_module_cache maps python module names to a tuple of the code in the module
     # and the pathname to the module.


### PR DESCRIPTION
##### SUMMARY

Pre-calculate date early and use it for all zipfile writes

This prevents an issue where the time could change on the controller between creation of the zipfile, and templating of the ansiballz code, inserting an invalid pre-1980 date into the ansiballz and used for our custom `sitecustomize.py`.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Fixes #80089
Closes #80578