### PR TITLE
ansible-test - Fix validate-modules Python handling

### DIFF
--- a/changelogs/fragments/ansible-test-validate-modules-non-python.yml
+++ b/changelogs/fragments/ansible-test-validate-modules-non-python.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test - The ``validate-modules`` sanity test no longer attempts to process files with unrecognized extensions as Python
+    (resolves https://github.com/ansible/ansible/issues/82604).

--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/unsupported_extension.nope
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/unsupported_extension.nope
@@ -1,0 +1,2 @@
+This file has an extension which is not supported by validate-modules.
+It should not be treated as a Python file or have Python-specific rules applied to it.

--- a/test/integration/targets/ansible-test-sanity-validate-modules/expected.txt
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/expected.txt
@@ -27,3 +27,5 @@ plugins/modules/semantic_markup.py:0:0: invalid-documentation-markup: Directive 
 plugins/modules/semantic_markup.py:0:0: invalid-documentation-markup: Directive "O(foo.bar=1)" contains a non-existing option "foo.bar"
 plugins/modules/semantic_markup.py:0:0: invalid-documentation-markup: Directive "RV(bam)" contains a non-existing return value "bam"
 plugins/modules/semantic_markup.py:0:0: invalid-documentation-markup: Directive "RV(does.not.exist=true)" contains a non-existing return value "does.not.exist"
+plugins/modules/unsupported_extension.nope:0:0: invalid-extension: Official Ansible modules must have a .py extension for python modules or a .ps1 for powershell modules
+plugins/modules/unsupported_extension.nope:0:0: missing-gplv3-license: GPLv3 license header not found in the first 20 lines of the module

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/module_args.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/module_args.py
@@ -167,10 +167,3 @@ def get_py_argument_spec(filename, collection):
         return argument_spec, fake.kwargs
     except (TypeError, IndexError):
         return {}, {}
-
-
-def get_argument_spec(filename, collection):
-    if filename.endswith('.py'):
-        return get_py_argument_spec(filename, collection)
-    else:
-        return get_ps_argument_spec(filename, collection)


### PR DESCRIPTION
##### SUMMARY

The ``validate-modules`` sanity test no longer attempts to process files with unrecognized extensions as Python.

Integration tests have been added to verify Python-specific checks do not apply to these files.

The `invalid-extension` and `missing-gplv3-license` checks still apply to these files. This may change in the future.

Resolves https://github.com/ansible/ansible/issues/82604

##### ISSUE TYPE

Bugfix Pull Request
