### PR TITLE
ansible-test - Fix Python coverage stub generation

### DIFF
--- a/test/lib/ansible_test/_internal/commands/coverage/combine.py
+++ b/test/lib/ansible_test/_internal/commands/coverage/combine.py
@@ -121,7 +121,7 @@ def _command_coverage_combine_python(args: CoverageCombineConfig, host_state: Ho
     coverage_files = get_python_coverage_files()
 
     def _default_stub_value(source_paths: list[str]) -> dict[str, set[tuple[int, int]]]:
-        return {path: set() for path in source_paths}
+        return {path: {(0, 0)} for path in source_paths}
 
     counter = 0
     sources = _get_coverage_targets(args, walk_compile_targets)


### PR DESCRIPTION
##### SUMMARY

As of coverage 7.1.0, files without arcs are not generated.

To work around this, an empty (0, 0) arc is used for each file instead.

This is a follow-up to https://github.com/ansible/ansible/pull/81077

##### ISSUE TYPE

Bugfix Pull Request

##### ADDITIONAL INFORMATION

Thanks to @sivel for the idea to use a (0, 0) arc to ensure the stubs are generated.