### PR TITLE
ansible-test - Limit deprecated check to core

### DIFF
--- a/changelogs/fragments/pylint-deprecated-comment-checker.yml
+++ b/changelogs/fragments/pylint-deprecated-comment-checker.yml
@@ -1,3 +1,3 @@
 minor_changes:
 - ansible-test - Add new pylint checker for new ``# deprecated:`` comments within code to trigger errors when time to remove code
-  that has no user facing deprecation message
+  that has no user facing deprecation message. Only supported in ansible-core, not collections.

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
@@ -30,6 +30,7 @@ disable=
     consider-using-max-builtin,
     consider-using-min-builtin,
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
+    deprecated-comment,  # custom plugin only used by ansible-core, not collections
     deprecated-method,  # results vary by Python version
     deprecated-module,  # results vary by Python version
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files


### PR DESCRIPTION
##### SUMMARY

Using `# deprecated:` comment checks in collections would effectively limit those collections to a single version of ansible-core.

##### ISSUE TYPE

Feature Pull Request
