### PR TITLE
Rename git module option gpg_whitelist to gpg_allowlist

### DIFF
--- a/changelogs/fragments/82377-git-gpg-whitelist-allowlist.yml
+++ b/changelogs/fragments/82377-git-gpg-whitelist-allowlist.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - git module - gpg_allowlist name was added in 2.17 and we will eventually deprecate the gpg_whitelist alias.


### PR DESCRIPTION
##### SUMMARY

Rename the `gpg_whitelist` option of git module to `gpg_allowlist` (and add an alias to avoid breaking existing workflows). This is a small step towards a more inclusive tech industry. Using the word "black" with negative connotations and "white" with positive is discouraged. More information can be found in this article:

https://www.businessinsider.com/companies-github-terms-master-slave-blacklist-whitelist-open-source-2020-6?op=1

##### ISSUE TYPE

- Feature Pull Request
