### PR TITLE
[2.15] ansible-galaxy role import -  remove name conversion

### DIFF
--- a/changelogs/fragments/fix-default-ansible-galaxy-role-import-name.yml
+++ b/changelogs/fragments/fix-default-ansible-galaxy-role-import-name.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - >-
+    ``ansible-galaxy role import`` - fix using the ``role_name`` in a standalone role's
+    ``galaxy_info`` metadata by disabling automatic removal of the ``ansible-role-`` prefix.
+    This matches the behavior of the Galaxy UI which also no longer implicitly removes the
+    ``ansible-role-`` prefix.
+    Use the ``--role-name`` option or add a ``role_name`` to the ``galaxy_info`` dictionary
+    in the role's ``meta/main.yml`` to use an alternate role name.

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -483,8 +483,6 @@ class GalaxyAPI:
         }
         if role_name:
             args['alternate_role_name'] = role_name
-        elif github_repo.startswith('ansible-role'):
-            args['alternate_role_name'] = github_repo[len('ansible-role') + 1:]
         data = self._call_galaxy(url, args=urlencode(args), method="POST")
         if data.get('results', None):
             return data['results']


### PR DESCRIPTION
Backport #82508 for consistency with new imports.

This fixes two things:
* remove the hardcoded alternate role name for repos following the ansible-role-$name convention
* by extension, galaxy_info['role_name'] won't be ignored

Removing the role name conversion allows a role that's imported via the web ui to be compatible with the cli without using `--role-name`, so I'm in favor of backporting even though it's a change in behavior. Alternatively, I could make a 2.15-specific fix for the 2nd issue by only setting the alternate_role_name for a repo that starts with ansible-role if the galaxy_info doesn't contain a role_name.

* Remove role name conversion based on whether the repo name starts with ansible-role

This was added in 2.3 to match the Galaxy ui behavior of truncating the 'ansible-role-' prefix automatically, but the new backend requires an alternate name to be provided or defined in the ``galaxy_info`` metadata.

Roles that were imported using the ansible-role-$name convention will need to use ``--role-name`` or add ``role_name`` to the ``galaxy_info`` dictionary in ``meta/main.yml``.

(cherry picked from commit d7be3824fee7858d187b6b1933f5a25f65576578)

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
