### PR TITLE
[stable-2.13] tarfile: Handle deprecation warning for extract and extractall (#81545)

### DIFF
--- a/changelogs/fragments/tarfile_extract_warn.yml
+++ b/changelogs/fragments/tarfile_extract_warn.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- tarfile - handle data filter deprecation warning message for extract and extractall (https://github.com/ansible/ansible/issues/80832).
+- ansible-galaxy - Enabled the ``data`` tarfile filter during role installation for Python versions that support it. A probing mechanism is used to avoid Python versions with a broken implementation.

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -24,6 +24,7 @@ __metaclass__ = type
 
 import errno
 import datetime
+import functools
 import os
 import tarfile
 import tempfile
@@ -41,6 +42,32 @@ from ansible.playbook.role.requirement import RoleRequirement
 from ansible.utils.display import Display
 
 display = Display()
+
+
+@functools.cache
+def _check_working_data_filter() -> bool:
+    """
+    Check if tarfile.data_filter implementation is working
+    for the current Python version or not
+    """
+
+    # Implemented the following code to circumvent broken implementation of data_filter
+    # in tarfile. See for more information - https://github.com/python/cpython/issues/107845
+    # deprecated: description='probing broken data filter implementation' python_version='3.11'
+    ret = False
+    if hasattr(tarfile, 'data_filter'):
+        # We explicitly check if tarfile.data_filter is broken or not
+        ti = tarfile.TarInfo('docs/README.md')
+        ti.type = tarfile.SYMTYPE
+        ti.linkname = '../README.md'
+
+        try:
+            tarfile.data_filter(ti, '/foo')
+        except tarfile.LinkOutsideDestinationError:
+            pass
+        else:
+            ret = True
+    return ret
 
 
 class GalaxyRole(object):
@@ -358,7 +385,12 @@ class GalaxyRole(object):
                                     if n_part != '..' and not n_part.startswith('~') and '$' not in n_part:
                                         n_final_parts.append(n_part)
                                 member.name = os.path.join(*n_final_parts)
-                                role_tar_file.extract(member, to_native(self.path))
+
+                                if _check_working_data_filter():
+                                    # deprecated: description='extract fallback without filter' python_version='3.11'
+                                    role_tar_file.extract(member, to_native(self.path), filter='data')  # type: ignore[call-arg]
+                                else:
+                                    role_tar_file.extract(member, to_native(self.path))
 
                         # write out the install info file for later use
                         self._write_galaxy_install_info()

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -44,7 +44,7 @@ from ansible.utils.display import Display
 display = Display()
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None)
 def _check_working_data_filter() -> bool:
     """
     Check if tarfile.data_filter implementation is working

--- a/packaging/release.py
+++ b/packaging/release.py
@@ -1342,7 +1342,11 @@ def test_sdist() -> None:
             except FileNotFoundError:
                 raise ApplicationError(f"Missing sdist: {sdist_file.relative_to(CHECKOUT_DIR)}") from None
 
-            sdist.extractall(temp_dir)
+            # deprecated: description='extractall fallback without filter' python_version='3.11'
+            if hasattr(tarfile, 'data_filter'):
+                sdist.extractall(temp_dir, filter='data')  # type: ignore[call-arg]
+            else:
+                sdist.extractall(temp_dir)
 
         pyc_glob = "*.pyc*"
         pyc_files = sorted(path.relative_to(temp_dir) for path in temp_dir.rglob(pyc_glob))

--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -152,7 +152,12 @@ def publish_collection(module, collection):
 
             # Extract the tarfile to sign the MANIFEST.json
             with tarfile.open(collection_path, mode='r') as collection_tar:
-                collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)))
+                # deprecated: description='extractall fallback without filter' python_version='3.11'
+                # Replace 'tar_filter' with 'data_filter' and 'filter=tar' with 'filter=data' once Python 3.12 is minimum requirement.
+                if hasattr(tarfile, 'tar_filter'):
+                    collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)), filter='tar')
+                else:
+                    collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)))
 
             manifest_path = os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version), 'MANIFEST.json')
             signature_path = os.path.join(module.params['signature_dir'], '%s-%s-%s-MANIFEST.json.asc' % (namespace, name, version))

--- a/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/validate_modules.py
@@ -154,7 +154,11 @@ class ValidateModulesTest(SanitySingleVersion):
                 temp_dir = process_scoped_temporary_directory(args)
 
                 with tarfile.open(path) as file:
-                    file.extractall(temp_dir)
+                    # deprecated: description='extractall fallback without filter' python_version='3.11'
+                    if hasattr(tarfile, 'data_filter'):
+                        file.extractall(temp_dir, filter='data')  # type: ignore[call-arg]
+                    else:
+                        file.extractall(temp_dir)
 
                 cmd.extend([
                     '--original-plugins', temp_dir,


### PR DESCRIPTION
* Python 3.11.4 introduces a new parameter 'filter' in extract and
extractall in tarfile. Handle deprecation warning message emitted
in Python 3.12.
* added probing mechanism in ansible-galaxy code to detect broken
data filter implementation in tarfile.

Fixes: #80832

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
Co-authored-by: Matt Clay <matt@mystile.com>
(cherry picked from commit 1cc5efa)


Co-authored-by: Abhijeet Kasurde <akasurde@redhat.com>