### PR TITLE
apt - update the sources first if the cache can't be opened with default_release

### DIFF
--- a/changelogs/fragments/apt_update_cache_with_new_source.yml
+++ b/changelogs/fragments/apt_update_cache_with_new_source.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt - handle the error if the default_release can't be configured, and try updating the sources in the cache before giving up (https://github.com/ansible/ansible/issues/28991).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1360,6 +1360,10 @@ def main():
     # max times we'll retry
     deadline = time.time() + p['lock_timeout']
 
+    # https://github.com/ansible/ansible/issues/28991
+    # we may need to update the available sources before we can configure the default_release
+    cache_primed = retry_default_release = False
+
     # keep running on lock issues unless timeout or resolution is hit.
     while True:
 
@@ -1372,8 +1376,20 @@ def main():
                     apt_pkg.config['APT::Default-Release'] = p['default_release']
                 except AttributeError:
                     apt_pkg.Config['APT::Default-Release'] = p['default_release']
-                # reopen cache w/ modified config
-                cache.open(progress=None)
+                # attempt to reopen cache w/ modified config
+                try:
+                    cache.open(progress=None)
+                except SystemError as e:
+                    if cache_primed or module.check_mode:
+                        raise e
+                    try:
+                        del apt_pkg.config['APT::Default-Release']
+                    except AttributeError:
+                        del apt_pkg.Config['APT::Default-Release']
+                    cache.open(progress=None)
+                    retry_default_release = True
+                else:
+                    retry_default_release = False
 
             mtimestamp, updated_cache_time = get_updated_cache_time()
             # Cache valid time is default 0, which will update the cache if
@@ -1410,6 +1426,10 @@ def main():
                     if module.check_mode or updated_cache_time != post_cache_update_time:
                         updated_cache = True
                     updated_cache_time = post_cache_update_time
+
+                    if retry_default_release:
+                        cache_primed = True
+                        continue
 
                 # If there is nothing else to do exit. This will set state as
                 #  changed based on if the cache was updated.
@@ -1537,6 +1557,8 @@ def main():
             module.fail_json(msg="Failed to lock apt for exclusive operation: %s" % lockFailedException)
         except apt.cache.FetchFailedException as fetchFailedException:
             module.fail_json(msg="Could not fetch updated apt files: %s" % fetchFailedException)
+        except SystemError as e:
+            module.fail_json(msg=to_native(e))
 
         # got here w/o exception and/or exit???
         module.fail_json(msg='Unexpected code path taken, we really should have exited before, this is a bug')


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/28991

Not sure how to test for this easily. At minimum we should handle the SystemError and indicate the user needs to update the cache from a previous operation.

<details>
  <summary>here's a reproducer</summary>
  <br>

  ```code
FROM debian:bullseye

RUN apt-get update && apt-get install -y \
    python3 \
    python3-pip \
    git \
    apt-utils

RUN pip install git+https://github.com/ansible/ansible.git@stable-2.15 --user

RUN echo '---\n\
- hosts: localhost\n\
    gather_facts: no\n\
    tasks:\n\
    - name: Add bullseye-backports repository\n\
      apt_repository:\n\
        filename: "bullseye-backports"\n\
        repo: "deb http://deb.debian.org/debian bullseye-backports main"\n\
        state: present\n\
        update_cache: false\n\
    - name: Install from bullseye-backports\n\
      apt:\n\
        name: "golang"\n\
        default_release: "bullseye-backports"\n\
        state: present\n\
        update_cache: yes' > /tmp/playbook.yml

CMD /bin/bash -c "python3 -m ansible playbook /tmp/playbook.yml -vvv"
  ```
</details>

without the patch, results in
```
TASK [Install from bullseye-backports] *****************************************
task path: /tmp/playbook.yml:11
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~root && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp `"&& mkdir "` echo /root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660 `" && echo ansible-tmp-1713979441.7980669-380-92052647695660="` echo /root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660 `" ) && sleep 0'
Using module file /root/.local/lib/python3.9/site-packages/ansible/modules/apt.py
<127.0.0.1> PUT /root/.ansible/tmp/ansible-local-6omabiozr/tmpl88k2hci TO /root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660/AnsiballZ_apt.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660/ /root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660/AnsiballZ_apt.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3 /root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660/AnsiballZ_apt.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660/AnsiballZ_apt.py", line 107, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660/AnsiballZ_apt.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660/AnsiballZ_apt.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible.modules.apt', init_globals=dict(_module_fqn='ansible.modules.apt', _modlib_path=modlib_path),
  File "/usr/lib/python3.9/runpy.py", line 210, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.9/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_apt_payload_sgb6pdqp/ansible_apt_payload.zip/ansible/modules/apt.py", line 1512, in <module>
  File "/tmp/ansible_apt_payload_sgb6pdqp/ansible_apt_payload.zip/ansible/modules/apt.py", line 1342, in main
  File "/usr/lib/python3/dist-packages/apt/cache.py", line 214, in open
    self._cache = apt_pkg.Cache(progress)
apt_pkg.Error: E:The value 'bullseye-backports' is invalid for APT::Default-Release as such a release is not available in the sources
fatal: [localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660/AnsiballZ_apt.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660/AnsiballZ_apt.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1713979441.7980669-380-92052647695660/AnsiballZ_apt.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible.modules.apt', init_globals=dict(_module_fqn='ansible.modules.apt', _modlib_path=modlib_path),\n  File \"/usr/lib/python3.9/runpy.py\", line 210, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_apt_payload_sgb6pdqp/ansible_apt_payload.zip/ansible/modules/apt.py\", line 1512, in <module>\n  File \"/tmp/ansible_apt_payload_sgb6pdqp/ansible_apt_payload.zip/ansible/modules/apt.py\", line 1342, in main\n  File \"/usr/lib/python3/dist-packages/apt/cache.py\", line 214, in open\n    self._cache = apt_pkg.Cache(progress)\napt_pkg.Error: E:The value 'bullseye-backports' is invalid for APT::Default-Release as such a release is not available in the sources\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
```

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
