### PR TITLE
ansible-galaxy - skip excluding virtual when determining what requirements are already installed

### DIFF
--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -695,7 +695,7 @@ def install_collections(
         req
         for req in unsatisfied_requirements
         for exs in existing_collections
-        if req.fqcn == exs.fqcn and meets_requirements(exs.ver, req.ver)
+        if req.fqcn == exs.fqcn and not req.is_virtual and meets_requirements(exs.ver, req.ver)
     }
 
     if not unsatisfied_requirements and not upgrade:

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -695,7 +695,7 @@ def install_collections(
         req
         for req in unsatisfied_requirements
         for exs in existing_collections
-        if req.fqcn == exs.fqcn and not req.is_virtual and meets_requirements(exs.ver, req.ver)
+        if req.fqcn == exs.fqcn and meets_requirements(exs.ver, req.ver)
     }
 
     if not unsatisfied_requirements and not upgrade:

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -397,7 +397,6 @@ class _ComputedReqKindsMixin:
                 req_type = 'dir'
                 req_source = src_path
             elif _is_collection_namespace_dir(src_path):
-                req_name = None  # No name for a virtual req or "namespace."?
                 req_type = 'subdirs'
                 req_source = src_path
             else:
@@ -441,6 +440,12 @@ class _ComputedReqKindsMixin:
 
         if req_type not in {'galaxy', 'subdirs'} and req_name is None:
             req_name = art_mgr.get_direct_collection_fqcn(tmp_inst_req)  # TODO: fix the cache key in artifacts manager?
+        elif req_type != 'galaxy' and req_source is not None and req_name is not None:
+            display.warning(
+                f"A collection name and source were provided for the requirement {collection_req}, "
+                "but only the source will determine the installed collection name."
+            )
+            req_name = None
 
         if req_type not in {'galaxy', 'subdirs'} and req_version == '*':
             req_version = art_mgr.get_direct_collection_version(tmp_inst_req)

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/reinstalling.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/reinstalling.yml
@@ -2,11 +2,30 @@
   command: 'ansible-galaxy collection install git+file://{{ test_repo_path }}/.git#/collection_1/'
   register: installed
 
+# https://github.com/ansible/ansible/issues/81687
+- name: Create a requirements file
+  copy:
+    dest: "{{ galaxy_dir }}/test_requirements.yml"
+    content: |
+      collections:
+        - name: ansible_test.collection_1
+          source: git+file://{{ test_repo_path }}/.git#/collection_1/
+          type: git
+          # the bug: shouldn't compare this value against non-virtual collections
+          version: HEAD
+
+- name: Rerun installing a collection with a dep using a requirements file
+  command: 'ansible-galaxy collection install -r {{ galaxy_dir }}/test_requirements.yml'
+  register: installed_again
+
 - name: SCM collections don't have a concrete artifact version so the collection should always be reinstalled
   assert:
     that:
-      - "'Created collection for ansible_test.collection_1' in installed.stdout"
-      - "'Created collection for ansible_test.collection_2' in installed.stdout"
+      - "'Created collection for ansible_test.collection_1' in item.stdout"
+      - "'Created collection for ansible_test.collection_2' in item.stdout"
+  loop:
+    - "{{ installed }}"
+    - "{{ installed_again }}"
 
 - name: The collection should also be reinstalled when --force flag is used
   command: 'ansible-galaxy collection install git+file://{{ test_repo_path }}/.git#/collection_1/ --force'
@@ -29,3 +48,8 @@
 
 - include_tasks: ./empty_installed_collections.yml
   when: cleanup
+
+- name: Remove requirements file
+  file:
+    path: "{{ galaxy_dir }}/test_requirements.yml"
+    state: absent


### PR DESCRIPTION
##### SUMMARY

Fix normalizing the fields in a requirements file (and give a warning) when `name` is provided with a `source` for a non-galaxy type requirement.

It would probably be better if the warning is only given if the name conflicts with the source, but we don't have the real name at this point.

Alternatively, we could just ignore `name` by excluding virtual collections here https://github.com/ansible/ansible/commit/a30b99487a4437923eb10855f0ae56616fb6a5d9.

Fixes #81687

cc @webknjaz, do you have a preferred approach?

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
