### PR TITLE
load virtual dependencies to handle as direct requests before dep resolution

### DIFF
--- a/changelogs/fragments/ansible-galaxy-fix-installing-prereleases.yml
+++ b/changelogs/fragments/ansible-galaxy-fix-installing-prereleases.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-galaxy collection - allow pre-releases without --pre if the pre-release is already installed.
+  - ansible-galaxy collection - fix installing pre-releases from virtual sources (https://github.com/ansible/ansible/issues/79168).

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -519,7 +519,7 @@ def get_virtual_requirement_dependencies(requirement, artifacts_manager, seen=No
         except AnsibleError:
             # Ignore if the concrete artifact manager fails to download git repos.
             # This will be an error (or warning if --ignore-errors is provided) once the dep resolver runs.
-            pass
+            yield from ()
     else:
         yield requirement
 

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -416,7 +416,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
             requirement.ver.startswith('<') or
             requirement.ver.startswith('>') or
             requirement.ver.startswith('!=')
-        ) or self._is_user_requested(candidate)
+        ) or self._is_user_requested(candidate) or candidate in self._preferred_candidates
         if is_pre_release(candidate.ver) and not allow_pre_release:
             return False
 

--- a/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
@@ -134,6 +134,10 @@
   loop_control:
     loop_var: resolvelib_version
 
+- name: test installing prereleases via scm direct requests
+  # In this test suite because the bug relies on the dep having versions on a Galaxy server
+  include_tasks: virtual_direct_requests.yml
+
 - name: publish collection with a dep on another server
   setup_collections:
     server: secondary

--- a/test/integration/targets/ansible-galaxy-collection/tasks/virtual_direct_requests.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/virtual_direct_requests.yml
@@ -1,0 +1,77 @@
+- environment:
+    ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
+  vars:
+    scm_path: "{{ galaxy_dir }}/scms"
+    metadata:
+      collection1: |-
+        name: collection1
+        version: "1.0.0"
+        dependencies:
+          test_prereleases.collection2: '*'
+      collection2: |
+        name: collection2
+        version: "1.0.0-dev0"
+        dependencies: {}
+      namespace_boilerplate: |-
+        namespace: test_prereleases
+        readme: README.md
+        authors:
+          - "ansible-core"
+        description: test prerelease priority with virtual collections
+        license:
+          - GPL-2.0-or-later
+        license_file: ''
+        tags: []
+        repository: https://github.com/ansible/ansible
+        documentation: https://github.com/ansible/ansible
+        homepage: https://github.com/ansible/ansible
+        issues: https://github.com/ansible/ansible
+        build_ignore: []
+  block:
+    - name: Initialize git repository
+      command: 'git init {{ scm_path }}/test_prereleases'
+
+    - name: Configure commiter for the repo
+      shell: git config user.email ansible-test@ansible.com && git config user.name ansible-test
+      args:
+        chdir: "{{ scm_path }}/test_prereleases"
+
+    - name: Add collections to the repo
+      file:
+        path: "{{ scm_path }}/test_prereleases/{{ item }}"
+        state: directory
+      loop:
+        - collection1
+        - collection2
+
+    - name: Add collection metadata
+      copy:
+        dest: "{{ scm_path }}/test_prereleases/{{ item }}/galaxy.yml"
+        content: "{{ metadata[item] + '\n' + metadata['namespace_boilerplate'] }}"
+      loop:
+        - collection1
+        - collection2
+
+    - name: Save the changes
+      shell: git add . && git commit -m "Add collections to test installing a git repo directly takes priority over indirect Galaxy dep"
+      args:
+        chdir: '{{ scm_path }}/test_prereleases'
+
+    - name: Validate the dependency also exists on Galaxy before test
+      command: "ansible-galaxy collection install test_prereleases.collection2"
+      register: prereq
+      failed_when: '"test_prereleases.collection2:1.0.0 was installed successfully" not in prereq.stdout'
+
+    - name: Install collections from source
+      command: "ansible-galaxy collection install git+file://{{ scm_path }}/test_prereleases"
+      register: prioritize_direct_req
+
+    - assert:
+        that:
+          - '"test_prereleases.collection2:1.0.0-dev0 was installed successfully" in prioritize_direct_req.stdout'
+
+  always:
+    - name: Clean up test repos
+      file:
+        path: "{{ scm_path }}"
+        state: absent

--- a/test/integration/targets/ansible-galaxy-collection/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/vars/main.yml
@@ -165,3 +165,10 @@ collection_list:
     name: parent
     dependencies:
       namespace1.name1: '*'
+
+  # non-prerelease is published to test that installing
+  # the pre-release from SCM doesn't accidentally prefer indirect
+  # dependencies from Galaxy
+  - namespace: test_prereleases
+    name: collection2
+    version: 1.0.0


### PR DESCRIPTION
##### SUMMARY

This is the fix for pre-releases separated from the version validation in #79112 (they're not really related), and I've reverted back to the original approach, handling outside of the dependency resolver. See the other PR for the attempt to handle the within the dependency resolver.

Note this conflicts with the original review from @webknjaz:

> I've got a bad feeling about the recursion here and a dependency resolution attempt outside the dependency resolver... Pretty sure the resolution should be scoped to the resolver.

But I don't believe it's an issue. I added some exception handling, so a missing git repo is only an error/warning once the dependency resolver runs. And while the function is recursive, the max depth should be 2 I think, in the case of dependencies like `git (virtual) -> subdirs (virtual) -> actual collection(s)`. There's a set of the seen collections, so circular dependencies won't be an issue. The recursion stops on the first non-virtual dependency so indirect requests are not mistakenly included.

This approach seems simpler because it's not needed for virtual requirements in general, only those requested directly, and we already do it here for subdirs.

Fixes #79168

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
