### PR TITLE
Block Outgoing Traffic to a Specific IP

### DIFF
--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -531,6 +531,14 @@ EXAMPLES = r'''
     log_prefix: "IPTABLES:INFO: "
     log_level: info
 
+- name: Block outgoing traffic to a specific IP
+  ansible.builtin.iptables:
+    chain: OUTPUT
+    protocol: all
+    destination: 8.8.8.8
+    jump: DROP
+  become: yes    
+
 - name: Allow connections on multiple ports
   ansible.builtin.iptables:
     chain: INPUT


### PR DESCRIPTION
##### SUMMARY

This rule blocks all outgoing traffic to the given IP address.

##### ISSUE TYPE
- Docs Pull Request

