### PR TITLE
Fixed typos in winrm.py file

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -148,7 +148,7 @@ DOCUMENTATION = """
               seconds higher than the WS-Man operation timeout, thus make the connection more
               robust on networks with long latency and/or many hops between server and client
               network wise.
-            - Setting the difference bewteen the operation and the read timeout to 10 seconds
+            - Setting the difference between the operation and the read timeout to 10 seconds
               alligns it to the defaults used in the winrm-module and the PSRP-module which also
               uses 10 seconds (30 seconds for read timeout and 20 seconds for operation timeout)
             - Corresponds to the C(operation_timeout_sec) and

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -149,7 +149,7 @@ DOCUMENTATION = """
               robust on networks with long latency and/or many hops between server and client
               network wise.
             - Setting the difference between the operation and the read timeout to 10 seconds
-              alligns it to the defaults used in the winrm-module and the PSRP-module which also
+              aligns it to the defaults used in the winrm-module and the PSRP-module which also
               uses 10 seconds (30 seconds for read timeout and 20 seconds for operation timeout)
             - Corresponds to the C(operation_timeout_sec) and
               C(read_timeout_sec) args in pywinrm so avoid setting these vars


### PR DESCRIPTION
##### SUMMARY

Fix typos in winrm.py #81824
 
winrm.py : 
- bewteen => between
- alligns => aligns

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

fixed the spelling mistakes in the file  lib/ansible/plugins/connection/winrm.py