### PR TITLE
tarfile: Handle deprecation warning for extract and extractall

### DIFF
--- a/changelogs/fragments/tarfile_extract_warn.yml
+++ b/changelogs/fragments/tarfile_extract_warn.yml
@@ -1,3 +1,4 @@
 ---
-minor_changes:
+bugfixes:
 - tarfile - handle data filter deprecation warning message for extract and extractall (https://github.com/ansible/ansible/issues/80832).
+- ansible-galaxy - implemented probing mechanism for broken data filter in tarfile.

--- a/changelogs/fragments/tarfile_extract_warn.yml
+++ b/changelogs/fragments/tarfile_extract_warn.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
 - tarfile - handle data filter deprecation warning message for extract and extractall (https://github.com/ansible/ansible/issues/80832).
-- ansible-galaxy - implemented probing mechanism for broken data filter in tarfile.
+- ansible-galaxy - Enabled the ``data`` tarfile filter during role installation for Python versions that support it. A probing mechanism is used to avoid Python versions with a broken implementation.

--- a/changelogs/fragments/tarfile_extract_warn.yml
+++ b/changelogs/fragments/tarfile_extract_warn.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- tarfile - handle data filter deprecation warning message for extract and extractall (https://github.com/ansible/ansible/issues/80832).

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -391,7 +391,11 @@ class GalaxyRole(object):
                                         continue
                                     n_final_parts.append(n_part)
                                 member.name = os.path.join(*n_final_parts)
-                                role_tar_file.extract(member, to_native(self.path))
+                                if hasattr(tarfile, 'data_filter'):
+                                    # Remove this check when Python 3.11 is EOL
+                                    role_tar_file.extract(member, to_native(self.path), filter='fully_trusted')
+                                else:
+                                    role_tar_file.extract(member, to_native(self.path))
 
                         # write out the install info file for later use
                         self._write_galaxy_install_info()

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -391,8 +391,8 @@ class GalaxyRole(object):
                                         continue
                                     n_final_parts.append(n_part)
                                 member.name = os.path.join(*n_final_parts)
-                                if hasattr(tarfile, 'data_filter'):
-                                    # Remove this check when Python 3.11 is EOL
+                                # deprecated: description='extract fallback without filter' python_version='3.11'
+                                if hasattr(tarfile, 'fully_trusted_filter'):
                                     role_tar_file.extract(member, to_native(self.path), filter='fully_trusted')
                                 else:
                                     role_tar_file.extract(member, to_native(self.path))

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -392,8 +392,8 @@ class GalaxyRole(object):
                                     n_final_parts.append(n_part)
                                 member.name = os.path.join(*n_final_parts)
                                 # deprecated: description='extract fallback without filter' python_version='3.11'
-                                if hasattr(tarfile, 'fully_trusted_filter'):
-                                    role_tar_file.extract(member, to_native(self.path), filter='fully_trusted')
+                                if hasattr(tarfile, 'data_filter'):
+                                    role_tar_file.extract(member, to_native(self.path), filter='data')
                                 else:
                                     role_tar_file.extract(member, to_native(self.path))
 

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -391,11 +391,14 @@ class GalaxyRole(object):
                                         continue
                                     n_final_parts.append(n_part)
                                 member.name = os.path.join(*n_final_parts)
+                                maybe_filter_kwargs = {
+                                    'filter': 'data',
+                                } if hasattr(tarfile, 'data_filter') else {}
                                 # deprecated: description='extract fallback without filter' python_version='3.11'
-                                if hasattr(tarfile, 'data_filter'):
-                                    role_tar_file.extract(member, to_native(self.path), filter='data')  # type: ignore[call-arg]
-                                else:
-                                    role_tar_file.extract(member, to_native(self.path))
+                                role_tar_file.extract(
+                                    member, to_native(self.path),
+                                    **maybe_filter_kwargs,
+                                )
 
                         # write out the install info file for later use
                         self._write_galaxy_install_info()

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -393,7 +393,7 @@ class GalaxyRole(object):
                                 member.name = os.path.join(*n_final_parts)
                                 # deprecated: description='extract fallback without filter' python_version='3.11'
                                 if hasattr(tarfile, 'data_filter'):
-                                    role_tar_file.extract(member, to_native(self.path), filter='data')
+                                    role_tar_file.extract(member, to_native(self.path), filter='data')  # type: ignore[call-arg]
                                 else:
                                     role_tar_file.extract(member, to_native(self.path))
 

--- a/packaging/release.py
+++ b/packaging/release.py
@@ -1341,9 +1341,10 @@ def test_sdist() -> None:
                 sdist = stack.enter_context(tarfile.open(sdist_file))
             except FileNotFoundError:
                 raise ApplicationError(f"Missing sdist: {sdist_file.relative_to(CHECKOUT_DIR)}") from None
+
+            # deprecated: description='extractall fallback without filter' python_version='3.11'
             if hasattr(tarfile, 'data_filter'):
-                # Remove this check when Python 3.11 is EOL
-                sdist.extractall(temp_dir, filter='data')
+                sdist.extractall(temp_dir, filter='data')  # type: ignore[call-arg]
             else:
                 sdist.extractall(temp_dir)
 

--- a/packaging/release.py
+++ b/packaging/release.py
@@ -1341,8 +1341,11 @@ def test_sdist() -> None:
                 sdist = stack.enter_context(tarfile.open(sdist_file))
             except FileNotFoundError:
                 raise ApplicationError(f"Missing sdist: {sdist_file.relative_to(CHECKOUT_DIR)}") from None
-
-            sdist.extractall(temp_dir)
+            if hasattr(tarfile, 'data_filter'):
+                # Remove this check when Python 3.11 is EOL
+                sdist.extractall(temp_dir, filter='data')
+            else:
+                sdist.extractall(temp_dir)
 
         pyc_glob = "*.pyc*"
         pyc_files = sorted(path.relative_to(temp_dir) for path in temp_dir.rglob(pyc_glob))

--- a/packaging/release.py
+++ b/packaging/release.py
@@ -1342,11 +1342,11 @@ def test_sdist() -> None:
             except FileNotFoundError:
                 raise ApplicationError(f"Missing sdist: {sdist_file.relative_to(CHECKOUT_DIR)}") from None
 
+            maybe_filter_kwargs = {
+                'filter': 'data',
+            } if hasattr(tarfile, 'data_filter') else {}
             # deprecated: description='extractall fallback without filter' python_version='3.11'
-            if hasattr(tarfile, 'data_filter'):
-                sdist.extractall(temp_dir, filter='data')  # type: ignore[call-arg]
-            else:
-                sdist.extractall(temp_dir)
+            sdist.extractall(temp_dir, **maybe_filter_kwargs)  # type: ignore[arg-type]
 
         pyc_glob = "*.pyc*"
         pyc_files = sorted(path.relative_to(temp_dir) for path in temp_dir.rglob(pyc_glob))

--- a/packaging/release.py
+++ b/packaging/release.py
@@ -1342,11 +1342,11 @@ def test_sdist() -> None:
             except FileNotFoundError:
                 raise ApplicationError(f"Missing sdist: {sdist_file.relative_to(CHECKOUT_DIR)}") from None
 
-            maybe_filter_kwargs = {
-                'filter': 'data',
-            } if hasattr(tarfile, 'data_filter') else {}
             # deprecated: description='extractall fallback without filter' python_version='3.11'
-            sdist.extractall(temp_dir, **maybe_filter_kwargs)  # type: ignore[arg-type]
+            if hasattr(tarfile, 'data_filter'):
+                sdist.extractall(temp_dir, filter='data')  # type: ignore[call-arg]
+            else:
+                sdist.extractall(temp_dir)
 
         pyc_glob = "*.pyc*"
         pyc_files = sorted(path.relative_to(temp_dir) for path in temp_dir.rglob(pyc_glob))

--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -136,6 +136,7 @@ def publish_collection(module, collection):
                 fd.write(b'data')
 
             os.symlink(b_target_file, os.path.join(b_collection_dir, b_target_file + b'-link'))
+            os.symlink(temp_fd.name, os.path.join(b_collection_dir, b_target_file + b'-outside-link'))
             os.symlink(os.path.join(b'..', b_target_file), os.path.join(b_collection_dir, b'docs', b_target_file))
             os.symlink(os.path.join(b_collection_dir, b_target_file),
                        os.path.join(b_collection_dir, b'plugins', b_target_file))
@@ -155,14 +156,11 @@ def publish_collection(module, collection):
 
             # Extract the tarfile to sign the MANIFEST.json
             with tarfile.open(collection_path, mode='r') as collection_tar:
-                maybe_filter_kwargs = {
-                    'filter': 'data',
-                } if hasattr(tarfile, 'data_filter') else {}
                 # deprecated: description='extractall fallback without filter' python_version='3.11'
-                collection_tar.extractall(
-                    path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)),
-                    **maybe_filter_kwargs
-                )
+                if hasattr(tarfile, 'tar_filter'):
+                    collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)), filter='tar')
+                else:
+                    collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)))
 
             manifest_path = os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version), 'MANIFEST.json')
             signature_path = os.path.join(module.params['signature_dir'], '%s-%s-%s-MANIFEST.json.asc' % (namespace, name, version))

