### PR TITLE
[stable-2.12] ansible-test - Fix parsing of cgroup entries

### DIFF
--- a/changelogs/fragments/ansible-test-cgroup-split.yml
+++ b/changelogs/fragments/ansible-test-cgroup-split.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix parsing of cgroup entries which contain a ``:`` in the path (https://github.com/ansible/ansible/issues/81977).

--- a/test/lib/ansible_test/_internal/cgroup.py
+++ b/test/lib/ansible_test/_internal/cgroup.py
@@ -41,7 +41,7 @@ class CGroupEntry:
     @classmethod
     def parse(cls, value: str) -> CGroupEntry:
         """Parse the given cgroup line from the proc filesystem and return a cgroup entry."""
-        cid, subsystem, path = value.split(':')
+        cid, subsystem, path = value.split(':', maxsplit=2)
 
         return cls(
             id=int(cid),


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/82040

(cherry picked from commit e933d9d8a6155478ce99518d111220e680201ca2)

##### ISSUE TYPE

Bugfix Pull Request
