### PR TITLE
Handle exception in interpreter discovery

### DIFF
--- a/changelogs/fragments/interpreter_discovery.yml
+++ b/changelogs/fragments/interpreter_discovery.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- interpreter_discovery - handle AnsibleError exception raised while interpreter discovery (https://github.com/ansible/ansible/issues/78264).

--- a/lib/ansible/executor/interpreter_discovery.py
+++ b/lib/ansible/executor/interpreter_discovery.py
@@ -10,6 +10,7 @@ import pkgutil
 import re
 
 from ansible import constants as C
+from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.distro import LinuxDistribution
 from ansible.utils.display import Display
@@ -150,6 +151,8 @@ def discover_interpreter(action, interpreter_name, discovery_mode, task_vars):
         return platform_interpreter
     except NotImplementedError as ex:
         display.vvv(msg=u'Python interpreter discovery fallback ({0})'.format(to_text(ex)), host=host)
+    except AnsibleError:
+        raise
     except Exception as ex:
         if not is_silent:
             display.warning(msg=u'Unhandled error in Python interpreter discovery for host {0}: {1}'.format(host, to_text(ex)))

--- a/test/units/executor/test_interpreter_discovery.py
+++ b/test/units/executor/test_interpreter_discovery.py
@@ -6,10 +6,12 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import pytest
 from unittest.mock import MagicMock
 
 from ansible.executor.interpreter_discovery import discover_interpreter
 from ansible.module_utils.common.text.converters import to_text
+from ansible.errors import AnsibleConnectionFailure
 
 mock_ubuntu_platform_res = to_text(
     r'{"osrelease_content": "NAME=\"Ubuntu\"\nVERSION=\"16.04.5 LTS (Xenial Xerus)\"\nID=ubuntu\nID_LIKE=debian\n'
@@ -84,3 +86,13 @@ def test_no_interpreters_found():
     assert mock_action.method_calls[1][0] == '_discovery_warnings.append'
     assert u'No python interpreters found for host host-fóöbär (tried' \
            in mock_action.method_calls[1][1][0]
+
+
+def test_ansible_error_exception():
+    mock_action = MagicMock()
+    mock_action._low_level_execute_command.side_effect = AnsibleConnectionFailure("host key mismatch")
+
+    with pytest.raises(AnsibleConnectionFailure) as context:
+        discover_interpreter(mock_action, 'python', 'auto_legacy', {'inventory_hostname': u'host'})
+
+    assert 'host key mismatch' == str(context.value)


### PR DESCRIPTION
##### SUMMARY

* Handle exception like AnsibleError, AnsibleConnectionFailure
  raise while interpreter discovery.

Fixes: #78264

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


