### PR TITLE
[backport][stable-2.14] 🧪 Replace GitHub SVN integration test with local TLS

### DIFF
--- a/test/integration/targets/subversion/roles/subversion/defaults/main.yml
+++ b/test/integration/targets/subversion/roles/subversion/defaults/main.yml
@@ -3,8 +3,7 @@ apache_port: 11386  # cannot use 80 as httptester overrides this
 subversion_test_dir: /tmp/ansible-svn-test-dir
 subversion_server_dir: /tmp/ansible-svn  # cannot use a path in the home dir without userdir or granting exec permission to the apache user
 subversion_repo_name: ansible-test-repo
-subversion_repo_url: http://127.0.0.1:{{ apache_port }}/svn/{{ subversion_repo_name }}
-subversion_repo_auth_url: http://127.0.0.1:{{ apache_port }}/svnauth/{{ subversion_repo_name }}
+subversion_repo_url: https://localhost:{{ apache_port }}/svn/{{ subversion_repo_name }}  # svn can't verify TLS certificates against IP addresses
+subversion_repo_auth_url: https://localhost:{{ apache_port }}/svnauth/{{ subversion_repo_name }}
 subversion_username: subsvn_user'''
 subversion_password: Password123!
-subversion_external_repo_url: https://github.com/ansible/ansible.github.com  # GitHub serves SVN

--- a/test/integration/targets/subversion/roles/subversion/tasks/setup.yml
+++ b/test/integration/targets/subversion/roles/subversion/tasks/setup.yml
@@ -42,8 +42,21 @@
   block:
   - name: trustme -- provision a venv
     command: >-
-      {{ ansible_python_interpreter }} -Im venv
+      {{ ansible_python_interpreter }}
+      -{% if ansible_python.version.major != 2 %}I{% endif %}m
+      {% if ansible_python.version.major != 2 %}venv{%
+         else %}virtualenv{% endif %}
+
       {{ venv_path }}
+  - name: trustme -- upgrade pip in venv | RHEL 7.9 & 8.8+py36
+    when: >-  # these don't know how to notice `cryptography` wheels
+      ansible_distribution == 'RedHat'
+      and ansible_distribution_major_version | int < 9
+    pip:
+      name: pip
+      state: latest
+      virtualenv: >-
+        {{ venv_path }}
   - name: trustme -- install tool
     pip:
       name: trustme
@@ -54,16 +67,18 @@
       argv:
       - >-
         {{ venv_python }}
-      - -Im
+      - -{%- if ansible_python.version.major != 2 -%}I{%- endif -%}m
       - trustme
       - --dir={{ subversion_server_dir }}
 
 - name: symlink trustme certificates into apache config dir - Red Hat
   when: ansible_os_family in ['RedHat']
+  # when: ansible_distribution in ['Fedora', 'RedHat']
   file:
     src: /tmp/ansible-svn/server.{{ item.trustme_filetype }}
     dest: /etc/pki/tls/{{ item.apache_target_path }}
     state: link
+    force: yes  # Othewise Apache on CentOS 7 uses its own fake certificate
   loop:
   - apache_target_path: certs/localhost.crt
     trustme_filetype: pem

--- a/test/integration/targets/subversion/roles/subversion/tasks/setup.yml
+++ b/test/integration/targets/subversion/roles/subversion/tasks/setup.yml
@@ -33,6 +33,45 @@
   include_tasks: setup_selinux.yml
   when: ansible_selinux.status == "enabled"
 
+- name: Generate CA and TLS certificates via trustme
+  vars:
+    venv_path: >-
+      {{ subversion_server_dir }}/.venv
+    venv_python: >-
+      {{ subversion_server_dir }}/.venv/bin/python
+  block:
+  - name: trustme -- provision a venv
+    command: >-
+      {{ ansible_python_interpreter }} -Im venv
+      {{ venv_path }}
+  - name: trustme -- install tool
+    pip:
+      name: trustme
+      virtualenv: >-
+        {{ venv_path }}
+  - name: trustme -- generate CA and TLS certs
+    command:
+      argv:
+      - >-
+        {{ venv_python }}
+      - -Im
+      - trustme
+      - --dir={{ subversion_server_dir }}
+
+- name: symlink trustme certificates into apache config dir - Red Hat
+  when: ansible_os_family in ['RedHat']
+  file:
+    src: /tmp/ansible-svn/server.{{ item.trustme_filetype }}
+    dest: /etc/pki/tls/{{ item.apache_target_path }}
+    state: link
+  loop:
+  - apache_target_path: certs/localhost.crt
+    trustme_filetype: pem
+  - apache_target_path: certs/server-chain.crt
+    trustme_filetype: pem
+  - apache_target_path: private/localhost.key
+    trustme_filetype: key
+
 - name: template out configuration file
   template:
     src: subversion.conf.j2
@@ -66,3 +105,14 @@
   async: 3600  # We kill apache manually in the clean up phase
   poll: 0
   when: ansible_os_family in ['RedHat']
+
+- lineinfile:
+    dest: >-
+      {{ ansible_env.HOME }}/.subversion/servers
+    regexp: >-
+      ^#\s*ssl-authority-files\s*=\s*
+    line: >-
+      ssl-authority-files = {{ subversion_server_dir }}/client.pem
+    insertafter: >-
+      ^\[global\]
+    state: present

--- a/test/integration/targets/subversion/roles/subversion/tasks/tests.yml
+++ b/test/integration/targets/subversion/roles/subversion/tasks/tests.yml
@@ -18,10 +18,11 @@
 
 # checks out every branch so using a small repo
 
-- name: initial checkout
+- name: initial checkout with validate_certs=true
   subversion:
     repo: '{{ subversion_repo_url }}'
     dest: '{{ subversion_test_dir }}/svn'
+    validate_certs: yes
   register: subverted
 
 - name: check if dir was checked out
@@ -130,16 +131,27 @@
       - "export_branches.stat.isdir"
       - "subverted4.changed"
 
-- name: clone a small external repo with validate_certs=true
-  subversion:
-    repo: "{{ subversion_external_repo_url }}"
-    dest: "{{ subversion_test_dir }}/svn-external1"
-    validate_certs: yes
+- name: unconfigure client-side TLS trust
+  block:
+  - name: remove TLS CA chain file path from the SVN config
+    lineinfile:
+      dest: >-
+        {{ ansible_env.HOME }}/.subversion/servers
+      regexp: >-
+        ^(?:#)?\s*ssl-authority-files\s*=\s*
+      state: absent
+  - name: drop the client TLS CA chain file
+    file:
+      path: >-
+        {{ subversion_server_dir }}/client.pem
+      state: absent
 
-- name: clone a small external repo with validate_certs=false
+- name: >-
+    clone a HTTPS-accessible repo with validate_certs=false
+    and untrusted CA over TLS
   subversion:
-    repo: "{{ subversion_external_repo_url }}"
-    dest: "{{ subversion_test_dir }}/svn-external2"
+    repo: '{{ subversion_repo_url }}'
+    dest: '{{ subversion_test_dir }}/svn-untrusted-tls'
     validate_certs: no
 
 # TBA: test for additional options or URL variants welcome

--- a/test/integration/targets/subversion/roles/subversion/templates/subversion.conf.j2
+++ b/test/integration/targets/subversion/roles/subversion/templates/subversion.conf.j2
@@ -39,7 +39,6 @@ LoadModule dav_svn_module    libexec/apache24/mod_dav_svn.so
 LoadModule authz_svn_module  libexec/apache24/mod_authz_svn.so
 {% elif ansible_os_family == "Suse" %}
 Include /etc/apache2/httpd.conf
-Include mods-available/ssl.load
 LoadModule dav_module       /usr/lib64/apache2/mod_dav.so
 LoadModule dav_svn_module   /usr/lib64/apache2/mod_dav_svn.so
 {% elif ansible_os_family == "Alpine" %}
@@ -52,7 +51,7 @@ Include /etc/httpd/conf/httpd.conf
 
 PidFile {{ subversion_server_dir }}/apache.pid
 Listen 127.0.0.1:{{ apache_port }} https
-{% if ansible_distribution not in ["Alpine", "Fedora", "Ubuntu"] %}
+{% if ansible_distribution not in ["Alpine", "CentOS", "Fedora", "openSUSE Leap", "Ubuntu"] %}
 Listen [::1]:{{ apache_port }} https
 {% endif %}
 SSLEngine on

--- a/test/integration/targets/subversion/roles/subversion/templates/subversion.conf.j2
+++ b/test/integration/targets/subversion/roles/subversion/templates/subversion.conf.j2
@@ -19,6 +19,7 @@ LogFormat "%h %l %u %t \"%r\" %>s %O" common
 LogFormat "%{Referer}i -> %U" referer
 LogFormat "%{User-agent}i" agent
 
+Include mods-available/ssl.load
 IncludeOptional mods-enabled/*.load
 IncludeOptional mods-enabled/*.conf
 IncludeOptional conf-enabled/*.conf
@@ -32,11 +33,13 @@ IncludeOptional sites-enabled/*conf
 
 {% elif ansible_os_family == "FreeBSD" %}
 Include /usr/local/etc/apache24/httpd.conf
+LoadModule ssl_module        libexec/apache24/mod_ssl.so
 LoadModule dav_module        libexec/apache24/mod_dav.so
 LoadModule dav_svn_module    libexec/apache24/mod_dav_svn.so
 LoadModule authz_svn_module  libexec/apache24/mod_authz_svn.so
 {% elif ansible_os_family == "Suse" %}
 Include /etc/apache2/httpd.conf
+Include mods-available/ssl.load
 LoadModule dav_module       /usr/lib64/apache2/mod_dav.so
 LoadModule dav_svn_module   /usr/lib64/apache2/mod_dav_svn.so
 {% elif ansible_os_family == "Alpine" %}
@@ -48,7 +51,14 @@ Include /etc/httpd/conf/httpd.conf
 {% endif %}
 
 PidFile {{ subversion_server_dir }}/apache.pid
-Listen 127.0.0.1:{{ apache_port }}
+Listen 127.0.0.1:{{ apache_port }} https
+{% if ansible_distribution not in ["Alpine", "Fedora", "Ubuntu"] %}
+Listen [::1]:{{ apache_port }} https
+{% endif %}
+SSLEngine on
+SSLCertificateFile	{{ subversion_server_dir }}/server.pem
+SSLCertificateKeyFile {{ subversion_server_dir }}/server.key
+SSLCertificateChainFile {{ subversion_server_dir }}/server.pem
 ErrorLog {{ subversion_server_dir }}/apache2-error.log
 
 <Location /svn>

--- a/test/integration/targets/subversion/vars/Alpine.yml
+++ b/test/integration/targets/subversion/vars/Alpine.yml
@@ -5,5 +5,6 @@ subversion_packages:
 - apache2-webdav
 - apache2-utils
 - apache2-ctl
+- apache2-ssl
 apache_user: apache
 apache_group: apache

--- a/test/integration/targets/subversion/vars/RedHat.yml
+++ b/test/integration/targets/subversion/vars/RedHat.yml
@@ -1,6 +1,7 @@
 ---
 subversion_packages:
 - mod_dav_svn
+- mod_ssl
 - subversion
 upgrade_packages:
 # prevent sqlite from being out-of-sync with the version subversion was compiled with

--- a/test/integration/targets/subversion/vars/Ubuntu-20.yml
+++ b/test/integration/targets/subversion/vars/Ubuntu-20.yml
@@ -1,5 +1,7 @@
 ---
 subversion_packages:
+- apache2  # /usr/sbin/apachectl
+- apache2-utils  # htpasswd
 - subversion
 - libapache2-mod-svn
 apache_user: www-data


### PR DESCRIPTION
Backport of PR #82334.

* Run svn integration test locally with TLS

This patch uses a `trustme` to make an ephemeral CA, and server, and client TLS artifacts for testing. These are integrated into the Apache web server via it's `mod_ssl`.

Resolves #82207

* Replace GitHub SVN HTTPS URL w/ localhost over TLS

This change gets rid of the need to use GitHub, which is just about to drop support for SVN [[1]]. Moreover, it eliminates the need to use external network for any SVN commands in the test.

[1]: https://github.blog/2023-01-20-sunsetting-subversion-support/

(cherry picked from commit dd0138ba2127eac0e809d68e00ae117df56db77e)

##### SUMMARY

$sbj.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Test Pull Request

##### ADDITIONAL INFORMATION

N/A