### PR TITLE
group: remove extraneous warning

### DIFF
--- a/changelogs/fragments/group_warning.yml
+++ b/changelogs/fragments/group_warning.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- group - remove extraneous warning shown when user does not exist (https://github.com/ansible/ansible/issues/77049).

--- a/lib/ansible/modules/group.py
+++ b/lib/ansible/modules/group.py
@@ -227,14 +227,7 @@ class Group(object):
                     if line.startswith(to_bytes(name_test)):
                         exists = True
                         break
-
-            if not exists:
-                self.module.warn(
-                    "'local: true' specified and group was not found in {file}. "
-                    "The local group may already exist if the local group database exists somewhere other than {file}.".format(file=self.GROUPFILE))
-
             return exists
-
         else:
             try:
                 if grp.getgrnam(self.name):


### PR DESCRIPTION
##### SUMMARY

* remove extraneous warning shown when group does not exist

Fixes: #77049

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/group_warning.yml
lib/ansible/modules/group.py

