### PR TITLE
don't warn about using a yescrypt hash as user password

### DIFF
--- a/changelogs/fragments/user-accept-yescrypt-hash.yml
+++ b/changelogs/fragments/user-accept-yescrypt-hash.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- user - accept yescrypt hash as user password

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -631,6 +631,9 @@ class User(object):
                         # sha512
                         if fields[1] == '6' and len(fields[-1]) != 86:
                             maybe_invalid = True
+                        # yescrypt
+                        if fields[1] == 'y' and len(fields[-1]) != 43:
+                            maybe_invalid = True
                     else:
                         maybe_invalid = True
             if maybe_invalid:

--- a/test/integration/targets/user/tasks/test_create_user_password.yml
+++ b/test/integration/targets/user/tasks/test_create_user_password.yml
@@ -1,5 +1,5 @@
 # test user add with password
-- name: add an encrypted password for user
+- name: add an sha512 password for user
   user:
     name: ansibulluser
     password: "$6$rounds=656000$TT4O7jz2M57npccl$33LF6FcUMSW11qrESXL1HX0BS.bsiT6aenFLLiVpsQh6hDtI9pJh5iY7x8J7ePkN4fP8hmElidHXaeD51pbGS."
@@ -88,3 +88,15 @@
           - "'warnings' not in test_user_encrypt3"
           - "'warnings' not in test_user_encrypt4"
           - "'warnings' not in test_user_encrypt5"
+
+- name: add an yescrypt password for user
+  user:
+    name: ansibulluser
+    password: "$y$jCT$ZiF3ZV39/maUl9Lzt2Hk80$Ih6bI4OXU52OnWWqt3T1BAmVn8eH.4qlcP.8/NOjGN5"
+    state: present
+    update_password: always
+  register: test_user_encrypt6
+
+- name: there should not be warnings
+  assert:
+    that: "'warnings' not in test_user_encrypt6"


### PR DESCRIPTION
##### SUMMARY

Even though `yescrypt` isn't currently supported for user password (https://github.com/ansible/ansible/issues/75797), using a `yescrypt` hash is and shouldn't trigger a warning.

##### ISSUE TYPE

- Bugfix Pull Request
