### PR TITLE
Misc typo fixes in connection plugin

### DIFF
--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -267,19 +267,19 @@ class ConnectionBase(AnsiblePlugin):
                 # its my cousin ...
                 value = self._shell._load_name
             else:
-                # deal with generic options if the plugin supports em (for exmaple not all connections have a remote user)
+                # deal with generic options if the plugin supports em (for example not all connections have a remote user)
                 options = C.config.get_plugin_options_from_var('connection', self._load_name, varname)
                 if options:
                     value = self.get_option(options[0])  # for these variables there should be only one option
                 elif 'become' not in varname:
-                    # fallback to play_context, unles becoem related  TODO: in the end should come from task/play and not pc
+                    # fallback to play_context, unless become related  TODO: in the end, should come from task/play and not pc
                     for prop, var_list in C.MAGIC_VARIABLE_MAPPING.items():
                         if varname in var_list:
                             try:
                                 value = getattr(self._play_context, prop)
                                 break
                             except AttributeError:
-                                # it was not defined, fine to ignore
+                                # It was not defined; fine to ignore
                                 continue
 
             if value is not None:


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Change: Fixed a spelling error in the __init.py__ file.
Rationale: The spelling error was causing confusion, and an issue has been raised related to it, so I corrected it to improve clarity.
Design Decisions: No significant design decisions were involved in this simple fix.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request


##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
This change addresses a minor spelling mistake in the documentation. It doesn't introduce any functional changes to the code.

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. Navigate to the __init.py file.
2. Scroll down to the line number 275 and 270.
3. Observe the spelling error: "becoem" and "exmaple."
4. Correct it "become" and "example"

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
