### PR TITLE
Fix two misspellings of occurred

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -601,7 +601,7 @@ class CLI(ABC):
             try:
                 p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             except OSError as e:
-                raise AnsibleError("Problem occured when trying to run the password script %s (%s)."
+                raise AnsibleError("Problem occurred when trying to run the password script %s (%s)."
                                    " If this is not a script, remove the executable bit from the file." % (pwd_file, e))
 
             stdout, stderr = p.communicate()


### PR DESCRIPTION
##### SUMMARY

I ran into a couple misspellings of "occurred" (mistaken: "occured") in v2.11 of Ansible. This PR fixes the remaining misspellings on `devel`.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

I would call this a "Chore" PR rather than docs or bugfix. I realize one part of it is docs and the other affects log output. Please advise if the latter is considered breaking.
