### PR TITLE
[stable-2.16] ansible-test - Skip pylint test on Python 3.12 (#81706)

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-python-3.12.yml
+++ b/changelogs/fragments/ansible-test-pylint-python-3.12.yml
@@ -1,0 +1,2 @@
+known_issues:
+  - ansible-test - The ``pylint`` sanity test is not supported on Python 3.12. Use Python 3.10 or 3.11 instead.

--- a/test/integration/targets/ansible-test-sanity-pylint/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-pylint/runme.sh
@@ -2,6 +2,11 @@
 
 set -eu
 
+if [ "${ANSIBLE_TEST_PYTHON_VERSION}" = "3.12" ]; then
+    echo "skipping test, pylint is not supported on Python 3.12"
+    exit
+fi
+
 source ../collection/setup.sh
 
 # Create test scenarios at runtime that do not pass sanity tests.

--- a/test/lib/ansible_test/_internal/commands/sanity/pylint.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/pylint.py
@@ -82,6 +82,12 @@ class PylintTest(SanitySingleVersion):
         """Error code for ansible-test matching the format used by the underlying test program, or None if the program does not use error codes."""
         return 'ansible-test'
 
+    @property
+    def supported_python_versions(self) -> t.Optional[tuple[str, ...]]:
+        """A tuple of supported Python versions or None if the test does not depend on specific Python versions."""
+        # NOTE: When removing the Python 3.12 exclusion, be sure to update the ansible-test-sanity-pylint integration test.
+        return tuple(version for version in super().supported_python_versions if version != '3.12')
+
     def filter_targets(self, targets: list[TestTarget]) -> list[TestTarget]:
         """Return the given list of test targets, filtered to include only those relevant for the test."""
         return [target for target in targets if os.path.splitext(target.path)[1] == '.py' or is_subdir(target.path, 'bin')]


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81706

(cherry picked from commit 379461283249df66231505d52fc099ef564b0911)

##### ISSUE TYPE

Feature Pull Request
