### PR TITLE
galaxy: check if the target for symlink exists

### DIFF
--- a/changelogs/fragments/galaxy_symlink.yml
+++ b/changelogs/fragments/galaxy_symlink.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- galaxy - check if the target for symlink exists (https://github.com/ansible/ansible/pull/81586).

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1325,6 +1325,8 @@ def _build_collection_tar(
 
                 if os.path.islink(b_src_path):
                     b_link_target = os.path.realpath(b_src_path)
+                    if not os.path.exists(b_link_target):
+                        raise AnsibleError(f"Failed to find the target path '{to_native(b_link_target)}' for the symlink '{to_native(b_src_path)}'.")
                     if _is_child_path(b_link_target, b_collection_path):
                         b_rel_path = os.path.relpath(b_link_target, start=os.path.dirname(b_src_path))
 

--- a/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
@@ -1,4 +1,29 @@
 ---
+- name: create a dangling symbolic link inside collection directory
+  ansible.builtin.file:
+    src: '/non-existent-path/README.md'
+    dest: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/docs/README.md'
+    state: link
+    force: yes
+
+- name: build basic collection based on current directory with dangling symlink
+  command: ansible-galaxy collection build {{ galaxy_verbosity }}
+  args:
+    chdir: '{{ galaxy_dir }}/scratch/ansible_test/my_collection'
+  register: fail_symlink_build
+  ignore_errors: yes
+
+- name: assert that build fails due to dangling symlink
+  assert:
+    that:
+      - fail_symlink_build.failed
+      - '"Failed to find the target path" in fail_symlink_build.stderr'
+
+- name: remove dangling symbolic link
+  ansible.builtin.file:
+    path: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/docs/README.md'
+    state: absent
+
 - name: build basic collection based on current directory
   command: ansible-galaxy collection build {{ galaxy_verbosity }}
   args:


### PR DESCRIPTION


##### SUMMARY

* symlinks in collection might be pointing to non-existent targets. Check and report the failure to the user.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

