### PR TITLE
[dnf] Do not try to resolve file path with whatprovides

### DIFF
--- a/changelogs/fragments/82462_dnf_whatprovides_installed.yml
+++ b/changelogs/fragments/82462_dnf_whatprovides_installed.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- dnf - give priority to already installed packages when resolving a package
+        name by provided path (https://github.com/ansible/ansible/issues/82461)


### PR DESCRIPTION
##### SUMMARY

Current assumption of taking just first result of whatprovides output leads to
unexpected results and installation failures/conflicts when multiple packages
provide the same file, while one of them might be already installed on the system.

So we potentially can resolve a package to a different one, while already having
another package installed on the system that satisfies requirement.

In order to avoid weird corner cases, we get rid of attempt to reslove
package name through whatprovides and simply pass a path from name to the dnf directly.

Fixes: #82461

##### ISSUE TYPE

- Bugfix Pull Request
