### PR TITLE
ansible-test - Add work-around for pytest>=8 errors

### DIFF
--- a/changelogs/fragments/ansible-test-pytest-8.yml
+++ b/changelogs/fragments/ansible-test-pytest-8.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ansible-test - Add a work-around for permission denied errors when using pytest >= 8 on multi-user systems with an installed version of ansible-test.
+  - ansible-test - Add a work-around for permission denied errors when using ``pytest >= 8`` on multi-user systems with an installed version of ``ansible-test``.

--- a/changelogs/fragments/ansible-test-pytest-8.yml
+++ b/changelogs/fragments/ansible-test-pytest-8.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Add a work-around for permission denied errors when using pytest >= 8 on multi-user systems with an installed version of ansible-test.

--- a/test/lib/ansible_test/_internal/commands/units/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/units/__init__.py
@@ -261,6 +261,7 @@ def command_units(args: UnitsConfig) -> None:
             '--junit-xml', os.path.join(ResultType.JUNIT.path, 'python%s-%s-units.xml' % (python.version, test_context)),
             '--strict-markers',  # added in pytest 4.5.0
             '--rootdir', data_context().content.root,
+            '--confcutdir', data_context().content.root,  # avoid permission errors when running from an installed version and using pytest >= 8
         ]  # fmt:skip
 
         if not data_context().content.collection:


### PR DESCRIPTION
##### SUMMARY

Resolves https://github.com/ansible/ansible/issues/82713

Adding the `--confcutdir` option to the `pytest` invocation prevents pytest >= 8 from searching for `conftest.py` in unwanted locations, such as all directories under `/home`. This can occur when running ansible-test from an install, where it sources a pytest config file from a path symlinked under `/tmp`.

Thanks to @sivel for digging into this and figuring out the `--confcutdir` option prevents the unwanted behavior.

##### ISSUE TYPE

Bugfix Pull Request
