### PR TITLE
load extra_vars from inventory

### DIFF
--- a/changelogs/fragments/82680-extra-vars-from-inventory-dir.yml
+++ b/changelogs/fragments/82680-extra-vars-from-inventory-dir.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Load 'extra_vars' from the inventory directory. This eliminates the need to redundantly define credentials and tokens when used in modules and dynamic inventories.

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -43,7 +43,7 @@ from ansible.vars.plugins import get_vars_from_inventory_sources
 
 display = Display()
 
-IGNORED_ALWAYS = [br"^\.", b"^host_vars$", b"^group_vars$", b"^vars_plugins$"]
+IGNORED_ALWAYS = [br"^\.", b"^host_vars$", b"^group_vars$", b"^extra_vars(.y[a]?ml)?$", b"^vars_plugins$"]
 IGNORED_PATTERNS = [to_bytes(x) for x in C.INVENTORY_IGNORE_PATTERNS]
 IGNORED_EXTS = [b'%s$' % to_bytes(re.escape(x)) for x in C.INVENTORY_IGNORE_EXTS]
 

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -184,6 +184,18 @@ def load_extra_vars(loader):
 
     if not getattr(load_extra_vars, 'extra_vars', None):
         extra_vars = {}
+
+        # load extra_vars from inventory
+        if loader:
+            for inventory_path in context.CLIARGS.get('inventory', tuple()):
+                for extra_var_file in loader.find_vars_files(inventory_path, 'extra_vars'):
+                    data = loader.load_from_file(extra_var_file)
+                    if isinstance(data, MutableMapping):
+                        extra_vars = combine_vars(extra_vars, data)
+                    else:
+                        raise AnsibleOptionsError("Invalid extra vars file supplied. '%s' could not be made into a dictionary" % extra_var_file)
+
+        # load extra_vars from CLIARGS
         for extra_vars_opt in context.CLIARGS.get('extra_vars', tuple()):
             data = None
             extra_vars_opt = to_text(extra_vars_opt, errors='surrogate_or_strict')


### PR DESCRIPTION
##### SUMMARY
This minor adjustment enables the direct retrieval of **extra_vars** from the inventory directory. Consequently, we can conveniently define variables for API tokens or credentials in that location, facilitating their use in modules and dynamic inventories. This serves as a viable alternative in scenarios where you cannot or prefer not to pass them through environment variables or the CLI argument --extra-vars.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION
This will not break any existing functions. The --extra-vars arg will work as before.

Example structure:
```
inventory/
  extra_vars/
    creds.yml # vars file
  hcloud.yml # config for dynamic inventory
  vmware.yml # config for dynamic inventory
```
```
inventory/
  extra_vars.yml # vars file
  hcloud.yml # config for dynamic inventory
  vmware.yml # config for dynamic inventory
```