### PR TITLE
copy - fix recursively setting mode and directory_mode with remote_src=True

### DIFF
--- a/changelogs/fragments/copy-module-fix-recursive-mode.yml
+++ b/changelogs/fragments/copy-module-fix-recursive-mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - copy - fix setting ``mode`` and ``directory_mode`` recursively when copying a remote directory (https://github.com/ansible/ansible/issues/81126).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -726,9 +726,6 @@ class AnsibleModule(object):
         if not self.selinux_enabled():
             return changed
 
-        if self.check_file_absent_if_check_mode(path):
-            return True
-
         cur_context = self.selinux_context(path)
         new_context = list(cur_context)
         # Iterate over the current context instead of the

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -375,8 +375,7 @@ def copy_diff_files(src, dest, module):
                 os.symlink(linkto, b_dest_item_path)
             else:
                 shutil.copyfile(b_src_item_path, b_dest_item_path)
-                if module.params['mode'] == 'preserve':
-                    shutil.copymode(b_src_item_path, b_dest_item_path)
+                shutil.copymode(b_src_item_path, b_dest_item_path)
             changed = True
     return changed
 
@@ -407,8 +406,7 @@ def copy_left_only(src, dest, module):
 
             if os.path.islink(b_src_item_path) and os.path.isfile(b_src_item_path) and local_follow is True:
                 shutil.copyfile(b_src_item_path, b_dest_item_path)
-                if module.params['mode'] == 'preserve':
-                    shutil.copymode(b_src_item_path, b_dest_item_path)
+                shutil.copymode(b_src_item_path, b_dest_item_path)
 
             if os.path.islink(b_src_item_path) and os.path.isfile(b_src_item_path) and local_follow is False:
                 linkto = os.readlink(b_src_item_path)
@@ -416,8 +414,7 @@ def copy_left_only(src, dest, module):
 
             if not os.path.islink(b_src_item_path) and os.path.isfile(b_src_item_path):
                 shutil.copyfile(b_src_item_path, b_dest_item_path)
-                if module.params['mode'] == 'preserve':
-                    shutil.copymode(b_src_item_path, b_dest_item_path)
+                shutil.copymode(b_src_item_path, b_dest_item_path)
 
             if not os.path.islink(b_src_item_path) and os.path.isdir(b_src_item_path):
                 shutil.copytree(b_src_item_path, b_dest_item_path, symlinks=not local_follow)

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -82,10 +82,10 @@ options:
       See CVE-2020-1736 for further details.
   directory_mode:
     description:
-    - Set the access permissions of newly created directories to the given mode.
-      Permissions on existing directories do not change.
-    - See O(mode) for the syntax of accepted values.
-    - The target system's defaults determine permissions when this parameter is not set.
+    - Set the access permissions of all directories copied from the O(src) to the given mode.
+      When O(dest) ends with a trailing slash, any intermediate destination directories created also use this mode.
+    - See O(mode) for the syntax of accepted values (V(preserve) is not supported).
+    - The target system's defaults determine permissions for newly created directories when this parameter is not set.
     type: raw
     version_added: '1.5'
   remote_src:
@@ -332,25 +332,25 @@ def adjust_recursive_directory_permissions(pre_existing_dir, new_directory_list,
     return changed
 
 
-def chown_path(module, path, owner, group):
-    """Update the owner/group if specified and different from the current owner/group."""
-    changed = module.set_owner_if_different(path, owner, False)
-    return module.set_group_if_different(path, group, changed)
-
-
-def chown_recursive(path, module):
+def walk_path_and_apply_fs_attributes(path, module, file_args, directory_args):
     changed = False
-    owner = module.params['owner']
-    group = module.params['group']
 
-    # TODO: Consolidate with the other methods calling set_*_if_different method, this is inefficient.
+    if file_args['mode'] == 'preserve':
+        # preserve is handled in copy_diff_files and copy_left_only where we have the src file
+        file_args['mode'] = None
+
+    if os.path.isfile(path):
+        file_args['path'] = path
+        changed |= module.set_fs_attributes_if_different(file_args, changed)
+        return changed
+
     for dirpath, dirnames, filenames in os.walk(path):
-        changed |= chown_path(module, dirpath, owner, group)
-        for subdir in [os.path.join(dirpath, d) for d in dirnames]:
-            changed |= chown_path(module, subdir, owner, group)
-        for filepath in [os.path.join(dirpath, f) for f in filenames]:
-            changed |= chown_path(module, filepath, owner, group)
-
+        for _dir in [dirpath] + [os.path.join(dirpath, d) for d in dirnames]:
+            directory_args['path'] = _dir
+            changed |= module.set_fs_attributes_if_different(directory_args, changed)
+        for _file in [os.path.join(dirpath, f) for f in filenames]:
+            file_args['path'] = _file
+            changed |= module.set_fs_attributes_if_different(file_args, changed)
     return changed
 
 
@@ -375,9 +375,8 @@ def copy_diff_files(src, dest, module):
                 os.symlink(linkto, b_dest_item_path)
             else:
                 shutil.copyfile(b_src_item_path, b_dest_item_path)
-                shutil.copymode(b_src_item_path, b_dest_item_path)
-
-            chown_path(module, b_dest_item_path, owner, group)
+                if module.params['mode'] == 'preserve':
+                    shutil.copymode(b_src_item_path, b_dest_item_path)
             changed = True
     return changed
 
@@ -401,7 +400,6 @@ def copy_left_only(src, dest, module):
 
             if os.path.islink(b_src_item_path) and os.path.isdir(b_src_item_path) and local_follow is True:
                 shutil.copytree(b_src_item_path, b_dest_item_path, symlinks=not local_follow)
-                chown_recursive(b_dest_item_path, module)
 
             if os.path.islink(b_src_item_path) and os.path.isdir(b_src_item_path) and local_follow is False:
                 linkto = os.readlink(b_src_item_path)
@@ -409,7 +407,8 @@ def copy_left_only(src, dest, module):
 
             if os.path.islink(b_src_item_path) and os.path.isfile(b_src_item_path) and local_follow is True:
                 shutil.copyfile(b_src_item_path, b_dest_item_path)
-                chown_path(module, b_dest_item_path, owner, group)
+                if module.params['mode'] == 'preserve':
+                    shutil.copymode(b_src_item_path, b_dest_item_path)
 
             if os.path.islink(b_src_item_path) and os.path.isfile(b_src_item_path) and local_follow is False:
                 linkto = os.readlink(b_src_item_path)
@@ -417,12 +416,11 @@ def copy_left_only(src, dest, module):
 
             if not os.path.islink(b_src_item_path) and os.path.isfile(b_src_item_path):
                 shutil.copyfile(b_src_item_path, b_dest_item_path)
-                shutil.copymode(b_src_item_path, b_dest_item_path)
-                chown_path(module, b_dest_item_path, owner, group)
+                if module.params['mode'] == 'preserve':
+                    shutil.copymode(b_src_item_path, b_dest_item_path)
 
             if not os.path.islink(b_src_item_path) and os.path.isdir(b_src_item_path):
                 shutil.copytree(b_src_item_path, b_dest_item_path, symlinks=not local_follow)
-                chown_recursive(b_dest_item_path, module)
 
             changed = True
     return changed
@@ -450,14 +448,12 @@ def copy_directory(src, dest, module):
     if not os.path.exists(dest):
         if not module.check_mode:
             shutil.copytree(src, dest, symlinks=not module.params['local_follow'])
-            chown_recursive(dest, module)
         changed = True
     else:
         diff_files_changed = copy_diff_files(src, dest, module)
         left_only_changed = copy_left_only(src, dest, module)
         common_dirs_changed = copy_common_dirs(src, dest, module)
-        owner_group_changed = chown_recursive(dest, module)
-        changed = any([diff_files_changed, left_only_changed, common_dirs_changed, owner_group_changed])
+        changed = any([diff_files_changed, left_only_changed, common_dirs_changed])
     return changed
 
 
@@ -485,7 +481,7 @@ def main():
 
     src = module.params['src']
     b_src = to_bytes(src, errors='surrogate_or_strict')
-    dest = module.params['dest']
+    dest = dest_root = module.params['dest']
     # Make sure we always have a directory component for later processing
     if os.path.sep not in dest:
         dest = '.{0}{1}'.format(os.path.sep, dest)
@@ -496,7 +492,6 @@ def main():
     validate = module.params.get('validate', None)
     follow = module.params['follow']
     local_follow = module.params['local_follow']
-    mode = module.params['mode']
     owner = module.params['owner']
     group = module.params['group']
     remote_src = module.params['remote_src']
@@ -510,8 +505,9 @@ def main():
     # Preserve is usually handled in the action plugin but mode + remote_src has to be done on the
     # remote host
     if module.params['mode'] == 'preserve':
-        module.params['mode'] = '0%03o' % stat.S_IMODE(os.stat(b_src).st_mode)
-    mode = module.params['mode']
+        mode = '0%03o' % stat.S_IMODE(os.stat(b_src).st_mode)
+    else:
+        mode = module.params['mode']
 
     changed = False
 
@@ -557,13 +553,7 @@ def main():
                 module.exit_json(msg='dest directory %s would be created' % dirname, changed=True, src=src)
             os.makedirs(b_dirname)
             changed = True
-            directory_args = module.load_file_common_arguments(module.params)
-            directory_mode = module.params["directory_mode"]
-            if directory_mode is not None:
-                directory_args['mode'] = directory_mode
-            else:
-                directory_args['mode'] = None
-            adjust_recursive_directory_permissions(pre_existing_dir, new_directory_list, module, directory_args, changed)
+            dest_root = os.path.join(pre_existing_dir, new_directory_list[0]) if new_directory_list else dirname
 
     if os.path.isdir(b_dest):
         basename = os.path.basename(src)
@@ -612,7 +602,8 @@ def main():
                     # if we have a mode, make sure we set it on the temporary
                     # file source as some validations may require it
                     module.set_mode_if_different(src, mode, False)
-                    chown_path(module, src, owner, group)
+                    module.set_owner_if_different(src, owner, False)
+                    module.set_group_if_different(src, group, False)
                     if "%s" not in validate:
                         module.fail_json(msg="validate must contain %%s: %s" % (validate))
                     (rc, out, err) = module.run_command(validate % src)
@@ -661,10 +652,11 @@ def main():
         res_args['backup_file'] = backup_file
 
     file_args = module.load_file_common_arguments(module.params, path=dest)
-    directory_mode = module.params['directory_mode']
-    if os.path.isdir(b_dest) and directory_mode is not None:
-        file_args['mode'] = directory_mode
-    res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'])
+    if file_args['mode'] == 'preserve' and os.path.isfile(dest):
+        file_args['mode'] = mode
+    directory_args = file_args.copy()
+    directory_args['mode'] = module.params['directory_mode']
+    res_args['changed'] |= walk_path_and_apply_fs_attributes(dest_root, module, file_args, directory_args)
 
     module.exit_json(**res_args)
 

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -406,7 +406,6 @@ def copy_left_only(src, dest, module):
 
             if os.path.islink(b_src_item_path) and os.path.isfile(b_src_item_path) and local_follow is True:
                 shutil.copyfile(b_src_item_path, b_dest_item_path)
-                shutil.copymode(b_src_item_path, b_dest_item_path)
 
             if os.path.islink(b_src_item_path) and os.path.isfile(b_src_item_path) and local_follow is False:
                 linkto = os.readlink(b_src_item_path)

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -477,7 +477,7 @@ def main():
 
     src = module.params['src']
     b_src = to_bytes(src, errors='surrogate_or_strict')
-    dest = dest_root = module.params['dest']
+    dest = module.params['dest']
     # Make sure we always have a directory component for later processing
     if os.path.sep not in dest:
         dest = '.{0}{1}'.format(os.path.sep, dest)
@@ -532,6 +532,7 @@ def main():
         )
 
     # Special handling for recursive copy - create intermediate dirs
+    created_intermediate_dir = None
     if dest.endswith(os.sep):
         if _original_basename:
             dest = os.path.join(dest, _original_basename)
@@ -549,7 +550,7 @@ def main():
                 module.exit_json(msg='dest directory %s would be created' % dirname, changed=True, src=src)
             os.makedirs(b_dirname)
             changed = True
-            dest_root = os.path.join(pre_existing_dir, new_directory_list[0]) if new_directory_list else dirname
+            created_intermediate_dir = os.path.join(pre_existing_dir, new_directory_list[0]) if new_directory_list else dirname
 
     if os.path.isdir(b_dest):
         basename = os.path.basename(src)
@@ -647,12 +648,12 @@ def main():
     if backup_file:
         res_args['backup_file'] = backup_file
 
-    file_args = module.load_file_common_arguments(module.params, path=dest)
+    file_args = module.load_file_common_arguments(module.params, path=created_intermediate_dir or dest)
     if file_args['mode'] == 'preserve' and os.path.isfile(dest):
         file_args['mode'] = mode
     directory_args = file_args.copy()
     directory_args['mode'] = module.params['directory_mode']
-    res_args['changed'] |= walk_path_and_apply_fs_attributes(dest_root, module, file_args, directory_args)
+    res_args['changed'] |= walk_path_and_apply_fs_attributes(file_args['path'], module, file_args, directory_args)
 
     module.exit_json(**res_args)
 

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -1673,6 +1673,7 @@
     file:
       path: '{{ remote_dir }}/testcase1_local_follow_true'
       state: directory
+      mode: '0555'
 
   - name: execute - Copy the directory on remote with local_follow True
     copy:
@@ -1680,6 +1681,8 @@
       src: '{{ remote_dir }}/remote_dir_src/'
       dest: '{{ remote_dir }}/testcase1_local_follow_true'
       local_follow: True
+      mode: '0555'
+      directory_mode: '0555'
     register: testcase1
 
   - name: gather - Stat the testcase1_local_follow_true
@@ -1708,14 +1711,55 @@
       that:
       - testcase1 is changed
       - "stat_testcase1_local_follow_true.stat.isdir"
+      - "stat_testcase1_local_follow_true.stat.mode == '0555'"
       - "stat_testcase1_local_follow_true_subdir.stat.isdir"
+      - "stat_testcase1_local_follow_true_subdir.stat.mode == '0555'"
       - "stat_testcase1_local_follow_true_file1.stat.exists"
+      - "stat_testcase1_local_follow_true_file1.stat.mode == '0555'"
       - "stat_remote_dir_src_file1_before.stat.checksum == stat_testcase1_local_follow_true_file1.stat.checksum"
       - "stat_testcase1_local_follow_true_subdir_file12.stat.exists"
       - "stat_remote_dir_src_subdir_file12_before.stat.checksum == stat_testcase1_local_follow_true_subdir_file12.stat.checksum"
       - "stat_testcase1_local_follow_true_link_file12.stat.exists"
       - "not stat_testcase1_local_follow_true_link_file12.stat.islnk"
+      - "stat_testcase1_local_follow_true_link_file12.stat.mode == '0555'"
       - "stat_remote_dir_src_subdir_file12_before.stat.checksum == stat_testcase1_local_follow_true_link_file12.stat.checksum"
+
+  - name: execute - Copy the directory on remote with local_follow True again
+    copy:
+      remote_src: True
+      src: '{{ remote_dir }}/remote_dir_src/'
+      dest: '{{ remote_dir }}/testcase1_local_follow_true'
+      local_follow: True
+      mode: '0555'
+      directory_mode: '0555'
+    register: testcase1_idempotent
+
+  - name: execute - Copy the directory on remote with local_follow True and modified mode
+    copy:
+      remote_src: True
+      src: '{{ remote_dir }}/remote_dir_src/'
+      dest: '{{ remote_dir }}/testcase1_local_follow_true'
+      local_follow: True
+      mode: '0547'
+      directory_mode: '0547'
+    register: testcase1_modified_mode
+
+  - name: gather - stat modified testcase1 files
+    stat:
+      path: '{{ remote_dir }}/{{ item }}'
+    register: testcase1_modified_stat
+    loop:
+      - testcase1_local_follow_true
+      - testcase1_local_follow_true/subdir
+      - testcase1_local_follow_true/file1
+      - testcase1_local_follow_true/subdir/file12
+
+  - name: assert - remote_dir_src has copied with local_follow True.
+    assert:
+      that:
+      - testcase1_idempotent is not changed
+      - testcase1_modified_mode is changed
+      - testcase1_modified_stat.results | map(attribute='stat') | map(attribute='mode') | unique == ['0547']
 
 ### local_follow: False
   - name: execute - Create a test dest dir


### PR DESCRIPTION
##### SUMMARY

Fixes #81126

Also simplified the chown_recursive function by walking the path once at most and using the module_utils functions to handle check mode, None values for owner/group/mode/directory_mode, and getting the cumulative changed value.

##### ISSUE TYPE

- Bugfix Pull Request
