### PR TITLE
remote log info

### DIFF
--- a/changelogs/fragments/log_id.yml
+++ b/changelogs/fragments/log_id.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - added configuration item ``TARGET_LOG_INFO`` that allows the user/author to add an information string to the log output on targets.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1962,7 +1962,7 @@ TARGET_LOG_INFO:
   description: A string to insert into target logging for tracking purposes
   env: [{name: ANSIBLE_TARGET_LOG_INFO}]
   ini:
-  - {key: target_log_info , section: defaults}
+  - {key: target_log_info, section: defaults}
   vars:
   - name: ansible_target_log_info
 TASK_TIMEOUT:

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1957,6 +1957,14 @@ TAGS_SKIP:
   ini:
   - {key: skip, section: tags}
   version_added: "2.5"
+TARGET_LOG_INFO:
+  name: Target log info
+  description: A string to insert into target logging for tracking purposes
+  env: [{name: ANSIBLE_REMOTE_LOG_INFO}]
+  ini:
+  - {key: remote_log_info , section: defaults}
+  vars:
+  - name: ansible_remote_log_info
 TASK_TIMEOUT:
   name: Task Timeout
   default: 0

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1960,11 +1960,11 @@ TAGS_SKIP:
 TARGET_LOG_INFO:
   name: Target log info
   description: A string to insert into target logging for tracking purposes
-  env: [{name: ANSIBLE_REMOTE_LOG_INFO}]
+  env: [{name: ANSIBLE_TARGET_LOG_INFO}]
   ini:
-  - {key: remote_log_info , section: defaults}
+  - {key: target_log_info , section: defaults}
   vars:
-  - name: ansible_remote_log_info
+  - name: ansible_target_log_info
 TASK_TIMEOUT:
   name: Task Timeout
   default: 0

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1965,6 +1965,7 @@ TARGET_LOG_INFO:
   - {key: target_log_info, section: defaults}
   vars:
   - name: ansible_target_log_info
+  version_added: "2.17"
 TASK_TIMEOUT:
   name: Task Timeout
   default: 0

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1300,13 +1300,16 @@ class AnsibleModule(object):
             # We want journal to always take text type
             # syslog takes bytes on py2, text type on py3
             if isinstance(msg, binary_type):
-                journal_msg = remove_values(msg.decode('utf-8', 'replace'), self.no_log_values)
+                journal_msg = msg.decode('utf-8', 'replace')
             else:
                 # TODO: surrogateescape is a danger here on Py3
-                journal_msg = remove_values(msg, self.no_log_values)
+                journal_msg = msg
 
             if self._target_log_info:
-                journal_msg = remove_values(self._target_log_info, self.no_log_values) + journal_msg
+                journal_msg = ' '.join([self._target_log_info, journal_msg])
+
+            # ensure we clean up secrets!
+            journal_msg = remove_values(journal_msg, self.no_log_values)
 
             if PY3:
                 syslog_msg = journal_msg

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1306,7 +1306,7 @@ class AnsibleModule(object):
                 journal_msg = remove_values(msg, self.no_log_values)
 
             if self._target_log_info:
-                journal_msg = remove_values(self._target_log_info) + journal_msg
+                journal_msg = remove_values(self._target_log_info, self.no_log_values) + journal_msg
 
             if PY3:
                 syslog_msg = journal_msg

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1305,6 +1305,9 @@ class AnsibleModule(object):
                 # TODO: surrogateescape is a danger here on Py3
                 journal_msg = remove_values(msg, self.no_log_values)
 
+            if self._remote_log_info:
+                journal_msg = self._remote_log_info + journal_msg
+
             if PY3:
                 syslog_msg = journal_msg
             else:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1306,7 +1306,7 @@ class AnsibleModule(object):
                 journal_msg = remove_values(msg, self.no_log_values)
 
             if self._target_log_info:
-                journal_msg = self._target_log_info + journal_msg
+                journal_msg = remove_values(self._target_log_info) + journal_msg
 
             if PY3:
                 syslog_msg = journal_msg

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1305,8 +1305,8 @@ class AnsibleModule(object):
                 # TODO: surrogateescape is a danger here on Py3
                 journal_msg = remove_values(msg, self.no_log_values)
 
