### PR TITLE
pip - only require setuptools or packaging in check mode

### DIFF
--- a/changelogs/fragments/82444-pip-fix-installing-module-dependencies.yml
+++ b/changelogs/fragments/82444-pip-fix-installing-module-dependencies.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pip - fix installing conditionally-optional module dependencies ``packaging`` and ``setuptools``. Check mode requires that ``packaging`` or ``setuptools`` are installed if version ranges are included in the package name (https://github.com/ansible/ansible/issues/82444).

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -803,8 +803,8 @@ def main():
                     )
                 elif len(recovered_package_name) == 1 and any(_op in recovered_package_name[0] for _op in op_dict.keys()):
                     module.fail_json(
-                        msg="The 'version' argument conflicts with any version specifier provided along with a package name. " \
-                            "Please remove the version specifier, and keep the 'version' argument."
+                        msg="The 'version' argument conflicts with any version specifier provided along with a package name. "
+                            "Please keep the version specifier, but remove the 'version' argument."
                     )
                 if not HAS_SETUPTOOLS and not HAS_PACKAGING and any(_op in version for _op in op_ranges):
                     module.fail_json(msg=missing_required_lib("packaging"), exception=PACKAGING_IMP_ERR)

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -142,7 +142,7 @@ notes:
 requirements:
 - pip
 - virtualenv
-- setuptools or packaging
+- setuptools or packaging if check mode is used and any of the packages to install include a version range
 author:
 - Matt Wright (@mattupstate)
 '''

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -787,7 +787,7 @@ def main():
                     break
 
             recovered_package_name = _recover_package_name(name)
-
+            op_ranges = set(op_dict.keys()) - {'=='}
             # check invalid combination of arguments
             if version is not None:
                 if len(recovered_package_name) > 1:
@@ -795,20 +795,19 @@ def main():
                         msg="'version' argument is ambiguous when installing multiple package distributions. "
                             "Please specify version restrictions next to each package in 'name' argument."
                     )
-                elif len(recovered_package_name) == 1 and any(_op in recovered_package_name[0] for _op in set(op_dict.keys())):
+                elif len(recovered_package_name) == 1 and any(_op in recovered_package_name[0] for _op in op_dict.keys()):
                     msg = "The 'version' argument conflicts with any version specifier provided along with a package name."
-                    if not HAS_SETUPTOOLS and not HAS_PACKAGING and any(_op in recovered_package_name[0] for _op in set(op_dict.keys()) - {'=='}):
+                    if not HAS_SETUPTOOLS and not HAS_PACKAGING and any(_op in recovered_package_name[0] for _op in op_ranges):
                         msg += " Please remove the version specifier, and keep the 'version' argument."
                     else:
                         msg += " Please keep the version specifier, but remove the 'version' argument."
                     module.fail_json(msg=msg)
 
-            op_ranges = set(op_dict.keys()) - {'=='}
             names_include_vrange = any(any(_op in _name for _op in op_ranges) for _name in recovered_package_name)
             if not HAS_SETUPTOOLS and not HAS_PACKAGING and names_include_vrange and module.check_mode:
                 module.fail_json(msg=missing_required_lib("packaging"), exception=PACKAGING_IMP_ERR)
 
-            # optionally convert raw input package names to Package instances
+            # convert raw input package names to Package instances
             packages = [Package(pkg) for pkg in recovered_package_name]
             # check invalid combination of arguments
             if version is not None:

--- a/test/integration/targets/pip/tasks/main.yml
+++ b/test/integration/targets/pip/tasks/main.yml
@@ -46,6 +46,9 @@
 
     - include_tasks: no_setuptools.yml
       when: ansible_python.version_info[:2] >= [3, 8]
+
+    - include_tasks: no_setuptools_or_packaging.yml
+      when: ansible_python.version_info[:2] >= [3, 8]
   always:
     - name: platform specific cleanup
       include_tasks: "{{ cleanup_filename }}"

--- a/test/integration/targets/pip/tasks/no_setuptools_or_packaging.yml
+++ b/test/integration/targets/pip/tasks/no_setuptools_or_packaging.yml
@@ -1,0 +1,49 @@
+- name: Get coverage version
+  pip:
+    name: coverage
+  check_mode: true
+  register: pip_coverage
+
+- name: create a virtualenv for use without packaging or setuptools
+  pip:
+    name:
+      # coverage is needed when ansible-test is invoked with --coverage
+      # and using a custom ansible_python_interpreter below
+      - '{{ pip_coverage.stdout_lines|select("match", "coverage==")|first }}'
+    virtualenv: "{{ remote_tmp_dir }}/no_package_parsing"
+
+- name: Remove packaging and setuptools
+  pip:
+    name:
+      - packaging
+      - setuptools
+      - pkg_resources  # This shouldn't be a thing, but ubuntu 20.04...
+    virtualenv: "{{ remote_tmp_dir }}/no_package_parsing"
+    state: absent
+
+- name: Ensure pkg_resources is gone
+  command: "{{ remote_tmp_dir }}/no_setuptools/bin/python -c 'import pkg_resources'"
+  register: result
+  failed_when: result.rc == 0
+
+- vars:
+    ansible_python_interpreter: "{{ remote_tmp_dir }}/no_package_parsing/bin/python"
+  block:
+    - name: Checkmode install packaging
+      pip:
+        name: packaging
+        virtualenv: "{{ remote_tmp_dir }}/no_package_parsing"
+      check_mode: true
+      register: packaging_check_mode
+
+    - assert:
+        that:
+          - packaging_check_mode is changed
+          - packaging_check_mode.stdout is not contains "packaging=="
+
+    - name: install packaging
+      pip:
+        name: packaging
+        virtualenv: "{{ remote_tmp_dir }}/no_package_parsing"
+      register: installed_packaging
+      failed_when: installed_packaging is not changed


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible/ansible/issues/82444

Allow the pip module to install setuptools/packaging when neither are required. Only required in check mode, if we need to parse a version range from the package name.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
