### PR TITLE
env-setup.fish: Correct syntax errors

### DIFF
--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -23,16 +23,16 @@ set -gx PREFIX_MANPATH $ANSIBLE_HOME/docs/man
 # Set PYTHONPATH
 if not set -q PYTHONPATH
     set -gx PYTHONPATH $PREFIX_PYTHONPATH
-else if not string match -qr "$PREFIX_PYTHONPATH($|:)" $PYTHONPATH
-    if not $QUIET
+else if not string match -qr $PREFIX_PYTHONPATH'($|:)' $PYTHONPATH
+    if not test -n "$QUIET"
         echo "Appending PYTHONPATH"
     end
     set -gx PYTHONPATH "$PREFIX_PYTHONPATH:$PYTHONPATH"
 end
 
 # Set ansible_test PYTHONPATH
-if not string match -qr "$ANSIBLE_TEST_PREFIX_PYTHONPATH($|:)" $PYTHONPATH
-    if not $QUIET
+if not string match -qr $ANSIBLE_TEST_PREFIX_PYTHONPATH'($|:)' $PYTHONPATH
+    if not test -n "$QUIET"
         echo "Appending PYTHONPATH"
     end
     set -gx PYTHONPATH "$ANSIBLE_TEST_PREFIX_PYTHONPATH:$PYTHONPATH"
@@ -46,7 +46,7 @@ end
 # Set MANPATH
 if not set -q MANPATH
     set -gx MANPATH $PREFIX_MANPATH
-else if not string match -qr "$PREFIX_MANPATH($|:)" $MANPATH
+else if not string match -qr $PREFIX_MANPATH'($|:)' $MANPATH
     set -gx MANPATH "$PREFIX_MANPATH:$MANPATH"
 end
 
@@ -71,11 +71,11 @@ function gen_egg_info
         rm -rf $PREFIX_PYTHONPATH/ansible*.egg-info
     end
     # Execute setup.py egg_info using the chosen Python interpreter
-    (eval $PYTHON_BIN setup.py egg_info)
+    eval $PYTHON_BIN setup.py egg_info
 end
 
 pushd $ANSIBLE_HOME
-if $QUIET
+if test -n "$QUIET"
     # Run gen_egg_info in the background and redirect output to /dev/null
     gen_egg_info &> /dev/null
     # Remove any .pyc files found


### PR DESCRIPTION
##### SUMMARY
Fix a few errors introduced in #81208 as well as some longer standing bugs.

- Single quote regular expression values to avoid shell expansion
- Properly test if the `$QUIET` variable is set and non-zero

I know `pip -e .` is _way_ better, but I just wanted this to keep working until it is nuked forever.
##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Testing variables in `fish` is [a bit nuanced](https://stackoverflow.com/a/47743269).

Existing output showing syntax errors:
```
> source ./hacking/env-setup.fish
./hacking/env-setup.fish (line 26): $| is not a valid variable in fish.
else if not string match -qr "$PREFIX_PYTHONPATH($|:)" $PYTHONPATH
```

```
> source ./hacking/env-setup.fish
./hacking/env-setup.fish (line 74): command substitutions not allowed here
    (eval $PYTHON_BIN setup.py egg_info)
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
```