--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -136,7 +136,6 @@ def publish_collection(module, collection):
                 fd.write(b'data')
 
             os.symlink(b_target_file, os.path.join(b_collection_dir, b_target_file + b'-link'))
-            os.symlink(temp_fd.name, os.path.join(b_collection_dir, b_target_file + b'-outside-link'))
             os.symlink(os.path.join(b'..', b_target_file), os.path.join(b_collection_dir, b'docs', b_target_file))
             os.symlink(os.path.join(b_collection_dir, b_target_file),
                        os.path.join(b_collection_dir, b'plugins', b_target_file))

--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -156,7 +156,11 @@ def publish_collection(module, collection):
 
             # Extract the tarfile to sign the MANIFEST.json
             with tarfile.open(collection_path, mode='r') as collection_tar:
-                collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)))
+                if hasattr(tarfile, 'data_filter'):
+                    # Remove this check when Python 3.11 is EOL
+                    collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)), filter='data')
+                else:
+                    collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)))
 
             manifest_path = os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version), 'MANIFEST.json')
             signature_path = os.path.join(module.params['signature_dir'], '%s-%s-%s-MANIFEST.json.asc' % (namespace, name, version))

--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -156,8 +156,8 @@ def publish_collection(module, collection):
 
             # Extract the tarfile to sign the MANIFEST.json
             with tarfile.open(collection_path, mode='r') as collection_tar:
