### PR TITLE
copy: print correct dest path when content + diff is used

### DIFF
--- a/changelogs/fragments/copy_diff.yml
+++ b/changelogs/fragments/copy_diff.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- copy - print correct destination filename when using `content` and `--diff` (https://github.com/ansible/ansible/issues/79749).

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1340,7 +1340,7 @@ class ActionBase(ABC):
         display.debug(u"_low_level_execute_command() done: rc=%d, stdout=%s, stderr=%s" % (rc, out, err))
         return dict(rc=rc, stdout=out, stdout_lines=out.splitlines(), stderr=err, stderr_lines=err.splitlines())
 
-    def _get_diff_data(self, destination, source, task_vars, source_file=True):
+    def _get_diff_data(self, destination, source, task_vars, content, source_file=True):
 
         # Note: Since we do not diff the source and destination before we transform from bytes into
         # text the diff between source and destination may not be accurate.  To fix this, we'd need
@@ -1398,7 +1398,10 @@ class ActionBase(ABC):
                     if b"\x00" in src_contents:
                         diff['src_binary'] = 1
                     else:
-                        diff['after_header'] = source
+                        if content:
+                            diff['after_header'] = destination
+                        else:
+                            diff['after_header'] = source
                         diff['after'] = to_text(src_contents)
             else:
                 display.debug(u"source of file passed in")

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -286,7 +286,7 @@ class ActionModule(ActionBase):
             # The checksums don't match and we will change or error out.
 
             if self._play_context.diff and not raw:
-                result['diff'].append(self._get_diff_data(dest_file, source_full, task_vars))
+                result['diff'].append(self._get_diff_data(dest_file, source_full, task_vars, content))
 
             if self._play_context.check_mode:
                 self._remove_tempfile_if_content_defined(content, content_tempfile)

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -84,6 +84,7 @@
     - import_tasks: check_mode.yml
 
     # https://github.com/ansible/ansible/issues/57618
+    # https://github.com/ansible/ansible/issues/79749
     - name: Test diff contents
       copy:
         content: 'Ansible managed\n'
@@ -95,6 +96,7 @@
         that:
           - 'diff_output.diff[0].before == ""'
           - '"Ansible managed" in diff_output.diff[0].after'
+          - '"file.txt" in diff_output.diff[0].after_header'
 
     - name: tests with remote_src and non files
       import_tasks: src_remote_file_is_not_file.yml


### PR DESCRIPTION
##### SUMMARY

* when --diff is used with content parameter, print destination
  path instead of temporary file path.

Fixes: #79749

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


