### PR TITLE
inventory: remove group_names sorting

### DIFF
--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -160,7 +160,7 @@ class Host:
         else:
             results['inventory_hostname_short'] = self.name.split('.')[0]
 
-        results['group_names'] = sorted([g.name for g in self.get_groups() if g.name != 'all'])
+        results['group_names'] = [g.name for g in self.get_groups() if g.name != 'all']
 
         return results
 


### PR DESCRIPTION
##### SUMMARY

Magic variable `group_names` has a sorted group names but i guess it should be passed as is.
Because we need to get right ordered (as defined) groups list to use it to build some logic with group
priorities.

##### ISSUE TYPE

- Improvements Pull Request

##### ADDITIONAL INFORMATION

Minor logical changes
