### PR TITLE
Implement a debugging reporter for collection dependency resolver

### DIFF
--- a/changelogs/fragments/81693-ansible-galaxy-depresolver-verbose-reporter.yml
+++ b/changelogs/fragments/81693-ansible-galaxy-depresolver-verbose-reporter.yml
@@ -1,0 +1,8 @@
+---
+
+bugfixes:
+- >-
+  ansible-galaxy - the dependency resolution steps are now very detailed
+  when collections installation is running under debug mode.
+
+...

--- a/lib/ansible/galaxy/dependency_resolution/__init__.py
+++ b/lib/ansible/galaxy/dependency_resolution/__init__.py
@@ -14,9 +14,13 @@ if t.TYPE_CHECKING:
     )
     from ansible.galaxy.dependency_resolution.dataclasses import Candidate
 
+from ansible import constants as C
 from ansible.galaxy.collection.galaxy_api_proxy import MultiGalaxyAPIProxy
 from ansible.galaxy.dependency_resolution.providers import CollectionDependencyProvider
 from ansible.galaxy.dependency_resolution.reporters import CollectionDependencyReporter
+from ansible.galaxy.dependency_resolution.reporters import CollectionDependencyDebuggingReporter
+from ansible.galaxy.dependency_resolution.reporters import CollectionDependencyReporter
+
 from ansible.galaxy.dependency_resolution.resolvers import CollectionDependencyResolver
 
 
@@ -45,5 +49,6 @@ def build_collection_dependency_resolver(
             upgrade=upgrade,
             include_signatures=include_signatures,
         ),
-        CollectionDependencyReporter(),
+        CollectionDependencyDebuggingReporter() if C.DEFAULT_DEBUG
+        else CollectionDependencyReporter(),
     )

--- a/lib/ansible/galaxy/dependency_resolution/reporters.py
+++ b/lib/ansible/galaxy/dependency_resolution/reporters.py
@@ -19,6 +19,12 @@ except ImportError:
     class Criterion:  # type: ignore[no-redef]
         pass
 
+try:
+    from resolvelib.structs import State
+except ImportError:
+    class State:  # type: ignore[no-redef]
+        pass
+
 from ansible.utils.display import Display
 from .dataclasses import Candidate, Requirement
 
@@ -99,3 +105,49 @@ class CollectionDependencyReporter(BaseReporter):
     def backtracking(self, candidate: Candidate) -> None:  # resolvelib < 0.9.0
         """Print out rejection messages on pre-defined limit hits."""
         self._maybe_log_rejection_message(candidate)
+
+
+class CollectionDependencyDebuggingReporter(CollectionDependencyReporter):
+    """A reporter that does an info log for every event it sees."""
+
+    def starting(self) -> None:
+        display.display('Reporter.starting()')
+
+    def starting_round(self, index: int) -> None:
+        display.display(f'Reporter.starting_round({index !r})')
+
+    def ending_round(
+            self,
+            index: int,
+            state: State[Requirement, Candidate, str],
+    ) -> None:
+        display.display(f'Reporter.ending_round({index !r}, {state !r})')
+
+    def ending(self, state: State[Requirement, Candidate, str]) -> None:
+        display.display(f'Reporter.ending({state !r})')
+
+    def adding_requirement(
+            self,
+            requirement: Requirement,
+            parent: Candidate,
+    ) -> None:
+        display.display(
+            f'Reporter.adding_requirement({requirement !r}, {parent !r})',
+        )
+
+    def rejecting_candidate(  # resolvelib >= 0.9.0
+            self,
+            criterion: Criterion[Candidate, Requirement],
+            candidate: Candidate,
+    ) -> None:
+        display.display(
+            f'Reporter.rejecting_candidate({criterion !r}, {candidate !r})',
+        )
+        return super().rejecting_candidate(criterion, candidate)
+
+    def backtracking(self, candidate: Candidate) -> None:  # resolvelib < 0.9.0
+        display.display(f'Reporter.backtracking({candidate !r})')
+        return super().backtracking(candidate)
+
+    def pinning(self, candidate: Candidate) -> None:
+        display.display(f'Reporter.pinning({candidate !r})')


### PR DESCRIPTION
##### SUMMARY

This change adds a dependency resolution reporter for tracing the decisions resolvelib is doing.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

* https://github.com/pypa/pip/blob/6f3a718/src/pip/_internal/resolution/resolvelib/reporter.py#L58
* https://github.com/sarugaku/resolvelib/blob/69d9fee/examples/reporter_demo.py#L98
* pip has a similar resolver toggled by the `PIP_RESOLVER_DEBUG` env var: https://github.com/pypa/pip/blob/205edfe/src/pip/_internal/resolution/resolvelib/resolver.py#L87-L90. Following that example, I chose to use `ANSIBLE_DEBUG=1` as a similar toggle to infer the intent of troubleshooting the CLI.