### PR TITLE
Implement concurrent role downloads via "max_concurrent_downloads" option

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import errno
 import datetime
 import functools
@@ -269,6 +270,177 @@ class GalaxyRole(object):
 
         return False
 
+    async def fetch_async(self, role_data):
+        """
+        Downloads the archived role to a temp location based on role data asynchronously using multithreading
+        """
+
+        loop = asyncio.get_running_loop()
+        temp_file_name = await loop.run_in_executor(None, self.fetch, role_data)
+        return temp_file_name
+
+    def _get_role_data_from_api(self):
+        role_data = self.api.lookup_role_by_name(self.src)
+        if not role_data:
+            raise AnsibleError("- sorry, %s was not found on %s." % (self.src, self.api.api_server))
+
+        if role_data.get('role_type') == 'APP':
+            # Container Role
+            display.warning("%s is a Container App role, and should only be installed using Ansible "
+                            "Container" % self.name)
+
+        role_versions = self.api.fetch_role_related('versions', role_data['id'])
+        if not self.version:
+            # convert the version names to LooseVersion objects
+            # and sort them to get the latest version. If there
+            # are no versions in the list, we'll grab the head
+            # of the master branch
+            if len(role_versions) > 0:
+                loose_versions = [LooseVersion(a.get('name', None)) for a in role_versions]
+                try:
+                    loose_versions.sort()
+                except TypeError:
+                    raise AnsibleError(
+                        'Unable to compare role versions (%s) to determine the most recent version due to incompatible version formats. '
+                        'Please contact the role author to resolve versioning conflicts, or specify an explicit role version to '
+                        'install.' % ', '.join([v.vstring for v in loose_versions])
+                    )
+                self.version = to_text(loose_versions[-1])
+            elif role_data.get('github_branch', None):
+                self.version = role_data['github_branch']
+            else:
+                self.version = 'master'
+        elif self.version != 'master':
+            if role_versions and to_text(self.version) not in [a.get('name', None) for a in role_versions]:
+                raise AnsibleError("- the specified version (%s) of %s was not found in the list of available versions (%s)." % (self.version,
+                                                                                                                                 self.name,
+                                                                                                                                 role_versions))
+
+        # check if there's a source link/url for our role_version
+        for role_version in role_versions:
+            if role_version['name'] == self.version and 'source' in role_version:
+                self.src = role_version['source']
+            if role_version['name'] == self.version and 'download_url' in role_version:
+                self.download_url = role_version['download_url']
+
+        return role_data
+
+    def _install_role_from_tmp_file(self, tmp_file):
+        display.debug("installing from %s" % tmp_file)
+
+        if not tarfile.is_tarfile(tmp_file):
+            raise AnsibleError("the downloaded file does not appear to be a valid tar archive.")
+        else:
+            role_tar_file = tarfile.open(tmp_file, "r")
+            # verify the role's meta file
+            meta_file = None
+            members = role_tar_file.getmembers()
+            # next find the metadata file
+            for member in members:
+                for meta_main in self.META_MAIN:
+                    if meta_main in member.name:
+                        # Look for parent of meta/main.yml
+                        # Due to possibility of sub roles each containing meta/main.yml
+                        # look for shortest length parent
+                        meta_parent_dir = os.path.dirname(os.path.dirname(member.name))
+                        if not meta_file:
+                            archive_parent_dir = meta_parent_dir
+                            meta_file = member
+                        else:
+                            if len(meta_parent_dir) < len(archive_parent_dir):
+                                archive_parent_dir = meta_parent_dir
+                                meta_file = member
+            if not meta_file:
+                raise AnsibleError("this role does not appear to have a meta/main.yml file.")
+            else:
+                try:
+                    self._metadata = yaml_load(role_tar_file.extractfile(meta_file))
+                except Exception:
+                    raise AnsibleError("this role does not appear to have a valid meta/main.yml file.")
+
+            paths = self.paths
+            if self.path != paths[0]:
+                # path can be passed though __init__
+                # FIXME should this be done in __init__?
+                paths[:0] = self.path
+            paths_len = len(paths)
+            for idx, path in enumerate(paths):
+                self.path = path
+                display.display("- extracting %s to %s" % (self.name, self.path))
+                try:
+                    if os.path.exists(self.path):
+                        if not os.path.isdir(self.path):
+                            raise AnsibleError("the specified roles path exists and is not a directory.")
+                        elif not context.CLIARGS.get("force", False):
+                            raise AnsibleError("the specified role %s appears to already exist. Use --force to replace it." % self.name)
+                        else:
+                            # using --force, remove the old path
+                            if not self.remove():
+                                raise AnsibleError("%s doesn't appear to contain a role.\n  please remove this directory manually if you really "
+                                                   "want to put the role here." % self.path)
+                    else:
+                        os.makedirs(self.path)
+
+                    # We strip off any higher-level directories for all of the files
+                    # contained within the tar file here. The default is 'github_repo-target'.
+                    # Gerrit instances, on the other hand, does not have a parent directory at all.
+                    for member in members:
+                        # we only extract files, and remove any relative path
+                        # bits that might be in the file for security purposes
+                        # and drop any containing directory, as mentioned above
+                        if not (member.isreg() or member.issym()):
+                            continue
+
+                        for attr in ('name', 'linkname'):
+                            if not (attr_value := getattr(member, attr, None)):
+                                continue
+
+                            if attr_value.startswith(os.sep) and not is_subpath(attr_value, archive_parent_dir):
+                                err = f"Invalid {attr} for tarfile member: path {attr_value} is not a subpath of the role {archive_parent_dir}"
+                                raise AnsibleError(err)
+
+                            if attr == 'linkname':
+                                # Symlinks are relative to the link
+                                relative_to_archive_dir = os.path.dirname(getattr(member, 'name', ''))
+                                archive_dir_path = os.path.join(archive_parent_dir, relative_to_archive_dir, attr_value)
+                            else:
+                                # Normalize paths that start with the archive dir
+                                attr_value = attr_value.replace(archive_parent_dir, "", 1)
+                                attr_value = os.path.join(*attr_value.split(os.sep))  # remove leading os.sep
+                                archive_dir_path = os.path.join(archive_parent_dir, attr_value)
+
+                            resolved_archive = unfrackpath(archive_parent_dir)
+                            resolved_path = unfrackpath(archive_dir_path)
+                            if not is_subpath(resolved_path, resolved_archive):
+                                err = f"Invalid {attr} for tarfile member: path {resolved_path} is not a subpath of the role {resolved_archive}"
+                                raise AnsibleError(err)
+
+                            relative_path = os.path.join(*resolved_path.replace(resolved_archive, "", 1).split(os.sep)) or '.'
+                            setattr(member, attr, relative_path)
+
+                        if _check_working_data_filter():
+                            # deprecated: description='extract fallback without filter' python_version='3.11'
+                            role_tar_file.extract(member, to_native(self.path), filter='data')  # type: ignore[call-arg]
+                        else:
+                            role_tar_file.extract(member, to_native(self.path))
+
+                    # write out the install info file for later use
+                    self._write_galaxy_install_info()
+                    break
+                except OSError as e:
+                    if e.errno == errno.EACCES and idx < paths_len - 1:
+                        continue
+                    raise AnsibleError("Could not update files in %s: %s" % (self.path, to_native(e)))
+
+            # return the parsed yaml metadata
+            display.display("- %s was installed successfully" % str(self))
+            if not (self.src and os.path.isfile(self.src)):
+                try:
+                    os.unlink(tmp_file)
+                except (OSError, IOError) as e:
+                    display.warning(u"Unable to remove tmp file (%s): %s" % (tmp_file, to_text(e)))
+            return True
+
     def install(self):
 
         if self.scm:
