### PR TITLE
Deprecate is_module parameter in get_docstring

### DIFF
--- a/changelogs/fragments/deprecate-is-module.yml
+++ b/changelogs/fragments/deprecate-is-module.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- passing is_module to get_docstring - is deprecated in favor of passing ``plugin_type='module'`` in instead (https://github.com/ansible/ansible/pull/82192).

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -515,7 +515,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
     def module_args(self, module_name):
         in_path = module_loader.find_plugin(module_name)
-        oc, a, _dummy1, _dummy2 = plugin_docs.get_docstring(in_path, fragment_loader, is_module=True)
+        oc, a, _dummy1, _dummy2 = plugin_docs.get_docstring(in_path, fragment_loader, plugin_type='module')
         return list(oc['options'].keys())
 
     def run(self):

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -14,7 +14,7 @@ from ansible.module_utils.common.text.converters import to_native
 from ansible.parsing.plugin_docs import read_docstring
 from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.utils.display import Display
-import functools
+from ansible.utils.sentinel import Sentinel
 
 display = Display()
 
@@ -205,20 +205,14 @@ def add_fragments(doc, filename, fragment_loader, is_module=False):
         raise AnsibleError('unknown doc_fragment(s) in file {0}: {1}'.format(filename, to_native(', '.join(unknown_fragments))))
 
 
-def _handle_deprecated_kwarg(func):
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        if len(args) >= 6 or 'is_module' in kwargs:
-            display.deprecated("is_module is deprecated, pass plugin_type='module' instead", version='2.19')
-        return func(*args, **kwargs)
-    return wrapper
-
-
-@_handle_deprecated_kwarg
-def get_docstring(filename, fragment_loader, verbose=False, ignore_errors=False, collection_name=None, is_module=None, plugin_type=None):
+def get_docstring(filename, fragment_loader, verbose=False, ignore_errors=False, collection_name=None, is_module=Sentinel, plugin_type=None):
     """
     DOCUMENTATION can be extended using documentation fragments loaded by the PluginLoader from the doc_fragments plugins.
     """
+    if is_module is Sentinel:
+        is_module = None
+    else:
+        display.deprecated("is_module is deprecated, pass plugin_type='module' instead", version='2.19')
 
     if is_module is None:
         if plugin_type is None:

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -14,6 +14,7 @@ from ansible.module_utils.common.text.converters import to_native
 from ansible.parsing.plugin_docs import read_docstring
 from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.utils.display import Display
+import functools
 
 display = Display()
 
@@ -204,6 +205,16 @@ def add_fragments(doc, filename, fragment_loader, is_module=False):
         raise AnsibleError('unknown doc_fragment(s) in file {0}: {1}'.format(filename, to_native(', '.join(unknown_fragments))))
 
 
+def _handle_deprecated_kwarg(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if len(args) >= 6 or 'is_module' in kwargs:
+            display.deprecated("is_module is deprecated, pass plugin_type='module' instead", version='2.19')
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@_handle_deprecated_kwarg
 def get_docstring(filename, fragment_loader, verbose=False, ignore_errors=False, collection_name=None, is_module=None, plugin_type=None):
     """
     DOCUMENTATION can be extended using documentation fragments loaded by the PluginLoader from the doc_fragments plugins.
@@ -215,7 +226,6 @@ def get_docstring(filename, fragment_loader, verbose=False, ignore_errors=False,
         else:
             is_module = (plugin_type == 'module')
     else:
-        # TODO deprecate is_module argument, now that we have 'type'
         pass
 
     data = read_docstring(filename, verbose=verbose, ignore_errors=ignore_errors)


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
A 3-year-old TODO in the source code said to deprecate `is_module` as a parameter to `get_docstring`. From reading the code I inferred that the preferred alternative would be to pass in `plugin_type='module'` instead.
