### PR TITLE
[git] Pass private key content from the control node

### DIFF
--- a/changelogs/fragments/81943-git_ssh-key-as-string-value.yml
+++ b/changelogs/fragments/81943-git_ssh-key-as-string-value.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - git module - Feature to pass a SSH key as a string value

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -77,7 +77,7 @@ options:
             - This ensures 'IdentitiesOnly=yes' is present in O(ssh_opts).
         type: path
         version_added: "1.5"
-    key_file_content:
+    key_content:
         description:
             - Specify an optional private key file to use for the checkout.
             - This ensures 'IdentitiesOnly=yes' is present in O(ssh_opts).
@@ -303,7 +303,7 @@ EXAMPLES = '''
   ansible.builtin.git:
     repo: https://github.com/ansible/ansible-examples.git
     dest: /src/ansible-examples
-    key_file_content: "{{ lookup('ansible.builtin.env', 'GPG_KEY') }}"
+    key_content: "{{ lookup('ansible.builtin.env', 'SSH_KEY') }}"
     single_branch: yes
     accept_hostkey: yes
 
@@ -1209,7 +1209,7 @@ def main():
             accept_hostkey=dict(default='no', type='bool'),
             accept_newhostkey=dict(default='no', type='bool'),
             key_file=dict(default=None, type='path', required=False),
-            key_file_content=dict(default=None, required=False, no_log=True),
+            key_content=dict(default=None, required=False, no_log=True),
             ssh_opts=dict(default=None, required=False),
             executable=dict(default=None, type='path'),
             bare=dict(default='no', type='bool'),
@@ -1222,7 +1222,7 @@ def main():
             separate_git_dir=dict(type='path'),
         ),
         mutually_exclusive=[('separate_git_dir', 'bare'), ('accept_hostkey', 'accept_newhostkey'),
-                            ('key_file', 'key_file_content')],
+                            ('key_file', 'key_content')],
         required_by={'archive_prefix': ['archive']},
         supports_check_mode=True
     )
@@ -1243,7 +1243,7 @@ def main():
     single_branch = module.params['single_branch']
     git_path = module.params['executable'] or module.get_bin_path('git', True)
     key_file = module.params['key_file']
-    key_file_content = module.params['key_file_content']
+    key_content = module.params['key_content']
     ssh_opts = module.params['ssh_opts']
     umask = module.params['umask']
     archive = module.params['archive']
@@ -1318,11 +1318,11 @@ def main():
     # iface changes so need it to make decisions
     git_version_used = git_version(git_path, module)
 
-    if key_file_content:
-        key_file_content += "\n" if not key_file_content.endswith("\n") else ""
-        key = to_bytes(key_file_content)
+    if key_content:
+        key_content += "\n" if not key_content.endswith("\n") else ""
+        key = to_bytes(key_content)
         # tempfile not saved on disk
-        tmpfd, key_file = tempfile.mkstemp()
+        tmpfd, key_file = tempfile.mkstemp(dir=module.tmpdir)
         module.add_cleanup_file(key_file)
         tmpfile = os.fdopen(tmpfd, "w+b")
         tmpfile.write(key)

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -82,6 +82,7 @@ options:
             - Specify an optional private key file to use for the checkout.
             - This ensures 'IdentitiesOnly=yes' is present in O(ssh_opts).
         type: str
+        version_added: "2.17"
     reference:
         description:
             - Reference repository (see "git clone --reference ...").

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -290,7 +290,7 @@ EXAMPLES = '''
     dest: /src/ansible-examples
     single_branch: yes
     version: master
-    
+
 - name: Example clone of a single branch using a private key on the target host
   ansible.builtin.git:
     repo: https://github.com/ansible/ansible-examples.git
