### PR TITLE
[stable-2.14] Additional Unsafe fixes (#82376)

### DIFF
--- a/changelogs/fragments/unsafe-fixes-2.yml
+++ b/changelogs/fragments/unsafe-fixes-2.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- unsafe data - Address an incompatibility with ``AnsibleUnsafeText`` and ``AnsibleUnsafeBytes`` when pickling with ``protocol=0``
+- unsafe data - Address an incompatibility when iterating or getting a single index from ``AnsibleUnsafeBytes``

--- a/lib/ansible/utils/unsafe_proxy.py
+++ b/lib/ansible/utils/unsafe_proxy.py
@@ -71,6 +71,9 @@ class AnsibleUnsafeBytes(bytes, AnsibleUnsafe):
     def _strip_unsafe(self):
         return super().__bytes__()
 
+    def __reduce__(self, /):
+        return (self.__class__, (self._strip_unsafe(),))
+
     def __str__(self, /):  # pylint: disable=invalid-str-returned
         return self.decode()
 
@@ -84,11 +87,9 @@ class AnsibleUnsafeBytes(bytes, AnsibleUnsafe):
         return AnsibleUnsafeText(super().__format__(format_spec))
 
     def __getitem__(self, key, /):
+        if isinstance(key, int):
+            return super().__getitem__(key)
         return self.__class__(super().__getitem__(key))
-
-    def __iter__(self, /):
-        cls = self.__class__
-        return (cls(c) for c in super().__iter__())
 
     def __reversed__(self, /):
         return self[::-1]
@@ -191,6 +192,9 @@ class AnsibleUnsafeBytes(bytes, AnsibleUnsafe):
 class AnsibleUnsafeText(str, AnsibleUnsafe):
     def _strip_unsafe(self, /):
         return super().__str__()
+
+    def __reduce__(self, /):
+        return (self.__class__, (self._strip_unsafe(),))
 
     def __str__(self, /):  # pylint: disable=invalid-str-returned
         return self

--- a/test/integration/targets/filter_urls/tasks/main.yml
+++ b/test/integration/targets/filter_urls/tasks/main.yml
@@ -19,6 +19,13 @@
       - "{'foo': 'bar', 'baz': 'buz'}|urlencode == 'foo=bar&baz=buz'"
       - "()|urlencode == ''"
 
+- name: verify urlencode works for unsafe strings
+  assert:
+    that:
+      - thing|urlencode == 'foo%3Abar'
+  vars:
+    thing: !unsafe foo:bar
+
 # Needed (temporarily) due to coverage reports not including the last task.
 - assert:
     that: true


### PR DESCRIPTION
* Allow older pickle protocols to pickle unsafe classes. Fixes #82356

* Address issues when iterating or getting single index from AnsibleUnsafeBytes. Fixes #82375

* clog frag
(cherry picked from commit afe3fc1)


Co-authored-by: Matt Martz <matt@sivel.net>