### PR TITLE
add a function for the centralised list of shell/command options

### DIFF
--- a/changelogs/fragments/81558-fix-interactive-shell-options.yml
+++ b/changelogs/fragments/81558-fix-interactive-shell-options.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - shell module - parameter-oriented invocation using 'cmd' was silently failing. Fix now adds 'cmd' argument in shell module and creates centralized list of options for usage in `splitter.py` (https://github.com/ansible/ansible/issues/73005).

--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -1,0 +1,25 @@
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def get_command_args():
+    '''
+    The function for a centralised list for retrieval of shell module options
+    '''
+    return dict(
+        _raw_params=dict(),
+        _uses_shell=dict(type='bool', default=False),
+        argv=dict(type='list', elements='str'),
+        chdir=dict(type='path'),
+        executable=dict(),
+        expand_argument_vars=dict(type='bool', default=True),
+        creates=dict(type='path'),
+        removes=dict(type='path'),
+        # The default for this really comes from the action plugin
+        stdin=dict(required=False),
+        stdin_add_newline=dict(type='bool', default=True),
+        strip_empty_ends=dict(type='bool', default=True),
+        cmd=dict(),
+    )

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -240,6 +240,7 @@ import shlex
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native, to_bytes, to_text
 from ansible.module_utils.common.collections import is_iterable
+from ansible.module_utils.shell import get_command_args
 
 
 def main():
@@ -248,20 +249,7 @@ def main():
     # hence don't copy this one if you are looking to build others!
     # NOTE: ensure splitter.py is kept in sync for exceptions
     module = AnsibleModule(
-        argument_spec=dict(
-            _raw_params=dict(),
-            _uses_shell=dict(type='bool', default=False),
-            argv=dict(type='list', elements='str'),
-            chdir=dict(type='path'),
-            executable=dict(),
-            expand_argument_vars=dict(type='bool', default=True),
-            creates=dict(type='path'),
-            removes=dict(type='path'),
-            # The default for this really comes from the action plugin
-            stdin=dict(required=False),
-            stdin_add_newline=dict(type='bool', default=True),
-            strip_empty_ends=dict(type='bool', default=True),
-        ),
+        argument_spec=get_command_args(),
         supports_check_mode=True,
     )
     shell = module.params['_uses_shell']

--- a/lib/ansible/parsing/splitter.py
+++ b/lib/ansible/parsing/splitter.py
@@ -80,7 +80,7 @@ def parse_kv(args, check_raw=False):
                 k = x[:pos]
                 v = x[pos + 1:]
 
-                if check_raw and k not in get_command_args().keys():
+                if check_raw and k not in get_command_args():
                     raw_params.append(orig_x)
                 else:
                     options[k.strip()] = unquote(v.strip())

--- a/lib/ansible/parsing/splitter.py
+++ b/lib/ansible/parsing/splitter.py
@@ -24,6 +24,7 @@ import re
 
 from ansible.errors import AnsibleParserError
 from ansible.module_utils.common.text.converters import to_text
+from ansible.module_utils.shell import get_command_args
 from ansible.parsing.quoting import unquote
 
 
@@ -79,8 +80,7 @@ def parse_kv(args, check_raw=False):
                 k = x[:pos]
                 v = x[pos + 1:]
 
-                # FIXME: make the retrieval of this list of shell/command options a function, so the list is centralized
-                if check_raw and k not in ('creates', 'removes', 'chdir', 'executable', 'warn', 'stdin', 'stdin_add_newline', 'strip_empty_ends'):
+                if check_raw and k not in get_command_args().keys():
                     raw_params.append(orig_x)
                 else:
                     options[k.strip()] = unquote(v.strip())

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -480,6 +480,18 @@
     - shell_result9 is failed or
       shell_result9 is changed
 
+- name: execute a shell command with parameter-oriented invocation using "cmd"
+  shell: 'cmd="echo test"'
+  register: shell_result10
+
+- name: Assert the shell with parameter-oriented invocation ran as expected
+  assert:
+    that:
+    - shell_result10 is changed
+    - shell_result10.rc == 0
+    - shell_result10.cmd == "echo test"
+    - shell_result10.stdout == "test"
+
 - name: remove the previously created file
   file:
     path: "{{ remote_tmp_dir_test }}/afile.txt"


### PR DESCRIPTION
##### SUMMARY

Fixes #73005

This PR
- adds `cmd` argument to the `shell`/`command` options
- moves the list of `shell` module options to a centralized function for usage in `splitter.py`
- adds an integration test

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Integration testing:
```bash
$ bin/ansible-test integration -v command_shell
...
TASK [command_shell : execute a shell command with parameter-oriented invocation using "cmd"] ***
changed: [testhost] => {"changed": true, "cmd": "echo test", "delta": "0:00:00.002359", "end": "2023-08-22 10:49:54.248467", "msg": "", "rc": 0, "start": "2023-08-22 10:49:54.246108", "stderr": "", "stderr_lines": [], "stdout": "test", "stdout_lines": ["test"]}

TASK [command_shell : Assert the shell with parameter-oriented invocation ran as expected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}
...
PLAY RECAP *********************************************************************
testhost                   : ok=91   changed=39   unreachable=0    failed=0    skipped=3    rescued=0    ignored=4   
```

Sanity testing:

```bash
$ bin/ansible-test sanity
...
Running sanity test "yamllint"
WARNING: Reviewing previous 25 warning(s):
WARNING: The validate-modules sanity test cannot compare against the base commit because it was not detected.
WARNING: Skipping tests disabled by default without --allow-disabled: package-data
WARNING: Skipping sanity test "compile" on Python 2.7 because it could not be found.
WARNING: Skipping sanity test "compile" on Python 3.6 because it could not be found.
WARNING: Skipping sanity test "compile" on Python 3.7 because it could not be found.
WARNING: Skipping sanity test "compile" on Python 3.8 because it could not be found.
WARNING: Skipping sanity test "compile" on Python 3.9 because it could not be found.
WARNING: Skipping sanity test "compile" on Python 3.11 because it could not be found.
WARNING: Skipping sanity test "compile" on Python 3.12 because it could not be found.
WARNING: Skipping sanity test "import" on Python 2.7 because it could not be found.
WARNING: Skipping sanity test "import" on Python 3.6 because it could not be found.
WARNING: Skipping sanity test "import" on Python 3.7 because it could not be found.
WARNING: Skipping sanity test "import" on Python 3.8 because it could not be found.
WARNING: Skipping sanity test "import" on Python 3.9 because it could not be found.
WARNING: Skipping sanity test "import" on Python 3.11 because it could not be found.
WARNING: Skipping sanity test "import" on Python 3.12 because it could not be found.
WARNING: Skipping sanity test "mypy" on Python 2.7 because it is unsupported. Supported Python versions: 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12
WARNING: Skipping sanity test "mypy" on Python 3.6 because it could not be found.
WARNING: Skipping sanity test "mypy" on Python 3.7 because it could not be found.
WARNING: Skipping sanity test "mypy" on Python 3.8 because it could not be found.
WARNING: Skipping sanity test "mypy" on Python 3.9 because it could not be found.
WARNING: Skipping sanity test "mypy" on Python 3.11 because it could not be found.
WARNING: Skipping sanity test "mypy" on Python 3.12 because it could not be found.
WARNING: Required program "pwsh" not found.
WARNING: Required program "shellcheck" not found.
```