### PR TITLE
Add support for Scrypt as a key derivation function

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1173,6 +1173,14 @@ DEFAULT_VAULT_PASSWORD_FILE:
   - {key: vault_password_file, section: defaults}
   type: path
   yaml: {key: defaults.vault_password_file}
+VAULT_SCRYPT_KDF:
+  name: Scrypt key derivation function enable flag
+  default: ~
+  description: 'Allows users to specify Scrypt as the key derivation function. If it is not provided, PBKDF2HMAC is used.'
+  env: [{name: ANSIBLE_VAULT_SCRYPT_KDF}]
+  ini:
+  - {key: vault_scrypt_kdf, section: defaults}
+  version_added: '2.15'
 DEFAULT_VERBOSITY:
   name: Verbosity
   default: 0

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -1174,7 +1174,7 @@ class VaultAES256:
                 r=8,
                 p=1,
             )
-            b_derivedkey = kdf.derive(b"my great password")
+            b_derivedkey = kdf.derive(b_password)
 
         return b_derivedkey
 

--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -606,3 +606,23 @@ out=$(diff salted_test1 salted_test2)
 # shoudl be diff
 out=$(diff salted_test1 salted_test3 || true)
 [ "${out}" != "" ]
+
+### SCRYPT KDF TESTING ###
+# prep files for encryption
+for scrypted in test1 test2 test3
+do
+    echo 'this is salty' > "salted_${scrypted}"
+done
+
+# encrypt files
+ANSIBLE_VAULT_SCRYPT_KDF=true ansible-vault encrypt scrypted_test1 --vault-password-file example1_password "$@"
+ANSIBLE_VAULT_SCRYPT_KDF=true ansible-vault encrypt scrypted_test2 --vault-password-file example1_password "$@"
+ansible-vault encrypt scrypted_test3 --vault-password-file example1_password "$@"
+
+# should be the same
+out=$(diff scrypted_test1 scrypted_test2)
+[ "${out}" == "" ]
+
+# shoudl be diff
+out=$(diff scrypted_test1 scrypted_test3 || true)
+[ "${out}" != "" ]


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
[Scrypt](https://datatracker.ietf.org/doc/html/rfc7914.html) is a memory hard key derivation function that helps to protect against offline password cracking attempts. 

I'm not sure if this is wanted or necessary, but I thought it could be a beneficial addition and wanted to raise the PR for the feature. I tried to make it minimally invasive in terms of usage changes and followed this [PR](https://github.com/ansible/ansible/pull/79063)  as an example for making the changes to vault. 

Let me know if this is something that the community might want included and if so, any other requirements for a PR. 



<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Reference implementation: https://cryptography.io/en/latest/hazmat/primitives/key-derivation-functions/#cryptography.hazmat.primitives.kdf.scrypt.Scrypt 
