### PR TITLE
Targeted fix for installing roles with symlinks containing '..'

### DIFF
--- a/changelogs/fragments/ansible-galaxy-role-install-symlink.yml
+++ b/changelogs/fragments/ansible-galaxy-role-install-symlink.yml
@@ -1,2 +1,2 @@
 bugfixes:
-   - ansible-galaxy role install - allow symlinks with '..' if they resolve to a path in the tarfile's role directory (https://github.com/ansible/ansible/issues/81965).
+  - ansible-galaxy role install - normalize tarfile paths and symlinks using ``ansible.utils.path.unfrackpath`` and consider them valid as long as the realpath is in the tarfile's role directory (https://github.com/ansible/ansible/issues/81965).

--- a/changelogs/fragments/ansible-galaxy-role-install-symlink.yml
+++ b/changelogs/fragments/ansible-galaxy-role-install-symlink.yml
@@ -1,0 +1,2 @@
+bugfixes:
+   - ansible-galaxy role install - allow symlinks with '..' if they resolve to a path in the tarfile's role directory (https://github.com/ansible/ansible/issues/81965).

--- a/test/integration/targets/ansible-galaxy-role/tasks/dir-traversal.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/dir-traversal.yml
@@ -23,6 +23,9 @@
   command:
     cmd: ansible-galaxy role install --roles-path '{{ remote_tmp_dir }}/dir-traversal/roles' dangerous.tar
     chdir: '{{ remote_tmp_dir }}/dir-traversal/source'
+  environment:
+    ANSIBLE_NOCOLOR: True
+    ANSIBLE_FORCE_COLOR: False
   ignore_errors: true
   register: galaxy_install_dangerous
 
@@ -42,3 +45,87 @@
       - dangerous_overwrite_content.content|default('')|b64decode == ''
       - not dangerous_overwrite_stat.stat.exists
       - galaxy_install_dangerous is failed
+      - >-
+        "symlink 'symlink' could not be found in the role" in (galaxy_install_dangerous.stderr | regex_replace('\n', ' '))
+
+- name: remove tarfile for next test
+  file:
+    path: '{{ item }}'
+    state: absent
+  loop:
+    - '{{ remote_tmp_dir }}/dir-traversal/source/dangerous.tar'
+    - '{{ remote_tmp_dir }}/dir-traversal/roles/dangerous.tar'
+
+- name: build dangerous dir traversal role that includes .. in the symlink path
+  script:
+    chdir: '{{ remote_tmp_dir }}/dir-traversal/source'
+    cmd: create-role-archive.py dangerous.tar content.txt {{ remote_tmp_dir }}/dir-traversal/source/../target/target-file-to-overwrite.txt
+    executable: '{{ ansible_playbook_python }}'
+
+- name: install dangerous role
+  command:
+    cmd: 'ansible-galaxy role install --roles-path {{ remote_tmp_dir }}/dir-traversal/roles dangerous.tar'
+    chdir: '{{ remote_tmp_dir }}/dir-traversal/source'
+  environment:
+    ANSIBLE_NOCOLOR: True
+    ANSIBLE_FORCE_COLOR: False
+  ignore_errors: true
+  register: galaxy_install_dangerous
+
+- name: check for overwritten file
+  stat:
+    path: '{{ remote_tmp_dir }}/dir-traversal/target/target-file-to-overwrite.txt'
+  register: dangerous_overwrite_stat
+
+- name: get overwritten content
+  slurp:
+    path: '{{ remote_tmp_dir }}/dir-traversal/target/target-file-to-overwrite.txt'
+  register: dangerous_overwrite_content
+  when: dangerous_overwrite_stat.stat.exists
+
+- assert:
+    that:
+      - dangerous_overwrite_content.content|default('')|b64decode == ''
+      - not dangerous_overwrite_stat.stat.exists
+      - galaxy_install_dangerous is failed
+      - >-
+        "symlink 'symlink' could not be found in the role" in (galaxy_install_dangerous.stderr | regex_replace('\n', ' '))
+- name: remove tarfile for next test
+  file:
+    path: '{{ remote_tmp_dir }}/dir-traversal/source/dangerous.tar'
+    state: absent
+
+- name: build dangerous dir traversal role that includes .. in the relative symlink path
+  script:
+    chdir: '{{ remote_tmp_dir }}/dir-traversal/source'
+    cmd: create-role-archive.py dangerous_rel.tar content.txt ../context.txt
+
+- name: install dangerous role with relative symlink
+  command:
+    cmd: 'ansible-galaxy role install --roles-path {{ remote_tmp_dir }}/dir-traversal/roles dangerous_rel.tar'
+    chdir: '{{ remote_tmp_dir }}/dir-traversal/source'
+  environment:
+    ANSIBLE_NOCOLOR: True
+    ANSIBLE_FORCE_COLOR: False
+  ignore_errors: true
+  register: galaxy_install_dangerous
+
+- name: check for symlink outside role
+  stat:
+    path: "{{ remote_tmp_dir | realpath }}/dir-traversal/roles/symlink"
+  register: symlink_outside_role
+
+- assert:
+    that:
+      - not symlink_outside_role.stat.exists
+      - galaxy_install_dangerous is failed
+      - >-
+        "symlink 'symlink' could not be found in the role" in (galaxy_install_dangerous.stderr | regex_replace('\n', ' '))
+- name: remove test directories
+  file:
+    path: '{{ remote_tmp_dir }}/dir-traversal/{{ item }}'
+    state: absent
+  loop:
+    - source
+    - target
+    - roles

