### PR TITLE
[stable-2.16] ansible-test - Update base/default containers

### DIFF
--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,6 +1,6 @@
-base image=quay.io/ansible/base-test-container:5.9.0 python=3.12,2.7,3.6,3.7,3.8,3.9,3.10,3.11
-default image=quay.io/ansible/default-test-container:8.11.0 python=3.12,2.7,3.6,3.7,3.8,3.9,3.10,3.11 context=collection
-default image=quay.io/ansible/ansible-core-test-container:8.11.0 python=3.12,2.7,3.6,3.7,3.8,3.9,3.10,3.11 context=ansible-core
+base image=quay.io/ansible/base-test-container:5.10.0 python=3.12,2.7,3.6,3.7,3.8,3.9,3.10,3.11
+default image=quay.io/ansible/default-test-container:8.12.0 python=3.12,2.7,3.6,3.7,3.8,3.9,3.10,3.11 context=collection
+default image=quay.io/ansible/ansible-core-test-container:8.12.0 python=3.12,2.7,3.6,3.7,3.8,3.9,3.10,3.11 context=ansible-core
 alpine3 image=quay.io/ansible/alpine3-test-container:6.3.0 python=3.11 cgroup=none audit=none
 centos7 image=quay.io/ansible/centos7-test-container:6.3.0 python=2.7 cgroup=v1-only
 fedora38 image=quay.io/ansible/fedora38-test-container:6.3.0 python=3.11


### PR DESCRIPTION
##### SUMMARY

This brings in the container updates to make Python 3.12 the default version used for testing.

##### ISSUE TYPE

Feature Pull Request
