### PR TITLE
ansible-test - Update base/default containers

### DIFF
--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,6 +1,6 @@
-base image=quay.io/ansible/base-test-container:5.9.0 python=3.12,3.7,3.8,3.9,3.10,3.11
-default image=quay.io/ansible/default-test-container:9.2.0 python=3.12,3.7,3.8,3.9,3.10,3.11 context=collection
-default image=quay.io/ansible/ansible-core-test-container:9.2.0 python=3.12,3.7,3.8,3.9,3.10,3.11 context=ansible-core
+base image=quay.io/ansible/base-test-container:6.0.0 python=3.12,3.7,3.8,3.9,3.10,3.11
+default image=quay.io/ansible/default-test-container:9.3.0 python=3.12,3.7,3.8,3.9,3.10,3.11 context=collection
+default image=quay.io/ansible/ansible-core-test-container:9.3.0 python=3.12,3.7,3.8,3.9,3.10,3.11 context=ansible-core
 alpine3 image=quay.io/ansible/alpine3-test-container:6.3.0 python=3.11 cgroup=none audit=none
 fedora38 image=quay.io/ansible/fedora38-test-container:6.3.0 python=3.11
 ubuntu2004 image=quay.io/ansible/ubuntu2004-test-container:6.3.0 python=3.8


### PR DESCRIPTION
##### SUMMARY

This drops Python 2.7 and 3.6 from the containers.

##### ISSUE TYPE

Feature Pull Request
