### PR TITLE
Add VMware virt detection for hardware version of ESXi 8.0.

### DIFF
--- a/changelogs/fragments/82455-new-vmware-productname.yml
+++ b/changelogs/fragments/82455-new-vmware-productname.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "facts - detect VMware ESXi 8.0 virtualization by product name VMware20,1"

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -175,7 +175,7 @@ class LinuxVirtual(Virtual):
                     virtual_facts['virtualization_type'] = 'RHEV'
                     found_virt = True
 
-        if product_name in ('VMware Virtual Platform', 'VMware7,1'):
+        if product_name in ('VMware Virtual Platform', 'VMware7,1', 'VMware20,1'):
             guest_tech.add('VMware')
             if not found_virt:
                 virtual_facts['virtualization_type'] = 'VMware'


### PR DESCRIPTION
##### SUMMARY

Ansible facts is not detecting "virtualization_type" on latest VMware ESXi 8.0.
Current code detects only legacy DMI product_name: 'VMware Virtual Platform', 'VMware7,1'.

On VMware ESXi 8.0, the guest OS is EL9/CentOS Stream 9.
```
$ cat /sys/devices/virtual/dmi/id/product_name
VMware20,1
```

I do not have access to ESXi 7 at this moment to enumerate all possible product names on ESXi.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION
I tested locally by modifying "module_utils/facts/virtual/linux.py",
I run command `ansible <hostname> -m ansible.builtin.setup` and compare the output

Before the patch
```
        "ansible_virtualization_role": "NA",
        "ansible_virtualization_tech_guest": [],
        "ansible_virtualization_tech_host": [],
        "ansible_virtualization_type": "NA",
```

After the patch
```
        "ansible_virtualization_role": "guest",
        "ansible_virtualization_tech_guest": [
            "VMware"
        ],
        "ansible_virtualization_tech_host": [],
        "ansible_virtualization_type": "VMware",
```