### PR TITLE
[2.16] Fix ansible.builtin.include_vars - depth (#80995)

### DIFF
--- a/changelogs/fragments/80995-include-all-var-files.yml
+++ b/changelogs/fragments/80995-include-all-var-files.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- include_vars - fix calculating ``depth`` relative to the root and ensure all files are included (https://github.com/ansible/ansible/issues/80987).

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -6,6 +6,7 @@ __metaclass__ = type
 
 from os import path, walk
 import re
+import pathlib
 
 import ansible.constants as C
 from ansible.errors import AnsibleError
@@ -182,16 +183,15 @@ class ActionModule(ActionBase):
             alphabetical order. Do not iterate pass the set depth.
             The default depth is unlimited.
         """
-        current_depth = 0
         sorted_walk = list(walk(self.source_dir, onerror=self._log_walk, followlinks=True))
         sorted_walk.sort(key=lambda x: x[0])
         for current_root, current_dir, current_files in sorted_walk:
-            current_depth += 1
-            if current_depth <= self.depth or self.depth == 0:
-                current_files.sort()
-                yield (current_root, current_files)
-            else:
-                break
+            # Depth 1 is the root, relative_to omits the root
+            current_depth = len(pathlib.Path(current_root).relative_to(self.source_dir).parts) + 1
+            if self.depth != 0 and current_depth > self.depth:
+                continue
+            current_files.sort()
+            yield (current_root, current_files)
 
     def _ignore_file(self, filename):
         """ Return True if a file matches the list of ignore_files.

--- a/test/integration/targets/include_vars/files/test_depth/sub1/sub11.yml
+++ b/test/integration/targets/include_vars/files/test_depth/sub1/sub11.yml
@@ -1,0 +1,1 @@
+sub11: defined

--- a/test/integration/targets/include_vars/files/test_depth/sub1/sub11/config11.yml
+++ b/test/integration/targets/include_vars/files/test_depth/sub1/sub11/config11.yml
@@ -1,0 +1,1 @@
+config11: defined

--- a/test/integration/targets/include_vars/files/test_depth/sub1/sub11/config112.yml
+++ b/test/integration/targets/include_vars/files/test_depth/sub1/sub11/config112.yml
@@ -1,0 +1,1 @@
+config112: defined

--- a/test/integration/targets/include_vars/files/test_depth/sub1/sub12.yml
+++ b/test/integration/targets/include_vars/files/test_depth/sub1/sub12.yml
@@ -1,0 +1,1 @@
+sub12: defined

--- a/test/integration/targets/include_vars/files/test_depth/sub2/sub21.yml
+++ b/test/integration/targets/include_vars/files/test_depth/sub2/sub21.yml
@@ -1,0 +1,1 @@
+sub21: defined

--- a/test/integration/targets/include_vars/files/test_depth/sub2/sub21/config211.yml
+++ b/test/integration/targets/include_vars/files/test_depth/sub2/sub21/config211.yml
@@ -1,0 +1,1 @@
+config211: defined

--- a/test/integration/targets/include_vars/files/test_depth/sub2/sub21/config212.yml
+++ b/test/integration/targets/include_vars/files/test_depth/sub2/sub21/config212.yml
@@ -1,0 +1,1 @@
+config212: defined

--- a/test/integration/targets/include_vars/files/test_depth/sub3/config3.yml
+++ b/test/integration/targets/include_vars/files/test_depth/sub3/config3.yml
@@ -1,0 +1,1 @@
+config3: defined

--- a/test/integration/targets/include_vars/tasks/main.yml
+++ b/test/integration/targets/include_vars/tasks/main.yml
@@ -255,3 +255,15 @@
   vars:
     hash1: "{{ role_path }}/test_symlink/symlink/hashes/hash1.yml"
     hash2: "{{ role_path }}/test_symlink/symlink/hashes/hash2.yml"
+
+- name: Test include_vars includes everything to the correct depth
+  ansible.builtin.include_vars:
+    dir: "{{ role_path }}/files/test_depth"
+    depth: 3
+    name: test_depth_var
+  register: test_depth
+
+- assert:
+    that:
+      - "test_depth.ansible_included_var_files|length == 8"
+      - "test_depth_var.keys()|length == 8"


### PR DESCRIPTION
##### SUMMARY
Fix ansible.builtin.include_vars - depth

* Changes as suggested by sivel

* Add changelog fragment and tests

Co-authored-by: Matt Martz <matt@sivel.net>
Co-authored-by: s-hertel <19572925+s-hertel@users.noreply.github.com>
(cherry picked from commit 48bed1e15ad7349a5458097910be64e56bd3b6e2)

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request