### PR TITLE
csvfile - add a keycol parameter to specify in which column to search.

### DIFF
--- a/changelogs/fragments/csvfile-keycol.yml
+++ b/changelogs/fragments/csvfile-keycol.yml
@@ -1,0 +1,4 @@
+---
+
+minor_changes:
+  - csvfile - add a keycol parameter to specify in which column to search.

--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -18,7 +18,8 @@ DOCUMENTATION = r"""
         default: "1"
       keycol:
         description:  column to search in (0 indexed).
-        default: "0"
+        default: 0
+        type: int
         version_added: "2.17"
       default:
         description: what to return if the value is not found in the file.
@@ -133,7 +134,7 @@ class LookupModule(LookupBase):
             creader = CSVReader(f, delimiter=to_native(delimiter), encoding=encoding)
 
             for row in creader:
-                if len(row) and row[int(keycol)] == key:
+                if len(row) and row[keycol] == key:
                     return row[int(col)]
         except Exception as e:
             raise AnsibleError("csvfile: %s" % to_native(e))

--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -16,6 +16,9 @@ DOCUMENTATION = r"""
       col:
         description:  column to return (0 indexed).
         default: "1"
+      keycol:
+        description:  column to search in (0 indexed).
+        default: "0"
       default:
         description: what to return if the value is not found in the file.
       delimiter:
@@ -122,14 +125,14 @@ class CSVReader:
 
 class LookupModule(LookupBase):
 
-    def read_csv(self, filename, key, delimiter, encoding='utf-8', dflt=None, col=1):
+    def read_csv(self, filename, key, delimiter, encoding='utf-8', dflt=None, col=1, keycol=0):
 
         try:
             f = open(to_bytes(filename), 'rb')
             creader = CSVReader(f, delimiter=to_native(delimiter), encoding=encoding)
 
             for row in creader:
-                if len(row) and row[0] == key:
+                if len(row) and row[int(keycol)] == key:
                     return row[int(col)]
         except Exception as e:
             raise AnsibleError("csvfile: %s" % to_native(e))
@@ -172,7 +175,7 @@ class LookupModule(LookupBase):
                 paramvals['delimiter'] = "\t"
 
             lookupfile = self.find_file_in_search_path(variables, 'files', paramvals['file'])
-            var = self.read_csv(lookupfile, key, paramvals['delimiter'], paramvals['encoding'], paramvals['default'], paramvals['col'])
+            var = self.read_csv(lookupfile, key, paramvals['delimiter'], paramvals['encoding'], paramvals['default'], paramvals['col'], paramvals['keycol'])
             if var is not None:
                 if isinstance(var, MutableSequence):
                     for v in var:

--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -19,6 +19,7 @@ DOCUMENTATION = r"""
       keycol:
         description:  column to search in (0 indexed).
         default: "0"
+        version_added: "2.17"
       default:
         description: what to return if the value is not found in the file.
       delimiter:

--- a/test/integration/targets/lookup_csvfile/tasks/main.yml
+++ b/test/integration/targets/lookup_csvfile/tasks/main.yml
@@ -41,6 +41,7 @@
   assert:
     that:
       - lookup('csvfile', 'Smith', file='people.csv', delimiter=',', col=1) == "Jane"
+      - lookup('csvfile', 'Jane', file='people.csv', delimiter=',', col=0, keycol=1) == "Smith"
       - lookup('csvfile', 'German von Lastname file=people.csv delimiter=, col=1') == "Demo"
 
 - name: Check tab-separated file


### PR DESCRIPTION
##### SUMMARY

The csvfile lookup module is great but it was limited to searching in the first column. This PR adds a `keycol` parameter (default's to the first) to be able to look in the n'th column.

##### ISSUE TYPE

- Feature Pull Request
