### PR TITLE
Support Termux in ansible.builtin.package

### DIFF
--- a/changelogs/fragments/81547-support-termux-apt.yml
+++ b/changelogs/fragments/81547-support-termux-apt.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - modules_utils - Support Termux in ansible.builtin.package

--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -44,6 +44,7 @@ PKG_MGRS = [{'path': '/usr/bin/rpm-ostree', 'name': 'atomic_container'},
             {'path': '/usr/bin/swupd', 'name': 'swupd'},
             {'path': '/usr/sbin/sorcery', 'name': 'sorcery'},
             {'path': '/usr/bin/installp', 'name': 'installp'},
+            {'path': '/data/data/com.termux/files/usr/bin/apt', 'name': 'apt'},
             ]
 
 


### PR DESCRIPTION
##### SUMMARY

This enables usage of `ansible.builtin.package` instead of `ansible.builtin.apt` in Termux environments (Android). Tested on Pixel Fold and Pixel 6.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

Example playbook:
```
- hosts: example
  tasks:
    - name: Install packages
      ansible.builtin.package:
        update_cache: yes
        name:
          - gitui
```

Fails because it can't find `apt`:

```paste below
TASK [Install packages] 
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NoneType: None
fatal: [example]: FAILED! => {"changed": false, "msg": "Could not find a module for unknown."}
```

Fixed after adding the right path:

```
TASK [Install packages] 
changed: [example]
```
