### PR TITLE
Add DCO and update CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,9 +10,11 @@ The GitHub issue tracker is not the best place for questions for various reasons
 
 ## CONTRIBUTING ?
 
-By contributing you agree that these contributions are your own (or approved by your employer) and you grant a full, complete, irrevocable copyright license to all users and developers of the project, present and future, pursuant to the license of the project. You can also read the same [CLA](https://docs.ansible.com/ansible/latest/community/contributor_license_agreement.html) on the Ansible docsite.
+By contributing to this project you agree to the Developer Certificate of Origin (DCO). This document was created by the Linux Kernel community and is a simple statement that you, as a contributor, have the legal right to make the contribution. See the DCO section below for details.
 
-Please review the [Community Guide](https://docs.ansible.com/ansible/latest/community/index.html) for more information on contributing to Ansible.
+The Ansible project is licensed under the [GPL-3.0](COPYING) or later, although some portions of the code fall under other licenses - this is noted in the individual files.
+
+The Ansible project accepts contributions through GitHub pull requests. Please review the [Community Guide](https://docs.ansible.com/ansible/latest/community/index.html) for more information on contributing to Ansible.
 
 ## BUG TO REPORT ?
 
@@ -23,3 +25,44 @@ You can report bugs or make enhancement requests at the [Ansible GitHub issue pa
 Also please make sure you are testing on the latest released version of Ansible or the development branch; see the [Installation Guide](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) for details.
 
 Thanks!
+
+## DEVELOPER CERTIFICATE OF ORIGIN (DCO) VERSION 1.1
+
+```text
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ The GitHub issue tracker is not the best place for questions for various reasons
 
 By contributing to this project you agree to the Developer Certificate of Origin (DCO). This document was created by the Linux Kernel community and is a simple statement that you, as a contributor, have the legal right to make the contribution. See the DCO section below for details.
 
-The Ansible project is licensed under the [GPL-3.0](COPYING) or later, although some portions of the code fall under other licenses - this is noted in the individual files.
+The Ansible project is licensed under the [GPL-3.0](COPYING) or later. Some portions of the code fall under other licenses as noted in individual files.
 
 The Ansible project accepts contributions through GitHub pull requests. Please review the [Community Guide](https://docs.ansible.com/ansible/latest/community/index.html) for more information on contributing to Ansible.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ The GitHub issue tracker is not the best place for questions for various reasons
 
 ## CONTRIBUTING ?
 
-By contributing to this project you agree to the Developer Certificate of Origin (DCO). This document was created by the Linux Kernel community and is a simple statement that you, as a contributor, have the legal right to make the contribution. See the DCO section below for details.
+By contributing to this project you agree to the [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco).
 
 The Ansible project is licensed under the [GPL-3.0](COPYING) or later. Some portions of the code fall under other licenses as noted in individual files.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,7 +26,9 @@ Also please make sure you are testing on the latest released version of Ansible 
 
 Thanks!
 
-## DEVELOPER CERTIFICATE OF ORIGIN (DCO) VERSION 1.1
+## DEVELOPER CERTIFICATE OF ORIGIN (DCO)
+
+This document was created by the Linux Kernel community and is a simple statement that you, as a contributor, have the legal right to make the contribution.
 
 ```text
 Developer Certificate of Origin


### PR DESCRIPTION
##### SUMMARY

Adopt the Developer Certificate of Origin & add the necessary DCO files to the repo root.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

Historically Ansible has had a "Contributor's License Agreement" ([here](https://github.com/ansible/ansible/blob/release1.5.0/CONTRIBUTING.md#contributors-license-agreement) in the original source, and today [lives in the docs](https://github.com/ansible/ansible-documentation/blob/devel/docs/docsite/rst/community/contributor_license_agreement.rst)) - this is not really a CLA as normally understood in open source, and has caused confusion in wider circles, especially when we talk about whether or not we use "proper" CLAs

To resolve this, we're proposing to use the Developer Certificate of Origin instead. This is commonly thought to require per-commit signoffs, but that is not actually required. As per [other examples](https://github.com/metal3-io/metal3-docs/) it is acceptable to have a prominent display of the DCO at the root of the repo, and a mention in CONTRIBUTING.md - this PR does both of those things. No action is needed on a per-commit basis with this approach.

This is paired with https://github.com/ansible/ansible-documentation/pull/598 which updates the development guides and associated pages. You can also see more discussion on https://github.com/ansible/ansible-documentation/issues/340, and of course I'll be happy to go into more detail if needed

/cc @richardfontana
