### PR TITLE
ansible-test - Bypass PEP 668 checks

### DIFF
--- a/changelogs/fragments/ansible-test-pep-668.yml
+++ b/changelogs/fragments/ansible-test-pep-668.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ansible-test - When ansible-test installs requirements, it now instructs pip to allow installs on externally managed environments as defined by PEP 668.
+                 This only occurs in ephemeral environments managed by ansible-test, such as containers, or when the `--requirements` option is used.

--- a/test/lib/ansible_test/_util/target/setup/requirements.py
+++ b/test/lib/ansible_test/_util/target/setup/requirements.py
@@ -249,6 +249,14 @@ def common_pip_environment():  # type: () -> t.Dict[str, str]
     """Return common environment variables used to run pip."""
     env = os.environ.copy()
 
+    # When ansible-test installs requirements outside a virtual environment, it does so under one of two conditions:
+    # 1) The environment is an ephemeral one provisioned by ansible-test.
+    # 2) The user has provided the `--requirements` option to force installation of requirements.
+    # It seems reasonable to bypass PEP 668 checks in both of these cases.
+    # Doing so with an environment variable allows it to work under any version of pip which supports it, without breaking older versions.
+    # NOTE: pip version 23.0 enforces PEP 668 but does not support the override, in which case upgrading pip is required.
+    env.update(PIP_BREAK_SYSTEM_PACKAGES='1')
+
     return env
 
 


### PR DESCRIPTION
##### SUMMARY

When ansible-test installs requirements, it now instructs pip to allow installs on externally managed environments as defined by PEP 668.

This only occurs in ephemeral environments managed by ansible-test, such as containers, or when the `--requirements` option is used.

##### ISSUE TYPE

Feature Pull Request

##### ADDITIONAL INFORMATION

Future versions of ansible-test may take a more nuanced approach to PEP 668.

This change does not extend to requirements installed by integration tests. In those cases pip installs should generally be done in a virtual environment created by `source virtualenv.sh` in a `runme.sh` script, or through virtual environment creation in the test role (when requirements apply only to the target, not the controller).