### PR TITLE
Harden the ansiballz and respawn python templates

### DIFF
--- a/changelogs/fragments/py-tmpl-hardening.yml
+++ b/changelogs/fragments/py-tmpl-hardening.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Harden python templates for respawn and ansiballz around str literal quoting

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -167,7 +167,7 @@ def _ansiballz_main():
     else:
         PY3 = True
 
-    ZIPDATA = """%(zipdata)s"""
+    ZIPDATA = %(zipdata)r
 
     # Note: temp_path isn't needed once we switch to zipimport
     def invoke_module(modlib_path, temp_path, json_params):
@@ -197,7 +197,7 @@ def _ansiballz_main():
         basic._ANSIBLE_ARGS = json_params
 %(coverage)s
         # Run the module!  By importing it as '__main__', it thinks it is executing as a script
-        runpy.run_module(mod_name='%(module_fqn)s', init_globals=dict(_module_fqn='%(module_fqn)s', _modlib_path=modlib_path),
+        runpy.run_module(mod_name=%(module_fqn)r, init_globals=dict(_module_fqn=%(module_fqn)r, _modlib_path=modlib_path),
                          run_name='__main__', alter_sys=True)
 
         # Ansible modules must exit themselves
@@ -288,7 +288,7 @@ def _ansiballz_main():
             basic._ANSIBLE_ARGS = json_params
 
             # Run the module!  By importing it as '__main__', it thinks it is executing as a script
-            runpy.run_module(mod_name='%(module_fqn)s', init_globals=None, run_name='__main__', alter_sys=True)
+            runpy.run_module(mod_name=%(module_fqn)r, init_globals=None, run_name='__main__', alter_sys=True)
 
             # Ansible modules must exit themselves
             print('{"msg": "New-style module did not handle its own exit", "failed": true}')
@@ -313,9 +313,9 @@ def _ansiballz_main():
         # store this in remote_tmpdir (use system tempdir instead)
         # Only need to use [ansible_module]_payload_ in the temp_path until we move to zipimport
         # (this helps ansible-test produce coverage stats)
-        temp_path = tempfile.mkdtemp(prefix='ansible_%(ansible_module)s_payload_')
+        temp_path = tempfile.mkdtemp(prefix='ansible_' + %(ansible_module)r + '_payload_')
 
-        zipped_mod = os.path.join(temp_path, 'ansible_%(ansible_module)s_payload.zip')
+        zipped_mod = os.path.join(temp_path, 'ansible_' + %(ansible_module)r + '_payload.zip')
 
         with open(zipped_mod, 'wb') as modlib:
             modlib.write(base64.b64decode(ZIPDATA))
@@ -338,7 +338,7 @@ if __name__ == '__main__':
 '''
 
 ANSIBALLZ_COVERAGE_TEMPLATE = '''
-        os.environ['COVERAGE_FILE'] = '%(coverage_output)s=python-%%s=coverage' %% '.'.join(str(v) for v in sys.version_info[:2])
+        os.environ['COVERAGE_FILE'] = %(coverage_output)r + '=python-%%s=coverage' %% '.'.join(str(v) for v in sys.version_info[:2])
 
         import atexit
 
@@ -348,7 +348,7 @@ ANSIBALLZ_COVERAGE_TEMPLATE = '''
             print('{"msg": "Could not import `coverage` module.", "failed": true}')
             sys.exit(1)
 
-        cov = coverage.Coverage(config_file='%(coverage_config)s')
+        cov = coverage.Coverage(config_file=%(coverage_config)r)
 
         def atexit_coverage():
             cov.stop()

--- a/lib/ansible/module_utils/common/respawn.py
+++ b/lib/ansible/module_utils/common/respawn.py
@@ -79,10 +79,9 @@ def _create_payload():
 import runpy
 import sys
 
-module_fqn = '{module_fqn}'
-modlib_path = '{modlib_path}'
-smuggled_args = b"""{smuggled_args}""".strip()
-
+module_fqn = {module_fqn!r}
+modlib_path = {modlib_path!r}
+smuggled_args = {smuggled_args!r}
 
 if __name__ == '__main__':
     sys.path.insert(0, modlib_path)
@@ -93,6 +92,6 @@ if __name__ == '__main__':
     runpy.run_module(module_fqn, init_globals=dict(_respawned=True), run_name='__main__', alter_sys=True)
     '''
 
-    respawn_code = respawn_code_template.format(module_fqn=module_fqn, modlib_path=modlib_path, smuggled_args=to_native(smuggled_args))
+    respawn_code = respawn_code_template.format(module_fqn=module_fqn, modlib_path=modlib_path, smuggled_args=smuggled_args.strip())
 
     return respawn_code

--- a/lib/ansible/module_utils/common/respawn.py
+++ b/lib/ansible/module_utils/common/respawn.py
@@ -8,7 +8,7 @@ import os
 import subprocess
 import sys
 
-from ansible.module_utils.common.text.converters import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 def has_respawned():


### PR DESCRIPTION
##### SUMMARY

Harden the ansiballz and respawn python templates

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<details>
<summary>ansiballz.diff...</summary>
<p>

```diff
--- /tmp/ansible-tmp-1695310065.6345081-73382-19459786457885/AnsiballZ_ping.py›·2023-09-21 10:27:45
+++ /tmp/ansible-tmp-1695310274.619092-73477-57134664104792/AnsiballZ_ping.py›··2023-09-21 10:31:14
@@ -89,7 +89,7 @@
     else:
         PY3 = True
 
-    ZIPDATA = """SNIP"""
+    ZIPDATA = 'SNIP'
 
     # Note: temp_path isn't needed once we switch to zipimport
     def invoke_module(modlib_path, temp_path, json_params):
@@ -118,7 +118,7 @@
         from ansible.module_utils import basic
         basic._ANSIBLE_ARGS = json_params
 
-        os.environ['COVERAGE_FILE'] = '/foo=python-%s=coverage' % '.'.join(str(v) for v in sys.version_info[:2])
+        os.environ['COVERAGE_FILE'] = '/foo' + '=python-%s=coverage' % '.'.join(str(v) for v in sys.version_info[:2])
 
         import atexit
 
@@ -255,9 +255,9 @@
         # store this in remote_tmpdir (use system tempdir instead)
         # Only need to use [ansible_module]_payload_ in the temp_path until we move to zipimport
         # (this helps ansible-test produce coverage stats)
-        temp_path = tempfile.mkdtemp(prefix='ansible_ping_payload_')
+        temp_path = tempfile.mkdtemp(prefix='ansible_' + 'ping' + '_payload_')
 
-        zipped_mod = os.path.join(temp_path, 'ansible_ping_payload.zip')
+        zipped_mod = os.path.join(temp_path, 'ansible_' + 'ping' + '_payload.zip')
 
         with open(zipped_mod, 'wb') as modlib:
             modlib.write(base64.b64decode(ZIPDATA))
```

</p>
</details>

<details>
<summary>respawn.diff...</summary>
<p>

```diff
--- respawn.py.old	2023-09-21 15:41:29.902614557 +0000
+++ respawn.py	2023-09-21 15:41:12.782191595 +0000
@@ -4,8 +4,7 @@

 module_fqn = 'ansible.modules.dnf'
 modlib_path = '/tmp/ansible_ansible.legacy.dnf_payload_SNIP/ansible_ansible.legacy.dnf_payload.zip'
-smuggled_args = b"""{"ANSIBLE_MODULE_ARGS": {"name": "python3.11", "_ansible_check_mode": false, "_ansible_no_log": false, "_ansible_debug": false, "_ansible_diff": false, "_ansible_verbosity": 1, "_ansible_version": "2.17.0.dev0", "_ansible_module_name": "ansible.legacy.dnf", "_ansible_syslog_facility": "LOG_USER", "_ansible_selinux_special_fs": ["fuse", "nfs", "vboxsf", "ramfs", "9p", "vfat"], "_ansible_string_conversion_action": "warn", "_ansible_socket": null, "_ansible_shell_executable": "/bin/sh", "_ansible_keep_remote_files": false, "_ansible_tmpdir": "/home/centos/.ansible/tmp/ansible-tmp-SNIP", "_ansible_remote_tmp": "~/.ansible/tmp"}}""".strip()
-
+smuggled_args = b'{"ANSIBLE_MODULE_ARGS": {"name": "python3.11", "_ansible_check_mode": false, "_ansible_no_log": false, "_ansible_debug": false, "_ansible_diff": false, "_ansible_verbosity": 1, "_ansible_version": "2.17.0.dev0", "_ansible_module_name": "ansible.legacy.dnf", "_ansible_syslog_facility": "LOG_USER", "_ansible_selinux_special_fs": ["fuse", "nfs", "vboxsf", "ramfs", "9p", "vfat"], "_ansible_string_conversion_action": "warn", "_ansible_socket": null, "_ansible_shell_executable": "/bin/sh", "_ansible_keep_remote_files": false, "_ansible_tmpdir": "/home/centos/.ansible/tmp/ansible-tmp-SNIP/", "_ansible_remote_tmp": "~/.ansible/tmp"}}'

 if __name__ == '__main__':
     sys.path.insert(0, modlib_path)
```

</p>
</details>