### PR TITLE
Corrected a typo In options list

### DIFF
--- a/lib/ansible/plugins/filter/extract.yml
+++ b/lib/ansible/plugins/filter/extract.yml
@@ -12,7 +12,7 @@ DOCUMENTATION:
       description: Index or key to extract.
       type: raw
       required: true
-    contianer:
+    container:
       description: Dictionary or list from which to extract a value.
       type: raw
       required: true


### PR DESCRIPTION
##### SUMMARY

This corrects a spelling mistake in the "ansible.builtin.extract" filter documentation page.

The word "container" in the options list was spelled "contianer".

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

