### PR TITLE
Respect `ANSIBLE_HOME` when determining SSH control path directory 

### DIFF
--- a/changelogs/fragments/82026-ssh-control-path-fix.yaml
+++ b/changelogs/fragments/82026-ssh-control-path-fix.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - SSH connection plugin - Previously, the default SSH ``control_path_dir`` was hardcoded to ``~/.ansible/cp``. Now, it respects the ``$ANSIBLE_HOME`` environment variable, resulting in a default of ``$ANSIBLE_HOME/cp`` (https://github.com/ansible/ansible/issues/79737).

--- a/changelogs/fragments/82026-ssh-control-path-fix.yaml
+++ b/changelogs/fragments/82026-ssh-control-path-fix.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - SSH connection plugin - Previously, the default SSH ``control_path_dir`` was hardcoded to ``~/.ansible/cp``. Now, it respects the ``$ANSIBLE_HOME`` environment variable, resulting in a default of ``$ANSIBLE_HOME/cp`` (https://github.com/ansible/ansible/issues/79737).
+  - SSH connection plugin - Previously, the default SSH ``control_path_dir`` was hardcoded to ``~/.ansible/cp``. Now, it respects the ``$ANSIBLE_HOME`` configuration setting, resulting in a default of ``$ANSIBLE_HOME/cp`` (https://github.com/ansible/ansible/issues/79737).

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -279,7 +279,7 @@ DOCUMENTATION = '''
           - name: ansible_control_path
             version_added: '2.7'
       control_path_dir:
-        default: ~/.ansible/cp
+        default: $ANSIBLE_HOME/cp
         description:
           - This sets the directory to use for ssh control path if the control path setting is null.
           - Also, provides the ``%(directory)s`` variable for the control path setting.

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -279,9 +279,9 @@ DOCUMENTATION = '''
           - name: ansible_control_path
             version_added: '2.7'
       control_path_dir:
-        default: $ANSIBLE_HOME/cp
         description:
           - This sets the directory to use for ssh control path if the control path setting is null.
+          - If null (default), it defaults to ``$ANSIBLE_HOME/cp``.
           - Also, provides the ``%(directory)s`` variable for the control path setting.
         type: string
         env:
@@ -395,6 +395,7 @@ import time
 import typing as t
 
 from functools import wraps
+import ansible.constants as C
 from ansible.errors import (
     AnsibleAuthenticationFailure,
     AnsibleConnectionFailure,
@@ -814,6 +815,8 @@ class Connection(ConnectionBase):
 
             if not controlpath:
                 self.control_path_dir = self.get_option('control_path_dir')
+                if self.control_path_dir is None:
+                    self.control_path_dir = os.path.join(C.ANSIBLE_HOME, "cp")
                 cpdir = unfrackpath(self.control_path_dir)
                 b_cpdir = to_bytes(cpdir, errors='surrogate_or_strict')
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -281,7 +281,8 @@ DOCUMENTATION = '''
       control_path_dir:
         description:
           - This sets the directory to use for ssh control path if the control path setting is null.
-          - If null (default), it defaults to ``$ANSIBLE_HOME/cp``.
+          - Since 2.17, if null (default), it defaults to ``$ANSIBLE_HOME/cp``.
+          - Prior to 2.17, it defaulted to ``~/.ansible/cp``, regardless of the value of ANSIBLE_HOME.
           - Also, provides the ``%(directory)s`` variable for the control path setting.
         type: string
         env:


### PR DESCRIPTION
##### SUMMARY

When choosing the default `control_path_directory` for SSH connections, Ansible will now respect the `ANSIBLE_HOME` configuration setting, instead of using a hardcoded `~/.ansible`.

Because this new behavior relies on a value from `ansible.constants`, I've removed the default for this variable from the docstring, in favor of calculating it in Python at the point of use.

Fixes #79737.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

When running the repro steps from the original issue, with the `-vvv` option, the new control path can be seen in action:
```
<citadel.local> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o 'ControlPath="/Users/sodle/.cache/ansible/cp/c8e8ca50e5"' citadel.local '/bin/sh -c '"'"'rm -f -r /home/sodle/.ansible/tmp/ansible-tmp-1697684386.315946-8679-39523000970181/ > /dev/null 2>&1 && sleep 0'"'"''
```
