### PR TITLE
Fixed Spelling Error In pause.py File

### DIFF
--- a/lib/ansible/modules/pause.py
+++ b/lib/ansible/modules/pause.py
@@ -15,7 +15,7 @@ description:
   - To pause/wait/sleep per host, use the M(ansible.builtin.wait_for) module.
   - You can use C(ctrl+c) if you wish to advance a pause earlier than it is set to expire or if you need to abort a playbook run entirely.
     To continue early press C(ctrl+c) and then C(c). To abort a playbook press C(ctrl+c) and then C(a).
-  - Prompting for a set amount of time is not supported. Pausing playbook execution is interruptable but does not return user input.
+  - Prompting for a set amount of time is not supported. Pausing playbook execution is interruptible but does not return user input.
   - The pause module integrates into async/parallelized playbooks without any special considerations (see Rolling Updates).
     When using pauses with the C(serial) playbook parameter (as in rolling updates) you are only prompted once for the current group of hosts.
   - This module is also supported for Windows targets.

--- a/lib/ansible/plugins/filter/comment.yml
+++ b/lib/ansible/plugins/filter/comment.yml
@@ -18,7 +18,7 @@ DOCUMENTATION:
     decoration:
       description: Indicator for comment or intermediate comment depending on the style.
       type: string
-    begining:
+    beginning:
       description: Indicator of the start of a comment block, only available for styles that support multiline comments.
       type: string
     end:

--- a/lib/ansible/plugins/filter/extract.yml
+++ b/lib/ansible/plugins/filter/extract.yml
@@ -17,7 +17,7 @@ DOCUMENTATION:
       type: raw
       required: true
     morekeys:
-      description: Indicies or keys to extract from the initial result (subkeys/subindices).
+      description: Indices or keys to extract from the initial result (subkeys/subindices).
       type: list
       elements: dictionary
       required: true


### PR DESCRIPTION
SUMMARY

This pull request addresses a spelling error in the builtin module by replacing " interruptable" with "interruptible". The change has been made to improve the accuracy and readability of the codebase.

ISSUE TYPE

Bugfix Pull Request

ADDITIONAL INFORMATION

Fixed a spelling error in lib/ansible/modules/pause.py by changing " interruptable" to "interruptible". 
This change resolves issue #81808.