### PR TITLE
Added code/tests to catch exception when ZIP file has invalid timestamp and parses timestamp.

### DIFF
--- a/test/integration/targets/unarchive/tasks/test_zip_invalid_datetimestamp.yml
+++ b/test/integration/targets/unarchive/tasks/test_zip_invalid_datetimestamp.yml
@@ -1,0 +1,40 @@
+- name: create our unarchive destination
+  file:
+    path: "{{ remote_tmp_dir }}/test_invalid"
+    state: directory
+
+- name: test that unarchive works with an archive that contains file with invalid datetimestamp
+  unarchive:
+    src: "zip_with_invalid_datetimestamp.zip"
+    dest: "{{ remote_tmp_dir }}/test_invalid"
+    remote_src: no
+  register: invalid_result0
+
+- name: Check that file is really there
+  stat:
+    path: "{{ remote_tmp_dir }}/test_invalid/eggs.txt"
+  register: invalid_stat0
+
+- name: Assert that invalid zip tests succeeded
+  assert:
+    that:
+      - "invalid_result0.changed == true"
+      - "invalid_stat0.stat.exists == true"
+
+- name: test that unarchive fails with an archive that contains file with invalid datetimestamp (idempotency)
+  unarchive:
+    src: "zip_with_invalid_datetimestamp.zip"
+    dest: "{{ remote_tmp_dir }}/test_invalid"
+    remote_src: no
+  register: invalid_result1
+  ignore_errors: true
+
+- name: Assert that invalid zip tests succeeded
+  assert:
+    that:
+      - "invalid_result1.changed == false"
+
+- name: remove invalid test directory
+  file:
+    path: "{{ remote_tmp_dir }}/test_invalid"
+    state: absent


### PR DESCRIPTION
##### SUMMARY

Added code to catch exception and throw a more readable error message when ZIP file has invalid timestamp.
Fixes https://github.com/ansible/ansible/issues/81092

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
