### PR TITLE
2.16: flush_handlers: handle a failure in a nested block with force_handlers (#81572)

### DIFF
--- a/changelogs/fragments/81532-fix-nested-flush_handlers.yml
+++ b/changelogs/fragments/81532-fix-nested-flush_handlers.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - flush_handlers - properly handle a handler failure in a nested block when ``force_handlers`` is set (http://github.com/ansible/ansible/issues/81532)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -52,7 +52,7 @@ class FailedStates(IntFlag):
     TASKS = 2
     RESCUE = 4
     ALWAYS = 8
-    HANDLERS = 16
+    HANDLERS = 16  # NOTE not in use anymore
 
 
 class HostState:
@@ -431,22 +431,18 @@ class PlayIterator:
                     state.update_handlers = False
                     state.cur_handlers_task = 0
 
-                if state.fail_state & FailedStates.HANDLERS == FailedStates.HANDLERS:
-                    state.update_handlers = True
-                    state.run_state = IteratingStates.COMPLETE
-                else:
-                    while True:
-                        try:
-                            task = state.handlers[state.cur_handlers_task]
-                        except IndexError:
-                            task = None
-                            state.run_state = state.pre_flushing_run_state
-                            state.update_handlers = True
+                while True:
+                    try:
+                        task = state.handlers[state.cur_handlers_task]
+                    except IndexError:
+                        task = None
+                        state.run_state = state.pre_flushing_run_state
+                        state.update_handlers = True
+                        break
+                    else:
+                        state.cur_handlers_task += 1
+                        if task.is_host_notified(host):
                             break
-                        else:
-                            state.cur_handlers_task += 1
-                            if task.is_host_notified(host):
-                                break
 
             elif state.run_state == IteratingStates.COMPLETE:
                 return (state, None)
@@ -487,20 +483,16 @@ class PlayIterator:
             else:
                 state.fail_state |= FailedStates.ALWAYS
                 state.run_state = IteratingStates.COMPLETE
-        elif state.run_state == IteratingStates.HANDLERS:
-            state.fail_state |= FailedStates.HANDLERS
-            state.update_handlers = True
-            if state._blocks[state.cur_block].rescue:
-                state.run_state = IteratingStates.RESCUE
-            elif state._blocks[state.cur_block].always:
-                state.run_state = IteratingStates.ALWAYS
-            else:
-                state.run_state = IteratingStates.COMPLETE
         return state
 
     def mark_host_failed(self, host):
         s = self.get_host_state(host)
         display.debug("marking host %s failed, current state: %s" % (host, s))
+        if s.run_state == IteratingStates.HANDLERS:
+            # we are failing `meta: flush_handlers`, so just reset the state to whatever
+            # it was before and let `_set_failed_state` figure out the next state
+            s.run_state = s.pre_flushing_run_state
+            s.update_handlers = True
         s = self._set_failed_state(s)
         display.debug("^ failed state is now: %s" % s)
         self.set_state_for_host(host.name, s)
@@ -515,8 +507,6 @@ class PlayIterator:
         elif state.run_state == IteratingStates.RESCUE and self._check_failed_state(state.rescue_child_state):
             return True
         elif state.run_state == IteratingStates.ALWAYS and self._check_failed_state(state.always_child_state):
-            return True
-        elif state.run_state == IteratingStates.HANDLERS and state.fail_state & FailedStates.HANDLERS == FailedStates.HANDLERS:
             return True
         elif state.fail_state != FailedStates.NONE:
             if state.run_state == IteratingStates.RESCUE and state.fail_state & FailedStates.RESCUE == 0:

--- a/test/integration/targets/handlers/nested_flush_handlers_failure_force.yml
+++ b/test/integration/targets/handlers/nested_flush_handlers_failure_force.yml
@@ -1,0 +1,19 @@
+- hosts: A,B
+  gather_facts: false
+  force_handlers: true
+  tasks:
+    - block:
+        - command: echo
+          notify: h
+
+        - meta: flush_handlers
+      rescue:
+        - debug:
+            msg: flush_handlers_rescued
+      always:
+        - debug:
+            msg: flush_handlers_always
+  handlers:
+    - name: h
+      fail:
+      when: inventory_hostname == "A"

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -198,3 +198,7 @@ ansible-playbook test_include_tasks_in_include_role.yml "$@" 2>&1 | tee out.txt
 
 ansible-playbook test_run_once.yml -i inventory.handlers "$@" 2>&1 | tee out.txt
 [ "$(grep out.txt -ce 'handler ran once')" = "1" ]
+
+ansible-playbook nested_flush_handlers_failure_force.yml -i inventory.handlers "$@" 2>&1 | tee out.txt
+[ "$(grep out.txt -ce 'flush_handlers_rescued')" = "1" ]
+[ "$(grep out.txt -ce 'flush_handlers_always')" = "2" ]


### PR DESCRIPTION
##### SUMMARY
Backport of #81572 

(cherry picked from commit a8b6ef7e7cbabaf87e57ea7df9df75eb7e7d1ab5)
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request