### PR TITLE
Enable vendored copy of distutils in entry_point test

### DIFF
--- a/test/integration/targets/entry_points/runme.sh
+++ b/test/integration/targets/entry_points/runme.sh
@@ -4,7 +4,6 @@ set -eu -o pipefail
 source virtualenv.sh
 set +x
 unset PYTHONPATH
-export SETUPTOOLS_USE_DISTUTILS=stdlib
 
 base_dir="$(dirname "$(dirname "$(dirname "$(dirname "${OUTPUT_DIR}")")")")"
 bin_dir="$(dirname "$(command -v pip)")"


### PR DESCRIPTION
##### SUMMARY

* Enable use of vendored copy of distutils by removing
  the environment variable SETUPTOOLS_USE_DISTUTILS

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE



- Test Pull Request