### PR TITLE
Make sure that all no_log parameters are processed even if some arguments have values of the wrong type

### DIFF
--- a/changelogs/fragments/81762-no_log.yml
+++ b/changelogs/fragments/81762-no_log.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - argument spec validation - make sure that all ``no_log`` parameters are processed even if some arguments have values of the wrong type (https://github.com/ansible/ansible/pull/81672).

--- a/lib/ansible/module_utils/common/arg_spec.py
+++ b/lib/ansible/module_utils/common/arg_spec.py
@@ -201,10 +201,10 @@ class ArgumentSpecValidator:
                 'collection_name': deprecation.get('collection_name'),
             })
 
-        try:
-            result._no_log_values.update(_list_no_log_values(self.argument_spec, result._validated_parameters))
-        except TypeError as te:
-            result.errors.append(NoLogError(to_native(te)))
+        no_log_introspection_errors = []
+        result._no_log_values.update(_list_no_log_values(self.argument_spec, result._validated_parameters, no_log_introspection_errors))
+        for error in no_log_introspection_errors:
+            result.errors.append(NoLogError(error))
 
         try:
             result._deprecations.extend(_list_deprecations(self.argument_spec, result._validated_parameters))

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -300,7 +300,7 @@ def _list_deprecations(argument_spec, parameters, prefix=''):
     return deprecations
 
 
-def _list_no_log_values(argument_spec, params):
+def _list_no_log_values(argument_spec, params, errors=None):
     """Return set of no log values
 
     :arg argument_spec: An argument spec dictionary
@@ -319,7 +319,11 @@ def _list_no_log_values(argument_spec, params):
                 try:
                     no_log_values.update(_return_datastructure_name(no_log_object))
                 except TypeError as e:
-                    raise TypeError('Failed to convert "%s": %s' % (arg_name, to_native(e)))
+                    message = 'Failed to convert "%s": %s' % (arg_name, to_native(e))
+                    if errors is not None:
+                        errors.append(message)
+                        continue
+                    raise TypeError(message)
 
         # Get no_log values from suboptions
         sub_argument_spec = arg_opts.get('options')
@@ -337,11 +341,21 @@ def _list_no_log_values(argument_spec, params):
                         # Validate dict fields in case they came in as strings
 
                         if isinstance(sub_param, str):
-                            sub_param = check_type_dict(sub_param)
+                            try:
+                                sub_param = check_type_dict(sub_param)
+                            except TypeError as e:
+                                if errors is not None:
+                                    errors.append(to_native(e))
+                                    continue
+                                raise
 
                         if not isinstance(sub_param, Mapping):
-                            raise TypeError("Value '{1}' in the sub parameter field '{0}' must be a {2}, "
-                                            "not '{1.__class__.__name__}'".format(arg_name, sub_param, wanted_type))
+                            message = ("Value '{1}' in the sub parameter field '{0}' must be a {2}, "
+                                       "not '{1.__class__.__name__}'".format(arg_name, sub_param, wanted_type))
+                            if errors is not None:
+                                errors.append(message)
+                                continue
+                            raise TypeError(message)
 
                         no_log_values.update(_list_no_log_values(sub_argument_spec, sub_param))
 


### PR DESCRIPTION
##### SUMMARY
Currently the `no_log` value processing terminates prematurely if values that should be dictionaries or lists of dictionaries have the wrong type. This can cause values passed to `no_log` parameters to show up in logs. The reason why that doesn't happen right now is another bug which makes argspec validation crash in that case later on (that bug is fixed in #81631). See the discussion in #81631 for details.

The patch was provided by @s-hertel in https://github.com/ansible/ansible/pull/81631#discussion_r1320421918, I added a changelog fragment and refactored the code slightly to remove code duplication.

##### ISSUE TYPE
- Bugfix Pull Request
