### PR TITLE
tests: update CloudStack test container to version 1.7.0.

### DIFF
--- a/changelogs/fragments/81732-cloudstack-test-container-1.7.0.yml
+++ b/changelogs/fragments/81732-cloudstack-test-container-1.7.0.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ansible-test - Updated the CloudStack test container to version 1.7.0.

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/cs.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/cs.py
@@ -38,7 +38,7 @@ class CsCloudProvider(CloudProvider):
     def __init__(self, args: IntegrationConfig) -> None:
         super().__init__(args)
 
-        self.image = os.environ.get('ANSIBLE_CLOUDSTACK_CONTAINER', 'quay.io/ansible/cloudstack-test-container:1.6.1')
+        self.image = os.environ.get('ANSIBLE_CLOUDSTACK_CONTAINER', 'quay.io/ansible/cloudstack-test-container:1.7.0')
         self.host = ''
         self.port = 0
 


### PR DESCRIPTION
##### SUMMARY

Bump cloudstack test container version fixes an issue with accessing admin keys in a json file export.

Also see https://github.com/ansible/cloudstack-test-container/pull/19

/cc @mattclay 

##### ISSUE TYPE

- Feature Pull Request

