### PR TITLE
🧪⇪ Bump `galaxy_ng` to v4.9.2 in tests

### DIFF
--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -853,10 +853,18 @@ class GalaxyAPI:
             try:
                 modified_date = self.get_collection_metadata(namespace, name).modified_str
             except GalaxyError as err:
-                if err.http_code != 404:
+                if err.http_code == 404:
+                    # No collection found, return an empty list to keep things consistent with the various APIs
+                    return []
+                elif err.http_code != 500 or 'v3' in self.available_api_versions:
                     raise
-                # No collection found, return an empty list to keep things consistent with the various APIs
-                return []
+
+                # v2 appears to have a bug on some versions, where the metadata URL is an HTTP error 500
+                # since this URL is only used to handle the cache, proceed as if the cache needs to be refreshed.
+                modified_date = None
+                if '%s.%s' % (namespace, name) in modified_cache:
+                    del modified_cache['%s.%s' % (namespace, name)]
+                    self._set_cache()
 
             cached_modified_date = modified_cache.get('%s.%s' % (namespace, name), None)
             if cached_modified_date != modified_date:

--- a/test/integration/targets/ansible-galaxy-collection/tasks/publish.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/publish.yml
@@ -31,6 +31,21 @@
     chdir: '{{ galaxy_dir }}'
   register: fail_publish_existing
   failed_when: fail_publish_existing is not failed
+  ignore_errors: true
+
+- name: get result of publish collection - {{ test_name }}
+  uri:
+    url: '{{ test_api_server }}v3/plugin/ansible/content/primary/collections/index/ansible_test/my_collection/versions/1.0.0/'
+    return_content: yes
+    user: '{{ pulp_user }}'
+    password: '{{ pulp_password }}'
+    force_basic_auth: true
+  register: publish_collection_update
+  when: fail_publish_existing is not failed
+
+- assert:
+    that:
+    - fail_publish_existing is failed or publish_collection_update["json"]["updated_at"] == publish_collection_actual["json"]["updated_at"]
 
 - name: reset published collections - {{ test_name }}
   include_tasks: pulp.yml

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/galaxy.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/galaxy.py
@@ -99,7 +99,7 @@ class GalaxyProvider(CloudProvider):
 
         self.image = os.environ.get(
             'ANSIBLE_PULP_CONTAINER',
-            'quay.io/pulp/galaxy:4.9.0'  # https://github.com/ansible/galaxy_ng
+            'quay.io/pulp/galaxy:4.9.2'  # https://github.com/ansible/galaxy_ng
         )
 
         self.uses_docker = True

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/galaxy.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/galaxy.py
@@ -99,7 +99,7 @@ class GalaxyProvider(CloudProvider):
 
         self.image = os.environ.get(
             'ANSIBLE_PULP_CONTAINER',
-            'quay.io/pulp/galaxy:4.7.1'
+            'quay.io/pulp/galaxy:4.9.0'  # https://github.com/ansible/galaxy_ng
         )
 
         self.uses_docker = True


### PR DESCRIPTION
It updates the underlying `pulp_ansible` to v0.20.2, which fixes a race condition that is occasionally observable in our CI when provisioning the initial dummy collections for testing.

Refs:

  * https://github.com/ansible/galaxy_ng/releases/tag/4.9.0
  * https://github.com/ansible/galaxy_ng/pull/1950
  * https://github.com/ansible/galaxy/issues/3267
  * https://github.com/pulp/pulp_ansible/issues/1571
  * https://github.com/pulp/pulp_ansible/pull/1572
  * https://github.com/pulp/pulp_ansible/pull/1595
  * https://github.com/pulp/pulp_ansible/issues/1623
  * https://github.com/pulp/pulp_ansible/pull/1624

##### SUMMARY

$sbj.

##### ISSUE TYPE

- Maintenance Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

N/A