### PR TITLE
expect docs - improve responses description

### DIFF
--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -90,19 +90,21 @@ EXAMPLES = r'''
   ansible.builtin.expect:
     command: passwd username
     responses:
-      # match prompts containing `password` in upper or lowercase, and provide the password
       (?i)password: "MySekretPa$$word"
   # you don't want to show passwords in your logs
   no_log: true
 
-- name: Generic question with multiple different responses
+- name: Match multiple regular expressions and demonstrate individual and repeated responses
   ansible.builtin.expect:
     command: /path/to/custom/command
     responses:
       Question:
+        # give a unique response for each of the 3 hypothetical prompts matched
         - response1
         - response2
         - response3
+      # give the same response for every matching prompt
+      "^Match another prompt$": "response"
 
 - name: Multiple questions with responses
   ansible.builtin.expect:

--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -37,9 +37,11 @@ options:
   responses:
     type: dict
     description:
-      - Mapping of expected string/regex and string to respond with. If the
-        response is a list, successive matches return successive
-        responses. List functionality is new in 2.1.
+      - Mapping of prompt regular expressions and corresponding answer(s).
+      - Each key in O(responses) is a Python regex U(https://docs.python.org/3/library/re.html#regular-expression-syntax).
+      - The value of each key is a string or list of strings.
+        If the value is a string and the prompt is encountered multiple times, the answer will be repeated.
+        Provide the value as a list to give different answers for successive matches.
     required: true
   timeout:
     type: raw
@@ -68,15 +70,10 @@ notes:
   - If you want to run a command through the shell (say you are using C(<),
     C(>), C(|), and so on), you must specify a shell in the command such as
     C(/bin/bash -c "/path/to/something | grep else").
-  - The question, or key, under O(responses) is a python regex match. Case
-    insensitive searches are indicated with a prefix of C(?i).
+  - Case insensitive searches are indicated with a prefix of C(?i).
   - The C(pexpect) library used by this module operates with a search window
     of 2000 bytes, and does not use a multiline regex match. To perform a
     start of line bound match, use a pattern like ``(?m)^pattern``
-  - By default, if a question is encountered multiple times, its string
-    response will be repeated. If you need different responses for successive
-    question matches, instead of a string response, use a list of strings as
-    the response. The list functionality is new in 2.1.
   - The M(ansible.builtin.expect) module is designed for simple scenarios.
     For more complex needs, consider the use of expect code with the M(ansible.builtin.shell)
     or M(ansible.builtin.script) modules. (An example is part of the M(ansible.builtin.shell) module documentation).
@@ -93,6 +90,7 @@ EXAMPLES = r'''
   ansible.builtin.expect:
     command: passwd username
     responses:
+      # match prompts containing `password` in upper or lowercase, and provide the password
       (?i)password: "MySekretPa$$word"
   # you don't want to show passwords in your logs
   no_log: true


### PR DESCRIPTION
##### SUMMARY

Fixes #82542

Consolidated some of the module notes with the description for `responses`, and added a link to regex syntax.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
