### PR TITLE
Allow asa_facts to be translated to cisco.asa.asa_facts

### DIFF
--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -5622,6 +5622,8 @@ plugin_routing:
       redirect: cisco.asa.asa_acl
     asa_config:
       redirect: cisco.asa.asa_config
+    asa_facts:
+      redirect: cisco.asa.asa_facts
     asa_og:
       redirect: cisco.asa.asa_og
     asa_command:


### PR DESCRIPTION
##### SUMMARY

Allow asa_facts to be translated to cisco.asa.asa_facts

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Currently, several other cisco.asa modules exist in ansible_builtin_runtime.yml but cisco.asa.asa_facts does not which can cause some confusion. This edit would give greater consistency when using the cisco.asa modules where someone could have a task like what is shown below

```
- name: Call asa_facts without FQCN
  asa_facts:
    gather_subset: all
```
as opposed to requiring the full FQCN

```
- name: Call asa_facts with FQCN
  cisco.asa.asa_facts:
    gather_subset: all
```
