### PR TITLE
[2.15] Fix pause CPU consumption (#81519)

### DIFF
--- a/changelogs/fragments/fix-display-prompt-cpu-consumption.yml
+++ b/changelogs/fragments/fix-display-prompt-cpu-consumption.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Prompting - add a short sleep between polling for user input to reduce CPU consumption (https://github.com/ansible/ansible/issues/81516).

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -698,6 +698,8 @@ class Display(metaclass=Singleton):
                 os.set_blocking(self._stdin_fd, False)
                 while key_pressed is None and (seconds is None or (time.time() - start < seconds)):
                     key_pressed = self._stdin.read(1)
+                    # throttle to prevent excess CPU consumption
+                    time.sleep(C.DEFAULT_INTERNAL_POLL_INTERVAL)
             finally:
                 os.set_blocking(self._stdin_fd, True)
                 if key_pressed is None:


### PR DESCRIPTION
##### SUMMARY
Backport for #81519

* Sleep for the DEFAULT_INTERNAL_POLL_INTERVAL between polling for user input

Fixes #81516

(cherry picked from commit 194f829b0f9b91cc279d402c18a6934c6e7d0911)

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

