### PR TITLE
assemble: fixed missing parameter error

### DIFF
--- a/changelogs/fragments/82359_assemble_diff.yml
+++ b/changelogs/fragments/82359_assemble_diff.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+ - assemble - fixed missing parameter 'content' in _get_diff_data API (https://github.com/ansible/ansible/issues/82359).

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1347,7 +1347,7 @@ class ActionBase(ABC):
         display.debug(u"_low_level_execute_command() done: rc=%d, stdout=%s, stderr=%s" % (rc, out, err))
         return dict(rc=rc, stdout=out, stdout_lines=out.splitlines(), stderr=err, stderr_lines=err.splitlines())
 
-    def _get_diff_data(self, destination, source, task_vars, content, source_file=True):
+    def _get_diff_data(self, destination, source, task_vars, content=None, source_file=True):
 
         # Note: Since we do not diff the source and destination before we transform from bytes into
         # text the diff between source and destination may not be accurate.  To fix this, we'd need

--- a/test/integration/targets/assemble/tasks/main.yml
+++ b/test/integration/targets/assemble/tasks/main.yml
@@ -152,3 +152,19 @@
     that:
     - "result.state == 'file'"
     - "result.checksum == '505359f48c65b3904127cf62b912991d4da7ed6d'"
+
+- name: test assemble with diff
+  assemble:
+    src: "./"
+    dest: "{{remote_tmp_dir}}/assembled11"
+    remote_src: false
+  diff: true
+  register: result
+
+- name: assert the fragments were assembled with diff
+  assert:
+    that:
+      - result.changed
+      - result.diff.after is defined
+      - result.diff.before is defined
+      - "result.state == 'file'"


### PR DESCRIPTION
##### SUMMARY

* content is an optional parameter for _get_diff_data API

Fixes: #82359

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


