### PR TITLE
encrypt: deprecate passlib_or_crypt

### DIFF
--- a/changelogs/fragments/passlib_or_crypt.yml
+++ b/changelogs/fragments/passlib_or_crypt.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- encrypt - deprecate passlib_or_crypt API (https://github.com/ansible/ansible/issues/55839).

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -34,7 +34,7 @@ from ansible.parsing.ajson import AnsibleJSONEncoder
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.template import recursive_check_defined
 from ansible.utils.display import Display
-from ansible.utils.encrypt import passlib_or_crypt, PASSLIB_AVAILABLE
+from ansible.utils.encrypt import do_encrypt, PASSLIB_AVAILABLE
 from ansible.utils.hashing import md5s, checksum_s
 from ansible.utils.unicode import unicode_wrap
 from ansible.utils.vars import merge_hash
@@ -292,7 +292,7 @@ def get_encrypted_password(password, hashtype='sha512', salt=None, salt_size=Non
         )
 
     try:
-        return passlib_or_crypt(password, hashtype, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
+        return do_encrypt(password, hashtype, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
     except AnsibleError as e:
         reraise(AnsibleFilterError, AnsibleFilterError(to_native(e), orig_exc=e), sys.exc_info()[2])
     except Exception as e:

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -610,7 +610,7 @@ class Display(metaclass=Singleton):
         if encrypt:
             # Circular import because encrypt needs a display class
             from ansible.utils.encrypt import do_encrypt
-            result = do_encrypt(result, encrypt, salt_size, salt)
+            result = do_encrypt(result, encrypt, salt_size=salt_size, salt=salt)
 
         # handle utf-8 chars
         result = to_text(result, errors='surrogate_or_strict')

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -271,7 +271,7 @@ class PasslibHash(BaseHash):
 
 def passlib_or_crypt(secret, algorithm, salt=None, salt_size=None, rounds=None, ident=None):
     display.deprecated("passlib_or_crypt API is deprecated in favor of do_encrypt", version='2.20')
-    return do_encrypt(secret=secret, algorithm=algorithm, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
+    return do_encrypt(secret, algorithm, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
 
 
 def do_encrypt(result, encrypt, salt_size=None, salt=None, ident=None, rounds=None):

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -274,9 +274,9 @@ def passlib_or_crypt(secret, algorithm, salt=None, salt_size=None, rounds=None, 
     return do_encrypt(secret=secret, algorithm=algorithm, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
 
 
-def do_encrypt(secret, algorithm, salt=None, salt_size=None, rounds=None, ident=None):
+def do_encrypt(result, encrypt, salt_size=None, salt=None, ident=None, rounds=None):
     if PASSLIB_AVAILABLE:
-        return PasslibHash(algorithm).hash(secret, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
+        return PasslibHash(encrypt).hash(result, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
     if HAS_CRYPT:
-        return CryptHash(algorithm).hash(secret, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
+        return CryptHash(encrypt).hash(result, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
     raise AnsibleError("Unable to encrypt nor hash, either crypt or passlib must be installed.", orig_exc=CRYPT_E)

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -166,7 +166,7 @@ class CryptHash(BaseHash):
             result = None
             orig_exc = e
 
-        # None as result would be interpreted by the some modules (user module)
+        # None as result would be interpreted by some modules (user module)
         # as no password at all.
         if not result:
             raise AnsibleError(
@@ -270,12 +270,13 @@ class PasslibHash(BaseHash):
 
 
 def passlib_or_crypt(secret, algorithm, salt=None, salt_size=None, rounds=None, ident=None):
+    display.deprecated("passlib_or_crypt API is deprecated in favor of do_encrypt", version='2.20')
+    return do_encrypt(secret=secret, algorithm=algorithm, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
+
+
+def do_encrypt(secret, algorithm, salt=None, salt_size=None, rounds=None, ident=None):
     if PASSLIB_AVAILABLE:
         return PasslibHash(algorithm).hash(secret, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
     if HAS_CRYPT:
         return CryptHash(algorithm).hash(secret, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
     raise AnsibleError("Unable to encrypt nor hash, either crypt or passlib must be installed.", orig_exc=CRYPT_E)
-
-
-def do_encrypt(result, encrypt, salt_size=None, salt=None, ident=None):
-    return passlib_or_crypt(result, encrypt, salt_size=salt_size, salt=salt, ident=ident)

--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -38,6 +38,13 @@ def assert_hash(expected, secret, algorithm, **settings):
 
 
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='macOS requires passlib')
+def test_passlib_or_crypt():
+    # deprecated: description='passlib_or_crypt deprecated' core_version='2.20'
+    expected = "$5$rounds=5000$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
+    assert encrypt.passlib_or_crypt("123", "sha256_crypt", salt="12345678", rounds=5000) == expected
+
+
+@pytest.mark.skipif(sys.platform.startswith('darwin'), reason='macOS requires passlib')
 def test_encrypt_with_rounds_no_passlib():
     with passlib_off():
         assert_hash("$5$rounds=5000$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7",

--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -28,10 +28,10 @@ class passlib_off(object):
 def assert_hash(expected, secret, algorithm, **settings):
 
     if encrypt.PASSLIB_AVAILABLE:
-        assert encrypt.passlib_or_crypt(secret, algorithm, **settings) == expected
+        assert encrypt.do_encrypt(secret, algorithm, **settings) == expected
         assert encrypt.PasslibHash(algorithm).hash(secret, **settings) == expected
     else:
-        assert encrypt.passlib_or_crypt(secret, algorithm, **settings) == expected
+        assert encrypt.do_encrypt(secret, algorithm, **settings) == expected
         with pytest.raises(AnsibleError) as excinfo:
             encrypt.PasslibHash(algorithm).hash(secret, **settings)
         assert excinfo.value.args[0] == "passlib must be installed and usable to hash with '%s'" % algorithm

--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -27,11 +27,10 @@ class passlib_off(object):
 
 def assert_hash(expected, secret, algorithm, **settings):
 
+    assert encrypt.do_encrypt(secret, algorithm, **settings) == expected
     if encrypt.PASSLIB_AVAILABLE:
-        assert encrypt.do_encrypt(secret, algorithm, **settings) == expected
         assert encrypt.PasslibHash(algorithm).hash(secret, **settings) == expected
     else:
-        assert encrypt.do_encrypt(secret, algorithm, **settings) == expected
         with pytest.raises(AnsibleError) as excinfo:
             encrypt.PasslibHash(algorithm).hash(secret, **settings)
         assert excinfo.value.args[0] == "passlib must be installed and usable to hash with '%s'" % algorithm
@@ -39,8 +38,11 @@ def assert_hash(expected, secret, algorithm, **settings):
 
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='macOS requires passlib')
 def test_passlib_or_crypt():
-    # deprecated: description='passlib_or_crypt deprecated' core_version='2.20'
-    expected = "$5$rounds=5000$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
+    with passlib_off():
+        expected = "$5$rounds=5000$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
+        assert encrypt.passlib_or_crypt("123", "sha256_crypt", salt="12345678", rounds=5000) == expected
+
+    expected = "$5$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
     assert encrypt.passlib_or_crypt("123", "sha256_crypt", salt="12345678", rounds=5000) == expected
 
 


### PR DESCRIPTION
##### SUMMARY

* deprecate passlib_or_crypt in favor of do_encrypt

Fixes: #55839

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
lib/ansible/plugins/filter/core.py
lib/ansible/utils/display.py
lib/ansible/utils/encrypt.py
test/units/utils/test_encrypt.py

