### PR TITLE
find: do not fail on PermissionError

### DIFF
--- a/changelogs/fragments/82027_find.yml
+++ b/changelogs/fragments/82027_find.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - find - do not fail on Permission errors (https://github.com/ansible/ansible/issues/82027).

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -262,6 +262,7 @@ skipped_paths:
     version_added: '2.12'
 '''
 
+import errno
 import fnmatch
 import grp
 import os
@@ -447,6 +448,8 @@ def statinfo(st):
 
 
 def handle_walk_errors(e):
+    if e.errno in (errno.EPERM, errno.EACCES):
+        return
     raise e
 
 

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -447,12 +447,6 @@ def statinfo(st):
     }
 
 
-def handle_walk_errors(e):
-    if e.errno in (errno.EPERM, errno.EACCES):
-        return
-    raise e
-
-
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -497,6 +491,12 @@ def main():
 
     filelist = []
     skipped = {}
+
+    def handle_walk_errors(e):
+        if e.errno in (errno.EPERM, errno.EACCES):
+            skipped[e.filename] = to_text(e)
+            return
+        raise e
 
     if params['age'] is None:
         age = None

--- a/test/integration/targets/find/aliases
+++ b/test/integration/targets/find/aliases
@@ -1,1 +1,2 @@
 shippable/posix/group1
+destructive

--- a/test/integration/targets/find/aliases
+++ b/test/integration/targets/find/aliases
@@ -1,2 +1,4 @@
 shippable/posix/group1
 destructive
+needs/root
+setup/always/setup_passlib_controller  # required for setup_test_user

--- a/test/integration/targets/find/meta/main.yml
+++ b/test/integration/targets/find/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
+  - setup_test_user
   - setup_remote_tmp_dir

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -423,13 +423,8 @@
 
 # Test permission error is correctly handled by find module
 - vars:
-    test_dir: /tmp
-    test_user_name: unpriv
+    test_dir: /tmp/permission_test
   block:
-    - name: make sure the test user is available
-      include_role:
-        name: setup_test_user
-
     - name: Set up content
       file:
         path: "{{ test_dir }}/{{ item.name }}"
@@ -476,6 +471,11 @@
           - "'{{ test_dir }}/readable/1-unreadable' in permission_issue.skipped_paths"
           - "'Permission denied' in permission_issue.skipped_paths['{{ test_dir }}/readable/1-unreadable']"
           - permission_issue.matched == 1
+  always:
+    - name: cleanup test directory
+      file:
+        dest: "{{ test_dir }}"
+        state: absent
 
 - name: Run mode tests
   import_tasks: mode.yml

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -422,35 +422,47 @@
       - '"checksum" in result.files[0]'
 
 # Test permission error is correctly handled by find module
-- block:
+- vars:
+    test_dir: /tmp
+  block:
     - name: create an unprivileged user for next test
       user:
         name: unpriv
         state: present
       register: user_details
 
-    - name: Set up a directory to test module error handling
+    - name: Set up content
       file:
-        path: "{{ remote_tmp_dir_test }}/unreadable/readme"
-        state: directory
-        owner: unpriv
-        group: "{{ user_details.group }}"
+        path: "{{ test_dir }}/{{ item.name }}"
+        state: "{{ item.state }}"
+        mode: "{{ item.mode }}"
+        owner: "{{ item.owner | default(omit) }}"
+        group: "{{ item.group | default(omit) }}"
+      loop:
+        - name: readable
+          state: directory
+          owner: unpriv
+          mode: "1711"
+        - name: readable/1-unreadable
+          state: directory
+          mode: "0700"
+        - name: readable/2-readable
+          state: touch
+          owner: unpriv
+          mode: "0777"
 
-    - name: Set directory permissions to unreadable
-      file:
-        path: "{{ remote_tmp_dir_test }}/unreadable/readme"
-        mode: "0000"
-        owner: unpriv
-        group: "{{ user_details.group }}"
-
-    - name: Get stat for directory created
-      stat:
-        path: "{{ remote_tmp_dir_test }}/unreadable/readme"
-
-    - name: Find a file in unreadable directory
+    - name: Find a file in readable directory
       find:
-        paths: "{{ remote_tmp_dir_test }}/unreadable/readme"
-        patterns: "sample"
+        paths: "{{ test_dir }}/readable/"
+        patterns: "*"
+        recurse: true
+      register: permission_issue
+      become_user: unpriv
+
+    - name: Find a file in readable directory
+      find:
+        paths: "{{ test_dir }}/readable/"
+        patterns: "*"
         recurse: true
       register: permission_issue
       become_user: unpriv
@@ -459,10 +471,12 @@
     - name: Check if the skipped_paths are populated correctly with permission error
       assert:
         that:
-          - "'{{ remote_tmp_dir_test }}/unreadable/readme' in permission_issue.skipped_paths"
-          - "'Permission denied' in permission_issue.skipped_paths['{{ remote_tmp_dir_test }}/unreadable/readme']"
+          - permission_issue is success
           - not permission_issue.changed
-          - permission_issue.matched == 0
+          - permission_issue.skipped_paths|length == 1
+          - "'{{ test_dir }}/readable/1-unreadable' in permission_issue.skipped_paths"
+          - "'Permission denied' in permission_issue.skipped_paths['{{ test_dir }}/readable/1-unreadable']"
+          - permission_issue.matched == 1
 
   always:
     - name: remove unprivileged user

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -424,12 +424,11 @@
 # Test permission error is correctly handled by find module
 - vars:
     test_dir: /tmp
+    test_user_name: unpriv
   block:
-    - name: create an unprivileged user for next test
-      user:
-        name: unpriv
-        state: present
-      register: user_details
+    - name: make sure the test user is available
+      include_role:
+        name: setup_test_user
 
     - name: Set up content
       file:
@@ -441,14 +440,14 @@
       loop:
         - name: readable
           state: directory
-          owner: unpriv
+          owner: "{{ test_user_name }}"
           mode: "1711"
         - name: readable/1-unreadable
           state: directory
           mode: "0700"
         - name: readable/2-readable
           state: touch
-          owner: unpriv
+          owner: "{{ test_user_name }}"
           mode: "0777"
 
     - name: Find a file in readable directory
@@ -457,7 +456,7 @@
         patterns: "*"
         recurse: true
       register: permission_issue
-      become_user: unpriv
+      become_user: "{{ test_user_name }}"
 
     - name: Find a file in readable directory
       find:
@@ -465,7 +464,7 @@
         patterns: "*"
         recurse: true
       register: permission_issue
-      become_user: unpriv
+      become_user: "{{ test_user_name }}"
       become: yes
 
     - name: Check if the skipped_paths are populated correctly with permission error
@@ -477,13 +476,6 @@
           - "'{{ test_dir }}/readable/1-unreadable' in permission_issue.skipped_paths"
           - "'Permission denied' in permission_issue.skipped_paths['{{ test_dir }}/readable/1-unreadable']"
           - permission_issue.matched == 1
-
-  always:
-    - name: remove unprivileged user
-      user:
-        name: unpriv
-        state: absent
-        remove: true
 
 - name: Run mode tests
   import_tasks: mode.yml

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -421,5 +421,55 @@
       - '"{{ remote_tmp_dir_test }}/astest/.hidden.txt" in astest_list'
       - '"checksum" in result.files[0]'
 
+# Test permission error is correctly handled by find module
+- block:
+    - name: create an unprivileged user for next test
+      user:
+        name: unpriv
+        state: present
+      register: user_details
+
+    - name: Set up a directory to test module error handling
+      file:
+        path: "{{ remote_tmp_dir_test }}/unreadable/readme"
+        state: directory
+        owner: unpriv
+        group: "{{ user_details.group }}"
+
+    - name: Set directory permissions to unreadable
+      file:
+        path: "{{ remote_tmp_dir_test }}/unreadable/readme"
+        mode: "0000"
+        owner: unpriv
+        group: "{{ user_details.group }}"
+
+    - name: Get stat for directory created
+      stat:
+        path: "{{ remote_tmp_dir_test }}/unreadable/readme"
+
+    - name: Find a file in unreadable directory
+      find:
+        paths: "{{ remote_tmp_dir_test }}/unreadable/readme"
+        patterns: "sample"
+        recurse: true
+      register: permission_issue
+      become_user: unpriv
+      become: yes
+
+    - name: Check if the skipped_paths are populated correctly with permission error
+      assert:
+        that:
+          - "'{{ remote_tmp_dir_test }}/unreadable/readme' in permission_issue.skipped_paths"
+          - "'Permission denied' in permission_issue.skipped_paths['{{ remote_tmp_dir_test }}/unreadable/readme']"
+          - not permission_issue.changed
+          - permission_issue.matched == 0
+
+  always:
+    - name: remove unprivileged user
+      user:
+        name: unpriv
+        state: absent
+        remove: true
+
 - name: Run mode tests
   import_tasks: mode.yml


### PR DESCRIPTION
##### SUMMARY

* Log and skip permission errors on files and directories

Fixes: #82027

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


