### PR TITLE
Fix pip changed status when installing from vcs

### DIFF
--- a/changelogs/fragments/81815-fix-pip-changed-status-vcs-install.yml
+++ b/changelogs/fragments/81815-fix-pip-changed-status-vcs-install.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pip - Incorrect changed status was returned in case of installation from VCS where the target commit was different but the version was the same. The fix now evaluates also the commits used for installation from VCS (https://github.com/ansible/ansible/issues/81751).

--- a/changelogs/fragments/81815-fix-pip-changed-status-vcs-install.yml
+++ b/changelogs/fragments/81815-fix-pip-changed-status-vcs-install.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - pip - Incorrect changed status was returned in case of installation from VCS where the target commit was different but the version was the same. The fix now evaluates also the commits used for installation from VCS (https://github.com/ansible/ansible/issues/81751).

--- a/changelogs/fragments/81816-fix-pip-changed-status-vcs-install.yml
+++ b/changelogs/fragments/81816-fix-pip-changed-status-vcs-install.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pip - Incorrect changed status was returned in case of installation from VCS where the target commit was different but the version was the same. The fix now evaluates also the commits used for installation from VCS (https://github.com/ansible/ansible/issues/81751).

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -800,7 +800,7 @@ def main():
             )
 
         if module.check_mode:
-            if extra_args or requirements or state == 'latest' or not name or state == "forcereinstall":
+            if extra_args or requirements or state == 'latest' or not name:
                 module.exit_json(changed=True)
 
             pkg_cmd, out_pip, err_pip = _get_packages(module, pip, chdir)
@@ -850,7 +850,7 @@ def main():
                 changed = 'Successfully installed' in out_pip
             else:
                 dummy, out_freeze_after, dummy = _get_packages(module, pip, chdir)
-                changed = out_freeze_before != out_freeze_after or state == "forcereinstall"
+                changed = out_freeze_before != out_freeze_after
 
         changed = changed or venv_created
 

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -800,7 +800,7 @@ def main():
             )
 
         if module.check_mode:
-            if extra_args or requirements or state == 'latest' or not name or state== "forcereinstall":
+            if extra_args or requirements or state == 'latest' or not name or state == "forcereinstall":
                 module.exit_json(changed=True)
 
             pkg_cmd, out_pip, err_pip = _get_packages(module, pip, chdir)

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -63,31 +63,6 @@
 - command: "{{ ansible_python.executable }} -c 'import {{ item }}'"
   loop: '{{ pip_test_modules }}'
 
-# force reinstall packages in check mode and ensure we recorded a change
-- name: forcereinstall packages in check mode
-  pip:
-    name: "{{ pip_test_packages }}"
-    state: forcereinstall
-  check_mode: true
-  register: forcereinstall_result_check_mode
-
-- name: verify we recorded a change
-  assert:
-    that:
-      - "forcereinstall_result_check_mode is changed"
-
-# force reinstall packages for real and ensure we recorded a change
-- name: forcereinstall packages
-  pip:
-    name: "{{ pip_test_packages }}"
-    state: forcereinstall
-  register: forcereinstall_result
-
-- name: verify we recorded a change
-  assert:
-    that:
-      - "forcereinstall_result is changed"
-
 # now remove it to test uninstallation of a package we are sure is installed
 
 - name: now uninstall so we can see that a change occurred

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -129,17 +129,16 @@
     that:
       - "not (url_installed is changed)"
 
-# Note: this is due to a bug of pip which in old version does not automatically refetch
-# refs after the first install
-- name: Fetch commits needed for following test
-  command: git fetch origin 8bfaaa3e5c63a9eda4449e606786802f4e95ba60 a48aa33f9fe5aa77d40fa2a38584750570d38ad6
-  args:
+# Note: this is needed due to an issue of pip 9.0.3 and python 3.6 to install
+# non refs commit (reproduced on RHEL 8.8 trying to run 'pip3 install -e git+https://github.com/dvarrazzo/pyiso8601@8bfaaa3e5c63a9eda4449e606786802f4e95ba60#egg=iso8601')
+- name: update git refs for backcompatibility with pip 9.0.3
+  shell: "git update-ref refs/heads/test 8bfaaa3e5c63a9eda4449e606786802f4e95ba60; git update-ref refs/heads/test1 a48aa33f9fe5aa77d40fa2a38584750570d38ad6"
+  args:  
     chdir: "{{ remote_tmp_dir }}/pipenv/src/iso8601/"
-
 
 - name: install the same module from url pointing to a specific commit
   pip:
-    name: "git+https://github.com/dvarrazzo/pyiso8601@8bfaaa3e5c63a9eda4449e606786802f4e95ba60#egg=iso8601"
+    name: "git+https://github.com/dvarrazzo/pyiso8601@test#egg=iso8601"
     virtualenv: "{{ remote_tmp_dir }}/pipenv"
     editable: true
     state: latest
@@ -152,7 +151,7 @@
 
 - name: install the same module from url pointing to the same specific commit
   pip:
-    name: "git+https://github.com/dvarrazzo/pyiso8601@8bfaaa3e5c63a9eda4449e606786802f4e95ba60#egg=iso8601"
+    name: "git+https://github.com/dvarrazzo/pyiso8601@test#egg=iso8601"
     virtualenv: "{{ remote_tmp_dir }}/pipenv"
     editable: true
     state: latest
@@ -165,7 +164,7 @@
 
 - name: install the same module from url pointing to a different specific commit with same package version
   pip:
-    name: "git+https://github.com/dvarrazzo/pyiso8601@a48aa33f9fe5aa77d40fa2a38584750570d38ad6#egg=iso8601"
+    name: "git+https://github.com/dvarrazzo/pyiso8601@test1#egg=iso8601"
     state: latest
     editable: true
     virtualenv: "{{ remote_tmp_dir }}/pipenv"

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -184,6 +184,7 @@
   pip:
     name: "git+https://github.com/dvarrazzo/pyiso8601@a48aa33f9fe5aa77d40fa2a38584750570d38ad6#egg=iso8601"
     state: latest
+    editable: true
     virtualenv: "{{ remote_tmp_dir }}/pipenv"
   register: url_installed_different_specific_commit_same_version
 

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -129,6 +129,14 @@
     that:
       - "not (url_installed is changed)"
 
+# Note: this is due to a bug of pip which in old version does not automatically refetch
+# refs after the first install
+- name: Fetch commits needed for following test
+  command: git fetch origin 8bfaaa3e5c63a9eda4449e606786802f4e95ba60 a48aa33f9fe5aa77d40fa2a38584750570d38ad6
+  args:
+    chdir: "{{ remote_tmp_dir }}/pipenv/src/iso8601/"
+
+
 - name: install the same module from url pointing to a specific commit
   pip:
     name: "git+https://github.com/dvarrazzo/pyiso8601@8bfaaa3e5c63a9eda4449e606786802f4e95ba60#egg=iso8601"

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -63,6 +63,31 @@
 - command: "{{ ansible_python.executable }} -c 'import {{ item }}'"
   loop: '{{ pip_test_modules }}'
 
+# force reinstall packages in check mode and ensure we recorded a change
+- name: forcereinstall packages in check mode
+  pip:
+    name: "{{ pip_test_packages }}"
+    state: forcereinstall
+  check_mode: true
+  register: forcereinstall_result_check_mode
+
+- name: verify we recorded a change
+  assert:
+    that:
+      - "forcereinstall_result_check_mode is changed"
+
+# force reinstall packages for real and ensure we recorded a change
+- name: forcereinstall packages
+  pip:
+    name: "{{ pip_test_packages }}"
+    state: forcereinstall
+  register: forcereinstall_result
+
+- name: verify we recorded a change
+  assert:
+    that:
+      - "forcereinstall_result is changed"
+
 # now remove it to test uninstallation of a package we are sure is installed
 
 - name: now uninstall so we can see that a change occurred
@@ -128,6 +153,45 @@
   assert:
     that:
       - "not (url_installed is changed)"
+
+- name: install the same module from url pointing to a specific commit
+  pip:
+    name: "git+https://github.com/dvarrazzo/pyiso8601@8bfaaa3e5c63a9eda4449e606786802f4e95ba60#egg=iso8601"
+    virtualenv: "{{ remote_tmp_dir }}/pipenv"
+    editable: true
+    state: latest
+  register: url_installed_specific_commit
+
+- name: verify we recorded a change
+  assert:
+    that:
+      - "url_installed_specific_commit is changed"
+
+- name: install the same module from url pointing to the same specific commit
+  pip:
+    name: "git+https://github.com/dvarrazzo/pyiso8601@8bfaaa3e5c63a9eda4449e606786802f4e95ba60#egg=iso8601"
+    virtualenv: "{{ remote_tmp_dir }}/pipenv"
+    editable: true
+    state: latest
+  register: url_installed_specific_commit_again
+
+- name: verify we did not record a change
+  assert:
+    that:
+      - "not (url_installed_specific_commit_again is changed)"
+
+- name: install the same module from url pointing to a different specific commit with same package version
+  pip:
+    name: "git+https://github.com/dvarrazzo/pyiso8601@a48aa33f9fe5aa77d40fa2a38584750570d38ad6#egg=iso8601"
+    state: latest
+    virtualenv: "{{ remote_tmp_dir }}/pipenv"
+  register: url_installed_different_specific_commit_same_version
+
+- name: verify we recorded a change
+  assert:
+    that:
+      - "url_installed_different_specific_commit_same_version is changed"
+
 
 # Test pip package in check mode doesn't always report changed.
 


### PR DESCRIPTION
##### SUMMARY

Fixes #81751.

The problem resided in the fact that pip list does not show the commit information related with modules installed from VCS, and this could lead to a wrong `changed` status reported, in case the module is installed again from a different branch or commit that does not change the version.

The main idea, as was mentioned also in the issue comments, is to incorporate in the check also the information reported by `pip freeze`, since this reports information also on the commit used when installing from VCS.

The related integration tests have been added to the existing ones. 

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request


##### ADDITIONAL INFORMATION

Starting from the following state, obtained using `pip freeze`: 
```paste below
-e git+https://github.com/dvarrazzo/pyiso8601@8bfaaa3e5c63a9eda4449e606786802f4e95ba60#egg=iso8601
```

and installing the module using a different commit (but same version), as follows

```
- name: install the same module from url pointing to a specific commit
      pip:
        name: "git+https://github.com/dvarrazzo/pyiso8601@8bfaaa3e5c63a9eda4449e606786802f4e95ba60#egg=iso8601"
        state: latest
        editable: true
```

 the result would currently be:  

```
PLAY [localhost] **********************************************************************

TASK [install the same module from url pointing to a specific commit] *****************
ok: [localhost]

PLAY RECAP ****************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 
```

while, executing again `pip freeze`, we would notice the change: 
```
-e git+https://github.com/dvarrazzo/pyiso8601@a48aa33f9fe5aa77d40fa2a38584750570d38ad6#egg=iso8601
```

After the fix, the execution will correctly report the `changed` status: 

```
PLAY [localhost] *************************************************************************************************************************************************************

TASK [install the same module from url pointing to a specific commit] ********************************************************************************************************
changed: [localhost]

PLAY RECAP *******************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```