### PR TITLE
[backport][stable-2.15] CI: remove FreeBSD 12.4 from test matrix (#81315)

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -91,8 +91,6 @@ stages:
               test: rhel/8.7@3.9
             - name: RHEL 9.1
               test: rhel/9.1
-            - name: FreeBSD 12.4
-              test: freebsd/12.4
             - name: FreeBSD 13.2
               test: freebsd/13.2
           groups:

--- a/changelogs/fragments/freebsd_12_4_removal.yml
+++ b/changelogs/fragments/freebsd_12_4_removal.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Removed `freebsd/12.4` remote.

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -3,7 +3,6 @@ alpine become=doas_sudo provider=aws arch=x86_64
 fedora/37 python=3.11 become=sudo provider=aws arch=x86_64  # untested in CI, known to occasionally hang during boot
 fedora/38 python=3.11 become=sudo provider=aws arch=x86_64
 fedora become=sudo provider=aws arch=x86_64
-freebsd/12.4 python=3.9 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd/13.2 python=3.8,3.7,3.9,3.10 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 macos/13.2 python=3.11 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64


### PR DESCRIPTION
Backport of PR #81315.

Fixes: #80417

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 11e261b54fc0a4801543c48bb6782f69376f9662)

##### SUMMARY

Fixes: #80417

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
.azure-pipelines/azure-pipelines.yml
changelogs/fragments/freebsd_12_4_removal.yml
test/lib/ansible_test/_data/completion/remote.txt