### PR TITLE
plugins/reboot: fix boot time command for FreeBSD

### DIFF
--- a/changelogs/fragments/82383-fix-boot-time-command-on-freebsd.yml
+++ b/changelogs/fragments/82383-fix-boot-time-command-on-freebsd.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reboot - Previously, on FreeBSD the boot time was used to verify that a target really rebooted. Unfortunately, it's not a fixed value and may change e.g. due to NTP updates leading to sporadic issues. Therefore, ansible is using the boot_id sysctl now. (https://github.com/ansible/ansible/pull/82383)

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -50,7 +50,7 @@ class ActionModule(ActionBase):
     DEPRECATED_ARGS = {}  # type: dict[str, str]
 
     BOOT_TIME_COMMANDS = {
-        'freebsd': '/sbin/sysctl kern.boottime',
+        'freebsd': '/sbin/sysctl -x kern.boot_id',
         'openbsd': '/sbin/sysctl kern.boottime',
         'macosx': 'who -b',
         'solaris': 'who -b',


### PR DESCRIPTION
##### SUMMARY

The boot time is not a fixed value [1]. It's adjusted by NTP.  That's not only an issue of FreeBSD. E.g. OpenBSD has the same issue [2]. On FreeBSD we can use the boot_id sysctl [3]. Unfortunately, OpenBSD doesn't have such a sysctl. So, we keep the boottime for now.

[1] https://cgit.freebsd.org/src/commit/?id=a512d0ab009eedf2f1876fce86d6386bfee626d8
[2] https://github.com/openbsd/src/blob/dd1c5868edaa80b7ad9df54e8b3eae1c49c42319/sys/kern/kern_tc.c#L735
[3] https://cgit.freebsd.org/src/commit/?id=34086d5bda29cc583755fc8948f59c3b61f8ce7d

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

