### PR TITLE
Fix example in strftime filter plugin help

### DIFF
--- a/lib/ansible/plugins/filter/strftime.yml
+++ b/lib/ansible/plugins/filter/strftime.yml
@@ -45,9 +45,9 @@ EXAMPLES: |
   vars:
     date1: '2022-11-15T03:23:13.686956868Z'
     date2: '2021-12-15T16:06:24.400087Z'
-    date_short: '{{ date1|regex_replace("([^.]+)(\.\d{6})(\d*)(.+)", "\1\2\4") }}' #shorten microseconds
+    date1_short: '{{ date1|regex_replace("([^.]+)(\.\d{6})(\d*)(.+)", "\1\2\4") }}' #shorten microseconds
     iso8601format: '%Y-%m-%dT%H:%M:%S.%fZ'
-    date_diff_isoed: '{{ (date1|to_datetime(isoformat) - date2|to_datetime(isoformat)).total_seconds() }}'
+    date_diff_isoed: '{{ (date1_short|to_datetime(iso8601format) - date2|to_datetime(iso8601format)).total_seconds() }}'
 
 RETURN:
   _value:

--- a/lib/ansible/plugins/filter/strftime.yml
+++ b/lib/ansible/plugins/filter/strftime.yml
@@ -41,14 +41,6 @@ EXAMPLES: |
   {{ '%Y-%m-%d' | strftime(0) }}          # => 1970-01-01
   {{ '%Y-%m-%d' | strftime(1441357287) }} # => 2015-09-04
 
-  # complex examples
-  vars:
-    date1: '2022-11-15T03:23:13.686956868Z'
-    date2: '2021-12-15T16:06:24.400087Z'
-    date1_short: '{{ date1|regex_replace("([^.]+)(\.\d{6})(\d*)(.+)", "\1\2\4") }}' #shorten microseconds
-    iso8601format: '%Y-%m-%dT%H:%M:%S.%fZ'
-    date_diff_isoed: '{{ (date1_short|to_datetime(iso8601format) - date2|to_datetime(iso8601format)).total_seconds() }}'
-
 RETURN:
   _value:
     description: A formatted date/time string.

--- a/lib/ansible/plugins/filter/to_datetime.yml
+++ b/lib/ansible/plugins/filter/to_datetime.yml
@@ -29,6 +29,16 @@ EXAMPLES: |
   # get amount of days between two dates. This returns only number of days and discards remaining hours, minutes, and seconds
   {{ (("2016-08-14 20:00:12" | to_datetime) - ("2015-12-25" | to_datetime('%Y-%m-%d'))).days  }}
 
+  # difference between to dotnet (100ns precision) and iso8601 microsecond timestamps
+  # the date1_short regex replace will work for any timestamp that has a higher than microsecond precision
+  # by cutting off anything more precise than microseconds
+  vars:
+    date1: '2022-11-15T03:23:13.6869568Z'
+    date2: '2021-12-15T16:06:24.400087Z'
+    date1_short: '{{ date1|regex_replace("([^.]+)(\.\d{6})(\d*)(.+)", "\1\2\4") }}' # shorten to microseconds
+    iso8601format: '%Y-%m-%dT%H:%M:%S.%fZ'
+    date_diff_isoed: '{{ (date1_short|to_datetime(iso8601format) - date2|to_datetime(iso8601format)).total_seconds() }}'
+
 RETURN:
   _value:
     description: C(datetime) object from the represented value.


### PR DESCRIPTION
##### SUMMARY
The example in the strftime help does not work, I fixed the references.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### ADDITIONAL INFORMATION
I am not sure why this lives in the strftime examples and not the to_datetime examples, but for now lets just get the example working