### PR TITLE
Additional Unsafe fixes

### DIFF
--- a/changelogs/fragments/unsafe-fixes-2.yml
+++ b/changelogs/fragments/unsafe-fixes-2.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- unsafe data - Address an incompatibility with ``AnsibleUnsafeText`` and ``AnsibleUnsafeBytes`` when pickling with ``protocol=0``
+- unsafe data - Address an incompatibility when iterating or getting a single index from ``AnsibleUnsafeBytes``

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -87,11 +87,9 @@ class AnsibleUnsafeBytes(bytes, AnsibleUnsafe):
         return AnsibleUnsafeText(super().__format__(format_spec))
 
     def __getitem__(self, key, /):
+        if isinstance(key, int):
+            return super().__getitem__(key)
         return self.__class__(super().__getitem__(key))
-
-    def __iter__(self, /):
-        cls = self.__class__
-        return (cls(c) for c in super().__iter__())
 
     def __reversed__(self, /):
         return self[::-1]

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -71,6 +71,9 @@ class AnsibleUnsafeBytes(bytes, AnsibleUnsafe):
     def _strip_unsafe(self):
         return super().__bytes__()
 
+    def __reduce__(self, /):
+        return (self.__class__, (self._strip_unsafe(),))
+
     def __str__(self, /):  # pylint: disable=invalid-str-returned
         return self.decode()
 
@@ -191,6 +194,9 @@ class AnsibleUnsafeBytes(bytes, AnsibleUnsafe):
 class AnsibleUnsafeText(str, AnsibleUnsafe):
     def _strip_unsafe(self, /):
         return super().__str__()
+
+    def __reduce__(self, /):
+        return (self.__class__, (self._strip_unsafe(),))
 
     def __str__(self, /):  # pylint: disable=invalid-str-returned
         return self

--- a/test/integration/targets/filter_urls/tasks/main.yml
+++ b/test/integration/targets/filter_urls/tasks/main.yml
@@ -19,6 +19,13 @@
       - "{'foo': 'bar', 'baz': 'buz'}|urlencode == 'foo=bar&baz=buz'"
       - "()|urlencode == ''"
 
+- name: verify urlencode works for unsafe strings
+  assert:
+    that:
+      - thing|urlencode == 'foo%3Abar'
+  vars:
+    thing: !unsafe foo:bar
+
 # Needed (temporarily) due to coverage reports not including the last task.
 - assert:
     that: true


### PR DESCRIPTION
##### SUMMARY
Additional Unsafe fixes

Fixes #82356 - pickling with `protocol=0`
Fixes #82375 - Fixes bytes iteration expectations

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
