### PR TITLE
[???] `Role.static` was always `True`...

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -942,7 +942,7 @@ DEFAULT_PRIVATE_KEY_FILE:
   type: path
 DEFAULT_PRIVATE_ROLE_VARS:
   name: Private role variables
-  default: False
+  default: ~
   description:
     - Makes role variables inaccessible from other roles.
     - This was introduced as a way to reset role variables to default values if

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -427,6 +427,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
         deps = []
         for role_include in self._metadata.dependencies:
             r = Role.load(role_include, play=self._play, parent_role=self)
+            r.static = self.static
             deps.append(r)
 
         return deps

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -90,15 +90,8 @@ class IncludeRole(TaskInclude):
         actual_role._metadata.allow_duplicates = self.allow_duplicates
         actual_role.static = self.statically_loaded
 
-        if self.public:
+        if self.public or (self.public is None and (C.DEFAULT_PRIVATE_ROLE_VARS is False or (C.DEFAULT_PRIVATE_ROLE_VARS is None and actual_role.static))):
             myplay.roles.append(actual_role)
-        elif self.public is None:
-            if actual_role.static:
-                if not C.DEFAULT_PRIVATE_ROLE_VARS:
-                    myplay.roles.append(actual_role)
-            else:
-                # NOTE C.DEFAULT_PRIVATE_ROLE_VARS does not have any effect on include_role, is that correct?
-                ...
 
         # save this for later use
         self._role_path = actual_role._role_path

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -88,6 +88,7 @@ class IncludeRole(TaskInclude):
         actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=from_files,
                                 from_include=True, validate=self.rolespec_validate, public=self.public)
         actual_role._metadata.allow_duplicates = self.allow_duplicates
+        actual_role.static = self.statically_loaded
 
         if self.statically_loaded or self.public:
             myplay.roles.append(actual_role)
@@ -121,10 +122,6 @@ class IncludeRole(TaskInclude):
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):
 
         ir = IncludeRole(block, role, task_include=task_include).load_data(data, variable_manager=variable_manager, loader=loader)
-
-        # dyanmic role!
-        if ir.action in C._ACTION_INCLUDE_ROLE:
-            ir.static = False
 
         # Validate options
         my_arg_names = frozenset(ir.args.keys())

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -90,8 +90,15 @@ class IncludeRole(TaskInclude):
         actual_role._metadata.allow_duplicates = self.allow_duplicates
         actual_role.static = self.statically_loaded
 
-        if self.statically_loaded or self.public:
+        if self.public:
             myplay.roles.append(actual_role)
+        elif self.public is None:
+            if actual_role.static:
+                if not C.DEFAULT_PRIVATE_ROLE_VARS:
+                    myplay.roles.append(actual_role)
+            else:
+                # NOTE C.DEFAULT_PRIVATE_ROLE_VARS does not have any effect on include_role, is that correct?
+                ...
 
         # save this for later use
         self._role_path = actual_role._role_path

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -200,7 +200,7 @@ class VariableManager:
             for role in play.get_roles():
                 # role is public and
                 #    either static or dynamic and completed
-                # role is not set
+                # role.public is not set
                 #    use config option as default
                 role_is_static_or_completed = role.static or role._completed.get(host.name, False)
                 if role.public and role_is_static_or_completed or \
@@ -392,7 +392,7 @@ class VariableManager:
             # unless the user has disabled this
             # role is public and
             #    either static or dynamic and completed
-            # role is not set
+            # role.public is not set
             #    use config option as default
             if host:
                 for role in play.get_roles():

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -196,7 +196,7 @@ class VariableManager:
         if self.safe_basedir:  # avoid adhoc/console loading cwd
             basedirs = [self._loader.get_basedir()]
 
-        if play:
+        if play and host:
             for role in play.get_roles():
                 # role is public and
                 #    either static or dynamic and completed
@@ -394,12 +394,13 @@ class VariableManager:
             #    either static or dynamic and completed
             # role is not set
             #    use config option as default
-            for role in play.get_roles():
-                role_is_static_or_completed = role.static or role._completed.get(host.name, False)
-                if role.public and role_is_static_or_completed or \
-                   role.public is None and not C.DEFAULT_PRIVATE_ROLE_VARS and role_is_static_or_completed:
+            if host:
+                for role in play.get_roles():
+                    role_is_static_or_completed = role.static or role._completed.get(host.name, False)
+                    if role.public and role_is_static_or_completed or \
+                       role.public is None and not C.DEFAULT_PRIVATE_ROLE_VARS and role_is_static_or_completed:
 
-                    all_vars = _combine_and_track(all_vars, role.get_vars(include_params=False, only_exports=True), "role '%s' exported vars" % role.name)
+                        all_vars = _combine_and_track(all_vars, role.get_vars(include_params=False, only_exports=True), "role '%s' exported vars" % role.name)
 
         # next, we merge in the vars from the role, which will specifically
         # follow the role dependency chain, and then we merge in the tasks

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -67,6 +67,7 @@ def preprocess_vars(a):
 
 
 def _get_public_roles(play, host):
+    # FIXME it seems like we should just not add roles that are not public into play.roles in the first place?
     for role in play.get_roles():
         # role is public and
         #    either static, or dynamic and completed

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -203,8 +203,7 @@ class VariableManager:
                 # role.public is not set
                 #    use config option as default
                 role_is_static_or_completed = role.static or role._completed.get(host.name, False)
-                if role.public and role_is_static_or_completed or \
-                   role.public is None and not C.DEFAULT_PRIVATE_ROLE_VARS and role_is_static_or_completed:
+                if (role.public or (role.public is None and not C.DEFAULT_PRIVATE_ROLE_VARS)) and role_is_static_or_completed:
                     all_vars = _combine_and_track(all_vars, role.get_default_vars(), "role '%s' defaults" % role.name)
         if task:
             # set basedirs
@@ -397,9 +396,7 @@ class VariableManager:
             if host:
                 for role in play.get_roles():
                     role_is_static_or_completed = role.static or role._completed.get(host.name, False)
-                    if role.public and role_is_static_or_completed or \
-                       role.public is None and not C.DEFAULT_PRIVATE_ROLE_VARS and role_is_static_or_completed:
-
+                    if (role.public or (role.public is None and not C.DEFAULT_PRIVATE_ROLE_VARS)) and role_is_static_or_completed:
                         all_vars = _combine_and_track(all_vars, role.get_vars(include_params=False, only_exports=True), "role '%s' exported vars" % role.name)
 
         # next, we merge in the vars from the role, which will specifically


### PR DESCRIPTION
##### SUMMARY

1. This is best read/reviewed by reading the commits individually from the first to the last.
2. This started by noticing that `Role.static` was always set to `True` and led to the next point.
3. On both `devel` and this PR running the following playbook with both `ANSIBLE_PRIVATE_ROLE_VARS=0` and `ANSIBLE_PRIVATE_ROLE_VARS=1` produces the same result:

`playbook.yml`:
```yaml
- hosts: localhost
  gather_facts: false
  tasks:
    - include_role:
        name: a

    - assert:
        that:
          - role_var is undefined
```

`roles/a/defaults/main.yml`:
```yaml
role_var: 1
```

but according to https://github.com/ansible/ansible/blob/ee86dafc6ec502525d992a07e6b7440665e3f200/lib/ansible/config/base.yml#L943-L955 the environment variable should have an effect. But since `include_role` and `import_role` have different default value for the `public` option, I am not sure how would that be possible? Or am I misunderstanding?

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request