### PR TITLE
Add support for crypt/libxcrypt via ctypes, as an alternative to passlib

### DIFF
--- a/lib/ansible/utils/crypt.py
+++ b/lib/ansible/utils/crypt.py
@@ -1,0 +1,31 @@
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+
+__all__ = ['CRYPT_NAME', 'crypt']
+
+# prefer ``libcrypt``/``libxcrypt`` over ``libc``
+# libc can return None, and still give us the functionality we need
+for _lib_name, _allow_none in (('crypt', False), ('c', True)):
+    _lib_so = ctypes.util.find_library(_lib_name)
+    if not _lib_so and not _allow_none:
+        # None will load ``libc`` in LoadLibrary, if we requested ``crypt``
+        # we don't want to allow that becoming ``libc``
+        continue
+    _lib = ctypes.cdll.LoadLibrary(_lib_so)
+    try:
+        crypt = _lib.crypt
+    except AttributeError:
+        # Whatever lib this is exists, but is missing ``crypt``
+        continue
+    crypt.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    crypt.restype = ctypes.c_char_p
+    break
+else:
+    raise ImportError('Cannot find crypt implementation')
+
+CRYPT_NAME = _lib_name

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -8,8 +8,6 @@ import string
 
 from collections import namedtuple
 
-import ctypes
-import ctypes.util
 import re
 import sys
 
@@ -33,30 +31,11 @@ try:
 except Exception as e:
     PASSLIB_E = e
 
-CRYPT_NAME = None
+CRYPT_NAME: str | None = None
 CRYPT_E = None
 HAS_CRYPT = False
 try:
-    # prefer ``libcrypt``/``libxcrypt`` over ``libc``
-    # libc can return None, and still give us the functionality we need
-    for _lib_name, _allow_none in (('crypt', False), ('c', True)):
-        _lib_so = ctypes.util.find_library(_lib_name)
-        if not _lib_so and not _allow_none:
-            # None will load ``libc`` in LoadLibrary, if we requested ``crypt``
-            # we don't want to allow that becoming ``libc``
-            continue
-        _lib = ctypes.cdll.LoadLibrary(_lib_so)
-        try:
-            crypt = _lib.crypt
-        except AttributeError:
-            # Whatever lib this is exists, but is missing ``crypt``
-            continue
-        crypt.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
-        crypt.restype = ctypes.c_char_p
-        break
-    else:
-        raise ImportError('Cannot find crypt implementation')
-    CRYPT_NAME = _lib_name
+    from ansible.utils.crypt import CRYPT_NAME, crypt
     HAS_CRYPT = True
 except Exception as e:
     CRYPT_E = e

--- a/test/integration/targets/filter_core/aliases
+++ b/test/integration/targets/filter_core/aliases
@@ -1,2 +1,4 @@
 shippable/posix/group4
 setup/always/setup_passlib_controller  # required for setup_test_user
+setup/always/setup_libxcrypt
+destructive

--- a/test/integration/targets/filter_core/password_hash.yml
+++ b/test/integration/targets/filter_core/password_hash.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  tasks:
+    - import_role:
+        name: filter_core
+        tasks_from: password_hash.yml
+      vars:
+        is_crypt: true

--- a/test/integration/targets/filter_core/runme.sh
+++ b/test/integration/targets/filter_core/runme.sh
@@ -7,6 +7,6 @@ ANSIBLE_ROLES_PATH=../ ansible-playbook handle_undefined_type_errors.yml "$@"
 
 # Remove passlib installed by setup_passlib_controller
 source virtualenv.sh
-SITE_PACKAGES=$(python -c "import sysconfig; print(sysconfig.get_path('purelib', scheme='venv'))")
-echo "raise ImportError('passlib')" > ${SITE_PACKAGES}/passlib.py
+SITE_PACKAGES=$(python -c "import sysconfig; print(sysconfig.get_path('purelib'))")
+echo "raise ImportError('passlib')" > "${SITE_PACKAGES}/passlib.py"
 ANSIBLE_ROLES_PATH=../ ansible-playbook password_hash.yml "$@"

--- a/test/integration/targets/filter_core/runme.sh
+++ b/test/integration/targets/filter_core/runme.sh
@@ -4,3 +4,7 @@ set -eux
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook runme.yml "$@"
 ANSIBLE_ROLES_PATH=../ ansible-playbook handle_undefined_type_errors.yml "$@"
+
+# Remove passlib installed by setup_passlib_controller
+python -m pip uninstall -y passlib
+ANSIBLE_ROLES_PATH=../ ansible-playbook password_hash.yml "$@"

--- a/test/integration/targets/filter_core/runme.sh
+++ b/test/integration/targets/filter_core/runme.sh
@@ -6,5 +6,7 @@ ANSIBLE_ROLES_PATH=../ ansible-playbook runme.yml "$@"
 ANSIBLE_ROLES_PATH=../ ansible-playbook handle_undefined_type_errors.yml "$@"
 
 # Remove passlib installed by setup_passlib_controller
-python -m pip uninstall -y passlib
+source virtualenv.sh
+SITE_PACKAGES=$(python -c "import sysconfig; print(sysconfig.get_path('purelib', scheme='venv'))")
+echo "raise ImportError('passlib')" > ${SITE_PACKAGES}/passlib.py
 ANSIBLE_ROLES_PATH=../ ansible-playbook password_hash.yml "$@"

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -453,40 +453,6 @@
       - '[1,3,5,7,9]|shuffle(seed=1337)|length == 5'
       - '22|shuffle == 22'
 
