### PR TITLE
Fix error when templating an unsafe string leading to a type error in Python

### DIFF
--- a/changelogs/fragments/82675-fix-unsafe-templating-leading-to-type-error.yml
+++ b/changelogs/fragments/82675-fix-unsafe-templating-leading-to-type-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - template - Fix error when templating an unsafe string which corresponds to an invalid type in Python (https://github.com/ansible/ansible/issues/82600).

--- a/lib/ansible/template/native_helpers.py
+++ b/lib/ansible/template/native_helpers.py
@@ -65,7 +65,7 @@ def ansible_eval_concat(nodes):
                     )
                 )
             )
-        except (ValueError, SyntaxError, MemoryError):
+        except (TypeError, ValueError, SyntaxError, MemoryError):
             pass
 
     return out
@@ -127,7 +127,7 @@ def ansible_native_concat(nodes):
             # parse the string ourselves without removing leading spaces/tabs.
             ast.parse(out, mode='eval')
         )
-    except (ValueError, SyntaxError, MemoryError):
+    except (TypeError, ValueError, SyntaxError, MemoryError):
         return out
 
     if isinstance(evaled, string_types):

--- a/test/integration/targets/template/unsafe.yml
+++ b/test/integration/targets/template/unsafe.yml
@@ -3,6 +3,7 @@
   vars:
     nottemplated: this should not be seen
     imunsafe: !unsafe '{{ nottemplated }}'
+    unsafe_set: !unsafe '{{ "test" }}'
   tasks:
 
     - set_fact:
@@ -12,11 +13,15 @@
     - set_fact:
           this_always_safe: '{{ imunsafe }}'
 
+    - set_fact:
+        this_unsafe_set: "{{ unsafe_set }}"
+
     - name: ensure nothing was templated
       assert:
         that:
         - this_always_safe == imunsafe
         - imunsafe == this_was_unsafe.strip()
+        - unsafe_set == this_unsafe_set.strip()
 
 
 - hosts: localhost


### PR DESCRIPTION
##### SUMMARY

Fixes #82600.

The PR applies the fix proposed in (https://github.com/ansible/ansible/issues/82600), namely to catch also the TypeError that otherwise does not allow to template unsafe strings that can lead to invalid types in Python, such as a set of sets, as happened in the case of the issue mentioned above. 

Moreover, the existing test was slightly modified to cover also this case. 

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

After the fix

```
ansible -i localhost -e ansible_connection=local -e '{"foo":{"__ansible_unsafe":"{{\"hello\"}}"}}' -m debug -a "msg={{foo}}" localhost
localhost | SUCCESS => {
    "msg": "{{\"hello\"}}"
}
```

Before the fix


```
ansible -i localhost -e ansible_connection=local -e '{"foo":{"__ansible_unsafe":"{{\"hello\"}}"}}' -m debug -a "msg={{foo}}" localhost
localhost | FAILED! => {
    "msg": "Unexpected templating type error occurred on ({{foo}}): unhashable type: 'set'. unhashable type: 'set'"
}

```