### PR TITLE
ansible-test ansible-doc sanity test: do not mangle plugin names in collections that start with an underscore

### DIFF
--- a/changelogs/fragments/82574-ansible-test-ansible-doc-underscore.yml
+++ b/changelogs/fragments/82574-ansible-test-ansible-doc-underscore.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ansible-test ansible-doc sanity test - do not remove underscores from plugin names in collections before calling ``ansible-doc`` (https://github.com/ansible/ansible/pull/82574)."

--- a/test/integration/targets/ansible-test-sanity-ansible-doc/ansible_collections/ns/col/plugins/modules/_module3.py
+++ b/test/integration/targets/ansible-test-sanity-ansible-doc/ansible_collections/ns/col/plugins/modules/_module3.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+DOCUMENTATION = '''
+module: _module3
+short_description: Another test module
+description: This is a test module that has not been deprecated.
+author:
+  - Ansible Core Team
+'''
+
+EXAMPLES = '''
+- minimal:
+'''
+
+RETURN = ''''''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={},
+    )
+
+    module.exit_json()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/lib/ansible_test/_internal/commands/sanity/ansible_doc.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/ansible_doc.py
@@ -79,7 +79,7 @@ class AnsibleDocTest(SanitySingleVersion):
                 plugin_parts = os.path.relpath(plugin_file_path, plugin_path).split(os.path.sep)
                 plugin_name = os.path.splitext(plugin_parts[-1])[0]
 
-                if plugin_name.startswith('_'):
+                if plugin_name.startswith('_') and not data_context().content.collection:
                     plugin_name = plugin_name[1:]
 
                 plugin_fqcn = data_context().content.prefix + '.'.join(plugin_parts[:-1] + [plugin_name])


### PR DESCRIPTION
##### SUMMARY
Right now having a plugin in a collection whose name starts with an underscore leads to ansible-doc failures as the test calls ansible-doc without the underscore to obtain the plugin's documentation.

See for example https://github.com/ansible-collections/community.internal_test_tools/actions/runs/7600108110/job/20697955887?pr=112.

##### ISSUE TYPE
- Bugfix Pull Request
