### PR TITLE
Fix set filters to use set operations

### DIFF
--- a/changelogs/fragments/set-filters.yml
+++ b/changelogs/fragments/set-filters.yml
@@ -3,3 +3,6 @@ bugfixes:
     Previously, list operations were performed unless the inputs were a hashable type such as ``str``, instead of a collection, such as a ``list`` or ``tuple``.
   - Set filters ``intersect``, ``difference``, ``symmetric_difference`` and ``union`` now always return a ``list``, never a ``set``.
     Previously, a ``set`` would be returned if the inputs were a hashable type such as ``str``, instead of a collection, such as a ``list`` or ``tuple``.
+minor_changes:
+  - Documentation for set filters ``intersect``, ``difference``, ``symmetric_difference`` and ``union`` now states
+    that the returned list items are in arbitrary order.

--- a/changelogs/fragments/set-filters.yml
+++ b/changelogs/fragments/set-filters.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - Set filters ``intersect``, ``difference``, ``symmetric_difference`` and ``union`` now use set operations when the given items are hashable.
+    Previously, list operations were performed unless the inputs were a hashable type such as ``str``, instead of a collection, such as a ``list`` or ``tuple``.
+  - Set filters ``intersect``, ``difference``, ``symmetric_difference`` and ``union`` now always return a ``list``, never a ``set``.
+    Previously, a ``set`` would be returned if the inputs were a hashable type such as ``str``, instead of a collection, such as a ``list`` or ``tuple``.

--- a/lib/ansible/plugins/filter/difference.yml
+++ b/lib/ansible/plugins/filter/difference.yml
@@ -5,6 +5,7 @@ DOCUMENTATION:
   short_description: the difference of one list from another
   description:
     - Provide a unique list of all the elements of the first list that do not appear in the second one.
+    - Items in the resulting list are returned in arbitrary order.
   options:
     _input:
       description: A list.

--- a/lib/ansible/plugins/filter/intersect.yml
+++ b/lib/ansible/plugins/filter/intersect.yml
@@ -5,6 +5,7 @@ DOCUMENTATION:
   short_description: intersection of lists
   description:
     - Provide a list with the common elements from other lists.
+    - Items in the resulting list are returned in arbitrary order.
   options:
     _input:
       description: A list.

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -18,14 +18,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# Make coding more python3-ish
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
+from __future__ import annotations
 
 import itertools
 import math
 
-from collections.abc import Hashable, Mapping, Iterable
+from collections.abc import Mapping, Iterable
 
 from jinja2.filters import pass_environment
 
@@ -84,27 +82,27 @@ def unique(environment, a, case_sensitive=None, attribute=None):
 
 @pass_environment
 def intersect(environment, a, b):
-    if isinstance(a, Hashable) and isinstance(b, Hashable):
-        c = set(a) & set(b)
-    else:
+    try:
+        c = list(set(a) & set(b))
+    except TypeError:
         c = unique(environment, [x for x in a if x in b], True)
     return c
 
 
 @pass_environment
 def difference(environment, a, b):
-    if isinstance(a, Hashable) and isinstance(b, Hashable):
-        c = set(a) - set(b)
-    else:
+    try:
+        c = list(set(a) - set(b))
+    except TypeError:
         c = unique(environment, [x for x in a if x not in b], True)
     return c
 
 
 @pass_environment
 def symmetric_difference(environment, a, b):
-    if isinstance(a, Hashable) and isinstance(b, Hashable):
-        c = set(a) ^ set(b)
-    else:
+    try:
+        c = list(set(a) ^ set(b))
+    except TypeError:
         isect = intersect(environment, a, b)
         c = [x for x in union(environment, a, b) if x not in isect]
     return c
@@ -112,9 +110,9 @@ def symmetric_difference(environment, a, b):
 
 @pass_environment
 def union(environment, a, b):
-    if isinstance(a, Hashable) and isinstance(b, Hashable):
-        c = set(a) | set(b)
-    else:
+    try:
+        c = list(set(a) | set(b))
+    except TypeError:
         c = unique(environment, a + b, True)
     return c
 

--- a/lib/ansible/plugins/filter/symmetric_difference.yml
+++ b/lib/ansible/plugins/filter/symmetric_difference.yml
@@ -5,6 +5,7 @@ DOCUMENTATION:
   short_description: different items from two lists
   description:
     - Provide a unique list of all the elements unique to each list.
