### PR TITLE
[backport-2.15] Replace FreeBSD 13.1 with 13.2 in CI and ansible-test

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -95,6 +95,8 @@ stages:
               test: freebsd/12.4
             - name: FreeBSD 13.1
               test: freebsd/13.1
+            - name: FreeBSD 13.2
+              test: freebsd/13.2
           groups:
             - 1
             - 2
@@ -109,6 +111,8 @@ stages:
               test: rhel/9.1
             - name: FreeBSD 13.1
               test: freebsd/13.1
+            - name: FreeBSD 13.2
+              test: freebsd/13.2
           groups:
             - 3
             - 4

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -93,8 +93,6 @@ stages:
               test: rhel/9.1
             - name: FreeBSD 12.4
               test: freebsd/12.4
-            - name: FreeBSD 13.1
-              test: freebsd/13.1
             - name: FreeBSD 13.2
               test: freebsd/13.2
           groups:
@@ -109,8 +107,6 @@ stages:
               test: rhel/8.7
             - name: RHEL 9.1
               test: rhel/9.1
-            - name: FreeBSD 13.1
-              test: freebsd/13.1
             - name: FreeBSD 13.2
               test: freebsd/13.2
           groups:

--- a/changelogs/fragments/ci_freebsd_new.yml
+++ b/changelogs/fragments/ci_freebsd_new.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Add FreeBSD 13.2 remote.

--- a/changelogs/fragments/fbsd13_1_remove.yml
+++ b/changelogs/fragments/fbsd13_1_remove.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Removed `freebsd/13.1` remote.

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -4,7 +4,7 @@ fedora/37 python=3.11 become=sudo provider=aws arch=x86_64  # untested in CI, kn
 fedora/38 python=3.11 become=sudo provider=aws arch=x86_64
 fedora become=sudo provider=aws arch=x86_64
 freebsd/12.4 python=3.9 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
-freebsd/13.2 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
+freebsd/13.2 python=3.8,3.7,3.9,3.10 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 macos/13.2 python=3.11 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64
 macos python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -5,6 +5,7 @@ fedora/38 python=3.11 become=sudo provider=aws arch=x86_64
 fedora become=sudo provider=aws arch=x86_64
 freebsd/12.4 python=3.9 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd/13.1 python=3.8,3.7,3.9,3.10 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
+freebsd/13.2 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 macos/13.2 python=3.11 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64
 macos python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -4,7 +4,6 @@ fedora/37 python=3.11 become=sudo provider=aws arch=x86_64  # untested in CI, kn
 fedora/38 python=3.11 become=sudo provider=aws arch=x86_64
 fedora become=sudo provider=aws arch=x86_64
 freebsd/12.4 python=3.9 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
-freebsd/13.1 python=3.8,3.7,3.9,3.10 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd/13.2 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 macos/13.2 python=3.11 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64


### PR DESCRIPTION
Backport of PRs #80698 and #81058.

(cherry picked from commit https://github.com/ansible/ansible/commit/d12aa7f69cefddf8b849a93186d4afd8e6615bc5)

* remove Freebsd 13.1 from test matrix

fixes https://github.com/ansible/ansible/issues/80416

Co-authored-by: Matt Clay <matt@mystile.com>
(cherry picked from commit https://github.com/ansible/ansible/commit/534f688a53f076691f93041726931e4b218e9769)

##### SUMMARY

N/A

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Maintenance Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

N/A