### PR TITLE
Ignore empty vault filenames

### DIFF
--- a/changelogs/fragments/82721-vault-empty.yml
+++ b/changelogs/fragments/82721-vault-empty.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
   - passing a directory as vault password file now raises a meaningful error (https://github.com/ansible/ansible/pull/82721).
-  - empty vault ids are now silently ignored (https://github.com/ansible/ansible/pull/82721).
+  - empty vault filenames are now silently ignored (https://github.com/ansible/ansible/pull/82721).

--- a/changelogs/fragments/82721-vault-empty.yml
+++ b/changelogs/fragments/82721-vault-empty.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - passing a directory as vault password file now raises a meaningful error (https://github.com/ansible/ansible/pull/82721).
+  - empty vault ids are now silently ignored (https://github.com/ansible/ansible/pull/82721).

--- a/changelogs/fragments/xxxxx-vault-empty.yml
+++ b/changelogs/fragments/xxxxx-vault-empty.yml
@@ -1,3 +1,4 @@
 ---
 bugfixes:
   - passing a directory as vault password file now raises a meaningful error (https://github.com/ansible/ansible/pull/xxxxx).
+  - empty vault ids are now silently ignored (https://github.com/ansible/ansible/pull/xxxxx).

--- a/changelogs/fragments/xxxxx-vault-empty.yml
+++ b/changelogs/fragments/xxxxx-vault-empty.yml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - passing a directory as vault password file now raises a meaningful error (https://github.com/ansible/ansible/pull/xxxxx).
-  - empty vault ids are now silently ignored (https://github.com/ansible/ansible/pull/xxxxx).

--- a/changelogs/fragments/xxxxx-vault-empty.yml
+++ b/changelogs/fragments/xxxxx-vault-empty.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - passing a directory as vault password file now raises a meaningful error (https://github.com/ansible/ansible/pull/xxxxx).

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -254,10 +254,6 @@ class CLI(ABC):
 
         last_exception = found_vault_secret = None
         for vault_id_slug in vault_ids:
-            if not vault_id_slug:
-                # silently ignore empty values
-                continue
-
             vault_id_name, vault_id_value = CLI.split_vault_id(vault_id_slug)
             if vault_id_value in ['prompt', 'prompt_ask_vault_pass']:
 
@@ -286,6 +282,10 @@ class CLI(ABC):
                 # update loader with new secrets incrementally, so we can load a vault password
                 # that is encrypted with a vault secret provided earlier
                 loader.set_vault_secrets(vault_secrets)
+                continue
+
+            if not vault_id_value:
+                # silently ignore empty filenames
                 continue
 
             # assuming anything else is a password file

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -254,6 +254,10 @@ class CLI(ABC):
 
         last_exception = found_vault_secret = None
         for vault_id_slug in vault_ids:
+            if not vault_id_slug:
+                # silently ignore empty values
+                continue
+
             vault_id_name, vault_id_value = CLI.split_vault_id(vault_id_slug)
             if vault_id_value in ['prompt', 'prompt_ask_vault_pass']:
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -356,6 +356,8 @@ def get_file_vault_secret(filename=None, vault_id=None, encoding=None, loader=No
     this_path = unfrackpath(filename, follow=False)
     if not os.path.exists(this_path):
         raise AnsibleError("The vault password file %s was not found" % this_path)
+    if not os.path.isfile(this_path):
+        raise AnsibleError("The vault password file %s is not a file" % this_path)
 
     # it is a script?
     if loader.is_executable(this_path):

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -359,19 +359,21 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
         match = vault.match_secrets(res, ['some_vault_id'])[0][1]
         self.assertEqual(match.bytes, b'prompt1_password')
 
-    def test_empty_id(self):
+    def test_empty_slug(self):
         res = cli.CLI.setup_vault_secrets(loader=self.fake_loader,
                                           vault_ids=[''])
         self.assertIsInstance(res, list)
         self.assertEqual(0, len(res))
 
-    @patch('ansible.cli.get_file_vault_secret')
-    def test_empty_file_part(self, mock_file_secret):
-        mock_file_secret.side_effect = AnsibleError('There is something wrong with your vault file')
-
+    def test_empty_name_part(self):
         self.assertRaisesRegex(AnsibleError,
-                               '.*There is something wrong with your vault file.*',
+                               '.*The vault password file .*/foo was not found.*',
                                cli.CLI.setup_vault_secrets,
                                loader=self.fake_loader,
-                               vault_ids=['foo@'])
-        mock_file_secret.assert_called_once()
+                               vault_ids=['@foo'])
+
+    def test_empty_value_part(self):
+        res = cli.CLI.setup_vault_secrets(loader=self.fake_loader,
+                                          vault_ids=['foo@'])
+        self.assertIsInstance(res, list)
+        self.assertEqual(0, len(res))


### PR DESCRIPTION
##### SUMMARY

Using an empty vault id (for example `--vault-id ""` on the command line) currently results in a `Permission denied` error. This is because the empty string resolves to the current work directory, and since it has (in most cases) the executable permission bit set, is treated as a vault password script, and tried to be executed; which fails for obvious reasons. I can think of no use case where you want (or actually even can) execute a directory, so explicitly check if the vault password file is a directory and raise a descriptive error. Symlinks are treated like the target they point to, so files work but directories raise the same (now more descriptive) error.

The motivation for using an empty vault id is to use the [`ANSIBLE_VAULT_IDENTITY_LIST`](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-vault-identity-list) env var with an empty value to reset the `vault_identity_list` option from the `ansible.cfg` at runtime. This currently results in the above `Permission denied` error because the config parser will never return an empty list, the best you can get is a list with the empty string. There is an interesting discussion in #80908 why the empty string is useful in some cases, so I deemed it best to solve this on the specific vault scope rather than on the general list-config one. In the context of vault password files, I don't see a use case for the empty string because of the above described resolution to a directory; so simply ignore them. Even with the restriction of the config parser, this makes it now possible to set an (effectively) empty vault id list, and thus reset it using the env var.

I am not quite sure if this still qualifies as a bugfix, or is actually more of an enhancement aka minor change.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

`ansible.cfg`
```
[defaults]
vault_identity_list = my-default-vault@file-that-does-not-exist
```

`playbook.yml` (not really important here, just for completeness)
```
---
- hosts: all
  tasks:
    - debug:
        msg:
          - "It works!"
```

Without this PR:
```
% ANSIBLE_VAULT_IDENTITY_LIST="" ansible-playbook playbook.yml -vvvvv
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
ansible-playbook [core 2.17.0.dev0]
  config file = /tmp/ansible-test/ansible.cfg
  configured module search path = ['/home/corubba/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/ansible-test/.venv/lib/python3.11/site-packages/ansible
  ansible collection location = /home/corubba/.ansible/collections:/usr/share/ansible/collections
  executable location = /tmp/ansible-test/.venv/bin/ansible-playbook
  python version = 3.11.7 (main, Jan 29 2024, 16:03:57) [GCC 13.2.1 20230801] (/tmp/ansible-test/.venv/bin/python)
  jinja version = 3.1.3
  libyaml = True
Using /tmp/ansible-test/ansible.cfg as config file
Reading vault password file: 
[WARNING]: Error in vault password file loading (None): Problem running vault password script /tmp/ansible-test ([Errno 13] Permission denied: '/tmp/ansible-test'). If this is not a script, remove the executable bit from the file.
ERROR! Problem running vault password script /tmp/ansible-test ([Errno 13] Permission denied: '/tmp/ansible-test'). If this is not a script, remove the executable bit from the file.
```

With this PR:
```
% ANSIBLE_VAULT_IDENTITY_LIST="" ansible-playbook playbook.yml -vvvvv
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
ansible-playbook [core 2.17.0.dev0]
  config file = /tmp/ansible-test/ansible.cfg
  configured module search path = ['/home/corubba/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/ansible-test/.venv/lib/python3.11/site-packages/ansible
  ansible collection location = /home/corubba/.ansible/collections:/usr/share/ansible/collections
  executable location = /tmp/ansible-test/.venv/bin/ansible-playbook
  python version = 3.11.7 (main, Jan 29 2024, 16:03:57) [GCC 13.2.1 20230801] (/tmp/ansible-test/.venv/bin/python)
  jinja version = 3.1.3
  libyaml = True
Using /tmp/ansible-test/ansible.cfg as config file
setting up inventory plugins
Loading collection ansible.builtin from 
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
Loading callback plugin default of type stdout, v2.0 from /tmp/ansible-test/.venv/lib/python3.11/site-packages/ansible/plugins/callback/default.py
Attempting to use 'default' callback.
Skipping callback 'default', as we already have a stdout callback.
Attempting to use 'junit' callback.
Attempting to use 'minimal' callback.
Skipping callback 'minimal', as we already have a stdout callback.
Attempting to use 'oneline' callback.
Skipping callback 'oneline', as we already have a stdout callback.
Attempting to use 'tree' callback.

PLAYBOOK: playbook.yml **************************************************************************************************************************************************************************************************************************************************************
Positional arguments: playbook.yml
verbosity: 5
connection: ssh
become_method: sudo
tags: ('all',)
inventory: ('/etc/ansible/hosts',)
forks: 5
1 plays in playbook.yml

PLAY [all] **************************************************************************************************************************************************************************************************************************************************************************
skipping: no hosts matched

PLAY RECAP **************************************************************************************************************************************************************************************************************************************************************************

```
```
% ANSIBLE_VAULT_IDENTITY_LIST="$(pwd)" ansible-playbook playbook.yml -vvvvv
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
ansible-playbook [core 2.17.0.dev0]
  config file = /tmp/ansible-test/ansible.cfg
  configured module search path = ['/home/corubba/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/ansible-test/.venv/lib/python3.11/site-packages/ansible
  ansible collection location = /home/corubba/.ansible/collections:/usr/share/ansible/collections
  executable location = /tmp/ansible-test/.venv/bin/ansible-playbook
  python version = 3.11.7 (main, Jan 29 2024, 16:03:57) [GCC 13.2.1 20230801] (/tmp/ansible-test/.venv/bin/python)
  jinja version = 3.1.3
  libyaml = True
Using /tmp/ansible-test/ansible.cfg as config file
Reading vault password file: /tmp/ansible-test
[WARNING]: Error getting vault password file (None): The vault password file /tmp/ansible-test is not a file
ERROR! The vault password file /tmp/ansible-test is not a file
```