### PR TITLE
Add argument "--and-tags" to only run plays and tasks tagged with all these values

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -417,6 +417,14 @@ class CLI(ABC):
                     tags.add(tag.strip())
             options.tags = list(tags)
 
+        # process and_tags
+        if hasattr(options, 'and_tags') and options.and_tags:
+            and_tags = set()
+            for tag_set in options.and_tags:
+                for tag in tag_set.split(u','):
+                    and_tags.add(tag.strip())
+            options.and_tags = list(and_tags)
+
         # process skip_tags
         if hasattr(options, 'skip_tags') and options.skip_tags:
             skip_tags = set()

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -383,6 +383,8 @@ def add_subset_options(parser):
     """Add options for commands which can run a subset of tasks"""
     parser.add_argument('-t', '--tags', dest='tags', default=C.TAGS_RUN, action='append',
                         help="only run plays and tasks tagged with these values")
+    parser.add_argument('--and-tags', dest='and_tags', default=[], action='append',
+                        help="only run plays and tasks tagged with all these values")
     parser.add_argument('--skip-tags', dest='skip_tags', default=C.TAGS_SKIP, action='append',
                         help="only run plays and tasks whose tags do not match these values")
 

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -287,6 +287,8 @@ class PullCLI(CLI):
             cmd += ' --ask-become-pass'
         if context.CLIARGS['skip_tags']:
             cmd += ' --skip-tags "%s"' % to_native(u','.join(context.CLIARGS['skip_tags']))
+        if context.CLIARGS['and_tags']:
+            cmd += ' --and-tags "%s"' % to_native(u','.join(context.CLIARGS['and_tags']))
         if context.CLIARGS['tags']:
             cmd += ' -t "%s"' % to_native(u','.join(context.CLIARGS['tags']))
         if context.CLIARGS['subset']:

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -375,7 +375,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
                     if filtered_block.has_tasks():
                         tmp_list.append(filtered_block)
                 elif ((task.action in C._ACTION_META and task.implicit) or
-                        task.evaluate_tags(self._play.only_tags, self._play.skip_tags, all_vars=all_vars)):
+                        task.evaluate_tags(self._play.only_tags, self._play.skip_tags, self._play.and_tags, all_vars=all_vars)):
                     tmp_list.append(task)
             return tmp_list
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -94,6 +94,7 @@ class Play(Base, Taggable, CollectionSearch):
         self.role_cache = {}
 
         self.only_tags = set(context.CLIARGS.get('tags', [])) or frozenset(('all',))
+        self.and_tags = set(context.CLIARGS.get('and_tags', []))
         self.skip_tags = set(context.CLIARGS.get('skip_tags', []))
 
         self._action_groups = {}

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -105,6 +105,7 @@ class PlayContext(Base):
 
     # general flags
     only_tags = FieldAttribute(isa='set', default=set)
+    and_tags = FieldAttribute(isa='set', default=set)
     skip_tags = FieldAttribute(isa='set', default=set)
 
     start_at_task = FieldAttribute(isa='string')

--- a/lib/ansible/playbook/taggable.py
+++ b/lib/ansible/playbook/taggable.py
@@ -47,7 +47,7 @@ class Taggable:
         else:
             raise AnsibleError('tags must be specified as a list', obj=ds)
 
-    def evaluate_tags(self, only_tags, skip_tags, all_vars):
+    def evaluate_tags(self, only_tags, skip_tags, and_tags, all_vars):
         ''' this checks if the current item should be executed depending on tag options '''
 
         if self.tags:
@@ -72,6 +72,13 @@ class Taggable:
             elif not tags.isdisjoint(only_tags):
                 should_run = True
             elif 'tagged' in only_tags and tags != self.untagged and 'never' not in tags:
+                should_run = True
+            else:
+                should_run = False
+
+        if should_run and and_tags:
+            # Check all tags exists
+            if all(tag in tags for tag in and_tags):
                 should_run = True
             else:
                 should_run = False

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -223,6 +223,7 @@ def load_options_vars(version):
                  'forks': 'forks',
                  'inventory': 'inventory_sources',
                  'skip_tags': 'skip_tags',
+                 'and_tags': 'and_tags',
                  'subset': 'limit',
                  'tags': 'run_tags',
                  'verbosity': 'verbosity'}

