### PR TITLE
Fixed small documentation inconsistency in the core module apt

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1200,7 +1200,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             state=dict(type='str', default='present', choices=['absent', 'build-dep', 'fixed', 'latest', 'present']),
-            update_cache=dict(type='bool', aliases=['update-cache']),
+            update_cache=dict(type='bool', default=False, aliases=['update-cache']),
             update_cache_retries=dict(type='int', default=5),
             update_cache_retry_max_delay=dict(type='int', default=12),
             cache_valid_time=dict(type='int', default=0),

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -34,9 +34,9 @@ options:
   update_cache:
     description:
       - Run the equivalent of C(apt-get update) before the operation. Can be run as part of the package installation or as a separate step.
-      - Default is not to update the cache.
     aliases: [ update-cache ]
     type: bool
+    default: 'no'
   update_cache_retries:
     description:
       - Amount of retries if the cache update fails. Also see O(update_cache_retry_max_delay).


### PR DESCRIPTION
##### SUMMARY

Fixes a small inconsistency in the documentation of the apt module. Instead of making the default known as the other options, the documentation includes the default in the description. Also adds the default to the argument_spec.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

None
