### PR TITLE
Do not ignore SyntaxError from jinja2.Environment.from_string

### DIFF
--- a/changelogs/fragments/82606-template-python-syntax-error.yml
+++ b/changelogs/fragments/82606-template-python-syntax-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - templating - ensure syntax errors originating from a template being compiled into Python code object result in a failure (https://github.com/ansible/ansible/issues/82606)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -945,7 +945,7 @@ class Templar:
 
             try:
                 t = myenv.from_string(data)
-            except TemplateSyntaxError as e:
+            except (TemplateSyntaxError, SyntaxError) as e:
                 raise AnsibleError("template error while templating string: %s. String: %s" % (to_native(e), to_native(data)), orig_exc=e)
             except Exception as e:
                 if 'recursion' in to_native(e):

--- a/test/integration/targets/templating/tasks/main.yml
+++ b/test/integration/targets/templating/tasks/main.yml
@@ -33,3 +33,14 @@
       - result is failed
       - >-
         "TemplateSyntaxError: Could not load \"asdf \": 'invalid plugin name: ansible.builtin.asdf '" in result.msg
+
+- name: Make sure syntax errors originating from a template being compiled into Python code object result in a failure
+  debug:
+    msg: "{{ lookup('vars', 'v1', default='', default='') }}"
+  ignore_errors: true
+  register: r
+
+- assert:
+    that:
+      - r is failed
+      - "'keyword argument repeated' in r.msg"


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Jinja may generate an invalid Python source code from a template. Trying to compile such source code into a Python code object results in SyntaxError being thrown. An example of such a template is providing the same keyword argument into a lookup twice, resulting in: `SyntaxError: keyword argument repeated`.

Since `jinja2.exceptions.TemplateSyntaxError` does not cover such a case, as it is not a Jinja parsing error, we need to catch SyntaxError explicitly ourselves.

Fixes #82606
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
