### PR TITLE
[backport][stable-2.16] Add macOS 14.3 to CI and `ansible-test`

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -79,8 +79,8 @@ stages:
       - template: templates/matrix.yml  # context/target
         parameters:
           targets:
-            - name: macOS 13.2
-              test: macos/13.2
+            - name: macOS 14.3
+              test: macos/14.3
             - name: RHEL 7.9
               test: rhel/7.9
             - name: RHEL 8.8 py36
@@ -99,8 +99,8 @@ stages:
       - template: templates/matrix.yml  # context/controller
         parameters:
           targets:
-            - name: macOS 13.2
-              test: macos/13.2
+            - name: macOS 14.3
+              test: macos/14.3
             - name: RHEL 8.8
               test: rhel/8.8
             - name: RHEL 9.2

--- a/changelogs/fragments/ansible-test-added-macos-14.3.yml
+++ b/changelogs/fragments/ansible-test-added-macos-14.3.yml
@@ -1,0 +1,6 @@
+---
+
+minor_changes:
+- ansible-test - Added a macOS 14.3 remote VM.
+
+...

--- a/test/integration/targets/ansible-galaxy-collection/handlers/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/handlers/main.yml
@@ -1,0 +1,7 @@
+- name: uninstall gpg
+  command: brew uninstall gpg
+  become: yes
+  become_user: >-
+    {{ brew_stat.stat.pw_name }}
+  environment:
+    HOMEBREW_NO_AUTO_UPDATE: True

--- a/test/integration/targets/ansible-galaxy-collection/tasks/setup_gpg.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/setup_gpg.yml
@@ -7,6 +7,27 @@
     - absent
     - directory
 
+- when: ansible_facts.distribution == 'MacOSX'
+  block:
+    - name: MACOS | Find brew binary
+      command: which brew
+      register: brew_which
+
+    - name: MACOS | Get owner of brew binary
+      stat:
+        path: >-
+          {{ brew_which.stdout }}
+      register: brew_stat
+
+    - command: brew install gpg
+      become: yes
+      become_user: >-
+        {{ brew_stat.stat.pw_name }}
+      environment:
+        HOMEBREW_NO_AUTO_UPDATE: True
+      notify:
+        - uninstall gpg
+
 - name: get username for generating key
   command: whoami
   register: user

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -5,6 +5,7 @@ fedora become=sudo provider=aws arch=x86_64
 freebsd/13.2 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 macos/13.2 python=3.11 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64
+macos/14.3 python=3.11 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64
 macos python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64
 rhel/7.9 python=2.7 become=sudo provider=aws arch=x86_64
 rhel/8.8 python=3.6,3.11 become=sudo provider=aws arch=x86_64


### PR DESCRIPTION
Backport of PR #82697.

Additionally, this patch takes care of installing GPG within the `ansible-galaxy-collection` test when running under macOS 14 and higher.

PR #82697

ci_complete

(cherry picked from commit 386edc666ec2a053b4d576fc4b2deeb46fe492b8)

##### SUMMARY

$sbj.

##### ISSUE TYPE

- Maintenance Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

N/A