### PR TITLE
Skip DNF modularity test for Fedora 39 and up

### DIFF
--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -66,7 +66,7 @@
 
 - include_tasks: modularity.yml
   when:
-    - (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('29', '>=')) or
+    - (ansible_distribution == 'Fedora' and ansible_distribution_major_version is version('39', '<')) or
       (ansible_distribution in ['RedHat', 'CentOS'] and ansible_distribution_major_version is version('8', '>='))
     - not dnf5|default(false)
   tags:


### PR DESCRIPTION
##### SUMMARY

* Modularity is deprecated in Fedora 39 and onwards,
  Skip modularity tests

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE



- Test Pull Request