### PR TITLE
Avoid delattr in test callback plugin

### DIFF
--- a/test/integration/targets/support-callback_plugins/callback_plugins/callback_debug.py
+++ b/test/integration/targets/support-callback_plugins/callback_plugins/callback_debug.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import functools
+
 from ansible.plugins.callback import CallbackBase
 
 
@@ -15,9 +17,8 @@ class CallbackModule(CallbackBase):
         super(CallbackModule, self).__init__(*args, **kwargs)
         self._display.display('__init__')
 
-        for cb in [x for x in dir(CallbackBase) if x.startswith('v2_')]:
-            delattr(CallbackBase, cb)
+        for name in (cb for cb in dir(self) if cb.startswith('v2_')):
+            setattr(self, name, functools.partial(self.handle_v2, name))
 
-    def __getattr__(self, name):
-        if name.startswith('v2_'):
-            return lambda *args, **kwargs: self._display.display(name)
+    def handle_v2(self, name, *args, **kwargs):
+        self._display.display(name)


### PR DESCRIPTION
##### SUMMARY

This prevents the test plugin from tampering with the base callback plugin, which causes issues with all other callback plugins running in the test.

##### ISSUE TYPE

Test Pull Request