--- a/test/integration/targets/ansible-galaxy-role/tasks/dir-traversal.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/dir-traversal.yml
@@ -45,8 +45,7 @@
       - dangerous_overwrite_content.content|default('')|b64decode == ''
       - not dangerous_overwrite_stat.stat.exists
       - galaxy_install_dangerous is failed
-      - >-
-        "symlink 'symlink' could not be found in the role" in (galaxy_install_dangerous.stderr | regex_replace('\n', ' '))
+      - "'is not a subpath of the role' in (galaxy_install_dangerous.stderr | regex_replace('\n', ' '))"
 
 - name: remove tarfile for next test
   file:
@@ -88,8 +87,8 @@
       - dangerous_overwrite_content.content|default('')|b64decode == ''
       - not dangerous_overwrite_stat.stat.exists
       - galaxy_install_dangerous is failed
-      - >-
-        "symlink 'symlink' could not be found in the role" in (galaxy_install_dangerous.stderr | regex_replace('\n', ' '))
+      - "'is not a subpath of the role' in (galaxy_install_dangerous.stderr | regex_replace('\n', ' '))"
+
 - name: remove tarfile for next test
   file:
     path: '{{ remote_tmp_dir }}/dir-traversal/source/dangerous.tar'
@@ -119,8 +118,8 @@
     that:
       - not symlink_outside_role.stat.exists
       - galaxy_install_dangerous is failed
-      - >-
-        "symlink 'symlink' could not be found in the role" in (galaxy_install_dangerous.stderr | regex_replace('\n', ' '))
+      - "'is not a subpath of the role' in (galaxy_install_dangerous.stderr | regex_replace('\n', ' '))"
+
 - name: remove test directories
   file:
     path: '{{ remote_tmp_dir }}/dir-traversal/{{ item }}'

--- a/test/integration/targets/ansible-galaxy-role/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/main.yml
@@ -25,14 +25,17 @@
 - name: Valid role archive
   command: "tar cf {{ remote_tmp_dir }}/valid-role.tar {{ remote_tmp_dir }}/role.d"
 
-- name: Invalid file
-  copy:
-    content: ""
+- name: Add invalid symlink
+  file:
+    state: link
+    src: "~/invalid"
     dest: "{{ remote_tmp_dir }}/role.d/tasks/~invalid.yml"