@@ -281,170 +453,37 @@ class GalaxyRole(object):
                 role_data = self.src
                 tmp_file = self.fetch(role_data)
             else:
-                role_data = self.api.lookup_role_by_name(self.src)
-                if not role_data:
-                    raise AnsibleError("- sorry, %s was not found on %s." % (self.src, self.api.api_server))
-
-                if role_data.get('role_type') == 'APP':
-                    # Container Role
-                    display.warning("%s is a Container App role, and should only be installed using Ansible "
-                                    "Container" % self.name)
-
-                role_versions = self.api.fetch_role_related('versions', role_data['id'])
-                if not self.version:
-                    # convert the version names to LooseVersion objects
-                    # and sort them to get the latest version. If there
-                    # are no versions in the list, we'll grab the head
-                    # of the master branch
-                    if len(role_versions) > 0:
-                        loose_versions = [LooseVersion(a.get('name', None)) for a in role_versions]
-                        try:
-                            loose_versions.sort()
-                        except TypeError:
-                            raise AnsibleError(
-                                'Unable to compare role versions (%s) to determine the most recent version due to incompatible version formats. '
-                                'Please contact the role author to resolve versioning conflicts, or specify an explicit role version to '
-                                'install.' % ', '.join([v.vstring for v in loose_versions])
-                            )
-                        self.version = to_text(loose_versions[-1])
-                    elif role_data.get('github_branch', None):
-                        self.version = role_data['github_branch']
-                    else:
-                        self.version = 'master'
-                elif self.version != 'master':
-                    if role_versions and to_text(self.version) not in [a.get('name', None) for a in role_versions]:
-                        raise AnsibleError("- the specified version (%s) of %s was not found in the list of available versions (%s)." % (self.version,
-                                                                                                                                         self.name,
-                                                                                                                                         role_versions))
-
-                # check if there's a source link/url for our role_version
-                for role_version in role_versions:
-                    if role_version['name'] == self.version and 'source' in role_version:
-                        self.src = role_version['source']
-                    if role_version['name'] == self.version and 'download_url' in role_version:
-                        self.download_url = role_version['download_url']
-
+                role_data = self._get_role_data_from_api()
                 tmp_file = self.fetch(role_data)
 
         else:
             raise AnsibleError("No valid role data found")
 
         if tmp_file:
