### PR TITLE
[2.15] switch available_hosts to `frozenset` from `list` in ansible-inventory (#81870)

### DIFF
--- a/changelogs/fragments/inv_available_hosts_to_frozenset.yml
+++ b/changelogs/fragments/inv_available_hosts_to_frozenset.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-inventory - index available_hosts for major performance boost when dumping large inventories

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -325,7 +325,7 @@ class InventoryCLI(CLI):
             return results
 
         hosts = self.inventory.get_hosts(top.name)
-        results = format_group(top, [h.name for h in hosts])
+        results = format_group(top, frozenset(h.name for h in hosts))
 
         # populate meta
         results['_meta'] = {'hostvars': {}}
@@ -381,7 +381,7 @@ class InventoryCLI(CLI):
 
             return results
 
-        available_hosts = [h.name for h in self.inventory.get_hosts(top.name)]
+        available_hosts = frozenset(h.name for h in self.inventory.get_hosts(top.name))
         return format_group(top, available_hosts)
 
     def toml_inventory(self, top):
@@ -425,7 +425,7 @@ class InventoryCLI(CLI):
 
             return results
 
-        available_hosts = [h.name for h in self.inventory.get_hosts(top.name)]
+        available_hosts = frozenset(h.name for h in self.inventory.get_hosts(top.name))
         results = format_group(top, available_hosts)
 
         return results


### PR DESCRIPTION
##### SUMMARY

* major speedup large inventories, since it's consulted iteratively

(cherry picked from commit c1343cc304296bfcec242e31faa3ccf3e4a9880c)

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
