### PR TITLE
ansible-galaxy-collection - fix config permissions for galaxy-importer

### DIFF
--- a/test/lib/ansible_test/_internal/commands/integration/cloud/galaxy.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/galaxy.py
@@ -144,6 +144,7 @@ class GalaxyProvider(CloudProvider):
                 display.info(f'>>> {friendly_name} Configuration\n{to_text(content)}', verbosity=3)
                 docker_exec(self.args, descriptor.container_id, ['mkdir', '-p', os.path.dirname(path)], True)
                 docker_cp_to(self.args, descriptor.container_id, temp_fd.name, path)
+                docker_exec(self.args, descriptor.container_id, ['chmod', '644', path], True)
 
         self._set_cloud_config('PULP_HOST', GALAXY_HOST_NAME)
         self._set_cloud_config('PULP_USER', 'admin')

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/galaxy.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/galaxy.py
@@ -144,7 +144,7 @@ class GalaxyProvider(CloudProvider):
                 display.info(f'>>> {friendly_name} Configuration\n{to_text(content)}', verbosity=3)
                 docker_exec(self.args, descriptor.container_id, ['mkdir', '-p', os.path.dirname(path)], True)
                 docker_cp_to(self.args, descriptor.container_id, temp_fd.name, path)
-                docker_exec(self.args, descriptor.container_id, ['chmod', '644', path], True)
+                docker_exec(self.args, descriptor.container_id, ['chown', 'pulp:pulp', path], True)
 
         self._set_cloud_config('PULP_HOST', GALAXY_HOST_NAME)
         self._set_cloud_config('PULP_USER', 'admin')


### PR DESCRIPTION
##### SUMMARY

These settings https://github.com/ansible/ansible/blob/devel/test/lib/ansible_test/_internal/commands/integration/cloud/galaxy.py#L72-L87 are ignored due to a permissions issue. Only root had read/write.

##### ISSUE TYPE

- Test Pull Request
