### PR TITLE
evaluate_tags: add `None` as fallback in case `_parent` is not existing

### DIFF
--- a/lib/ansible/playbook/taggable.py
+++ b/lib/ansible/playbook/taggable.py
@@ -56,7 +56,7 @@ class Taggable:
             while obj is not None:
                 if (_tags := getattr(obj, "_tags", Sentinel)) is not Sentinel:
                     obj._tags = _flatten_tags(templar.template(_tags))
-                obj = obj._parent
+                obj = getattr(obj, "_parent", None)
             tags = set(self.tags)
         else:
             # this makes isdisjoint work for untagged


### PR DESCRIPTION
##### SUMMARY
Not every `Taggable` object has a `_parent`.
Due to the changes introduced in commit a05d254ca29e59d7e315fac1212d8708bdde8af7, this now leads to errors when using `evaluate_tags`. In our case, this affected [`Role`-objects](https://github.com/ansible/ansible/blob/devel/lib/ansible/playbook/role/__init__.py#L99).

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Error message that occurred due to the commit in our callback plugin:
```
[WARNING]: Failure using method (v2_playbook_on_start) in callback plugin (<ansible.plugins.callback.magic_vault.CallbackModule object at 0x7ffa3604c810>): 'Role' object has no attribute '_parent'
Callback Exception: 
  File "/usr/lib/python3.11/site-packages/ansible/executor/task_queue_manager.py", line 465, in send_callback
    method(*new_args, **kwargs)
   File "/.../AGDSN/Ansible/callback_plugins/magic_vault.py", line 117, in v2_playbook_on_start
    pending_roles = self._get_pending_roles(play)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/.../AGDSN/Ansible/callback_plugins/magic_vault.py", line 212, in _get_pending_roles
    if role.evaluate_tags(play.only_tags, play.skip_tags, []):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3.11/site-packages/ansible/playbook/taggable.py", line 64, in evaluate_tags
    obj = obj._parent
          ^^^^^^^^^^^
66 plays in site.yml
```