-- name: Verify password_hash throws on weird salt_size type
-  set_fact:
-    foo: '{{"hey"|password_hash(salt_size=[999])}}'
-  ignore_errors: yes
-  register: password_hash_1
-
-- name: Verify password_hash throws on weird hashtype
-  set_fact:
-    foo: '{{"hey"|password_hash(hashtype="supersecurehashtype")}}'
-  ignore_errors: yes
-  register: password_hash_2
-
-- name: Verify password_hash
-  assert:
-    that:
-      - "'what in the WORLD is up?'|password_hash|length == 120 or 'what in the WORLD is up?'|password_hash|length == 106"
-      # This throws a vastly different error on py2 vs py3, so we just check
-      # that it's a failure, not a substring of the exception.
-      - password_hash_1 is failed
-      - password_hash_2 is failed
-      - "'not support' in password_hash_2.msg"
-
-- name: test using passlib with an unsupported hash type
-  set_fact:
-    foo: '{{"hey"|password_hash("msdcc")}}'
-  ignore_errors: yes
-  register: unsupported_hash_type
-
-- assert:
-    that:
-      - unsupported_hash_type.msg == msg
-  vars:
-    msg: "msdcc is not in the list of supported passlib algorithms: md5, blowfish, sha256, sha512"
-
 - name: Verify to_uuid throws on weird namespace
   set_fact:
     foo: '{{"hey"|to_uuid(namespace=22)}}'
@@ -739,3 +705,5 @@
     splitty:
       - "1,2,3"
       - "4,5,6"
+
+- include_tasks: password_hash.yml

--- a/test/integration/targets/filter_core/tasks/password_hash.yml
+++ b/test/integration/targets/filter_core/tasks/password_hash.yml
@@ -1,0 +1,45 @@
+- name: Verify password_hash throws on weird salt_size type
+  set_fact:
+    foo: '{{"hey"|password_hash(salt_size=[999])}}'
+  ignore_errors: yes
+  register: password_hash_1
+
+- name: Verify password_hash throws on weird hashtype
+  set_fact:
+    foo: '{{"hey"|password_hash(hashtype="supersecurehashtype")}}'
+  ignore_errors: yes
+  register: password_hash_2
+
+- name: Debug the output for the next assert
+  debug:
+    msg: "{{ 'what in the WORLD is up?'|password_hash }}"
+
+- name: Verify password_hash
+  assert:
+    that:
+      - "'what in the WORLD is up?'|password_hash|length == 120 or 'what in the WORLD is up?'|password_hash|length == 106"
+      # This throws a vastly different error on py2 vs py3, so we just check
+      # that it's a failure, not a substring of the exception.
+      - password_hash_1 is failed
+      - password_hash_2 is failed
+      - "'not support' in password_hash_2.msg"
+
+- name: test using an unsupported hash type
+  set_fact:
+    foo: '{{"hey"|password_hash("msdcc")}}'
+  ignore_errors: yes
+  register: unsupported_hash_type
+
+- assert:
+    that:
+      - unsupported_hash_type.msg == msg
+  vars:
+    msg: "msdcc is not in the list of supported passlib algorithms: md5, blowfish, sha256, sha512"
+  when: is_crypt|default(false) is false
+
+- assert:
+    that:
+      - unsupported_hash_type.msg == msg
+  vars:
+    msg: crypt does not support 'msdcc' algorithm. crypt does not support 'msdcc' algorithm
+  when: is_crypt|default(false) is true

--- a/test/integration/targets/setup_libxcrypt/handlers/main.yml
+++ b/test/integration/targets/setup_libxcrypt/handlers/main.yml
@@ -1,0 +1,6 @@
+- name: uninstall libxcrypt
+  command: brew uninstall libxcrypt
+  become: yes
+  become_user: "{{ brew_stat.stat.pw_name }}"
+  environment:
+    HOMEBREW_NO_AUTO_UPDATE: True

--- a/test/integration/targets/setup_libxcrypt/tasks/main.yml
+++ b/test/integration/targets/setup_libxcrypt/tasks/main.yml
@@ -1,0 +1,28 @@
+- when: ansible_facts.distribution == 'MacOSX'
+  block:
+    - name: MACOS | Find brew binary
+      command: which brew
+      register: brew_which
+
+    - name: MACOS | Get owner of brew binary
+      stat:
+        path: "{{ brew_which.stdout }}"
+      register: brew_stat
+
+    - become: yes
+      become_user: "{{ brew_stat.stat.pw_name }}"
+      environment:
+        HOMEBREW_NO_AUTO_UPDATE: True
+      block:
+        - name: MAXOS | Install libxcrypt
+          command: brew install libxcrypt
+
+        - name: MACOS | Get brew prefix
+          command: brew --prefix
+          register: brew_prefix
+
+        - name: MACOS | Link libxcrypt
+          file:
+            src: '{{ brew_prefix.stdout_lines.0 }}/opt/libxcrypt/lib/libcrypt.dylib'
+            dest: /usr/local/lib/libcrypt.dylib
+            state: link


### PR DESCRIPTION
##### SUMMARY

Add support for crypt/libxcrypt via ctypes, as an alternative to passlib

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
