### PR TITLE
[PoC] Use per run on the fly jinja2 byte code caching

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -764,6 +764,20 @@ DEFAULT_JINJA2_NATIVE:
   type: boolean
   yaml: {key: jinja2_native}
   version_added: 2.7
+JINJA2_BYTECODE_CACHE:
+  name: Cache the jinja2 bytecode for compiled templates
+  description:
+    - This option, which is enabled by default, will cache the jinja2 generated
+      bytecode for templates reducing execution time, specifically for template
+      heavy playbooks. Disabling this will prevent the bytecode cache from
+      being used.
+  env:
+    - {name: ANSIBLE_JINJA2_BYTECODE_CACHE}
+  ini:
+    - {key: jinja2_bytecode_cache, section: defaults}
+  type: boolean
+  default: True
+  version_added: '2.17'
 DEFAULT_KEEP_REMOTE_FILES:
   name: Keep remote files
   default: False

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -230,6 +230,9 @@ def from_yaml_all(data):
     return data
 
 
+# context prevents this filter from being treated as a constant
+# and evaluated at compile time, and instead defers evaluation
+# to execution time
 @pass_context
 def rand(context, end, start=None, step=None, seed=None):
     if seed is None:
@@ -249,7 +252,9 @@ def rand(context, end, start=None, step=None, seed=None):
     else:
         raise AnsibleFilterError('random can only be used on sequences and integers')
 
-
+# context prevents this filter from being treated as a constant
+# and evaluated at compile time, and instead defers evaluation
+# to execution time
 @pass_context
 def randomize_list(context, mylist, seed=None):
     try:
@@ -275,6 +280,9 @@ def get_hash(data, hashtype='sha1'):
     return h.hexdigest()
 
 
