### PR TITLE
Add an example for cleaning up the async job cache

### DIFF
--- a/lib/ansible/modules/async_status.py
+++ b/lib/ansible/modules/async_status.py
@@ -24,7 +24,7 @@ options:
   mode:
     description:
     - If V(status), obtain the status.
-    - If V(cleanup), clean up the async job cache (by default in C(~/.ansible_async/)) for the specified job O(jid).
+    - If V(cleanup), clean up the async job cache (by default in C(~/.ansible_async/)) for the specified job O(jid), without waiting for it to finish.
     type: str
     choices: [ cleanup, status ]
     default: status
@@ -70,6 +70,11 @@ EXAMPLES = r'''
   until: job_result.finished
   retries: 100
   delay: 10
+
+- name: Clean up async file
+  ansible.builtin.async_status:
+    jid: '{{ yum_sleeper.ansible_job_id }}'
+    mode: cleanup
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY
Also clarify that async_status mode cleanup doesn't wait for it to complete

See #81664

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
