### PR TITLE
changed the salt type from int to string

### DIFF
--- a/lib/ansible/plugins/filter/password_hash.yml
+++ b/lib/ansible/plugins/filter/password_hash.yml
@@ -19,7 +19,7 @@ DOCUMENTATION:
       choices: [ md5, blowfish, sha256, sha512 ]
     salt:
       description: Secret string that is used for the hashing, if none is provided a random one can be generated.
-      type: int
+      type: string
     rounds:
       description: Number of encryption rounds, default varies by algorithm used.
       type: int


### PR DESCRIPTION
##### SUMMARY

Fixes #82257 

Modified the salt type from int to string in the following file: https://github.com/ansible/ansible/blob/fbdb666411f0d2c833e2a74cbf35593b22abb69f/lib/ansible/plugins/filter/password_hash.yml#L22

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