+    - Items in the resulting list are returned in arbitrary order.
   options:
     _input:
       description: A list.

--- a/lib/ansible/plugins/filter/union.yml
+++ b/lib/ansible/plugins/filter/union.yml
@@ -5,6 +5,7 @@ DOCUMENTATION:
   short_description: union of lists
   description:
     - Provide a unique list of all the elements of two lists.
+    - Items in the resulting list are returned in arbitrary order.
   options:
     _input:
       description: A list.

--- a/test/integration/targets/filter_mathstuff/tasks/main.yml
+++ b/test/integration/targets/filter_mathstuff/tasks/main.yml
@@ -64,44 +64,44 @@
     that:
       - '[1,2,3]|intersect([4,5,6]) == []'
       - '[1,2,3]|intersect([3,4,5,6]) == [3]'
-      - '[1,2,3]|intersect([3,2,1]) == [1,2,3]'
-      - '(1,2,3)|intersect((4,5,6))|list == []'
-      - '(1,2,3)|intersect((3,4,5,6))|list == [3]'
+      - '[1,2,3]|intersect([3,2,1]) | sort == [1,2,3]'
+      - '(1,2,3)|intersect((4,5,6)) == []'
+      - '(1,2,3)|intersect((3,4,5,6)) == [3]'
       - '["a","A","b"]|intersect(["B","c","C"]) == []'
       - '["a","A","b"]|intersect(["b","B","c","C"]) == ["b"]'
-      - '["a","A","b"]|intersect(["b","A","a"]) == ["a","A","b"]'
-      - '("a","A","b")|intersect(("B","c","C"))|list == []'
-      - '("a","A","b")|intersect(("b","B","c","C"))|list == ["b"]'
+      - '["a","A","b"]|intersect(["b","A","a"]) | sort(case_sensitive=True) == ["A","a","b"]'
+      - '("a","A","b")|intersect(("B","c","C")) == []'
+      - '("a","A","b")|intersect(("b","B","c","C")) == ["b"]'
 
 - name: Verify difference
   tags: difference
   assert:
     that:
-      - '[1,2,3]|difference([4,5,6]) == [1,2,3]'
-      - '[1,2,3]|difference([3,4,5,6]) == [1,2]'
+      - '[1,2,3]|difference([4,5,6]) | sort == [1,2,3]'
+      - '[1,2,3]|difference([3,4,5,6]) | sort == [1,2]'
       - '[1,2,3]|difference([3,2,1]) == []'
-      - '(1,2,3)|difference((4,5,6))|list == [1,2,3]'
-      - '(1,2,3)|difference((3,4,5,6))|list == [1,2]'
-      - '["a","A","b"]|difference(["B","c","C"]) == ["a","A","b"]'
-      - '["a","A","b"]|difference(["b","B","c","C"]) == ["a","A"]'
+      - '(1,2,3)|difference((4,5,6)) | sort == [1,2,3]'
+      - '(1,2,3)|difference((3,4,5,6)) | sort == [1,2]'
+      - '["a","A","b"]|difference(["B","c","C"]) | sort(case_sensitive=True) == ["A","a","b"]'
+      - '["a","A","b"]|difference(["b","B","c","C"]) | sort(case_sensitive=True) == ["A","a"]'
       - '["a","A","b"]|difference(["b","A","a"]) == []'
-      - '("a","A","b")|difference(("B","c","C"))|list|sort(case_sensitive=True) == ["A","a","b"]'
-      - '("a","A","b")|difference(("b","B","c","C"))|list|sort(case_sensitive=True) == ["A","a"]'
+      - '("a","A","b")|difference(("B","c","C")) | sort(case_sensitive=True) == ["A","a","b"]'
+      - '("a","A","b")|difference(("b","B","c","C")) | sort(case_sensitive=True) == ["A","a"]'
 
 - name: Verify symmetric_difference
   tags: symmetric_difference
   assert:
     that:
