### PR TITLE
make constant loading dynamic

### DIFF
--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -96,7 +96,7 @@ class ConfigCLI(CLI):
         super(ConfigCLI, self).__init__(args, callback)
 
         # we don't want 'dynamic' constants
-        C.force_preload()
+        C._force_preload()
 
     def init_parser(self):
 

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -95,6 +95,9 @@ class ConfigCLI(CLI):
         self.config = None
         super(ConfigCLI, self).__init__(args, callback)
 
+        # we don't want 'dynamic' constants
+        C.force_preload()
+
     def init_parser(self):
 
         super(ConfigCLI, self).init_parser(

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -272,6 +272,7 @@ config = ConfigManager()
 
 
 def __getattr__(config_constant):
+    """ Module level 'getter' that populates constants on demand and avoids having to preload them """
 
     if config_constant not in globals():
         try:
@@ -286,8 +287,8 @@ def __getattr__(config_constant):
 
     return globals()[config_constant]
 
+# we always initalize these constants as others depend on them for basic config templating.
 for c in __INITIALIZE:
-    # we always initalize these constants as others depend on them for basic config templating.
-    # TODO: create a dep system to avoid hardcoded list, previouslly relied on order in base.yml
-    #       now relies on order in hardcoded constant in this file.
+    # NOTE: We should create a dep system to avoid hardcoded list, previouslly relied on order in base.yml
+    #      now relies on order in hardcoded constant in this file.
     __getattr__(c)

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -267,8 +267,10 @@ MAGIC_VARIABLE_MAPPING = dict(
 )
 
 
-# INITALIZE CONFIG MANAGER
-config = ConfigManager()
+def force_preload():
+    """ read all available constants, used for config dumps """
+    for setting in config.get_configuration_definitions():
+        set_constant(setting, config.get_config_value(setting, variables=vars()))
 
 
 def __getattr__(config_constant):
@@ -286,6 +288,10 @@ def __getattr__(config_constant):
         handle_config_noise()
 
     return globals()[config_constant]
+
+
+# INITALIZE CONFIG MANAGER
+config = ConfigManager()
 
 # we always initalize these constants as others depend on them for basic config templating.
 for c in __INITIALIZE:

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -83,9 +83,9 @@ class _DeprecatedSequenceConstant(Sequence):
 
 
 def __getattr__(config_constant):
-    ''' Handle dynamicall generating a 'constant' when first requested,
+    """ Handle dynamicall generating a 'constant' when first requested,
         otherwise just return it from cached value.
-    '''
+    """
 
     if config_constant not in globals():
         try:
@@ -267,8 +267,9 @@ MAGIC_VARIABLE_MAPPING = dict(
 )
 
 
-def force_preload():
+def _force_preload():
     """ read all available constants, used for config dumps """
+    # NOTE: previous templating dependencies should already be covered, order does not matter anymore
     for setting in config.get_configuration_definitions():
         set_constant(setting, config.get_config_value(setting, variables=vars()))
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -271,11 +271,9 @@ MAGIC_VARIABLE_MAPPING = dict(
 )
 
 
-# INITALIZE CONFIG MANAGER
-config = ConfigManager()
-
-# we always initalize these constants as others depend on them for basic config templating.
+# we always initialize these constants as others depend on them for basic config templating.
 for c in __INITIALIZE:
-    # NOTE: We should create a dep system to avoid hardcoded list, previouslly relied on order in base.yml
-    #      now relies on order in hardcoded constant in this file.
+    # NOTE: We should create a dep system to avoid a hardcoded list,
+    #       previously relied on the order in base.yml.
+    #       now relies on order in hardcoded constant in this file.
     __getattr__(c)

--- a/test/integration/targets/deprecations/runme.sh
+++ b/test/integration/targets/deprecations/runme.sh
@@ -6,19 +6,19 @@ export ANSIBLE_DEPRECATION_WARNINGS=True
 
 ### check general config
 
-# check for entry key valid, no deprecation
+# not using anything deprecated , so no notice
 [ "$(ANSIBLE_CONFIG='entry_key_not_deprecated.cfg' ansible -m meta -a 'noop'  localhost 2>&1 | grep -c 'DEPRECATION')" -eq "0" ]
 
-# key is deprecated, but not accessed, so no notice
+# entry source is deprecated, but entry is not consumed, so no notice
 [ "$(ANSIBLE_CONFIG='entry_key_deprecated.cfg' ansible -m meta -a 'noop' localhost 2>&1 | grep -c 'DEPRECATION')" -eq "0" ]
 
-# check for entry key deprecation including the name of the option, must be defined and accessed to trigger
+# check for entry source deprecation including the name of the option, consumed so must trigger
 [ "$(ANSIBLE_CONFIG='entry_key_deprecated.cfg' ansible -m debug -a 'msg={{q("config", "_Z_TEST_ENTRY")}}' localhost 2>&1 | grep -c "\[DEPRECATION WARNING\]: \[testing\]deprecated option.")" -eq "1" ]
 
-# check for entry deprecation, must be loaded to trigger
+# check deprecated entry is not accessed, so no notice
 [ "$(ANSIBLE_CONFIG='entry_key_deprecated2.cfg' ansible -m meta -a 'noop'  localhost 2>&1 | grep -c 'DEPRECATION')" -eq "0" ]
 
-# check for deprecation of entry itself, must be consumed to trigger
+# check deprecated entry, consumed so must trigger
 [ "$(ANSIBLE_TEST_ENTRY2=1 ansible -m debug -a 'msg={{q("config", "_Z_TEST_ENTRY_2")}}' localhost  2>&1 | grep -c 'DEPRECATION')" -eq "1" ]
 
 

--- a/test/integration/targets/deprecations/runme.sh
+++ b/test/integration/targets/deprecations/runme.sh
@@ -9,14 +9,17 @@ export ANSIBLE_DEPRECATION_WARNINGS=True
 # check for entry key valid, no deprecation
 [ "$(ANSIBLE_CONFIG='entry_key_not_deprecated.cfg' ansible -m meta -a 'noop'  localhost 2>&1 | grep -c 'DEPRECATION')" -eq "0" ]
 
-# check for entry key deprecation including the name of the option, must be defined to trigger
-[ "$(ANSIBLE_CONFIG='entry_key_deprecated.cfg' ansible -m meta -a 'noop' localhost 2>&1 | grep -c "\[DEPRECATION WARNING\]: \[testing\]deprecated option.")" -eq "1" ]
+# key is deprecated, but not accessed, so no notice
+[ "$(ANSIBLE_CONFIG='entry_key_deprecated.cfg' ansible -m meta -a 'noop' localhost 2>&1 | grep -c 'DEPRECATION')" -eq "0" ]
+
+# check for entry key deprecation including the name of the option, must be defined and accessed to trigger
+[ "$(ANSIBLE_CONFIG='entry_key_deprecated.cfg' ansible -m debug -a 'msg={{q("config", "_Z_TEST_ENTRY")}}' localhost 2>&1 | grep -c "\[DEPRECATION WARNING\]: \[testing\]deprecated option.")" -eq "1" ]
+
+# check for entry deprecation, must be loaded to trigger
+[ "$(ANSIBLE_CONFIG='entry_key_deprecated2.cfg' ansible -m meta -a 'noop'  localhost 2>&1 | grep -c 'DEPRECATION')" -eq "0" ]
 
 # check for deprecation of entry itself, must be consumed to trigger
 [ "$(ANSIBLE_TEST_ENTRY2=1 ansible -m debug -a 'msg={{q("config", "_Z_TEST_ENTRY_2")}}' localhost  2>&1 | grep -c 'DEPRECATION')" -eq "1" ]
-
-# check for entry deprecation, just need key defined to trigger
-[ "$(ANSIBLE_CONFIG='entry_key_deprecated2.cfg' ansible -m meta -a 'noop'  localhost 2>&1 | grep -c 'DEPRECATION')" -eq "1" ]
 
 
 ### check plugin config

--- a/test/integration/targets/deprecations/runme.sh
+++ b/test/integration/targets/deprecations/runme.sh
@@ -6,7 +6,7 @@ export ANSIBLE_DEPRECATION_WARNINGS=True
 
 ### check general config
 
-# not using anything deprecated , so no notice
+# not using anything deprecated, so no notice
 [ "$(ANSIBLE_CONFIG='entry_key_not_deprecated.cfg' ansible -m meta -a 'noop'  localhost 2>&1 | grep -c 'DEPRECATION')" -eq "0" ]
 
 # entry source is deprecated, but entry is not consumed, so no notice


### PR DESCRIPTION
Don't load a configuration unless we need it.

Config deprecations/warnings less noisy as they will only trigger for config sources if setting is consumed
##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request
