### PR TITLE
ensure correct handling of ansible_loop_var and ansible_index_var iin ansible.builtin.include_tasks

### DIFF
--- a/changelogs/fragments/82655_fixed_ansible-loop-index-var.yml
+++ b/changelogs/fragments/82655_fixed_ansible-loop-index-var.yml
@@ -1,9 +1,2 @@
-## Changelog
-
-### Bug Fixes
-
-- Fix an issue in `ansible.builtin.include_tasks` where `ansible_loop_var` and `ansible_index_var` were not working as expected in a loop (Issue #82655 https://github.com/ansible/ansible/issues/82655)
-
-### Internal Changes
-
-- Update `included_file.py` to properly set `ansible_loop_var` and `ansible_index_var` in `ansible.builtin.include_tasks` when used in a loop
+bugfixes:
+    - include_tasks - include `ansible_loop_var` and `ansible_index_var` in a loop (https://github.com/ansible/ansible/issues/82655).

--- a/changelogs/fragments/82655_fixed_ansible-loop-index-var.yml
+++ b/changelogs/fragments/82655_fixed_ansible-loop-index-var.yml
@@ -1,0 +1,9 @@
+## Changelog
+
+### Bug Fixes
+
+- Fix an issue in `ansible.builtin.include_tasks` where `ansible_loop_var` and `ansible_index_var` were not working as expected in a loop (Issue #82655 https://github.com/ansible/ansible/issues/82655)
+
+### Internal Changes
+
+- Update `included_file.py` to properly set `ansible_loop_var` and `ansible_index_var` in `ansible.builtin.include_tasks` when used in a loop

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -95,8 +95,10 @@ class IncludedFile:
                     index_var = include_result.get('ansible_index_var')
                     if loop_var in include_result:
                         task_vars[loop_var] = special_vars[loop_var] = include_result[loop_var]
+                        task_vars['ansible_loop_var'] = special_vars['ansible_loop_var'] = loop_var
                     if index_var and index_var in include_result:
                         task_vars[index_var] = special_vars[index_var] = include_result[index_var]
+                        task_vars['ansible_index_var'] = special_vars['ansible_index_var'] = index_var
                     if '_ansible_item_label' in include_result:
                         task_vars['_ansible_item_label'] = special_vars['_ansible_item_label'] = include_result['_ansible_item_label']
                     if 'ansible_loop' in include_result:

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -128,7 +128,7 @@ def test_process_include_tasks_results(mock_iterator, mock_variable_manager):
     assert res[0]._filename == os.path.join(os.getcwd(), 'include_test.yml')
     assert res[0]._hosts == ['testhost1', 'testhost2']
     assert res[0]._args == {}
-    assert res[0]._vars == {}
+    assert res[0]._vars == {'ansible_loop_var': 'item'}
 
 
 def test_process_include_tasks_diff_files(mock_iterator, mock_variable_manager):
@@ -169,8 +169,8 @@ def test_process_include_tasks_diff_files(mock_iterator, mock_variable_manager):
     assert res[0]._args == {}
     assert res[1]._args == {}
 
-    assert res[0]._vars == {}
-    assert res[1]._vars == {}
+    assert res[0]._vars == {'ansible_loop_var': 'item'}
+    assert res[1]._vars == {'ansible_loop_var': 'index'}
 
 
 def test_process_include_tasks_simulate_free(mock_iterator, mock_variable_manager):
@@ -208,8 +208,8 @@ def test_process_include_tasks_simulate_free(mock_iterator, mock_variable_manage
     assert res[0]._args == {}
     assert res[1]._args == {}
 
-    assert res[0]._vars == {}
-    assert res[1]._vars == {}
+    assert res[0]._vars == {'ansible_loop_var': 'item'}
+    assert res[1]._vars == {'ansible_loop_var': 'index'}
 
 
 def test_process_include_simulate_free_block_role_tasks(mock_iterator,
@@ -305,8 +305,8 @@ def test_process_include_simulate_free_block_role_tasks(mock_iterator,
     assert res[0]._args == {}
     assert res[1]._args == {}
 
-    assert res[0]._vars == {}
-    assert res[1]._vars == {}
+    assert res[0]._vars == {'ansible_loop_var': 'item'}
+    assert res[1]._vars == {'ansible_loop_var': 'index'}
 
 
 def test_empty_raw_params():

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -208,8 +208,8 @@ def test_process_include_tasks_simulate_free(mock_iterator, mock_variable_manage
     assert res[0]._args == {}
     assert res[1]._args == {}
 
-    assert res[0]._vars == {'ansible_loop_var': 'item'}
-    assert res[1]._vars == {'ansible_loop_var': 'index'}
+    assert res[0]._vars == {}
+    assert res[1]._vars == {}
 
 
 def test_process_include_simulate_free_block_role_tasks(mock_iterator,
@@ -305,8 +305,8 @@ def test_process_include_simulate_free_block_role_tasks(mock_iterator,
     assert res[0]._args == {}
     assert res[1]._args == {}
 
-    assert res[0]._vars == {'ansible_loop_var': 'item'}
-    assert res[1]._vars == {'ansible_loop_var': 'index'}
+    assert res[0]._vars == {}
+    assert res[1]._vars == {}
 
 
 def test_empty_raw_params():


### PR DESCRIPTION
The issue was identified in ansible.builtin.include_tasks when using ansible_loop_var and ansible_index_var in a loop. The variables were not being processed correctly, leading to unexpected behavior. This fix addresses the problem and ensures proper handling of ansible_loop_var and ansible_index_var in the mentioned scenario.

##### SUMMARY

The changes in included_file.py address GitHub issue #82655 by fixing the handling of ansible_loop_var and ansible_index_var when using ansible.builtin.include_tasks in a loop. This ensures correct processing of loop variables, resolving the reported bug and enhancing predictability in loop scenarios.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
