### PR TITLE
Fixed spelling error in files

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -206,7 +206,7 @@ attributes:
 notes:
    - Three of the upgrade modes (V(full), V(safe) and its alias V(true)) required C(aptitude) up to 2.3, since 2.4 C(apt-get) is used as a fall-back.
    - In most cases, packages installed with apt will start newly installed services by default. Most distributions have mechanisms to avoid this.
-     For example when installing Postgresql-9.5 in Debian 9, creating an excutable shell script (/usr/sbin/policy-rc.d) that throws
+     For example when installing Postgresql-9.5 in Debian 9, creating an executable shell script (/usr/sbin/policy-rc.d) that throws
      a return code of 101 will stop Postgresql 9.5 starting up after install. Remove the file or remove its execute permission afterwards.
    - The apt-get commandline supports implicit regex matches here but we do not because it can let typos through easier
      (If you typo C(foo) as C(fo) apt-get would install packages that have "fo" in their name with a warning and a prompt for the user.

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -261,7 +261,7 @@ EXAMPLES = r'''
 
 - name: Download file from a file path
   ansible.builtin.get_url:
-    url: file:///tmp/afile.txt
+    url: file:///tmp/a_file.txt
     dest: /tmp/afilecopy.txt
 
 - name: < Fetch file that requires authentication.

--- a/lib/ansible/plugins/filter/comment.yml
+++ b/lib/ansible/plugins/filter/comment.yml
@@ -18,7 +18,7 @@ DOCUMENTATION:
     decoration:
       description: Indicator for comment or intermediate comment depending on the style.
       type: string
-    begining:
+    beginning:
       description: Indicator of the start of a comment block, only available for styles that support multiline comments.
       type: string
     end:

--- a/lib/ansible/plugins/filter/extract.yml
+++ b/lib/ansible/plugins/filter/extract.yml
@@ -17,7 +17,7 @@ DOCUMENTATION:
       type: raw
       required: true
     morekeys:
-      description: Indicies or keys to extract from the initial result (subkeys/subindices).
+      description: Indices or keys to extract from the initial result (subkeys/subindices).
       type: list
       elements: dictionary
       required: true


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
This pull request addresses the typos in the plugins and modules files.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

Bugfix Pull Request


##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The following typos have been fixed:

lib/ansible/modules/apt.py:209: excutable ==> executable
lib/ansible/modules/get_url.py:264: afile ==> a_file
lib/ansible/plugins/filter/comment.yml:21: begining ==> beginning
lib/ansible/plugins/filter/extract.yml:20: Indicies ==> Indices

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
