### PR TITLE
Reword warning if the reserved keyword `_ansible_` is used

### DIFF
--- a/changelogs/fragments/mod_args.yml
+++ b/changelogs/fragments/mod_args.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Reword warning if the reserved keyword _ansible_ used as a module parameter (https://github.com/ansible/ansible/issues/82514).

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -179,7 +179,11 @@ class ModuleArgsParser:
             for arg in args:
                 arg = to_text(arg)
                 if arg.startswith('_ansible_'):
-                    raise AnsibleError("invalid parameter specified for action '%s': '%s'" % (action, arg))
+                    err_msg = (
+                        f"Invalid parameter specified beginning with keyword '_ansible_' for action '{action !s}': '{arg !s}'. "
+                        "The prefix '_ansible_' is reserved for internal use only."
+                    )
+                    raise AnsibleError(err_msg)
 
         # finally, update the args we're going to return with the ones
         # which were normalized above

--- a/test/integration/targets/set_fact/runme.sh
+++ b/test/integration/targets/set_fact/runme.sh
@@ -34,3 +34,6 @@ ansible-playbook -i inventory set_fact_empty_str_key.yml
 
 # https://github.com/ansible/ansible/issues/21088
 ansible-playbook -i inventory "$@" set_fact_auto_unsafe.yml
+
+ansible-playbook -i inventory "$@" set_fact_ansible_vars.yml 2>&1 | tee test_set_fact_ansible_vars.out
+test "$(grep -E -c 'is reserved for internal use only.' test_set_fact_ansible_vars.out)" = 1

--- a/test/integration/targets/set_fact/set_fact_ansible_vars.yml
+++ b/test/integration/targets/set_fact/set_fact_ansible_vars.yml
@@ -1,0 +1,9 @@
+- name: Test set_fact with key starting with reserved keyword '_ansible_'
+  hosts: testhost
+  gather_facts: no
+  tasks:
+    - name: Define fact with key starting with reserved keyword '_ansible_'
+      set_fact:
+        _ansible_foo: bar
+      ignore_errors: yes
+      register: r


### PR DESCRIPTION
##### SUMMARY

Warn user if the reserved keyword `_ansible_` is used as a
module parameter.

Fixes: #82514

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


