### PR TITLE
Fix condition for unquoting configuration strings from ini files

### DIFF
--- a/changelogs/fragments/82387-unquote-strings-from-ini-files.yml
+++ b/changelogs/fragments/82387-unquote-strings-from-ini-files.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix condition for unquoting configuration strings from ini files (https://github.com/ansible/ansible/issues/82387).

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -143,7 +143,7 @@ def ensure_type(value, value_type, origin=None):
         elif value_type in ('str', 'string'):
             if isinstance(value, (string_types, AnsibleVaultEncryptedUnicode, bool, int, float, complex)):
                 value = to_text(value, errors='surrogate_or_strict')
-                if origin == 'ini':
+                if origin and origin.startswith('ini: '):
                     value = unquote(value)
             else:
                 errmsg = 'string'
@@ -151,7 +151,7 @@ def ensure_type(value, value_type, origin=None):
         # defaults to string type
         elif isinstance(value, (string_types, AnsibleVaultEncryptedUnicode)):
             value = to_text(value, errors='surrogate_or_strict')
-            if origin == 'ini':
+            if origin and origin.startswith('ini: '):
                 value = unquote(value)
 
         if errmsg:
@@ -520,24 +520,32 @@ class ConfigManager(object):
             if self._parsers.get(cfile, None) is None:
                 self._parse_config_file(cfile)
 
+            # attempt to read from config file
             if value is None and cfile is not None:
                 ftype = get_config_type(cfile)
                 if ftype and defs[config].get(ftype):
-                    if ftype == 'ini':
-                        # load from ini config
-                        try:  # FIXME: generalize _loop_entries to allow for files also, most of this code is dupe
-                            for ini_entry in defs[config]['ini']:
-                                temp_value = get_ini_config_value(self._parsers[cfile], ini_entry)
-                                if temp_value is not None:
-                                    value = temp_value
-                                    origin = cfile
-                                    if 'deprecated' in ini_entry:
-                                        self.DEPRECATED.append(('[%s]%s' % (ini_entry['section'], ini_entry['key']), ini_entry['deprecated']))
-                        except Exception as e:
-                            sys.stderr.write("Error while loading ini config %s: %s" % (cfile, to_native(e)))
-                    elif ftype == 'yaml':
-                        # FIXME: implement, also , break down key from defs (. notation???)
-                        origin = cfile
+                    try:
+                        for entry in defs[config][ftype]:
+                            # load from config
+                            if ftype == 'ini':
+                                temp_value = get_ini_config_value(self._parsers[cfile], entry)
+                            elif ftype == 'yaml':
+                                raise AnsibleError('YAML configuration type has not been implemented yet')
+                            else:
+                                raise AnsibleError('Invalid configuration file type: %s' % ftype)
+
+                            if temp_value is not None:
+                                # set value and origin
+                                value = temp_value
+                                origin = '%s: %s' % (ftype, cfile)
+                                if 'deprecated' in entry:
+                                    if ftype == 'ini':
+                                        self.DEPRECATED.append(('[%s]%s' % (entry['section'], entry['key']), entry['deprecated']))
+                                    else:
+                                        raise AnsibleError('Unimplemented file type: %s' % ftype)
+
+                    except Exception as e:
+                        sys.stderr.write("Error while loading config %s: %s" % (cfile, to_native(e)))
 
             # set default if we got here w/o a value
             if value is None:

--- a/test/integration/targets/config/files/types.env
+++ b/test/integration/targets/config/files/types.env
@@ -9,3 +9,6 @@ ANSIBLE_TYPES_NOTVALID=
 
 # totallynotvalid(list): does nothihng, just for testing values
 ANSIBLE_TYPES_TOTALLYNOTVALID=
+
+# str_mustunquote(string): does nothihng, just for testing values
+ANSIBLE_TYPES_STR_MUSTUNQUOTE=

--- a/test/integration/targets/config/files/types.ini
+++ b/test/integration/targets/config/files/types.ini
@@ -11,3 +11,8 @@ totallynotvalid=
 # (list) does nothihng, just for testing values
 valid=
 
+
+[string_values]
+# (string) does nothihng, just for testing values
+str_mustunquote=
+

--- a/test/integration/targets/config/files/types.vars
+++ b/test/integration/targets/config/files/types.vars
@@ -13,3 +13,7 @@ ansible_types_notvalid: ''
 # totallynotvalid(list): does nothihng, just for testing values
 ansible_types_totallynotvalid: ''
 
+
+# str_mustunquote(string): does nothihng, just for testing values
+ansible_types_str_mustunquote: ''
+

--- a/test/integration/targets/config/lookup_plugins/types.py
+++ b/test/integration/targets/config/lookup_plugins/types.py
@@ -54,6 +54,16 @@ DOCUMENTATION = """
                 - name: ANSIBLE_TYPES_TOTALLYNOTVALID
             vars:
                 - name: ansible_types_totallynotvalid
+        str_mustunquote:
+            description: does nothihng, just for testing values
+            type: string
+            ini:
+                - section: string_values
+                  key: str_mustunquote
+            env:
+                - name: ANSIBLE_TYPES_STR_MUSTUNQUOTE
+            vars:
+                - name: ansible_types_str_mustunquote
 """
 
 EXAMPLES = """

--- a/test/integration/targets/config/type_munging.cfg
+++ b/test/integration/targets/config/type_munging.cfg
@@ -6,3 +6,6 @@ valid = 1, 2, 3
 mustunquote = '1', '2', '3'
 notvalid = [1, 2, 3]
 totallynotvalid = ['1', '2', '3']
+
+[string_values]
+str_mustunquote = 'foo'

--- a/test/integration/targets/config/types.yml
+++ b/test/integration/targets/config/types.yml
@@ -1,7 +1,7 @@
 - hosts: localhost
   gather_facts: false
   tasks:
-    - name: ensures we got the list we expected
+    - name: ensures we got the values we expected
       block:
         - name: initialize plugin
           debug: msg={{ lookup('types', 'starting test') }}
@@ -11,6 +11,7 @@
             mustunquote: '{{ lookup("config", "mustunquote", plugin_type="lookup", plugin_name="types") }}'
             notvalid: '{{ lookup("config", "notvalid", plugin_type="lookup", plugin_name="types") }}'
             totallynotvalid: '{{ lookup("config", "totallynotvalid", plugin_type="lookup", plugin_name="types") }}'
+            str_mustunquote: '{{ lookup("config", "str_mustunquote", plugin_type="lookup", plugin_name="types") }}'
 
         - assert:
             that:
@@ -18,8 +19,10 @@
             - 'mustunquote|type_debug == "list"'
             - 'notvalid|type_debug == "list"'
             - 'totallynotvalid|type_debug == "list"'
+            - 'str_mustunquote|type_debug == "AnsibleUnsafeText"'
             - valid[0]|int == 1
             - mustunquote[0]|int == 1
             - "notvalid[0] == '[1'"
             # using 'and true' to avoid quote hell
             - totallynotvalid[0] == "['1'" and True
+            - str_mustunquote == "foo"

--- a/test/units/config/test_manager.py
+++ b/test/units/config/test_manager.py
@@ -64,12 +64,12 @@ ensure_test_data = [
 ]
 
 ensure_unquoting_test_data = [
-    ('"value"', '"value"', 'str', 'env'),
-    ('"value"', '"value"', 'str', 'yaml'),
-    ('"value"', 'value', 'str', 'ini'),
-    ('\'value\'', 'value', 'str', 'ini'),
-    ('\'\'value\'\'', '\'value\'', 'str', 'ini'),
-    ('""value""', '"value"', 'str', 'ini')
+    ('"value"', '"value"', 'str', 'env: ENVVAR'),
+    ('"value"', '"value"', 'str', 'yaml: %s' % os.path.join(curdir, 'test.yml')),
+    ('"value"', 'value', 'str', 'ini: %s' % cfg_file),
+    ('\'value\'', 'value', 'str', 'ini: %s' % cfg_file),
+    ('\'\'value\'\'', '\'value\'', 'str', 'ini: %s' % cfg_file),
+    ('""value""', '"value"', 'str', 'ini: %s' % cfg_file)
 ]
 
 
@@ -99,13 +99,13 @@ class TestConfigManager:
         assert os.path.join(os.getcwd(), 'test.yml') == resolve_path('./test.yml')
 
     def test_value_and_origin_from_ini(self):
-        assert self.manager.get_config_value_and_origin('config_entry') == ('fromini', cfg_file)
+        assert self.manager.get_config_value_and_origin('config_entry') == ('fromini', 'ini: %s' % cfg_file)
 
     def test_value_from_ini(self):
         assert self.manager.get_config_value('config_entry') == 'fromini'
 
     def test_value_and_origin_from_alt_ini(self):
-        assert self.manager.get_config_value_and_origin('config_entry', cfile=cfg_file2) == ('fromini2', cfg_file2)
+        assert self.manager.get_config_value_and_origin('config_entry', cfile=cfg_file2) == ('fromini2', 'ini: %s' % cfg_file2)
 
     def test_value_from_alt_ini(self):
         assert self.manager.get_config_value('config_entry', cfile=cfg_file2) == 'fromini2'

--- a/test/units/config/test_manager.py
+++ b/test/units/config/test_manager.py
@@ -64,12 +64,12 @@ ensure_test_data = [
 ]
 
 ensure_unquoting_test_data = [
-    ('"value"', '"value"', 'str', 'env: ENVVAR'),
-    ('"value"', '"value"', 'str', 'yaml: %s' % os.path.join(curdir, 'test.yml')),
-    ('"value"', 'value', 'str', 'ini: %s' % cfg_file),
-    ('\'value\'', 'value', 'str', 'ini: %s' % cfg_file),
-    ('\'\'value\'\'', '\'value\'', 'str', 'ini: %s' % cfg_file),
-    ('""value""', '"value"', 'str', 'ini: %s' % cfg_file)
+    ('"value"', '"value"', 'str', 'env: ENVVAR', None),
+    ('"value"', '"value"', 'str', os.path.join(curdir, 'test.yml'), 'yaml'),
+    ('"value"', 'value', 'str', cfg_file, 'ini'),
+    ('\'value\'', 'value', 'str', cfg_file, 'ini'),
+    ('\'\'value\'\'', '\'value\'', 'str', cfg_file, 'ini'),
+    ('""value""', '"value"', 'str', cfg_file, 'ini')
 ]
 
 
@@ -86,9 +86,9 @@ class TestConfigManager:
     def test_ensure_type(self, value, expected_type, python_type):
         assert isinstance(ensure_type(value, expected_type), python_type)
 
-    @pytest.mark.parametrize("value, expected_value, value_type, origin", ensure_unquoting_test_data)
-    def test_ensure_type_unquoting(self, value, expected_value, value_type, origin):
-        actual_value = ensure_type(value, value_type, origin)
+    @pytest.mark.parametrize("value, expected_value, value_type, origin, origin_ftype", ensure_unquoting_test_data)
+    def test_ensure_type_unquoting(self, value, expected_value, value_type, origin, origin_ftype):
+        actual_value = ensure_type(value, value_type, origin, origin_ftype)
         assert actual_value == expected_value
 
     def test_resolve_path(self):
@@ -99,13 +99,13 @@ class TestConfigManager:
         assert os.path.join(os.getcwd(), 'test.yml') == resolve_path('./test.yml')
 
     def test_value_and_origin_from_ini(self):
-        assert self.manager.get_config_value_and_origin('config_entry') == ('fromini', 'ini: %s' % cfg_file)
+        assert self.manager.get_config_value_and_origin('config_entry') == ('fromini', cfg_file)
 
     def test_value_from_ini(self):
         assert self.manager.get_config_value('config_entry') == 'fromini'
 
     def test_value_and_origin_from_alt_ini(self):
-        assert self.manager.get_config_value_and_origin('config_entry', cfile=cfg_file2) == ('fromini2', 'ini: %s' % cfg_file2)
+        assert self.manager.get_config_value_and_origin('config_entry', cfile=cfg_file2) == ('fromini2', cfg_file2)
 
     def test_value_from_alt_ini(self):
         assert self.manager.get_config_value('config_entry', cfile=cfg_file2) == 'fromini2'


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Fixes ansible#82387

When the configuration variable comes from an ini file, its `origin` is set to the actual file path, not to the string `'ini'`.

Therefore, when `origin` is detected to be a path to an existing file, we use `get_config_type(origin)` to compute its actual type, as this function will indeed return `'ini'` if `origin` points to an ini file.

Thanks! :)

snip
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request


##### COMPONENT NAME

lib/ansible/config/manager.py