+            return self._install_role_from_tmp_file(tmp_file)
 
-            display.debug("installing from %s" % tmp_file)
+        return False
 
-            if not tarfile.is_tarfile(tmp_file):
-                raise AnsibleError("the downloaded file does not appear to be a valid tar archive.")
+    async def install_async(self):
+
+        if self.scm:
+            # create tar file from scm url
+            tmp_file = await RoleRequirement.scm_archive_role_async(keep_scm_meta=context.CLIARGS['keep_scm_meta'], **self.spec)
+        elif self.src:
+            if os.path.isfile(self.src):
+                tmp_file = self.src
+            elif '://' in self.src:
+                role_data = self.src
+                tmp_file = await self.fetch_async(role_data)
             else:
-                role_tar_file = tarfile.open(tmp_file, "r")
-                # verify the role's meta file
-                meta_file = None
-                members = role_tar_file.getmembers()
-                # next find the metadata file
-                for member in members:
-                    for meta_main in self.META_MAIN:
-                        if meta_main in member.name:
-                            # Look for parent of meta/main.yml
-                            # Due to possibility of sub roles each containing meta/main.yml
-                            # look for shortest length parent
-                            meta_parent_dir = os.path.dirname(os.path.dirname(member.name))
-                            if not meta_file:
-                                archive_parent_dir = meta_parent_dir
-                                meta_file = member
-                            else:
-                                if len(meta_parent_dir) < len(archive_parent_dir):
-                                    archive_parent_dir = meta_parent_dir
-                                    meta_file = member
-                if not meta_file:
-                    raise AnsibleError("this role does not appear to have a meta/main.yml file.")
-                else:
-                    try:
-                        self._metadata = yaml_load(role_tar_file.extractfile(meta_file))
-                    except Exception:
-                        raise AnsibleError("this role does not appear to have a valid meta/main.yml file.")
+                role_data = self._get_role_data_from_api()
+                tmp_file = await self.fetch_async(role_data)
 
-                paths = self.paths
-                if self.path != paths[0]:
-                    # path can be passed though __init__
-                    # FIXME should this be done in __init__?
-                    paths[:0] = self.path
-                paths_len = len(paths)
-                for idx, path in enumerate(paths):
-                    self.path = path
-                    display.display("- extracting %s to %s" % (self.name, self.path))
-                    try:
-                        if os.path.exists(self.path):
-                            if not os.path.isdir(self.path):
-                                raise AnsibleError("the specified roles path exists and is not a directory.")
-                            elif not context.CLIARGS.get("force", False):
-                                raise AnsibleError("the specified role %s appears to already exist. Use --force to replace it." % self.name)
-                            else:
-                                # using --force, remove the old path
-                                if not self.remove():
-                                    raise AnsibleError("%s doesn't appear to contain a role.\n  please remove this directory manually if you really "
-                                                       "want to put the role here." % self.path)
-                        else:
-                            os.makedirs(self.path)
+        else:
+            raise AnsibleError("No valid role data found")
 
