### PR TITLE
support 8 character permission strings

### DIFF
--- a/changelogs/fragments/81699-zip-permission.yml
+++ b/changelogs/fragments/81699-zip-permission.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unarchive - add support for 8 character permission strings for zip archives (https://github.com/ansible/ansible/pull/81705).

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -500,7 +500,7 @@ class ZipArchive(object):
                 continue
 
             # Check first and seventh field in order to skip header/footer
-            if len(pcs[0]) != 7 and len(pcs[0]) != 10:
+            if len(pcs[0]) != 7 and len(pcs[0]) != 8 and len(pcs[0]) != 10:
                 continue
             if len(pcs[6]) != 15:
                 continue
@@ -548,6 +548,12 @@ class ZipArchive(object):
                 if path[-1] == '/':
                     permstr = 'rwxrwxrwx'
                 elif permstr == 'rwx---':
+                    permstr = 'rwxrwxrwx'
+                else:
+                    permstr = 'rw-rw-rw-'
+                file_umask = umask
+            elif len(permstr) == 7:
+                if permstr == 'rwxa---':
                     permstr = 'rwxrwxrwx'
                 else:
                     permstr = 'rw-rw-rw-'

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -500,7 +500,7 @@ class ZipArchive(object):
                 continue
 
             # Check first and seventh field in order to skip header/footer
-            if len(pcs[0]) not in (7,8,10):
+            if len(pcs[0]) not in (7, 8, 10):
                 continue
             if len(pcs[6]) != 15:
                 continue

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -500,6 +500,7 @@ class ZipArchive(object):
                 continue
 
             # Check first and seventh field in order to skip header/footer
+            # 7 or 8 are FAT, 10 is normal unix perms
             if len(pcs[0]) not in (7, 8, 10):
                 continue
             if len(pcs[6]) != 15:

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -500,7 +500,7 @@ class ZipArchive(object):
                 continue
 
             # Check first and seventh field in order to skip header/footer
-            if len(pcs[0]) != 7 and len(pcs[0]) != 8 and len(pcs[0]) != 10:
+            if len(pcs[0]) not in (7,8,10):
                 continue
             if len(pcs[6]) != 15:
                 continue


### PR DESCRIPTION
##### SUMMARY

Fix for #81699

Some fat permissions are 7 characters long rather than 6. This uses the same logic to set the correct permission string.

##### ISSUE TYPE

- Bugfix Pull Request

