### PR TITLE
yum/dnf/dnf5/zypper documentation - fix small grammatical error

### DIFF
--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -29,7 +29,7 @@ options:
     description:
       - "A package name or package specifier with version, like C(name-1.0).
         When using state=latest, this can be '*' which means run: dnf -y update.
-        You can also pass a url or a local path to a rpm file.
+        You can also pass a url or a local path to an rpm file.
         To operate on several packages this can accept a comma separated string of packages or a list of packages."
       - Comparison operators for package version are valid here C(>), C(<), C(>=), C(<=). Example - C(name >= 1.0).
         Spaces around the operator are required.

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -19,7 +19,7 @@ options:
     description:
       - "A package name or package specifier with version, like C(name-1.0).
         When using state=latest, this can be '*' which means run: dnf -y update.
-        You can also pass a url or a local path to a rpm file.
+        You can also pass a url or a local path to an rpm file.
         To operate on several packages this can accept a comma separated string of packages or a list of packages."
       - Comparison operators for package version are valid here C(>), C(<), C(>=), C(<=). Example - C(name >= 1.0).
         Spaces around the operator are required.

--- a/lib/ansible/modules/yum.py
+++ b/lib/ansible/modules/yum.py
@@ -37,7 +37,7 @@ options:
       - If a previous version is specified, the task also needs to turn O(allow_downgrade) on.
         See the O(allow_downgrade) documentation for caveats with downgrading packages.
       - When using O(state=latest), this can be V('*') which means run C(yum -y update).
-      - You can also pass a url or a local path to a rpm file (using O(state=present)).
+      - You can also pass a url or a local path to an rpm file (using O(state=present)).
         To operate on several packages this can accept a comma separated string of packages or (as of 2.0) a list of packages.
     aliases: [ pkg ]
     type: list

--- a/test/support/integration/plugins/modules/zypper.py
+++ b/test/support/integration/plugins/modules/zypper.py
@@ -41,7 +41,7 @@ options:
         - Package name C(name) or package specifier or a list of either.
         - Can include a version like C(name=1.0), C(name>3.4) or C(name<=2.7). If a version is given, C(oldpackage) is implied and zypper is allowed to
           update the package within the version range given.
-        - You can also pass a url or a local path to a rpm file.
+        - You can also pass a url or a local path to an rpm file.
         - When using state=latest, this can be '*', which updates all installed packages.
         required: true
         aliases: [ 'pkg' ]


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes small grammatical issue ("a rpm" -> "an rpm") in documentation

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request