--- a/test/lib/ansible_test/_internal/cli/commands/integration/__init__.py
+++ b/test/lib/ansible_test/_internal/cli/commands/integration/__init__.py
@@ -64,6 +64,12 @@ def add_integration_common(
     )
 
     parser.add_argument(
+        '--and-tags',
+        metavar='TAGS',
+        help='only run plays and tasks tagged with all these values',
+    )
+
+    parser.add_argument(
         '--skip-tags',
         metavar='TAGS',
         help='only run plays and tasks whose tags do not match these values',

--- a/test/lib/ansible_test/_internal/commands/integration/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/integration/__init__.py
@@ -720,6 +720,9 @@ def command_integration_role(
             if args.tags:
                 cmd += ['--tags', args.tags]
 
+            if args.tags:
+                cmd += ['--and-tags', args.and_tags]
+
             if args.skip_tags:
                 cmd += ['--skip-tags', args.skip_tags]
 

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -287,6 +287,7 @@ class IntegrationConfig(TestConfig):
         self.changed_all_mode: str = args.changed_all_mode
         self.list_targets: bool = args.list_targets
         self.tags = args.tags
+        self.and_tags = args.and_tags
         self.skip_tags = args.skip_tags
         self.diff = args.diff
         self.no_temp_workdir: bool = args.no_temp_workdir

--- a/test/units/playbook/test_taggable.py
+++ b/test/units/playbook/test_taggable.py
@@ -32,73 +32,82 @@ class TaggableTestObj(Taggable):
 
 class TestTaggable(unittest.TestCase):
 
-    def assert_evaluate_equal(self, test_value, tags, only_tags, skip_tags):
+    def assert_evaluate_equal(self, test_value, tags, only_tags, skip_tags, and_tags, all_vars=None):
         taggable_obj = TaggableTestObj()
         taggable_obj.tags = tags
 
-        evaluate = taggable_obj.evaluate_tags(only_tags, skip_tags, {})
+        evaluate = taggable_obj.evaluate_tags(only_tags, skip_tags, and_tags, all_vars)
 
         self.assertEqual(test_value, evaluate)
 
+    def test_evaluate_tags_without_tags(self):
+        self.assert_evaluate_equal(True, ['tag1', 'tag2'], [], [], [])
+
     def test_evaluate_tags_tag_in_only_tags(self):
-        self.assert_evaluate_equal(True, ['tag1', 'tag2'], ['tag1'], [])
+        self.assert_evaluate_equal(True, ['tag1', 'tag2'], ['tag1'], [], [])
 
     def test_evaluate_tags_tag_in_skip_tags(self):
-        self.assert_evaluate_equal(False, ['tag1', 'tag2'], [], ['tag1'])
+        self.assert_evaluate_equal(False, ['tag1', 'tag2'], [], ['tag1'], [])
+
+    def test_evaluate_tags_tags_in_and_tags(self):
+        self.assert_evaluate_equal(True, ['tag1', 'tag2'], [], [], ['tag1', 'tag2'])
+
+    def test_evaluate_tags_skip_is_all_tags_not_in_and_tags(self):
+        self.assert_evaluate_equal(False, ['tag1', 'tag2'], [], [], ['tag1', 'tag3'])
 
     def test_evaluate_tags_special_always_in_object_tags(self):
-        self.assert_evaluate_equal(True, ['tag', 'always'], ['random'], [])
+        self.assert_evaluate_equal(True, ['tag', 'always'], ['random'], [], [])
 
     def test_evaluate_tags_tag_in_skip_tags_special_always_in_object_tags(self):
-        self.assert_evaluate_equal(False, ['tag', 'always'], ['random'], ['tag'])
+        self.assert_evaluate_equal(False, ['tag', 'always'], ['random'], ['tag'], [])
 
     def test_evaluate_tags_special_always_in_skip_tags_and_always_in_tags(self):
-        self.assert_evaluate_equal(False, ['tag', 'always'], [], ['always'])
+        self.assert_evaluate_equal(False, ['tag', 'always'], [], ['always'], [])
 
     def test_evaluate_tags_special_tagged_in_only_tags_and_object_tagged(self):
-        self.assert_evaluate_equal(True, ['tag'], ['tagged'], [])
+        self.assert_evaluate_equal(True, ['tag'], ['tagged'], [], [])
 
     def test_evaluate_tags_special_tagged_in_only_tags_and_object_untagged(self):
-        self.assert_evaluate_equal(False, [], ['tagged'], [])
+        self.assert_evaluate_equal(False, [], ['tagged'], [], [])
 
     def test_evaluate_tags_special_tagged_in_skip_tags_and_object_tagged(self):
-        self.assert_evaluate_equal(False, ['tag'], [], ['tagged'])
+        self.assert_evaluate_equal(False, ['tag'], [], ['tagged'], [])
 
     def test_evaluate_tags_special_tagged_in_skip_tags_and_object_untagged(self):
-        self.assert_evaluate_equal(True, [], [], ['tagged'])
+        self.assert_evaluate_equal(True, [], [], ['tagged'], [])
 
     def test_evaluate_tags_special_untagged_in_only_tags_and_object_tagged(self):
-        self.assert_evaluate_equal(False, ['tag'], ['untagged'], [])
+        self.assert_evaluate_equal(False, ['tag'], ['untagged'], [], [])
 
     def test_evaluate_tags_special_untagged_in_only_tags_and_object_untagged(self):
-        self.assert_evaluate_equal(True, [], ['untagged'], [])
+        self.assert_evaluate_equal(True, [], ['untagged'], [], [])
 
     def test_evaluate_tags_special_untagged_in_skip_tags_and_object_tagged(self):
-        self.assert_evaluate_equal(True, ['tag'], [], ['untagged'])
+        self.assert_evaluate_equal(True, ['tag'], [], ['untagged'], [])
 
     def test_evaluate_tags_special_untagged_in_skip_tags_and_object_untagged(self):
-        self.assert_evaluate_equal(False, [], [], ['untagged'])
+        self.assert_evaluate_equal(False, [], [], ['untagged'], [])
 
     def test_evaluate_tags_special_all_in_only_tags(self):
-        self.assert_evaluate_equal(True, ['tag'], ['all'], ['untagged'])
+        self.assert_evaluate_equal(True, ['tag'], ['all'], ['untagged'], [])
 
     def test_evaluate_tags_special_all_in_only_tags_and_object_untagged(self):
-        self.assert_evaluate_equal(True, [], ['all'], [])
+        self.assert_evaluate_equal(True, [], ['all'], [], [])
 
     def test_evaluate_tags_special_all_in_skip_tags(self):
-        self.assert_evaluate_equal(False, ['tag'], ['tag'], ['all'])
+        self.assert_evaluate_equal(False, ['tag'], ['tag'], ['all'], [])
 
     def test_evaluate_tags_special_all_in_only_tags_and_special_all_in_skip_tags(self):
-        self.assert_evaluate_equal(False, ['tag'], ['all'], ['all'])
+        self.assert_evaluate_equal(False, ['tag'], ['all'], ['all'], [])
 
     def test_evaluate_tags_special_all_in_skip_tags_and_always_in_object_tags(self):
-        self.assert_evaluate_equal(True, ['tag', 'always'], [], ['all'])
+        self.assert_evaluate_equal(True, ['tag', 'always'], [], ['all'], [])
 
     def test_evaluate_tags_special_all_in_skip_tags_and_special_always_in_skip_tags_and_always_in_object_tags(self):
-        self.assert_evaluate_equal(False, ['tag', 'always'], [], ['all', 'always'])
+        self.assert_evaluate_equal(False, ['tag', 'always'], [], ['all', 'always'], [])
 
     def test_evaluate_tags_accepts_lists(self):
-        self.assert_evaluate_equal(True, ['tag1', 'tag2'], ['tag2'], [])
+        self.assert_evaluate_equal(True, ['tag1', 'tag2'], ['tag2'], [], [])
 
     def test_evaluate_tags_with_repeated_tags(self):
-        self.assert_evaluate_equal(False, ['tag', 'tag'], [], ['tag'])
+        self.assert_evaluate_equal(False, ['tag', 'tag'], [], ['tag'], [])


### PR DESCRIPTION
##### SUMMARY

I have a use case where it is necessary to select many tags --tags with AND condition, not OR.
My implementation choice is to create an news argument `--and-tags` to keep it simple.

If you have a better proposal or an improvement to make. It is welcome.

##### ISSUE TYPE
- Feature Pull Request

##### ADDITIONAL INFORMATION

Possible use case with `--and-tags` : 
`ansible-playbook [...] --tags=apache --and-tags=reload` equal to `ansible-playbook [...] --and-tags=apache,reload`
Only reload apache.

Issues attached :
- My initial issue https://github.com/ansible/ansible/issues/82318
- https://github.com/ansible/ansible/issues/71733
- https://github.com/ansible/ansible/issues/11396
- https://stackoverflow.com/questions/30036126/how-can-i-run-only-ansible-tasks-with-multiple-tags