### PR TITLE
subelements filter: add wantkeys parameter

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -506,9 +506,9 @@ def subelements(obj, subelements, skip_missing=False, wantkeys=False):
     '''
     if isinstance(obj, dict):
         if wantkeys:
-                element_list = obj
-            else:
-                element_list = list(obj.values())
+            element_list = obj
+        else:
+            element_list = list(obj.values())
     elif isinstance(obj, list):
         element_list = obj[:]
     else:
@@ -531,9 +531,9 @@ def subelements(obj, subelements, skip_missing=False, wantkeys=False):
         for subelement in subelement_list:
             try:
                 if wantkeys:
-                        values = list(values[subelement])
-                    else:
-                        values = values[subelement]
+                    values = list(values[subelement])
+                else:
+                    values = values[subelement]
             except KeyError:
                 if skip_missing:
                     values = []

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -495,7 +495,7 @@ def flatten(mylist, levels=None, skip_nulls=True):
     return ret
 
 
-def subelements(obj, subelements, skip_missing=False):
+def subelements(obj, subelements, skip_missing=False, wantkeys=False):
     '''Accepts a dict or list of dicts, and a dotted accessor and produces a product
     of the element and the results of the dotted accessor
 
@@ -505,7 +505,10 @@ def subelements(obj, subelements, skip_missing=False):
 
     '''
     if isinstance(obj, dict):
-        element_list = list(obj.values())
+        if wantkeys:
+                element_list = obj
+            else:
+                element_list = list(obj.values())
     elif isinstance(obj, list):
         element_list = obj[:]
     else:
@@ -521,10 +524,16 @@ def subelements(obj, subelements, skip_missing=False):
     results = []
 
     for element in element_list:
-        values = element
+        if wantkeys:
+            values = element_list[element]
+        else:
+            values = element
         for subelement in subelement_list:
             try:
-                values = values[subelement]
+                if wantkeys:
+                        values = list(values[subelement])
+                    else:
+                        values = values[subelement]
             except KeyError:
                 if skip_missing:
                     values = []

--- a/lib/ansible/plugins/filter/subelements.yml
+++ b/lib/ansible/plugins/filter/subelements.yml
@@ -19,6 +19,11 @@ DOCUMENTATION:
       description: If V(True), ignore missing subelements, otherwise missing subelements generate an error.
       type: bool
       default: no
+    wantkeys:
+      description: If V(True), produces only keys, otherwise using dictionary subelement generate an error.
+      type: bool
+      default: no
+    
 
 EXAMPLES: |
   # data


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
I have added optional wantkeys parameter to subelements filter. It will be useful when you need create product with only keys of element and  subelement.

I'm fully convinced that way this solution is done is most efficient, but it will preserve earlier functionality and makes it possible to use filter in different way. There might be alternative way to solve this problem but there wasn't any clear examples for my  usecase.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #82492

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request
- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
