### PR TITLE
expect - hide responses from the invocation with echo=false

### DIFF
--- a/changelogs/fragments/82188-expect-responses-invocation.yml
+++ b/changelogs/fragments/82188-expect-responses-invocation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - expect - omit the ``responses`` from the module invocation when response strings are not echoed (https://github.com/ansible/ansible/issues/82188).

--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -51,7 +51,8 @@ options:
     default: 30
   echo:
     description:
-      - Whether or not to echo out your response strings.
+      - Whether or not pexepct will echo your response strings.
+      - When response strings are not echoed, the C(responses) are also omitted from the module invocation.
     default: false
     type: bool
 requirements:
@@ -179,6 +180,9 @@ def main():
         except TypeError as te:
             module.fail_json(msg=f"argument 'timeout' is of type {type(timeout)} and we were unable to convert to int: {te}")
     echo = module.params['echo']
+    if not echo:
+        # Mutate params to hide responses from the invocation displayed with -vvv
+        del module.params['responses']
 
     events = dict()
     for key, value in responses.items():

--- a/test/integration/targets/expect/files/test_command.py
+++ b/test/integration/targets/expect/files/test_command.py
@@ -8,6 +8,8 @@ except NameError:
     input_function = input
 
 prompts = sys.argv[1:] or ['foo']
+if (quiet := prompts[-1] == '--quiet'):
+    del prompts[-1]
 
 # latin1 encoded bytes
 # to ensure pexpect doesn't have any encoding errors
@@ -21,4 +23,5 @@ print()
 
 for prompt in prompts:
     user_input = input_function(prompt)
-    print(user_input)
+    if not quiet:
+        print(user_input)

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -220,15 +220,24 @@
 - name: test the task invocation by running ansible in command task
   vars:
     pexpect_python: "{{ hostvars['localhost']['ansible_python_interpreter'] }}"
+    localhost_cmd_file: "{{ output_dir }}/test_command.py"
   module_defaults:
     ansible.builtin.pip:
       virtualenv_python: "{{ pexpect_python }}"
   block:
     - include_role:
         name: setup_pexpect
+        apply:
+          delegate_to: localhost
+          vars:
+            setup_pexpect_tmpdir: "{{ output_dir }}"
+
+    - name: copy script into output directory
+      copy: src=test_command.py dest={{ localhost_cmd_file }} mode=0444
+      delegate_to: localhost
 
     - command: |
-        ansible localhost -m expect -a "command='{{pexpect_python}} {{test_command_file}} foo --quiet' responses='{\"foo\": \"bar\"}'" -vvv
+        ansible localhost -m expect -a "command='{{pexpect_python}} {{localhost_cmd_file}} foo --quiet' responses='{\"foo\": \"bar\"}'" -vvv
       delegate_to: localhost
       register: task_invocation
 

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -216,3 +216,16 @@
     that:
     - "non_zero_result.failed"
     - "non_zero_result.msg == 'non-zero return code'"
+
+- name: run ansible via command to validate the invocation
+  command: |
+    ansible localhost -m expect -a "{{ module_args }}" -vvv
+  vars:
+    module_args: |
+      command='{{ansible_python_interpreter}} {{test_command_file}} foo --quiet' responses='{\"foo\": \"bar\"}'
+  register: task_invocation
+
+- assert:
+    that:
+      - "'invocation' in task_invocation.stdout"
+      - "'bar' not in task_invocation.stdout"

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -217,15 +217,22 @@
     - "non_zero_result.failed"
     - "non_zero_result.msg == 'non-zero return code'"
 
-- name: run ansible via command to validate the invocation
-  command: |
-    ansible localhost -m expect -a "{{ module_args }}" -vvv
+- name: test the task invocation by running ansible in command task
   vars:
-    module_args: |
-      command='{{ansible_python_interpreter}} {{test_command_file}} foo --quiet' responses='{\"foo\": \"bar\"}'
-  register: task_invocation
+    pexpect_python: "{{ hostvars['localhost']['ansible_python_interpreter'] }}"
+  module_defaults:
+    ansible.builtin.pip:
+      virtualenv_python: "{{ pexpect_python }}"
+  block:
+    - include_role:
+        name: setup_pexpect
 
-- assert:
-    that:
-      - "'invocation' in task_invocation.stdout"
-      - "'bar' not in task_invocation.stdout"
+    - command: |
+        ansible localhost -m expect -a "command='{{pexpect_python}} {{test_command_file}} foo --quiet' responses='{\"foo\": \"bar\"}'" -vvv
+      delegate_to: localhost
+      register: task_invocation
+
+    - assert:
+        that:
+          - "'invocation' in task_invocation.stdout"
+          - "'bar' not in task_invocation.stdout"

--- a/test/integration/targets/setup_pexpect/tasks/main.yml
+++ b/test/integration/targets/setup_pexpect/tasks/main.yml
@@ -1,19 +1,22 @@
-- name: Copy constraints file
-  copy:
-    src: constraints.txt
-    dest: "{{ remote_tmp_dir }}/pexpect-constraints.txt"
+- vars:
+    pexpect_constraint_dir: "{{ setup_pexpect_tmpdir | default(remote_tmp_dir) }}"
+  block:
+  - name: Copy constraints file
+    copy:
+      src: constraints.txt
+      dest: "{{ pexpect_constraint_dir }}/pexpect-constraints.txt"
 
-- name: Install pexpect with --user
-  pip:
-    name: pexpect
-    extra_args: '--user --constraint "{{ remote_tmp_dir }}/pexpect-constraints.txt"'
-    state: present
-  ignore_errors: yes  # fails when inside a virtual environment
-  register: pip_user
+  - name: Install pexpect with --user
+    pip:
+      name: pexpect
+      extra_args: '--user --constraint "{{ pexpect_constraint_dir }}/pexpect-constraints.txt"'
+      state: present
+    ignore_errors: yes  # fails when inside a virtual environment
+    register: pip_user
 
-- name: Install pexpect
-  pip:
-    name: pexpect
-    extra_args: '--constraint "{{ remote_tmp_dir }}/pexpect-constraints.txt"'
-    state: present
-  when: pip_user is failed
+  - name: Install pexpect
+    pip:
+      name: pexpect
+      extra_args: '--constraint "{{ pexpect_constraint_dir }}/pexpect-constraints.txt"'
+      state: present
+    when: pip_user is failed


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible/ansible/issues/82188

Modules don't usually sanitize their own invocation this way, so I'm wondering if this be better as a more general feature to hide task invocations.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
