### PR TITLE
Replace ConfigParser.readfp() with read_file()

### DIFF
--- a/changelogs/fragments/81656-cf_readfp-deprecated.yml
+++ b/changelogs/fragments/81656-cf_readfp-deprecated.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Replace uses of ``configparser.ConfigParser.readfp()`` which was removed in Python 3.12 with ``configparser.ConfigParser.read_file()`` (https://github.com/ansible/ansible/issues/81656)

--- a/lib/ansible/module_utils/facts/system/local.py
+++ b/lib/ansible/module_utils/facts/system/local.py
@@ -91,7 +91,7 @@ class LocalFactCollector(BaseFactCollector):
                 # if that fails read it with ConfigParser
                 cp = configparser.ConfigParser()
                 try:
-                    cp.readfp(StringIO(out))
+                    cp.read_file(StringIO(out))
                 except configparser.Error:
                     fact = "error loading facts as JSON or ini - please check content: %s" % fn
                     module.warn(fact)

--- a/lib/ansible/module_utils/facts/system/local.py
+++ b/lib/ansible/module_utils/facts/system/local.py
@@ -91,7 +91,11 @@ class LocalFactCollector(BaseFactCollector):
                 # if that fails read it with ConfigParser
                 cp = configparser.ConfigParser()
                 try:
-                    cp.read_file(StringIO(out))
+                    try:
+                        cp.read_file(StringIO(out))
+                    except AttributeError:
+                        # Python 2
+                        cp.readfp(StringIO(out))
                 except configparser.Error:
                     fact = "error loading facts as JSON or ini - please check content: %s" % fn
                     module.warn(fact)

--- a/lib/ansible/module_utils/facts/system/local.py
+++ b/lib/ansible/module_utils/facts/system/local.py
@@ -26,6 +26,7 @@ import ansible.module_utils.compat.typing as t
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.facts.utils import get_file_content
 from ansible.module_utils.facts.collector import BaseFactCollector
+from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import configparser, StringIO
 
 
@@ -91,10 +92,9 @@ class LocalFactCollector(BaseFactCollector):
                 # if that fails read it with ConfigParser
                 cp = configparser.ConfigParser()
                 try:
-                    try:
+                    if PY3:
                         cp.read_file(StringIO(out))
-                    except AttributeError:
-                        # Python 2
+                    else:
                         cp.readfp(StringIO(out))
                 except configparser.Error:
                     fact = "error loading facts as JSON or ini - please check content: %s" % fn

--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -190,7 +190,7 @@ class LookupModule(LookupBase):
             config.seek(0, os.SEEK_SET)
 
             try:
-                self.cp.readfp(config)
+                self.cp.read_file(config)
             except configparser.DuplicateOptionError as doe:
                 raise AnsibleLookupError("Duplicate option in '{file}': {error}".format(file=paramvals['file'], error=to_native(doe)))
 


### PR DESCRIPTION
##### SUMMARY
[readfp](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.readfp) was removed in Python 3.12.

Fixes #81656
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request