### PR TITLE
Added new connection plugin prepare_command method

### DIFF
--- a/changelogs/fragments/connection-prepare-cmd.yml
+++ b/changelogs/fragments/connection-prepare-cmd.yml
@@ -1,0 +1,7 @@
+minor_changes:
+- >-
+  connection - Added new method to connection plugins called ``prepare_command``. This method can be used by connection
+  plugins to have finer control over how the command is built to match the connection plugins implementation. The
+  default behaviour on how commands are constructed remains unchanged.
+bugfixes:
+- psrp - Support setting ``chdir`` with ``script`` when using the ``psrp`` connection plugin - https://github.com/ansible/ansible/issues/81277

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -599,7 +599,6 @@ class Connection(ConnectionBase):
             self.has_native_async = True
             self.always_pipeline_modules = True
             self.module_implementation_preferences = ('.ps1', '.exe', '')
-            self.allow_executable = False
 
     # The connection is created by running ssh/scp/sftp from the exec_command,
     # put_file, and fetch_file methods, so we don't need to do any connection

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -243,7 +243,6 @@ class Connection(ConnectionBase):
 
     transport = 'winrm'
     module_implementation_preferences = ('.ps1', '.exe', '')
-    allow_executable = False
     has_pipelining = True
     allow_extras = True
 

--- a/test/integration/targets/connection_psrp/files/cd_script.ps1
+++ b/test/integration/targets/connection_psrp/files/cd_script.ps1
@@ -1,0 +1,1 @@
+$pwd.Path

--- a/test/integration/targets/connection_psrp/tests.yml
+++ b/test/integration/targets/connection_psrp/tests.yml
@@ -134,3 +134,36 @@
         path: /tmp/empty.txt
         state: absent
       delegate_to: localhost
+
+ # https://github.com/ansible/ansible/issues/81277
+  # First few tests ensure the cd checking doesn't impact raw commands and only
+  # ones added by _low_level_execute_command
+  - name: run raw command with cd command without normal command separator
+    raw: cd C:\Windows; $pwd.Path
+    register: raw_cd1
+
+  - name: run raw command with cd command with normal command separator
+    raw: cd c:\Windows ; $pwd.Path
+    register: raw_cd2
+
+  - name: run raw command with common PowerShell encoded command wrapper
+    raw: cd c:\Windows ; PowerShell -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -EncodedCommand {{ '$pwd.Path' | b64encode(encoding='utf-16-le') }}
+    register: raw_cd3
+
+  - name: assert raw cd commands worked
+    assert:
+      that:
+      - raw_cd1.stdout == 'C:\\Windows'
+      - raw_cd2.stdout == 'C:\\Windows'
+      - raw_cd3.stdout == 'C:\\Windows'
+
+  - name: run script with chdir
+    script: cd_script.ps1
+    args:
+      chdir: C:\Windows
+    register: script_cd
+
+  - name: assert script chdir output
+    assert:
+      that:
+      - script_cd.stdout

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -34,6 +34,7 @@ from ansible.module_utils.six.moves import shlex_quote, builtins
 from ansible.module_utils.common.text.converters import to_bytes
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.action import ActionBase
+from ansible.plugins.connection import ConnectionBase
 from ansible.plugins.loader import init_plugin_loader
 from ansible.template import Templar
 from ansible.vars.clean import clean_facts
@@ -753,13 +754,16 @@ class TestActionBase(unittest.TestCase):
     def test_action_base_sudo_only_if_user_differs(self):
         fake_loader = MagicMock()
         fake_loader.get_basedir.return_value = os.getcwd()
+        fake_connection = MagicMock(spec=ConnectionBase)
+        fake_connection.exec_command.return_value = (0, '', '')
+        fake_connection.prepare_command = lambda info: ConnectionBase.prepare_command(fake_connection, info)
         play_context = PlayContext()
 
         action_base = DerivedActionBase(None, None, play_context, fake_loader, None, None)
         action_base.get_become_option = MagicMock(return_value='root')
         action_base._get_remote_user = MagicMock(return_value='root')
 
-        action_base._connection = MagicMock(exec_command=MagicMock(return_value=(0, '', '')))
+        action_base._connection = fake_connection
 
         action_base._connection._shell = shell = MagicMock(append_command=MagicMock(return_value=('JOINED CMD')))
 


### PR DESCRIPTION
##### SUMMARY
Adds a new method to the connection plugins that allow plugins to control how a command is processed before being run. This API provides the extra information needed as discrete objects rather than an already processed command string.

Fixes the psrp connection to support script setting chdir by using this new API.

Fixes: https://github.com/ansible/ansible/issues/81277

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### ADDITIONAL INFORMATION
The `allow_executable` shell attribute overrides have been removed as the logic is consolidated into one area. The attribute is still checked to allow backwards compatibility with connection plugins outside of Ansible. Sometime in the future this attribute should potentially be deprecated to simplify the plugins a bit more.