+# context prevents this filter from being treated as a constant
+# and evaluated at compile time, and instead defers evaluation
+# to execution time
 @pass_context
 def get_encrypted_password(context, password, hashtype='sha512', salt=None, salt_size=None, rounds=None, ident=None):
     passlib_mapping = {

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -21,7 +21,7 @@ from collections.abc import Mapping
 from functools import partial
 from random import Random, SystemRandom, shuffle
 
-from jinja2.filters import pass_environment, pass_context
+from jinja2.filters import pass_environment
 
 from ansible.errors import AnsibleError, AnsibleFilterError, AnsibleFilterTypeError
 from ansible.module_utils.six import string_types, integer_types, reraise, text_type
@@ -230,11 +230,7 @@ def from_yaml_all(data):
     return data
 
 
-# context prevents this filter from being treated as a constant
-# and evaluated at compile time, and instead defers evaluation
-# to execution time
-@pass_context
-def rand(context, end, start=None, step=None, seed=None):
+def rand(end, start=None, step=None, seed=None):
     if seed is None:
         r = SystemRandom()
     else:
@@ -253,11 +249,7 @@ def rand(context, end, start=None, step=None, seed=None):
         raise AnsibleFilterError('random can only be used on sequences and integers')
 
 
-# context prevents this filter from being treated as a constant
-# and evaluated at compile time, and instead defers evaluation
-# to execution time
-@pass_context
-def randomize_list(context, mylist, seed=None):
+def randomize_list(mylist, seed=None):
     try:
         mylist = list(mylist)
         if seed:
@@ -281,11 +273,7 @@ def get_hash(data, hashtype='sha1'):
     return h.hexdigest()
 
 
-# context prevents this filter from being treated as a constant
-# and evaluated at compile time, and instead defers evaluation
-# to execution time
-@pass_context
-def get_encrypted_password(context, password, hashtype='sha512', salt=None, salt_size=None, rounds=None, ident=None):
+def get_encrypted_password(password, hashtype='sha512', salt=None, salt_size=None, rounds=None, ident=None):
     passlib_mapping = {
         'md5': 'md5_crypt',
         'blowfish': 'bcrypt',

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -21,7 +21,7 @@ from collections.abc import Mapping
 from functools import partial
 from random import Random, SystemRandom, shuffle
 
-from jinja2.filters import pass_environment
+from jinja2.filters import pass_environment, pass_context
 
 from ansible.errors import AnsibleError, AnsibleFilterError, AnsibleFilterTypeError
 from ansible.module_utils.six import string_types, integer_types, reraise, text_type
@@ -230,8 +230,8 @@ def from_yaml_all(data):
     return data
 
 
-@pass_environment
-def rand(environment, end, start=None, step=None, seed=None):
+@pass_context
+def rand(context, end, start=None, step=None, seed=None):
     if seed is None:
         r = SystemRandom()
     else:

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -252,6 +252,7 @@ def rand(context, end, start=None, step=None, seed=None):
     else:
         raise AnsibleFilterError('random can only be used on sequences and integers')
 
+
 # context prevents this filter from being treated as a constant
 # and evaluated at compile time, and instead defers evaluation
 # to execution time

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -250,7 +250,8 @@ def rand(context, end, start=None, step=None, seed=None):
         raise AnsibleFilterError('random can only be used on sequences and integers')
 
 
-def randomize_list(mylist, seed=None):
+@pass_context
+def randomize_list(context, mylist, seed=None):
     try:
         mylist = list(mylist)
         if seed:
@@ -274,7 +275,8 @@ def get_hash(data, hashtype='sha1'):
     return h.hexdigest()
 
 
-def get_encrypted_password(password, hashtype='sha512', salt=None, salt_size=None, rounds=None, ident=None):
+@pass_context
+def get_encrypted_password(context, password, hashtype='sha512', salt=None, salt_size=None, rounds=None, ident=None):
     passlib_mapping = {
         'md5': 'md5_crypt',
         'blowfish': 'bcrypt',

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -644,7 +644,7 @@ class AnsibleEnvironment(NativeEnvironment):
                 ('trim_blocks', self.trim_blocks),
                 ('variable_end_string', self.variable_end_string),
                 ('variable_start_string', self.variable_start_string),
-                ('native', self.__class__ == AnsibleNativeEnvironment),
+                ('native', self.__class__ is AnsibleNativeEnvironment),
             )
         )
         return f'{source}[overrides={overrides}]'
@@ -764,6 +764,9 @@ class Templar:
 
         :returns: Copy of Templar with updated environment.
         """
+        if environment_class not in {AnsibleEnvironment, AnsibleNativeEnvironment}:
+            raise AnsibleAssertionError('environment_class must be one of AnsibleEnvironment or AnsibleNativeEnvironment')
+
         # We need to use __new__ to skip __init__, mainly not to create a new
         # environment there only to override it below
         new_env = object.__new__(environment_class)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -542,11 +542,6 @@ class AnsibleEnvironment(NativeEnvironment):
     context_class = AnsibleContext
     template_class = AnsibleJ2Template
     concat = staticmethod(ansible_eval_concat)  # type: ignore[assignment]
-    _overrides = (
-        'autoescape', 'block_end_string', 'block_start_string', 'comment_end_string', 'comment_start_string',
-        'keep_trailing_newline', 'line_comment_prefix', 'line_statement_prefix', 'lstrip_blocks', 'newline_sequence',
-        'trim_blocks', 'variable_end_string', 'variable_start_string',
-    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -560,10 +555,26 @@ class AnsibleEnvironment(NativeEnvironment):
         self.finalize = _ansible_finalize
 
     def _make_bucket_name(self, source):
-        override = ';'.join(
-            f'{k}={getattr(self, k, None)!r}' for k in self._overrides
-        ) + f';native={isinstance(self, AnsibleNativeEnvironment)};'
-        return f'{source}[overrides={override}]'
+        overrides = hash(
+            (
+                ('autoescape', self.autoescape),
+                ('block_end_string', self.block_end_string),
+                ('block_start_string', self.block_start_string),
+                ('comment_end_string', self.comment_end_string),
+                ('comment_start_string', self.comment_start_string),
+                ('extensions', tuple(self.extensions)),
+                ('keep_trailing_newline', self.keep_trailing_newline),
+                ('line_comment_prefix', self.line_comment_prefix),
+                ('line_statement_prefix', self.line_statement_prefix),
+                ('lstrip_blocks', self.lstrip_blocks),
+                ('newline_sequence', self.newline_sequence),
+                ('trim_blocks', self.trim_blocks),
+                ('variable_end_string', self.variable_end_string),
+                ('variable_start_string', self.variable_start_string),
+                ('native', self.__class__ == AnsibleNativeEnvironment),
+            )
+        )
+        return f'{source}[overrides={overrides}]'
 
     def from_string(
         self,

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -583,8 +583,8 @@ class AnsibleEnvironment(NativeEnvironment):
     def compile(  # type: ignore[override]
         self,
         source: str,
-        name: t.Optional[str] = None,
-        filename: t.Optional[str] = None,
+        name: str | None = None,
+        filename: str | None = None,
         raw: bool = False,
         defer_init: bool = False,
     ) -> CodeType:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -554,7 +554,7 @@ class AnsibleEnvironment(NativeEnvironment):
         self.undefined = AnsibleUndefined
         self.finalize = _ansible_finalize
 
-    def _make_bucket_name(self, source):
+    def _make_bucket_name(self, source: str) -> str:
         overrides = hash(
             (
                 ('autoescape', self.autoescape),

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -583,6 +583,9 @@ class AnsibleEnvironment(NativeEnvironment):
         template_class: t.Type[Template] | None = None,
     ) -> Template:
 
+        if not C.JINJA2_BYTECODE_CACHE:
+            return super().from_string(source, globals=globals, template_class=template_class)
+
         cache_dir = os.path.join(C.DEFAULT_LOCAL_TMP, 'j2cache')
         if not os.path.isdir(cache_dir):
             os.makedirs(cache_dir, mode=0o700, exist_ok=True)

--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -114,37 +114,37 @@ def test_encrypt_default_rounds():
 def test_password_hash_filter_no_passlib():
     with passlib_off():
         assert not encrypt.PASSLIB_AVAILABLE
-        assert get_encrypted_password(None, "123", "md5", salt="12345678") == "$1$12345678$tRy4cXc3kmcfRZVj4iFXr/"
+        assert get_encrypted_password("123", "md5", salt="12345678") == "$1$12345678$tRy4cXc3kmcfRZVj4iFXr/"
 
         with pytest.raises(AnsibleFilterError):
-            get_encrypted_password(None, "123", "crypt16", salt="12")
+            get_encrypted_password("123", "crypt16", salt="12")
 
 
 @pytest.mark.skipif(not encrypt.PASSLIB_AVAILABLE, reason='passlib must be installed to run this test')
 def test_password_hash_filter_passlib():
 
     with pytest.raises(AnsibleFilterError):
-        get_encrypted_password(None, "123", "sha257", salt="12345678")
+        get_encrypted_password("123", "sha257", salt="12345678")
 
     # Uses passlib default rounds value for sha256 matching crypt behaviour
-    assert get_encrypted_password(None, "123", "sha256", salt="12345678") == "$5$rounds=535000$12345678$uy3TurUPaY71aioJi58HvUY8jkbhSQU8HepbyaNngv."
-    assert get_encrypted_password(None, "123", "sha256", salt="12345678", rounds=5000) == "$5$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
+    assert get_encrypted_password("123", "sha256", salt="12345678") == "$5$rounds=535000$12345678$uy3TurUPaY71aioJi58HvUY8jkbhSQU8HepbyaNngv."
+    assert get_encrypted_password("123", "sha256", salt="12345678", rounds=5000) == "$5$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
 
-    assert (get_encrypted_password(None, "123", "sha256", salt="12345678", rounds=10000) ==
+    assert (get_encrypted_password("123", "sha256", salt="12345678", rounds=10000) ==
             "$5$rounds=10000$12345678$JBinliYMFEcBeAXKZnLjenhgEhTmJBvZn3aR8l70Oy/")
 
-    assert (get_encrypted_password(None, "123", "sha512", salt="12345678", rounds=6000) ==
+    assert (get_encrypted_password("123", "sha512", salt="12345678", rounds=6000) ==
             "$6$rounds=6000$12345678$l/fC67BdJwZrJ7qneKGP1b6PcatfBr0dI7W6JLBrsv8P1wnv/0pu4WJsWq5p6WiXgZ2gt9Aoir3MeORJxg4.Z/")
 
-    assert (get_encrypted_password(None, "123", "sha512", salt="12345678", rounds=5000) ==
+    assert (get_encrypted_password("123", "sha512", salt="12345678", rounds=5000) ==
             "$6$12345678$LcV9LQiaPekQxZ.OfkMADjFdSO2k9zfbDQrHPVcYjSLqSdjLYpsgqviYvTEP/R41yPmhH3CCeEDqVhW1VHr3L.")
 
-    assert get_encrypted_password(None, "123", "crypt16", salt="12") == "12pELHK2ME3McUFlHxel6uMM"
+    assert get_encrypted_password("123", "crypt16", salt="12") == "12pELHK2ME3McUFlHxel6uMM"
 
     # Try algorithm that uses a raw salt
-    assert get_encrypted_password(None, "123", "pbkdf2_sha256")
+    assert get_encrypted_password("123", "pbkdf2_sha256")
     # Try algorithm with ident
-    assert get_encrypted_password(None, "123", "pbkdf2_sha256", ident='invalid_ident')
+    assert get_encrypted_password("123", "pbkdf2_sha256", ident='invalid_ident')
 
 
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='macOS requires passlib')

--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -114,37 +114,37 @@ def test_encrypt_default_rounds():
 def test_password_hash_filter_no_passlib():
     with passlib_off():
         assert not encrypt.PASSLIB_AVAILABLE
-        assert get_encrypted_password("123", "md5", salt="12345678") == "$1$12345678$tRy4cXc3kmcfRZVj4iFXr/"
+        assert get_encrypted_password(None, "123", "md5", salt="12345678") == "$1$12345678$tRy4cXc3kmcfRZVj4iFXr/"
 
         with pytest.raises(AnsibleFilterError):
-            get_encrypted_password("123", "crypt16", salt="12")
+            get_encrypted_password(None, "123", "crypt16", salt="12")
 
 
 @pytest.mark.skipif(not encrypt.PASSLIB_AVAILABLE, reason='passlib must be installed to run this test')
 def test_password_hash_filter_passlib():
 
     with pytest.raises(AnsibleFilterError):
-        get_encrypted_password("123", "sha257", salt="12345678")
+        get_encrypted_password(None, "123", "sha257", salt="12345678")
 
     # Uses passlib default rounds value for sha256 matching crypt behaviour
-    assert get_encrypted_password("123", "sha256", salt="12345678") == "$5$rounds=535000$12345678$uy3TurUPaY71aioJi58HvUY8jkbhSQU8HepbyaNngv."
-    assert get_encrypted_password("123", "sha256", salt="12345678", rounds=5000) == "$5$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
+    assert get_encrypted_password(None, "123", "sha256", salt="12345678") == "$5$rounds=535000$12345678$uy3TurUPaY71aioJi58HvUY8jkbhSQU8HepbyaNngv."
+    assert get_encrypted_password(None, "123", "sha256", salt="12345678", rounds=5000) == "$5$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
 
-    assert (get_encrypted_password("123", "sha256", salt="12345678", rounds=10000) ==
+    assert (get_encrypted_password(None, "123", "sha256", salt="12345678", rounds=10000) ==
             "$5$rounds=10000$12345678$JBinliYMFEcBeAXKZnLjenhgEhTmJBvZn3aR8l70Oy/")
 
-    assert (get_encrypted_password("123", "sha512", salt="12345678", rounds=6000) ==
+    assert (get_encrypted_password(None, "123", "sha512", salt="12345678", rounds=6000) ==
             "$6$rounds=6000$12345678$l/fC67BdJwZrJ7qneKGP1b6PcatfBr0dI7W6JLBrsv8P1wnv/0pu4WJsWq5p6WiXgZ2gt9Aoir3MeORJxg4.Z/")
 
-    assert (get_encrypted_password("123", "sha512", salt="12345678", rounds=5000) ==
+    assert (get_encrypted_password(None, "123", "sha512", salt="12345678", rounds=5000) ==
             "$6$12345678$LcV9LQiaPekQxZ.OfkMADjFdSO2k9zfbDQrHPVcYjSLqSdjLYpsgqviYvTEP/R41yPmhH3CCeEDqVhW1VHr3L.")
 
-    assert get_encrypted_password("123", "crypt16", salt="12") == "12pELHK2ME3McUFlHxel6uMM"
+    assert get_encrypted_password(None, "123", "crypt16", salt="12") == "12pELHK2ME3McUFlHxel6uMM"
 
     # Try algorithm that uses a raw salt
-    assert get_encrypted_password("123", "pbkdf2_sha256")
+    assert get_encrypted_password(None, "123", "pbkdf2_sha256")
     # Try algorithm with ident
-    assert get_encrypted_password("123", "pbkdf2_sha256", ident='invalid_ident')
+    assert get_encrypted_password(None, "123", "pbkdf2_sha256", ident='invalid_ident')
 
 
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='macOS requires passlib')


### PR DESCRIPTION
##### SUMMARY

This PR uses the byte code caching provided by jinja2 to speed up processing of templates, especially in the cases where a template is referenced many times.  This does not cache results, it only caches the python code generated by jinja2, bypassing the need to repeatedly parse a jinja2 statement to compile to python code.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

###### TODO

- [x] Allow this functionality to be toggled?
- [x] ~Cache file write locking?~

###### Stats

On a particularly template heavy reproducer I have access to:

devel: 6m1s
PR: 2m3s