### PR TITLE
ansible-doc: interpret double newlines as paragraph breaks in documentation strings

### DIFF
--- a/changelogs/fragments/82465-ansible-doc-paragraphs.yml
+++ b/changelogs/fragments/82465-ansible-doc-paragraphs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ansible-doc - treat double newlines in documentation strings as paragraph breaks. This is useful to create multi-paragraph notes in module/plugin documentation (https://github.com/ansible/ansible/pull/82465)."

--- a/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/modules/randommodule.py
+++ b/test/integration/targets/ansible-doc/collections/ansible_collections/testns/testcol/plugins/modules/randommodule.py
@@ -64,6 +64,15 @@ seealso:
       description: See also the Ansible docsite.
     - ref: foo_bar
       description: Some foo bar.
+notes:
+    - This is a note.
+    - |-
+      This is a multi-paragraph note.
+
+      This is its second paragraph.
+      This is just another line in the second paragraph.
+      Eventually this will break into a new line,
+      depending with which line width this is rendered.
 '''
 
 EXAMPLES = '''

--- a/test/integration/targets/ansible-doc/randommodule-text.output
+++ b/test/integration/targets/ansible-doc/randommodule-text.output
@@ -75,6 +75,15 @@ OPTIONS (= is mandatory):
         type: str
 
 
+NOTES:
+      * This is a note.
+      * This is a multi-paragraph note.
+        This is its second paragraph. This is just another line
+        in the second paragraph. Eventually this will break into
+        a new line, depending with which line width this is
+        rendered.
+
+
 SEE ALSO:
       * Module ansible.builtin.ping
            The official documentation on the

--- a/test/integration/targets/ansible-doc/randommodule.output
+++ b/test/integration/targets/ansible-doc/randommodule.output
@@ -21,6 +21,10 @@
             "filename": "./collections/ansible_collections/testns/testcol/plugins/modules/randommodule.py",
             "has_action": false,
             "module": "randommodule",
+            "notes": [
+                "This is a note.",
+                "This is a multi-paragraph note.\n\nThis is its second paragraph.\nThis is just another line in the second paragraph.\nEventually this will break into a new line,\ndepending with which line width this is rendered."
+            ],
             "options": {
                 "sub": {
                     "description": "Suboptions. Contains O(sub.subtest), which can be set to V(123). You can use E(TEST_ENV) to set this.",


### PR DESCRIPTION
##### SUMMARY
This allows the ansible-doc text UI to display multi-paragraph notes. (One such note exists in https://github.com/ansible-collections/community.docker/pull/739.)

Texts are already handled this way by antsibull-docs, since the double newline is interpreted as a new paragraph in RST.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request
