### PR TITLE
lineinfile, remove incorrect/unused 'others' option

### DIFF
--- a/lib/ansible/modules/lineinfile.py
+++ b/lib/ansible/modules/lineinfile.py
@@ -126,10 +126,6 @@ options:
     type: bool
     default: no
     version_added: "2.5"
-  others:
-    description:
-      - All arguments accepted by the M(ansible.builtin.file) module also work here.
-    type: str
 extends_documentation_fragment:
     - action_common_attributes
     - action_common_attributes.files

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -37,7 +37,6 @@ lib/ansible/modules/git.py use-argspec-type-path
 lib/ansible/modules/git.py validate-modules:doc-required-mismatch
 lib/ansible/modules/lineinfile.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/lineinfile.py validate-modules:doc-default-does-not-match-spec
-lib/ansible/modules/lineinfile.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/package_facts.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/replace.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/replace.py pylint:used-before-assignment  # false positive detection by pylint


### PR DESCRIPTION
 this was to document 'file' options are usable .. but we already
 import the file fragment to document those options.

fixes #82429
##### ISSUE TYPE
- Docs Pull Request
