### PR TITLE
Replace launchpad.net/api with api.launchpad.net @ apt_repository module

### DIFF
--- a/changelogs/fragments/81978-fix-lp-api-endpoint.yml
+++ b/changelogs/fragments/81978-fix-lp-api-endpoint.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - apt_repository.py - Use api.launchpad.net endpoint instead of launchpad.net/api

--- a/changelogs/fragments/81978-fix-lp-api-endpoint.yml
+++ b/changelogs/fragments/81978-fix-lp-api-endpoint.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - apt_repository.py - Use api.launchpad.net endpoint instead of launchpad.net/api

--- a/changelogs/fragments/81978-launchpad-api-endpoint.yml
+++ b/changelogs/fragments/81978-launchpad-api-endpoint.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - apt_repository.py - use api.launchpad.net endpoint instead of launchpad.net/api

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -456,6 +456,8 @@ class SourcesList(object):
 
 class UbuntuSourcesList(SourcesList):
 
+    # prefer api.launchpad.net over launchpad.net/api
+    # see: https://github.com/ansible/ansible/pull/81978#issuecomment-1767062178
     LP_API = 'https://api.launchpad.net/1.0/~%s/+archive/%s'
 
     def __init__(self, module):

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -456,7 +456,7 @@ class SourcesList(object):
 
 class UbuntuSourcesList(SourcesList):
 
-    LP_API = 'https://launchpad.net/api/1.0/~%s/+archive/%s'
+    LP_API = 'https://api.launchpad.net/1.0/~%s/+archive/%s'
 
     def __init__(self, module):
         self.module = module


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

See: https://help.launchpad.net/API and https://help.launchpad.net/API/Hacking
launchpad.net is the web endpoint
api.launchpad.net is the web services (api) endpoint

When using the `apt_repository` module with molecule, and setting up/tearing down my test environment frequently, I intermittently ran into issues with the web endpoint. Namely, in some cases, the endpoint will return 0 bytes of data (presumably if the data is cached). The api endpoint seems to return the full object even if it is 'not modified'. The result of 0 bytes of data being returned was a `JSONDecodeError` when attempting to add a ppa repository.

```yaml
- name: Add ansible repository
  ansible.builtin.apt_repository:
    repo: ppa:ansible/ansible
    update_cache: true
    state: present
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```python-traceback
The full traceback is:
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1697388928.1372871-71804-82371821093402/AnsiballZ_apt_repository.py", line 107, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1697388928.1372871-71804-82371821093402/AnsiballZ_apt_repository.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1697388928.1372871-71804-82371821093402/AnsiballZ_apt_repository.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible.modules.apt_repository', init_globals=dict(_module_fqn='ansible.modules.apt_repository', _modlib_path=modlib_path),
  File "/usr/lib/python3.10/runpy.py", line 224, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_ansible.builtin.apt_repository_payload_kckl7er1/ansible_ansible.builtin.apt_repository_payload.zip/ansible/modules/apt_repository.py", line 765, in <module>
  File "/tmp/ansible_ansible.builtin.apt_repository_payload_kckl7er1/ansible_ansible.builtin.apt_repository_payload.zip/ansible/modules/apt_repository.py", line 709, in main
  File "/tmp/ansible_ansible.builtin.apt_repository_payload_kckl7er1/ansible_ansible.builtin.apt_repository_payload.zip/ansible/modules/apt_repository.py", line 540, in add_source
  File "/tmp/ansible_ansible.builtin.apt_repository_payload_kckl7er1/ansible_ansible.builtin.apt_repository_payload.zip/ansible/modules/apt_repository.py", line 482, in _get_ppa_info
  File "/usr/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
fatal: [ubuntu]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1697388928.1372871-71804-82371821093402/AnsiballZ_apt_repository.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1697388928.1372871-71804-82371821093402/AnsiballZ_apt_repository.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1697388928.1372871-71804-82371821093402/AnsiballZ_apt_repository.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible.modules.apt_repository', init_globals=dict(_module_fqn='ansible.modules.apt_repository', _modlib_path=modlib_path),\n  File \"/usr/lib/python3.10/runpy.py\", line 224, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_ansible.builtin.apt_repository_payload_kckl7er1/ansible_ansible.builtin.apt_repository_payload.zip/ansible/modules/apt_repository.py\", line 765, in <module>\n  File \"/tmp/ansible_ansible.builtin.apt_repository_payload_kckl7er1/ansible_ansible.builtin.apt_repository_payload.zip/ansible/modules/apt_repository.py\", line 709, in main\n  File \"/tmp/ansible_ansible.builtin.apt_repository_payload_kckl7er1/ansible_ansible.builtin.apt_repository_payload.zip/ansible/modules/apt_repository.py\", line 540, in add_source\n  File \"/tmp/ansible_ansible.builtin.apt_repository_payload_kckl7er1/ansible_ansible.builtin.apt_repository_payload.zip/ansible/modules/apt_repository.py\", line 482, in _get_ppa_info\n  File \"/usr/lib/python3.10/json/__init__.py\", line 346, in loads\n    return _default_decoder.decode(s)\n  File \"/usr/lib/python3.10/json/decoder.py\", line 337, in decode\n    obj, end = self.raw_decode(s, idx=_w(s, 0).end())\n  File \"/usr/lib/python3.10/json/decoder.py\", line 355, in raw_decode\n    raise JSONDecodeError(\"Expecting value\", s, err.value) from None\njson.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}

```

after:
```yaml
changed: [ubuntu] => {
    "changed": true,
    "diff": [],
    "invocation": {
        "module_args": {
            "codename": null,
            "filename": null,
            "install_python_apt": true,
            "mode": null,
            "repo": "ppa:ansible/ansible",
            "state": "present",
            "update_cache": true,
            "update_cache_retries": 5,
            "update_cache_retry_max_delay": 12,
            "validate_certs": true
        }
    },
    "repo": "ppa:ansible/ansible",
    "sources_added": [
        "/etc/apt/sources.list.d/ppa_ansible_ansible_jammy.list"
    ],
    "sources_removed": [],
    "state": "present"
}
```
