### PR TITLE
[ansible-galaxy] Remove role name conversion when the repo startswith 'ansible-role'

### DIFF
--- a/changelogs/fragments/fix-default-ansible-galaxy-role-import-name.yml
+++ b/changelogs/fragments/fix-default-ansible-galaxy-role-import-name.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - >-
+    ``ansible-galaxy role import`` - fix using the ``role_name`` in a standalone role's
+    ``galaxy_info`` metadata by removing the CLI magic remove the ``ansible-role-`` prefix.
+    This matches the behavior of Galaxy which also no longer implicitly removes the
+    ``ansible-role-`` prefix.
+    Use the ``--role-name`` option or add a ``role_name`` to the ``galaxy_info`` dictionary
+    in the role's ``meta/main.yml`` to use an alternate role name.

--- a/changelogs/fragments/fix-default-ansible-galaxy-role-import-name.yml
+++ b/changelogs/fragments/fix-default-ansible-galaxy-role-import-name.yml
@@ -2,7 +2,7 @@ bugfixes:
   - >-
     ``ansible-galaxy role import`` - fix using the ``role_name`` in a standalone role's
     ``galaxy_info`` metadata by removing the CLI magic remove the ``ansible-role-`` prefix.
-    This matches the behavior of Galaxy which also no longer implicitly removes the
+    This matches the behavior of the Galaxy UI which also no longer implicitly removes the
     ``ansible-role-`` prefix.
     Use the ``--role-name`` option or add a ``role_name`` to the ``galaxy_info`` dictionary
     in the role's ``meta/main.yml`` to use an alternate role name.

--- a/changelogs/fragments/fix-default-ansible-galaxy-role-import-name.yml
+++ b/changelogs/fragments/fix-default-ansible-galaxy-role-import-name.yml
@@ -1,7 +1,7 @@
 bugfixes:
   - >-
     ``ansible-galaxy role import`` - fix using the ``role_name`` in a standalone role's
-    ``galaxy_info`` metadata by removing the CLI magic remove the ``ansible-role-`` prefix.
+    ``galaxy_info`` metadata by disabling automatic removal of the ``ansible-role-`` prefix.
     This matches the behavior of the Galaxy UI which also no longer implicitly removes the
     ``ansible-role-`` prefix.
     Use the ``--role-name`` option or add a ``role_name`` to the ``galaxy_info`` dictionary

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -482,8 +482,6 @@ class GalaxyAPI:
         }
         if role_name:
             args['alternate_role_name'] = role_name
-        elif github_repo.startswith('ansible-role'):
-            args['alternate_role_name'] = github_repo[len('ansible-role') + 1:]
         data = self._call_galaxy(url, args=urlencode(args), method="POST")
         if data.get('results', None):
             return data['results']


### PR DESCRIPTION
##### SUMMARY

Fix using the ``galaxy_info`` for the role name when the repo starts with `ansible-role`.

This was added in https://github.com/ansible/ansible/commit/bd9ca5ef28dff4f788f92bc2068a5a490e7c9be9 to match the Galaxy ui's behavior at the time of truncating the 'ansible-role-' prefix automatically, but the new backend requires the alternate name to be specified.

Roles that were imported using the ansible-role-$name convention will need to use ``--role-name`` or add ``role_name`` to the ``galaxy_info`` dictionary in ``meta/main.yml``, or follow the guidelines to change the role https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/community/userguide/#changing-roles.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
