### PR TITLE
ansible-test - Use pylint unidiomatic-typecheck

### DIFF
--- a/changelogs/fragments/ansible-test-unidiomatic-type-check.yml
+++ b/changelogs/fragments/ansible-test-unidiomatic-type-check.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - The ``unidiomatic-typecheck`` rule has been removed from the ``validate-modules`` sanity test.
+  - ansible-test - The ``unidiomatic-typecheck`` rule has been enabled in the ``pylint`` sanity test.

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
@@ -102,7 +102,6 @@ disable=
     undefined-loop-variable,
     unexpected-keyword-arg,
     ungrouped-imports,
-    unidiomatic-typecheck,
     unnecessary-pass,
     unnecessary-dunder-call,
     unsubscriptable-object,

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
@@ -95,7 +95,6 @@ disable=
     undefined-loop-variable,
     unexpected-keyword-arg,
     ungrouped-imports,
-    unidiomatic-typecheck,
     unnecessary-pass,
     unsubscriptable-object,
     unsupported-assignment-operation,

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -94,7 +94,6 @@ REPLACER_WINDOWS = REPLACER_WINDOWS.decode('utf-8')
 
 REJECTLIST_DIRS = frozenset(('.git', 'test', '.github', '.idea'))
 INDENT_REGEX = re.compile(r'([\t]*)')
-TYPE_REGEX = re.compile(r'.*(if|or)(\s+[^"\']*|\s+)(?<!_)(?<!str\()type\([^)].*')
 SYS_EXIT_REGEX = re.compile(r'[^#]*sys.exit\s*\(.*')
 NO_LOG_REGEX = re.compile(r'(?:pass(?!ive)|secret|token|key)', re.I)
 
@@ -440,21 +439,6 @@ class ModuleValidator(Validator):
                 code='missing-python-interpreter',
                 msg='Interpreter line is not "#!/usr/bin/python"',
             )
-
-    def _check_type_instead_of_isinstance(self, powershell=False):
-        if powershell:
-            return
-        for line_no, line in enumerate(self.text.splitlines()):
-            typekeyword = TYPE_REGEX.match(line)
-            if typekeyword:
-                # TODO: add column
-                self.reporter.error(
-                    path=self.object_path,
-                    code='unidiomatic-typecheck',
-                    msg=('Type comparison using type() found. '
-                         'Use isinstance() instead'),
-                    line=line_no + 1
-                )
 
     def _check_for_sys_exit(self):
         # Optimize out the happy path
@@ -2377,9 +2361,6 @@ class ModuleValidator(Validator):
         if not self._just_docs() and not self._sidecar_doc() and not end_of_deprecation_should_be_removed_only:
             if self.plugin_type == 'module':
                 self._check_interpreter(powershell=self._powershell_module())
-            self._check_type_instead_of_isinstance(
-                powershell=self._powershell_module()
-            )
 
 
 class PythonPackageValidator(Validator):

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -57,6 +57,7 @@ lib/ansible/module_utils/compat/selinux.py import-3.9!skip # pass/fail depends o
 lib/ansible/module_utils/compat/selinux.py import-3.10!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.11!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.12!skip # pass/fail depends on presence of libselinux.so
+lib/ansible/module_utils/compat/selinux.py pylint:unidiomatic-typecheck
 lib/ansible/module_utils/distro/_distro.py no-assert
 lib/ansible/module_utils/distro/_distro.py pep8!skip # bundled code we don't want to modify
 lib/ansible/module_utils/distro/_distro.py pylint:undefined-variable # ignore bundled
@@ -75,6 +76,7 @@ lib/ansible/module_utils/pycompat24.py no-get-exception
 lib/ansible/module_utils/six/__init__.py empty-init # breaks namespacing, bundled, do not override
 lib/ansible/module_utils/six/__init__.py pylint:self-assigning-variable
 lib/ansible/module_utils/six/__init__.py pylint:trailing-comma-tuple
+lib/ansible/module_utils/six/__init__.py pylint:unidiomatic-typecheck
 lib/ansible/module_utils/six/__init__.py replace-urlopen
 lib/ansible/module_utils/urls.py replace-urlopen
 lib/ansible/parsing/yaml/objects.py pylint:arguments-renamed


### PR DESCRIPTION
##### SUMMARY

This replaces the regex based check previously used within the validate-modules sanity test.

NOTE: The pylint check overlaps with a similar check for pep8.
      Both are used, since the pep8 based check is more nuanced than the one in pylint.
      For example, allowing `is` checks, but not `==` comparisons.
      If the pylint check is ignored, the pep8 check would still be relevant.

Resolves https://github.com/ansible/ansible/issues/72391

##### ISSUE TYPE

Feature Pull Request
