### PR TITLE
get_bin_path: remove deprecated 'required' param

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -994,7 +994,7 @@ class AnsibleModule(object):
 
     def get_file_attributes(self, path, include_version=True):
         output = {}
-        attrcmd = self.get_bin_path('lsattr', False)
+        attrcmd = self.get_bin_path('lsattr')
         if attrcmd:
             flags = '-vd' if include_version else '-d'
             attrcmd = [attrcmd, flags, path]
@@ -1411,7 +1411,7 @@ class AnsibleModule(object):
         Find system executable in PATH.
 
         :param arg: The executable to find.
-        :param required: if executable is not found and required is ``True``, fail_json
+        :param required: if the executable is not found and required is ``True``, fail_json
         :param opt_dirs: optional list of directories to search in addition to ``PATH``
         :returns: if found return full path; otherwise return None
         '''

--- a/lib/ansible/module_utils/common/process.py
+++ b/lib/ansible/module_utils/common/process.py
@@ -7,20 +7,19 @@ __metaclass__ = type
 import os
 
 from ansible.module_utils.common.file import is_executable
+from ansible.module_utils.common.collections import is_iterable
 
 
-def get_bin_path(arg, opt_dirs=None, required=None):
+def get_bin_path(arg, opt_dirs=None):
     '''
-    Find system executable in PATH. Raises ValueError if executable is not found.
+    Find system executable in PATH. Raises ValueError if the executable is not found.
     Optional arguments:
