### PR TITLE
[stable-2.16] ansible-test - Update distro containers (#81851)

### DIFF
--- a/changelogs/fragments/ansible-test-distro-containers.yml
+++ b/changelogs/fragments/ansible-test-distro-containers.yml
@@ -1,2 +1,4 @@
 minor_changes:
   - ansible-test - The openSUSE test container has been updated to openSUSE Leap 15.5.
+  - ansible-test - Updated the distro test containers to version 6.3.0 to include coverage 7.3.2 for Python 3.8+.
+                   The alpine3 container is now based on 3.18 instead of 3.17 and includes Python 3.11 instead of Python 3.10.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,9 +1,9 @@
 base image=quay.io/ansible/base-test-container:5.9.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12
 default image=quay.io/ansible/default-test-container:8.11.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12 context=collection
 default image=quay.io/ansible/ansible-core-test-container:8.11.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12 context=ansible-core
-alpine3 image=quay.io/ansible/alpine3-test-container:5.0.0 python=3.10 cgroup=none audit=none
-centos7 image=quay.io/ansible/centos7-test-container:5.0.0 python=2.7 cgroup=v1-only
-fedora38 image=quay.io/ansible/fedora38-test-container:6.1.0 python=3.11
-opensuse15 image=quay.io/ansible/opensuse15-test-container:6.0.0 python=3.6
-ubuntu2004 image=quay.io/ansible/ubuntu2004-test-container:5.0.0 python=3.8
-ubuntu2204 image=quay.io/ansible/ubuntu2204-test-container:5.0.0 python=3.10
+alpine3 image=quay.io/ansible/alpine3-test-container:6.3.0 python=3.11 cgroup=none audit=none
+centos7 image=quay.io/ansible/centos7-test-container:6.3.0 python=2.7 cgroup=v1-only
+fedora38 image=quay.io/ansible/fedora38-test-container:6.3.0 python=3.11
+opensuse15 image=quay.io/ansible/opensuse15-test-container:6.3.0 python=3.6
+ubuntu2004 image=quay.io/ansible/ubuntu2004-test-container:6.3.0 python=3.8
+ubuntu2204 image=quay.io/ansible/ubuntu2204-test-container:6.3.0 python=3.10


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/81851

* ansible-test - Update distro containers

* Update the alpine3 container to Python 3.11

* Update changelog. (cherry picked from commit b7903669b473ffbb7266f379c07125a1ef3d5041)

##### ISSUE TYPE

Feature Pull Request
