### PR TITLE
Remove python 2.7 and python 3.6 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -54,8 +54,6 @@ stages:
           nameFormat: Python {0}
           testFormat: units/{0}
           targets:
-            - test: 2.7
-            - test: 3.6
             - test: 3.7
             - test: 3.8
             - test: 3.9
@@ -81,10 +79,6 @@ stages:
           targets:
             - name: macOS 13.2
               test: macos/13.2
-            - name: RHEL 7.9
-              test: rhel/7.9
-            - name: RHEL 8.8 py36
-              test: rhel/8.8@3.6
             - name: RHEL 8.8 py311
               test: rhel/8.8@3.11
             - name: RHEL 9.2 py39
@@ -135,12 +129,8 @@ stages:
           targets:
             - name: Alpine 3
               test: alpine3
-            - name: CentOS 7
-              test: centos7
             - name: Fedora 38
               test: fedora38
-            - name: openSUSE 15
-              test: opensuse15
             - name: Ubuntu 20.04
               test: ubuntu2004
             - name: Ubuntu 22.04

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,9 +1,7 @@
-base image=quay.io/ansible/base-test-container:5.8.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12
-default image=quay.io/ansible/default-test-container:9.1.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12 context=collection
-default image=quay.io/ansible/ansible-core-test-container:9.1.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12 context=ansible-core
+base image=quay.io/ansible/base-test-container:5.8.0 python=3.11,3.7,3.8,3.9,3.10,3.12
+default image=quay.io/ansible/default-test-container:9.1.0 python=3.11,3.7,3.8,3.9,3.10,3.12 context=collection
+default image=quay.io/ansible/ansible-core-test-container:9.1.0 python=3.11,3.7,3.8,3.9,3.10,3.12 context=ansible-core
 alpine3 image=quay.io/ansible/alpine3-test-container:5.0.0 python=3.10 cgroup=none audit=none
-centos7 image=quay.io/ansible/centos7-test-container:5.0.0 python=2.7 cgroup=v1-only
 fedora38 image=quay.io/ansible/fedora38-test-container:6.1.0 python=3.11
-opensuse15 image=quay.io/ansible/opensuse15-test-container:6.0.0 python=3.6
 ubuntu2004 image=quay.io/ansible/ubuntu2004-test-container:5.0.0 python=3.8
 ubuntu2204 image=quay.io/ansible/ubuntu2204-test-container:5.0.0 python=3.10

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -6,8 +6,7 @@ freebsd/13.2 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=a
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 macos/13.2 python=3.11 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64
 macos python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64
-rhel/7.9 python=2.7 become=sudo provider=aws arch=x86_64
-rhel/8.8 python=3.6,3.11 become=sudo provider=aws arch=x86_64
+rhel/8.8 python=3.11 become=sudo provider=aws arch=x86_64
 rhel/9.2 python=3.9,3.11 become=sudo provider=aws arch=x86_64
 rhel become=sudo provider=aws arch=x86_64
 ubuntu/22.04 python=3.10 become=sudo provider=aws arch=x86_64

--- a/test/lib/ansible_test/_util/target/common/constants.py
+++ b/test/lib/ansible_test/_util/target/common/constants.py
@@ -6,8 +6,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 REMOTE_ONLY_PYTHON_VERSIONS = (
-    '2.7',
-    '3.6',
     '3.7',
     '3.8',
     '3.9',

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -50,18 +50,12 @@ lib/ansible/modules/user.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/user.py validate-modules:use-run-command-not-popen
 lib/ansible/modules/yum.py validate-modules:parameter-invalid
 lib/ansible/module_utils/basic.py pylint:unused-import  # deferring resolution to allow enabling the rule now
-lib/ansible/module_utils/compat/_selectors2.py future-import-boilerplate # ignore bundled
-lib/ansible/module_utils/compat/_selectors2.py metaclass-boilerplate # ignore bundled
-lib/ansible/module_utils/compat/selinux.py import-2.7!skip # pass/fail depends on presence of libselinux.so
-lib/ansible/module_utils/compat/selinux.py import-3.6!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.7!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.8!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.9!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.10!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.11!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.12!skip # pass/fail depends on presence of libselinux.so
-lib/ansible/module_utils/distro/_distro.py future-import-boilerplate # ignore bundled
-lib/ansible/module_utils/distro/_distro.py metaclass-boilerplate # ignore bundled
 lib/ansible/module_utils/distro/_distro.py no-assert
 lib/ansible/module_utils/distro/_distro.py pep8!skip # bundled code we don't want to modify
 lib/ansible/module_utils/distro/_distro.py pylint:undefined-variable # ignore bundled
@@ -78,8 +72,6 @@ lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1 pslint:PSUse
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1 pslint:PSUseApprovedVerbs
 lib/ansible/module_utils/pycompat24.py no-get-exception
 lib/ansible/module_utils/six/__init__.py empty-init # breaks namespacing, bundled, do not override
-lib/ansible/module_utils/six/__init__.py future-import-boilerplate # ignore bundled
-lib/ansible/module_utils/six/__init__.py metaclass-boilerplate # ignore bundled
 lib/ansible/module_utils/six/__init__.py no-basestring
 lib/ansible/module_utils/six/__init__.py no-dict-iteritems
 lib/ansible/module_utils/six/__init__.py no-dict-iterkeys
@@ -126,7 +118,6 @@ test/integration/targets/module_precedence/lib_with_extension/a.ini shebang
 test/integration/targets/module_precedence/lib_with_extension/ping.ini shebang
 test/integration/targets/module_precedence/roles_with_extension/foo/library/a.ini shebang
 test/integration/targets/module_precedence/roles_with_extension/foo/library/ping.ini shebang
-test/integration/targets/module_utils/library/test.py future-import-boilerplate # allow testing of Python 2.x implicit relative imports
 test/integration/targets/old_style_modules_posix/library/helloworld.sh shebang
 test/integration/targets/template/files/encoding_1252_utf-8.expected no-smart-quotes
 test/integration/targets/template/files/encoding_1252_windows-1252.expected no-smart-quotes


### PR DESCRIPTION
##### SUMMARY

Remove python 2.7 and python 3.6 from CI

##### ISSUE TYPE

- Test Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
