### PR TITLE
Copy target min python check into ansiballz template

### DIFF
--- a/changelogs/fragments/82068-ansiballz-min-py-check.yml
+++ b/changelogs/fragments/82068-ansiballz-min-py-check.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Target minimum python check - Copy check into AnsiballZ template, to get earlier check before module code executes
+  (https://github.com/ansible/ansible/issues/82068)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -74,6 +74,28 @@ _MODULE_UTILS_PATH = os.path.join(os.path.dirname(__file__), '..', 'module_utils
 
 # ******************************************************************************
 
+ANSIBALLZ_MIN_PYTHON = '''
+import sys
+import json
+
+# Used for determining if the system is running a new enough python version
+# and should only restrict on our documented minimum versions
+_PY_MIN = (3, 7)
+
+if sys.version_info < _PY_MIN:
+    print(json.dumps(dict(
+        failed=True,
+        msg=(
+            "ansible-core requires a minimum of Python version "
+            "{0}. Current version: {1}"
+        ).format(
+            '.'.join(map(str, _PY_MIN)),
+            ''.join(sys.version.splitlines()),
+        )
+    )))
+    sys.exit(1)
+'''
+
 ANSIBALLZ_TEMPLATE = u'''%(shebang)s
 %(coding)s
 _ANSIBALLZ_WRAPPER = True # For test-module.py script to tell this is a ANSIBALLZ_WRAPPER
@@ -104,6 +126,9 @@ _ANSIBALLZ_WRAPPER = True # For test-module.py script to tell this is a ANSIBALL
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+%(min_python)s
+
 def _ansiballz_main():
     import os
     import os.path
@@ -1275,6 +1300,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
             date_time=date_time,
             coverage=coverage,
             rlimit=rlimit,
+            min_python=ANSIBALLZ_MIN_PYTHON,
         )))
         b_module_data = output.getvalue()
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -14,7 +14,13 @@ _PY_MIN = (3, 7)
 if sys.version_info < _PY_MIN:
     print(json.dumps(dict(
         failed=True,
-        msg=f"ansible-core requires a minimum of Python version {'.'.join(map(str, _PY_MIN))}. Current version: {''.join(sys.version.splitlines())}",
+        msg=(
+            "ansible-core requires a minimum of Python version "
+            "{0}. Current version: {1}"
+        ).format(
+            '.'.join(map(str, _PY_MIN)),
+            ''.join(sys.version.splitlines()),
+        )
     )))
     sys.exit(1)
 


### PR DESCRIPTION
##### SUMMARY

Copy target min python check into ansiballz template. Fixes #82068

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```console
porky | FAILED! => {
    "changed": false,
    "msg": "ansible-core requires a minimum of Python version 3.7. Current version: 3.6.12 (default, Sep 17 2020, 10:43:21) [GCC 9.3.0]"
}
```
