### PR TITLE
Typo in documentation `then` -> `than`

### DIFF
--- a/lib/ansible/modules/blockinfile.py
+++ b/lib/ansible/modules/blockinfile.py
@@ -111,7 +111,7 @@ notes:
   - As of Ansible 2.3, the O(dest) option has been changed to O(path) as default, but O(dest) still works as well.
   - Option O(ignore:follow) has been removed in Ansible 2.5, because this module modifies the contents of the file
     so O(ignore:follow=no) does not make sense.
-  - When more then one block should be handled in one file you must change the O(marker) per task.
+  - When more than one block should be handled in one file you must change the O(marker) per task.
 extends_documentation_fragment:
     - action_common_attributes
     - action_common_attributes.files


### PR DESCRIPTION
##### SUMMARY

Small typo in `blockinfile_module`'s doc

##### ISSUE TYPE

- Docs Pull Request
