### PR TITLE
dnf module can be used to update packages to latest

### DIFF
--- a/changelogs/fragments/dnf-update-only-latest.yml
+++ b/changelogs/fragments/dnf-update-only-latest.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf - fix a failure when a package from URI was specified and ``update_only`` was set (https://github.com/ansible/ansible/issues/81376).

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -385,7 +385,6 @@ import sys
 
 from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.urls import fetch_file
-from ansible.module_utils.six import text_type
 from ansible.module_utils.compat.version import LooseVersion
 
 from ansible.module_utils.basic import AnsibleModule
@@ -582,6 +581,7 @@ class DnfModule(YumDnf):
             import dnf.cli
             import dnf.const
             import dnf.exceptions
+            import dnf.package
             import dnf.subject
             import dnf.util
             HAS_DNF = True
@@ -966,12 +966,14 @@ class DnfModule(YumDnf):
     def _update_only(self, pkgs):
         not_installed = []
         for pkg in pkgs:
-            if self._is_installed(pkg):
+            if self._is_installed(
+                    self._package_dict(pkg)["nevra"] if isinstance(pkg, dnf.package.Package) else pkg
+            ):
                 try:
-                    if isinstance(to_text(pkg), text_type):
-                        self.base.upgrade(pkg)
-                    else:
+                    if isinstance(pkg, dnf.package.Package):
                         self.base.package_upgrade(pkg)
+                    else:
+                        self.base.upgrade(pkg)
                 except Exception as e:
                     self.module.fail_json(
                         msg="Error occurred attempting update_only operation: {0}".format(to_native(e)),

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -668,6 +668,28 @@
         - "'changed' in dnf_result"
         - "'results' in dnf_result"
 
+# Install RPM from url with update_only
+- name: install from url with update_only
+  dnf:
+    name: "file://{{ pkg_path }}"
+    state: latest
+    update_only: true
+    disable_gpg_check: true
+  register: dnf_result
+
+- name: verify installation
+  assert:
+    that:
+        - "dnf_result is success"
+        - "not dnf_result is changed"
+        - "dnf_result is not failed"
+
+- name: verify dnf module outputs
+  assert:
+    that:
+        - "'changed' in dnf_result"
+        - "'results' in dnf_result"
+
 - name: Create a temp RPM file which does not contain nevra information
   file:
     name: "/tmp/non_existent_pkg.rpm"


### PR DESCRIPTION
[Fixes 81376](https://github.com/ansible/ansible/issues/81376).

Allow users to update packages with dnf using:
-- update-only: true
   state: latest

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
DNF module update_only functionality was altered to allow packages or names of packages to be updated. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
