### PR TITLE
Add skips for encrypt unit tests for Python 3.13

### DIFF
--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -36,16 +36,20 @@ def assert_hash(expected, secret, algorithm, **settings):
 
 
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='macOS requires passlib')
-def test_passlib_or_crypt():
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason='Python <= 3.12 required')
+def test_passlib_or_crypt_no_passlib():
     with passlib_off():
         expected = "$5$rounds=5000$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
         assert encrypt.passlib_or_crypt("123", "sha256_crypt", salt="12345678", rounds=5000) == expected
 
+
+def test_passlib_or_crypt():
     expected = "$5$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
     assert encrypt.passlib_or_crypt("123", "sha256_crypt", salt="12345678", rounds=5000) == expected
 
 
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='macOS requires passlib')
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason='Python <= 3.12 required')
 def test_encrypt_with_rounds_no_passlib():
     with passlib_off():
         assert_hash("$5$rounds=5000$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7",
@@ -85,6 +89,7 @@ def test_encrypt_with_rounds():
 
 
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='macOS requires passlib')
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason='Python <= 3.12 required')
 def test_encrypt_default_rounds_no_passlib():
     with passlib_off():
         assert_hash("$1$12345678$tRy4cXc3kmcfRZVj4iFXr/",
@@ -111,6 +116,7 @@ def test_encrypt_default_rounds():
 
 
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='macOS requires passlib')
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason='Python <= 3.12 required')
 def test_password_hash_filter_no_passlib():
     with passlib_off():
         assert not encrypt.PASSLIB_AVAILABLE
@@ -148,6 +154,7 @@ def test_password_hash_filter_passlib():
 
 
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='macOS requires passlib')
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason='Python <= 3.12 required')
 def test_do_encrypt_no_passlib():
     with passlib_off():
         assert not encrypt.PASSLIB_AVAILABLE
@@ -183,6 +190,7 @@ def test_random_salt():
 
 
 @pytest.mark.skipif(sys.platform.startswith('darwin'), reason='macOS requires passlib')
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason='Python <= 3.12 required')
 def test_invalid_crypt_salt():
     pytest.raises(
         AnsibleError,


### PR DESCRIPTION
##### SUMMARY

Add skips for encrypt unit tests for Python 3.13.

##### ISSUE TYPE

Test Pull Request
