### PR TITLE
Update attribute description for check_mode

### DIFF
--- a/lib/ansible/plugins/doc_fragments/action_common_attributes.py
+++ b/lib/ansible/plugins/doc_fragments/action_common_attributes.py
@@ -10,8 +10,7 @@ class ModuleDocFragment(object):
     DOCUMENTATION = r'''
 attributes:
     check_mode:
-      description: Can run in check_mode and return changed status prediction without modifying target, if not supported 
-      the action will be skipped.
+      description: Can run in check_mode and return changed status prediction without modifying target, if not supported the action will be skipped.
     diff_mode:
       description: Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode
     platform:

--- a/lib/ansible/plugins/doc_fragments/action_common_attributes.py
+++ b/lib/ansible/plugins/doc_fragments/action_common_attributes.py
@@ -10,7 +10,8 @@ class ModuleDocFragment(object):
     DOCUMENTATION = r'''
 attributes:
     check_mode:
-      description: Full support means that it can be run in check_mode and return changed status prediction without modifying target
+      description: Can run in check_mode and return changed status prediction without modifying target, if not supported 
+      the action will be skipped.
     diff_mode:
       description: Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode
     platform:

--- a/lib/ansible/plugins/doc_fragments/action_common_attributes.py
+++ b/lib/ansible/plugins/doc_fragments/action_common_attributes.py
@@ -10,7 +10,7 @@ class ModuleDocFragment(object):
     DOCUMENTATION = r'''
 attributes:
     check_mode:
-      description: Can run in check_mode and return changed status prediction without modifying target
+      description: Full support means that it can be run in check_mode and return changed status prediction without modifying target
     diff_mode:
       description: Will return details on what has changed (or possibly needs changing in check_mode), when in diff mode
     platform:


### PR DESCRIPTION
##### SUMMARY

As per https://github.com/ansible/ansible-documentation/issues/1006 and https://github.com/ansible/ansible/pull/82427, some readers are confused by the attribute description field. The recommendation is to prepend each description with a phrase such as "Full support means that..."

So i'm trying to fix this documentation clarification by adding "Full support means that..." to check_mode attributes description

Fixes Clarify attribute descriptions #82509
Right now the attribute description for check_mode always says

Can run in check_mode and return changed status prediction without modifying target
Even if the module explicitly doesn't support check mode (support none) like in the [uri](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/uri_module.html#attributes) example. I can see this being confusing for people reading the docs who might skip over the Support side and read Description thinking this does support check mode when it does not.


##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION


```
I just add "Full support means that..." to "Can run in check_mode and return changed status prediction without modifying target".
So now it is: "Full support means that it can be run in check_mode and return changed status prediction without modifying target"
```
