### PR TITLE
[backport][stable-2.15] Support `action_plugin` in plugin_routing_schema (#82562)

### DIFF
--- a/changelogs/fragments/fix-runtime-metadata-modules-action_plugin.yml
+++ b/changelogs/fragments/fix-runtime-metadata-modules-action_plugin.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- >-
+  ``ansible-test sanity --test runtime-metadata`` - add ``action_plugin`` as a valid field
+  for modules in the schema (https://github.com/ansible/ansible/pull/82562).

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/meta/runtime.yml
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/meta/runtime.yml
@@ -1,0 +1,4 @@
+plugin_routing:
+  modules:
+    module:
+      action_plugin: ns.col.action

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/failure/meta/runtime.yml
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/failure/meta/runtime.yml
@@ -1,0 +1,4 @@
+plugin_routing:
+  lookup:
+    lookup:
+      action_plugin: invalid

--- a/test/integration/targets/ansible-test-sanity-validate-modules/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/runme.sh
@@ -8,6 +8,16 @@ ansible-test sanity --test validate-modules --color --truncate 0 --failure-ok --
 diff -u "${TEST_DIR}/expected.txt" actual-stdout.txt
 grep -F -f "${TEST_DIR}/expected.txt" actual-stderr.txt
 
+cd ../col
+ansible-test sanity --test runtime-metadata
+
+cd ../failure
+if ansible-test sanity --test runtime-metadata 2>&1 | tee out.txt; then
+  echo "runtime-metadata in failure should be invalid"
+  exit 1
+fi
+grep out.txt -e 'extra keys not allowed'
+
 cd ../ps_only
 
 if ! command -V pwsh; then

--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
@@ -197,21 +197,26 @@ def validate_metadata_file(path, is_ansible, check_deprecation_dates=False):
         avoid_additional_data
     )
 
-    plugin_routing_schema = Any(
-        Schema({
-            ('deprecation'): Any(deprecation_schema),
-            ('tombstone'): Any(tombstoning_schema),
-            ('redirect'): fqcr,
-        }, extra=PREVENT_EXTRA),
+    plugins_routing_common_schema = Schema({
+        ('deprecation'): Any(deprecation_schema),
+        ('tombstone'): Any(tombstoning_schema),
+        ('redirect'): fqcr,
+    }, extra=PREVENT_EXTRA)
+
+    plugin_routing_schema = Any(plugins_routing_common_schema)
+
+    # Adjusted schema for modules only
+    plugin_routing_schema_modules = Any(
+        plugins_routing_common_schema.extend({
+            ('action_plugin'): fqcr}
+        )
     )
 
     # Adjusted schema for module_utils
     plugin_routing_schema_mu = Any(
-        Schema({
-            ('deprecation'): Any(deprecation_schema),
-            ('tombstone'): Any(tombstoning_schema),
-            ('redirect'): Any(*string_types),
-        }, extra=PREVENT_EXTRA),
+        plugins_routing_common_schema.extend({
+            ('redirect'): Any(*string_types)}
+        ),
     )
 
     list_dict_plugin_routing_schema = [{str_type: plugin_routing_schema}
@@ -219,6 +224,9 @@ def validate_metadata_file(path, is_ansible, check_deprecation_dates=False):
 
     list_dict_plugin_routing_schema_mu = [{str_type: plugin_routing_schema_mu}
                                           for str_type in string_types]
+
+    list_dict_plugin_routing_schema_modules = [{str_type: plugin_routing_schema_modules}
+                                               for str_type in string_types]
 
     plugin_schema = Schema({
         ('action'): Any(None, *list_dict_plugin_routing_schema),
@@ -233,7 +241,7 @@ def validate_metadata_file(path, is_ansible, check_deprecation_dates=False):
         ('inventory'): Any(None, *list_dict_plugin_routing_schema),
         ('lookup'): Any(None, *list_dict_plugin_routing_schema),
         ('module_utils'): Any(None, *list_dict_plugin_routing_schema_mu),
-        ('modules'): Any(None, *list_dict_plugin_routing_schema),
+        ('modules'): Any(None, *list_dict_plugin_routing_schema_modules),
         ('netconf'): Any(None, *list_dict_plugin_routing_schema),
         ('shell'): Any(None, *list_dict_plugin_routing_schema),
         ('strategy'): Any(None, *list_dict_plugin_routing_schema),


### PR DESCRIPTION
##### SUMMARY

As per #77265 and [devel loader code](https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/loader.py#L533-L534) as well, `action_plugin` should be a valid entry in `plugin_routing` schema.

Related PR: https://github.com/ansible-collections/cisco.nxos/pull/804

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request (?)