+                # deprecated: description='extractall fallback without filter' python_version='3.11'
                 if hasattr(tarfile, 'data_filter'):
-                    # Remove this check when Python 3.11 is EOL
                     collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)), filter='data')
                 else:
                     collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)))

--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -156,11 +156,14 @@ def publish_collection(module, collection):
 
             # Extract the tarfile to sign the MANIFEST.json
             with tarfile.open(collection_path, mode='r') as collection_tar:
+                maybe_filter_kwargs = {
+                    'filter': 'data',
+                } if hasattr(tarfile, 'data_filter') else {}
                 # deprecated: description='extractall fallback without filter' python_version='3.11'
-                if hasattr(tarfile, 'data_filter'):
-                    collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)), filter='data')
-                else:
-                    collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)))
+                collection_tar.extractall(
+                    path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)),
+                    **maybe_filter_kwargs
+                )
 
             manifest_path = os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version), 'MANIFEST.json')
             signature_path = os.path.join(module.params['signature_dir'], '%s-%s-%s-MANIFEST.json.asc' % (namespace, name, version))

--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -157,6 +157,7 @@ def publish_collection(module, collection):
             # Extract the tarfile to sign the MANIFEST.json
             with tarfile.open(collection_path, mode='r') as collection_tar:
                 # deprecated: description='extractall fallback without filter' python_version='3.11'
