### PR TITLE
[backport][stable-2.16] Bump `coverage.py` to v7.3.2 in `ansible-test`

### DIFF
--- a/changelogs/fragments/ansible-test-coverage-update.yml
+++ b/changelogs/fragments/ansible-test-coverage-update.yml
@@ -1,7 +1,7 @@
 ---
 
 minor_changes:
-- ansible-test — Python 3.8–3.12 will use ``coverage`` v7.3.0.
+- ansible-test — Python 3.8–3.12 will use ``coverage`` v7.3.2.
 - ansible-test — ``coverage`` v6.5.0 is to be used only under Python 3.7.
 
 ...

--- a/test/lib/ansible_test/_data/requirements/ansible-test.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible-test.txt
@@ -1,5 +1,5 @@
 # The test-constraints sanity test verifies this file, but changes must be made manually to keep it in up-to-date.
 virtualenv == 16.7.12 ; python_version < '3'
-coverage == 7.3.0 ; python_version >= '3.8' and python_version <= '3.12'
+coverage == 7.3.2 ; python_version >= '3.8' and python_version <= '3.12'
 coverage == 6.5.0 ; python_version >= '3.7' and python_version <= '3.7'
 coverage == 4.5.4 ; python_version >= '2.6' and python_version <= '3.6'

--- a/test/lib/ansible_test/_internal/coverage_util.py
+++ b/test/lib/ansible_test/_internal/coverage_util.py
@@ -69,7 +69,7 @@ class CoverageVersion:
 
 COVERAGE_VERSIONS = (
     # IMPORTANT: Keep this in sync with the ansible-test.txt requirements file.
-    CoverageVersion('7.3.0', 7, (3, 8), (3, 12)),
+    CoverageVersion('7.3.2', 7, (3, 8), (3, 12)),
     CoverageVersion('6.5.0', 7, (3, 7), (3, 7)),
     CoverageVersion('4.5.4', 0, (2, 6), (3, 6)),
 )


### PR DESCRIPTION
Backport of PR #81844.

This patch upgrades the `coverage.py` version used under Python 3.8 through 3.12.

Ref #80427

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
^ $sbj ^

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ansible-test`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A