### PR TITLE
docs: improve readability & scope of docs for ansible.builtin.assert

### DIFF
--- a/lib/ansible/modules/assert.py
+++ b/lib/ansible/modules/assert.py
@@ -73,12 +73,17 @@ author:
 '''
 
 EXAMPLES = r'''
-- ansible.builtin.assert: { that: "ansible_os_family != 'RedHat'" }
+- name: A single condition can be supplied as string instead of list
+  ansible.builtin.assert:
+    that: "ansible_os_family != 'RedHat'"
 
-- ansible.builtin.assert:
+- name: Use yaml multiline strings to ease escaping
+  ansible.builtin.assert:
     that:
       - "'foo' in some_command_result.stdout"
       - number_of_the_counting == 3
+      - >
+        "reject" not in some_command_result.stderr
 
 - name: After version 2.7 both 'msg' and 'fail_msg' can customize failing assertion message
   ansible.builtin.assert:


### PR DESCRIPTION
##### SUMMARY

Improve the examples for the ansible.builtin.assert module.

As someone publicly pointed out[1] assert uses some yaml syntax hard to read. Fix that, and add a different example for yaml syntax which actually helps. Also, document (`name:`) the examples.

[1]: <https://chaos.social/@zhenech/111443753920941437>

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
