### PR TITLE
Remove '$' from list of illegal characters in role filenames

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -376,7 +376,7 @@ class GalaxyRole(object):
                                     # It will create the parent directory as an empty file and will
                                     # explode if the directory contains valid files.
                                     # Leaving this as is since the whole module needs a rewrite.
-                                    if n_part != '..' and not n_part.startswith('~') and '$' not in n_part:
+                                    if n_part != '..' and not n_part.startswith('~'):
                                         n_final_parts.append(n_part)
                                 member.name = os.path.join(*n_final_parts)
                                 role_tar_file.extract(member, to_native(self.path))


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible/galaxy/issues/271 and https://github.com/ansible/ansible/issues/81553
 
##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

I can't find any reason to have '$' in the list of role filenames to skip.  

If there is a reason, it would be nice if we could clearly document it, as omitting files with '$' in the name causes https://github.com/ansible/galaxy/issues/271

See https://github.com/ansible/galaxy/issues/271 for a step-by-step reproduction of the problem