### PR TITLE
Throw LockFailedException if apt cmd encounters a lock file

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -820,9 +820,9 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             changed = APT_GET_ZERO not in out
 
         data = dict(changed=changed, stdout=out, stderr=err, diff=diff)
-    
+
         check_locked_error(out, err)
-        
+
         if rc:
             status = False
             data = dict(msg="'%s' failed: %s" % (cmd, err), stdout=out, stderr=err, rc=rc)
@@ -1544,6 +1544,7 @@ def main():
 def check_locked_error(stdout, stderr):
     if ("lock was locked" in stderr or "lock was locked" in stdout):
         raise apt.cache.LockFailedException
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/78658

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

An earlier attempt (https://github.com/ansible/ansible/issues/78658) to fix this issue didn't work for me because because `DPkg::Lock::Timeout` is an `apt` parameter not a `dpkg` one.

The code supports the `lock_timeout` parameter but the problem here is that the when the lock issue is encountered, the code subsequently runs `m.fail_json` which then calls `sys.exit` and this bypasses the `except apt.cache.LockFailedException` handler so the cmd is never re-tried.

I'm sure there are better solutions to this issue but I'm raising this PR here just in case others want to use this solution by overriding apt.py locally.

