### PR TITLE
role argument spec - only validate documented role params

### DIFF
--- a/changelogs/fragments/improve-role-param-validation.yml
+++ b/changelogs/fragments/improve-role-param-validation.yml
@@ -1,0 +1,7 @@
+bugfixes:
+- >-
+  Implicit role validate_argument_spec tasks now only validate documented role params.
+  Previously, all role params had to be documented, making it difficult to use
+  dependencies (which often specify role params for ansible-galaxy install) or overriding
+  variables not specific to the dependency (such as connection variables).
+  (https://github.com/ansible/ansible/issues/82154)

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -390,7 +390,6 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
             'args': {
                 # Pass only the 'options' portion of the arg spec to the module.
                 'argument_spec': argument_spec.get('options', {}),
-                'provided_arguments': self._role_params,
                 'validate_args_context': {
                     'type': 'role',
                     'name': self._role_name,

--- a/test/integration/targets/roles_arg_spec/roles/role_with_deps/meta/main.yml
+++ b/test/integration/targets/roles_arg_spec/roles/role_with_deps/meta/main.yml
@@ -1,0 +1,7 @@
+dependencies:
+  # src/scm/version/role are used by ansible-galaxy when installing dependencies
+  # only validate these fields if the argument spec includes them
+  - role: validate_role_req
+    scm: svn
+    src: othersource
+    version: "1.0.0"

--- a/test/integration/targets/roles_arg_spec/roles/validate_role_req/meta/main.yml
+++ b/test/integration/targets/roles_arg_spec/roles/validate_role_req/meta/main.yml
@@ -1,0 +1,8 @@
+argument_specs:
+  main:
+    short_description: Main entrypoint to test validating documented role params
+    options:
+      version:
+        description:
+          - Role argument which intentionally conflicts with ansible-galaxy dependency syntax.
+        type: int

--- a/test/integration/targets/roles_arg_spec/test.yml
+++ b/test/integration/targets/roles_arg_spec/test.yml
@@ -455,3 +455,28 @@
     - name: Import role with an empty argument_specs key
       import_role:
         name: empty_argspec
+
+- name: "New play to reset vars: Test not validating ambiguous role params by default"
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - block:
+      - name: Include role with dependencies using ansible-galaxy requirements syntax
+        include_role:
+          name: role_with_deps
+
+      - fail:
+          msg: "should not get here"
+
+      rescue:
+        - debug: var=ansible_failed_result
+
+        - name: Validate failure for role params
+          assert:
+            that:
+              - ansible_failed_result.argument_errors | length == 1
+              - ansible_failed_result.argument_errors[0] is search(expected_error)
+              - ansible_failed_result.validate_args_context.name == 'validate_role_req'
+              - ansible_failed_result.validate_args_context.argument_spec_name == "main"
+          vars:
+            expected_error: "^argument 'version' is of type str and we were unable to convert to int"


### PR DESCRIPTION
##### SUMMARY

Fixes #82154

Validate normally if these are documented by the role, but don't require documentation since the role may be unaware of these fields used by ansible-galaxy.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
