### PR TITLE
add LOCAL_SEARCH_PATH configuration (paths in which Ansible will search for local files when source path is relative)

### DIFF
--- a/changelogs/fragments/82634-local_search_path-config.yml
+++ b/changelogs/fragments/82634-local_search_path-config.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - add LOCAL_SEARCH_PATH configuration

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -2115,4 +2115,13 @@ VERBOSE_TO_STDERR:
     - section: defaults
       key: verbose_to_stderr
   type: bool
+LOCAL_SEARCH_PATH:
+  version_added: '2.17'
+  name: Additional prefered search paths for local files
+  default: '{{ "" }}'
+  description: Colon-separated paths in which Ansible will search for local files when source path is relative.
+  env: [{name: ANSIBLE_LOCAL_SEARCH_PATH}]
+  ini:
+  - {key: local_search_path, section: defaults}
+  type: pathspec
 ...

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -2123,6 +2123,7 @@ LOCAL_SEARCH_PATH:
     - This option allows you to globally configure additional paths for local file lookups with relative paths
       (see :ref:`ansible_collections.ansible.builtin.file`, :ref:`ansible_collections.ansible.builtin.copy`,
       :ref:`ansible_collections.ansible.builtin.template` etc.)
+  default: []
   env: [{name: ANSIBLE_LOCAL_SEARCH_PATH}]
   ini:
   - {key: local_search_path, section: defaults}

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -2118,10 +2118,15 @@ VERBOSE_TO_STDERR:
 LOCAL_SEARCH_PATH:
   version_added: '2.17'
   name: Additional prefered search paths for local files
-  default: '{{ "" }}'
-  description: Colon-separated paths in which Ansible will search for local files when source path is relative.
+  description:
+    - Colon-separated paths in which Ansible will also search for local files when source path is relative.
+    - This option allows you to globally configure additional paths for local file lookups with relative paths
+      (see :ref:`ansible_collections.ansible.builtin.file`, :ref:`ansible_collections.ansible.builtin.copy`,
+      :ref:`ansible_collections.ansible.builtin.template` etc.)
   env: [{name: ANSIBLE_LOCAL_SEARCH_PATH}]
   ini:
   - {key: local_search_path, section: defaults}
+  vars:
+  - name: ansible_local_search_path
   type: pathspec
 ...

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -778,7 +778,7 @@ class Base(FieldAttributeBase):
         Return the list of paths you should search for files, in order.
         This follows role/playbook dependency chain.
         '''
-        path_stack = []
+        path_stack = [] + C.LOCAL_SEARCH_PATH
 
         dep_chain = self.get_dep_chain()
         # inside role: add the dependency chain from current to dependent

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -778,7 +778,7 @@ class Base(FieldAttributeBase):
         Return the list of paths you should search for files, in order.
         This follows role/playbook dependency chain.
         '''
-        path_stack = [] + C.LOCAL_SEARCH_PATH
+        path_stack = []
 
         dep_chain = self.get_dep_chain()
         # inside role: add the dependency chain from current to dependent

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1423,15 +1423,17 @@ class ActionBase(ABC):
 
         return diff
 
-    def _find_needle(self, dirname, needle):
+    def _find_needle(self, dirname, needle, task_vars=None):
         '''
             find a needle in haystack of paths, optionally using 'dirname' as a subdir.
             This will build the ordered list of paths to search and pass them to dwim
             to get back the first existing file found.
         '''
 
+        path_stack = C.config.get_config_value('LOCAL_SEARCH_PATH', variables=task_vars)
+
         # dwim already deals with playbook basedirs
-        path_stack = self._task.get_search_path()
+        path_stack += self._task.get_search_path()
 
         # if missing it will return a file not found exception
         return self._loader.path_dwim_relative_stack(path_stack, dirname, needle)

--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -108,7 +108,7 @@ class ActionModule(ActionBase):
                 raise _AnsibleActionDone()
             else:
                 try:
-                    src = self._find_needle('files', src)
+                    src = self._find_needle('files', src, task_vars)
                 except AnsibleError as e:
                     raise AnsibleActionFail(to_native(e))
 

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -466,7 +466,7 @@ class ActionModule(ActionBase):
             trailing_slash = source.endswith(os.path.sep)
             try:
                 # find in expected paths
-                source = self._find_needle('files', source)
+                source = self._find_needle('files', source, task_vars)
             except AnsibleError as e:
                 result['failed'] = True
                 result['msg'] = to_text(e)

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -119,7 +119,7 @@ class ActionModule(ActionBase):
                     results.update(updated_results)
         else:
             try:
-                self.source_file = self._find_needle('vars', self.source_file)
+                self.source_file = self._find_needle('vars', self.source_file, task_vars)
                 failed, err_msg, updated_results = (
                     self._load_files(self.source_file)
                 )

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -97,7 +97,7 @@ class ActionModule(ActionBase):
             if executable:
                 executable = to_native(new_module_args['executable'], errors='surrogate_or_strict')
             try:
-                source = self._loader.get_real_file(self._find_needle('files', source), decrypt=self._task.args.get('decrypt', True))
+                source = self._loader.get_real_file(self._find_needle('files', source, task_vars), decrypt=self._task.args.get('decrypt', True))
             except AnsibleError as e:
                 raise AnsibleActionFail(to_native(e))
 

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -90,7 +90,7 @@ class ActionModule(ActionBase):
                 raise AnsibleActionFail("newline_sequence needs to be one of: \n, \r or \r\n")
             else:
                 try:
