### PR TITLE
Implement an informative reporter for resolvelib

### DIFF
--- a/changelogs/fragments/81709-ansible-galaxy-slow-resolution-hints.yml
+++ b/changelogs/fragments/81709-ansible-galaxy-slow-resolution-hints.yml
@@ -1,0 +1,10 @@
+---
+
+minor_changes:
+- >-
+  ``ansible-galaxy collection install`` — the collection dependency resolver
+  now prints out conflicts it hits during dependency resolution when it's
+  taking too long and it ends up backtracking a lot. It also displays
+  suggestions on how to help it compute the result more quickly.
+
+...

--- a/lib/ansible/galaxy/dependency_resolution/reporters.py
+++ b/lib/ansible/galaxy/dependency_resolution/reporters.py
@@ -18,11 +18,8 @@ except ImportError:
 try:
     from resolvelib.resolvers import Criterion
 except ImportError:
-    try:
-        from resolvelib.resolvers.criterion import Criterion
-    except ImportError:
-        class Criterion:  # type: ignore[no-redef]
-            pass
+    class Criterion:  # type: ignore[no-redef]
+        pass
 
 from ansible.utils.display import Display
 from .dataclasses import Candidate, Requirement

--- a/lib/ansible/galaxy/dependency_resolution/reporters.py
+++ b/lib/ansible/galaxy/dependency_resolution/reporters.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import typing as t
 from collections import defaultdict
 from contextlib import suppress as suppress_exceptions
-from logging import getLogger
 
 try:
     from resolvelib import BaseReporter
@@ -25,7 +24,11 @@ except ImportError:
         class Criterion:  # type: ignore[no-redef]
             pass
 
+from ansible.utils.display import Display
 from .dataclasses import Candidate, Requirement
+
+
+display = Display()
 
 
 _CLI_APP_NAME = 'ansible-galaxy'
@@ -46,8 +49,6 @@ _MESSAGES_AT_REJECT_COUNT = {
         'runtime. If you want to abort this run, press Ctrl + C.'
     ),
 }
-
-_logger = getLogger(__name__)
 
 
 class CollectionDependencyReporter(BaseReporter):
@@ -76,7 +77,7 @@ class CollectionDependencyReporter(BaseReporter):
         except KeyError as key_err:
             raise LookupError from key_err
 
