### PR TITLE
[stable-2.14] Add test coverage for winrm (#81910)

### DIFF
--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -441,3 +441,23 @@ class TestWinRMKerbAuth(object):
         assert str(err.value) == \
             "Kerberos auth failure for principal username with pexpect: " \
             "Error with kinit\n<redacted>"
+
+    def test_exec_command_with_timeout(self, monkeypatch):
+        requests_exc = pytest.importorskip("requests.exceptions")
+
+        pc = PlayContext()
+        new_stdin = StringIO()
+        conn = connection_loader.get('winrm', pc, new_stdin)
+
+        mock_proto = MagicMock()
+        mock_proto.run_command.side_effect = requests_exc.Timeout("msg")
+
+        conn._connected = True
+        conn._winrm_host = 'hostname'
+
+        monkeypatch.setattr(conn, "_winrm_connect", lambda: mock_proto)
+
+        with pytest.raises(AnsibleConnectionFailure) as e:
+            conn.exec_command('cmd', in_data=None, sudoable=True)
+
+        assert str(e.value) == "winrm connection error: msg"


### PR DESCRIPTION
(cherry picked from commit 282908c57e32e9f9ef17e2a5f899b6aa8caaf452)

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/81910 and https://github.com/ansible/ansible/pull/81923

##### ISSUE TYPE
- Test Pull Request