### PR TITLE
ansible-galaxy - fix traceback error for invalid req file (#81917) - 2.16

### DIFF
--- a/changelogs/fragments/81901-galaxy-requirements-format.yml
+++ b/changelogs/fragments/81901-galaxy-requirements-format.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy - Provide a better error message when using a requirements file with an invalid format - https://github.com/ansible/ansible/issues/81901

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -835,7 +835,7 @@ class GalaxyCLI(CLI):
             for role_req in file_requirements:
                 requirements['roles'] += parse_role_req(role_req)
 
-        else:
+        elif isinstance(file_requirements, dict):
             # Newer format with a collections and/or roles key
             extra_keys = set(file_requirements.keys()).difference(set(['roles', 'collections']))
             if extra_keys:
@@ -853,6 +853,9 @@ class GalaxyCLI(CLI):
                 )
                 for collection_req in file_requirements.get('collections') or []
             ]
+
+        else:
+            raise AnsibleError(f"Expecting requirements yaml to be a list or dictionary but got {type(file_requirements).__name__}")
 
         return requirements
 

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -771,6 +771,20 @@ def test_collection_install_with_names(collection_install):
     assert mock_install.call_args[0][6] is False  # force_deps
 
 
+def test_collection_install_with_invalid_requirements_format(collection_install):
+    output_dir = collection_install[2]
+
+    requirements_file = os.path.join(output_dir, 'requirements.yml')
+    with open(requirements_file, 'wb') as req_obj:
+        req_obj.write(b'"invalid"')
+
+    galaxy_args = ['ansible-galaxy', 'collection', 'install', '--requirements-file', requirements_file,
+                   '--collections-path', output_dir]
+
+    with pytest.raises(AnsibleError, match="Expecting requirements yaml to be a list or dictionary but got str"):
+        GalaxyCLI(args=galaxy_args).run()
+
+
 def test_collection_install_with_requirements_file(collection_install):
     mock_install, mock_warning, output_dir = collection_install
 


### PR DESCRIPTION
Provide a better error message when encountering a YAML requirements file that is not a dictionary or list.

##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/81917

##### ISSUE TYPE
- Bugfix Pull Request
