### PR TITLE
Add Alp-Dolomite to Suse family list

### DIFF
--- a/changelogs/fragments/82496-add-alp-dolomite-suse-family.yaml
+++ b/changelogs/fragments/82496-add-alp-dolomite-suse-family.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - distribution.py - Recognize ALP-Dolomite as part of the SUSE OS family in Ansible, fixing its previous misidentification (https://github.com/ansible/ansible/pull/82496).

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -517,7 +517,7 @@ class Distribution(object):
                                 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux',
                                 'Pop!_OS', 'Parrot', 'Pardus GNU/Linux', 'Uos', 'Deepin', 'OSMC'],
                      'Suse': ['SuSE', 'SLES', 'SLED', 'openSUSE', 'openSUSE Tumbleweed',
-                              'SLES_SAP', 'SUSE_LINUX', 'openSUSE Leap'],
+                              'SLES_SAP', 'SUSE_LINUX', 'openSUSE Leap', 'ALP-Dolomite'],
                      'Archlinux': ['Archlinux', 'Antergos', 'Manjaro'],
                      'Mandrake': ['Mandrake', 'Mandriva'],
                      'Solaris': ['Solaris', 'Nexenta', 'OmniOS', 'OpenIndiana', 'SmartOS'],

--- a/test/units/module_utils/facts/system/distribution/fixtures/alp-dolomite.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/alp-dolomite.json
@@ -1,0 +1,23 @@
+{
+    "platform.dist": ["", "", ""],
+    "distro": {
+        "codename": "",
+        "id": "alp-dolomite",
+        "name": "SUSE ALP Dolomite",
+        "version": "1.0",
+        "version_best": "1.0",
+        "os_release_info": {},
+        "lsb_release_info": {}
+    },
+    "input": {
+      "/etc/os-release": "NAME=\"ALP-Dolomite\"\nVERSION=\"1.0\"\nID=alp-dolomite\nID_LIKE=\"suse\"\nVERSION_ID=\"1.0\"\nPRETTY_NAME=\"SUSE ALP Dolomite 1.0\"\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:suse:alp-dolomite:1.0\"\nHOME_URL=\"https://susealp.io/\"\nDOCUMENTATION_URL=\"https://documentation.suse.com/#alp\"\nLOGO=\"distributor-logo\"\n"
+    },
+    "name": "SUSE ALP Dolomite 1.0",
+    "result": {
+        "distribution_release": "NA",
+        "distribution": "ALP-Dolomite",
+        "distribution_major_version": "1",
+        "os_family": "Suse",
+        "distribution_version": "1.0"
+    }
+}


### PR DESCRIPTION
SUMMARY:

This pull request addresses the issue of adding ALP-Dolomite to the list of SUSE family operating systems in Ansible. Currently, ALP-Dolomite is not recognized as a part of the SUSE OS family in Ansible. The proposed changes aim to update the distribution.py file to include ALP-Dolomite under the SUSE OS family.

ISSUE TYPE: Bugfix Pull Request

ADDITIONAL INFORMATION:

The ALP-Dolomite reference can be found in the [ALP-Dolomite Documentation](https://documentation.suse.com/alp/dolomite/html/alp-dolomite/concept-alp.html).

Before the change:

~~~
ansible -m setup -c local -i playbooks/inventory/localhost localhost | grep os_fam
    "ansible_os_family": "ALP-Dolomite",
~~~

After the change:
~~~
ansible -m setup -c local -i playbooks/inventory/localhost localhost | grep os_fam
    "ansible_os_family": "Suse",
~~~

These changes ensure the successful recognition and handling of ALP-Dolomite as a SUSE family OS in Ansible.