### PR TITLE
vars: handle exception in combine_vars

### DIFF
--- a/changelogs/fragments/81659_varswithsources.yml
+++ b/changelogs/fragments/81659_varswithsources.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- vars - handle exception while combining VarsWithSources and dict (https://github.com/ansible/ansible/issues/81659).

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -85,11 +85,15 @@ def combine_vars(a, b, merge=None):
 
     if merge or merge is None and C.DEFAULT_HASH_BEHAVIOUR == "merge":
         return merge_hash(a, b)
-    else:
-        # HASH_BEHAVIOUR == 'replace'
-        _validate_mutable_mappings(a, b)
-        result = a | b
-        return result
+
+    # HASH_BEHAVIOUR == 'replace'
+    _validate_mutable_mappings(a, b)
+    # NOTE: In the case of ANSIBLE_DEBUG=1 task_vars is VarsWithSources(MutableMapping)
+    # so '|' operator cannot be used as it can be used only on dicts
+    # https://peps.python.org/pep-0584/#what-about-mapping-and-mutablemapping
+    result = a.copy()
+    result.update(b)
+    return result
 
 
 def merge_hash(x, y, recursive=True, list_merge='replace'):

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -88,11 +88,7 @@ def combine_vars(a, b, merge=None):
 
     # HASH_BEHAVIOUR == 'replace'
     _validate_mutable_mappings(a, b)
-    # NOTE: In the case of ANSIBLE_DEBUG=1 task_vars is VarsWithSources(MutableMapping)
-    # so '|' operator cannot be used as it can be used only on dicts
-    # https://peps.python.org/pep-0584/#what-about-mapping-and-mutablemapping
-    result = a.copy()
-    result.update(b)
+    result = a | b
     return result
 
 

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -786,3 +786,21 @@ class VarsWithSources(MutableMapping):
 
     def copy(self):
         return VarsWithSources.new_vars_with_sources(self.data.copy(), self.sources.copy())
+
+    def __or__(self, other):
+        if isinstance(other, MutableMapping):
+            c = self.data.copy()
+            c.update(other)
+            return c
+        return NotImplemented
+
+    def __ror__(self, other):
+        if isinstance(other, MutableMapping):
+            c = self.data.copy()
+            c.update(other)
+            return c
+        return NotImplemented
+
+    def __ior__(self, other):
+        self.data.update(other)
+        return self.data

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -796,8 +796,9 @@ class VarsWithSources(MutableMapping):
 
     def __ror__(self, other):
         if isinstance(other, MutableMapping):
-            c = self.data.copy()
+            c = self.__class__()
             c.update(other)
+            c.update(self.data)
             return c
         return NotImplemented
 

--- a/test/units/utils/test_vars.py
+++ b/test/units/utils/test_vars.py
@@ -27,6 +27,7 @@ from unittest import mock
 from units.compat import unittest
 from ansible.errors import AnsibleError
 from ansible.utils.vars import combine_vars, merge_hash
+from ansible.vars.manager import VarsWithSources
 
 
 class TestVariableUtils(unittest.TestCase):
@@ -40,6 +41,11 @@ class TestVariableUtils(unittest.TestCase):
         dict(
             a=dict(a=1),
             b=dict(b=2),
+            result=dict(a=1, b=2),
+        ),
+        dict(
+            a=dict(a=1),
+            b=VarsWithSources().new_vars_with_sources(dict(b=2), dict(b='task vars')),
             result=dict(a=1, b=2),
         ),
         dict(
@@ -58,6 +64,11 @@ class TestVariableUtils(unittest.TestCase):
             a=dict(a=1),
             b=dict(b=2),
             result=dict(a=1, b=2)
+        ),
+        dict(
+            a=dict(a=1),
+            b=VarsWithSources().new_vars_with_sources(dict(b=2), dict(b='task vars')),
+            result=dict(a=1, b=2),
         ),
         dict(
             a=dict(a=1, c=dict(foo='bar')),


### PR DESCRIPTION
##### SUMMARY

* Handle TypeError raised when combining VarsWithSources and Dict
  in combine_vars API.

fixes: #81659

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


