### PR TITLE
Deprecate `required` param in get_bin_path

### DIFF
--- a/changelogs/fragments/get_bin_path_required_parameter.yml
+++ b/changelogs/fragments/get_bin_path_required_parameter.yml
@@ -1,3 +1,3 @@
 ---
 deprecated_features:
-    - The 'required' parameter in 'process.get_bin_path' API is deprecated (https://github.com/ansible/ansible/issues/82464).
+    - The 'required' parameter in 'ansible.module_utils.common.process.get_bin_path' API is deprecated (https://github.com/ansible/ansible/issues/82464).

--- a/changelogs/fragments/get_bin_path_required_parameter.yml
+++ b/changelogs/fragments/get_bin_path_required_parameter.yml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+    - The 'required' parameter in 'process.get_bin_path' API is deprecated (https://github.com/ansible/ansible/issues/82464).

--- a/lib/ansible/module_utils/common/process.py
+++ b/lib/ansible/module_utils/common/process.py
@@ -6,19 +6,27 @@ from __future__ import annotations
 import os
 
 from ansible.module_utils.common.file import is_executable
+from ansible.module_utils.common.warnings import deprecate
 
 
 def get_bin_path(arg, opt_dirs=None, required=None):
     '''
-    Find system executable in PATH. Raises ValueError if executable is not found.
+    Find system executable in PATH. Raises ValueError if the executable is not found.
     Optional arguments:
-       - required:  [Deprecated] Prior to 2.10, if executable is not found and required is true it raises an Exception.
-                    In 2.10 and later, an Exception is always raised. This parameter will be removed in 2.14.
+       - required:  [Deprecated] Before 2.10, if executable is not found and required is true it raises an Exception.
+                    In 2.10 and later, an Exception is always raised. This parameter will be removed in 2.21.
        - opt_dirs:  optional list of directories to search in addition to PATH
     In addition to PATH and opt_dirs, this function also looks through /sbin, /usr/sbin and /usr/local/sbin. A lot of
     modules, especially for gathering facts, depend on this behaviour.
     If found return full path, otherwise raise ValueError.
     '''
+    if required is not None:
+        deprecate(
+            msg="The `required` parameter in `get_bin_path` API is deprecated.",
+            version="2.21",
+            collection_name="ansible.builtin",
+        )
+
     opt_dirs = [] if opt_dirs is None else opt_dirs
 
     sbin_paths = ['/sbin', '/usr/sbin', '/usr/local/sbin']


### PR DESCRIPTION
##### SUMMARY

* The parameter `required` in process.get_bin_path API
  is deprecated. Will be removed in 2.21

Fixes: #82464

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


