### PR TITLE
iptables module: Enable support for pmtu clamp

### DIFF
--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -641,7 +641,7 @@ def construct_rule(params):
     if params.get('jump') and params['jump'].lower() == 'tee':
         append_param(rule, params['gateway'], '--gateway', False)
     if params.get('clamp_mss_to_pmtu') and params['jump'].lower() == 'tcpmss':
-        append_param(rule, params['clamp_mss_to_pmtu'], '--clamp-mss-to-pmtu', False)
+        append_clamp_mss_to_pmtu(rule, params['clamp_mss_to_pmtu'], '--clamp-mss-to-pmtu', False)
     append_param(rule, params['log_prefix'], '--log-prefix', False)
     append_param(rule, params['log_level'], '--log-level', False)
     append_param(rule, params['to_destination'], '--to-destination', False)

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -638,7 +638,7 @@ def construct_rule(params):
     append_param(rule, params['jump'], '-j', False)
     if params.get('jump') and params['jump'].lower() == 'tee':
         append_param(rule, params['gateway'], '--gateway', False)
-    if params.get('jump') and params['jump'].lower() == 'tcpmss':
+    if params.get('clamp_mss_to_pmtu') and params['jump'].lower() == 'tcpmss':
         append_param(rule, params['clamp_mss_to_pmtu'], '--clamp-mss-to-pmtu', False)
     append_param(rule, params['log_prefix'], '--log-prefix', False)
     append_param(rule, params['log_level'], '--log-level', False)

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -385,8 +385,8 @@ options:
     version_added: "2.13"
   clamp_mss_to_pmtu:
     description:
-      - This paramater controls the running of the iptables -j tcpmss --clamp-mss-to-pmtu
-      - If V(true) and jump is set to tcpmss, then iptables will clamp MSS value to path MTU.
+      - This paramater controls the running of the iptables -j TCPMSS --clamp-mss-to-pmtu
+      - If V(true) and jump is set to TCPMSS, then iptables will clamp MSS value to path MTU.
     type: bool
     default: false
     version_added: "2.13"
@@ -623,10 +623,9 @@ def append_wait(rule, param, flag):
         rule.extend([flag, param])
 
 
-def append_clamp_mss_to_pmtu(rule, param, jump):
+def append_clamp_mss_to_pmtu(rule, param, flag):
     if param:
-        if jump == 'tcpmss':
-            rule.extend(['--clamp-mss-to-pmtu'])
+        rule.extend([flag])
 
 
 def construct_rule(params):
@@ -640,8 +639,8 @@ def construct_rule(params):
     append_param(rule, params['jump'], '-j', False)
     if params.get('jump') and params['jump'].lower() == 'tee':
         append_param(rule, params['gateway'], '--gateway', False)
-    if params.get('clamp_mss_to_pmtu') and params['jump'].lower() == 'tcpmss':
-        append_clamp_mss_to_pmtu(rule, params['clamp_mss_to_pmtu'], '--clamp-mss-to-pmtu', False)
+    if params.get('clamp_mss_to_pmtu') and params['jump'].lower() == 'TCPMSS':
+        append_clamp_mss_to_pmtu(rule, params['clamp_mss_to_pmtu'], '--clamp-mss-to-pmtu')
     append_param(rule, params['log_prefix'], '--log-prefix', False)
     append_param(rule, params['log_level'], '--log-level', False)
     append_param(rule, params['to_destination'], '--to-destination', False)

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -549,8 +549,7 @@ EXAMPLES = r'''
     match: tcp
     tcp_flags:
       flags:
-        - "SYN,RST"
-        - "SYN"
+        - "SYN,RST SYN"
       flags_set: []
     jump: TCPMSS
     clamp_mss_to_pmtu: yes

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -622,10 +622,12 @@ def append_wait(rule, param, flag):
     if param:
         rule.extend([flag, param])
 
+
 def append_clamp_mss_to_pmtu(rule, param, jump):
     if param:
         if jump == 'tcpmss':
             rule.extend(['--clamp-mss-to-pmtu'])
+
 
 def construct_rule(params):
     rule = []

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -860,6 +860,7 @@ def main():
         rule=' '.join(construct_rule(module.params)),
         state=module.params['state'],
         chain_management=module.params['chain_management'],
+        clamp_mss_to_pmtu=module.params['clamp_mss_to_pmtu'],
     )
 
     ip_version = module.params['ip_version']

--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -1199,7 +1199,7 @@ class TestIptables(ModuleTestCase):
             'out_interface': 'eth1',
             'protocol': 'tcp',
             'match': 'tcp',
-            'tcp_flags':  {
+            'tcp_flags': {
                 'flags': ["SYN,RST", "SYN"],
                 'flags_set': ['']
             },

--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -1204,7 +1204,7 @@ class TestIptables(ModuleTestCase):
                 'flags_set': ['']
             },
             'jump': 'TCPMSS',
-            'clamp_mss_to_pmtu': 'true',
+            'clamp_mss_to_pmtu': True,
         })
 
         commands_results = [

--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -1200,7 +1200,7 @@ class TestIptables(ModuleTestCase):
             'protocol': 'tcp',
             'match': 'tcp',
             'tcp_flags': {
-                'flags': ["SYN,RST", "SYN"],
+                'flags': ["SYN,RST SYN"],
                 'flags_set': ['']
             },
             'jump': 'TCPMSS',
@@ -1222,10 +1222,10 @@ class TestIptables(ModuleTestCase):
             '/sbin/iptables',
             '-t', 'mangle',
             '-C', 'POSTROUTING',
-            '-o', 'eth1',
             '-p', 'tcp',
             '-m', 'tcp',
-            '--tcp-flags', 'SYN,RST', 'SYN',
+            '--tcp-flags', 'SYN,RST SYN'
             '-j', 'TCPMSS',
             '--clamp-mss-to-pmtu',
+            '-o', 'eth1',
         ])


### PR DESCRIPTION
##### SUMMARY

Fixes #82525

iptables has a native option to clamp the MSS within a rule to the path MTU. This patch enables support for this option. An example rule is:
```
iptables -A POSTROUTING -o eth1 -p tcp -m tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
```

##### ISSUE TYPE
- Feature Pull Request