+    force: yes
 
-- name: Invalid file
-  copy:
-    content: ""
+- name: Add another invalid symlink
+  file:
+    state: link
+    src: "/"
     dest: "{{ remote_tmp_dir }}/role.d/tasks/invalid$name.yml"
 
 - name: Valid requirements file

--- a/test/integration/targets/ansible-galaxy-role/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/main.yml
@@ -66,3 +66,4 @@
   command: ansible-galaxy role remove invalid-testrole
 
 - import_tasks: dir-traversal.yml
+- import_tasks: valid-role-symlinks.yml

--- a/test/integration/targets/ansible-galaxy-role/tasks/valid-role-symlinks.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/valid-role-symlinks.yml
@@ -1,0 +1,78 @@
+- name: create test directories
+  file:
+    path: '{{ remote_tmp_dir }}/dir-traversal/{{ item }}'
+    state: directory
+  loop:
+    - source
+    - target
+    - roles
+
+- name: create subdir in the role content to test relative symlinks
+  file:
+    dest: '{{ remote_tmp_dir }}/dir-traversal/source/role_subdir'
+    state: directory
+
+- copy:
+    dest: '{{ remote_tmp_dir }}/dir-traversal/source/role_subdir/.keep'
+    content: ''
+
+- set_fact:
+    installed_roles: "{{ remote_tmp_dir | realpath }}/dir-traversal/roles"
+
+- name: build role with symlink to a directory in the role
+  script:
+    chdir: '{{ remote_tmp_dir }}/dir-traversal/source'
+    cmd: create-role-archive.py safe-link-dir.tar ./ role_subdir/..
+    executable: '{{ ansible_playbook_python }}'
+
+- name: install role successfully
+  command:
+    cmd: 'ansible-galaxy role install --roles-path {{ remote_tmp_dir }}/dir-traversal/roles safe-link-dir.tar'
+    chdir: '{{ remote_tmp_dir }}/dir-traversal/source'
+  register: galaxy_install_ok
+
+- name: check for the directory symlink in the role
+  stat:
+    path: "{{ installed_roles }}/safe-link-dir.tar/symlink"
+  register: symlink_in_role
+
+- assert:
+    that:
+      - symlink_in_role.stat.exists
+      - symlink_in_role.stat.lnk_source == installed_roles + '/safe-link-dir.tar'
+
+- name: remove tarfile for next test
+  file:
+    path: '{{ remote_tmp_dir }}/dir-traversal/source/safe-link-dir.tar'
+    state: absent
+
+- name: build role with safe relative symlink
+  script:
+    chdir: '{{ remote_tmp_dir }}/dir-traversal/source'
+    cmd: create-role-archive.py safe.tar ./ role_subdir/../context.txt
+    executable: '{{ ansible_playbook_python }}'
+
+- name: install role successfully
+  command:
+    cmd: 'ansible-galaxy role install --roles-path {{ remote_tmp_dir }}/dir-traversal/roles safe.tar'
+    chdir: '{{ remote_tmp_dir }}/dir-traversal/source'
+  register: galaxy_install_ok
+
+- name: check for symlink in role
+  stat:
+    path: "{{ installed_roles }}/safe.tar/symlink"
+  register: symlink_in_role
+
+- assert:
+    that:
+      - symlink_in_role.stat.exists
+      - symlink_in_role.stat.lnk_source == installed_roles + '/safe.tar/context.txt'
+
+- name: remove test directories
+  file:
+    path: '{{ remote_tmp_dir }}/dir-traversal/{{ item }}'
+    state: absent
+  loop:
+    - source
+    - target
+    - roles


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible/ansible/issues/81965

I'd like to backport this as far as acceptable since the fix for the symlink CVE was backported to 2.13, so I separated this from the other fixes in https://github.com/ansible/ansible/pull/82052 related to installing broken roles.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
