### PR TITLE
validate_argument_spec: fixed example syntax

### DIFF
--- a/lib/ansible/modules/validate_argument_spec.py
+++ b/lib/ansible/modules/validate_argument_spec.py
@@ -51,32 +51,32 @@ attributes:
 EXAMPLES = r'''
 - name: verify vars needed for this task file are present when included
   ansible.builtin.validate_argument_spec:
-        argument_spec: '{{required_data}}'
+        argument_spec: '{{ required_data }}'
   vars:
     required_data:
-        # unlike spec file, just put the options in directly
-        stuff:
-            description: stuff
-            type: str
-            choices: ['who', 'knows', 'what']
-            default: what
-        but:
-            description: i guess we need one
-            type: str
-            required: true
+      # unlike spec file, just put the options in directly
+      stuff:
+        description: stuff
+        type: str
+        choices: ['who', 'knows', 'what']
+        default: what
+      but:
+        description: i guess we need one
+        type: str
+        required: true
 
 
 - name: verify vars needed for this task file are present when included, with spec from a spec file
   ansible.builtin.validate_argument_spec:
-        argument_spec: "{{(lookup('ansible.builtin.file', 'myargspec.yml') | from_yaml )['specname']['options']}}"
+    argument_spec: "{{ (lookup('ansible.builtin.file', 'myargspec.yml') | from_yaml )['specname']['options'] }}"
 
 
 - name: verify vars needed for next include and not from inside it, also with params i'll only define there
   block:
     - ansible.builtin.validate_argument_spec:
-        argument_spec: "{{lookup('ansible.builtin.file', 'nakedoptions.yml'}}"
+        argument_spec: "{{ lookup('ansible.builtin.file', 'nakedoptions.yml') }}"
         provided_arguments:
-            but: "that i can define on the include itself, like in it's `vars:` keyword"
+          but: "that i can define on the include itself, like in it's `vars:` keyword"
 
     - name: the include itself
       vars:


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixed the syntax of the example in the validate_argument_spec module. Including lack of `)`.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below
N/A
```
