### PR TITLE
Lazy load Templar for [changed,failed]_when

### DIFF
--- a/changelogs/fragments/basestrategy-lazy-templar.yml
+++ b/changelogs/fragments/basestrategy-lazy-templar.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "``StrategyBase._process_pending_results`` - create a ``Templar`` on demand for templating ``changed_when``/``failed_when``."

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -571,10 +571,7 @@ class StrategyBase:
         Reads results off the final queue and takes appropriate action
         based on the result (executing callbacks, updating state, etc.).
         '''
-
         ret_results = []
-        handler_templar = Templar(self._loader)
-
         cur_pass = 0
         while True:
             try:
@@ -702,7 +699,7 @@ class StrategyBase:
                         else:
                             all_task_vars = found_task_vars
                         all_task_vars[original_task.register] = wrap_var(result_item)
-                        post_process_whens(result_item, original_task, handler_templar, all_task_vars)
+                        post_process_whens(result_item, original_task, Templar(self._loader), all_task_vars)
                         if original_task.loop or original_task.loop_with:
                             new_item_result = TaskResult(
                                 task_result._host,


### PR DESCRIPTION
##### SUMMARY
The `handler_templar` in `StrategyBase._process_pending_results` was used for templating handler names which is no longer the case. Now it is only used for templating `changed_when`/`failed_when`. To prevent re-creating templars each time results are processed, just create it on-demand when whens are processed.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
