### PR TITLE
Adding note about implicit groups

### DIFF
--- a/changelogs/fragments/82580_constructed.yml
+++ b/changelogs/fragments/82580_constructed.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ansible-doc - Adding a note that only group_vars of explicit groups are loaded (https://github.com/ansible/ansible/pull/82580)."

--- a/changelogs/fragments/82580_constructed.yml
+++ b/changelogs/fragments/82580_constructed.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "ansible-doc - Adding a note that only group_vars of explicit groups are loaded (https://github.com/ansible/ansible/pull/82580)."
+  - "constructed inventory plugin - Adding a note that only group_vars of explicit groups are loaded (https://github.com/ansible/ansible/pull/82580)."

--- a/lib/ansible/plugins/doc_fragments/constructed.py
+++ b/lib/ansible/plugins/doc_fragments/constructed.py
@@ -79,18 +79,4 @@ options:
     type: boolean
     default: True
     version_added: '2.11'
-  use_vars_plugins:
-    description:
-      - Normally, for performance reasons, vars plugins get executed after the inventory sources complete the base inventory,
-        this option allows for getting vars related to hosts/groups from those plugins.
-      - The host_group_vars (enabled by default) 'vars plugin' is the one responsible for reading host_vars/ and group_vars/ directories.
-      - This will execute all vars plugins, even those that are not supposed to execute at the 'inventory' stage.
-        See vars plugins docs for details on 'stage'.
-      - Please note that only group_vars of explicitly defined groups are loaded
-      - Implicit groups, such as 'all' or 'ungrouped', need to be explicitly defined in any previous inventory to apply the
-        corresponding group_vars
-    type: boolean
-    default: false
-    required: false
-    version_added: '2.11'
 '''

--- a/lib/ansible/plugins/doc_fragments/constructed.py
+++ b/lib/ansible/plugins/doc_fragments/constructed.py
@@ -79,4 +79,18 @@ options:
     type: boolean
     default: True
     version_added: '2.11'
+  use_vars_plugins:
+    description:
+      - Normally, for performance reasons, vars plugins get executed after the inventory sources complete the base inventory,
+        this option allows for getting vars related to hosts/groups from those plugins.
+      - The host_group_vars (enabled by default) 'vars plugin' is the one responsible for reading host_vars/ and group_vars/ directories.
+      - This will execute all vars plugins, even those that are not supposed to execute at the 'inventory' stage.
+        See vars plugins docs for details on 'stage'.
+      - Please note that only group_vars of explicitly defined groups are loaded
+      - Implicit groups, such as 'all' or 'ungrouped', need to be explicitly defined in any previous inventory to apply the
+        corresponding group_vars
+    type: boolean
+    default: false
+    required: false
+    version_added: '2.11'
 '''

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -18,6 +18,19 @@ DOCUMENTATION = '''
             description: token that ensures this is a source file for the 'constructed' plugin.
             required: True
             choices: ['ansible.builtin.constructed', 'constructed']
+        use_vars_plugins:
+            description:
+                - Normally, for performance reasons, vars plugins get executed after the inventory sources complete the base inventory,
+                  this option allows for getting vars related to hosts/groups from those plugins.
+                - The host_group_vars (enabled by default) 'vars plugin' is the one responsible for reading host_vars/ and group_vars/ directories.
+                - This will execute all vars plugins, even those that are not supposed to execute at the 'inventory' stage.
+                  See vars plugins docs for details on 'stage'.
+                - Implicit groups, such as 'all' or 'ungrouped', need to be explicitly defined in any previous inventory to apply the
+                  corresponding group_vars
+            required: false
+            default: false
+            type: boolean
+            version_added: '2.11'
     extends_documentation_fragment:
       - constructed
 '''

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -18,17 +18,6 @@ DOCUMENTATION = '''
             description: token that ensures this is a source file for the 'constructed' plugin.
             required: True
             choices: ['ansible.builtin.constructed', 'constructed']
-        use_vars_plugins:
-            description:
-                - Normally, for performance reasons, vars plugins get executed after the inventory sources complete the base inventory,
-                  this option allows for getting vars related to hosts/groups from those plugins.
-                - The host_group_vars (enabled by default) 'vars plugin' is the one responsible for reading host_vars/ and group_vars/ directories.
-                - This will execute all vars plugins, even those that are not supposed to execute at the 'inventory' stage.
-                  See vars plugins docs for details on 'stage'.
-            required: false
-            default: false
-            type: boolean
-            version_added: '2.11'
     extends_documentation_fragment:
       - constructed
 '''


### PR DESCRIPTION
##### SUMMARY
Adding a note that implicit groups need to be explicitly defined for `ansible.builtin.constructed` to load the group vars.

As discussed in #82561.

##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION
First time contribution here. I hope that I understood correctly that I need to remove a portion of the documentation of one file and add it to the doc_fragments portion of the corresponding plugin.
Please let me know if anything needs adjusting.