-      - '[1,2,3]|symmetric_difference([4,5,6]) == [1,2,3,4,5,6]'
-      - '[1,2,3]|symmetric_difference([3,4,5,6]) == [1,2,4,5,6]'
+      - '[1,2,3]|symmetric_difference([4,5,6]) | sort == [1,2,3,4,5,6]'
+      - '[1,2,3]|symmetric_difference([3,4,5,6]) | sort == [1,2,4,5,6]'
       - '[1,2,3]|symmetric_difference([3,2,1]) == []'
-      - '(1,2,3)|symmetric_difference((4,5,6))|list == [1,2,3,4,5,6]'
-      - '(1,2,3)|symmetric_difference((3,4,5,6))|list == [1,2,4,5,6]'
-      - '["a","A","b"]|symmetric_difference(["B","c","C"]) == ["a","A","b","B","c","C"]'
-      - '["a","A","b"]|symmetric_difference(["b","B","c","C"]) == ["a","A","B","c","C"]'
+      - '(1,2,3)|symmetric_difference((4,5,6)) | sort == [1,2,3,4,5,6]'
+      - '(1,2,3)|symmetric_difference((3,4,5,6)) | sort == [1,2,4,5,6]'
+      - '["a","A","b"]|symmetric_difference(["B","c","C"]) | sort(case_sensitive=True) == ["A","B","C","a","b","c"]'
+      - '["a","A","b"]|symmetric_difference(["b","B","c","C"]) | sort(case_sensitive=True) == ["A","B","C","a","c"]'
       - '["a","A","b"]|symmetric_difference(["b","A","a"]) == []'
-      - '("a","A","b")|symmetric_difference(("B","c","C"))|list|sort(case_sensitive=True) == ["A","B","C","a","b","c"]'
-      - '("a","A","b")|symmetric_difference(("b","B","c","C"))|list|sort(case_sensitive=True) == ["A","B","C","a","c"]'
+      - '("a","A","b")|symmetric_difference(("B","c","C")) | sort(case_sensitive=True) == ["A","B","C","a","b","c"]'
+      - '("a","A","b")|symmetric_difference(("b","B","c","C")) | sort(case_sensitive=True) == ["A","B","C","a","c"]'
 
 - name: Verify union
   tags: union
@@ -112,11 +112,11 @@
       - '[1,2,3]|union([3,2,1]) == [1,2,3]'
       - '(1,2,3)|union((4,5,6))|list == [1,2,3,4,5,6]'
       - '(1,2,3)|union((3,4,5,6))|list == [1,2,3,4,5,6]'
-      - '["a","A","b"]|union(["B","c","C"]) == ["a","A","b","B","c","C"]'
-      - '["a","A","b"]|union(["b","B","c","C"]) == ["a","A","b","B","c","C"]'
-      - '["a","A","b"]|union(["b","A","a"]) == ["a","A","b"]'
-      - '("a","A","b")|union(("B","c","C"))|list|sort(case_sensitive=True) == ["A","B","C","a","b","c"]'
-      - '("a","A","b")|union(("b","B","c","C"))|list|sort(case_sensitive=True) == ["A","B","C","a","b","c"]'
+      - '["a","A","b"]|union(["B","c","C"]) | sort(case_sensitive=True) == ["A","B","C","a","b","c"]'
+      - '["a","A","b"]|union(["b","B","c","C"]) | sort(case_sensitive=True) == ["A","B","C","a","b","c"]'
+      - '["a","A","b"]|union(["b","A","a"]) | sort(case_sensitive=True) == ["A","a","b"]'
+      - '("a","A","b")|union(("B","c","C")) | sort(case_sensitive=True) == ["A","B","C","a","b","c"]'
+      - '("a","A","b")|union(("b","B","c","C")) | sort(case_sensitive=True) == ["A","B","C","a","b","c"]'
 
 - name: Verify min
   tags: min


### PR DESCRIPTION
##### SUMMARY

  - Set filters ``intersect``, ``difference``, ``symmetric_difference`` and ``union`` now use set operations when the given items are hashable. Previously, list operations were performed unless the inputs were a hashable type such as ``str``, instead of a collection, such as a ``list`` or ``tuple``.
  - Set filters ``intersect``, ``difference``, ``symmetric_difference`` and ``union`` now always return a ``list``, never a ``set``. Previously, a ``set`` would be returned if the inputs were a hashable type such as ``str``, instead of a collection, such as a ``list`` or ``tuple``.

##### ISSUE TYPE

Bugfix Pull Request
