### PR TITLE
Fix issues with ansible-playbook-callbacks test (#82407)

### DIFF
--- a/test/integration/targets/ansible-playbook-callbacks/all-callbacks.yml
+++ b/test/integration/targets/ansible-playbook-callbacks/all-callbacks.yml
@@ -96,14 +96,14 @@
       ignore_errors: true
 
     - name: async poll ok
-      command: sleep 2
-      async: 3
-      poll: 1
+      command: sleep 3
+      async: 5
+      poll: 2
 
     - name: async poll failed
-      shell: sleep 2; false
-      async: 3
-      poll: 1
+      shell: sleep 3; false
+      async: 5
+      poll: 2
       ignore_errors: true
 
     - include_tasks: include_me.yml
@@ -111,7 +111,7 @@
     - name: diff
       copy:
         content: diff
-        dest: '{{ remote_tmp_dir.path }}/diff.txt'
+        dest: '{{ remote_tmp_dir }}/diff.txt'
       diff: true
 
 - hosts: i_dont_exist

--- a/test/integration/targets/ansible-playbook-callbacks/callbacks_list.expected
+++ b/test/integration/targets/ansible-playbook-callbacks/callbacks_list.expected
@@ -1,12 +1,14 @@
  1 __init__
-83 v2_on_any
+92 v2_on_any
+ 1 v2_on_file_diff
  4 v2_playbook_on_handler_task_start
  2 v2_playbook_on_include
+ 1 v2_playbook_on_no_hosts_matched
  3 v2_playbook_on_notify
- 1 v2_playbook_on_play_start
+ 3 v2_playbook_on_play_start
  1 v2_playbook_on_start
  1 v2_playbook_on_stats
-17 v2_playbook_on_task_start
+19 v2_playbook_on_task_start
  1 v2_playbook_on_vars_prompt
  1 v2_runner_item_on_failed
  2 v2_runner_item_on_ok
@@ -15,8 +17,8 @@
  1 v2_runner_on_async_ok
  2 v2_runner_on_async_poll
  5 v2_runner_on_failed
-15 v2_runner_on_ok
+16 v2_runner_on_ok
  1 v2_runner_on_skipped
-21 v2_runner_on_start
+23 v2_runner_on_start
  1 v2_runner_on_unreachable
  2 v2_runner_retry

--- a/test/integration/targets/ansible-playbook-callbacks/runme.sh
+++ b/test/integration/targets/ansible-playbook-callbacks/runme.sh
@@ -5,6 +5,7 @@ set -eux
 export ANSIBLE_CALLBACK_PLUGINS=../support-callback_plugins/callback_plugins
 export ANSIBLE_ROLES_PATH=../
 export ANSIBLE_STDOUT_CALLBACK=callback_debug
+export ANSIBLE_HOST_PATTERN_MISMATCH=warning
 
 ansible-playbook all-callbacks.yml 2>/dev/null | sort | uniq -c | tee callbacks_list.out
 


### PR DESCRIPTION
##### SUMMARY

This PR fixes various issues with the ansible-playbook-callbacks integration test.

##### ISSUE TYPE

- Test Pull Request

##### ADDITIONAL INFORMATION

The timing of the async tasks was a little unpredictable, meaning that sometimes we would get an unexpected number of v2_runner_on_async_poll callbacks, and fail the test. This change fixes the issue by increasing the poll interval to 2 seconds and the sleep duration to 3 seconds, such that on a reasonably responsive system we will poll twice per task, with the sleep ending in the middle of the two polls.

The include_me.yml file does not exist in this integration test. It has been added.

The remote_tmp_dir.path expression is invalid - the setup_remote_tmp_dir role uses set_fact to set remote_tmp_dir to remote_tmp_dir.path.

The integration tests run with ANSIBLE_HOST_PATTERN_MISMATCH=error, meaning that the final play was never reached. Set ANSIBLE_HOST_PATTERN_MISMATCH=warning to continue past the play and trigger the v2_playbook_on_no_hosts_matched callback.