-            if self._remote_log_info:
-                journal_msg = self._remote_log_info + journal_msg
+            if self._target_log_info:
+                journal_msg = self._target_log_info + journal_msg
 
             if PY3:
                 syslog_msg = journal_msg

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -82,6 +82,7 @@ _ADDITIONAL_CHECKS = (
 
 # if adding boolean attribute, also add to PASS_BOOL
 # some of this dupes defaults from controller config
+# keep in sync with copy in lib/ansible/module_utils/csharp/Ansible.Basic.cs
 PASS_VARS = {
     'check_mode': ('check_mode', False),
     'debug': ('_debug', False),

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -91,6 +91,7 @@ PASS_VARS = {
     'module_name': ('_name', None),
     'no_log': ('no_log', False),
     'remote_tmp': ('_remote_tmp', None),
+    'remote_log_info': ('_remote_log_info', None),
     'selinux_special_fs': ('_selinux_special_fs', ['fuse', 'nfs', 'vboxsf', 'ramfs', '9p', 'vfat']),
     'shell_executable': ('_shell', '/bin/sh'),
     'socket': ('_socket_path', None),

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -91,7 +91,7 @@ PASS_VARS = {
     'module_name': ('_name', None),
     'no_log': ('no_log', False),
     'remote_tmp': ('_remote_tmp', None),
-    'remote_log_info': ('_remote_log_info', None),
+    'target_log_info': ('_target_log_info', None),
     'selinux_special_fs': ('_selinux_special_fs', ['fuse', 'nfs', 'vboxsf', 'ramfs', '9p', 'vfat']),
     'shell_executable': ('_shell', '/bin/sh'),
     'socket': ('_socket_path', None),

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -261,6 +261,7 @@ namespace Ansible.Basic
             DiffMode = false;
             KeepRemoteFiles = false;
             ModuleName = "undefined win module";
+			TargetLogInfo = ''
             NoLog = (bool)argumentSpec["no_log"];
             Verbosity = 0;
             AppDomain.CurrentDomain.ProcessExit += CleanupFiles;

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -380,7 +380,15 @@ namespace Ansible.Basic
             }
             if (sanitise)
                 message = (string)RemoveNoLogValues(message, noLogValues);
-            message = String.Format("{0} {1}- {2}", ModuleName, TargetLogInfo, message);
+
+			if (String.IsNullOrWhiteSpace(TargetLogInfo))
+			{
+			    message = String.Format("{0} - {1}", ModuleName, message);
+			}
+			else
+			{
+			    message = String.Format("{0} {1} - {2}", ModuleName, TargetLogInfo, message);
+			}
 
             using (EventLog eventLog = new EventLog("Application"))
             {

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -262,7 +262,7 @@ namespace Ansible.Basic
             DiffMode = false;
             KeepRemoteFiles = false;
             ModuleName = "undefined win module";
-			TargetLogInfo = ''
+			TargetLogInfo = ""
             NoLog = (bool)argumentSpec["no_log"];
             Verbosity = 0;
             AppDomain.CurrentDomain.ProcessExit += CleanupFiles;

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -61,7 +61,7 @@ namespace Ansible.Basic
         private Dictionary<string, string> passVars = new Dictionary<string, string>()
         {
             // null values means no mapping, not used in Ansible.Basic.AnsibleModule
-			// keep in sync with python counterpart in lib/ansible/module_utils/common/parameters.py
+            // keep in sync with python counterpart in lib/ansible/module_utils/common/parameters.py
             { "check_mode", "CheckMode" },
             { "debug", "DebugMode" },
             { "diff", "DiffMode" },
@@ -262,7 +262,7 @@ namespace Ansible.Basic
             DiffMode = false;
             KeepRemoteFiles = false;
             ModuleName = "undefined win module";
-			TargetLogInfo = "";
+            TargetLogInfo = "";
             NoLog = (bool)argumentSpec["no_log"];
             Verbosity = 0;
             AppDomain.CurrentDomain.ProcessExit += CleanupFiles;
@@ -379,16 +379,18 @@ namespace Ansible.Basic
                 }
             }
             if (sanitise)
+            {
                 message = (string)RemoveNoLogValues(message, noLogValues);
+            }
 
-			if (String.IsNullOrWhiteSpace(TargetLogInfo))
-			{
-			    message = String.Format("{0} - {1}", ModuleName, message);
-			}
-			else
-			{
-			    message = String.Format("{0} {1} - {2}", ModuleName, TargetLogInfo, message);
-			}
+            if (String.IsNullOrWhiteSpace(TargetLogInfo))
+            {
+                message = String.Format("{0} - {1}", ModuleName, message);
+            }
+            else
+            {
+                message = String.Format("{0} {1} - {2}", ModuleName, TargetLogInfo, message);
+            }
 
             using (EventLog eventLog = new EventLog("Application"))
             {

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -262,7 +262,7 @@ namespace Ansible.Basic
             DiffMode = false;
             KeepRemoteFiles = false;
             ModuleName = "undefined win module";
-			TargetLogInfo = ""
+			TargetLogInfo = "";
             NoLog = (bool)argumentSpec["no_log"];
             Verbosity = 0;
             AppDomain.CurrentDomain.ProcessExit += CleanupFiles;

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -75,7 +75,7 @@ namespace Ansible.Basic
             { "socket", null },
             { "string_conversion_action", null },
             { "syslog_facility", null },
-            { "target_log_info", null },
+            { "target_log_info", "TargetLogInfo"},
             { "tmpdir", "tmpdir" },
             { "verbosity", "Verbosity" },
             { "version", "AnsibleVersion" },
@@ -378,7 +378,7 @@ namespace Ansible.Basic
             }
             if (sanitise)
                 message = (string)RemoveNoLogValues(message, noLogValues);
-            message = String.Format("{0} - {1}", ModuleName, message);
+            message = String.Format("{0} {1}- {2}", ModuleName, TargetLogInfo, message);
 
             using (EventLog eventLog = new EventLog("Application"))
             {

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -129,6 +129,7 @@ namespace Ansible.Basic
         public bool KeepRemoteFiles { get; private set; }
         public string ModuleName { get; private set; }
         public bool NoLog { get; private set; }
+        public string TargetLogInfo { get; private set; }
         public int Verbosity { get; private set; }
         public string AnsibleVersion { get; private set; }
 

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -61,6 +61,7 @@ namespace Ansible.Basic
         private Dictionary<string, string> passVars = new Dictionary<string, string>()
         {
             // null values means no mapping, not used in Ansible.Basic.AnsibleModule
+			// keep in sync with python counterpart in lib/ansible/module_utils/common/parameters.py
             { "check_mode", "CheckMode" },
             { "debug", "DebugMode" },
             { "diff", "DiffMode" },
@@ -74,6 +75,7 @@ namespace Ansible.Basic
             { "socket", null },
             { "string_conversion_action", null },
             { "syslog_facility", null },
+            { "target_log_info", null },
             { "tmpdir", "tmpdir" },
             { "verbosity", "Verbosity" },
             { "version", "AnsibleVersion" },

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -378,10 +378,6 @@ namespace Ansible.Basic
                     logSource = "Application";
                 }
             }
-            if (sanitise)
-            {
-                message = (string)RemoveNoLogValues(message, noLogValues);
-            }
 
             if (String.IsNullOrWhiteSpace(TargetLogInfo))
             {
@@ -390,6 +386,11 @@ namespace Ansible.Basic
             else
             {
                 message = String.Format("{0} {1} - {2}", ModuleName, TargetLogInfo, message);
+            }
+
+            if (sanitise)
+            {
+                message = (string)RemoveNoLogValues(message, noLogValues);
             }
 
             using (EventLog eventLog = new EventLog("Application"))

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1001,7 +1001,7 @@ class ActionBase(ABC):
         module_args['_ansible_ignore_unknown_opts'] = ignore_unknown_opts
 
         # allow user to insert string to add context to remote loggging
-        module_args['_ansible_remote_log_info'] = C.config.get_config_value('REMOTE_LOG_INFO', variables=task_vars)
+        module_args['_ansible_target_log_info'] = C.config.get_config_value('TARGET_LOG_INFO', variables=task_vars)
 
     def _execute_module(self, module_name=None, module_args=None, tmp=None, task_vars=None, persist_files=False, delete_remote_tmp=None, wrap_async=False,
                         ignore_unknown_opts: bool = False):

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1000,6 +1000,9 @@ class ActionBase(ABC):
         # tells the module to ignore options that are not in its argspec.
         module_args['_ansible_ignore_unknown_opts'] = ignore_unknown_opts
 
+        # allow user to insert string to add context to remote loggging
+        module_args['_ansible_remote_log_info'] = C.config.get_config_value('REMOTE_LOG_INFO', variables=task_vars)
+
     def _execute_module(self, module_name=None, module_args=None, tmp=None, task_vars=None, persist_files=False, delete_remote_tmp=None, wrap_async=False,
                         ignore_unknown_opts: bool = False):
         '''

--- a/test/integration/targets/module_utils_Ansible.Basic/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/module_utils_Ansible.Basic/library/ansible_basic_tests.ps1
@@ -155,6 +155,7 @@ $tests = @{
         "_ansible_shell_executable": "ignored",
         "_ansible_socket": "ignored",
         "_ansible_syslog_facility": "ignored",
+		"_ansible_target_log_info": "ignored",
         "_ansible_tmpdir": "$($m_tmpdir -replace "\\", "\\")",
         "_ansible_verbosity": 3,
         "_ansible_version": "2.8.0"

--- a/test/integration/targets/module_utils_Ansible.Basic/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/module_utils_Ansible.Basic/library/ansible_basic_tests.ps1
@@ -155,7 +155,7 @@ $tests = @{
         "_ansible_shell_executable": "ignored",
         "_ansible_socket": "ignored",
         "_ansible_syslog_facility": "ignored",
-		"_ansible_target_log_info": "ignored",
+        "_ansible_target_log_info": "ignored",
         "_ansible_tmpdir": "$($m_tmpdir -replace "\\", "\\")",
         "_ansible_verbosity": 3,
         "_ansible_version": "2.8.0"


### PR DESCRIPTION
fixes #81710

Includes the value of the `ansible_target_log_info` var in all module invocations (also globally settable on the control node via the `ANSIBLE_TARGET_LOG_INFO` envvar). Python and Powershell Ansible modules will include this value in  syslog/event log messages they write.

An AWX/Controller job template should be able to set this envvar to the current job ID to have it reflected in the target host's log messages.

##### ISSUE TYPE

- Feature Pull Request
