### PR TITLE
Output MarkDown version next to RST version of changelog

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include COPYING
 include bin/*
+include changelogs/CHANGELOG*.md
 include changelogs/CHANGELOG*.rst
 include changelogs/changelog.yaml
 include licenses/*.txt

--- a/changelogs/README.md
+++ b/changelogs/README.md
@@ -1,8 +1,8 @@
 Changelogs
 ==========
 
-As part of the release process a version-specific `CHANGELOG-vX.Y.rst` will be generated from fragments in
-the `fragments` directory.
+As part of the release process a version-specific `CHANGELOG-vX.Y.rst` and `CHANGELOG-vX.Y.md` will be generated from
+fragments in the `fragments` directory.
 
 On release branches once a release has been created, consult the branch's version-specific file for changes that have
 occurred in that branch. The `devel` branch does not have a generated changelog, only changelog fragments.

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -11,6 +11,9 @@ mention_ancestor: false
 notesdir: fragments
 prelude_section_name: release_summary
 new_plugins_after_name: removed_features
+output_formats:
+- md
+- rst
 sections:
 - ['major_changes', 'Major Changes']
 - ['minor_changes', 'Minor Changes']

--- a/packaging/release.py
+++ b/packaging/release.py
@@ -973,7 +973,7 @@ def create_github_release_notes(upstream: Remote, repository: str, version: Vers
     variables = dict(
         version=version,
         releases=get_release_artifact_details(repository, version, validate),
-        changelog=f"https://github.com/{upstream.user}/{upstream.repo}/blob/v{version}/changelogs/CHANGELOG-v{version.major}.{version.minor}.rst",
+        changelog=f"https://github.com/{upstream.user}/{upstream.repo}/blob/v{version}/changelogs/CHANGELOG-v{version.major}.{version.minor}.md",
     )
 
     release_notes = template.render(**variables).strip()
@@ -1094,7 +1094,7 @@ This release is a maintenance release containing numerous bugfixes.
 {% endif %}
 The full changelog can be found here:
 
-https://github.com/{{ upstream.user }}/{{ upstream.repo }}/blob/v{{ version }}/changelogs/CHANGELOG-v{{ info.short }}.rst
+https://github.com/{{ upstream.user }}/{{ upstream.repo }}/blob/v{{ version }}/changelogs/CHANGELOG-v{{ info.short }}.md
 
 
 Schedule for future releases

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -161,9 +161,13 @@ def main() -> None:
             # Make sure a changelog exists for this version when testing from devel.
             # When testing from a stable branch the changelog will already exist.
             major_minor_version = '.'.join(__version__.split('.')[:2])
-            changelog_path = f'changelogs/CHANGELOG-v{major_minor_version}.rst'
-            pathlib.Path(clean_repo_dir, changelog_path).touch()
-            complete_file_list.append(changelog_path)
+            changelog_paths = [
+                f'changelogs/CHANGELOG-v{major_minor_version}.rst',
+                f'changelogs/CHANGELOG-v{major_minor_version}.md',
+            ]
+            for changelog_path in changelog_paths:
+                pathlib.Path(clean_repo_dir, changelog_path).touch()
+                complete_file_list.append(changelog_path)
 
         expected_sdist_files = collect_sdist_files(complete_file_list)
         expected_wheel_files = collect_wheel_files(complete_file_list)


### PR DESCRIPTION
##### SUMMARY
antsibull-changelog (from version 0.24.0 on) can now output both RST and MD verisons of the changelog. (RST changelog fragments are converted to MD.)

This became kind of necessary since GitHub's RST rendering stopped working recently for larger RST files (https://github.com/orgs/community/discussions/86715#discussioncomment-8435972). Right now the ansible-core 2.16 changelog still renders: https://github.com/ansible/ansible/blob/stable-2.16/changelogs/CHANGELOG-v2.16.rst - but that can stop at any moment. The 2.15 (https://github.com/ansible/ansible/blob/stable-2.15/changelogs/CHANGELOG-v2.15.rst) and 2.14 (https://github.com/ansible/ansible/blob/stable-2.14/changelogs/CHANGELOG-v2.14.rst) changelogs only show as source.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request
