### PR TITLE
remove 'allow_duplicates' param for include/import role

### DIFF
--- a/lib/ansible/modules/import_role.py
+++ b/lib/ansible/modules/import_role.py
@@ -38,11 +38,6 @@ options:
       - File to load from a role's C(defaults/) directory.
     type: str
     default: main
-  allow_duplicates:
-    description:
-      - Overrides the role's metadata setting to allow using a role more than once with the same parameters.
-    type: bool
-    default: yes
   handlers_from:
     description:
       - File to load from a role's C(handlers/) directory.

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -45,11 +45,6 @@ options:
       - File to load from a role's C(defaults/) directory.
     type: str
     default: main
-  allow_duplicates:
-    description:
-      - Overrides the role's metadata setting to allow using a role more than once with the same parameters.
-    type: bool
-    default: yes
   public:
     description:
       - This option dictates whether the role's C(vars) and C(defaults) are exposed to the play. If set to V(true)


### PR DESCRIPTION
##### SUMMARY

Part of correcting the documentation about how to deduplicate roles. I've read several issues, many of them closed. I believe that `allow_duplicates` was never implemented for either `include_role` or for `import_role`, and that Ansible currently runs the same role multiple times if a play imports or includes it more than once. This PR removes the parameter from the module documentation for those two modules. A [companion PR in ansible-documentation](https://github.com/ansible/ansible-documentation/pull/1123) updates the pages on reusing roles to match.

If this isn't correct, I'm happy to change the PR to reflect whatever the current actual behavior of Ansible is.

Related to https://github.com/ansible/ansible-documentation/issues/90. 

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

N/A