### PR TITLE
[stable-2.16] ansible-test - Improve compatibility with pylint 3

### DIFF
--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/deprecated.py
@@ -14,9 +14,22 @@ from tokenize import COMMENT, TokenInfo
 
 import astroid
 
-from pylint.interfaces import IAstroidChecker, ITokenChecker
+# support pylint 2.x and 3.x -- remove when supporting only 3.x
+try:
+    from pylint.interfaces import IAstroidChecker, ITokenChecker
+except ImportError:
+    class IAstroidChecker:
+        """Backwards compatibility for 2.x / 3.x support."""
+
+    class ITokenChecker:
+        """Backwards compatibility for 2.x / 3.x support."""
+
+try:
+    from pylint.checkers.utils import check_messages
+except ImportError:
+    from pylint.checkers.utils import only_required_for_messages as check_messages
+
 from pylint.checkers import BaseChecker, BaseTokenChecker
-from pylint.checkers.utils import check_messages
 
 from ansible.module_utils.compat.version import LooseVersion
 from ansible.module_utils.six import string_types
@@ -214,14 +227,14 @@ class AnsibleDeprecatedChecker(BaseChecker):
     @property
     def collection_name(self) -> t.Optional[str]:
         """Return the collection name, or None if ansible-core is being tested."""
-        return self.config.collection_name
+        return self.linter.config.collection_name
 
     @property
     def collection_version(self) -> t.Optional[SemanticVersion]:
         """Return the collection version, or None if ansible-core is being tested."""
-        if self.config.collection_version is None:
+        if self.linter.config.collection_version is None:
             return None
-        sem_ver = SemanticVersion(self.config.collection_version)
+        sem_ver = SemanticVersion(self.linter.config.collection_version)
         # Ignore pre-release for version comparison to catch issues before the final release is cut.
         sem_ver.prerelease = ()
         return sem_ver

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/string_format.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/string_format.py
@@ -5,10 +5,21 @@
 from __future__ import annotations
 
 import astroid
-from pylint.interfaces import IAstroidChecker
+
+# support pylint 2.x and 3.x -- remove when supporting only 3.x
+try:
+    from pylint.interfaces import IAstroidChecker
+except ImportError:
+    class IAstroidChecker:
+        """Backwards compatibility for 2.x / 3.x support."""
+
+try:
+    from pylint.checkers.utils import check_messages
+except ImportError:
+    from pylint.checkers.utils import only_required_for_messages as check_messages
+
 from pylint.checkers import BaseChecker
 from pylint.checkers import utils
-from pylint.checkers.utils import check_messages
 
 MSGS = {
     'E9305': ("disabled",  # kept for backwards compatibility with inline ignores, remove after 2.14 is EOL

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/unwanted.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/unwanted.py
@@ -6,8 +6,14 @@ import typing as t
 
 import astroid
 
+# support pylint 2.x and 3.x -- remove when supporting only 3.x
+try:
+    from pylint.interfaces import IAstroidChecker
+except ImportError:
+    class IAstroidChecker:
+        """Backwards compatibility for 2.x / 3.x support."""
+
 from pylint.checkers import BaseChecker
-from pylint.interfaces import IAstroidChecker
 
 ANSIBLE_TEST_MODULES_PATH = os.environ['ANSIBLE_TEST_MODULES_PATH']
 ANSIBLE_TEST_MODULE_UTILS_PATH = os.environ['ANSIBLE_TEST_MODULE_UTILS_PATH']


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81841

(cherry picked from commit f31c287348d24065d343b7802531b9159e799189)

##### ISSUE TYPE

Test Pull Request
