### PR TITLE
Fix task.resolved_action callbacks

### DIFF
--- a/changelogs/fragments/correct-callback-fqcn-old-style-action-invocation.yml
+++ b/changelogs/fragments/correct-callback-fqcn-old-style-action-invocation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix the task attribute ``resolved_action`` to show the FQCN instead of ``None`` when ``action`` or ``local_action`` is used in the playbook.

--- a/changelogs/fragments/correct-callback-fqcn-old-style-action-invocation.yml
+++ b/changelogs/fragments/correct-callback-fqcn-old-style-action-invocation.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - Fix the task attribute ``resolved_action`` to show the FQCN instead of ``None`` when ``action`` or ``local_action`` is used in the playbook.
+  - Fix using ``module_defaults`` with ``local_action``/``action`` (https://github.com/ansible/ansible/issues/81905).

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -303,7 +303,7 @@ class ModuleArgsParser:
             delegate_to = 'localhost'
             action, args = self._normalize_parameters(thing, action=action, additional_args=additional_args)
 
-        if action is not None:
+        if action is not None and not skip_action_validation:
             context = _get_action_context(action, self._collection_list)
             if context is not None and context.resolved:
                 self.resolved_action = context.resolved_fqcn

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -53,6 +53,18 @@ BUILTIN_TASKS = frozenset(add_internal_fqcns((
 )))
 
 
+def _get_action_context(action_or_module, collection_list):
+    module_context = module_loader.find_plugin_with_context(action_or_module, collection_list=collection_list)
+    if module_context and module_context.resolved and module_context.action_plugin:
+        action_or_module = module_context.action_plugin
+
+    if action_loader.has_plugin(action_or_module, collection_list=collection_list):
+        context = action_loader.find_plugin_with_context(action_or_module, collection_list=collection_list)
+    else:
+        context = module_context
+    return context
+
+
 class ModuleArgsParser:
 
     """
@@ -291,6 +303,11 @@ class ModuleArgsParser:
             delegate_to = 'localhost'
             action, args = self._normalize_parameters(thing, action=action, additional_args=additional_args)
 
+        if action is not None:
+            context = _get_action_context(action, self._collection_list)
+            if context is not None and context.resolved:
+                self.resolved_action = context.resolved_fqcn
+
         # module: <stuff> is the more new-style invocation
 
         # filter out task attributes so we're only querying unrecognized keys as actions/modules
@@ -306,9 +323,7 @@ class ModuleArgsParser:
                 is_action_candidate = True
             else:
                 try:
-                    context = action_loader.find_plugin_with_context(item, collection_list=self._collection_list)
-                    if not context.resolved:
-                        context = module_loader.find_plugin_with_context(item, collection_list=self._collection_list)
+                    context = _get_action_context(item, self._collection_list)
                 except AnsibleError as e:
                     if e.obj is None:
                         e.obj = self._task_ds

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -58,9 +58,8 @@ def _get_action_context(action_or_module, collection_list):
     if module_context and module_context.resolved and module_context.action_plugin:
         action_or_module = module_context.action_plugin
 
-    if action_loader.has_plugin(action_or_module, collection_list=collection_list):
-        context = action_loader.find_plugin_with_context(action_or_module, collection_list=collection_list)
-    else:
+    context = action_loader.find_plugin_with_context(action_or_module, collection_list=collection_list)
+    if not context or not context.resolved:
         context = module_context
     return context
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -208,6 +208,7 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
             # But if it wasn't, we can add the yaml object now to get more detail
             raise AnsibleParserError(to_native(e), obj=ds, orig_exc=e)
         else:
+            # Set the resolved action plugin (or if it does not exist, module) for callbacks.
             self.resolved_action = args_parser.resolved_action
 
         # the command/shell/script modules used to support the `cmd` arg,

--- a/test/integration/targets/collections/test_task_resolved_plugin/unqualified_and_collections_kw.yml
+++ b/test/integration/targets/collections/test_task_resolved_plugin/unqualified_and_collections_kw.yml
@@ -10,5 +10,7 @@
     - ping:
     - collection_action:
     - collection_module:
-    - formerly_action:
-    - formerly_module:
+    - local_action:
+        module: formerly_action
+    - action:
+        module: formerly_module

--- a/test/integration/targets/module_defaults/tasks/main.yml
+++ b/test/integration/targets/module_defaults/tasks/main.yml
@@ -10,16 +10,23 @@
     - debug:
       register: foo
 
+    - local_action:
+        module: debug
+      register: local_action_foo
+
     - name: test that 'debug' task used default 'msg' param
       assert:
-        that: foo.msg == "test default"
+        that:
+          - foo.msg == "test default"
+          - local_action_foo.msg == "test default"
 
     - name: remove test file
       file:
         state: absent
 
     - name: touch test file
-      file:
+      local_action:
+        module: file
         state: touch
 
     - name: stat test file

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -46,9 +46,9 @@ class TestBlock(unittest.TestCase):
 
     def test_load_block_with_tasks(self):
         ds = dict(
-            block=[dict(action='block')],
-            rescue=[dict(action='rescue')],
-            always=[dict(action='always')],
+            block=[dict(action='ping')],
+            rescue=[dict(action='ping')],
+            always=[dict(action='ping')],
             # otherwise=[dict(action='otherwise')],
         )
         b = Block.load(ds)
@@ -63,16 +63,16 @@ class TestBlock(unittest.TestCase):
         # self.assertIsInstance(b.otherwise[0], Task)
 
     def test_load_implicit_block(self):
-        ds = [dict(action='foo')]
+        ds = [dict(action='ping')]
         b = Block.load(ds)
         self.assertEqual(len(b.block), 1)
         self.assertIsInstance(b.block[0], Task)
 
     def test_deserialize(self):
         ds = dict(
-            block=[dict(action='block')],
-            rescue=[dict(action='rescue')],
-            always=[dict(action='always')],
+            block=[dict(action='ping')],
+            rescue=[dict(action='ping')],
+            always=[dict(action='ping')],
         )
         b = Block.load(ds)
         data = dict(parent=ds, parent_type='Block')

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -20,6 +20,10 @@ from __future__ import annotations
 import unittest
 from ansible.playbook.block import Block
 from ansible.playbook.task import Task
+from ansible.plugins.loader import init_plugin_loader
+
+
+init_plugin_loader()
 
 
 class TestBlock(unittest.TestCase):
@@ -46,9 +50,9 @@ class TestBlock(unittest.TestCase):
 
     def test_load_block_with_tasks(self):
         ds = dict(
-            block=[dict(action='ping')],
-            rescue=[dict(action='ping')],
-            always=[dict(action='ping')],
+            block=[dict(action='block')],
+            rescue=[dict(action='rescue')],
+            always=[dict(action='always')],
             # otherwise=[dict(action='otherwise')],
         )
         b = Block.load(ds)
@@ -63,16 +67,16 @@ class TestBlock(unittest.TestCase):
         # self.assertIsInstance(b.otherwise[0], Task)
 
     def test_load_implicit_block(self):
-        ds = [dict(action='ping')]
+        ds = [dict(action='foo')]
         b = Block.load(ds)
         self.assertEqual(len(b.block), 1)
         self.assertIsInstance(b.block[0], Task)
 
     def test_deserialize(self):
         ds = dict(
-            block=[dict(action='ping')],
-            rescue=[dict(action='ping')],
-            always=[dict(action='ping')],
+            block=[dict(action='block')],
+            rescue=[dict(action='rescue')],
+            always=[dict(action='always')],
         )
         b = Block.load(ds)
         data = dict(parent=ds, parent_type='Block')

--- a/test/units/playbook/test_helpers.py
+++ b/test/units/playbook/test_helpers.py
@@ -122,16 +122,16 @@ class TestLoadListOfTasks(unittest.TestCase, MixinForMocks):
                                ds, play=self.mock_play,
                                variable_manager=self.mock_variable_manager, loader=self.fake_loader)
 
-    def test_unknown_action(self):
-        action_name = 'foo_test_unknown_action'
+    def test_known_action(self):
+        action_name = 'ping'
         ds = [{'action': action_name}]
         res = helpers.load_list_of_tasks(ds, play=self.mock_play,
                                          variable_manager=self.mock_variable_manager, loader=self.fake_loader)
         self._assert_is_task_list_or_blocks(res)
         self.assertEqual(res[0].action, action_name)
 
-    def test_block_unknown_action(self):
-        action_name = 'foo_test_block_unknown_action'
+    def test_block_known_action(self):
+        action_name = 'ping'
         ds = [{
             'block': [{'action': action_name}]
         }]
@@ -316,9 +316,9 @@ class TestLoadListOfRoles(unittest.TestCase, MixinForMocks):
         for r in res:
             self.assertIsInstance(r, RoleInclude)
 
-    def test_block_unknown_action(self):
+    def test_block_known_action(self):
         ds = [{
-            'block': [{'action': 'foo_test_block_unknown_action'}]
+            'block': [{'action': 'ping'}]
         }]
         ds = [{'name': 'bogus_role'}]
         res = helpers.load_list_of_roles(ds, self.mock_play,
@@ -352,8 +352,8 @@ class TestLoadListOfBlocks(unittest.TestCase, MixinForMocks):
                                variable_manager=None,
                                loader=None)
 
-    def test_block_unknown_action(self):
-        ds = [{'action': 'foo', 'collections': []}]
+    def test_block_known_action(self):
+        ds = [{'action': 'ping', 'collections': []}]
         mock_play = MagicMock(name='MockPlay')
         res = helpers.load_list_of_blocks(ds, mock_play, parent_block=None, role=None, task_include=None, use_handlers=False, variable_manager=None,
                                           loader=None)

--- a/test/units/playbook/test_helpers.py
+++ b/test/units/playbook/test_helpers.py
@@ -24,13 +24,16 @@ from unittest.mock import MagicMock
 from units.mock.loader import DictDataLoader
 
 from ansible import errors
+from ansible.playbook import helpers
 from ansible.playbook.block import Block
 from ansible.playbook.handler import Handler
 from ansible.playbook.task import Task
 from ansible.playbook.task_include import TaskInclude
 from ansible.playbook.role.include import RoleInclude
+from ansible.plugins.loader import init_plugin_loader
 
-from ansible.playbook import helpers
+
+init_plugin_loader()
 
 
 class MixinForMocks(object):
@@ -122,16 +125,16 @@ class TestLoadListOfTasks(unittest.TestCase, MixinForMocks):
                                ds, play=self.mock_play,
                                variable_manager=self.mock_variable_manager, loader=self.fake_loader)
 
-    def test_known_action(self):
-        action_name = 'ping'
+    def test_unknown_action(self):
+        action_name = 'foo_test_unknown_action'
         ds = [{'action': action_name}]
         res = helpers.load_list_of_tasks(ds, play=self.mock_play,
                                          variable_manager=self.mock_variable_manager, loader=self.fake_loader)
         self._assert_is_task_list_or_blocks(res)
         self.assertEqual(res[0].action, action_name)
 
-    def test_block_known_action(self):
-        action_name = 'ping'
+    def test_block_unknown_action(self):
+        action_name = 'foo_test_block_unknown_action'
         ds = [{
             'block': [{'action': action_name}]
         }]
@@ -316,9 +319,9 @@ class TestLoadListOfRoles(unittest.TestCase, MixinForMocks):
         for r in res:
             self.assertIsInstance(r, RoleInclude)
 
-    def test_block_known_action(self):
+    def test_block_unknown_action(self):
         ds = [{
-            'block': [{'action': 'ping'}]
+            'block': [{'action': 'foo_test_block_unknown_action'}]
         }]
         ds = [{'name': 'bogus_role'}]
         res = helpers.load_list_of_roles(ds, self.mock_play,
@@ -352,8 +355,8 @@ class TestLoadListOfBlocks(unittest.TestCase, MixinForMocks):
                                variable_manager=None,
                                loader=None)
 
-    def test_block_known_action(self):
-        ds = [{'action': 'ping', 'collections': []}]
+    def test_block_unknown_action(self):
+        ds = [{'action': 'foo', 'collections': []}]
         mock_play = MagicMock(name='MockPlay')
         res = helpers.load_list_of_blocks(ds, mock_play, parent_block=None, role=None, task_include=None, use_handlers=False, variable_manager=None,
                                           loader=None)


### PR DESCRIPTION
##### SUMMARY

Noticed while looking at the related fix to not use this attribute for module_defaults in https://github.com/ansible/ansible/pull/81909.

Not sure if there is a better way to set this - it feels a bit redundant to load the plugin context additional times.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request