-                        # We strip off any higher-level directories for all of the files
-                        # contained within the tar file here. The default is 'github_repo-target'.
-                        # Gerrit instances, on the other hand, does not have a parent directory at all.
-                        for member in members:
-                            # we only extract files, and remove any relative path
-                            # bits that might be in the file for security purposes
-                            # and drop any containing directory, as mentioned above
-                            if not (member.isreg() or member.issym()):
-                                continue
-
-                            for attr in ('name', 'linkname'):
-                                if not (attr_value := getattr(member, attr, None)):
-                                    continue
-
-                                if attr_value.startswith(os.sep) and not is_subpath(attr_value, archive_parent_dir):
-                                    err = f"Invalid {attr} for tarfile member: path {attr_value} is not a subpath of the role {archive_parent_dir}"
-                                    raise AnsibleError(err)
-
-                                if attr == 'linkname':
-                                    # Symlinks are relative to the link
-                                    relative_to_archive_dir = os.path.dirname(getattr(member, 'name', ''))
-                                    archive_dir_path = os.path.join(archive_parent_dir, relative_to_archive_dir, attr_value)
-                                else:
-                                    # Normalize paths that start with the archive dir
-                                    attr_value = attr_value.replace(archive_parent_dir, "", 1)
-                                    attr_value = os.path.join(*attr_value.split(os.sep))  # remove leading os.sep
-                                    archive_dir_path = os.path.join(archive_parent_dir, attr_value)
-
-                                resolved_archive = unfrackpath(archive_parent_dir)
-                                resolved_path = unfrackpath(archive_dir_path)
-                                if not is_subpath(resolved_path, resolved_archive):
-                                    err = f"Invalid {attr} for tarfile member: path {resolved_path} is not a subpath of the role {resolved_archive}"
-                                    raise AnsibleError(err)
-
-                                relative_path = os.path.join(*resolved_path.replace(resolved_archive, "", 1).split(os.sep)) or '.'
-                                setattr(member, attr, relative_path)
-
-                            if _check_working_data_filter():
-                                # deprecated: description='extract fallback without filter' python_version='3.11'
-                                role_tar_file.extract(member, to_native(self.path), filter='data')  # type: ignore[call-arg]
-                            else:
-                                role_tar_file.extract(member, to_native(self.path))
-
-                        # write out the install info file for later use
-                        self._write_galaxy_install_info()
-                        break
-                    except OSError as e:
-                        if e.errno == errno.EACCES and idx < paths_len - 1:
-                            continue
-                        raise AnsibleError("Could not update files in %s: %s" % (self.path, to_native(e)))
-
-                # return the parsed yaml metadata
-                display.display("- %s was installed successfully" % str(self))
-                if not (self.src and os.path.isfile(self.src)):
-                    try:
-                        os.unlink(tmp_file)
-                    except (OSError, IOError) as e:
-                        display.warning(u"Unable to remove tmp file (%s): %s" % (tmp_file, to_text(e)))
-                return True
+        if tmp_file:
+            return self._install_role_from_tmp_file(tmp_file)
 
         return False
 

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -21,7 +21,7 @@ from ansible.errors import AnsibleError
 from ansible.module_utils.six import string_types
 from ansible.playbook.role.definition import RoleDefinition
 from ansible.utils.display import Display
-from ansible.utils.galaxy import scm_archive_resource
+from ansible.utils.galaxy import scm_archive_resource, scm_archive_resource_async
 
 __all__ = ['RoleRequirement']
 
@@ -124,3 +124,8 @@ class RoleRequirement(RoleDefinition):
     def scm_archive_role(src, scm='git', name=None, version='HEAD', keep_scm_meta=False):
 
         return scm_archive_resource(src, scm=scm, name=name, version=version, keep_scm_meta=keep_scm_meta)
+
+    @staticmethod
+    async def scm_archive_role_async(src, scm='git', name=None, version='HEAD', keep_scm_meta=False):
+
+        return await scm_archive_resource_async(src, scm=scm, name=name, version=version, keep_scm_meta=keep_scm_meta)


### PR DESCRIPTION
##### SUMMARY

Implement concurrent role downloads via "max_concurrent_downloads" option

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

This adds the "--max-concurrent-downloads" option (default : 1) to activate concurrent role downloads.

When using a slow git repository this can make a huge performance difference.

Some testing results (installing 40 roles with no dependencies):

| Test  | Time |
| ------------- | ------------- |
| git+ssh (bitbucket cloud) | 74,2 s |
| git+https (bitbucket cloud) | 58,4 s |
| git+ssh (bitbucket on-premise) | 22,5 s |
| git+https (bitbucket on-premise) |	17,1 s  |
| git+ssh (self-hosted gitlab)	| 12,9 s |
| git+ssh (bitbucket cloud) "--max-concurrent-downloads 10" | 8,9 s |

I tried to implement this in the most stable way possible, so only the "role.install()" call is multithreaded, and by default no multithreading is used at all.

The code should be ready, but I will do some further testing by tomorrow evening.

As I am quite new to ansible programming I tried my best to implement in the correct way, but please let me know if anything can be improved.
