### PR TITLE
ansible-test validate-modules sanity test: do not treat leading underscore in plugin names as attempted deprecation

### DIFF
--- a/changelogs/fragments/82575-ansible-test-validate-modules-underscore.yml
+++ b/changelogs/fragments/82575-ansible-test-validate-modules-underscore.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ansible-test validate-modules sanity test - do not treat leading underscores for plugin names in collections as an attempted deprecation (https://github.com/ansible/ansible/pull/82575)."

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/_not_deprecated.py
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/_not_deprecated.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+DOCUMENTATION = '''
+module: _not_deprecated
+short_description: This module is not deprecated
+description: Its name has a leading underscore, but it is not deprecated.
+author:
+  - Ansible Core Team
+'''
+
+EXAMPLES = '''#'''
+RETURN = ''''''
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+if __name__ == '__main__':
+    module = AnsibleModule(argument_spec=dict())
+    module.exit_json()

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -1100,14 +1100,6 @@ class ModuleValidator(Validator):
                         ' documentation for removed'
                 )
         else:
-            # We are testing a collection
-            if self.object_name.startswith('_'):
-                self.reporter.error(
-                    path=self.object_path,
-                    code='collections-no-underscore-on-deprecation',
-                    msg='Deprecated content in collections MUST NOT start with "_", update meta/runtime.yml instead',
-                )
-
             if not (doc_deprecated == routing_says_deprecated):
                 # DOCUMENTATION.deprecated and meta/runtime.yml disagree
                 self.reporter.error(


### PR DESCRIPTION
##### SUMMARY
Right now having a plugin in a collection whose name starts with an underscore leads to validate-modules failures as the sanity test claims that `Deprecated content in collections MUST NOT start with "_", update meta/runtime.yml instead`.

While it is true that deprecated content must not use the `_` prefix, there is valid non-deprecated content that uses the `_` prefix, for example to indicate that the plugin is internal / private to the collection and should not be used.

See for example https://github.com/ansible-collections/community.internal_test_tools/actions/runs/7600108110/job/20697955887?pr=112.

##### ISSUE TYPE
- Bugfix Pull Request
