### PR TITLE
unreachable delegation fix

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -624,11 +624,11 @@ class StrategyBase:
             elif task_result.is_unreachable():
                 ignore_unreachable = original_task.ignore_unreachable
                 if not ignore_unreachable:
-                    delegated_host = result.get('ansible_delegated_host', None)
+                    delegated_host = task_result.get('ansible_delegated_host', None)
                     if original_task.delegate_to is not None and delegated_host:
                         self._tqm._unreachable_hosts[delegated_host] = True
                         iterator._play._removed_hosts.append(delegated_host)
-                        if origianl_host.name not in self._tqm._unreachable_hosts:
+                        if original_host.name not in self._tqm._unreachable_hosts:
                             iterator.mark_host_failed(original_host)
                         self._tqm._stats.increment('failures', original_host.name)
                     else:

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -624,9 +624,17 @@ class StrategyBase:
             elif task_result.is_unreachable():
                 ignore_unreachable = original_task.ignore_unreachable
                 if not ignore_unreachable:
-                    self._tqm._unreachable_hosts[original_host.name] = True
-                    iterator._play._removed_hosts.append(original_host.name)
-                    self._tqm._stats.increment('dark', original_host.name)
+                    delegated_host = result.get('ansible_delegated_host', None)
+                    if original_task.delegate_to is not None and delegated_host:
+                        self._tqm._unreachable_hosts[delegated_host] = True
+                        iterator._play._removed_hosts.append(delegated_host)
+                        if origianl_host.name not in self._tqm._unreachable_hosts:
+                            iterator.mark_host_failed(original_host)
+                        self._tqm._stats.increment('failures', original_host.name)
+                    else:
+                        self._tqm._unreachable_hosts[original_host.name] = True
+                        iterator._play._removed_hosts.append(original_host.name)
+                        self._tqm._stats.increment('dark', original_host.name)
                 else:
                     self._tqm._stats.increment('ok', original_host.name)
                     self._tqm._stats.increment('ignored', original_host.name)


### PR DESCRIPTION
When a delegated to host is unreachable, do not make inventory_hostname unreachable, but failed and set delegated_to host as unreachable.

fixes # 35030
##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
