### PR TITLE
Update example value from yes to true

### DIFF
--- a/lib/ansible/modules/fetch.py
+++ b/lib/ansible/modules/fetch.py
@@ -107,17 +107,17 @@ EXAMPLES = r'''
   ansible.builtin.fetch:
     src: /tmp/somefile
     dest: /tmp/prefix-{{ inventory_hostname }}
-    flat: yes
+    flat: true
 
 - name: Specifying a destination path
   ansible.builtin.fetch:
     src: /tmp/uniquefile
     dest: /tmp/special/
-    flat: yes
+    flat: true
 
 - name: Storing in a path relative to the playbook
   ansible.builtin.fetch:
     src: /tmp/uniquefile
     dest: special/prefix-{{ inventory_hostname }}
-    flat: yes
+    flat: true
 '''


### PR DESCRIPTION
##### SUMMARY

In the example, the value of flat is yes instead of the advised value true

##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION

This is the advice in ansible documentation: Use lowercase ‘true’ or ‘false’ for boolean values in dictionaries if you want to be compatible with default yamllint options. src: https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html
