### PR TITLE
Use FQCN in example in apt module docs

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -321,7 +321,7 @@ EXAMPLES = '''
     purge: true
 
 - name: Run the equivalent of "apt-get clean" as a separate step
-  apt:
+  ansible.builtin.apt:
     clean: yes
 '''
 


### PR DESCRIPTION
##### SUMMARY
Updates an example in the apt module docs to use the fully qualified collection name. I was helping some folks debug an issue and the difference in this example confused them.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### ADDITIONAL INFORMATION

n/a