### PR TITLE
[2.16] Fix reporting role as not found when remote_data is None (#81829)

### DIFF
--- a/changelogs/fragments/fix-ansible-galaxy-info-no-role-found.yml
+++ b/changelogs/fragments/fix-ansible-galaxy-info-no-role-found.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy info - fix reporting no role found when lookup_role_by_name returns None.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1265,6 +1265,9 @@ class GalaxyCLI(CLI):
 
                 if remote_data:
                     role_info.update(remote_data)
+                else:
+                    data = u"- the role %s was not found" % role
+                    break
 
             elif context.CLIARGS['offline'] and not gr._exists:
                 data = u"- the role %s was not found" % role


### PR DESCRIPTION
##### SUMMARY
Backport #81829 

(cherry picked from commit 7fab5525630f725e8e5ddb184c251bf6b9d7e53c)


##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
```
