### PR TITLE
ansible-vault - suggest --stdin-name when --name is provided without command line args

### DIFF
--- a/changelogs/fragments/81804-ansible-vault-add-stderr-for-unused-name.yml
+++ b/changelogs/fragments/81804-ansible-vault-add-stderr-for-unused-name.yml
@@ -1,3 +1,2 @@
 bugfixes:
   - ansible-vault encrypt_string - give informative message when --name is provided and won't be used.
-  - ansible-vault encrypt_string - remove trailing whitespace before determining whether there is anything to encrypt.

--- a/changelogs/fragments/81804-ansible-vault-add-stderr-for-unused-name.yml
+++ b/changelogs/fragments/81804-ansible-vault-add-stderr-for-unused-name.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-vault encrypt_string - give informative message when --name is provided and won't be used.
+  - ansible-vault encrypt_string - remove trailing whitespace before determining whether there is anything to encrypt.

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -141,6 +141,13 @@ class VaultCLI(CLI):
             if '-' in options.args or not options.args or options.encrypt_string_stdin_name:
                 self.encrypt_string_read_stdin = True
 
+                # If we're going to read 1 arg from stdin implicitly (no command line args),
+                # set --stdin-name to the first --name if it wasn't provided
+                if not options.encrypt_string_stdin_name and not options.args and options.encrypt_string_names:
+                    options.encrypt_string_stdin_name = options.encrypt_string_names[0]
+                    if len(options.encrypt_string_names) > 1:
+                        display.display('The number of --name options do not match the number of args.', stderr=True)
+
             # TODO: prompting from stdin and reading from stdin seem mutually exclusive, but verify that.
             if options.encrypt_string_prompt and self.encrypt_string_read_stdin:
                 raise AnsibleOptionsError('The --prompt option is not supported if also reading input from stdin')
@@ -329,7 +336,7 @@ class VaultCLI(CLI):
                 display.display("Reading plaintext input from stdin. (ctrl-d to end input, twice if your content does not already have a newline)", stderr=True)
 
             stdin_text = sys.stdin.read()
-            if stdin_text == '':
+            if stdin_text.rstrip() == '':
                 raise AnsibleOptionsError('stdin was empty, not encrypting')
 
             if sys.stdout.isatty() and not stdin_text.endswith("\n"):

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -329,7 +329,7 @@ class VaultCLI(CLI):
                 display.display("Reading plaintext input from stdin. (ctrl-d to end input, twice if your content does not already have a newline)", stderr=True)
 
             stdin_text = sys.stdin.read()
-            if stdin_text.rstrip() == '':
+            if stdin_text == '':
                 raise AnsibleOptionsError('stdin was empty, not encrypting')
 
             if sys.stdout.isatty() and not stdin_text.endswith("\n"):

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -141,13 +141,6 @@ class VaultCLI(CLI):
             if '-' in options.args or not options.args or options.encrypt_string_stdin_name:
                 self.encrypt_string_read_stdin = True
 
-                # If we're going to read 1 arg from stdin implicitly (no command line args),
-                # set --stdin-name to the first --name if it wasn't provided
-                if not options.encrypt_string_stdin_name and not options.args and options.encrypt_string_names:
-                    options.encrypt_string_stdin_name = options.encrypt_string_names[0]
-                    if len(options.encrypt_string_names) > 1:
-                        display.display('The number of --name options do not match the number of args.', stderr=True)
-
             # TODO: prompting from stdin and reading from stdin seem mutually exclusive, but verify that.
             if options.encrypt_string_prompt and self.encrypt_string_read_stdin:
                 raise AnsibleOptionsError('The --prompt option is not supported if also reading input from stdin')
@@ -361,6 +354,8 @@ class VaultCLI(CLI):
                 display.display('The last named variable will be "%s". The rest will not have'
                                 ' names.' % context.CLIARGS['encrypt_string_names'][-1],
                                 stderr=True)
+            elif not name_and_text_list and context.CLIARGS['encrypt_string_names']:
+                display.display("No command line arguments provided to use with --name. To name an argument from stdin use --stdin-name.", stderr=True)
 
             # Add the rest of the args without specifying a name
             for extra_arg in args[len(name_and_text_list):]:

--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -358,8 +358,8 @@ vaulted_var="$(ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VA
 grep 'the_var_from_stdin' <<< "${vaulted_var}"
 
 # from stdin and positional args
