### PR TITLE
ansible-galaxy fix scm dependency error

### DIFF
--- a/changelogs/fragments/galaxy_dep_res_msgs.yml
+++ b/changelogs/fragments/galaxy_dep_res_msgs.yml
@@ -1,0 +1,4 @@
+minor_changes:
+    - ansible-galaxy dependency resolution messages have changed the unexplained 'virtual' collection for the specific type ('scm', 'dir', etc) that is more user friendly
+bugfixes:
+    - ansible-galaxy error on dependency resolution will not error itself due to 'virtual' collections not having a name/namespace.

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -544,7 +544,7 @@ def download_collections(
         for fqcn, concrete_coll_pin in dep_map.copy().items():  # FIXME: move into the provider
             if concrete_coll_pin.is_virtual:
                 display.display(
-                    '{coll_type!s} collection {coll!s} is not downloadable'.
+                    '{coll!s} is not downloadable'.
                     format(coll=to_text(concrete_coll_pin), coll_type=concrete_coll_pin.type),
                 )
                 continue

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -741,7 +741,7 @@ def install_collections(
         for fqcn, concrete_coll_pin in dependency_map.items():
             if concrete_coll_pin.is_virtual:
                 display.vvvv(
-                    "'{coll!s}' is {concrete_coll_pin.type}, skipping.".
+                    "Encountered {coll!s}, skipping.".
                     format(coll=to_text(concrete_coll_pin)),
                 )
                 continue

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -544,7 +544,7 @@ def download_collections(
         for fqcn, concrete_coll_pin in dep_map.copy().items():  # FIXME: move into the provider
             if concrete_coll_pin.is_virtual:
                 display.display(
-                    '{concrete_coll_pin.type} collection {coll!s} is not downloadable'.
+                    '{concrete_coll_pin.type!s} collection {coll!s} is not downloadable'.
                     format(coll=to_text(concrete_coll_pin)),
                 )
                 continue

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -545,7 +545,7 @@ def download_collections(
             if concrete_coll_pin.is_virtual:
                 display.display(
                     '{coll!s} is not downloadable'.
-                    format(coll=to_text(concrete_coll_pin), coll_type=concrete_coll_pin.type),
+                    format(coll=to_text(concrete_coll_pin)),
                 )
                 continue
 

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -544,7 +544,7 @@ def download_collections(
         for fqcn, concrete_coll_pin in dep_map.copy().items():  # FIXME: move into the provider
             if concrete_coll_pin.is_virtual:
                 display.display(
-                    'Virtual collection {coll!s} is not downloadable'.
+                    '{concrete_coll_pin.type} collection {coll!s} is not downloadable'.
                     format(coll=to_text(concrete_coll_pin)),
                 )
                 continue
@@ -741,7 +741,7 @@ def install_collections(
         for fqcn, concrete_coll_pin in dependency_map.items():
             if concrete_coll_pin.is_virtual:
                 display.vvvv(
-                    "'{coll!s}' is virtual, skipping.".
+                    "'{coll!s}' is {concrete_coll_pin.type}, skipping.".
                     format(coll=to_text(concrete_coll_pin)),
                 )
                 continue
@@ -1857,7 +1857,7 @@ def _resolve_depenency_map(
         parents = [
             "%s.%s:%s" % (p.namespace, p.name, p.ver)
             for p in dep_exc.criterion.iter_parent()
-            if p is not None
+            if p is not None and not p.is_virtual
         ]
 
         error_msg_lines = [

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1855,9 +1855,8 @@ def _resolve_depenency_map(
         raise AnsibleError('\n'.join(error_msg_lines)) from dep_exc
     except CollectionDependencyInconsistentCandidate as dep_exc:
         parents = [
-            "%s.%s:%s" % (p.namespace, p.name, p.ver)
-            for p in dep_exc.criterion.iter_parent()
-            if p is not None and not p.is_virtual
+            str(p) for p in dep_exc.criterion.iter_parent()
+            if p is not None
         ]
 
         error_msg_lines = [

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -544,8 +544,8 @@ def download_collections(
         for fqcn, concrete_coll_pin in dep_map.copy().items():  # FIXME: move into the provider
             if concrete_coll_pin.is_virtual:
                 display.display(
-                    '{concrete_coll_pin.type!s} collection {coll!s} is not downloadable'.
-                    format(coll=to_text(concrete_coll_pin)),
+                    '{coll_type!s} collection {coll!s} is not downloadable'.
+                    format(coll=to_text(concrete_coll_pin), coll_type=concrete_coll_pin.type),
                 )
                 continue
 

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -463,8 +463,8 @@ class _ComputedReqKindsMixin:
     def __unicode__(self):
         if self.fqcn is None:
             return (
-                u'"{self.type} collection Git repo"' if self.is_scm
-                else u'"{self.type} collection namespace"'
+                f'"{self.type} collection Git repo"' if self.is_scm
+                else f'"{self.type} collection namespace"'
             )
 
         return (
@@ -504,14 +504,14 @@ class _ComputedReqKindsMixin:
     @property
     def namespace(self):
         if self.is_virtual:
-            raise TypeError('{self.type} collections do not have a namespace')
+            raise TypeError(f'{self.type} collections do not have a namespace')
 
         return self._get_separate_ns_n_name()[0]
 
     @property
     def name(self):
         if self.is_virtual:
-            raise TypeError('{self.type} collections do not have a name')
+            raise TypeError(f'{self.type} collections do not have a name')
 
         return self._get_separate_ns_n_name()[-1]
 

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -463,8 +463,8 @@ class _ComputedReqKindsMixin:
     def __unicode__(self):
         if self.fqcn is None:
             return (
-                u'"virtual collection Git repo"' if self.is_scm
-                else u'"virtual collection namespace"'
+                u'"{self.type} collection Git repo"' if self.is_scm
+                else u'"{self.type} collection namespace"'
             )
 
         return (
@@ -504,14 +504,14 @@ class _ComputedReqKindsMixin:
     @property
     def namespace(self):
         if self.is_virtual:
-            raise TypeError('Virtual collections do not have a namespace')
+            raise TypeError('{self.type} collections do not have a namespace')
 
         return self._get_separate_ns_n_name()[0]
 
     @property
     def name(self):
         if self.is_virtual:
-            raise TypeError('Virtual collections do not have a name')
+            raise TypeError('{self.type} collections do not have a name')
 
         return self._get_separate_ns_n_name()[-1]
 

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -463,8 +463,8 @@ class _ComputedReqKindsMixin:
     def __unicode__(self):
         if self.fqcn is None:
             return (
-                f'"{self.type} collection Git repo"' if self.is_scm
-                else f'"{self.type} collection namespace"'
+                f'{self.type} collection from a Git repo' if self.is_scm
+                else f'{self.type} collection from a namespace'
             )
 
         return (


### PR DESCRIPTION
This fixes having an 'error within the error', as when raising a dependency issue we would error out on missing properties for a 'virtual collection' (from scm/dir not galaxy).

 Also changed usage of 'virtual collection' to actual collection type, which should be more intelligible to the users

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

