### PR TITLE
🔥 Exterminate `__builtin__` import from tests

### DIFF
--- a/test/units/module_utils/basic/test_set_mode_if_different.py
+++ b/test/units/module_utils/basic/test_set_mode_if_different.py
@@ -5,15 +5,11 @@
 
 from __future__ import annotations
 
+import builtins
 import errno
 import os
 
 from itertools import product
-
-try:
-    import builtins
-except ImportError:
-    import __builtin__ as builtins
 
 import pytest
 


### PR DESCRIPTION
This patch removes an import fallback that was only executed under Python 2. Now that we don't run tests against that runtime, it generates an uncovered line. Dropping it will slightly increase the coverage metric as a side effect.

##### SUMMARY

$sbj.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Maintenance Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A
