### PR TITLE
update the user.py file of line 920 to line 924 for using tilde issues

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -917,9 +917,8 @@ class User(object):
             if self.move_home:
                 cmd.append('-m')
 
-        # flakes8: noqa
         if self.shell is not None:
-            expanded_shell = os.path.abspath(os.path.expanduser(self.shell))
+            expanded_shell = os.path.expanduser(self.shell)
             if info[6] != expanded_shell:
                 cmd.append('-s')
                 cmd.append(expanded_shell)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -918,7 +918,7 @@ class User(object):
                 cmd.append('-m')
 
         if self.shell is not None:
-            expanded_shell = os.path.abspath(os.path.expanduser(self.shell))
+            expanded_shell = str(os.path.abspath(os.path.expanduser(self.shell)))
             if info[6] != expanded_shell:
                 cmd.append('-s')
                 cmd.append(expanded_shell)
@@ -3117,7 +3117,7 @@ def main():
             groups=dict(type='list', elements='str'),
             comment=dict(type='str'),
             home=dict(type='path'),
-            shell=dict(type='path'),
+            shell=dict(type='str'),
             password=dict(type='str', no_log=True),
             login_class=dict(type='str'),
             password_expire_max=dict(type='int', no_log=False),

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -917,9 +917,11 @@ class User(object):
             if self.move_home:
                 cmd.append('-m')
 
-        if self.shell is not None and info[6] != self.shell:
-            cmd.append('-s')
-            cmd.append(self.shell)
+        if self.shell is not None:
+            expanded_shell = os.path.expanduser(self.shell)
+            if info[6] != expanded_shell:
+                cmd.append('-s')
+                cmd.append(expanded_shell)
 
         if self.expires is not None:
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -917,6 +917,7 @@ class User(object):
             if self.move_home:
                 cmd.append('-m')
 
+        # flake8: noqa
         if self.shell is not None:
             expanded_shell = os.path.expanduser(self.shell)
             if info[6] != expanded_shell:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -917,8 +917,9 @@ class User(object):
             if self.move_home:
                 cmd.append('-m')
 
+        # flakes8: noqa
         if self.shell is not None:
-            expanded_shell = str(os.path.abspath(os.path.expanduser(self.shell)))
+            expanded_shell = os.path.abspath(os.path.expanduser(self.shell))
             if info[6] != expanded_shell:
                 cmd.append('-s')
                 cmd.append(expanded_shell)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -917,9 +917,8 @@ class User(object):
             if self.move_home:
                 cmd.append('-m')
 
-        # flake8: noqa
         if self.shell is not None:
-            expanded_shell = os.path.expanduser(self.shell)
+            expanded_shell = os.path.abspath(os.path.expanduser(self.shell))
             if info[6] != expanded_shell:
                 cmd.append('-s')
                 cmd.append(expanded_shell)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3117,7 +3117,7 @@ def main():
             groups=dict(type='list', elements='str'),
             comment=dict(type='str'),
             home=dict(type='path'),
-            shell=dict(type='str'),
+            shell=dict(type='path'),
             password=dict(type='str', no_log=True),
             login_class=dict(type='str'),
             password_expire_max=dict(type='int', no_log=False),


### PR DESCRIPTION
##### SUMMARY

resolution of tilde expansion when checking equality between the desired shell and the one already in use

Fixes #82490

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

I used os.path.expanduser to expand the tilde in the shell path before comparing the values


```paste below

```
