### PR TITLE
wait_for_connection - fix rediscovering ping interpreter for delegate_to

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -79,6 +79,7 @@ class ActionBase(ABC):
 
         # interpreter discovery state
         self._discovered_interpreter_key = None
+        self._delegate_discovered_interpreter_key = None
         self._discovered_interpreter = False
         self._discovery_deprecation_warnings = []
         self._discovery_warnings = []
@@ -327,6 +328,8 @@ class ActionBase(ABC):
                     # preserve this so _execute_module can propagate back to controller as a fact
                     self._discovered_interpreter_key = discovered_key
                 else:
+                    # allow action plugins to rediscover the delegate_to interpreter
+                    self._delegate_discovered_interpreter_key = discovered_key
                     task_vars['ansible_delegated_vars'][self._task.delegate_to]['ansible_facts'][discovered_key] = self._discovered_interpreter
 
         return (module_style, module_shebang, module_data, module_path)

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -81,6 +81,8 @@ class ActionModule(ActionBase):
             # re-run interpreter discovery if we ran it in the first iteration
             if self._discovered_interpreter_key:
                 task_vars['ansible_facts'].pop(self._discovered_interpreter_key, None)
+            elif self._task.delegate_to and self._delegate_discovered_interpreter_key:
+                task_vars['ansible_delegated_vars'][self._task.delegate_to]['ansible_facts'].pop(self._delegate_discovered_interpreter_key)
             # call connection reset between runs if it's there
             try:
                 self._connection.reset()


### PR DESCRIPTION
##### SUMMARY
I think this fixes #80514.

`self._discovered_interpreter_key` isn't set for `delegate_to` without delegating facts https://github.com/ansible/ansible/blob/stable-2.16/lib/ansible/plugins/action/__init__.py#L332 so `wait_for_connection` doesn't attempt to rediscover the interpreter per ping attempt in that case. I added a new attribute, since `self._discovered_interpreter_key` is already used to export the controller's interpreter.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