-        _logger.info(collection_rejection_message.format(fqcn=candidate.fqcn))
+        display.display(collection_rejection_message.format(fqcn=candidate.fqcn))
 
     def rejecting_candidate(  # resolvelib >= 0.9.0
             self,
@@ -98,7 +99,7 @@ class CollectionDependencyReporter(BaseReporter):
             else:
                 msg += 'The user requested '
             msg += repr(req)
-        _logger.debug(msg)
+        display.debug(msg)
 
     def backtracking(self, candidate: Candidate) -> None:  # resolvelib < 0.9.0
         """Print out rejection messages on pre-defined limit hits."""

--- a/lib/ansible/galaxy/dependency_resolution/reporters.py
+++ b/lib/ansible/galaxy/dependency_resolution/reporters.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import typing as t
 from collections import defaultdict
 from contextlib import suppress as suppress_exceptions
 
@@ -59,7 +58,7 @@ class CollectionDependencyReporter(BaseReporter):
         """Initialize the collection rejection counter."""
         super().__init__()
 
-        self.reject_count_by_fqcn: t.DefaultDict[str, int] = defaultdict(int)
+        self.reject_count_by_fqcn: defaultdict[str, int] = defaultdict(int)
 
     def _log_mapped_rejection_message(self, candidate: Candidate) -> None:
         """Print out rejection messages on pre-defined limit hits."""

--- a/lib/ansible/galaxy/dependency_resolution/reporters.py
+++ b/lib/ansible/galaxy/dependency_resolution/reporters.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from contextlib import suppress as suppress_exceptions
 
 try:
     from resolvelib import BaseReporter
@@ -60,20 +59,22 @@ class CollectionDependencyReporter(BaseReporter):
 
         self.reject_count_by_fqcn: defaultdict[str, int] = defaultdict(int)
 
-    def _log_mapped_rejection_message(self, candidate: Candidate) -> None:
+    def _maybe_log_rejection_message(self, candidate: Candidate) -> bool:
         """Print out rejection messages on pre-defined limit hits."""
         # Inspired by https://github.com/pypa/pip/commit/9731131
         self.reject_count_by_fqcn[candidate.fqcn] += 1
 
         collection_rejections_count = self.reject_count_by_fqcn[candidate.fqcn]
-        try:
-            collection_rejection_message = _MESSAGES_AT_REJECT_COUNT[
-                collection_rejections_count
-            ]
-        except KeyError as key_err:
-            raise LookupError from key_err
 
+        if collection_rejections_count not in _MESSAGES_AT_REJECT_COUNT:
+            return False
+
+        collection_rejection_message = _MESSAGES_AT_REJECT_COUNT[
+            collection_rejections_count
+        ]
         display.display(collection_rejection_message.format(fqcn=candidate.fqcn))
+
+        return True
 
     def rejecting_candidate(  # resolvelib >= 0.9.0
             self,
@@ -81,9 +82,7 @@ class CollectionDependencyReporter(BaseReporter):
             candidate: Candidate,
     ) -> None:
         """Augment rejection messages with conflict details."""
-        try:
-            self._log_mapped_rejection_message(candidate)
-        except LookupError:
+        if not self._maybe_log_rejection_message(candidate):
             return
 
         msg = 'Will try a different candidate, due to conflict:'
@@ -99,5 +98,4 @@ class CollectionDependencyReporter(BaseReporter):
 
     def backtracking(self, candidate: Candidate) -> None:  # resolvelib < 0.9.0
         """Print out rejection messages on pre-defined limit hits."""
-        with suppress_exceptions(LookupError):
-            return self._log_mapped_rejection_message(candidate)
+        self._maybe_log_rejection_message(candidate)

--- a/lib/ansible/galaxy/dependency_resolution/reporters.py
+++ b/lib/ansible/galaxy/dependency_resolution/reporters.py
@@ -5,11 +5,49 @@
 
 from __future__ import annotations
 
+import typing as t
+from collections import defaultdict
+from contextlib import suppress as suppress_exceptions
+from logging import getLogger
+
 try:
     from resolvelib import BaseReporter
 except ImportError:
     class BaseReporter:  # type: ignore[no-redef]
         pass
+
+try:
+    from resolvelib.resolvers import Criterion
+except ImportError:
+    try:
+        from resolvelib.resolvers.criterion import Criterion
+    except ImportError:
+        class Criterion:  # type: ignore[no-redef]
+            pass
+
+from .dataclasses import Candidate, Requirement
+
+
+_CLI_APP_NAME = 'ansible-galaxy'
+_MESSAGES_AT_REJECT_COUNT = {
+    1: (
+        f'{_CLI_APP_NAME} is looking at multiple versions of {{fqcn}} to '
+        'determine which version is compatible with other '
+        'requirements. This could take a while.'
+    ),
+    8: (
+        f'{_CLI_APP_NAME} is looking at multiple versions of {{fqcn}} to '
+        'determine which version is compatible with other '
+        'requirements. This could take a while.'
+    ),
+    13: (
+        'This is taking longer than usual. You might need to provide '
+        'the dependency resolver with stricter constraints to reduce '
+        'runtime. If you want to abort this run, press Ctrl + C.'
+    ),
+}
+
+_logger = getLogger(__name__)
 
 
 class CollectionDependencyReporter(BaseReporter):
@@ -18,3 +56,51 @@ class CollectionDependencyReporter(BaseReporter):
     This is a proxy class allowing us to abstract away importing resolvelib
     outside of the `ansible.galaxy.dependency_resolution` Python package.
     """
+
+    def __init__(self) -> None:
+        """Initialize the collection rejection counter."""
+        super().__init__()
+
+        self.reject_count_by_fqcn: t.DefaultDict[str, int] = defaultdict(int)
+
+    def _log_mapped_rejection_message(self, candidate: Candidate) -> None:
+        """Print out rejection messages on pre-defined limit hits."""
+        # Inspired by https://github.com/pypa/pip/commit/9731131
+        self.reject_count_by_fqcn[candidate.fqcn] += 1
+
+        collection_rejections_count = self.reject_count_by_fqcn[candidate.fqcn]
+        try:
+            collection_rejection_message = _MESSAGES_AT_REJECT_COUNT[
+                collection_rejections_count
+            ]
+        except KeyError as key_err:
+            raise LookupError from key_err
+
+        _logger.info(collection_rejection_message.format(fqcn=candidate.fqcn))
+
+    def rejecting_candidate(  # resolvelib >= 0.9.0
+            self,
+            criterion: Criterion[Candidate, Requirement],
+            candidate: Candidate,
+    ) -> None:
+        """Augment rejection messages with conflict details."""
+        try:
+            self._log_mapped_rejection_message(candidate)
+        except LookupError:
+            return
+
+        msg = 'Will try a different candidate, due to conflict:'
+        for req_info in criterion.information:
+            req, parent = req_info.requirement, req_info.parent
+            msg += '\n    '
+            if parent:
+                msg += f'{parent !r} depends on '
+            else:
+                msg += 'The user requested '
+            msg += repr(req)
+        _logger.debug(msg)
+
+    def backtracking(self, candidate: Candidate) -> None:  # resolvelib < 0.9.0
+        """Print out rejection messages on pre-defined limit hits."""
+        with suppress_exceptions(LookupError):
+            return self._log_mapped_rejection_message(candidate)

--- a/lib/ansible/galaxy/dependency_resolution/reporters.py
+++ b/lib/ansible/galaxy/dependency_resolution/reporters.py
@@ -99,7 +99,7 @@ class CollectionDependencyReporter(BaseReporter):
             else:
                 msg += 'The user requested '
             msg += str(req)
-        display.debug(msg)
+        display.v(msg)
 
     def backtracking(self, candidate: Candidate) -> None:  # resolvelib < 0.9.0
         """Print out rejection messages on pre-defined limit hits."""

--- a/lib/ansible/galaxy/dependency_resolution/reporters.py
+++ b/lib/ansible/galaxy/dependency_resolution/reporters.py
@@ -95,10 +95,10 @@ class CollectionDependencyReporter(BaseReporter):
             req, parent = req_info.requirement, req_info.parent
             msg += '\n    '
             if parent:
-                msg += f'{parent !r} depends on '
+                msg += f'{parent !s} depends on '
             else:
                 msg += 'The user requested '
-            msg += repr(req)
+            msg += str(req)
         display.debug(msg)
 
     def backtracking(self, candidate: Candidate) -> None:  # resolvelib < 0.9.0


### PR DESCRIPTION
##### SUMMARY

Prior to this change, when the dependency resolver started looping over multiple versions of the same collection due to backtracking, it might take a lot of time to consider and disregard tens or hundreds of versions. But to the end-user, it looks like “nothing is happening, the program is *stuck*”. Even worse if such a time-consuming backtracking hits multiple collections and it “hangs” for longer cumulative period of time.

This patch improves the perceived responsiveness by printing out informational messages with the current status whenever the backtracking for a collection happens for the first, the eighth and the thirteenth times. The last message also reminds them that they can interrupt the process and attempt to adjust the constraints.

In debug mode, it also shows what caused conflicts leading up to candidate rejections.

This is heavily inspired by https://github.com/pypa/pip/commit/9731131.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

N/A