### PR TITLE
var names not matching in example.

### DIFF
--- a/lib/ansible/plugins/test/superset.yml
+++ b/lib/ansible/plugins/test/superset.yml
@@ -19,7 +19,7 @@ DOCUMENTATION:
       required: True
 EXAMPLES: |
   big: [1,2,3,4,5]
-  sml: [3,4]
+  small: [3,4]
   issmallinbig: '{{ big is superset(small) }}'
 RETURN:
   _value:


### PR DESCRIPTION
Update to var name as example is not correct.

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Update var from sml to small as incorrect in documenation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION

Example is not valid as var name is incorrect. 

```
    small: [3,4]
```
