### PR TITLE
Avoid internal error when validating argspec

### DIFF
--- a/changelogs/fragments/81631-argspec-bugfix.yml
+++ b/changelogs/fragments/81631-argspec-bugfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "argspec validation - when an unexpected value like a number of boolean is specified for a dictionary, the validation resulted in an internal error (https://github.com/ansible/ansible/pull/81631)."

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -738,11 +738,11 @@ def _validate_sub_spec(
                 elements = parameters[param]
 
             for idx, sub_parameters in enumerate(elements):
-                no_log_values.update(set_fallbacks(sub_spec, sub_parameters))
-
                 if not isinstance(sub_parameters, dict):
                     errors.append(SubParameterTypeError("value of '%s' must be of type dict or list of dicts" % param))
                     continue
+
+                no_log_values.update(set_fallbacks(sub_spec, sub_parameters))
 
                 # Set prefix for warning messages
                 new_prefix = prefix + param
@@ -828,9 +828,6 @@ def env_fallback(*args, **kwargs):
 
 def set_fallbacks(argument_spec, parameters):
     no_log_values = set()
-    if not isinstance(parameters, Mapping):
-        # The wrong type is handled somewhere else
-        return no_log_values
     for param, value in argument_spec.items():
         fallback = value.get('fallback', (None,))
         fallback_strategy = fallback[0]

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -828,6 +828,9 @@ def env_fallback(*args, **kwargs):
 
 def set_fallbacks(argument_spec, parameters):
     no_log_values = set()
+    if not isinstance(parameters, Mapping):
+        # The wrong type is handled somewhere else
+        return no_log_values
     for param, value in argument_spec.items():
         fallback = value.get('fallback', (None,))
         fallback_strategy = fallback[0]

--- a/test/integration/targets/argspec/roles/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/roles/argspec/tasks/main.yml
@@ -490,6 +490,13 @@
         other_alias: bar
   register: alias_warning_listdict
 
+- argspec:
+    required: value
+    required_one_of_one: value
+    apply_defaults: true
+  ignore_errors: true
+  register: regression_dict_wrong_type
+
 - assert:
     that:
       - argspec_required_fail is failed
@@ -657,3 +664,6 @@
 
       - "'Both option apply_defaults.bar and its alias apply_defaults.bar_alias2 are set.' in alias_warning_dict.warnings"
       - "'Both option required_one_of[0].other and its alias required_one_of[0].other_alias are set.' in alias_warning_listdict.warnings"
+
+      - regression_dict_wrong_type is failed
+      - regression_dict_wrong_type.msg == "Value 'True' in the sub parameter field 'apply_defaults' must be a dict, not 'bool'"

--- a/test/integration/targets/no_log/no_log_suboptions_invalid.yml
+++ b/test/integration/targets/no_log/no_log_suboptions_invalid.yml
@@ -46,3 +46,6 @@
         subopt_list:
           - subopt1: "{{ s211 }}"
           - subopt1: "{{ s212 }}"
+      when: false  # TODO FIXME: The code that should prevent 'AGROUND' ending up in the output
+                   #             has been broken for some time; its misbehavior was masked by
+                   #             the bug fixed in https://github.com/ansible/ansible/pull/81631.


### PR DESCRIPTION
##### SUMMARY
Reported in https://github.com/ansible-collections/community.docker/issues/680.

When passing a boolean or number to a parameter that expects a dictionary, there is an exception in the fallback handling since it assumes that the value is a dictionary.

Fixes this and adds a regression test.

##### ISSUE TYPE
- Bugfix Pull Request
