### PR TITLE
fix loading vars_plugins in roles

### DIFF
--- a/changelogs/fragments/fix-vars-plugins-in-roles.yml
+++ b/changelogs/fragments/fix-vars-plugins-in-roles.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix loading vars_plugins in roles (https://github.com/ansible/ansible/issues/82239).

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -1097,8 +1097,16 @@ class PluginLoader:
             self._update_object(obj, basename, path, resolved=fqcn)
 
             if self._plugin_instance_cache is not None:
-                # Use get_with_context to cache the plugin the first time we see it.
-                self.get_with_context(fqcn)[0]
+                needs_enabled = False
+                if hasattr(obj, 'REQUIRES_ENABLED'):
+                    needs_enabled = obj.REQUIRES_ENABLED
+                elif hasattr(obj, 'REQUIRES_WHITELIST'):
+                    needs_enabled = obj.REQUIRES_WHITELIST
+                    display.deprecated("The VarsModule class variable 'REQUIRES_WHITELIST' is deprecated. "
+                                       "Use 'REQUIRES_ENABLED' instead.", version=2.18)
+                if not needs_enabled:
+                    # Use get_with_context to cache the plugin the first time we see it.
+                    self.get_with_context(fqcn)[0]
 
             yield obj
 

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -13,7 +13,7 @@ import pkgutil
 import sys
 import warnings
 
-from collections import defaultdict, namedtuple, OrderedDict
+from collections import defaultdict, namedtuple
 from importlib import import_module
 from traceback import format_exc
 
@@ -237,7 +237,7 @@ class PluginLoader:
         self._module_cache = MODULE_CACHE[class_name]
         self._paths = PATH_CACHE[class_name]
         self._plugin_path_cache = PLUGIN_PATH_CACHE[class_name]
-        self._plugin_instance_cache = OrderedDict() if self.subdir == 'vars_plugins' else None
+        self._plugin_instance_cache = {} if self.subdir == 'vars_plugins' else None
 
         self._searched_paths = set()
 
@@ -262,7 +262,7 @@ class PluginLoader:
             self._module_cache = MODULE_CACHE[self.class_name]
             self._paths = PATH_CACHE[self.class_name]
             self._plugin_path_cache = PLUGIN_PATH_CACHE[self.class_name]
-            self._plugin_instance_cache = OrderedDict() if self.subdir == 'vars_plugins' else None
+            self._plugin_instance_cache = {} if self.subdir == 'vars_plugins' else None
             self._searched_paths = set()
 
     def __setstate__(self, data):

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -237,10 +237,7 @@ class PluginLoader:
         self._module_cache = MODULE_CACHE[class_name]
         self._paths = PATH_CACHE[class_name]
         self._plugin_path_cache = PLUGIN_PATH_CACHE[class_name]
-        try:
-            self._plugin_instance_cache = OrderedDict() if self.type == 'vars' else None
-        except ValueError:
-            self._plugin_instance_cache = None
+        self._plugin_instance_cache = OrderedDict() if self.subdir == 'vars_plugins' else None
 
         self._searched_paths = set()
 
@@ -265,7 +262,7 @@ class PluginLoader:
             self._module_cache = MODULE_CACHE[self.class_name]
             self._paths = PATH_CACHE[self.class_name]
             self._plugin_path_cache = PLUGIN_PATH_CACHE[self.class_name]
-            self._plugin_instance_cache = OrderedDict() if self.type == 'vars' else None
+            self._plugin_instance_cache = OrderedDict() if self.subdir == 'vars_plugins' else None
             self._searched_paths = set()
 
     def __setstate__(self, data):

--- a/lib/ansible/vars/plugins.py
+++ b/lib/ansible/vars/plugins.py
@@ -80,7 +80,7 @@ def _plugin_should_run(plugin, stage):
 
 def get_vars_from_path(loader, path, entities, stage):
     data = {}
-    if not vars_loader._paths:
+    if vars_loader._paths is None:
         # cache has been reset, reload all()
         _prime_vars_loader()
 

--- a/lib/ansible/vars/plugins.py
+++ b/lib/ansible/vars/plugins.py
@@ -80,8 +80,8 @@ def _plugin_should_run(plugin, stage):
 
 def get_vars_from_path(loader, path, entities, stage):
     data = {}
-    # FIXME: _prime_vars_loader shouldn't run repeatedly if there are no plugins
-    if not vars_loader._plugin_instance_cache:
+    if not vars_loader._paths:
+        # cache has been reset, reload all()
         _prime_vars_loader()
 
     for plugin_name in vars_loader._plugin_instance_cache:

--- a/lib/ansible/vars/plugins.py
+++ b/lib/ansible/vars/plugins.py
@@ -19,28 +19,11 @@ display = Display()
 
 def _prime_vars_loader():
     # find 3rd party legacy vars plugins once, and look them up by name subsequently
-    for auto_run_plugin in vars_loader.all(class_only=True):
-        needs_enabled = False
-        if hasattr(auto_run_plugin, 'REQUIRES_ENABLED'):
-            needs_enabled = auto_run_plugin.REQUIRES_ENABLED
-        elif hasattr(auto_run_plugin, 'REQUIRES_WHITELIST'):
-            needs_enabled = auto_run_plugin.REQUIRES_WHITELIST
-            display.deprecated("The VarsModule class variable 'REQUIRES_WHITELIST' is deprecated. "
-                               "Use 'REQUIRES_ENABLED' instead.", version=2.18)
-        if needs_enabled:
-            del vars_loader._plugin_instance_cache[auto_run_plugin.ansible_name]
-
+    list(vars_loader.all(class_only=True))
     for plugin_name in C.VARIABLE_PLUGINS_ENABLED:
         if not plugin_name:
             continue
-        if (plugin := vars_loader.get(plugin_name)) is not None:
-            collection = '.' in plugin.ansible_name and not plugin.ansible_name.startswith('ansible.builtin.')
-            # Warn if a collection plugin has REQUIRES_ENABLED because it has no effect.
-            if collection and (hasattr(plugin, 'REQUIRES_ENABLED') or hasattr(plugin, 'REQUIRES_WHITELIST')):
-                display.warning(
-                    "Vars plugins in collections must be enabled to be loaded, REQUIRES_ENABLED is not supported. "
-                    "This should be removed from the plugin %s." % plugin.ansible_name
-                )
+        vars_loader.get(plugin_name)
 
 
 def get_plugin_vars(loader, plugin, path, entities):
@@ -96,9 +79,7 @@ def _plugin_should_run(plugin, stage):
 
 
 def get_vars_from_path(loader, path, entities, stage):
-
     data = {}
-
     # FIXME: _prime_vars_loader shouldn't run repeatedly if there are no plugins
     if not vars_loader._plugin_instance_cache:
         _prime_vars_loader()
@@ -106,6 +87,14 @@ def get_vars_from_path(loader, path, entities, stage):
     for plugin_name in vars_loader._plugin_instance_cache:
         if (plugin := vars_loader.get(plugin_name)) is None:
             continue
+
+        collection = '.' in plugin.ansible_name and not plugin.ansible_name.startswith('ansible.builtin.')
+        # Warn if a collection plugin has REQUIRES_ENABLED because it has no effect.
+        if collection and (hasattr(plugin, 'REQUIRES_ENABLED') or hasattr(plugin, 'REQUIRES_WHITELIST')):
+            display.warning(
+                "Vars plugins in collections must be enabled to be loaded, REQUIRES_ENABLED is not supported. "
+                "This should be removed from the plugin %s." % plugin.ansible_name
+            )
 
         if not _plugin_should_run(plugin, stage):
             continue

--- a/test/integration/targets/old_style_vars_plugins/roles/a/tasks/main.yml
+++ b/test/integration/targets/old_style_vars_plugins/roles/a/tasks/main.yml
@@ -1,0 +1,3 @@
+- assert:
+    that:
+      - auto_role_var is defined

--- a/test/integration/targets/old_style_vars_plugins/roles/a/vars_plugins/auto_role_vars.py
+++ b/test/integration/targets/old_style_vars_plugins/roles/a/vars_plugins/auto_role_vars.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from ansible.plugins.vars import BaseVarsPlugin
+
+
+class VarsModule(BaseVarsPlugin):
+    # Implicitly
+    # REQUIRES_ENABLED = False
+
+    def get_vars(self, loader, path, entities):
+        return {'auto_role_var': True}

--- a/test/integration/targets/old_style_vars_plugins/runme.sh
+++ b/test/integration/targets/old_style_vars_plugins/runme.sh
@@ -46,3 +46,5 @@ ANSIBLE_DEBUG=True ansible-playbook test_task_vars.yml > out.txt
 [ "$(grep -c "Loading VarsModule 'host_group_vars'" out.txt)" -eq 1 ]
 [ "$(grep -c "Loading VarsModule 'require_enabled'" out.txt)" -lt 3 ]
 [ "$(grep -c "Loading VarsModule 'auto_enabled'" out.txt)" -gt 50 ]
+
+ansible localhost -m include_role -a 'name=a' "$@"


### PR DESCRIPTION
##### SUMMARY

Fixes #82239

Adding a new role dir to the plugin loader clears the plugin loader cache, but the variable `cached_vars_plugin_order` in ansible.vars.plugins is never reset, preventing new plugins from being found.

Remove cache in the middle and use the vars plugin loader cache as the load-order. To make this possible, the cache keys now include non-stateless vars plugins (the value is a None, unresolved PluginLoadContext() tuple to be easily distinguished from stateless plugins).

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
