### PR TITLE
Make `Currently supported...` and `Does nothing...` lines consistent

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -223,10 +223,9 @@ options:
     profile:
         description:
             - Sets the profile of the user.
-            - Does nothing when used with other platforms.
             - Can set multiple profiles using comma separation.
             - To delete all the profiles, use O(profile='').
-            - Currently supported on Illumos/Solaris.
+            - Currently supported on Illumos/Solaris. Does nothing when used with other platforms.
         type: str
         version_added: "2.8"
     authorization:
@@ -240,10 +239,9 @@ options:
     role:
         description:
             - Sets the role of the user.
-            - Does nothing when used with other platforms.
             - Can set multiple roles using comma separation.
             - To delete all roles, use O(role='').
-            - Currently supported on Illumos/Solaris.
+            - Currently supported on Illumos/Solaris. Does nothing when used with other platforms.
         type: str
         version_added: "2.8"
     password_expire_max:
@@ -267,8 +265,7 @@ options:
     umask:
         description:
             - Sets the umask of the user.
-            - Does nothing when used with other platforms.
-            - Currently supported on Linux.
+            - Currently supported on Linux. Does nothing when used with other platforms.
             - Requires O(local) is omitted or V(False).
         type: str
         version_added: "2.12"


### PR DESCRIPTION
##### SUMMARY

The phrase `Does nothing when used with other platforms.` sometimes appears before the supported platforms. 
Combine this phrase with the supported platform line to be consistent with line 236:
https://github.com/ansible/ansible/blob/6a47149fbf71ec8abe2d76e9102806b6217cc4d3/lib/ansible/modules/user.py#L236

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

I was reading the documentation on `ansible.builtin.user` and while reading some descriptions noticed that "other platforms" was referenced before the supported platform.
