### PR TITLE
Add install_suggests in apt module

### DIFF
--- a/changelogs/fragments/apt_install_suggests.yml
+++ b/changelogs/fragments/apt_install_suggests.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - apt - add parameter for install_suggests (https://github.com/ansible/ansible/issues/81173).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -68,18 +68,22 @@ options:
     type: str
   install_recommends:
     description:
-      - Corresponds to the C(--no-install-recommends) option for I(apt). V(true) installs recommended packages. V(false) does not install
-        recommended packages. By default, Ansible will use the same defaults as the operating system. Suggested packages are never installed
-        unless O(install_suggests=true).
+      - Corresponds to the C(--no-install-recommends) option for I(apt).
+      - V(true) installs recommended packages.
+      - V(false) does not install recommended packages.
+      - By default, Ansible will use the same defaults as the operating system.
+      - Suggested packages are never installed unless O(install_suggests=true).
     aliases: [ install-recommends ]
     type: bool
   install_suggests:
     description:
-      - Corresponds to the C(--install-suggests) option for I(apt). V(true) installs suggested packages. V(false) does not install
-        suggested packages. By default, Ansible will use the same defaults as the operating system.
+      - Corresponds to the C(--install-suggests) option for I(apt).
+      - V(true) installs suggested packages.
+      - V(false) does not install suggested packages.
+      - By default, Ansible will use the same defaults as the operating system.
     aliases: [ install-suggests ]
     type: bool
-    version_added: "2.16"
+    version_added: "2.18"
   force:
     description:
       - 'Corresponds to the C(--force-yes) to I(apt-get) and implies O(allow_unauthenticated=yes) and O(allow_downgrade=yes)'
@@ -1367,7 +1371,6 @@ def main():
 
     updated_cache = False
     updated_cache_time = 0
-    install_recommends = p['install_recommends']
     install_suggests = p['install_suggests']
     allow_unauthenticated = p['allow_unauthenticated']
     allow_downgrade = p['allow_downgrade']

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -79,6 +79,7 @@ options:
         suggested packages. By default, Ansible will use the same defaults as the operating system.
     aliases: [ install-suggests ]
     type: bool
+    version_added: "2.16"
   force:
     description:
       - 'Corresponds to the C(--force-yes) to I(apt-get) and implies O(allow_unauthenticated=yes) and O(allow_downgrade=yes)'

--- a/test/integration/targets/apt/tasks/url-with-deps.yml
+++ b/test/integration/targets/apt/tasks/url-with-deps.yml
@@ -64,7 +64,7 @@
       failed_when: False
       register: rolldice_dpkg_result
 
-    - name: verify real installation of bar
+    - name: verify real installation of baz
       assert:
         that:
         - apt_url_deps is changed
@@ -73,6 +73,31 @@
         - rolldice_dpkg_result is successful
         - rolldice_dpkg_result.rc == 0
 
+    - name: Install package from local repo for install_suggests
+      apt:
+        deb: "{{ repodir }}/dists/stable/main/binary-all/taz_1.0.0_all.deb"
+        install_suggests: yes
+      register: install_suggests_test
+
+    - name: check to make sure we installed the package
+      shell: dpkg -l | grep taz
+      failed_when: False
+      register: taz_dpkg_result
+
+    - name: check to make sure we installed the package's recommends
+      shell: dpkg -l | grep ed
+      failed_when: False
+      register: ed_dpkg_result
+
+    - name: verify real installation of taz
+      assert:
+        that:
+        - install_suggests_test is changed
+        - taz_dpkg_result is successful
+        - taz_dpkg_result.rc == 0
+        - ed_dpkg_result is successful
+        - ed_dpkg_result.rc == 0
+
   always:
     - name: uninstall packages with apt
       apt:
@@ -80,5 +105,7 @@
           - echo-hello
           - rolldice
           - baz
+          - taz
+          - ed
         state: absent
         purge: yes

--- a/test/integration/targets/setup_deb_repo/files/package_specs/stable/taz-1.0.0
+++ b/test/integration/targets/setup_deb_repo/files/package_specs/stable/taz-1.0.0
@@ -1,0 +1,9 @@
+Priority: optional
+Standards-Version: 2.3.3
+Package: taz
+Version: 1.0.0
+Section: system
+Maintainer: John Doe <john@doe.com>
+Architecture: all
+Description: Dummy package
+suggests: ed


### PR DESCRIPTION
##### SUMMARY

This PR adds `install_suggests` to the `apt` module to allow installing suggested packages.

Fixes #81173

##### ISSUE TYPE

- Feature Pull Request
