### PR TITLE
Fix outdated S3 URLs

### DIFF
--- a/test/integration/targets/dnf/vars/main.yml
+++ b/test/integration/targets/dnf/vars/main.yml
@@ -3,4 +3,4 @@ dnf_log_files:
     - /var/log/dnf.rpm.log
     - /var/log/dnf.librepo.log
 
-skip_broken_repo_baseurl: "https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/dnf/skip-broken/RPMS/"
+skip_broken_repo_baseurl: "https://ci-files.testing.ansible.com/test/integration/targets/dnf/skip-broken/RPMS/"

--- a/test/integration/targets/unarchive/tasks/test_download.yml
+++ b/test/integration/targets/unarchive/tasks/test_download.yml
@@ -8,7 +8,7 @@
   block:
   - name: unarchive a tar from an URL
     unarchive:
-      src: "https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/apt/echo-hello-source.tar.gz"
+      src: "https://ci-files.testing.ansible.com/test/integration/targets/apt/echo-hello-source.tar.gz"
       dest: "{{ remote_tmp_dir }}/test-unarchive-tar-gz"
       mode: "0700"
       remote_src: yes


### PR DESCRIPTION
##### SUMMARY

We should always use the CloudFront backed endpoint (ci-files) not the direct S3 bucket reference (ansible-ci-files).

##### ISSUE TYPE

Test Pull Request
