### PR TITLE
Fix traceback and allow installing roles with version None

### DIFF
--- a/changelogs/fragments/a-g-install-version-None.yml
+++ b/changelogs/fragments/a-g-install-version-None.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy role install - fix installing roles from Galaxy that have version ``None`` (https://github.com/ansible/ansible/issues/81832).

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -297,7 +297,7 @@ class GalaxyRole(object):
                     # are no versions in the list, we'll grab the head
                     # of the master branch
                     if len(role_versions) > 0:
-                        loose_versions = [LooseVersion(a.get('name', None)) for a in role_versions]
+                        loose_versions = [v for a in role_versions if (v := LooseVersion()) and v.parse(a.get('name') or '') is None]
                         try:
                             loose_versions.sort()
                         except TypeError:


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible/ansible/issues/81832, thanks to @sivel for the patch.

Since this bug is specific to installing from Galaxy, I can't easily add a test for this until we have a test server for roles.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
