### PR TITLE
uri: Handle the "force" parameter properly

### DIFF
--- a/changelogs/fragments/82187-uri-handle-force.yml
+++ b/changelogs/fragments/82187-uri-handle-force.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - ansible.builtin.uri - the module was ignoring the ``force`` parameter and always
+    requesting a cached copy (via the ``If-Modified-Since`` header) when downloading
+    to an existing local file. Disable caching when ``force`` is ``true``, as
+    documented (https://github.com/ansible/ansible/issues/82166).

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -585,7 +585,7 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout, c
                            method=method, timeout=socket_timeout, unix_socket=module.params['unix_socket'],
                            ca_path=ca_path, unredirected_headers=unredirected_headers,
                            use_proxy=module.params['use_proxy'], decompress=decompress,
-                           ciphers=ciphers, use_netrc=use_netrc, **kwargs)
+                           ciphers=ciphers, use_netrc=use_netrc, force=module.params['force'], **kwargs)
 
     if src:
         # Try to close the open file handle

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -633,6 +633,22 @@
     that:
       - "'content' in file_out.stdout"
 
+- name: Test downloading cached file
+  uri:
+    url: "https://{{ httpbin_host }}/cache"
+
+- name: Test downloading cached file to existing file results in "304 Not Modified"
+  uri:
+    url: "https://{{ httpbin_host }}/cache"
+    dest: "{{ remote_tmp_dir }}/output"
+    status_code: [304]
+
+- name: Test downloading cached file to existing file with "force"
+  uri:
+    url: "https://{{ httpbin_host }}/cache"
+    dest: "{{ remote_tmp_dir }}/output"
+    force: true
+
 - name: Clean up
   file:
     dest: "{{ remote_tmp_dir }}/output"

--- a/test/units/modules/test_uri.py
+++ b/test/units/modules/test_uri.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright:
+#   (c) 2023 Ansible Project
+# License: GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase, set_module_args
+from ansible.modules import uri
+
+
+class TestUri(ModuleTestCase):
+
+    def test_main_no_args(self):
+        """Module must fail if called with no args."""
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({})
+            uri.main()
+
+    def test_main_no_force(self):
+        """The "force" parameter to fetch_url() must be absent or false when the module is called without "force"."""
+        set_module_args({"url": "http://example.com/"})
+        resp = MagicMock()
+        resp.headers.get_content_type.return_value = "text/html"
+        info = {"url": "http://example.com/", "status": 200}
+        with patch.object(uri, "fetch_url", return_value=(resp, info)) as fetch_url:
+            with self.assertRaises(AnsibleExitJson):
+                uri.main()
+            fetch_url.assert_called_once()
+            assert not fetch_url.call_args[1].get("force")
+
+    def test_main_force(self):
+        """The "force" parameter to fetch_url() must be true when the module is called with "force"."""
+        set_module_args({"url": "http://example.com/", "force": True})
+        resp = MagicMock()
+        resp.headers.get_content_type.return_value = "text/html"
+        info = {"url": "http://example.com/", "status": 200}
+        with patch.object(uri, "fetch_url", return_value=(resp, info)) as fetch_url:
+            with self.assertRaises(AnsibleExitJson):
+                uri.main()
+            fetch_url.assert_called_once()
+            assert fetch_url.call_args[1].get("force")


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
The `uri` module documents a `force` parameter that can be used to disable caching. The module accepted the parameter but didn't pass it through to the `fetch_url()` method which implements the logic to handle setting the appropriate headers for disabling caching. This change passes the "force" parameter through as expected, allowing caching to be disabled when requested by the module caller.

Fixes #82166 

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

When calling the `uri` module with a `dest` parameter that exists, the `If-Modified-Since` header was being set unconditionally to the last modified time of the file. This would result in `304 Not Modified` responses in situations where it was not appropriate, for example downloading to a newly created tempfile. Setting `force: true` should have avoided that behavior and prevented caching, but the parameter was not being passed through. The included test cases demonstrate the incorrect behavior.

Without the change, downloading a file from a host which respects `If-Modified-Since` to a recently-created local file would result in:

```paste below
TASK [uri : Test downloading cached file to existing file with "force"] ********
fatal: [testhost]: FAILED! => {"access_control_allow_credentials": "true", "access_control_allow_origin": "*", "changed": false, "connection": "close", "date": "Thu, 09 Nov 2023 17:35:39 GMT", "elapsed": 0, "gid": 0, "group": "root", "mode": "0644", "msg": "Status code was 304 and not [200]: HTTP Error 304: NOT MODIFIED", "owner": "root", "path": "/tmp/ansible.soroedni.test/output", "redirected": false, "secontext": "unconfined_u:object_r:admin_home_t:s0", "server": "nginx/1.19.2", "size": 7, "state": "file", "status": 304, "uid": 0, "url": "https://ansible.http.tests/cache"}
```