-multiple_vars="$(ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "the_var_not_from_stdin" --stdin-name "the_var_from_stdin" < "${TEST_FILE}")"
-grep -e 'the_var_from_stdin' -e 'the_var_not_from_stdin' <<< "${multiple_vars}"
+multiple_vars="$(ansible-vault encrypt_string not_secret "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "the_var_not_from_stdin" --stdin-name "the_var_from_stdin" < "${TEST_FILE}")"
+grep 'the_var_from_stdin' <<< "${multiple_vars}" && grep 'the_var_not_from_stdin' <<< "${multiple_vars}"
 
 # write to file
 ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "blippy" "a test string names blippy" --output "${MYTMPDIR}/enc_string_test_file"

--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -351,15 +351,13 @@ ansible-vault encrypt_string "$@" --vault-id "${NEW_VAULT_PASSWORD}" --name "bli
 # from stdin
 ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" < "${TEST_FILE}"
 
-vaulted_var="$(ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --stdin-name "the_var_from_stdin" < "${TEST_FILE}")"
-grep 'the_var_from_stdin' <<< "${vaulted_var}"
+ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --stdin-name "the_var_from_stdin" < "${TEST_FILE}" | grep 'the_var_from_stdin'
 
-vaulted_var="$(ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "the_var_from_stdin" < "${TEST_FILE}")"
-grep 'the_var_from_stdin' <<< "${vaulted_var}"
+ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "the_var_from_stdin" < "${TEST_FILE}" | grep -vz 'the_var_from_stdin'
 
 # from stdin and positional args
-multiple_vars="$(ansible-vault encrypt_string not_secret "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "the_var_not_from_stdin" --stdin-name "the_var_from_stdin" < "${TEST_FILE}")"
-grep 'the_var_from_stdin' <<< "${multiple_vars}" && grep 'the_var_not_from_stdin' <<< "${multiple_vars}"
+ansible-vault encrypt_string not_secret "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "the_var_not_from_stdin" --stdin-name "the_var_from_stdin" < "${TEST_FILE}" | tee out.txt
+grep out.txt -e 'the_var_from_stdin' && grep out.txt -e 'the_var_not_from_stdin'
 
 # write to file
 ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "blippy" "a test string names blippy" --output "${MYTMPDIR}/enc_string_test_file"

--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -351,7 +351,15 @@ ansible-vault encrypt_string "$@" --vault-id "${NEW_VAULT_PASSWORD}" --name "bli
 # from stdin
 ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" < "${TEST_FILE}"
 
-ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --stdin-name "the_var_from_stdin" < "${TEST_FILE}"
+vaulted_var="$(ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --stdin-name "the_var_from_stdin" < "${TEST_FILE}")"
+grep 'the_var_from_stdin' <<< "${vaulted_var}"
+
+vaulted_var="$(ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "the_var_from_stdin" < "${TEST_FILE}")"
+grep 'the_var_from_stdin' <<< "${vaulted_var}"
+
+# from stdin and positional args
+multiple_vars="$(ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "the_var_not_from_stdin" --stdin-name "the_var_from_stdin" < "${TEST_FILE}")"
+grep -e 'the_var_from_stdin' -e 'the_var_not_from_stdin' <<< "${multiple_vars}"
 
 # write to file
 ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "blippy" "a test string names blippy" --output "${MYTMPDIR}/enc_string_test_file"

--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -353,7 +353,7 @@ ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" 
 
 ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --stdin-name "the_var_from_stdin" < "${TEST_FILE}" | grep 'the_var_from_stdin'
 
-ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "the_var_from_stdin" < "${TEST_FILE}" | grep -vz 'the_var_from_stdin'
+ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "the_var_from_stdin" < "${TEST_FILE}" | grep -v 'the_var_from_stdin'
 
 # from stdin and positional args
 ansible-vault encrypt_string not_secret "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "the_var_not_from_stdin" --stdin-name "the_var_from_stdin" < "${TEST_FILE}" | tee out.txt


### PR DESCRIPTION
##### SUMMARY

~Fixes~ Improves a couple issues pointed out in https://github.com/ansible/ansible/issues/71619#issuecomment-1513996997

> The --stdin-name option works for both input supplied via stdin or at the prompt even when stdin is empty.
ansible-vault encrypt_string --vault-password-file <(echo password) --stdin-name abc will print abc: !vault ...snip... even though no stdin was supplied.

I can't reproduce this, but I'm guessing there's a trailing newline or something. This strips trailing whitespace when evaluating if there's anything to encrypt.

> The --name argument does nothing on my system, whether argument is supplied via stdin or at the prompt when stdin is empty.

Rather than silently ignoring `--name` if there are no command line args, this adds a message to inform the user `--stdin-name` is the only way to name an arg via stdin currently.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
