### PR TITLE
Allow include_tasks handlers for searching role subdirs

### DIFF
--- a/changelogs/fragments/82241-handler-include-tasks-from.yml
+++ b/changelogs/fragments/82241-handler-include-tasks-from.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix issue where an ``include_tasks`` handler in a role was not able to locate a file in ``tasks/`` when ``tasks_from`` was used as a role entry point and ``main.yml`` was not present (https://github.com/ansible/ansible/issues/82241)

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -147,8 +147,8 @@ class IncludedFile:
                                     dirname = 'handlers' if isinstance(original_task, Handler) else 'tasks'
                                     new_basedir = os.path.join(original_task._role._role_path, dirname, cumulative_path)
                                     candidates = [
-                                        loader.path_dwim_relative(original_task._role._role_path, dirname, include_target),
-                                        loader.path_dwim_relative(new_basedir, dirname, include_target)
+                                        loader.path_dwim_relative(original_task._role._role_path, dirname, include_target, is_role=True),
+                                        loader.path_dwim_relative(new_basedir, dirname, include_target, is_role=True)
                                     ]
                                     for include_file in candidates:
                                         try:

--- a/test/integration/targets/handlers/82241.yml
+++ b/test/integration/targets/handlers/82241.yml
@@ -1,0 +1,6 @@
+- hosts: A
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: role-82241
+        tasks_from: entry_point.yml

--- a/test/integration/targets/handlers/roles/role-82241/handlers/main.yml
+++ b/test/integration/targets/handlers/roles/role-82241/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: handler
+  include_tasks: included_tasks.yml

--- a/test/integration/targets/handlers/roles/role-82241/tasks/entry_point.yml
+++ b/test/integration/targets/handlers/roles/role-82241/tasks/entry_point.yml
@@ -1,0 +1,2 @@
+- command: echo
+  notify: handler

--- a/test/integration/targets/handlers/roles/role-82241/tasks/included_tasks.yml
+++ b/test/integration/targets/handlers/roles/role-82241/tasks/included_tasks.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: included_task_from_tasks_dir

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -210,3 +210,6 @@ ansible-playbook force_handlers_blocks_81533-2.yml -i inventory.handlers "$@" 2>
 ansible-playbook nested_flush_handlers_failure_force.yml -i inventory.handlers "$@" 2>&1 | tee out.txt
 [ "$(grep out.txt -ce 'flush_handlers_rescued')" = "1" ]
 [ "$(grep out.txt -ce 'flush_handlers_always')" = "2" ]
+
+ansible-playbook 82241.yml -i inventory.handlers "$@" 2>&1 | tee out.txt
+[ "$(grep out.txt -ce 'included_task_from_tasks_dir')" = "1" ]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
https://github.com/ansible/ansible/pull/81733 follow up.

Fixes #82241
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
