### PR TITLE
Disable nightly CI runs

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -12,15 +12,6 @@ pr:
       - devel
       - stable-*
 
-schedules:
-  - cron: 0 7 * * *
-    displayName: Nightly
-    always: true
-    branches:
-      include:
-        - devel
-        - stable-*
-
 variables:
   - name: checkoutPath
     value: ansible


### PR DESCRIPTION
##### SUMMARY

With downstream EOL less than 5 weeks away, and frequent CentOS 6 failures, it makes sense to disable nightly runs now.

##### ISSUE TYPE

Test Pull Request
