### PR TITLE
[stable-2.15] Add compat function for parsing Content-Disposition header (#81807)

### DIFF
--- a/changelogs/fragments/81806-py2-content-disposition.yml
+++ b/changelogs/fragments/81806-py2-content-disposition.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- uri/urls - Add compat function to handle the ability to parse the filename from a Content-Disposition header
+  (https://github.com/ansible/ansible/issues/81806)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -771,6 +771,18 @@ def extract_pem_certs(b_data):
         yield match.group(0)
 
 
+def _py2_get_param(headers, param, header='content-type'):
+    m = httplib.HTTPMessage(io.StringIO())
+    cd = headers.getheader(header) or ''
+    try:
+        m.plisttext = cd[cd.index(';'):]
+        m.parseplist()
+    except ValueError:
+        return None
+
+    return m.getparam(param)
+
+
 def get_response_filename(response):
     url = response.geturl()
     path = urlparse(url)[2]
@@ -778,7 +790,12 @@ def get_response_filename(response):
     if filename:
         filename = unquote(filename)
 
-    return response.headers.get_param('filename', header='content-disposition') or filename
+    if PY2:
+        get_param = functools.partial(_py2_get_param, response.headers)
+    else:
+        get_param = response.headers.get_param
+
+    return get_param('filename', header='content-disposition') or filename
 
 
 def parse_content_type(response):

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -766,6 +766,30 @@
     dest: "{{ remote_tmp_dir }}/output"
     state: absent
 
+- name: Test download root to dir without content-disposition
+  uri:
+    url: "https://{{ httpbin_host }}/"
+    dest: "{{ remote_tmp_dir }}"
+  register: get_root_no_filename
+
+- name: Test downloading to dir without content-disposition
+  uri:
+    url: "https://{{ httpbin_host }}/response-headers"
+    dest: "{{ remote_tmp_dir }}"
+  register: get_dir_no_filename
+
+- name: Test downloading to dir with content-disposition
+  uri:
+    url: 'https://{{ httpbin_host }}/response-headers?Content-Disposition=attachment%3B%20filename%3D%22filename.json%22'
+    dest: "{{ remote_tmp_dir }}"
+  register: get_dir_filename
+
+- assert:
+    that:
+      - get_root_no_filename.path == remote_tmp_dir ~ "/index.html"
+      - get_dir_no_filename.path == remote_tmp_dir ~ "/response-headers"
+      - get_dir_filename.path == remote_tmp_dir ~ "/filename.json"
+
 - name: Test follow_redirects=none
   import_tasks: redirect-none.yml
 


### PR DESCRIPTION
* py2 compat for get_param

* Add tests, and handle ValueError

* Add clog frag
(cherry picked from commit 831dc6e)


Co-authored-by: Matt Martz <matt@sivel.net>