### PR TITLE
Remove deprecated APIs from ansible-doc

### DIFF
--- a/changelogs/fragments/81716-ansible-doc.yml
+++ b/changelogs/fragments/81716-ansible-doc.yml
@@ -1,0 +1,3 @@
+---
+removed_features:
+  - Remove deprecated APIs from ansible-docs (https://github.com/ansible/ansible/issues/81716).

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -51,11 +51,6 @@ PB_LOADED = {}
 SNIPPETS = ['inventory', 'lookup', 'module']
 
 
-def add_collection_plugins(plugin_list, plugin_type, coll_filter=None):
-    display.deprecated("add_collection_plugins method, use ansible.plugins.list functions instead.", version='2.17')
-    plugin_list.update(list_plugins(plugin_type, coll_filter))
-
-
 def jdump(text):
     try:
         display.display(json_dump(text))
@@ -423,11 +418,6 @@ class DocCLI(CLI, RoleMixin):
                 plugin = f"{plugin}, {entrypoint} entrypoint"
             return f"`{text}' (of {plugin})"
         return f"`{text}'"
-
-    @classmethod
-    def find_plugins(cls, path, internal, plugin_type, coll_filter=None):
-        display.deprecated("find_plugins method as it is incomplete/incorrect. use ansible.plugins.list functions instead.", version='2.17')
-        return list_plugins(plugin_type, coll_filter, [path]).keys()
 
     @classmethod
     def tty_ify(cls, text):

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -201,5 +201,4 @@ README.md pymarkdown:line-length
 test/integration/targets/ansible-vault/invalid_format/README.md pymarkdown:no-bare-urls
 test/support/README.md pymarkdown:no-bare-urls
 test/units/cli/test_data/role_skeleton/README.md pymarkdown:line-length
-lib/ansible/cli/doc.py pylint:ansible-deprecated-version  # 2.17 deprecation
 lib/ansible/utils/encrypt.py pylint:ansible-deprecated-version  # 2.17 deprecation


### PR DESCRIPTION
##### SUMMARY

* Removed add_collection_plugins
* Removed find_plugins

Fixes: #81716

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


