### PR TITLE
ansible-test - remove rhel 9.2 test remote

### DIFF
--- a/changelogs/fragments/ansible-test-remove-rhel-9_2-remote.yml
+++ b/changelogs/fragments/ansible-test-remove-rhel-9_2-remote.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ansible-test - Remove rhel/9.2 test remote"

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -6,7 +6,6 @@ freebsd/13.2 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=a
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 macos/13.2 python=3.11 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64
 macos python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64
-rhel/9.2 python=3.9,3.11 become=sudo provider=aws arch=x86_64
 rhel/9.3 python=3.9,3.11 become=sudo provider=aws arch=x86_64
 rhel become=sudo provider=aws arch=x86_64
 ubuntu/22.04 python=3.10 become=sudo provider=aws arch=x86_64


### PR DESCRIPTION
##### SUMMARY
Scheduled to be merged on November 27th, see https://github.com/ansible-collections/news-for-maintainers/issues/62.
<!--- Describe the change below, including rationale and design decisions -->
Fixes #82024
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Feature Pull Request