-                    source = self._find_needle('templates', source)
+                    source = self._find_needle('templates', source, task_vars)
                 except AnsibleError as e:
                     raise AnsibleActionFail(to_text(e))
 

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -69,7 +69,7 @@ class ActionModule(ActionBase):
 
             if not remote_src:
                 try:
-                    source = self._loader.get_real_file(self._find_needle('files', source), decrypt=decrypt)
+                    source = self._loader.get_real_file(self._find_needle('files', source, task_vars), decrypt=decrypt)
                 except AnsibleError as e:
                     raise AnsibleActionFail(to_text(e))
 

--- a/lib/ansible/plugins/action/uri.py
+++ b/lib/ansible/plugins/action/uri.py
@@ -45,7 +45,7 @@ class ActionModule(ActionBase):
 
             if src:
                 try:
-                    src = self._find_needle('files', src)
+                    src = self._find_needle('files', src, task_vars)
                 except AnsibleError as e:
                     raise AnsibleActionFail(to_native(e))
 
@@ -67,7 +67,7 @@ class ActionModule(ActionBase):
                         continue
 
                     try:
-                        filename = self._find_needle('files', filename)
+                        filename = self._find_needle('files', filename, task_vars)
                     except AnsibleError as e:
                         raise AnsibleActionFail(to_native(e))
 

--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 
+from ansible import constants as C
 from ansible.errors import AnsibleFileNotFound
 from ansible.plugins import AnsiblePlugin
 from ansible.utils.display import Display
@@ -108,10 +109,12 @@ class LookupBase(AnsiblePlugin):
         Return a file (needle) in the task's expected search path.
         '''
 
+        paths = C.config.get_config_value('LOCAL_SEARCH_PATH', variables=myvars)
+
         if 'ansible_search_path' in myvars:
-            paths = myvars['ansible_search_path']
+            paths += myvars['ansible_search_path']
         else:
-            paths = [self.get_basedir(myvars)]
+            paths.append(self.get_basedir(myvars))
 
         result = None
         try:

--- a/test/integration/targets/copy/files-different/corge.txt
+++ b/test/integration/targets/copy/files-different/corge.txt
@@ -1,0 +1,1 @@
+corge.txt

--- a/test/integration/targets/copy/tasks/relative_src_and_local_search_path.yml
+++ b/test/integration/targets/copy/tasks/relative_src_and_local_search_path.yml
@@ -1,0 +1,17 @@
+- set_fact:
+    ansible_local_search_path: "{{role_path}}/files-different/"
+
+- name: Copy file from ansible_local_search_path
+  copy:
+    src: corge.txt
+    dest: '{{ remote_dir }}'
+  register: copy_result
+
+- debug:
+    var: copy_result
+    verbosity: 1
+
+- name: Verify that the file was marked as changed
+  assert:
+    that:
+      - "copy_result.changed == true"

--- a/test/integration/targets/lookup_file/tasks/main.yml
+++ b/test/integration/targets/lookup_file/tasks/main.yml
@@ -11,3 +11,15 @@
   assert:
     that:
         - "foo == 'bar'"
+
+- name: load the file relative as a fact
+  set_fact:
+    ansible_local_search_path: "{{ output_dir }}"
+    foo: "{{ lookup('file', 'foo.txt' ) }}"
+
+- debug: var=foo
+
+- name: verify relative file lookup
+  assert:
+    that:
+        - "foo == 'bar'"

--- a/test/integration/targets/lookup_file/tasks/main.yml
+++ b/test/integration/targets/lookup_file/tasks/main.yml
@@ -12,9 +12,12 @@
     that:
         - "foo == 'bar'"
 
-- name: load the file relative as a fact
+- name: prepare relative file lookup
   set_fact:
     ansible_local_search_path: "{{ output_dir }}"
+
+- name: load the file relative as a fact
+  set_fact:
     foo: "{{ lookup('file', 'foo.txt' ) }}"
 
 - debug: var=foo

--- a/test/support/windows-integration/plugins/action/win_copy.py
+++ b/test/support/windows-integration/plugins/action/win_copy.py
@@ -397,7 +397,7 @@ class ActionModule(ActionBase):
             trailing_slash = source.endswith(os.path.sep)
             try:
                 # find in expected paths
-                source = self._find_needle('files', source)
+                source = self._find_needle('files', source, task_vars)
             except AnsibleError as e:
                 result['failed'] = True
                 result['msg'] = to_text(e)


### PR DESCRIPTION
##### SUMMARY

Add LOCAL_SEARCH_PATH configuration. Colon-separated paths in which Ansible will search for local files when source path is relative.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

This gives the user the possibility to add paths for resolving local relative paths.

Example `ANSIBLE_LOCAL_SEARCH_PATH=/my/path/on/local`

```yaml
- copy:
    src: a-file.txt
    dest: /tmp/
```

will now first searched in
 - `/my/path/on/local/files/a-file.txt` and
 - `/my/path/on/local/a-file.txt`

The `ansible_search_path` variable is `['/my/path/on/local', ...]`.

See ansible/ansible-documentation#1101