### PR TITLE
Include import_* tasks in play iterator

### DIFF
--- a/changelogs/fragments/static-tasks.yml
+++ b/changelogs/fragments/static-tasks.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- >-
+  Include the explicit import_tasks and import_role tasks in the play iterator for the strategy to see. By default
+  these tasks are skipped but a strategy can utilise them in a special way if needed. This will cause the import_* to
+  be displayed in UI as a normal task when it is run.

--- a/changelogs/fragments/static-tasks.yml
+++ b/changelogs/fragments/static-tasks.yml
@@ -1,5 +1,4 @@
 minor_changes:
 - >-
   Include the explicit import_tasks and import_role tasks in the play iterator for the strategy to see. By default
-  these tasks are skipped but a strategy can utilise them in a special way if needed. This will cause the import_* to
-  be displayed in UI as a normal task when it is run.
+  these tasks are skipped but a strategy can utilise them in a special way if needed.

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -241,7 +241,9 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         loader=loader,
                         variable_manager=variable_manager,
                     )
-                    task_list.append(ti_copy)
+
+                    if not use_handlers:
+                        task_list.append(ti_copy)
 
                     tags = ti_copy.tags[:]
 
@@ -286,7 +288,9 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     templar = Templar(loader=loader, variables=all_vars)
                     ir.post_validate(templar=templar)
                     ir._role_name = templar.template(ir._role_name)
-                    task_list.append(ir)
+
+                    if not use_handlers:
+                        task_list.append(ir)
 
                     # uses compiled list from object
                     blocks, dummy = ir.get_block_list(variable_manager=variable_manager, loader=loader)

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -241,6 +241,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         loader=loader,
                         variable_manager=variable_manager,
                     )
+                    task_list.append(ti_copy)
 
                     tags = ti_copy.tags[:]
 
@@ -285,6 +286,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     templar = Templar(loader=loader, variables=all_vars)
                     ir.post_validate(templar=templar)
                     ir._role_name = templar.template(ir._role_name)
+                    task_list.append(ir)
 
                     # uses compiled list from object
                     blocks, dummy = ir.get_block_list(variable_manager=variable_manager, loader=loader)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -351,6 +351,11 @@ class StrategyBase:
 
         display.debug("entering _queue_task() for %s/%s" % (host.name, task.action))
 
+        # import_* tasks should be ignored as they are already handled when
+        # the play was loaded.
+        if task.action in C._ACTION_IMPORT_TASKS + C._ACTION_IMPORT_ROLE:
+            return
+
         # Add a write lock for tasks.
         # Maybe this should be added somewhere further up the call stack but
         # this is the earliest in the code where we have task (1) extracted

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -354,6 +354,8 @@ class StrategyBase:
         # import_* tasks should be ignored as they are already handled when
         # the play was loaded.
         if task.action in C._ACTION_IMPORT_TASKS + C._ACTION_IMPORT_ROLE:
+            if host.name in self._blocked_hosts:
+                del self._blocked_hosts[host.name]
             return
 
         # Add a write lock for tasks.

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -191,7 +191,7 @@ class StrategyModule(StrategyBase):
                                                     "as tasks are executed independently on each host")
                                 if isinstance(task, Handler):
                                     self._tqm.send_callback('v2_playbook_on_handler_task_start', task)
-                                else:
+                                elif action not in C._ACTION_IMPORT_TASKS + C._ACTION_IMPORT_ROLE:
                                     self._tqm.send_callback('v2_playbook_on_task_start', task, is_conditional=False)
                                 self._queue_task(host, task, task_vars, play_context)
                                 # each task is counted as a worker being busy

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -230,7 +230,7 @@ class StrategyModule(StrategyBase):
                             display.debug("here goes the callback...")
                             if isinstance(task, Handler):
                                 self._tqm.send_callback('v2_playbook_on_handler_task_start', task)
-                            else:
+                            elif action not in C._ACTION_IMPORT_TASKS + C._ACTION_IMPORT_ROLE:
                                 self._tqm.send_callback('v2_playbook_on_task_start', task, is_conditional=False)
                             task.name = saved_name
                             callback_sent = True


### PR DESCRIPTION
##### SUMMARY
Includes the import_tasks and import_role tasks in the play iterator which allows a strategy plugin to use this task for its own purposes. This is designed to allow custom plugins to inspect more about the current state of the play tasks during execution as needed.

The end goal for this feature is for it to be used with the [ansibug](https://github.com/jborean93/ansibug) debugger.

##### ISSUE TYPE
- Feature Pull Request