### PR TITLE
Restore import_role variable exporting behavior (#81840)

### DIFF
--- a/changelogs/fragments/import_role_goes_public.yml
+++ b/changelogs/fragments/import_role_goes_public.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "``import_role`` reverts to previous behavior of exporting vars at compile time."

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -49,10 +49,10 @@ class IncludeRole(TaskInclude):
 
     # =================================================================================
     # ATTRIBUTES
+    public = NonInheritableFieldAttribute(isa='bool', default=None, private=False, always_post_validate=True)
 
     # private as this is a 'module options' vs a task property
     allow_duplicates = NonInheritableFieldAttribute(isa='bool', default=True, private=True, always_post_validate=True)
-    public = NonInheritableFieldAttribute(isa='bool', default=False, private=True, always_post_validate=True)
     rolespec_validate = NonInheritableFieldAttribute(isa='bool', default=True, private=True, always_post_validate=True)
 
     def __init__(self, block=None, role=None, task_include=None):

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -197,13 +197,13 @@ class VariableManager:
 
         if play:
             if not C.DEFAULT_PRIVATE_ROLE_VARS:
-                # first we compile any vars specified in defaults/main.yml
-                # for all roles within the specified play
                 for role in play.get_roles():
-                    # role from roles or include_role+public or import_role and completed
-                    if not role.from_include or role.public or (role.static and role._completed.get(to_text(host), False)):
+                    # role is public and
+                    #    either static or dynamic and completed
+                    # role is not set
+                    #    use config option as default
+                    if role.static or role.public and role._completed.get(host.name, False):
                         all_vars = _combine_and_track(all_vars, role.get_default_vars(), "role '%s' defaults" % role.name)
-
         if task:
             # set basedirs
             if C.PLAYBOOK_VARS_ROOT == 'all':  # should be default
@@ -386,11 +386,15 @@ class VariableManager:
                 raise AnsibleParserError("Error while reading vars files - please supply a list of file names. "
                                          "Got '%s' of type %s" % (vars_files, type(vars_files)))
 
-            # By default, we now merge in all exported vars from all roles in the play,
-            # unless the user has disabled this via a config option
+            # We now merge in all exported vars from all roles in the play,
+            # unless the user has disabled this
+            # role is public and
+            #    either static or dynamic and completed
+            # role is not set
+            #    use config option as default
             if not C.DEFAULT_PRIVATE_ROLE_VARS:
                 for role in play.get_roles():
-                    if not role.from_include or role.public or (role.static and role._completed.get(to_text(host), False)):
+                    if role.static or role.public and role._completed.get(host.name, False):
                         all_vars = _combine_and_track(all_vars, role.get_vars(include_params=False, only_exports=True), "role '%s' exported vars" % role.name)
 
         # next, we merge in the vars from the role, which will specifically

--- a/test/integration/targets/include_import/public_exposure/no_bleeding.yml
+++ b/test/integration/targets/include_import/public_exposure/no_bleeding.yml
@@ -5,8 +5,8 @@
     - name: Static imports should expose vars at parse time, not at execution time
       assert:
         that:
-          - static_defaults_var is not defined
-          - static_vars_var is not defined
+          - static_defaults_var == 'static_defaults'
+          - static_vars_var == 'static_vars'
     - import_role:
         name: static
     - assert:

--- a/test/integration/targets/include_import/public_exposure/playbook.yml
+++ b/test/integration/targets/include_import/public_exposure/playbook.yml
@@ -10,16 +10,12 @@
     - name: Static imports should expose vars at parse time, not at execution time
       assert:
         that:
-          - static_defaults_var is not defined
-          - static_vars_var is not defined
-          - static_task_var is not defined
+          - static_defaults_var == 'static_defaults'
+          - static_vars_var == 'static_vars'
     - import_role:
         name: static
     - assert:
         that:
-          - static_vars_var is defined
-          - static_tasks_var is defined
-          - static_defaults_var is defined
           - static_tasks_var == 'static_tasks'
           - static_defaults_var == 'static_defaults'
           - static_vars_var == 'static_vars'

--- a/test/integration/targets/roles/vars_scope.yml
+++ b/test/integration/targets/roles/vars_scope.yml
@@ -63,8 +63,7 @@
           play_only: play
           roles_and_role_vars: role_vars
           role_vars_only: role_vars
-
-- name: play and import
+- name: play baseline (no roles)
   hosts: localhost
   gather_facts: false
   vars_files:
@@ -81,6 +80,30 @@
           play_and_roles_and_role_vars: play
           play_and_role_vars: play
           play_only: play
+
+- name: play and import
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - vars/play.yml
+  tasks:
+    - include_tasks: roles/vars_scope/tasks/check_vars.yml
+      vars:
+        defined:
+          play_and_import: play
+          play_and_include: play
+          play_and_roles: play
+          play_only: play
+          default_only: default
+          import_and_role_vars: role_vars
+          include_and_role_vars: role_vars
+          play_and_import_and_role_vars: role_vars
+          play_and_role_vars: role_vars
+          play_and_role_vars_and_role_vars: role_vars
+          play_and_include_and_role_vars: role_vars
+          play_and_roles_and_role_vars: role_vars
+          roles_and_role_vars: role_vars
+          role_vars_only: role_vars
 
     - name: static import
       import_role:


### PR DESCRIPTION
* Import role public (#81772)

revert to previous behavior to push vars to play at compile time add `public` parameter to allow per import control of exporting (vs just the global config)

Co-authored-by: tchernomax <maxime.deroucy@gmail.com>
Co-authored-by: Sloane Hertel <19572925+s-hertel@users.noreply.github.com>
(cherry picked from commit ab6a544e8626eb6767e9578d63b41313f287c796)

* adapted to prev version

 - removed new functionality
 - restored global config functioning overriding specific public option

* remove typoe

* quote it

(cherry picked from commit 9a4bc7e7b3b03955ce32a4f3c1a54330251f0448)


##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
