### PR TITLE
Implement relative path in checksumfile

### DIFF
--- a/changelogs/fragments/81967-get_url-relative-path.yml
+++ b/changelogs/fragments/81967-get_url-relative-path.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "``ansible.modules.get_url`` Implement relative url for checksum file"

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -391,6 +391,19 @@ def url_filename(url):
     return fn
 
 
+def url_path(url):
+    fn = os.path.dirname(urlsplit(url)[2])
+    if fn == '':
+        return '/'
+    return fn
+
+
+def pre_prefix(str, prefix):
+    if str.startswith(prefix):
+        str_new = str[len(prefix):]
+    return str_new
+
+
 def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, headers=None, tmp_dest='', method='GET', unredirected_headers=None,
             decompress=True, ciphers=None, use_netrc=True):
     """
@@ -576,7 +589,13 @@ def main():
             with open(checksum_tmpsrc) as f:
                 lines = [line.rstrip('\n') for line in f]
             os.remove(checksum_tmpsrc)
-            filename = url_filename(url)
+            path = url_path(url)
+            relative_path = pre_prefix(path, os.path.commonpath([path, url_path(checksum_url)]))
+
+            if relative_path == '' :
+                filename = url_filename(url)
+            else :
+                filename = "%s/%s" % (relative_path, url_filename(url))
             checksum_map = parse_digest_lines(filename=filename, lines=lines)
             # Look through each line in the checksum file for a hash corresponding to
             # the filename in the url, returning the first hash that is found.

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -316,6 +316,11 @@
     dest: "{{ files_dir }}"
     state: directory
 
+- name: create files_dir subdir
+  file:
+    dest: "{{ files_dir }}/subdir"
+    state: directory
+
 - name: create src file
   copy:
     dest: '{{ files_dir }}/{{ item }}.txt'
@@ -325,6 +330,7 @@
     - 71420
     - 86132
     - 86132_single_space
+    - subdir/relative
 
 - name: create sha1 checksum file of src
   copy:
@@ -336,6 +342,7 @@
       a97e6837f60cec6da4491bab387296bbcd72bdba 86132_single_space.txt
       3911340502960ca33aece01129234460bfeb2791  not_target1.txt
       1b4b6adf30992cedb0f6edefd6478ff0a593b2e4  not_target2.txt
+      a97e6837f60cec6da4491bab387296bbcd72bdba  subdir/relative.txt
 
 - name: create sha256 checksum file of src
   copy:
@@ -347,6 +354,7 @@
       b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006. 86132_single_space.txt
       30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892  not_target1.txt
       d0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b  not_target2.txt
+      b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006.  subdir/relative.txt
 
 - name: create sha256 checksum file of src with a dot leading path
   copy:
@@ -358,6 +366,7 @@
       b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006. ./86132_single_space.txt
       30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892  ./not_target1.txt
       d0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b  ./not_target2.txt
+      b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006.  ./subdir/relative.txt
 
 - name: create sha256 checksum file of src with a * leading path
   copy:
@@ -369,6 +378,7 @@
       b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006. *86132_single_space.txt
       30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892 *not_target1.txt
       d0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b *not_target2.txt
+      b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006. *subdir/relative.txt
 
 - name: create sha256 checksum file of src in BSD-style checksum (--tag)
   copy:
@@ -456,6 +466,28 @@
 - stat:
     path: "{{ remote_tmp_dir }}/27617sha256_with_asterisk.txt"
   register: stat_result_sha256_with_asterisk
+
+- name: download src with sha256 checksum url with relative paths
+  get_url:
+    url: 'http://localhost:{{ http_port }}/subdir/relative.txt'
+    dest: '{{ remote_tmp_dir }}/relative256.txt'
+    checksum: 'sha256:http://localhost:{{ http_port }}/sha256sum.txt'
+  register: result_sha256_relative
+
+- stat:
+    path: "{{ remote_tmp_dir }}/relative256.txt"
+  register: stat_result_sha256_relative
+
+- name: download src with sha1 checksum url with relative paths
+  get_url:
+    url: 'http://localhost:{{ http_port }}/subdir/relative.txt'
+    dest: '{{ remote_tmp_dir }}/relative1.txt'
+    checksum: 'sha1:http://localhost:{{ http_port }}/sha1sum.txt'
+  register: result_sha1_relative
+
+- stat:
+    path: "{{ remote_tmp_dir }}/relative1.txt"
+  register: stat_result_sha1_relative
 
 - name: download src with sha256 checksum url with file scheme
   get_url:
@@ -605,17 +637,21 @@
     that:
       - result_sha1 is changed
       - result_sha1_check_mode is changed
+      - result_sha1_relative is changed
       - result_sha256 is changed
       - result_sha256_with_dot is changed
       - result_sha256_with_asterisk is changed
       - result_sha256_with_file_scheme is changed
       - result_sha256_with_bsd_style is changed
+      - result_sha256_relative is changed
       - "stat_result_sha1.stat.exists == true"
+      - "stat_result_sha1_relative.stat.exists == true"
       - "stat_result_sha256.stat.exists == true"
       - "stat_result_sha256_with_dot.stat.exists == true"
       - "stat_result_sha256_with_asterisk.stat.exists == true"
       - "stat_result_sha256_with_file_scheme.stat.exists == true"
       - stat_result_sha256_with_bsd_style.stat.exists
+      - "stat_result_sha256_relative.stat.exists == true"
       - result_sha1_71420 is changed
       - result_sha256_71420 is changed
       - result_sha256_with_dot_71420 is changed


### PR DESCRIPTION
##### SUMMARY

Implement relative path url when checksum file and file isn't at same level.

##### ISSUE TYPE

Feature Pull Request

##### ADDITIONAL INFORMATION

By exemple get_url don't work for download file on Debian repository : 

```
- name:  Download OS tar 
  ansible.builtin.get_url:
    url: 'https://deb.debian.org/debian/dists/bullseye/main/installer-amd64/current/images/netboot/netboot.tar.gz'
    dest: '/srv/tftp/images/netboot.tar.gz'
    checksum: 'sha256:https://deb.debian.org/debian/dists/bullseye/main/installer-amd64/current/images/SHA256SUMS'
    mode: '0644'
```

