### PR TITLE
Make roles generation compatible with ansible-lint autofix feature

### DIFF
--- a/lib/ansible/galaxy/data/default/role/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/role/meta/main.yml.j2
@@ -40,12 +40,12 @@ galaxy_info:
   #   - 99.99
 
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
+  # List tags for your role here, one per line. A tag is a keyword that describes
+  # and categorizes the role. Users find roles by searching for tags. Be sure to
+  # remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+  #       Maximum 20 tags per role.
 
 dependencies: []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,

--- a/lib/ansible/galaxy/data/network/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/network/meta/main.yml.j2
@@ -37,12 +37,12 @@ galaxy_info:
   #   - 99.99
 
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
+  # List tags for your role here, one per line. A tag is a keyword that describes
+  # and categorizes the role. Users find roles by searching for tags. Be sure to
+  # remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+  #       Maximum 20 tags per role.
 
 dependencies: []
   # List your role dependencies here, one per line. Be sure to remove the '[]' above,

--- a/test/units/cli/test_data/role_skeleton/meta/main.yml.j2
+++ b/test/units/cli/test_data/role_skeleton/meta/main.yml.j2
@@ -45,13 +45,13 @@ galaxy_info:
   #   - 99.99
 
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is
-    # a keyword that describes and categorizes the role.
-    # Users find roles by searching for tags. Be sure to
-    # remove the '[]' above if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of
-    # alphanumeric characters. Maximum 20 tags per role.
+  # List tags for your role here, one per line. A tag is
+  # a keyword that describes and categorizes the role.
+  # Users find roles by searching for tags. Be sure to
+  # remove the '[]' above if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of
+  # alphanumeric characters. Maximum 20 tags per role.
 
 dependencies: []
   # List your role dependencies here, one per line.


### PR DESCRIPTION
##### SUMMARY

While generating Ansible role using the ansible-galaxy role init command, it creates a default meta/main.yml file. If we later run ansible-lint --fix against that role, it changes the comment indentation for the galaxy_tags section. 

All the required fields for meta/main.yml to pass ansible-lint are in the default file created by ansible-galaxy role init and its indention should be suitable for ansible-lint --fix. 

Hence, this PR tries to make the generated meta/main.yml file compatible with ansible-lint --fix.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### COMPONENT NAME

<!--- Pick one below and delete the rest -->

- galaxy


Related: https://github.com/ansible/ansible/issues/82394, Fixes: https://github.com/ansible/ansible-lint/issues/3941