### PR TITLE
Always stringify collection requirement versions

### DIFF
--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -309,6 +309,8 @@ class _ComputedReqKindsMixin:
     def from_requirement_dict(cls, collection_req, art_mgr, validate_signature_options=True):
         req_name = collection_req.get('name', None)
         req_version = collection_req.get('version', '*')
+        if req_version is not None:
+            req_version = str(req_version)
         req_type = collection_req.get('type')
         # TODO: decide how to deprecate the old src API behavior
         req_source = collection_req.get('source', None)


### PR DESCRIPTION
Before this change, whenever a numeric version was specified in `requirements.yml`, the YAML parser would read it as `int` or `float` which would leak straight down into the dependency resolver. This patch makes an unconditional conversion of that data into `str` right before constructing `Requirement` objects.

Fixes #79109
Fixes #78067

##### SUMMARY

$sbj.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

N/A