### PR TITLE
Remove unneeded Task.is_static assignment

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -93,7 +93,6 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
     from ansible.playbook.role_include import IncludeRole
     from ansible.playbook.handler_task_include import HandlerTaskInclude
     from ansible.template import Templar
-    from ansible.utils.plugin_docs import get_versioned_doclink
 
     if not isinstance(ds, list):
         raise AnsibleAssertionError('The ds (%s) should be a list but was a %s' % (ds, type(ds)))
@@ -257,7 +256,6 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     else:
                         task_list.extend(included_blocks)
                 else:
-                    t.is_static = False
                     task_list.append(t)
 
             elif action in C._ACTION_ALL_PROPER_INCLUDE_IMPORT_ROLES:


### PR DESCRIPTION
##### SUMMARY
Added in b38f746 but there is/was no Task.is_static so this just creates a new attribute dynamically that is/was never used.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request