### PR TITLE
reboot: show last error message in verbose log

### DIFF
--- a/changelogs/fragments/reboot.yml
+++ b/changelogs/fragments/reboot.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- reboot - show last error message in verbose logs (https://github.com/ansible/ansible/issues/81574).

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -129,7 +129,7 @@ class ActionModule(ActionBase):
         else:
             args = self._get_value_from_facts('SHUTDOWN_COMMAND_ARGS', distribution, 'DEFAULT_SHUTDOWN_COMMAND_ARGS')
 
-            # Convert seconds to minutes. If less that 60, set it to 0.
+            # Convert seconds to minutes. If less than 60, set it to 0.
             delay_min = self.pre_reboot_delay // 60
             reboot_message = self._task.args.get('msg', self.DEFAULT_REBOOT_MESSAGE)
             return args.format(delay_sec=self.pre_reboot_delay, delay_min=delay_min, message=reboot_message)
@@ -236,7 +236,7 @@ class ActionModule(ActionBase):
         display.vvv("{action}: attempting to get system boot time".format(action=self._task.action))
         connect_timeout = self._task.args.get('connect_timeout', self._task.args.get('connect_timeout_sec', self.DEFAULT_CONNECT_TIMEOUT))
 
-        # override connection timeout from defaults to custom value
+        # override connection timeout from defaults to the custom value
         if connect_timeout:
             try:
                 display.debug("{action}: setting connect_timeout to {value}".format(action=self._task.action, value=connect_timeout))
@@ -310,11 +310,15 @@ class ActionModule(ActionBase):
                         error = to_text(e).splitlines()[-1]
                     except IndexError as e:
                         error = to_text(e)
-                    display.debug("{action}: {desc} fail '{err}', retrying in {sleep:.4} seconds...".format(
+                    msg = "{action}: {desc} fail '{err}', retrying in {sleep:.4} seconds...".format(
                         action=self._task.action,
                         desc=action_desc,
                         err=error,
-                        sleep=fail_sleep))
+                        sleep=fail_sleep,
+                    )
+
+                    display.debug(msg)
+                    display.vvv(msg)
                 fail_count += 1
                 time.sleep(fail_sleep)
 
@@ -406,7 +410,7 @@ class ActionModule(ActionBase):
         self._supports_check_mode = True
         self._supports_async = True
 
-        # If running with local connection, fail so we don't reboot ourself
+        # If running with local connection, fail so we don't reboot ourselves
         if self._connection.transport == 'local':
             msg = 'Running {0} with local connection would reboot the control node.'.format(self._task.action)
             return {'changed': False, 'elapsed': 0, 'rebooted': False, 'failed': True, 'msg': msg}

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -310,12 +310,7 @@ class ActionModule(ActionBase):
                         error = to_text(e).splitlines()[-1]
                     except IndexError as e:
                         error = to_text(e)
-                    msg = "{action}: {desc} fail '{err}', retrying in {sleep:.4} seconds...".format(
-                        action=self._task.action,
-                        desc=action_desc,
-                        err=error,
-                        sleep=fail_sleep,
-                    )
+                    msg = f"{self._task.action}: {action_desc} fail '{error}', retrying in {fail_sleep:.4f} seconds..."
 
                     display.debug(msg)
                     display.vvv(msg)


### PR DESCRIPTION
##### SUMMARY

* Last error message is now presented in verbose log

Fixes: #81574

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