-       - required:  [Deprecated] Prior to 2.10, if executable is not found and required is true it raises an Exception.
-                    In 2.10 and later, an Exception is always raised. This parameter will be removed in 2.14.
        - opt_dirs:  optional list of directories to search in addition to PATH
     In addition to PATH and opt_dirs, this function also looks through /sbin, /usr/sbin and /usr/local/sbin. A lot of
     modules, especially for gathering facts, depend on this behaviour.
     If found return full path, otherwise raise ValueError.
     '''
-    opt_dirs = [] if opt_dirs is None else opt_dirs
+    opt_dirs = [] if not is_iterable(opt_dirs) else opt_dirs
 
     sbin_paths = ['/sbin', '/usr/sbin', '/usr/local/sbin']
     paths = []

--- a/lib/ansible/module_utils/facts/hardware/aix.py
+++ b/lib/ansible/module_utils/facts/hardware/aix.py
@@ -131,17 +131,19 @@ class AIXHardware(Hardware):
         data = out.split()
         dmi_facts['firmware_version'] = data[1].strip('IBM,')
         lsconf_path = self.module.get_bin_path("lsconf")
-        if lsconf_path:
-            rc, out, err = self.module.run_command(lsconf_path)
-            if rc == 0 and out:
-                for line in out.splitlines():
-                    data = line.split(':')
-                    if 'Machine Serial Number' in line:
-                        dmi_facts['product_serial'] = data[1].strip()
-                    if 'LPAR Info' in line:
-                        dmi_facts['lpar_info'] = data[1].strip()
-                    if 'System Model' in line:
-                        dmi_facts['product_name'] = data[1].strip()
+        if lsconf_path is None:
+            return dmi_facts
+
+        rc, out, err = self.module.run_command(lsconf_path)
+        if rc == 0 and out:
+            for line in out.splitlines():
+                data = line.split(':')
+                if 'Machine Serial Number' in line:
+                    dmi_facts['product_serial'] = data[1].strip()
+                if 'LPAR Info' in line:
+                    dmi_facts['lpar_info'] = data[1].strip()
+                if 'System Model' in line:
+                    dmi_facts['product_name'] = data[1].strip()
         return dmi_facts
 
     def get_vgs_facts(self):
@@ -233,8 +235,8 @@ class AIXHardware(Hardware):
         device_facts = {}
         device_facts['devices'] = {}
 
-        lsdev_cmd = self.module.get_bin_path('lsdev', True)
-        lsattr_cmd = self.module.get_bin_path('lsattr', True)
+        lsdev_cmd = self.module.get_bin_path('lsdev', required=True)
+        lsattr_cmd = self.module.get_bin_path('lsattr', required=True)
         rc, out_lsdev, err = self.module.run_command(lsdev_cmd)
 
         for line in out_lsdev.splitlines():

--- a/lib/ansible/module_utils/facts/hardware/darwin.py
+++ b/lib/ansible/module_utils/facts/hardware/darwin.py
@@ -135,6 +135,8 @@ class DarwinHardware(Hardware):
         # On Darwin, the default format is annoying to parse.
         # Use -b to get the raw value and decode it.
         sysctl_cmd = self.module.get_bin_path('sysctl')
+        if sysctl_cmd is None:
+            return {}
         cmd = [sysctl_cmd, '-b', 'kern.boottime']
 
         # We need to get raw bytes, not UTF-8.

--- a/lib/ansible/module_utils/facts/hardware/freebsd.py
+++ b/lib/ansible/module_utils/facts/hardware/freebsd.py
@@ -130,6 +130,8 @@ class FreeBSDHardware(Hardware):
         # On FreeBSD, the default format is annoying to parse.
         # Use -b to get the raw value and decode it.
         sysctl_cmd = self.module.get_bin_path('sysctl')
+        if sysctl_cmd is None:
+            return {}
         cmd = [sysctl_cmd, '-b', 'kern.boottime']
 
         # We need to get raw bytes, not UTF-8.

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -820,7 +820,7 @@ class LinuxHardware(Hardware):
         dm_prefix = '/dev/dm-'
         mapper_device = dm_device
         if dm_device.startswith(dm_prefix):
-            dmsetup_cmd = self.module.get_bin_path('dmsetup', True)
+            dmsetup_cmd = self.module.get_bin_path('dmsetup', required=True)
             mapper_prefix = '/dev/mapper/'
             rc, dm_name, err = self.module.run_command("%s info -C --noheadings -o name %s" % (dmsetup_cmd, dm_device))
             if rc == 0:
@@ -832,10 +832,10 @@ class LinuxHardware(Hardware):
 
         lvm_facts = {'lvm': 'N/A'}
 
-        if os.getuid() == 0 and self.module.get_bin_path('vgs'):
+        vgs_path = self.module.get_bin_path('vgs')
+        if os.getuid() == 0 and vgs_path:
             lvm_util_options = '--noheadings --nosuffix --units g --separator ,'
 
-            vgs_path = self.module.get_bin_path('vgs')
             # vgs fields: VG #PV #LV #SN Attr VSize VFree
             vgs = {}
             if vgs_path:

--- a/lib/ansible/module_utils/facts/hardware/netbsd.py
+++ b/lib/ansible/module_utils/facts/hardware/netbsd.py
@@ -163,9 +163,10 @@ class NetBSDHardware(Hardware):
     def get_uptime_facts(self):
         # On NetBSD, we need to call sysctl with -n to get this value as an int.
         sysctl_cmd = self.module.get_bin_path('sysctl')
-        cmd = [sysctl_cmd, '-n', 'kern.boottime']
+        if sysctl_cmd is None:
+            return {}
 
-        rc, out, err = self.module.run_command(cmd)
+        rc, out, err = self.module.run_command([sysctl_cmd, '-n', 'kern.boottime'])
 
         if rc != 0:
             return {}

--- a/lib/ansible/module_utils/facts/hardware/openbsd.py
+++ b/lib/ansible/module_utils/facts/hardware/openbsd.py
@@ -114,9 +114,9 @@ class OpenBSDHardware(Hardware):
     def get_uptime_facts(self):
         # On openbsd, we need to call it with -n to get this value as an int.
         sysctl_cmd = self.module.get_bin_path('sysctl')
-        cmd = [sysctl_cmd, '-n', 'kern.boottime']
-
-        rc, out, err = self.module.run_command(cmd)
+        if sysctl_cmd is None:
+            return {}
+        rc, out, err = self.module.run_command([sysctl_cmd, '-n', 'kern.boottime'])
 
         if rc != 0:
             return {}

--- a/lib/ansible/module_utils/facts/hardware/sunos.py
+++ b/lib/ansible/module_utils/facts/hardware/sunos.py
@@ -174,6 +174,8 @@ class SunOSHardware(Hardware):
         platform_sbin = '/usr/platform/' + platform.rstrip() + '/sbin'
 
         prtdiag_path = self.module.get_bin_path("prtdiag", opt_dirs=[platform_sbin])
+        if prtdiag_path is None:
+            return dmi_facts
         rc, out, err = self.module.run_command(prtdiag_path)
         # rc returns 1
         if out:

--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -331,30 +331,31 @@ class LinuxNetwork(Network):
 
         data = {}
         ethtool_path = self.module.get_bin_path("ethtool")
-        # FIXME: exit early on falsey ethtool_path and un-indent
-        if ethtool_path:
-            args = [ethtool_path, '-k', device]
-            rc, stdout, stderr = self.module.run_command(args, errors='surrogate_then_replace')
-            # FIXME: exit early on falsey if we can
-            if rc == 0:
-                features = {}
-                for line in stdout.strip().splitlines():
-                    if not line or line.endswith(":"):
-                        continue
-                    key, value = line.split(": ")
-                    if not value:
-                        continue
-                    features[key.strip().replace('-', '_')] = value.strip()
-                data['features'] = features
+        if ethtool_path is None:
+            return data
 
-            args = [ethtool_path, '-T', device]
-            rc, stdout, stderr = self.module.run_command(args, errors='surrogate_then_replace')
-            if rc == 0:
-                data['timestamping'] = [m.lower() for m in re.findall(r'SOF_TIMESTAMPING_(\w+)', stdout)]
-                data['hw_timestamp_filters'] = [m.lower() for m in re.findall(r'HWTSTAMP_FILTER_(\w+)', stdout)]
-                m = re.search(r'PTP Hardware Clock: (\d+)', stdout)
-                if m:
-                    data['phc_index'] = int(m.groups()[0])
+        args = [ethtool_path, '-k', device]
+        rc, stdout, stderr = self.module.run_command(args, errors='surrogate_then_replace')
+        # FIXME: exit early on falsey if we can
+        if rc == 0:
+            features = {}
+            for line in stdout.strip().splitlines():
+                if not line or line.endswith(":"):
+                    continue
+                key, value = line.split(": ")
+                if not value:
+                    continue
+                features[key.strip().replace('-', '_')] = value.strip()
+            data['features'] = features
+
+        args = [ethtool_path, '-T', device]
+        rc, stdout, stderr = self.module.run_command(args, errors='surrogate_then_replace')
+        if rc == 0:
+            data['timestamping'] = [m.lower() for m in re.findall(r'SOF_TIMESTAMPING_(\w+)', stdout)]
+            data['hw_timestamp_filters'] = [m.lower() for m in re.findall(r'HWTSTAMP_FILTER_(\w+)', stdout)]
+            m = re.search(r'PTP Hardware Clock: (\d+)', stdout)
+            if m:
+                data['phc_index'] = int(m.groups()[0])
 
         return data
 

--- a/lib/ansible/module_utils/facts/other/ohai.py
+++ b/lib/ansible/module_utils/facts/other/ohai.py
@@ -37,8 +37,7 @@ class OhaiFactCollector(BaseFactCollector):
                                                 namespace=namespace)
 
     def find_ohai(self, module):
-        ohai_path = module.get_bin_path('ohai')
-        return ohai_path
+        return module.get_bin_path('ohai')
 
     def run_ohai(self, module, ohai_path,):
         rc, out, err = module.run_command(ohai_path)

--- a/lib/ansible/module_utils/facts/system/caps.py
+++ b/lib/ansible/module_utils/facts/system/caps.py
@@ -33,29 +33,33 @@ class SystemCapabilitiesFactCollector(BaseFactCollector):
         rc = -1
         facts_dict = {'system_capabilities_enforced': 'N/A',
                       'system_capabilities': 'N/A'}
-        if module:
-            capsh_path = module.get_bin_path('capsh')
-            if capsh_path:
-                # NOTE: -> get_caps_data()/parse_caps_data() for easier mocking -akl
-                try:
-                    rc, out, err = module.run_command([capsh_path, "--print"], errors='surrogate_then_replace', handle_exceptions=False)
-                except (IOError, OSError) as e:
-                    module.warn('Could not query system capabilities: %s' % str(e))
+        if module is None:
+            return facts_dict
 
-            if rc == 0:
-                enforced_caps = []
-                enforced = 'NA'
-                for line in out.splitlines():
-                    if len(line) < 1:
-                        continue
-                    if line.startswith('Current:'):
-                        if line.split(':')[1].strip() == '=ep':
-                            enforced = 'False'
-                        else:
-                            enforced = 'True'
-                            enforced_caps = [i.strip() for i in line.split('=')[1].split(',')]
+        capsh_path = module.get_bin_path('capsh')
+        if capsh_path is None:
+            return facts_dict
 
-                facts_dict['system_capabilities_enforced'] = enforced
-                facts_dict['system_capabilities'] = enforced_caps
+        # NOTE: -> get_caps_data()/parse_caps_data() for easier mocking -akl
+        try:
+            rc, out, err = module.run_command([capsh_path, "--print"], errors='surrogate_then_replace', handle_exceptions=False)
+        except (IOError, OSError) as e:
+            module.warn('Could not query system capabilities: %s' % str(e))
+
+        if rc == 0:
+            enforced_caps = []
+            enforced = 'NA'
+            for line in out.splitlines():
+                if len(line) < 1:
+                    continue
+                if line.startswith('Current:'):
+                    if line.split(':')[1].strip() == '=ep':
+                        enforced = 'False'
+                    else:
+                        enforced = 'True'
+                        enforced_caps = [i.strip() for i in line.split('=')[1].split(',')]
+
+            facts_dict['system_capabilities_enforced'] = enforced
+            facts_dict['system_capabilities'] = enforced_caps
 
         return facts_dict

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -362,7 +362,7 @@ class LinuxVirtual(Virtual):
         # dmidecode is the safest option to parse virtualization related values
         dmi_bin = self.module.get_bin_path('dmidecode')
         # We still want to continue even if dmidecode is not available
-        if dmi_bin is not None:
+        if dmi_bin:
             (rc, out, err) = self.module.run_command('%s -s system-product-name' % dmi_bin)
             if rc == 0:
                 # Strip out commented lines (specific dmidecode output)

--- a/lib/ansible/module_utils/facts/virtual/sysctl.py
+++ b/lib/ansible/module_utils/facts/virtual/sysctl.py
@@ -34,57 +34,59 @@ class VirtualSysctlDetectionMixin(object):
         found_virt = False
 
         self.detect_sysctl()
-        if self.sysctl_path:
-            rc, out, err = self.module.run_command("%s -n %s" % (self.sysctl_path, key))
-            if rc == 0:
-                if re.match('(KVM|kvm|Bochs|SmartDC).*', out):
-                    guest_tech.add('kvm')
-                    if not found_virt:
-                        virtual_product_facts['virtualization_type'] = 'kvm'
-                        virtual_product_facts['virtualization_role'] = 'guest'
-                        found_virt = True
-                if re.match('.*VMware.*', out):
-                    guest_tech.add('VMware')
-                    if not found_virt:
-                        virtual_product_facts['virtualization_type'] = 'VMware'
-                        virtual_product_facts['virtualization_role'] = 'guest'
-                        found_virt = True
-                if out.rstrip() == 'VirtualBox':
-                    guest_tech.add('virtualbox')
-                    if not found_virt:
-                        virtual_product_facts['virtualization_type'] = 'virtualbox'
-                        virtual_product_facts['virtualization_role'] = 'guest'
-                        found_virt = True
-                if re.match('(HVM domU|XenPVH|XenPV|XenPVHVM).*', out):
-                    guest_tech.add('xen')
-                    if not found_virt:
-                        virtual_product_facts['virtualization_type'] = 'xen'
-                        virtual_product_facts['virtualization_role'] = 'guest'
-                        found_virt = True
-                if out.rstrip() == 'Hyper-V':
-                    guest_tech.add('Hyper-V')
-                    if not found_virt:
-                        virtual_product_facts['virtualization_type'] = 'Hyper-V'
-                        virtual_product_facts['virtualization_role'] = 'guest'
-                        found_virt = True
-                if out.rstrip() == 'Parallels':
-                    guest_tech.add('parallels')
-                    if not found_virt:
-                        virtual_product_facts['virtualization_type'] = 'parallels'
-                        virtual_product_facts['virtualization_role'] = 'guest'
-                        found_virt = True
-                if out.rstrip() == 'RHEV Hypervisor':
-                    guest_tech.add('RHEV')
-                    if not found_virt:
-                        virtual_product_facts['virtualization_type'] = 'RHEV'
-                        virtual_product_facts['virtualization_role'] = 'guest'
-                        found_virt = True
-                if (key == 'security.jail.jailed') and (out.rstrip() == '1'):
-                    guest_tech.add('jails')
-                    if not found_virt:
-                        virtual_product_facts['virtualization_type'] = 'jails'
-                        virtual_product_facts['virtualization_role'] = 'guest'
-                        found_virt = True
+        if self.sysctl_path is None:
+            return virtual_product_facts
+
+        rc, out, err = self.module.run_command("%s -n %s" % (self.sysctl_path, key))
+        if rc == 0:
+            if re.match('(KVM|kvm|Bochs|SmartDC).*', out):
+                guest_tech.add('kvm')
+                if not found_virt:
+                    virtual_product_facts['virtualization_type'] = 'kvm'
+                    virtual_product_facts['virtualization_role'] = 'guest'
+                    found_virt = True
+            if re.match('.*VMware.*', out):
+                guest_tech.add('VMware')
+                if not found_virt:
+                    virtual_product_facts['virtualization_type'] = 'VMware'
+                    virtual_product_facts['virtualization_role'] = 'guest'
+                    found_virt = True
+            if out.rstrip() == 'VirtualBox':
+                guest_tech.add('virtualbox')
+                if not found_virt:
+                    virtual_product_facts['virtualization_type'] = 'virtualbox'
+                    virtual_product_facts['virtualization_role'] = 'guest'
+                    found_virt = True
+            if re.match('(HVM domU|XenPVH|XenPV|XenPVHVM).*', out):
+                guest_tech.add('xen')
+                if not found_virt:
+                    virtual_product_facts['virtualization_type'] = 'xen'
+                    virtual_product_facts['virtualization_role'] = 'guest'
+                    found_virt = True
+            if out.rstrip() == 'Hyper-V':
+                guest_tech.add('Hyper-V')
+                if not found_virt:
+                    virtual_product_facts['virtualization_type'] = 'Hyper-V'
+                    virtual_product_facts['virtualization_role'] = 'guest'
+                    found_virt = True
+            if out.rstrip() == 'Parallels':
+                guest_tech.add('parallels')
+                if not found_virt:
+                    virtual_product_facts['virtualization_type'] = 'parallels'
+                    virtual_product_facts['virtualization_role'] = 'guest'
+                    found_virt = True
+            if out.rstrip() == 'RHEV Hypervisor':
+                guest_tech.add('RHEV')
+                if not found_virt:
+                    virtual_product_facts['virtualization_type'] = 'RHEV'
+                    virtual_product_facts['virtualization_role'] = 'guest'
+                    found_virt = True
+            if (key == 'security.jail.jailed') and (out.rstrip() == '1'):
+                guest_tech.add('jails')
+                if not found_virt:
+                    virtual_product_facts['virtualization_type'] = 'jails'
+                    virtual_product_facts['virtualization_role'] = 'guest'
+                    found_virt = True
 
         virtual_product_facts['virtualization_tech_guest'] = guest_tech
         virtual_product_facts['virtualization_tech_host'] = host_tech
@@ -95,17 +97,19 @@ class VirtualSysctlDetectionMixin(object):
         host_tech = set()
         guest_tech = set()
         self.detect_sysctl()
-        if self.sysctl_path:
-            rc, out, err = self.module.run_command("%s -n %s" % (self.sysctl_path, key))
-            if rc == 0:
-                if out.rstrip() == 'QEMU':
-                    guest_tech.add('kvm')
-                    virtual_vendor_facts['virtualization_type'] = 'kvm'
-                    virtual_vendor_facts['virtualization_role'] = 'guest'
-                if out.rstrip() == 'OpenBSD':
-                    guest_tech.add('vmm')
-                    virtual_vendor_facts['virtualization_type'] = 'vmm'
-                    virtual_vendor_facts['virtualization_role'] = 'guest'
+        if self.sysctl_path is None:
+            return virtual_vendor_facts
+
+        rc, out, err = self.module.run_command("%s -n %s" % (self.sysctl_path, key))
+        if rc == 0:
+            if out.rstrip() == 'QEMU':
+                guest_tech.add('kvm')
+                virtual_vendor_facts['virtualization_type'] = 'kvm'
+                virtual_vendor_facts['virtualization_role'] = 'guest'
+            if out.rstrip() == 'OpenBSD':
+                guest_tech.add('vmm')
+                virtual_vendor_facts['virtualization_type'] = 'vmm'
+                virtual_vendor_facts['virtualization_role'] = 'guest'
 
         virtual_vendor_facts['virtualization_tech_guest'] = guest_tech
         virtual_vendor_facts['virtualization_tech_host'] = host_tech

--- a/lib/ansible/module_utils/service.py
+++ b/lib/ansible/module_utils/service.py
@@ -94,7 +94,7 @@ def get_ps(module, pattern):
         flags = '-ef'
     else:
         flags = 'auxww'
-    psbin = module.get_bin_path('ps', True)
+    psbin = module.get_bin_path('ps', required=True)
 
     (rc, psout, pserr) = module.run_command([psbin, flags])
     if rc == 0:
@@ -265,7 +265,7 @@ def check_ps(module, pattern):
         psflags = 'auxww'
 
     # Find ps binary
-    psbin = module.get_bin_path('ps', True)
+    psbin = module.get_bin_path('ps', required=True)
 
     (rc, out, err) = module.run_command('%s %s' % (psbin, psflags))
     # If rc is 0, set running as appropriate

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -832,7 +832,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
 
 
 def get_field_of_deb(m, deb_file, field="Version"):
-    cmd_dpkg = m.get_bin_path("dpkg", True)
+    cmd_dpkg = m.get_bin_path("dpkg", required=True)
     cmd = cmd_dpkg + " --field %s %s" % (deb_file, field)
     rc, stdout, stderr = m.run_command(cmd)
     if rc != 0:
@@ -1302,7 +1302,7 @@ def main():
             module.fail_json(msg="{0} must be installed and visible from {1}.".format(apt_pkg_name, sys.executable))
 
     global APTITUDE_CMD
-    APTITUDE_CMD = module.get_bin_path("aptitude", False)
+    APTITUDE_CMD = module.get_bin_path("aptitude")
     global APT_GET_CMD
     APT_GET_CMD = module.get_bin_path("apt-get")
 

--- a/lib/ansible/modules/debconf.py
+++ b/lib/ansible/modules/debconf.py
@@ -129,7 +129,7 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def get_password_value(module, pkg, question, vtype):
-    getsel = module.get_bin_path('debconf-get-selections', True)
+    getsel = module.get_bin_path('debconf-get-selections', required=True)
     cmd = [getsel]
     rc, out, err = module.run_command(cmd)
     if rc != 0:
@@ -151,7 +151,7 @@ def get_password_value(module, pkg, question, vtype):
 
 
 def get_selections(module, pkg):
-    cmd = [module.get_bin_path('debconf-show', True), pkg]
+    cmd = [module.get_bin_path('debconf-show', required=True), pkg]
     rc, out, err = module.run_command(' '.join(cmd))
 
     if rc != 0:
@@ -167,7 +167,7 @@ def get_selections(module, pkg):
 
 
 def set_selection(module, pkg, question, vtype, value, unseen):
-    setsel = module.get_bin_path('debconf-set-selections', True)
+    setsel = module.get_bin_path('debconf-set-selections', required=True)
     cmd = [setsel]
     if unseen:
         cmd.append('-u')

--- a/lib/ansible/modules/dpkg_selections.py
+++ b/lib/ansible/modules/dpkg_selections.py
@@ -66,7 +66,7 @@ def main():
         supports_check_mode=True,
     )
 
-    dpkg = module.get_bin_path('dpkg', True)
+    dpkg = module.get_bin_path('dpkg', required=True)
 
     locale = get_best_parsable_locale(module)
     DPKG_ENV = dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale, LC_CTYPE=locale)

--- a/lib/ansible/modules/getent.py
+++ b/lib/ansible/modules/getent.py
@@ -141,7 +141,7 @@ def main():
     service = module.params.get('service')
     fail_key = module.params.get('fail_key')
 
-    getent_bin = module.get_bin_path('getent', True)
+    getent_bin = module.get_bin_path('getent', required=True)
 
     if key is not None:
         cmd = [getent_bin, database, key]

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -1218,7 +1218,7 @@ def main():
     gpg_whitelist = module.params['gpg_whitelist']
     reference = module.params['reference']
     single_branch = module.params['single_branch']
-    git_path = module.params['executable'] or module.get_bin_path('git', True)
+    git_path = module.params['executable'] or module.get_bin_path('git', required=True)
     key_file = module.params['key_file']
     ssh_opts = module.params['ssh_opts']
     umask = module.params['umask']

--- a/lib/ansible/modules/group.py
+++ b/lib/ansible/modules/group.py
@@ -161,7 +161,7 @@ class Group(object):
             command_name = 'lgroupdel'
         else:
             command_name = 'groupdel'
-        cmd = [self.module.get_bin_path(command_name, True), self.name]
+        cmd = [self.module.get_bin_path(command_name, required=True), self.name]
         return self.execute_command(cmd)
 
     def _local_check_gid_exists(self):
@@ -176,7 +176,7 @@ class Group(object):
             self._local_check_gid_exists()
         else:
             command_name = 'groupadd'
-        cmd = [self.module.get_bin_path(command_name, True)]
+        cmd = [self.module.get_bin_path(command_name, required=True)]
         for key in kwargs:
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('-g')
@@ -194,7 +194,7 @@ class Group(object):
             self._local_check_gid_exists()
         else:
             command_name = 'groupmod'
-        cmd = [self.module.get_bin_path(command_name, True)]
+        cmd = [self.module.get_bin_path(command_name, required=True)]
         info = self.group_info()
         for key in kwargs:
             if key == 'gid':
@@ -263,7 +263,7 @@ class Linux(Group):
             command_name = 'lgroupdel'
         else:
             command_name = 'groupdel'
-        cmd = [self.module.get_bin_path(command_name, True)]
+        cmd = [self.module.get_bin_path(command_name, required=True)]
         if self.force:
             cmd.append('-f')
         cmd.append(self.name)
@@ -286,7 +286,7 @@ class SunOS(Group):
     GROUPFILE = '/etc/group'
 
     def group_add(self, **kwargs):
-        cmd = [self.module.get_bin_path('groupadd', True)]
+        cmd = [self.module.get_bin_path('groupadd', required=True)]
         for key in kwargs:
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('-g')
@@ -314,11 +314,11 @@ class AIX(Group):
     GROUPFILE = '/etc/group'
 
     def group_del(self):
-        cmd = [self.module.get_bin_path('rmgroup', True), self.name]
+        cmd = [self.module.get_bin_path('rmgroup', required=True), self.name]
         return self.execute_command(cmd)
 
     def group_add(self, **kwargs):
-        cmd = [self.module.get_bin_path('mkgroup', True)]
+        cmd = [self.module.get_bin_path('mkgroup', required=True)]
         for key in kwargs:
             if key == 'gid' and kwargs[key] is not None:
                 cmd.append('id=' + str(kwargs[key]))
@@ -328,7 +328,7 @@ class AIX(Group):
         return self.execute_command(cmd)
 
     def group_mod(self, **kwargs):
-        cmd = [self.module.get_bin_path('chgroup', True)]
+        cmd = [self.module.get_bin_path('chgroup', required=True)]
         info = self.group_info()
         for key in kwargs:
             if key == 'gid':
@@ -359,11 +359,11 @@ class FreeBsdGroup(Group):
     GROUPFILE = '/etc/group'
 
     def group_del(self):
-        cmd = [self.module.get_bin_path('pw', True), 'groupdel', self.name]
+        cmd = [self.module.get_bin_path('pw', required=True), 'groupdel', self.name]
         return self.execute_command(cmd)
 
     def group_add(self, **kwargs):
-        cmd = [self.module.get_bin_path('pw', True), 'groupadd', self.name]
+        cmd = [self.module.get_bin_path('pw', required=True), 'groupadd', self.name]
         if self.gid is not None:
             cmd.append('-g')
             cmd.append(str(self.gid))
@@ -372,7 +372,7 @@ class FreeBsdGroup(Group):
         return self.execute_command(cmd)
 
     def group_mod(self, **kwargs):
-        cmd = [self.module.get_bin_path('pw', True), 'groupmod', self.name]
+        cmd = [self.module.get_bin_path('pw', required=True), 'groupmod', self.name]
         info = self.group_info()
         cmd_len = len(cmd)
         if self.gid is not None and int(self.gid) != info[2]:
@@ -415,7 +415,7 @@ class DarwinGroup(Group):
     distribution = None
 
     def group_add(self, **kwargs):
-        cmd = [self.module.get_bin_path('dseditgroup', True)]
+        cmd = [self.module.get_bin_path('dseditgroup', required=True)]
         cmd += ['-o', 'create']
         if self.gid is not None:
             cmd += ['-i', str(self.gid)]
@@ -429,7 +429,7 @@ class DarwinGroup(Group):
         return (rc, out, err)
 
     def group_del(self):
-        cmd = [self.module.get_bin_path('dseditgroup', True)]
+        cmd = [self.module.get_bin_path('dseditgroup', required=True)]
         cmd += ['-o', 'delete']
         cmd += ['-L', self.name]
         (rc, out, err) = self.execute_command(cmd)
@@ -438,7 +438,7 @@ class DarwinGroup(Group):
     def group_mod(self, gid=None):
         info = self.group_info()
         if self.gid is not None and int(self.gid) != info[2]:
-            cmd = [self.module.get_bin_path('dseditgroup', True)]
+            cmd = [self.module.get_bin_path('dseditgroup', required=True)]
             cmd += ['-o', 'edit']
             if gid is not None:
                 cmd += ['-i', str(gid)]
@@ -450,7 +450,7 @@ class DarwinGroup(Group):
     def get_lowest_available_system_gid(self):
         # check for lowest available system gid (< 500)
         try:
-            cmd = [self.module.get_bin_path('dscl', True)]
+            cmd = [self.module.get_bin_path('dscl', required=True)]
             cmd += ['/Local/Default', '-list', '/Groups', 'PrimaryGroupID']
             (rc, out, err) = self.execute_command(cmd)
             lines = out.splitlines()
@@ -483,11 +483,11 @@ class OpenBsdGroup(Group):
     GROUPFILE = '/etc/group'
 
     def group_del(self):
-        cmd = [self.module.get_bin_path('groupdel', True), self.name]
+        cmd = [self.module.get_bin_path('groupdel', required=True), self.name]
         return self.execute_command(cmd)
 
     def group_add(self, **kwargs):
-        cmd = [self.module.get_bin_path('groupadd', True)]
+        cmd = [self.module.get_bin_path('groupadd', required=True)]
         if self.gid is not None:
             cmd.append('-g')
             cmd.append(str(self.gid))
@@ -497,7 +497,7 @@ class OpenBsdGroup(Group):
         return self.execute_command(cmd)
 
     def group_mod(self, **kwargs):
-        cmd = [self.module.get_bin_path('groupmod', True)]
+        cmd = [self.module.get_bin_path('groupmod', required=True)]
         info = self.group_info()
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
@@ -529,11 +529,11 @@ class NetBsdGroup(Group):
     GROUPFILE = '/etc/group'
 
     def group_del(self):
-        cmd = [self.module.get_bin_path('groupdel', True), self.name]
+        cmd = [self.module.get_bin_path('groupdel', required=True), self.name]
         return self.execute_command(cmd)
 
     def group_add(self, **kwargs):
-        cmd = [self.module.get_bin_path('groupadd', True)]
+        cmd = [self.module.get_bin_path('groupadd', required=True)]
         if self.gid is not None:
             cmd.append('-g')
             cmd.append(str(self.gid))
@@ -543,7 +543,7 @@ class NetBsdGroup(Group):
         return self.execute_command(cmd)
 
     def group_mod(self, **kwargs):
-        cmd = [self.module.get_bin_path('groupmod', True)]
+        cmd = [self.module.get_bin_path('groupmod', required=True)]
         info = self.group_info()
         if self.gid is not None and int(self.gid) != info[2]:
             cmd.append('-g')
@@ -572,7 +572,7 @@ class BusyBoxGroup(Group):
     """
 
     def group_add(self, **kwargs):
-        cmd = [self.module.get_bin_path('addgroup', True)]
+        cmd = [self.module.get_bin_path('addgroup', required=True)]
         if self.gid is not None:
             cmd.extend(['-g', str(self.gid)])
 
@@ -584,7 +584,7 @@ class BusyBoxGroup(Group):
         return self.execute_command(cmd)
 
     def group_del(self):
-        cmd = [self.module.get_bin_path('delgroup', True), self.name]
+        cmd = [self.module.get_bin_path('delgroup', required=True), self.name]
         return self.execute_command(cmd)
 
     def group_mod(self, **kwargs):

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -178,7 +178,7 @@ class CommandStrategy(BaseStrategy):
 
     def __init__(self, module):
         super(CommandStrategy, self).__init__(module)
-        self.hostname_cmd = self.module.get_bin_path(self.COMMAND, True)
+        self.hostname_cmd = self.module.get_bin_path(self.COMMAND, required=True)
 
     def get_current_hostname(self):
         cmd = [self.hostname_cmd]
@@ -287,7 +287,7 @@ class AlpineStrategy(FileStrategy):
 
     def set_current_hostname(self, name):
         super(AlpineStrategy, self).set_current_hostname(name)
-        hostname_cmd = self.module.get_bin_path(self.COMMAND, True)
+        hostname_cmd = self.module.get_bin_path(self.COMMAND, required=True)
 
         cmd = [hostname_cmd, '-F', self.FILE]
         rc, out, err = self.module.run_command(cmd)
@@ -305,7 +305,7 @@ class SystemdStrategy(BaseStrategy):
 
     def __init__(self, module):
         super(SystemdStrategy, self).__init__(module)
-        self.hostnamectl_cmd = self.module.get_bin_path(self.COMMAND, True)
+        self.hostnamectl_cmd = self.module.get_bin_path(self.COMMAND, required=True)
 
     def get_current_hostname(self):
         cmd = [self.hostnamectl_cmd, '--transient', 'status']
@@ -396,7 +396,7 @@ class OpenBSDStrategy(FileStrategy):
 
     def __init__(self, module):
         super(OpenBSDStrategy, self).__init__(module)
-        self.hostname_cmd = self.module.get_bin_path(self.COMMAND, True)
+        self.hostname_cmd = self.module.get_bin_path(self.COMMAND, required=True)
 
     def get_current_hostname(self):
         cmd = [self.hostname_cmd]
@@ -422,7 +422,7 @@ class SolarisStrategy(BaseStrategy):
 
     def __init__(self, module):
         super(SolarisStrategy, self).__init__(module)
-        self.hostname_cmd = self.module.get_bin_path(self.COMMAND, True)
+        self.hostname_cmd = self.module.get_bin_path(self.COMMAND, required=True)
 
     def set_current_hostname(self, name):
         cmd_option = '-t'
@@ -458,7 +458,7 @@ class FreeBSDStrategy(BaseStrategy):
 
     def __init__(self, module):
         super(FreeBSDStrategy, self).__init__(module)
-        self.hostname_cmd = self.module.get_bin_path(self.COMMAND, True)
+        self.hostname_cmd = self.module.get_bin_path(self.COMMAND, required=True)
 
     def get_current_hostname(self):
         cmd = [self.hostname_cmd]
@@ -529,7 +529,7 @@ class DarwinStrategy(BaseStrategy):
     def __init__(self, module):
         super(DarwinStrategy, self).__init__(module)
 
-        self.scutil = self.module.get_bin_path('scutil', True)
+        self.scutil = self.module.get_bin_path('scutil', required=True)
         self.name_types = ('HostName', 'ComputerName', 'LocalHostName')
         self.scrubbed_name = self._scrub_hostname(self.module.params['name'])
 

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -846,7 +846,7 @@ def main():
     )
 
     ip_version = module.params['ip_version']
-    iptables_path = module.get_bin_path(BINS[ip_version], True)
+    iptables_path = module.get_bin_path(BINS[ip_version], required=True)
 
     # Check if chain option is required
     if args['flush'] is False and args['chain'] is None:

--- a/lib/ansible/modules/known_hosts.py
+++ b/lib/ansible/modules/known_hosts.py
@@ -125,7 +125,7 @@ def enforce_state(module, params):
     hash_host = params.get("hash_host")
     state = params.get("state")
     # Find the ssh-keygen binary
-    sshkeygen = module.get_bin_path("ssh-keygen", True)
+    sshkeygen = module.get_bin_path("ssh-keygen", required=True)
 
     if not key and state != "absent":
         module.fail_json(msg="No key specified when adding a host")

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -433,7 +433,7 @@ def _get_pip(module, env=None, executable=None):
         if env is None:
             opt_dirs = []
             for basename in candidate_pip_basenames:
-                pip = module.get_bin_path(basename, False, opt_dirs)
+                pip = module.get_bin_path(basename, required=False, opt_dirs=opt_dirs)
                 if pip is not None:
                     break
             else:
@@ -515,7 +515,7 @@ def _get_package_info(module, package, env=None):
         opt_dirs = ['%s/bin' % env]
     else:
         opt_dirs = []
-    python_bin = module.get_bin_path('python', False, opt_dirs)
+    python_bin = module.get_bin_path('python', required=False, opt_dirs=opt_dirs)
 
     if python_bin is None:
         formatted_dep = None
@@ -537,7 +537,7 @@ def setup_virtualenv(module, env, chdir, out, err):
     # Find the binary for the command in the PATH
     # and switch the command for the explicit path.
     if os.path.basename(cmd[0]) == cmd[0]:
-        cmd[0] = module.get_bin_path(cmd[0], True)
+        cmd[0] = module.get_bin_path(cmd[0], required=True)
 
     # Add the system-site-packages option if that
     # is enabled, otherwise explicitly set the option

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -102,7 +102,7 @@ class RpmKey(object):
         keyfile = None
         should_cleanup_keyfile = False
         self.module = module
-        self.rpm = self.module.get_bin_path('rpm', True)
+        self.rpm = self.module.get_bin_path('rpm', required=True)
         state = module.params['state']
         key = module.params['key']
         fingerprint = module.params['fingerprint']

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -347,7 +347,7 @@ class Service(object):
             psflags = 'auxww'
 
         # Find ps binary
-        psbin = self.module.get_bin_path('ps', True)
+        psbin = self.module.get_bin_path('ps', required=True)
 
         (rc, psout, pserr) = self.execute_command('%s %s' % (psbin, psflags))
         # If rc is 0, set running as appropriate
@@ -1023,10 +1023,7 @@ class FreeBsdService(Service):
     distribution = None
 
     def get_service_tools(self):
-        self.svc_cmd = self.module.get_bin_path('service', True)
-        if not self.svc_cmd:
-            self.module.fail_json(msg='unable to find service binary')
-
+        self.svc_cmd = self.module.get_bin_path('service', required=True)
         self.sysrc_cmd = self.module.get_bin_path('sysrc')
 
     def get_service_status(self):
@@ -1289,15 +1286,8 @@ class SunOSService(Service):
     distribution = None
 
     def get_service_tools(self):
-        self.svcs_cmd = self.module.get_bin_path('svcs', True)
-
-        if not self.svcs_cmd:
-            self.module.fail_json(msg='unable to find svcs binary')
-
-        self.svcadm_cmd = self.module.get_bin_path('svcadm', True)
-
-        if not self.svcadm_cmd:
-            self.module.fail_json(msg='unable to find svcadm binary')
+        self.svcs_cmd = self.module.get_bin_path('svcs', required=True)
+        self.svcadm_cmd = self.module.get_bin_path('svcadm', required=True)
 
         if self.svcadm_supports_sync():
             self.svcadm_sync = '-s'
@@ -1424,25 +1414,10 @@ class AIX(Service):
     distribution = None
 
     def get_service_tools(self):
-        self.lssrc_cmd = self.module.get_bin_path('lssrc', True)
-
-        if not self.lssrc_cmd:
-            self.module.fail_json(msg='unable to find lssrc binary')
-
-        self.startsrc_cmd = self.module.get_bin_path('startsrc', True)
-
-        if not self.startsrc_cmd:
-            self.module.fail_json(msg='unable to find startsrc binary')
-
-        self.stopsrc_cmd = self.module.get_bin_path('stopsrc', True)
-
-        if not self.stopsrc_cmd:
-            self.module.fail_json(msg='unable to find stopsrc binary')
-
-        self.refresh_cmd = self.module.get_bin_path('refresh', True)
-
-        if not self.refresh_cmd:
-            self.module.fail_json(msg='unable to find refresh binary')
+        self.lssrc_cmd = self.module.get_bin_path('lssrc', required=True)
+        self.startsrc_cmd = self.module.get_bin_path('startsrc', required=True)
+        self.stopsrc_cmd = self.module.get_bin_path('stopsrc', required=True)
+        self.refresh_cmd = self.module.get_bin_path('refresh', required=True)
 
     def get_service_status(self):
         status = self.get_aix_src_status()

--- a/lib/ansible/modules/subversion.py
+++ b/lib/ansible/modules/subversion.py
@@ -316,7 +316,7 @@ def main():
     force = module.params['force']
     username = module.params['username']
     password = module.params['password']
-    svn_path = module.params['executable'] or module.get_bin_path('svn', True)
+    svn_path = module.params['executable'] or module.get_bin_path('svn', required=True)
     export = module.params['export']
     switch = module.params['switch']
     checkout = module.params['checkout']

--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -365,7 +365,7 @@ def main():
             if globpattern in unit:
                 module.fail_json(msg="This module does not currently support using glob patterns, found '%s' in service name: %s" % (globpattern, unit))
 
-    systemctl = module.get_bin_path('systemctl', True)
+    systemctl = module.get_bin_path('systemctl', required=True)
 
     if os.getenv('XDG_RUNTIME_DIR') is None:
         os.environ['XDG_RUNTIME_DIR'] = '/run/user/%s' % os.geteuid()

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -660,7 +660,7 @@ class User(object):
         else:
             command_name = 'userdel'
 
-        cmd = [self.module.get_bin_path(command_name, True)]
+        cmd = [self.module.get_bin_path(command_name, required=True)]
         if self.force and not self.local:
             cmd.append('-f')
         if self.remove:
@@ -673,12 +673,12 @@ class User(object):
 
         if self.local:
             command_name = 'luseradd'
-            lgroupmod_cmd = self.module.get_bin_path('lgroupmod', True)
-            lchage_cmd = self.module.get_bin_path('lchage', True)
+            lgroupmod_cmd = self.module.get_bin_path('lgroupmod', required=True)
+            lchage_cmd = self.module.get_bin_path('lchage', required=True)
         else:
             command_name = 'useradd'
 
-        cmd = [self.module.get_bin_path(command_name, True)]
+        cmd = [self.module.get_bin_path(command_name, required=True)]
 
         if self.uid is not None:
             cmd.append('-u')
@@ -813,7 +813,7 @@ class User(object):
         else:
             command_name = 'usermod'
 
-        usermod_path = self.module.get_bin_path(command_name, True)
+        usermod_path = self.module.get_bin_path(command_name, required=True)
 
         # for some reason, usermod --help cannot be used by non root
         # on RH/Fedora, due to lack of execute bit for others
@@ -836,15 +836,15 @@ class User(object):
 
         if self.local:
             command_name = 'lusermod'
-            lgroupmod_cmd = self.module.get_bin_path('lgroupmod', True)
+            lgroupmod_cmd = self.module.get_bin_path('lgroupmod', required=True)
             lgroupmod_add = set()
             lgroupmod_del = set()
-            lchage_cmd = self.module.get_bin_path('lchage', True)
+            lchage_cmd = self.module.get_bin_path('lchage', required=True)
             lexpires = None
         else:
             command_name = 'usermod'
 
-        cmd = [self.module.get_bin_path(command_name, True)]
+        cmd = [self.module.get_bin_path(command_name, required=True)]
         info = self.user_info()
         has_append = self._check_usermod_append()
 
@@ -1113,7 +1113,7 @@ class User(object):
             return (None, '', '')  # target state already reached
 
         command_name = 'chage'
-        cmd = [self.module.get_bin_path(command_name, True)]
+        cmd = [self.module.get_bin_path(command_name, required=True)]
         if min_needs_change:
             cmd.extend(["-m", self.password_expire_min])
         if max_needs_change:
@@ -1186,7 +1186,7 @@ class User(object):
                 overwrite = 'y'
             else:
                 return (None, 'Key already exists, use "force: yes" to overwrite', '')
-        cmd = [self.module.get_bin_path('ssh-keygen', True)]
+        cmd = [self.module.get_bin_path('ssh-keygen', required=True)]
         cmd.append('-t')
         cmd.append(self.ssh_type)
         if self.ssh_bits > 0:
@@ -1259,7 +1259,7 @@ class User(object):
         ssh_key_file = self.get_ssh_key_path()
         if not os.path.exists(ssh_key_file):
             return (1, 'SSH Key file %s does not exist' % ssh_key_file, '')
-        cmd = [self.module.get_bin_path('ssh-keygen', True)]
+        cmd = [self.module.get_bin_path('ssh-keygen', required=True)]
         cmd.append('-l')
         cmd.append('-f')
         cmd.append(ssh_key_file)
@@ -1353,7 +1353,7 @@ class FreeBsdUser(User):
         info = self.user_info()
         if self.password_lock and not info[1].startswith('*LOCKED*'):
             cmd = [
-                self.module.get_bin_path('pw', True),
+                self.module.get_bin_path('pw', required=True),
                 'lock',
                 self.name
             ]
@@ -1363,7 +1363,7 @@ class FreeBsdUser(User):
             return self.execute_command(cmd)
         elif self.password_lock is False and info[1].startswith('*LOCKED*'):
             cmd = [
-                self.module.get_bin_path('pw', True),
+                self.module.get_bin_path('pw', required=True),
                 'unlock',
                 self.name
             ]
@@ -1376,7 +1376,7 @@ class FreeBsdUser(User):
 
     def remove_user(self):
         cmd = [
-            self.module.get_bin_path('pw', True),
+            self.module.get_bin_path('pw', required=True),
             'userdel',
             '-n',
             self.name
@@ -1388,7 +1388,7 @@ class FreeBsdUser(User):
 
     def create_user(self):
         cmd = [
-            self.module.get_bin_path('pw', True),
+            self.module.get_bin_path('pw', required=True),
             'useradd',
             '-n',
             self.name,
@@ -1456,7 +1456,7 @@ class FreeBsdUser(User):
         # we have to set the password in a second command
         if self.password is not None:
             cmd = [
-                self.module.get_bin_path('chpass', True),
+                self.module.get_bin_path('chpass', required=True),
                 '-p',
                 self.password,
                 self.name
@@ -1478,7 +1478,7 @@ class FreeBsdUser(User):
 
     def modify_user(self):
         cmd = [
-            self.module.get_bin_path('pw', True),
+            self.module.get_bin_path('pw', required=True),
             'usermod',
             '-n',
             self.name
@@ -1595,7 +1595,7 @@ class FreeBsdUser(User):
         # we have to set the password in a second command
         if self.update_password == 'always' and self.password is not None and info[1].lstrip('*LOCKED*') != self.password.lstrip('*LOCKED*'):
             cmd = [
-                self.module.get_bin_path('chpass', True),
+                self.module.get_bin_path('chpass', required=True),
                 '-p',
                 self.password,
                 self.name
@@ -1645,7 +1645,7 @@ class OpenBSDUser(User):
     SHADOWFILE = '/etc/master.passwd'
 
     def create_user(self):
-        cmd = [self.module.get_bin_path('useradd', True)]
+        cmd = [self.module.get_bin_path('useradd', required=True)]
 
         if self.uid is not None:
             cmd.append('-u')
@@ -1700,14 +1700,14 @@ class OpenBSDUser(User):
         return self.execute_command(cmd)
 
     def remove_user_userdel(self):
-        cmd = [self.module.get_bin_path('userdel', True)]
+        cmd = [self.module.get_bin_path('userdel', required=True)]
         if self.remove:
             cmd.append('-r')
         cmd.append(self.name)
         return self.execute_command(cmd)
 
     def modify_user(self):
-        cmd = [self.module.get_bin_path('usermod', True)]
+        cmd = [self.module.get_bin_path('usermod', required=True)]
         info = self.user_info()
 
         if self.uid is not None and info[2] != int(self.uid):
@@ -1769,7 +1769,7 @@ class OpenBSDUser(User):
         if self.login_class is not None:
             # find current login class
             user_login_class = None
-            userinfo_cmd = [self.module.get_bin_path('userinfo', True), self.name]
+            userinfo_cmd = [self.module.get_bin_path('userinfo', required=True), self.name]
             (rc, out, err) = self.execute_command(userinfo_cmd, obey_checkmode=False)
 
             for line in out.splitlines():
@@ -1820,7 +1820,7 @@ class NetBSDUser(User):
     SHADOWFILE = '/etc/master.passwd'
 
     def create_user(self):
-        cmd = [self.module.get_bin_path('useradd', True)]
+        cmd = [self.module.get_bin_path('useradd', required=True)]
 
         if self.uid is not None:
             cmd.append('-u')
@@ -1877,14 +1877,14 @@ class NetBSDUser(User):
         return self.execute_command(cmd)
 
     def remove_user_userdel(self):
-        cmd = [self.module.get_bin_path('userdel', True)]
+        cmd = [self.module.get_bin_path('userdel', required=True)]
         if self.remove:
             cmd.append('-r')
         cmd.append(self.name)
         return self.execute_command(cmd)
 
     def modify_user(self):
-        cmd = [self.module.get_bin_path('usermod', True)]
+        cmd = [self.module.get_bin_path('usermod',required= True)]
         info = self.user_info()
 
         if self.uid is not None and info[2] != int(self.uid):
@@ -2011,7 +2011,7 @@ class SunOS(User):
         return (minweeks, maxweeks, warnweeks)
 
     def remove_user(self):
-        cmd = [self.module.get_bin_path('userdel', True)]
+        cmd = [self.module.get_bin_path('userdel', required=True)]
         if self.remove:
             cmd.append('-r')
         cmd.append(self.name)
@@ -2019,7 +2019,7 @@ class SunOS(User):
         return self.execute_command(cmd)
 
     def create_user(self):
-        cmd = [self.module.get_bin_path('useradd', True)]
+        cmd = [self.module.get_bin_path('useradd', required=True)]
 
         if self.uid is not None:
             cmd.append('-u')
@@ -2124,7 +2124,7 @@ class SunOS(User):
         return (rc, out, err)
 
     def modify_user_usermod(self):
-        cmd = [self.module.get_bin_path('usermod', True)]
+        cmd = [self.module.get_bin_path('usermod', required=True)]
         cmd_len = len(cmd)
         info = self.user_info()
 
@@ -2302,7 +2302,7 @@ class DarwinUser(User):
             self.fields.append(('hidden', 'IsHidden'))
 
     def _get_dscl(self):
-        return [self.module.get_bin_path('dscl', True), self.dscl_directory]
+        return [self.module.get_bin_path('dscl', required=True), self.dscl_directory]
 
     def _list_user_groups(self):
         cmd = self._get_dscl()
@@ -2628,7 +2628,7 @@ class AIX(User):
     SHADOWFILE = '/etc/security/passwd'
 
     def remove_user(self):
-        cmd = [self.module.get_bin_path('userdel', True)]
+        cmd = [self.module.get_bin_path('userdel', required=True)]
         if self.remove:
             cmd.append('-r')
         cmd.append(self.name)
@@ -2636,7 +2636,7 @@ class AIX(User):
         return self.execute_command(cmd)
 
     def create_user_useradd(self, command_name='useradd'):
-        cmd = [self.module.get_bin_path(command_name, True)]
+        cmd = [self.module.get_bin_path(command_name, required=True)]
 
         if self.uid is not None:
             cmd.append('-u')
@@ -2682,7 +2682,7 @@ class AIX(User):
         # set password with chpasswd
         if self.password is not None:
             cmd = []
-            cmd.append(self.module.get_bin_path('chpasswd', True))
+            cmd.append(self.module.get_bin_path('chpasswd', required=True))
             cmd.append('-e')
             cmd.append('-c')
             self.execute_command(cmd, data="%s:%s" % (self.name, self.password))
@@ -2690,7 +2690,7 @@ class AIX(User):
         return (rc, out, err)
 
     def modify_user_usermod(self):
-        cmd = [self.module.get_bin_path('usermod', True)]
+        cmd = [self.module.get_bin_path('usermod', required=True)]
         info = self.user_info()
 
         if self.uid is not None and info[2] != int(self.uid):
@@ -2754,7 +2754,7 @@ class AIX(User):
         # set password with chpasswd
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:
             cmd = []
-            cmd.append(self.module.get_bin_path('chpasswd', True))
+            cmd.append(self.module.get_bin_path('chpasswd', required=True))
             cmd.append('-e')
             cmd.append('-c')
             (rc2, out2, err2) = self.execute_command(cmd, data="%s:%s" % (self.name, self.password))
@@ -2968,7 +2968,7 @@ class BusyBox(User):
     """
 
     def create_user(self):
-        cmd = [self.module.get_bin_path('adduser', True)]
+        cmd = [self.module.get_bin_path('adduser', required=True)]
 
         cmd.append('-D')
 
@@ -3016,7 +3016,7 @@ class BusyBox(User):
             self.module.fail_json(name=self.name, msg=err, rc=rc)
 
         if self.password is not None:
-            cmd = [self.module.get_bin_path('chpasswd', True)]
+            cmd = [self.module.get_bin_path('chpasswd', required=True)]
             cmd.append('--encrypted')
             data = '{name}:{password}'.format(name=self.name, password=self.password)
             rc, out, err = self.execute_command(cmd, data=data)
@@ -3027,7 +3027,7 @@ class BusyBox(User):
         # Add to additional groups
         if self.groups is not None and len(self.groups):
             groups = self.get_groups_set()
-            add_cmd_bin = self.module.get_bin_path('adduser', True)
+            add_cmd_bin = self.module.get_bin_path('adduser', required=True)
             for group in groups:
                 cmd = [add_cmd_bin, self.name, group]
                 rc, out, err = self.execute_command(cmd)
@@ -3039,7 +3039,7 @@ class BusyBox(User):
     def remove_user(self):
 
         cmd = [
-            self.module.get_bin_path('deluser', True),
+            self.module.get_bin_path('deluser', required=True),
             self.name
         ]
 
@@ -3055,8 +3055,8 @@ class BusyBox(User):
         out = ''
         err = ''
         info = self.user_info()
-        add_cmd_bin = self.module.get_bin_path('adduser', True)
-        remove_cmd_bin = self.module.get_bin_path('delgroup', True)
+        add_cmd_bin = self.module.get_bin_path('adduser', required=True)
+        remove_cmd_bin = self.module.get_bin_path('delgroup', required=True)
 
         # Manage group membership
         if self.groups is not None and len(self.groups):
@@ -3080,7 +3080,7 @@ class BusyBox(User):
 
         # Manage password
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:
-            cmd = [self.module.get_bin_path('chpasswd', True)]
+            cmd = [self.module.get_bin_path('chpasswd', required=True)]
             cmd.append('--encrypted')
             data = '{name}:{password}'.format(name=self.name, password=self.password)
             rc, out, err = self.execute_command(cmd, data=data)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1884,7 +1884,7 @@ class NetBSDUser(User):
         return self.execute_command(cmd)
 
     def modify_user(self):
-        cmd = [self.module.get_bin_path('usermod',required= True)]
+        cmd = [self.module.get_bin_path('usermod', required=True)]
         info = self.user_info()
 
         if self.uid is not None and info[2] != int(self.uid):

--- a/test/support/integration/plugins/modules/pkgng.py
+++ b/test/support/integration/plugins/modules/pkgng.py
@@ -356,7 +356,7 @@ def main():
         supports_check_mode=True,
         mutually_exclusive=[["rootdir", "chroot", "jail"]])
 
-    pkgng_path = module.get_bin_path('pkg', True)
+    pkgng_path = module.get_bin_path('pkg', required=True)
 
     p = module.params
 


### PR DESCRIPTION
##### SUMMARY

* get_bin_path core API had a deprecated parameter `required=True`
  removing this parameter.
* no change in get_bin_path API which is provided by module_utils

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


