### PR TITLE
ansible-vault: Check if the destination is writable

### DIFF
--- a/changelogs/fragments/ansible-vault.yml
+++ b/changelogs/fragments/ansible-vault.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- ansible-vault - fail when the destination file location is not writable before performing encryption (https://github.com/ansible/ansible/issues/81455).

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -1044,10 +1044,10 @@ class VaultEditor:
         since in the plaintext case, the original contents can be of any text encoding
         or arbitrary binary data.
 
-        When used to write the result of vault encryption, the val of the 'data' arg
-        should be a utf-8 encoded byte string and not a text typ and not a text type..
+        When used to write the result of vault encryption, the value of the 'data' arg
+        should be a utf-8 encoded byte string and not a text type.
 
-        When used to write the result of vault decryption, the val of the 'data' arg
+        When used to write the result of vault decryption, the value of the 'data' arg
         should be a byte string and not a text type.
 
         :arg data: the byte string (bytes) data
@@ -1077,6 +1077,8 @@ class VaultEditor:
             output = getattr(sys.stdout, 'buffer', sys.stdout)
             output.write(b_file_data)
         else:
+            if not os.access(os.path.dirname(thefile), os.W_OK):
+                raise AnsibleError("Destination '%s' not writable" % (os.path.dirname(thefile)))
             # file names are insecure and prone to race conditions, so remove and create securely
             if os.path.isfile(thefile):
                 if shred:

--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -47,6 +47,18 @@ echo $?
 # view the vault encrypted password file
 ansible-vault view "$@" --vault-id vault-password encrypted-vault-password
 
+# check if ansible-vault fails when destination is not writable
+NOT_WRITABLE_DIR="${MYTMPDIR}/not_writable"
+TEST_FILE_EDIT4="${NOT_WRITABLE_DIR}/testfile"
+mkdir "${NOT_WRITABLE_DIR}"
+touch "${TEST_FILE_EDIT4}"
+chmod ugo-w "${NOT_WRITABLE_DIR}"
+ansible-vault encrypt "$@" --vault-password-file vault-password "${TEST_FILE_EDIT4}" < /dev/null > log 2>&1 && :
+grep "not writable" log && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (1 is expected)"
+[ $WRONG_RC -eq 1 ]
+
 # encrypt with a password from a vault encrypted password file and multiple vault-ids
 # should fail because we dont know which vault id to use to encrypt with
 ansible-vault encrypt "$@" --vault-id vault-password --vault-id encrypted-vault-password "${TEST_FILE_ENC_PASSWORD}" && :


### PR DESCRIPTION
##### SUMMARY

* Before performing shredding the original file, check if the
  destination file location is writable or not. This will
  prevent corruption of original file.

Fixes: #81455

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


