### PR TITLE
user - add mobile paramter for creating mobile accounts on macOS

### DIFF
--- a/changelogs/fragments/user-add-mobile-paramter.yml
+++ b/changelogs/fragments/user-add-mobile-paramter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- user - Add mobile parameter for creating mobile accounts on macOS (https://github.com/ansible/ansible/pull/81534).


### PR DESCRIPTION
##### SUMMARY

This adds a `mobile` bool parameter to the user module to enable creating mobile accounts on macOS.  Fixes #78486 
##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

```yaml
- name: create mobile user
  user:
    name: USER
    mobile: yes
```

```paste below
↳  hostname | CHANGED | 1.70s
{
  - stdout: ""
  - rc: 0
  - stderr: ""
  - start: 2023-08-17 09:23:26.193445
  - end: 2023-08-17 09:23:27.499124
  - msg: ""
  - cmd: [ 
    - /System/Library/CoreServices/ManagedClient.app/Contents/Resources/createmobileaccount
    - -n
    - USER
    - -D
   ]
  - delta: 0:00:01.305679
  - stderr_lines: []
  - ansible_facts: {
    - discovered_interpreter_python: /usr/bin/python3
  }
}
```
