### PR TITLE
Update user group list syntax

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -314,7 +314,7 @@ EXAMPLES = r'''
   ansible.builtin.user:
     name: james
     shell: /bin/bash
-    groups: admins,developers
+    groups: ['admins', 'developers']
     append: yes
 
 - name: Remove the user 'johnd'


### PR DESCRIPTION
##### SUMMARY

Updates the user group list syntax in the example.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

The documentation for [ansible.builtin.user.groups](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html#parameter-groups) reads:

> A list of supplementary groups which the user is also a member of.
> By default, the user is removed from all other groups. Configure [append](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html#ansible-collections-ansible-builtin-user-module-parameter-append) to modify this.
> When set to an empty string '', the user is removed from all groups except the primary group.
> Before Ansible 2.3, the only input format allowed was a comma separated string.

Below, an example contains the following snippet, which uses the pre-2.3 syntax:
```yaml
- name: Add the user 'james' with a bash shell, appending the group 'admins' and 'developers' to the user's groups
  ansible.builtin.user:
    name: james
    shell: /bin/bash
    groups: admins,developers
    append: yes
```

This pr changes the example to use the new syntax
