### PR TITLE
add intentional coverage for copy with force=false

### DIFF
--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -92,6 +92,18 @@
       - "stat_results.stat.issock == false"
       - "stat_results.stat.checksum == ('foo.txt\n'|hash('sha1'))"
 
+- name: Test copying content with force=false when the dest already exists
+  copy:
+    content: other_data
+    dest: "{{ remote_file }}"
+    mode: 0444
+    force: False
+  register: repeat_copy_result
+
+- name: Assert no changes are made
+  assert:
+    that: repeat_copy_result is not changed
+
 - name: Overwrite the file via same means
   copy:
     src: foo.txt


### PR DESCRIPTION
##### SUMMARY

See https://github.com/ansible/ansible/issues/81689

Replaces yum incidental coverage
```
Source: lib/ansible/modules/stat.py (1 arcs, 2/539 lines):
GitHub: https://github.com/ansible/ansible/blob/7d3d4572edcb4e436883a9aca2859f620077390a/lib/ansible/modules/stat.py

 507          if get_checksum:  ### (here) -> 511

 511      if get_mime:  ### 507 -> (here)

Source: lib/ansible/plugins/action/copy.py (4 arcs, 6/599 lines):
GitHub: https://github.com/ansible/ansible/blob/7d3d4572edcb4e436883a9aca2859f620077390a/lib/ansible/plugins/action/copy.py

 231      def _copy_file(self, source_full, source_rel, content, content_tempfile,  ### 280 -> (here)

 278          if dest_status['exists'] and not force:  ### (here) -> 280

 280              return None  ### 278 -> (here)  ### (here) -> -231

 509          for source_full, source_rel in source_files['files']:  ### 521 -> (here)

 520              if module_return is None:  ### (here) -> 521
 521                  continue  ### 520 -> (here)  ### (here) -> 509
```

##### ISSUE TYPE

- Test Pull Request