### PR TITLE
Properly template tags in parent blocks

### DIFF
--- a/changelogs/fragments/81053-templated-tags-inheritance.yml
+++ b/changelogs/fragments/81053-templated-tags-inheritance.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Properly template tags in parent blocks (https://github.com/ansible/ansible/issues/81053)

--- a/lib/ansible/playbook/taggable.py
+++ b/lib/ansible/playbook/taggable.py
@@ -23,6 +23,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils.six import string_types
 from ansible.playbook.attribute import FieldAttribute
 from ansible.template import Templar
+from ansible.utils.sentinel import Sentinel
 
 
 def _flatten_tags(tags: list) -> list:
@@ -55,8 +56,8 @@ class Taggable:
             templar = Templar(loader=self._loader, variables=all_vars)
             obj = self
             while obj is not None:
-                if hasattr(obj, "_tags"):
-                    obj._tags = _flatten_tags(templar.template(obj._tags))
+                if (_tags := getattr(obj, "_tags", Sentinel)) is not Sentinel:
+                    obj._tags = _flatten_tags(templar.template(_tags))
                 obj = obj._parent
             tags = set(self.tags)
         else:

--- a/test/integration/targets/tags/runme.sh
+++ b/test/integration/targets/tags/runme.sh
@@ -73,3 +73,12 @@ ansible-playbook -i ../../inventory ansible_run_tags.yml -e expect=list --tags t
 ansible-playbook -i ../../inventory ansible_run_tags.yml -e expect=untagged --tags untagged "$@"
 ansible-playbook -i ../../inventory ansible_run_tags.yml -e expect=untagged_list --tags untagged,tag3 "$@"
 ansible-playbook -i ../../inventory ansible_run_tags.yml -e expect=tagged --tags tagged "$@"
+
+ansible-playbook test_template_parent_tags.yml "$@" 2>&1 | tee out.txt
+[ "$(grep out.txt -ce 'Tagged_task')" = "1" ]; rm out.txt
+
+ansible-playbook test_template_parent_tags.yml --tags tag1 "$@" 2>&1 | tee out.txt
+[ "$(grep out.txt -ce 'Tagged_task')" = "1" ]; rm out.txt
+
+ansible-playbook test_template_parent_tags.yml --skip-tags tag1 "$@" 2>&1 | tee out.txt
+[ "$(grep out.txt -ce 'Tagged_task')" = "0" ]; rm out.txt

--- a/test/integration/targets/tags/test_template_parent_tags.yml
+++ b/test/integration/targets/tags/test_template_parent_tags.yml
@@ -1,0 +1,10 @@
+- hosts: localhost
+  gather_facts: false
+  vars:
+    tags_in_var:
+      - tag1
+  tasks:
+    - block:
+        - name: Tagged_task
+          debug:
+      tags: "{{ tags_in_var }}"

--- a/test/units/playbook/test_taggable.py
+++ b/test/units/playbook/test_taggable.py
@@ -29,6 +29,7 @@ class TaggableTestObj(Taggable):
     def __init__(self):
         self._loader = DictDataLoader({})
         self.tags = []
+        self._parent = None
 
 
 class TestTaggable(unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY
When templating tags (which happens outside of standard `post_validate`) we need to template each object in the inheritance chain and set the templated values on those objects individually. That way when `task.tags` is called the `extend` functionality properly picks up the templated values of all parents into one flatten list.

Fixes #81053

ci_complete
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
