### PR TITLE
Deprecate support for the v2 galaxy API

### DIFF
--- a/changelogs/fragments/deprecate-v2-galaxy-api.yml
+++ b/changelogs/fragments/deprecate-v2-galaxy-api.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-galaxy - Deprecate use of the Galaxy v2 API (https://github.com/ansible/ansible/issues/81781)

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -139,7 +139,7 @@ def g_connect(versions):
                     'The v2 Ansible Galaxy API is deprecated and no longer supported. '
                     'Ensure that you have configured the ansible-galaxy CLI to utilize an '
                     'updated and supported version of Ansible Galaxy.',
-                    version='2.17'
+                    version='2.20'
                 )
 
             return method(self, *args, **kwargs)

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -134,7 +134,7 @@ def g_connect(versions):
                                       self.name, self.api_server))
 
             # Warn only when we know we are talking to a collections API
-            if 'v1' not in versions and {'v3'}.difference(available_versions) == {'v3'}:
+            if common_versions == {'v2'}:
                 display.deprecated(
                     'The v2 Ansible Galaxy API is deprecated and no longer supported. '
                     'Ensure that you have configured the ansible-galaxy CLI to utilize an '

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -133,6 +133,15 @@ def g_connect(versions):
                                    % (method.__name__, ", ".join(versions), ", ".join(available_versions),
                                       self.name, self.api_server))
 
+            # Warn only when we know we are talking to a collections API
+            if 'v1' not in versions and {'v3'}.difference(available_versions) == {'v3'}:
+                display.deprecated(
+                    'The v2 Ansible Galaxy API is deprecated and no longer supported. '
+                    'Ensure that you have configured the ansible-galaxy CLI to utilize an '
+                    'updated and supported version of Ansible Galaxy.',
+                    version='2.17'
+                )
+
             return method(self, *args, **kwargs)
         return wrapped
     return decorator


### PR DESCRIPTION
##### SUMMARY

Deprecate support for the v2 galaxy API. Fixes #81781

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

The v2 API is being removed in https://github.com/pulp/pulp_ansible/pull/1701

GalaxyNG and the new community galaxy do not include the v2 API.

The plan is likely to backport this to 2.16, and then just remove the functionality from devel for 2.17.