### PR TITLE
Fix dnf module crash for non-existent url

### DIFF
--- a/changelogs/fragments/fix-dnf-install-missing-url.yml
+++ b/changelogs/fragments/fix-dnf-install-missing-url.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix handling missing urls in ansible.module_utils.urls.fetch_file for Python 3.

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -2058,7 +2058,7 @@ def fetch_file(module, url, data=None, headers=None, method=None,
     try:
         rsp, info = fetch_url(module, url, data, headers, method, use_proxy, force, last_mod_time, timeout,
                               unredirected_headers=unredirected_headers, decompress=decompress, ciphers=ciphers)
-        if not rsp:
+        if not rsp or (rsp.code and rsp.code >= 400):
             module.fail_json(msg="Failure downloading %s, %s" % (url, info['msg']))
         data = rsp.read(bufsize)
         while data:

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -504,6 +504,7 @@
     that:
         - "dnf_result is failed"
         - "not dnf_result.changed"
+        - "'Failure downloading' in dnf_result.msg"
 
 - name: verify dnf module outputs
   assert:

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -504,7 +504,7 @@
     that:
         - "dnf_result is failed"
         - "not dnf_result.changed"
-        - "'Failure downloading' in dnf_result.msg"
+        - "'Failure downloading' in dnf_result.msg or 'Failed to download' in dnf_result.msg"
 
 - name: verify dnf module outputs
   assert:


### PR DESCRIPTION
##### SUMMARY
This fixes the error when downloading a non-existent URL with the `dnf` module. Before the module crashed without handling the error.

This arc (see #81689) occurs for Python 2.7 only, because `rsp.read` is None (not callable).

```
Source: lib/ansible/module_utils/urls.py (3 arcs, 4/2075 lines):
GitHub: https://github.com/ansible/ansible/blob/7d3d4572edcb4e436883a9aca2859f620077390a/lib/ansible/module_utils/urls.py

2030  def fetch_file(module, url, data=None, headers=None, method=None,  ### 2069 -> (here)

2063          data = rsp.read(bufsize)  ### (here) -> 2068

2068      except Exception as e:  ### 2063 -> (here)  ### (here) -> 2069
2069          module.fail_json(msg="Failure downloading %s, %s" % (url, to_native(e)))  ### 2068 -> (here)  ### (here) -> -2030
```

In Python 3, `rsp.read` is a method even if there's an error code. Since this function was not working on Python 3 (a missing URL ends up being downloaded as an empty file), the dnf module crashes without handling the error.

With this fix, neither Python 2 nor Python 3 hit this arc, but if it's worth pursing I could probably contrive a flask app to hit it...

##### ISSUE TYPE
- Bugfix Pull Request