### PR TITLE
add error handling when parsing values in ini files

### DIFF
--- a/changelogs/fragments/local_facts_d.yml
+++ b/changelogs/fragments/local_facts_d.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - local - handle error while parsing values in ini files (https://github.com/ansible/ansible/issues/82717).

--- a/test/integration/targets/facts_d/files/bad.fact
+++ b/test/integration/targets/facts_d/files/bad.fact
@@ -1,0 +1,2 @@
+[bad fact]
+value = this is a % bad % fact

--- a/test/integration/targets/facts_d/tasks/main.yml
+++ b/test/integration/targets/facts_d/tasks/main.yml
@@ -19,6 +19,7 @@
           mode: '0775'
         - name: unreadable
           mode: '0000'
+        - name: bad
 
     - name: Create dangling symlink
       file:
@@ -39,15 +40,16 @@
 - name: check for expected results from local facts
   assert:
     that:
-        - "'ansible_facts' in setup_result"
-        - "'ansible_local' in setup_result.ansible_facts"
-        - "'ansible_env' not in setup_result.ansible_facts"
-        - "'ansible_user_id' not in setup_result.ansible_facts"
-        - "'preferences' in setup_result.ansible_facts['ansible_local']"
-        - "'general' in setup_result.ansible_facts['ansible_local']['preferences']"
-        - "'bar' in setup_result.ansible_facts['ansible_local']['preferences']['general']"
-        - "setup_result.ansible_facts['ansible_local']['preferences']['general']['bar'] == 'loaded'"
-        - setup_result['ansible_facts']['ansible_local']['goodscript']['script_ran']|bool
-        - setup_result['ansible_facts']['ansible_local']['basdscript'].startswith("Failure executing fact script")
-        - setup_result['ansible_facts']['ansible_local']['unreadable'].startswith('error loading facts')
-        - setup_result['ansible_facts']['ansible_local']['dead_symlink'].startswith('Could not stat fact')
+      - "'ansible_facts' in setup_result"
+      - "'ansible_local' in setup_result.ansible_facts"
+      - "'ansible_env' not in setup_result.ansible_facts"
+      - "'ansible_user_id' not in setup_result.ansible_facts"
+      - "'preferences' in setup_result.ansible_facts['ansible_local']"
+      - "'general' in setup_result.ansible_facts['ansible_local']['preferences']"
+      - "'bar' in setup_result.ansible_facts['ansible_local']['preferences']['general']"
+      - "setup_result.ansible_facts['ansible_local']['preferences']['general']['bar'] == 'loaded'"
+      - setup_result['ansible_facts']['ansible_local']['goodscript']['script_ran']|bool
+      - setup_result['ansible_facts']['ansible_local']['basdscript'].startswith("Failure executing fact script")
+      - setup_result['ansible_facts']['ansible_local']['unreadable'].startswith('error loading facts')
+      - setup_result['ansible_facts']['ansible_local']['dead_symlink'].startswith('Could not stat fact')
+      - setup_result['ansible_facts']['ansible_local']['bad'].startswith('error loading facts as ini')


### PR DESCRIPTION

##### SUMMARY

local facts - added error handling when ConfigParser parses values.  error was not trapped before, causing the whole module to fail and ansilbe_local to not populate by one bad value.

This is a bug in all versions.  Would recommend a backport to prevent unexpected behavior.

Fixes: #82717

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

See original issue https://github.com/ansible/ansible/issues/82717

this fix will now add a warning when CP throws an error, including the error itself to help the user.

```paste below
# ansible localhost -m ansible.builtin.setup -a 'filter=ansible_local'
[WARNING]: error loading facts as ini - please check content: /etc/ansible/facts.d/99-bad.fact ('%' must be followed by '%' or '(', found: '% bad % fact')
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_local": {
            "00-good": {
                "good fact": {
                    "value": "this is a good fact"
                }
            },
            "99-bad": "error loading facts as ini - please check content: /etc/ansible/facts.d/99-bad.fact ('%' must be followed by '%' or '(', found: '% bad % fact')"
        }
    },
    "changed": false
}
```
