### PR TITLE
Use functools.update_wrapper instead of a copy

### DIFF
--- a/changelogs/fragments/functools-update-wrapper.yml
+++ b/changelogs/fragments/functools-update-wrapper.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Use Python's built-in ``functools.update_wrapper`` instead an inline copy from Python 3.7.

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import ast
 import datetime
+import functools
 import os
 import pwd
 import re
@@ -295,23 +296,7 @@ def _unroll_iterator(func):
             return list(ret)
         return ret
 
-    return _update_wrapper(wrapper, func)
-
-
-def _update_wrapper(wrapper, func):
-    # This code is duplicated from ``functools.update_wrapper`` from Py3.7.
-    # ``functools.update_wrapper`` was failing when the func was ``functools.partial``
-    for attr in ('__module__', '__name__', '__qualname__', '__doc__', '__annotations__'):
-        try:
-            value = getattr(func, attr)
-        except AttributeError:
-            pass
-        else:
-            setattr(wrapper, attr, value)
-    for attr in ('__dict__',):
-        getattr(wrapper, attr).update(getattr(func, attr, {}))
-    wrapper.__wrapped__ = func
-    return wrapper
+    return functools.update_wrapper(wrapper, func)
 
 
 def _wrap_native_text(func):
@@ -324,7 +309,7 @@ def _wrap_native_text(func):
         ret = func(*args, **kwargs)
         return NativeJinjaText(ret)
 
-    return _update_wrapper(wrapper, func)
+    return functools.update_wrapper(wrapper, func)
 
 
 class AnsibleUndefined(StrictUndefined):


### PR DESCRIPTION
##### SUMMARY

Use Python's built-in ``functools.update_wrapper`` instead an inline copy from Python 3.7.

##### ISSUE TYPE

Feature Pull Request
