### PR TITLE
[stable-2.14] ansible-test - Always use managed entry points (#81537)

### DIFF
--- a/changelogs/fragments/ansible-test-entry-points.yml
+++ b/changelogs/fragments/ansible-test-entry-points.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test - Always use ansible-test managed entry points for ansible-core CLI tools when not running from source.
+                   This fixes issues where CLI entry points created during install are not compatible with ansible-test.

--- a/test/integration/targets/ansible-test-installed/aliases
+++ b/test/integration/targets/ansible-test-installed/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group3  # runs in the distro test containers
+shippable/generic/group1  # runs in the default test container
+context/controller
+needs/target/collection

--- a/test/integration/targets/ansible-test-installed/ansible_collections/ns/col/tests/integration/targets/installed/aliases
+++ b/test/integration/targets/ansible-test-installed/ansible_collections/ns/col/tests/integration/targets/installed/aliases
@@ -1,0 +1,1 @@
+context/controller

--- a/test/integration/targets/ansible-test-installed/ansible_collections/ns/col/tests/integration/targets/installed/runme.sh
+++ b/test/integration/targets/ansible-test-installed/ansible_collections/ns/col/tests/integration/targets/installed/runme.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# This test ensures that the bin entry points created by ansible-test work
+# when ansible-test is running from an install instead of from source.
+
+set -eux
+
+# The third PATH entry is the injected bin directory created by ansible-test.
+bin_dir="$(python -c 'import os; print(os.environ["PATH"].split(":")[2])')"
+
+while IFS= read -r name
+do
+    bin="${bin_dir}/${name}"
+
+    entry_point="${name//ansible-/}"
+    entry_point="${entry_point//ansible/adhoc}"
+
+    echo "=== ${name} (${entry_point})=${bin} ==="
+
+    if [ "${name}" == "ansible-test" ]; then
+        echo "skipped - ansible-test does not support self-testing from an install"
+    else
+        "${bin}" --version | tee /dev/stderr | grep -Eo "(^${name}\ \[core\ .*|executable location = ${bin}$)"
+    fi
+done < entry-points.txt

--- a/test/integration/targets/ansible-test-installed/runme.sh
+++ b/test/integration/targets/ansible-test-installed/runme.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+base_dir="$(dirname "$(dirname "$(dirname "$(dirname "${OUTPUT_DIR}")")")")"
+bin_dir="${base_dir}/bin"
+
+source ../collection/setup.sh
+source virtualenv.sh
+
+unset PYTHONPATH
+
+# find the bin entry points to test
+ls "${bin_dir}" > tests/integration/targets/installed/entry-points.txt
+
+# deps are already installed, using --no-deps to avoid re-installing them
+pip install "${base_dir}" --disable-pip-version-check --no-deps
+
+# verify entry point generation without delegation
+ansible-test integration --color --truncate 0 "${@}"
+
+# verify entry point generation with same-host delegation
+ansible-test integration --venv --color --truncate 0 "${@}"

--- a/test/lib/ansible_test/_internal/commands/sanity/bin_symlinks.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/bin_symlinks.py
@@ -32,7 +32,7 @@ from ...payload import (
 )
 
 from ...util import (
-    ANSIBLE_BIN_PATH,
+    ANSIBLE_SOURCE_ROOT,
 )
 
 
@@ -52,7 +52,7 @@ class BinSymlinksTest(SanityVersionNeutral):
         return True
 
     def test(self, args: SanityConfig, targets: SanityTargets) -> TestResult:
-        bin_root = ANSIBLE_BIN_PATH
+        bin_root = os.path.join(ANSIBLE_SOURCE_ROOT, 'bin')
         bin_names = os.listdir(bin_root)
         bin_paths = sorted(os.path.join(bin_root, path) for path in bin_names)
 

--- a/test/lib/ansible_test/_internal/constants.py
+++ b/test/lib/ansible_test/_internal/constants.py
@@ -33,6 +33,7 @@ SECCOMP_CHOICES = [
 # This bin symlink map must exactly match the contents of the bin directory.
 # It is necessary for payload creation to reconstruct the bin directory when running ansible-test from an installed version of ansible.
 # It is also used to construct the injector directory at runtime.
+# It is also used to construct entry points when not running ansible-test from source.
 ANSIBLE_BIN_SYMLINK_MAP = {
     'ansible': '../lib/ansible/cli/adhoc.py',
     'ansible-config': '../lib/ansible/cli/config.py',

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -33,7 +33,6 @@ from .util import (
     SubprocessError,
     display,
     filter_args,
-    ANSIBLE_BIN_PATH,
     ANSIBLE_LIB_ROOT,
     ANSIBLE_TEST_ROOT,
     OutputStream,
@@ -42,6 +41,10 @@ from .util import (
 from .util_common import (
     ResultType,
     process_scoped_temporary_directory,
+)
+
+from .ansible_util import (
+    get_ansible_bin_path,
 )
 
 from .containers import (
@@ -145,7 +148,7 @@ def delegate_command(args: EnvironmentConfig, host_state: HostState, exclude: li
             con.extract_archive(chdir=working_directory, src=payload_file)
     else:
         content_root = working_directory
-        ansible_bin_path = ANSIBLE_BIN_PATH
+        ansible_bin_path = get_ansible_bin_path(args)
 
     command = generate_command(args, host_state.controller_profile.python, ansible_bin_path, content_root, exclude, require)
 

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -74,14 +74,12 @@ ANSIBLE_TEST_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # assume running from install
 ANSIBLE_ROOT = os.path.dirname(ANSIBLE_TEST_ROOT)
-ANSIBLE_BIN_PATH = os.path.dirname(os.path.abspath(sys.argv[0]))
 ANSIBLE_LIB_ROOT = os.path.join(ANSIBLE_ROOT, 'ansible')
 ANSIBLE_SOURCE_ROOT = None
 
 if not os.path.exists(ANSIBLE_LIB_ROOT):
     # running from source
     ANSIBLE_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(ANSIBLE_TEST_ROOT)))
-    ANSIBLE_BIN_PATH = os.path.join(ANSIBLE_ROOT, 'bin')
     ANSIBLE_LIB_ROOT = os.path.join(ANSIBLE_ROOT, 'lib', 'ansible')
     ANSIBLE_SOURCE_ROOT = ANSIBLE_ROOT
 


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81537

(cherry picked from commit 390e508d27db7a51eece36bb6d9698b63a5b638a)

##### ISSUE TYPE

Bugfix Pull Request
