### PR TITLE
Update urls.py cert paths for ubuntu 20.04

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -539,6 +539,9 @@ def get_ca_certs(cafile=None, capath=None):
         paths_checked.add('/etc/pki/ca-trust/extracted/pem')
         paths_checked.add('/etc/pki/tls/certs')
         paths_checked.add('/usr/share/ca-certificates/cacert.org')
+        # add paths that are present in WSLv1 Ubuntu 20.04
+        paths_checked.add('/usr/lib/ssl/certs')
+        paths_checked.add('/etc/ssl/certs')
     elif system == u'FreeBSD':
         paths_checked.add('/usr/local/share/certs')
     elif system == u'OpenBSD':


### PR DESCRIPTION
##### SUMMARY

For users leveraging Ubuntu WSLv1, there is no default path for certs that matches  

##### ISSUE TYPE  

- Bugfix Pull Request  

##### ADDITIONAL INFORMATION

The only workaround for for this is to create a sym link between a quoted default cert path from the code to the default cert path in Ubuntu 20.04 (This could be the case for other Ubuntu versions but was not tested).
