### PR TITLE
file: add a note about follow=false

### DIFF
--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -66,7 +66,7 @@ options:
     - >
       Force the creation of the symlinks in two cases: the source file does
       not exist (but will appear later); the destination exists and is a file (so, we need to unlink the
-      O(path) file and create symlink to the O(src) file in place of it).
+      O(path) file and create a symlink to the O(src) file in place of it).
     type: bool
     default: no
   follow:
@@ -74,6 +74,8 @@ options:
     - This flag indicates that filesystem links, if they exist, should be followed.
     - O(follow=yes) and O(state=link) can modify O(src) when combined with parameters such as O(mode).
     - Previous to Ansible 2.5, this was V(false) by default.
+    - While creating a symlink with a non-existent destination, set O(follow) to V(false) to avoid a warning message related to permission issues.
+      The warning message is added to notify the user that we can not set permissions to the non-existent destination.
     type: bool
     default: yes
     version_added: '1.8'


### PR DESCRIPTION
##### SUMMARY

While creating a symlink, we apply fs attributes changes
to the destination. But in case of a non-existent destination, we warn
the user. This warning message can be suppressed by setting follow=false.
Add a note of this behavior in the `follow` parameter.

Fixes: #50543

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE

- Docs Pull Request

