### PR TITLE
setup.cfg: add `Programming Language :: Python :: 3.12` classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
     Topic :: System :: Installation/Setup
     Topic :: System :: Systems Administration


### PR DESCRIPTION
##### SUMMARY

ansible-core 2.16+ supports Python 3.12. This corrects missing metadata.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
