### PR TITLE
2.16: Do not ignore SyntaxError from jinja2.Environment.from_string (#82607)

### DIFF
--- a/changelogs/fragments/82606-template-python-syntax-error.yml
+++ b/changelogs/fragments/82606-template-python-syntax-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - templating - ensure syntax errors originating from a template being compiled into Python code object result in a failure (https://github.com/ansible/ansible/issues/82606)

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -973,7 +973,7 @@ class Templar:
 
             try:
                 t = myenv.from_string(data)
-            except TemplateSyntaxError as e:
+            except (TemplateSyntaxError, SyntaxError) as e:
                 raise AnsibleError("template error while templating string: %s. String: %s" % (to_native(e), to_native(data)), orig_exc=e)
             except Exception as e:
                 if 'recursion' in to_native(e):

--- a/test/integration/targets/templating/tasks/main.yml
+++ b/test/integration/targets/templating/tasks/main.yml
@@ -33,3 +33,14 @@
       - result is failed
       - >-
         "TemplateSyntaxError: Could not load \"asdf \": 'invalid plugin name: ansible.builtin.asdf '" in result.msg
+
+- name: Make sure syntax errors originating from a template being compiled into Python code object result in a failure
+  debug:
+    msg: "{{ lookup('vars', 'v1', default='', default='') }}"
+  ignore_errors: true
+  register: r
+
+- assert:
+    that:
+      - r is failed
+      - "'keyword argument repeated' in r.msg"


### PR DESCRIPTION
##### SUMMARY
Backport of #82607 

(cherry picked from commit 6d34eb88d95c02013d781a29dfffaaf2901cd81f)
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
