### PR TITLE
Update default test container Python to 3.12 and support for PyLint 3.0.1

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-python-3.12.yml
+++ b/changelogs/fragments/ansible-test-pylint-python-3.12.yml
@@ -1,2 +1,0 @@
-known_issues:
-  - ansible-test - The ``pylint`` sanity test is not supported on Python 3.12. Use Python 3.10 or 3.11 instead.

--- a/changelogs/fragments/ansible-test-pylint-update.yml
+++ b/changelogs/fragments/ansible-test-pylint-update.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test - Update ``pylint`` to version 3.0.1.
+  - ansible-test - Include missing ``pylint`` requirements for Python 3.10.

--- a/changelogs/fragments/ansible-test-python-3.12-compat.yml
+++ b/changelogs/fragments/ansible-test-python-3.12-compat.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Add a ``pylint`` plugin to work around a known issue on Python 3.12.

--- a/changelogs/fragments/ansible-test-python-default.yml
+++ b/changelogs/fragments/ansible-test-python-default.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Make Python 3.12 the default version used in the ``base`` and ``default`` containers.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,6 +1,6 @@
-base image=quay.io/ansible/base-test-container:5.9.0 python=3.11,3.7,3.8,3.9,3.10,3.12
-default image=quay.io/ansible/default-test-container:9.2.0 python=3.11,3.7,3.8,3.9,3.10,3.12 context=collection
-default image=quay.io/ansible/ansible-core-test-container:9.2.0 python=3.11,3.7,3.8,3.9,3.10,3.12 context=ansible-core
+base image=quay.io/ansible/base-test-container:5.9.0 python=3.12,3.7,3.8,3.9,3.10,3.11
+default image=quay.io/ansible/default-test-container:9.2.0 python=3.12,3.7,3.8,3.9,3.10,3.11 context=collection
+default image=quay.io/ansible/ansible-core-test-container:9.2.0 python=3.12,3.7,3.8,3.9,3.10,3.11 context=ansible-core
 alpine3 image=quay.io/ansible/alpine3-test-container:6.3.0 python=3.11 cgroup=none audit=none
 fedora38 image=quay.io/ansible/fedora38-test-container:6.3.0 python=3.11
 ubuntu2004 image=quay.io/ansible/ubuntu2004-test-container:6.3.0 python=3.8

--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
@@ -4,6 +4,8 @@ dill==0.3.7
 isort==5.12.0
 mccabe==0.7.0
 platformdirs==3.11.0
-pylint==3.0.0
+pylint==3.0.1
 PyYAML==6.0.1
+tomli==2.0.1
 tomlkit==0.12.1
+typing_extensions==4.8.0

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/hide_unraisable.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/hide_unraisable.py
@@ -1,0 +1,24 @@
+"""Temporary plugin to prevent stdout noise pollution from finalization of abandoned generators under Python 3.12"""
+from __future__ import annotations
+
+import sys
+import typing as t
+
+if t.TYPE_CHECKING:
+    from pylint.lint import PyLinter
+
+
+def _mask_finalizer_valueerror(ur: t.Any) -> None:
+    """Mask only ValueErrors from finalizing abandoned generators; delegate everything else"""
+    # work around Py3.12 finalizer changes that sometimes spews this error message to stdout
+    # see https://github.com/pylint-dev/pylint/issues/9138
+    if ur.exc_type is ValueError and 'generator already executing' in str(ur.exc_value):
+        return
+
+    sys.__unraisablehook__(ur)
+
+
+def register(linter: PyLinter) -> None:  # pylint: disable=unused-argument
+    """PyLint plugin registration entrypoint"""
+    if sys.version_info >= (3, 12):
+        sys.unraisablehook = _mask_finalizer_valueerror


### PR DESCRIPTION
##### SUMMARY

Includes temporary workaround for https://github.com/pylint-dev/pylint/issues/9138 - should enable ansible-test to successfully use pylint 3.0.1 under Python 3.12.


##### ISSUE TYPE
- Bugfix Pull Request

