### PR TITLE
[stable-2.14] ansible-test - Add work-around for pytest>=8 errors (#82723)

### DIFF
--- a/changelogs/fragments/ansible-test-pytest-8.yml
+++ b/changelogs/fragments/ansible-test-pytest-8.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Add a work-around for permission denied errors when using ``pytest >= 8`` on multi-user systems with an installed version of ``ansible-test``.

--- a/test/lib/ansible_test/_internal/commands/units/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/units/__init__.py
@@ -262,6 +262,7 @@ def command_units(args: UnitsConfig) -> None:
             '--junit-xml', os.path.join(ResultType.JUNIT.path, 'python%s-%s-units.xml' % (python.version, test_context)),
             '--strict-markers',  # added in pytest 4.5.0
             '--rootdir', data_context().content.root,
+            '--confcutdir', data_context().content.root,  # avoid permission errors when running from an installed version and using pytest >= 8
         ]  # fmt:skip
 
         if not data_context().content.collection:


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/82723

* ansible-test - Add work-around for pytest>=8 errors
* Update changelogs/fragments/ansible-test-pytest-8.yml

(cherry picked from commit a1edb61ce7a645019496273cfe77b33cd3e64a2d)

##### ISSUE TYPE

Bugfix Pull Request
