### PR TITLE
Deprecating paramiko options in base config

### DIFF
--- a/changelogs/fragments/paramiko_globals.yml
+++ b/changelogs/fragments/paramiko_globals.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+    - paramiko connection plugin, configuration items in the global scope are being deprecated and will be removed in favor or the existing same options in the plugin itself.
+      Users should not need to change anything (how to configure them are the same) but plugin authors using the global constants should move to using the plugin's get_option().

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1793,13 +1793,16 @@ PAGER:
       version_added: '2.15'
     - name: PAGER
 PARAMIKO_HOST_KEY_AUTO_ADD:
-  # TODO: move to plugin
   default: False
   description: 'TODO: write it'
   env: [{name: ANSIBLE_PARAMIKO_HOST_KEY_AUTO_ADD}]
   ini:
   - {key: host_key_auto_add, section: paramiko_connection}
   type: boolean
+  deprecated:
+    why: This option was moved to the plugin itself
+    version: "2.20"
+    alternatives: Use the option from the plugin itself.
 PARAMIKO_LOOK_FOR_KEYS:
   name: look for keys
   default: True
@@ -1808,6 +1811,10 @@ PARAMIKO_LOOK_FOR_KEYS:
   ini:
   - {key: look_for_keys, section: paramiko_connection}
   type: boolean
+  deprecated:
+    why: This option was moved to the plugin itself
+    version: "2.20"
+    alternatives: Use the option from the plugin itself.
 PERSISTENT_CONTROL_PATH_DIR:
   name: Persistence socket path
   default: '{{ ANSIBLE_HOME ~ "/pc" }}'


### PR DESCRIPTION
They exist in the plugin itself since 2.14


##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

