### PR TITLE
Missing Exception Handling in SSH Plugin Fixed Error Verbosity Issue

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -459,15 +459,26 @@ def _handle_error(
         # No exception is raised, so the connection is retried - except when attempting to use
         # sshpass_prompt with an sshpass that won't let us pass -P, in which case we fail loudly.
         elif return_tuple[0] in [1, 2, 3, 4, 6]:
-            msg = 'sshpass error:'
+            error_code = return_tuple[0]
+            cmd_error = to_native(return_tuple[2]).rstrip()
+            error_messages = {
+                1: "sshpass: Invalid command line argument. Command given ({})".format(cmd_error),
+                2: "sshpass: Conflicting arguments given. Arguments given ({})".format(cmd_error),
+                3: "sshpass: General runtime error",
+                4: "sshpass: Unrecognized response from ssh",
+                6: "sshpass: Host public key is unknown"
+            }
+            msg = error_messages.get(error_code, "sshpass: Unknown error")
             if no_log:
-                msg = '{0} <error censored due to no log>'.format(msg)
+                msg = "Error censored due to no log"
+                raise AnsibleConnectionFailure(msg)
             else:
                 details = to_native(return_tuple[2]).rstrip()
                 if "sshpass: invalid option -- 'P'" in details:
                     details = 'Installed sshpass version does not support customized password prompts. ' \
                               'Upgrade sshpass to use sshpass_prompt, or otherwise switch to ssh keys.'
                     raise AnsibleError('{0} {1}'.format(msg, details))
+                
                 msg = '{0} {1}'.format(msg, details)
 
     if return_tuple[0] == 255:

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -478,7 +478,7 @@ def _handle_error(
                     details = 'Installed sshpass version does not support customized password prompts. ' \
                               'Upgrade sshpass to use sshpass_prompt, or otherwise switch to ssh keys.'
                     raise AnsibleError('{0} {1}'.format(msg, details))
-                
+
                 msg = '{0} {1}'.format(msg, details)
 
     if return_tuple[0] == 255:


### PR DESCRIPTION
Fix for issue #58133 

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
- Added error verbosity for sshpass errors 1-6 excluding 5
- raised an exception if no_log
- converted erroneous command to text

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
