### PR TITLE
Add support for TLS 1.3 Post Handshake Auth

### DIFF
--- a/changelogs/fragments/urls-tls13-post-handshake-auth.yml
+++ b/changelogs/fragments/urls-tls13-post-handshake-auth.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- urls - Add support for TLS 1.3 post handshake certificate authentication - https://github.com/ansible/ansible/issues/81782

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -496,6 +496,12 @@ def make_context(cafile=None, cadata=None, capath=None, ciphers=None, validate_c
         context.set_ciphers(':'.join(map(to_native, ciphers)))
 
     if client_cert:
+        # TLS 1.3 needs this to be set to True to allow post handshake cert
+        # authentication. This functionality was added in Python 3.8 and was
+        # backported to 3.6.7, and 3.7.1 so needs a check for now.
+        if hasattr(context, "post_handshake_auth"):
+            context.post_handshake_auth = True
+
         context.load_cert_chain(client_cert, keyfile=client_key)
 
     return context


### PR DESCRIPTION
##### SUMMARY
TLS 1.3 adds a different method it can use to request a client certificate after the handshake but Python does not allow this by default. This commit sets the attribute needed to enable this scenario when using client certificates on Python 3.8+.

Fixes: https://github.com/ansible/ansible/issues/81782

##### ISSUE TYPE
- Feature Pull Request