### PR TITLE
propagate WorkerProcess create/start exceptions

### DIFF
--- a/changelogs/fragments/82471_propagate_worker_start_fail.yml
+++ b/changelogs/fragments/82471_propagate_worker_start_fail.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - propagate WorkerProcess startup failure exceptions (https://github.com/ansible/ansible/issues/82471)

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -136,263 +136,256 @@ class StrategyModule(StrategyBase):
         self._set_hosts_cache(iterator._play)
 
         while work_to_do and not self._tqm._terminated:
+            display.debug("getting the remaining hosts for this loop")
+            hosts_left = self.get_hosts_left(iterator)
+            display.debug("done getting the remaining hosts for this loop")
 
-            try:
-                display.debug("getting the remaining hosts for this loop")
-                hosts_left = self.get_hosts_left(iterator)
-                display.debug("done getting the remaining hosts for this loop")
+            # queue up this task for each host in the inventory
+            callback_sent = False
+            work_to_do = False
 
-                # queue up this task for each host in the inventory
-                callback_sent = False
-                work_to_do = False
+            host_tasks = self._get_next_task_lockstep(hosts_left, iterator)
 
-                host_tasks = self._get_next_task_lockstep(hosts_left, iterator)
+            # skip control
+            skip_rest = False
+            choose_step = True
 
-                # skip control
-                skip_rest = False
-                choose_step = True
+            # flag set if task is set to any_errors_fatal
+            any_errors_fatal = False
 
-                # flag set if task is set to any_errors_fatal
-                any_errors_fatal = False
-
-                results = []
-                for (host, task) in host_tasks:
-                    if not task:
-                        continue
-
-                    if self._tqm._terminated:
-                        break
-
-                    run_once = False
-                    work_to_do = True
-
-                    # check to see if this task should be skipped, due to it being a member of a
-                    # role which has already run (and whether that role allows duplicate execution)
-                    if not isinstance(task, Handler) and task._role:
-                        role_obj = self._get_cached_role(task, iterator._play)
-                        if role_obj.has_run(host) and role_obj._metadata.allow_duplicates is False:
-                            display.debug("'%s' skipped because role has already run" % task)
-                            continue
-
-                    display.debug("getting variables")
-                    task_vars = self._variable_manager.get_vars(play=iterator._play, host=host, task=task,
-                                                                _hosts=self._hosts_cache, _hosts_all=self._hosts_cache_all)
-                    self.add_tqm_variables(task_vars, play=iterator._play)
-                    templar = Templar(loader=self._loader, variables=task_vars)
-                    display.debug("done getting variables")
-
-                    # test to see if the task across all hosts points to an action plugin which
-                    # sets BYPASS_HOST_LOOP to true, or if it has run_once enabled. If so, we
-                    # will only send this task to the first host in the list.
-
-                    task_action = templar.template(task.action)
-
-                    try:
-                        action = action_loader.get(task_action, class_only=True, collection_list=task.collections)
-                    except KeyError:
-                        # we don't care here, because the action may simply not have a
-                        # corresponding action plugin
-                        action = None
-
-                    if task_action in C._ACTION_META:
-                        # for the linear strategy, we run meta tasks just once and for
-                        # all hosts currently being iterated over rather than one host
-                        results.extend(self._execute_meta(task, play_context, iterator, host))
-                        if task.args.get('_raw_params', None) not in ('noop', 'reset_connection', 'end_host', 'role_complete', 'flush_handlers'):
-                            run_once = True
-                        if (task.any_errors_fatal or run_once) and not task.ignore_errors:
-                            any_errors_fatal = True
-                    else:
-                        # handle step if needed, skip meta actions as they are used internally
-                        if self._step and choose_step:
-                            if self._take_step(task):
-                                choose_step = False
-                            else:
-                                skip_rest = True
-                                break
-
-                        run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
-
-                        if (task.any_errors_fatal or run_once) and not task.ignore_errors:
-                            any_errors_fatal = True
-
-                        if not callback_sent:
-                            display.debug("sending task start callback, copying the task so we can template it temporarily")
-                            saved_name = task.name
-                            display.debug("done copying, going to template now")
-                            try:
-                                task.name = to_text(templar.template(task.name, fail_on_undefined=False), nonstring='empty')
-                                display.debug("done templating")
-                            except Exception:
-                                # just ignore any errors during task name templating,
-                                # we don't care if it just shows the raw name
-                                display.debug("templating failed for some reason")
-                            display.debug("here goes the callback...")
-                            if isinstance(task, Handler):
-                                self._tqm.send_callback('v2_playbook_on_handler_task_start', task)
-                            else:
-                                self._tqm.send_callback('v2_playbook_on_task_start', task, is_conditional=False)
-                            task.name = saved_name
-                            callback_sent = True
-                            display.debug("sending task start callback")
-
-                        self._blocked_hosts[host.get_name()] = True
-                        self._queue_task(host, task, task_vars, play_context)
-                        del task_vars
-
-                    if isinstance(task, Handler):
-                        if run_once:
-                            task.clear_hosts()
-                        else:
-                            task.remove_host(host)
-
-                    # if we're bypassing the host loop, break out now
-                    if run_once:
-                        break
-
-                    results.extend(self._process_pending_results(iterator, max_passes=max(1, int(len(self._tqm._workers) * 0.1))))
-
-                # go to next host/task group
-                if skip_rest:
+            results = []
+            for (host, task) in host_tasks:
+                if not task:
                     continue
 
-                display.debug("done queuing things up, now waiting for results queue to drain")
-                if self._pending_results > 0:
-                    results.extend(self._wait_on_pending_results(iterator))
+                if self._tqm._terminated:
+                    break
 
-                self.update_active_connections(results)
+                run_once = False
+                work_to_do = True
 
-                included_files = IncludedFile.process_include_results(
-                    results,
-                    iterator=iterator,
-                    loader=self._loader,
-                    variable_manager=self._variable_manager
-                )
+                # check to see if this task should be skipped, due to it being a member of a
+                # role which has already run (and whether that role allows duplicate execution)
+                if not isinstance(task, Handler) and task._role:
+                    role_obj = self._get_cached_role(task, iterator._play)
+                    if role_obj.has_run(host) and role_obj._metadata.allow_duplicates is False:
+                        display.debug("'%s' skipped because role has already run" % task)
+                        continue
 
-                if len(included_files) > 0:
-                    display.debug("we have included files to process")
+                display.debug("getting variables")
+                task_vars = self._variable_manager.get_vars(play=iterator._play, host=host, task=task,
+                                                            _hosts=self._hosts_cache, _hosts_all=self._hosts_cache_all)
+                self.add_tqm_variables(task_vars, play=iterator._play)
+                templar = Templar(loader=self._loader, variables=task_vars)
+                display.debug("done getting variables")
 
-                    display.debug("generating all_blocks data")
-                    all_blocks = dict((host, []) for host in hosts_left)
-                    display.debug("done generating all_blocks data")
-                    included_tasks = []
-                    failed_includes_hosts = set()
-                    for included_file in included_files:
-                        display.debug("processing included file: %s" % included_file._filename)
-                        is_handler = False
+                # test to see if the task across all hosts points to an action plugin which
+                # sets BYPASS_HOST_LOOP to true, or if it has run_once enabled. If so, we
+                # will only send this task to the first host in the list.
+
+                task_action = templar.template(task.action)
+
+                try:
+                    action = action_loader.get(task_action, class_only=True, collection_list=task.collections)
+                except KeyError:
+                    # we don't care here, because the action may simply not have a
+                    # corresponding action plugin
+                    action = None
+
+                if task_action in C._ACTION_META:
+                    # for the linear strategy, we run meta tasks just once and for
+                    # all hosts currently being iterated over rather than one host
+                    results.extend(self._execute_meta(task, play_context, iterator, host))
+                    if task.args.get('_raw_params', None) not in ('noop', 'reset_connection', 'end_host', 'role_complete', 'flush_handlers'):
+                        run_once = True
+                    if (task.any_errors_fatal or run_once) and not task.ignore_errors:
+                        any_errors_fatal = True
+                else:
+                    # handle step if needed, skip meta actions as they are used internally
+                    if self._step and choose_step:
+                        if self._take_step(task):
+                            choose_step = False
+                        else:
+                            skip_rest = True
+                            break
+
+                    run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
+
+                    if (task.any_errors_fatal or run_once) and not task.ignore_errors:
+                        any_errors_fatal = True
+
+                    if not callback_sent:
+                        display.debug("sending task start callback, copying the task so we can template it temporarily")
+                        saved_name = task.name
+                        display.debug("done copying, going to template now")
                         try:
-                            if included_file._is_role:
-                                new_ir = self._copy_included_file(included_file)
+                            task.name = to_text(templar.template(task.name, fail_on_undefined=False), nonstring='empty')
+                            display.debug("done templating")
+                        except Exception:
+                            # just ignore any errors during task name templating,
+                            # we don't care if it just shows the raw name
+                            display.debug("templating failed for some reason")
+                        display.debug("here goes the callback...")
+                        if isinstance(task, Handler):
+                            self._tqm.send_callback('v2_playbook_on_handler_task_start', task)
+                        else:
+                            self._tqm.send_callback('v2_playbook_on_task_start', task, is_conditional=False)
+                        task.name = saved_name
+                        callback_sent = True
+                        display.debug("sending task start callback")
 
-                                new_blocks, handler_blocks = new_ir.get_block_list(
-                                    play=iterator._play,
-                                    variable_manager=self._variable_manager,
-                                    loader=self._loader,
-                                )
+                    self._blocked_hosts[host.get_name()] = True
+                    self._queue_task(host, task, task_vars, play_context)
+                    del task_vars
+
+                if isinstance(task, Handler):
+                    if run_once:
+                        task.clear_hosts()
+                    else:
+                        task.remove_host(host)
+
+                # if we're bypassing the host loop, break out now
+                if run_once:
+                    break
+
+                results.extend(self._process_pending_results(iterator, max_passes=max(1, int(len(self._tqm._workers) * 0.1))))
+
+            # go to next host/task group
+            if skip_rest:
+                continue
+
+            display.debug("done queuing things up, now waiting for results queue to drain")
+            if self._pending_results > 0:
+                results.extend(self._wait_on_pending_results(iterator))
+
+            self.update_active_connections(results)
+
+            included_files = IncludedFile.process_include_results(
+                results,
+                iterator=iterator,
+                loader=self._loader,
+                variable_manager=self._variable_manager
+            )
+
+            if len(included_files) > 0:
+                display.debug("we have included files to process")
+
+                display.debug("generating all_blocks data")
+                all_blocks = dict((host, []) for host in hosts_left)
+                display.debug("done generating all_blocks data")
+                included_tasks = []
+                failed_includes_hosts = set()
+                for included_file in included_files:
+                    display.debug("processing included file: %s" % included_file._filename)
+                    is_handler = False
+                    try:
+                        if included_file._is_role:
+                            new_ir = self._copy_included_file(included_file)
+
+                            new_blocks, handler_blocks = new_ir.get_block_list(
+                                play=iterator._play,
+                                variable_manager=self._variable_manager,
+                                loader=self._loader,
+                            )
+                        else:
+                            is_handler = isinstance(included_file._task, Handler)
+                            new_blocks = self._load_included_file(included_file, iterator=iterator, is_handler=is_handler)
+
+                        # let PlayIterator know about any new handlers included via include_role or
+                        # import_role within include_role/include_taks
+                        iterator.handlers = [h for b in iterator._play.handlers for h in b.block]
+
+                        display.debug("iterating over new_blocks loaded from include file")
+                        for new_block in new_blocks:
+                            if is_handler:
+                                for task in new_block.block:
+                                    task.notified_hosts = included_file._hosts[:]
+                                final_block = new_block
                             else:
-                                is_handler = isinstance(included_file._task, Handler)
-                                new_blocks = self._load_included_file(included_file, iterator=iterator, is_handler=is_handler)
+                                task_vars = self._variable_manager.get_vars(
+                                    play=iterator._play,
+                                    task=new_block.get_first_parent_include(),
+                                    _hosts=self._hosts_cache,
+                                    _hosts_all=self._hosts_cache_all,
+                                )
+                                display.debug("filtering new block on tags")
+                                final_block = new_block.filter_tagged_tasks(task_vars)
+                                display.debug("done filtering new block on tags")
 
-                            # let PlayIterator know about any new handlers included via include_role or
-                            # import_role within include_role/include_taks
-                            iterator.handlers = [h for b in iterator._play.handlers for h in b.block]
+                                included_tasks.extend(final_block.get_tasks())
 
-                            display.debug("iterating over new_blocks loaded from include file")
-                            for new_block in new_blocks:
-                                if is_handler:
-                                    for task in new_block.block:
-                                        task.notified_hosts = included_file._hosts[:]
-                                    final_block = new_block
-                                else:
-                                    task_vars = self._variable_manager.get_vars(
-                                        play=iterator._play,
-                                        task=new_block.get_first_parent_include(),
-                                        _hosts=self._hosts_cache,
-                                        _hosts_all=self._hosts_cache_all,
-                                    )
-                                    display.debug("filtering new block on tags")
-                                    final_block = new_block.filter_tagged_tasks(task_vars)
-                                    display.debug("done filtering new block on tags")
+                            for host in hosts_left:
+                                if host in included_file._hosts:
+                                    all_blocks[host].append(final_block)
 
-                                    included_tasks.extend(final_block.get_tasks())
+                        display.debug("done iterating over new_blocks loaded from include file")
+                    except AnsibleParserError:
+                        raise
+                    except AnsibleError as e:
+                        if included_file._is_role:
+                            # include_role does not have on_include callback so display the error
+                            display.error(to_text(e), wrap_text=False)
+                        for r in included_file._results:
+                            r._result['failed'] = True
+                            failed_includes_hosts.add(r._host)
+                        continue
 
-                                for host in hosts_left:
-                                    if host in included_file._hosts:
-                                        all_blocks[host].append(final_block)
+                for host in failed_includes_hosts:
+                    self._tqm._failed_hosts[host.name] = True
+                    iterator.mark_host_failed(host)
 
-                            display.debug("done iterating over new_blocks loaded from include file")
-                        except AnsibleParserError:
-                            raise
-                        except AnsibleError as e:
-                            if included_file._is_role:
-                                # include_role does not have on_include callback so display the error
-                                display.error(to_text(e), wrap_text=False)
-                            for r in included_file._results:
-                                r._result['failed'] = True
-                                failed_includes_hosts.add(r._host)
-                            continue
+                # finally go through all of the hosts and append the
+                # accumulated blocks to their list of tasks
+                display.debug("extending task lists for all hosts with included blocks")
 
-                    for host in failed_includes_hosts:
+                for host in hosts_left:
+                    iterator.add_tasks(host, all_blocks[host])
+
+                iterator.all_tasks[iterator.cur_task:iterator.cur_task] = included_tasks
+
+                display.debug("done extending task lists")
+                display.debug("done processing included files")
+
+            display.debug("results queue empty")
+
+            display.debug("checking for any_errors_fatal")
+            failed_hosts = []
+            unreachable_hosts = []
+            for res in results:
+                if res.is_failed():
+                    failed_hosts.append(res._host.name)
+                elif res.is_unreachable():
+                    unreachable_hosts.append(res._host.name)
+
+            if any_errors_fatal and (failed_hosts or unreachable_hosts):
+                for host in hosts_left:
+                    if host.name not in failed_hosts:
                         self._tqm._failed_hosts[host.name] = True
                         iterator.mark_host_failed(host)
+            display.debug("done checking for any_errors_fatal")
 
-                    # finally go through all of the hosts and append the
-                    # accumulated blocks to their list of tasks
-                    display.debug("extending task lists for all hosts with included blocks")
+            display.debug("checking for max_fail_percentage")
+            if iterator._play.max_fail_percentage is not None and len(results) > 0:
+                percentage = iterator._play.max_fail_percentage / 100.0
 
+                if (len(self._tqm._failed_hosts) / iterator.batch_size) > percentage:
                     for host in hosts_left:
-                        iterator.add_tasks(host, all_blocks[host])
-
-                    iterator.all_tasks[iterator.cur_task:iterator.cur_task] = included_tasks
-
-                    display.debug("done extending task lists")
-                    display.debug("done processing included files")
-
-                display.debug("results queue empty")
-
-                display.debug("checking for any_errors_fatal")
-                failed_hosts = []
-                unreachable_hosts = []
-                for res in results:
-                    if res.is_failed():
-                        failed_hosts.append(res._host.name)
-                    elif res.is_unreachable():
-                        unreachable_hosts.append(res._host.name)
-
-                if any_errors_fatal and (failed_hosts or unreachable_hosts):
-                    for host in hosts_left:
+                        # don't double-mark hosts, or the iterator will potentially
+                        # fail them out of the rescue/always states
                         if host.name not in failed_hosts:
                             self._tqm._failed_hosts[host.name] = True
                             iterator.mark_host_failed(host)
-                display.debug("done checking for any_errors_fatal")
-
-                display.debug("checking for max_fail_percentage")
-                if iterator._play.max_fail_percentage is not None and len(results) > 0:
-                    percentage = iterator._play.max_fail_percentage / 100.0
-
-                    if (len(self._tqm._failed_hosts) / iterator.batch_size) > percentage:
-                        for host in hosts_left:
-                            # don't double-mark hosts, or the iterator will potentially
-                            # fail them out of the rescue/always states
-                            if host.name not in failed_hosts:
-                                self._tqm._failed_hosts[host.name] = True
-                                iterator.mark_host_failed(host)
-                        self._tqm.send_callback('v2_playbook_on_no_hosts_remaining')
-                        result |= self._tqm.RUN_FAILED_BREAK_PLAY
-                    display.debug('(%s failed / %s total )> %s max fail' % (len(self._tqm._failed_hosts), iterator.batch_size, percentage))
-                display.debug("done checking for max_fail_percentage")
-
-                display.debug("checking to see if all hosts have failed and the running result is not ok")
-                if result != self._tqm.RUN_OK and len(self._tqm._failed_hosts) >= len(hosts_left):
-                    display.debug("^ not ok, so returning result now")
                     self._tqm.send_callback('v2_playbook_on_no_hosts_remaining')
-                    return result
-                display.debug("done checking to see if all hosts have failed")
+                    result |= self._tqm.RUN_FAILED_BREAK_PLAY
+                display.debug('(%s failed / %s total )> %s max fail' % (len(self._tqm._failed_hosts), iterator.batch_size, percentage))
+            display.debug("done checking for max_fail_percentage")
 
-            except (IOError, EOFError) as e:
-                display.debug("got IOError/EOFError in task loop: %s" % e)
-                # most likely an abort, return failed
-                return self._tqm.RUN_UNKNOWN_ERROR
+            display.debug("checking to see if all hosts have failed and the running result is not ok")
+            if result != self._tqm.RUN_OK and len(self._tqm._failed_hosts) >= len(hosts_left):
+                display.debug("^ not ok, so returning result now")
+                self._tqm.send_callback('v2_playbook_on_no_hosts_remaining')
+                return result
+            display.debug("done checking to see if all hosts have failed")
 
         # run the base class run() method, which executes the cleanup function
         # and runs any outstanding handlers which have been triggered

--- a/test/integration/targets/concurrency/aliases
+++ b/test/integration/targets/concurrency/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group4
+context/controller

--- a/test/integration/targets/concurrency/hosts
+++ b/test/integration/targets/concurrency/hosts
@@ -1,0 +1,6 @@
+[many]
+host[01:10]
+
+[many:vars]
+ansible_connection=local
+ansible_python_interpreter={{ansible_playbook_python}}

--- a/test/integration/targets/concurrency/runme.sh
+++ b/test/integration/targets/concurrency/runme.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+# set `fileno` limit artificially low to induce "too many open files" failures with a low number of forks
+ulimit -n 30
+
+echo "running test playbook and capturing output..."
+
+# run test playbook with enough hosts/forks to quickly exhaust the low open files limit
+set +e
+ansible-playbook -i hosts -f 20 test.yml 2>&1 | tee out.txt
+RC=$?
+set -e
+
+echo "ansible-playbook should yield RC==250 (unexpected error)"
+[[ $RC == 250 ]] && echo PASS
+
+echo "'some workers will fail' task ran?"
+grep "some workers will fail" out.txt && echo PASS
+
+echo "'should not run' task did not run?"
+grep "should not run" out.txt || echo PASS
+
+echo "PASS: all tests ok"

--- a/test/integration/targets/concurrency/test.yml
+++ b/test/integration/targets/concurrency/test.yml
@@ -1,0 +1,8 @@
+- hosts: many
+  gather_facts: no
+  tasks:
+    - name: some workers will fail
+      raw: echo hi
+    - name: should not run
+      raw: |
+        echo "hi again"


### PR DESCRIPTION
##### SUMMARY
ci_complete

fixes #82471

* failure to start a worker process for any reason should be immediately fatal
* add hint text for OSError 23/24 (too many open files)
* add integration test to induce OSError 24 on worker startup

This change purposely fails fast- we need to minimize risky operations like custom callbacks that could fail in unpredictable ways when we're in a likely unrecoverable state like "too many open files". The more arbitrary code we allow to run, the less likely we are to be able to ensure timely propagation of the failure.

NB: This change looks much larger than it really is- just removed a couple of ancient exception handlers that wrapped very large method bodies in favor of a more targeted exception translator. The method bodies were long enough that the GH diff algorithm didn't figure it out...

##### ISSUE TYPE

- Bugfix Pull Request
