### PR TITLE
ansible-test - Invoke container sleep through env

### DIFF
--- a/changelogs/fragments/ansible-test-container-sleep.yml
+++ b/changelogs/fragments/ansible-test-container-sleep.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ansible-test - When invoking ``sleep`` in containers during container setup, the ``env`` command is used to avoid invoking
+                 the shell builtin, if present.

--- a/test/lib/ansible_test/_internal/host_profiles.py
+++ b/test/lib/ansible_test/_internal/host_profiles.py
@@ -806,6 +806,7 @@ class DockerProfile(ControllerHostProfile[DockerConfig], SshTargetHostProfile[Do
           - Avoid hanging indefinitely or for an unreasonably long time.
 
         NOTE: The container must have a POSIX-compliant default shell "sh" with a non-builtin "sleep" command.
+              The "sleep" command is invoked through "env" to avoid using a shell builtin "sleep" (if present).
         """
         command = ''
 
@@ -813,7 +814,7 @@ class DockerProfile(ControllerHostProfile[DockerConfig], SshTargetHostProfile[Do
             command += f'{init_config.command} && '
 
         if sleep or init_config.command_privileged:
-            command += 'sleep 60 ; '
+            command += 'env sleep 60 ; '
 
         if not command:
             return None


### PR DESCRIPTION
##### SUMMARY

ansible-test - Invoke container sleep through env.

##### ISSUE TYPE

Bugfix Pull Request
