### PR TITLE
Fix ansible-test issues with detecting docker host and forwarding ports

### DIFF
--- a/changelogs/fragments/ansible-test-docker-forwards.yml
+++ b/changelogs/fragments/ansible-test-docker-forwards.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- ansible-test - Properly detect docker host when using ``ssh://`` protocol for connecting to the docker daemon.
+- ansible-test - Explicitly supply ``ControlPath=none`` when setting up port fowarding over SSH to address
+  the scenario where the local ssh configuration uses ``ControlPath`` for all hosts, and would prevent
+  ports to be forwarded after the initial connection to the host.

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -496,7 +496,7 @@ def get_docker_hostname() -> str:
     """Return the hostname of the Docker service."""
     docker_host = os.environ.get('DOCKER_HOST')
 
-    if docker_host and docker_host.startswith('tcp://'):
+    if docker_host and docker_host.startswith(('tcp://', 'ssh://')):
         try:
             hostname = urllib.parse.urlparse(docker_host)[1].split(':')[0]
             display.info('Detected Docker host: %s' % hostname, verbosity=1)

--- a/test/lib/ansible_test/_internal/ssh.py
+++ b/test/lib/ansible_test/_internal/ssh.py
@@ -245,7 +245,7 @@ def create_ssh_port_forwards(
     """
     options: dict[str, t.Union[str, int]] = dict(
         LogLevel='INFO',  # info level required to get messages on stderr indicating the ports assigned to each forward
-        ControlPath='none',  # if the user has ControlPath set up for every host, it will prevent creation of fowards
+        ControlPath='none',  # if the user has ControlPath set up for every host, it will prevent creation of forwards
     )
 
     cli_args = []

--- a/test/lib/ansible_test/_internal/ssh.py
+++ b/test/lib/ansible_test/_internal/ssh.py
@@ -245,6 +245,7 @@ def create_ssh_port_forwards(
     """
     options: dict[str, t.Union[str, int]] = dict(
         LogLevel='INFO',  # info level required to get messages on stderr indicating the ports assigned to each forward
+        ControlPath='none',  # if the user has ControlPath set up for every host, it will prevent creation of fowards
     )
 
     cli_args = []


### PR DESCRIPTION
##### SUMMARY

This PR addresses 2 related issues in ansible-test when forwarding ports for docker containers in tests:

1. Detect docker host when using `ssh://` to connect to the docker daemon
2. Disable `ControlPath` when creating port forwards, since if the mux exists already, port forwards won't be created

##### ISSUE TYPE

- Test Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
