### PR TITLE
service_facts: Add support to save services facts under user defined variable

### DIFF
--- a/changelogs/fragments/82703-add-optional-argument-to-service-facts.yml
+++ b/changelogs/fragments/82703-add-optional-argument-to-service-facts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - service_facts - add service_facts_var as an optional argument to service_facts module to specify under what variable to save the retrieved facts


### PR DESCRIPTION
At my organization, we are using a dynamic script that builds an inventory based on group variables and host vars files. We have a functional group called services which contains all the sub-groups and their respective attributes used when applying our collections to our server.

Our problem here is that some collections are calling `ansible.builtin.service_facts` and this module will override the `services` key in our host_vars with the service facts causing our playbooks to fail because the previous vars under services do not exist anymore.

##### SUMMARY

Adding an argument to specify under which variable to save the service facts while keeping the default to `services` to not break existing flows.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

Taking for example the following inventory file:
```
 ~/ansible (devel) $ cat inventory.yml
---
all:
  hosts:
   mtzks1:
     services:
       gitlab_runner:
         instance: 1
         cpu: 32
         memory_gb: 128
       artifactory:
         role: master
         db_hostname: jfrog-db.domain.com
```
The following playbook would fail with the current `service_facts` module:
```
 ~/ansible (devel) $ cat testmod-devel.yml
---
- name: Testing service_facts with argument
  hosts: localhost
  connection: local
  gather_facts: true
  tasks:
  - name: Check services
    debug:
      msg: "services = {{ services }}"

  - name: Run service_facts
    service_facts:

  - name: Check services
    debug:
      msg: 'services = {{ services.gitlab_runner }} AND {{ services.artifactory }}'
```

E.g output:
```
~/ansible (devel) $ ansible-playbook -i inventory.yml testmod-devel.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.

PLAY [Testing service_facts with argument] **********************************************************************************************************************************************************************************************************************************
TASK [Gathering Facts] ******************************************************************************************************************************************************************************************************************************************************
[WARNING]: Platform linux on host localhost is using the discovered Python interpreter at /home/cnfrancis/ansible/venv/bin/python3.12, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-
core/devel/reference_appendices/interpreter_discovery.html for more information.
ok: [localhost]

TASK [Check services] *******************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "services = {'gitlab_runner': {'instance': 1, 'cpu': 32, 'memory_gb': 128}, 'artifactory': {'role': 'master', 'db_hostname': 'jfrog-db.domain.com'}}"
}

TASK [Run service_facts] ****************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Check services] *******************************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'gitlab_runner'\n\nThe error appears to be in '/home/cnfrancis/ansible/testmod-devel.yml': line 14, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n  - name: Check services\n    ^ here\n"}

PLAY RECAP ******************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

Now, with the suggested change using the same playbook it would still fail as expected because by default it uses the `services` name to store the services facts
```
~/ansible (add-var-name-option-to-service-facts-modile) $ ansible-playbook -i inventory.yml testmod-devel.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.

PLAY [Testing service_facts with argument] **********************************************************************************************************************************************************************************************************************************
TASK [Gathering Facts] ******************************************************************************************************************************************************************************************************************************************************
[WARNING]: Platform linux on host localhost is using the discovered Python interpreter at /home/cnfrancis/ansible/venv/bin/python3.12, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-
core/devel/reference_appendices/interpreter_discovery.html for more information.
ok: [localhost]

TASK [Check services] *******************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "services = {'gitlab_runner': {'instance': 1, 'cpu': 32, 'memory_gb': 128}, 'artifactory': {'role': 'master', 'db_hostname': 'jfrog-db.domain.com'}}"
}

TASK [Run service_facts] ****************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Check services] *******************************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'gitlab_runner'\n\nThe error appears to be in '/home/cnfrancis/ansible/testmod-devel.yml': line 14, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n  - name: Check services\n    ^ here\n"}

PLAY RECAP ******************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```


### Final Results
Updated playbook:
```
---
- name: Testing service_facts with argument
  hosts: localhost
  connection: local
  gather_facts: true
  tasks:
  - name: Check services
    debug:
      msg: "services = {{ services }}"

  - name: Run service_facts
    service_facts:
      service_facts_var: host_services

  - name: Check services
    debug:
      msg: 'services = {{ services.gitlab_runner }} AND {{ services.artifactory }}'
```

Output
```
~/ansible (add-var-name-option-to-service-facts-modile) $ ansible-playbook -i inventory.yml testmod-new.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.

PLAY [Testing service_facts with argument] **********************************************************************************************************************************************************************************************************************************
TASK [Gathering Facts] ******************************************************************************************************************************************************************************************************************************************************
[WARNING]: Platform linux on host localhost is using the discovered Python interpreter at /home/cnfrancis/ansible/venv/bin/python3.12, but future installation of another Python interpreter could change the meaning of that path. See https://docs.ansible.com/ansible-
core/devel/reference_appendices/interpreter_discovery.html for more information.
ok: [localhost]

TASK [Check services] *******************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "services = {'gitlab_runner': {'instance': 1, 'cpu': 32, 'memory_gb': 128}, 'artifactory': {'role': 'master', 'db_hostname': 'jfrog-db.domain.com'}}"
}

TASK [Run service_facts] ****************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Check services] *******************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "services = {'instance': 1, 'cpu': 32, 'memory_gb': 128} AND {'role': 'master', 'db_hostname': 'jfrog-db.domain.com'}"
}

PLAY RECAP ******************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

