### PR TITLE
win_fetch - improve test time by not scanning Win dir

### DIFF
--- a/test/integration/targets/win_fetch/tasks/main.yml
+++ b/test/integration/targets/win_fetch/tasks/main.yml
@@ -176,8 +176,13 @@
       - "fetch_missing_implicit.msg"
       - "fetch_missing_implicit is not changed"
 
+- name: create empty temp directory
+  win_file:
+    path: '{{ remote_tmp_dir }}\fetch_tmp'
+    state: directory
+
 - name: attempt to fetch a directory
-  fetch: src="C:\\Windows" dest={{ host_output_dir }}
+  fetch: src="{{ remote_tmp_dir }}\\fetch_tmp" dest={{ host_output_dir }}
   register: fetch_dir
   ignore_errors: true
 
@@ -224,4 +229,3 @@
   assert:
     that:
     - "fetch_wildcard_file_nofail is not failed"
-   


### PR DESCRIPTION
##### SUMMARY
A part of the fetch operation is to call `stat` on the path specified. For Windows this means it'll get the size of the target which can be an expensive operation for directories with lots of children. This changes the test so it uses an empty dir to speed up the test times.

##### ISSUE TYPE
- Test Pull Request