### PR TITLE
[2.16] expect - fix argument spec error with timeout=null (#82522)

### DIFF
--- a/changelogs/fragments/fix-expect-indefinite-timeout.yml
+++ b/changelogs/fragments/fix-expect-indefinite-timeout.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - expect - fix argument spec error using timeout=null (https://github.com/ansible/ansible/issues/80982).

--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -43,7 +43,7 @@ options:
         responses. List functionality is new in 2.1.
     required: true
   timeout:
-    type: int
+    type: raw
     description:
       - Amount of time in seconds to wait for the expected strings. Use
         V(null) to disable timeout.
@@ -122,6 +122,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_bytes, to_native
+from ansible.module_utils.common.validation import check_type_int
 
 
 def response_closure(module, question, responses):
@@ -147,7 +148,7 @@ def main():
             creates=dict(type='path'),
             removes=dict(type='path'),
             responses=dict(type='dict', required=True),
-            timeout=dict(type='int', default=30),
+            timeout=dict(type='raw', default=30),
             echo=dict(type='bool', default=False),
         )
     )
@@ -162,6 +163,11 @@ def main():
     removes = module.params['removes']
     responses = module.params['responses']
     timeout = module.params['timeout']
+    if timeout is not None:
+        try:
+            timeout = check_type_int(timeout)
+        except TypeError as te:
+            module.fail_json(msg=f"argument 'timeout' is of type {type(timeout)} and we were unable to convert to int: {te}")
     echo = module.params['echo']
 
     events = dict()

--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -167,7 +167,9 @@ def main():
         try:
             timeout = check_type_int(timeout)
         except TypeError as te:
-            module.fail_json(msg=f"argument 'timeout' is of type {type(timeout)} and we were unable to convert to int: {te}")
+            module.fail_json(
+                msg="argument 'timeout' is of type {timeout_type} and we were unable to convert to int: {te}".format(timeout_type=type(timeout), te=te)
+            )
     echo = module.params['echo']
 
     events = dict()

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -148,6 +148,15 @@
     - "echo_result.stdout_lines[-2] == 'foobar'"
     - "echo_result.stdout_lines[-1] == 'bar'"
 
+- name: test timeout is valid as null
+  expect:
+    command: "{{ansible_python_interpreter}} {{test_command_file}}"
+    responses:
+      foo: bar
+    echo: true
+    timeout: null  # wait indefinitely
+  timeout: 2  # but shouldn't be waiting long
+
 - name: test response list
   expect:
     command: "{{ansible_python_interpreter}} {{test_command_file}} foo foo"


### PR DESCRIPTION
##### SUMMARY

* Fix using timeout=null to wait indefinitely

* fix error message

(cherry picked from commit da9edd7760526cb91cb0a3c28ce31c242a6e718e)

##### ISSUE TYPE

- Bugfix Pull Request