@@ -298,7 +298,7 @@ EXAMPLES = '''
     key_file: /home/ansible/.ssh/id_ed25519
     single_branch: yes
     accept_hostkey: yes
-    
+
 - name: Example clone of a single branch using a private key from the control node
   ansible.builtin.git:
     repo: https://github.com/ansible/ansible-examples.git
@@ -1209,7 +1209,7 @@ def main():
             accept_hostkey=dict(default='no', type='bool'),
             accept_newhostkey=dict(default='no', type='bool'),
             key_file=dict(default=None, type='path', required=False),
-            key_file_content=dict(default=None, required=False),
+            key_file_content=dict(default=None, required=False, no_log=True),
             ssh_opts=dict(default=None, required=False),
             executable=dict(default=None, type='path'),
             bare=dict(default='no', type='bool'),

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -1321,10 +1321,12 @@ def main():
     if key_file_content:
         key_file_content += "\n" if not key_file_content.endswith("\n") else ""
         key = to_bytes(key_file_content)
-        tmpfile = tempfile.NamedTemporaryFile(prefix="tmp_", delete=False)
+        # tempfile not saved on disk
+        tmpfd, key_file = tempfile.mkstemp()
+        module.add_cleanup_file(key_file)
+        tmpfile = os.fdopen(tmpfd, "w+b")
         tmpfile.write(key)
         tmpfile.close()
-        key_file = tmpfile.name
 
     # GIT_SSH=<path> as an environment variable, might create sh wrapper script for older versions.
     set_git_ssh_env(key_file, ssh_opts, git_version_used, module)

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -79,8 +79,7 @@ options:
         version_added: "1.5"
     key_content:
         description:
-            - Specify an optional private key file to use for the checkout.
-            - This ensures 'IdentitiesOnly=yes' is present in O(ssh_opts).
+            - Specify an optional private key string value to use for the checkout.
         type: str
         version_added: "2.17"
     reference:

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -29,6 +29,7 @@
   - import_tasks: formats.yml
   - import_tasks: missing_hostkey.yml
   - import_tasks: missing_hostkey_acceptnew.yml
+  - import_tasks: private-key.yml
   - import_tasks: no-destination.yml
   - import_tasks: specific-revision.yml
   - import_tasks: submodules.yml

--- a/test/integration/targets/git/tasks/private-key.yml
+++ b/test/integration/targets/git/tasks/private-key.yml
@@ -3,14 +3,14 @@
     repo: '{{ repo_format2 }}'
     dest: '{{ checkout_dir }}'
     single_branch: yes
-    key_file_content: "{{ lookup('ansible.builtin.env', 'GPG_KEY', default='nobody') }}"
+    key_content: "{{ lookup('ansible.builtin.env', 'SSH_KEY', default='nobody') }}"
     key_file: '{{ github_ssh_private_key }}'
     accept_hostkey: yes
   ignore_errors: True
   register: failed_git
   when: github_ssh_private_key is defined
 
-- name: Assert that mutually exclusive parameters key_file_content & key_file failed
+- name: Assert that mutually exclusive parameters key_content & key_file failed
   assert:
     that:
       - failed_git is failed

--- a/test/integration/targets/git/tasks/private-key.yml
+++ b/test/integration/targets/git/tasks/private-key.yml
@@ -1,0 +1,18 @@
+- name: Try with both src and content to ensure it fails
+  ansible.builtin.git:
+    repo: '{{ repo_format2 }}'
+    dest: '{{ checkout_dir }}'
+    single_branch: yes
+    key_file_content: "{{ lookup('ansible.builtin.env', 'GPG_KEY', default='nobody') }}"
+    key_file: '{{ github_ssh_private_key }}'
+    accept_hostkey: yes
+  ignore_errors: True
+  register: failed_git
+  when: github_ssh_private_key is defined
+
+- name: Assert that mutually exclusive parameters key_file_content & key_file failed
+  assert:
+    that:
+      - failed_git is failed
+      - "'mutually exclusive' in failed_git.msg"
+  when: github_ssh_private_key is defined


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Currently our control hosts access secrets from either env. vars or AWS SSM and it would be handy if the content of a private key could be passed directly from the control hosts to avoid having private keys sitting on the remote hosts.

Env. vars.
```bash
export SSH_KEY="-----BEGIN OPENSSH PRIVATE KEY-----
kahsdkashdausdhiasudhaksdhkdshj
..........
kdhksdfhks
-----END OPENSSH PRIVATE KEY-----"
```
```yaml
- ansible.builtin.git:
    repo: "{{ repo_url }}"
    dest: "{{ remote_dir.path }}"
    key_content: "{{ lookup('ansible.builtin.env', 'SSH_KEY') }}"
    single_branch: yes
    accept_hostkey: yes
```

Env. vars.
```yaml
- ansible.builtin.git:
    repo: "{{ repo_url }}"
    dest: "{{ remote_dir.path }}"
    key_content: '{{ lookup("aws_ssm", "/test/ansible/git.key", region="us-east-1" )}}'
    single_branch: yes
    accept_hostkey: yes
```

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->


```paste below

```
