### PR TITLE
Support Decimal in AnsibleJSONEncoder

### DIFF
--- a/changelogs/fragments/json-encoder-support-decimal.yml
+++ b/changelogs/fragments/json-encoder-support-decimal.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "``AnsibleJSONEncoder`` now also supports encoding of Decimal values
+  - Wihtout this change you get the error ``Object of type Decimal is not JSON serializable`` when trying to convert a Decimal value to json
+  - One example will be when you have an inventory variable in decimal format (eg. ram_gb for a virtual machine) and try to list the inventory with ansible-inventory

--- a/changelogs/fragments/json-encoder-support-decimal.yml
+++ b/changelogs/fragments/json-encoder-support-decimal.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - "``AnsibleJSONEncoder`` now also supports encoding of Decimal values
-  - Wihtout this change you get the error ``Object of type Decimal is not JSON serializable`` when trying to convert a Decimal value to json
+  - "``AnsibleJSONEncoder`` now also supports encoding of Decimal values"
+  - Without this change you get the error ``Object of type Decimal is not JSON serializable`` when trying to convert a Decimal value to json
   - One example will be when you have an inventory variable in decimal format (eg. ram_gb for a virtual machine) and try to list the inventory with ansible-inventory

--- a/lib/ansible/module_utils/common/json.py
+++ b/lib/ansible/module_utils/common/json.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 
 import datetime
+from decimal import Decimal
 
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six.moves.collections_abc import Mapping
@@ -68,6 +69,9 @@ class AnsibleJSONEncoder(json.JSONEncoder):
         elif isinstance(o, (datetime.date, datetime.datetime)):
             # date object
             value = o.isoformat()
+        elif isinstance(o, Decimal):
+            # Decimal object
+            value = str(o)
         else:
             # use default encoder
             value = super(AnsibleJSONEncoder, self).default(o)


### PR DESCRIPTION
##### SUMMARY

Adds support of Decimal variables to the AnsibleJSONEncoder

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

Without this change you get the error ``Object of type Decimal is not JSON serializable`` when trying to convert a Decimal value to json

I ran into this problem when developing an inventory plugin that reads values from a database and I checked the correct working of the plugin using the ansible-inventory command.
As one value is of type Decimal the above mentioned error occured.

One more note:
I hope this PR is well formated, this is the first time I am creating a PR.