### PR TITLE
removed provided_arguments to prevent parsing dependency role source

### DIFF
--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -352,7 +352,6 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
                 'module': 'ansible.builtin.validate_argument_spec',
                 # Pass only the 'options' portion of the arg spec to the module.
                 'argument_spec': argument_spec.get('options', {}),
-                'provided_arguments': self._role_params,
                 'validate_args_context': {
                     'type': 'role',
                     'name': self._role_name,


### PR DESCRIPTION
##### SUMMARY

Fixes #82154 

##### ISSUE TYPE
Bugfix Pull Request

##### ADDITIONAL INFORMATION

`provided_arguments` for `ansible.builtin.validate_argument_spec` while importing role is either empty dict or dict with source of role

Example of `ansible.builtin.validate_argument_spec` before (causes error described in Issue)
```json
{
    "action": {
        "argument_spec": {
            "role_b_left": {
                "description": "Left border",
                "required": True,
                "type": "int"
            },
            "role_b_right": {
                "description": "Right border",
                "required": True,
                "type": "int"
            }
        },
        "module": "ansible.builtin.validate_argument_spec",
        "provided_arguments": {
            "src": "git+ssh://<link to role_a>",
            "version": "master"
        }
       ...
}
```

and after
```json
{
    "action": {
        "argument_spec": {
            "role_b_left": {
                "description": "Left border",
                "required": True,
                "type": "int"
            },
            "role_b_right": {
                "description": "Right border",
                "required": True,
                "type": "int"
            }
        },
        "module": "ansible.builtin.validate_argument_spec",
       ...
}
```

`validate_args_context` is unchanged