### PR TITLE
fix typo in example human_to_bytes filter

### DIFF
--- a/lib/ansible/plugins/filter/human_to_bytes.yml
+++ b/lib/ansible/plugins/filter/human_to_bytes.yml
@@ -23,7 +23,7 @@ EXAMPLES: |
   size: '{{ "1.15 GB" | human_to_bytes }}'
 
   # size => 1234803098
-  size: '{{ "1.15" | human_to_bytes(deafult_unit="G") }}'
+  size: '{{ "1.15" | human_to_bytes(default_unit="G") }}'
 
   # this is an error, wants bits, got bytes
   ERROR: '{{ "1.15 GB" | human_to_bytes(isbits=true) }}'


### PR DESCRIPTION
##### SUMMARY

Fix typo in doc example of `ansible.builtin.human_to_bytes`

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request

