### PR TITLE
add the PID after the timestamp

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1591,9 +1591,9 @@ class AnsibleModule(object):
 
         backupdest = ''
         if os.path.exists(fn):
-            # backups named basename.PID.YYYY-MM-DD@HH:MM:SS~
-            ext = time.strftime("%Y-%m-%d@%H:%M:%S~", time.localtime(time.time()))
-            backupdest = '%s.%s.%s' % (fn, os.getpid(), ext)
+            # backups named basename.YYYY-MM-DD@HH:MM:SS.PID~
+            ext = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
+            backupdest = '%s.%s.%s~' % (fn, ext, os.getpid())
 
             try:
                 self.preserved_copy(fn, backupdest)


### PR DESCRIPTION
moving the `PID` to the end of `backupdest` makes the backup files sortable by date, which makes finding files way easier

##### SUMMARY

We've been running into sorting issues a lot when there are many many backup files which accumulate after a while and finding the latest change is rather difficult when the PID is before the timestamp. 

Moving the PID behind the timestamp should not hurt anyone, because the nature of the PID makes it rather unreliable to predict the filename anyway.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

before the change, files would be named

```
foo.conf.88719.2023-12-18@14:43:36~
foo.conf.89487.2023-12-11@14:45:32~
```

with this change, they are named

```
foo.conf.2023-12-18@15:53:59~.942
foo.conf.2023-12-18@16:03:40.4655~
```