+                # Replace 'tar_filter' with 'data_filter' and 'filter=tar' with 'filter=data' once Python 3.12 is minimum requirement.
                 if hasattr(tarfile, 'tar_filter'):
                     collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)), filter='tar')
                 else:

--- a/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
@@ -159,9 +159,9 @@ class ValidateModulesTest(SanitySingleVersion):
                 temp_dir = process_scoped_temporary_directory(args)
 
                 with tarfile.open(path) as file:
+                    # deprecated: description='extractall fallback without filter' python_version='3.11'
                     if hasattr(tarfile, 'data_filter'):
-                        # Remove this check when Python 3.11 is EOL
-                        file.extractall(temp_dir, filter='data')
+                        file.extractall(temp_dir, filter='data')  # type: ignore[call-arg]
                     else:
                         file.extractall(temp_dir)
 

--- a/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
@@ -160,8 +160,8 @@ class ValidateModulesTest(SanitySingleVersion):
 
                 with tarfile.open(path) as file:
                     # deprecated: description='extractall fallback without filter' python_version='3.11'
-                    if hasattr(tarfile, 'tar_filter'):
-                        file.extractall(temp_dir, filter='tar')  # type: ignore[call-arg]
+                    if hasattr(tarfile, 'data_filter'):
+                        file.extractall(temp_dir, filter='data')  # type: ignore[call-arg]
                     else:
                         file.extractall(temp_dir)
 

--- a/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
@@ -160,10 +160,11 @@ class ValidateModulesTest(SanitySingleVersion):
 
                 with tarfile.open(path) as file:
                     # deprecated: description='extractall fallback without filter' python_version='3.11'
-                    if hasattr(tarfile, 'data_filter'):
-                        file.extractall(temp_dir, filter='data')  # type: ignore[call-arg]
-                    else:
-                        file.extractall(temp_dir)
+                    maybe_filter_kwargs = {
+                        'filter': 'data',
+                    } if hasattr(tarfile, 'data_filter') else {}
+                    # deprecated: description='extractall fallback without filter' python_version='3.11'
+                    file.extractall(temp_dir, **maybe_filter_kwargs)  # type: ignore[arg-type]
 
                 cmd.extend([
                     '--original-plugins', temp_dir,

--- a/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
@@ -159,7 +159,11 @@ class ValidateModulesTest(SanitySingleVersion):
                 temp_dir = process_scoped_temporary_directory(args)
 
                 with tarfile.open(path) as file:
-                    file.extractall(temp_dir)
+                    if hasattr(tarfile, 'data_filter'):
+                        # Remove this check when Python 3.11 is EOL
+                        file.extractall(temp_dir, filter='data')
+                    else:
+                        file.extractall(temp_dir)
 
                 cmd.extend([
                     '--original-plugins', temp_dir,

--- a/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
@@ -160,11 +160,10 @@ class ValidateModulesTest(SanitySingleVersion):
 
                 with tarfile.open(path) as file:
                     # deprecated: description='extractall fallback without filter' python_version='3.11'
-                    maybe_filter_kwargs = {
-                        'filter': 'data',
-                    } if hasattr(tarfile, 'data_filter') else {}
-                    # deprecated: description='extractall fallback without filter' python_version='3.11'
-                    file.extractall(temp_dir, **maybe_filter_kwargs)  # type: ignore[arg-type]
+                    if hasattr(tarfile, 'tar_filter'):
+                        file.extractall(temp_dir, filter='tar')  # type: ignore[call-arg]
+                    else:
+                        file.extractall(temp_dir)
 
                 cmd.extend([
                     '--original-plugins', temp_dir,


### PR DESCRIPTION
##### SUMMARY

Python 3.11.4 introduces new parameter 'filter' in extract and
extractall in tarfile. Handle deprecation warning message emitted
in Python 3.12.

Fixes: #80832

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE

Bugfix Pull Request
