### PR TITLE
Avoid creating GALAXY_TOKEN_PATH for configured servers

### DIFF
--- a/changelogs/fragments/ansible-galaxy-fix-tokenfile-creation.yml
+++ b/changelogs/fragments/ansible-galaxy-fix-tokenfile-creation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - avoid creating the ``GALAXY_TOKEN_PATH`` as a side effect of configured servers that don't use ``username``/``password`` or ``auth_url`` for authentication.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -675,7 +675,7 @@ class GalaxyCLI(CLI):
                     )
                 elif token_val:
                     # The galaxy v1 / github / django / 'Token'
-                    server_options['token'] = GalaxyToken(token=token_val)
+                    server_options['token'] = GalaxyToken(token=token_val, config={})
 
             server_options.update(galaxy_options)
             config_servers.append(GalaxyAPI(

--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -121,10 +121,10 @@ class GalaxyToken(object):
 
     token_type = 'Token'
 
-    def __init__(self, token=None):
+    def __init__(self, token=None, config=None):
         self.b_file = to_bytes(C.GALAXY_TOKEN_PATH, errors='surrogate_or_strict')
         # Done so the config file is only opened when set/get/save is called
-        self._config = None
+        self._config = config
         self._token = token
 
     @property


### PR DESCRIPTION
##### SUMMARY

If a `username`/`password` or `auth_url` isn't provided for a configured server we auto-create the token file for the non-configured servers as a side effect, even though the file is only used for the default server or a url with --server.

Possibly what was happening in https://github.com/ansible/ansible/issues/82260#issuecomment-1821805638.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
