### PR TITLE
Fixed spelling errors in built-in modules

### DIFF
--- a/lib/ansible/plugins/filter/comment.yml
+++ b/lib/ansible/plugins/filter/comment.yml
@@ -18,7 +18,7 @@ DOCUMENTATION:
     decoration:
       description: Indicator for comment or intermediate comment depending on the style.
       type: string
-    begining:
+    beginning:
       description: Indicator of the start of a comment block, only available for styles that support multiline comments.
       type: string
     end:

--- a/lib/ansible/plugins/filter/extract.yml
+++ b/lib/ansible/plugins/filter/extract.yml
@@ -17,7 +17,7 @@ DOCUMENTATION:
       type: raw
       required: true
     morekeys:
-      description: Indicies or keys to extract from the initial result (subkeys/subindices).
+      description: Indices or keys to extract from the initial result (subkeys/subindices).
       type: list
       elements: dictionary
       required: true


### PR DESCRIPTION
SUMMARY

This pull request addresses a spelling error in the builtin module by replacing "Indicies" with "Indices" and " begining" with "beginning". The change has been made to improve the accuracy and readability of the codebase.

ISSUE TYPE

Bugfix Pull Request

ADDITIONAL INFORMATION

Fixed a spelling error in ' lib/ansible/plugins/filter/extract.yml '  by changing "Indicies" to "Indices".
Fixed a spelling error in ' lib/ansible/plugins/filter/comment.yml '  by changing " begining" to "beginning".



This change resolves issue #81808.