### PR TITLE
iptables - set jump to DSCP when set_dscp_mark or set_dscp_mark_class is set

### DIFF
--- a/changelogs/fragments/77077_iptables.yml
+++ b/changelogs/fragments/77077_iptables.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- iptables - set jump to DSCP when set_dscp_mark or set_dscp_mark_class is set (https://github.com/ansible/ansible/issues/77077).

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -37,7 +37,7 @@ notes:
 options:
   table:
     description:
-      - This option specifies the packet matching table which the command should operate on.
+      - This option specifies the packet matching table on which the command should operate.
       - If the kernel is configured with automatic module loading, an attempt will be made
          to load the appropriate module for that table if it is not already there.
     type: str
@@ -133,9 +133,9 @@ options:
     description:
       - Specifies a match to use, that is, an extension module that tests for
         a specific property.
-      - The set of matches make up the condition under which a target is invoked.
+      - The set of matches makes up the condition under which a target is invoked.
       - Matches are evaluated first to last if specified as an array and work in short-circuit
-        fashion, i.e. if one extension yields false, evaluation will stop.
+        fashion, i.e. if one extension yields false, the evaluation will stop.
     type: list
     elements: str
     default: []
@@ -143,7 +143,7 @@ options:
     description:
       - This specifies the target of the rule; i.e., what to do if the packet matches it.
       - The target can be a user-defined chain (other than the one
-        this rule is in), one of the special builtin targets which decide the
+        this rule is in), one of the special builtin targets that decide the
         fate of the packet immediately, or an extension (see EXTENSIONS
         below).
       - If this option is omitted in a rule (and the goto parameter
@@ -152,13 +152,13 @@ options:
     type: str
   gateway:
     description:
-      - This specifies the IP address of host to send the cloned packets.
+      - This specifies the IP address of the host to send the cloned packets.
       - This option is only valid when O(jump) is set to V(TEE).
     type: str
     version_added: "2.8"
   log_prefix:
     description:
-      - Specifies a log text for the rule. Only make sense with a LOG jump.
+      - Specifies a log text for the rule. Only makes sense with a LOG jump.
     type: str
     version_added: "2.5"
   log_level:
@@ -171,7 +171,7 @@ options:
     choices: [ '0', '1', '2', '3', '4', '5', '6', '7', 'emerg', 'alert', 'crit', 'error', 'warning', 'notice', 'info', 'debug' ]
   goto:
     description:
-      - This specifies that the processing should continue in a user specified chain.
+      - This specifies that the processing should continue in a user-specified chain.
       - Unlike the jump argument return will not continue processing in
         this chain but instead in the chain that called us via jump.
     type: str
@@ -199,7 +199,7 @@ options:
         of fragmented packets.
       - Since there is no way to tell the source or destination ports of such
         a packet (or ICMP type), such a packet will not match any rules which specify them.
-      - When the "!" argument precedes fragment argument, the rule will only match head fragments,
+      - When the "!" argument precedes the fragment argument, the rule will only match head fragments,
         or unfragmented packets.
     type: str
   set_counters:
@@ -265,6 +265,7 @@ options:
     description:
       - This allows specifying a DSCP mark to be added to packets.
         It takes either an integer or hex value.
+      - If the parameter is set, O(jump) is set to V(DSCP).
       - Mutually exclusive with O(set_dscp_mark_class).
     type: str
     version_added: "2.1"
@@ -272,6 +273,7 @@ options:
     description:
       - This allows specifying a predefined DiffServ class which will be
         translated to the corresponding DSCP mark.
+      - If the parameter is set, O(jump) is set to V(DSCP).
       - Mutually exclusive with O(set_dscp_mark).
     type: str
     version_added: "2.1"
@@ -288,7 +290,7 @@ options:
     default: []
   src_range:
     description:
-      - Specifies the source IP range to match in the iprange module.
+      - Specifies the source IP range to match the iprange module.
     type: str
     version_added: "2.8"
   dst_range:
@@ -298,7 +300,7 @@ options:
     version_added: "2.8"
   match_set:
     description:
-      - Specifies a set name which can be defined by ipset.
+      - Specifies a set name that can be defined by ipset.
       - Must be used together with the match_set_flags parameter.
       - When the V(!) argument is prepended then it inverts the rule.
       - Uses the iptables set extension.
@@ -326,14 +328,14 @@ options:
     version_added: "2.1"
   uid_owner:
     description:
-      - Specifies the UID or username to use in match by owner rule.
+      - Specifies the UID or username to use in the match by owner rule.
       - From Ansible 2.6 when the C(!) argument is prepended then the it inverts
         the rule to apply instead to all users except that one specified.
     type: str
     version_added: "2.1"
   gid_owner:
     description:
-      - Specifies the GID or group to use in match by owner rule.
+      - Specifies the GID or group to use in the match by owner rule.
     type: str
     version_added: "2.9"
   reject_with:
@@ -363,7 +365,7 @@ options:
       - Only built-in chains can have policies.
       - This parameter requires the O(chain) parameter.
       - If you specify this parameter, all other parameters will be ignored.
-      - This parameter is used to set default policy for the given O(chain).
+      - This parameter is used to set the default policy for the given O(chain).
         Do not confuse this with O(jump) parameter.
     type: str
     choices: [ ACCEPT, DROP, QUEUE, RETURN ]
@@ -385,9 +387,9 @@ options:
   numeric:
     description:
       - This parameter controls the running of the list -action of iptables, which is used internally by the module
-      - Does not affect the actual functionality. Use this if iptables hangs when creating chain or altering policy
+      - Does not affect the actual functionality. Use this if iptables hang when creating a chain or altering policy
       - If V(true), then iptables skips the DNS-lookup of the IP addresses in a chain when it uses the list -action
-      - Listing is used internally for example when setting a policy or creting of a chain
+      - Listing is used internally for example when setting a policy or creating a chain
     type: bool
     default: false
     version_added: "2.15"
@@ -635,11 +637,16 @@ def construct_rule(params):
     append_param(rule, params['destination_port'], '--destination-port', False)
     append_param(rule, params['to_ports'], '--to-ports', False)
     append_param(rule, params['set_dscp_mark'], '--set-dscp', False)
+    if params.get('set_dscp_mark') and params.get('jump').lower() != 'dscp':
+        append_jump(rule, params['set_dscp_mark'], 'DSCP')
+
     append_param(
         rule,
         params['set_dscp_mark_class'],
         '--set-dscp-class',
         False)
+    if params.get('set_dscp_mark_class') and params.get('jump').lower() != 'dscp':
+        append_jump(rule, params['set_dscp_mark_class'], 'DSCP')
     append_match_flag(rule, params['syn'], '--syn', True)
     if 'conntrack' in params['match']:
         append_csv(rule, params['ctstate'], '--ctstate')
@@ -673,6 +680,9 @@ def construct_rule(params):
     append_param(rule, params['gid_owner'], '--gid-owner', False)
     if params['jump'] is None:
         append_jump(rule, params['reject_with'], 'REJECT')
+        append_jump(rule, params['set_dscp_mark_class'], 'DSCP')
+        append_jump(rule, params['set_dscp_mark'], 'DSCP')
+
     append_param(rule, params['reject_with'], '--reject-with', False)
     append_param(
         rule,
@@ -826,6 +836,10 @@ def main():
         mutually_exclusive=(
             ['set_dscp_mark', 'set_dscp_mark_class'],
             ['flush', 'policy'],
+        ),
+        required_by=dict(
+            set_dscp_mark=('jump',),
+            set_dscp_mark_class=('jump',),
         ),
         required_if=[
             ['jump', 'TEE', ['gateway']],


### PR DESCRIPTION
##### SUMMARY

set_dscp_mark and set_dscp_mark_class is only valid when jump is set to
DSCP.

Fixes: #77077

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


