### PR TITLE
Execute ScriptVaultSecret on demand instead of on load

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -425,11 +425,19 @@ class FileVaultSecret(VaultSecret):
 
 
 class ScriptVaultSecret(FileVaultSecret):
-    def _read_file(self, filename):
-        if not self.loader.is_executable(filename):
-            raise AnsibleVaultError("The vault password script %s was not executable" % filename)
+    @property
+    def bytes(self):
+        if self._bytes is None:
+            self._bytes = self._read_file(self.filename)
+        return self._bytes
 
+    def load(self):
+        if not self.loader.is_executable(self.filename):
+            raise AnsibleVaultError("The vault password script %s was not executable" % self.filename)
+
+    def _read_file(self, filename):
         command = self._build_command()
+        display.vvvvv(u'The vault password script is reading the secret from %r' % self)
 
         stdout, stderr, p = self._run(command)
 


### PR DESCRIPTION
##### SUMMARY

A vault secret script can do whatever is needed to return a vault password. This can mean loading something from a local password store or accessing a remote password storage solution. When combining the password script with multiple vault_identity_list entries this adds a lot of unneeded loading of vault indentity passwords. Most of which may not be required to complete the ansible run.

This commit delays executing for Script and ClientScriptVaultSecret classes until the bytes password is accessed.

We currently have a `vault_identity_list` with 35 different entries. Each entry requires authorization and loading them takes a while making the startup time for ansible significant. Executing the password scripts on demand would solve 2 problems:
- users don't have to change their configuration to exclude entries they cannot access.
- the time to load unused passwords is removed from the execution time.

##### ISSUE TYPE
- Feature Pull Request

##### ADDITIONAL INFORMATION

```
$ grep vault_id_match ansible.cfg 
vault_id_match = true
# Before
$ time ansible-vault decrypt < tmp.yaml
Decryption successful
...
real    0m13,144s
user    0m3,159s
sys     0m0,729s
# After
$ time ansible-vault decrypt < tmp.yaml
Decryption successful
...
real    0m0,494s
user    0m0,229s
sys     0m0,016s
```
