### PR TITLE
Use underlying `AnsibleError` exception as cause

### DIFF
--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -21,6 +21,7 @@ import re
 import traceback
 
 from collections.abc import Sequence
+from warnings import warn as _emit_warning
 
 from ansible.errors.yaml_strings import (
     YAML_COMMON_DICT_ERROR,
@@ -33,6 +34,10 @@ from ansible.errors.yaml_strings import (
     YAML_AND_SHORTHAND_ERROR,
 )
 from ansible.module_utils.common.text.converters import to_native, to_text
+
+
+_UNDERLYING_EXC_SENTINEL = Exception()
+"""A sentinel object for use as a default for arguments in callables."""
 
 
 class AnsibleError(Exception):
@@ -50,14 +55,42 @@ class AnsibleError(Exception):
     which should be returned by the DataLoader() class.
     """
 
-    def __init__(self, message="", obj=None, show_content=True, suppress_extended_error=False, orig_exc=None):
+    def __init__(
+        self,
+        message="",
+        obj=None,
+        show_content=True,
+        suppress_extended_error=False,
+        orig_exc=_UNDERLYING_EXC_SENTINEL,
+    ):
         super(AnsibleError, self).__init__(message)
 
         self._show_content = show_content
         self._suppress_extended_error = suppress_extended_error
         self._message = to_native(message)
         self.obj = obj
-        self.orig_exc = orig_exc
+        if orig_exc is not _UNDERLYING_EXC_SENTINEL:
+            _emit_warning(
+                'Passing the underlying error through the `orig_exc` argument '
+                'is deprecated. Instead, use native Python 3 exception cause '
+                'chaining syntax: `raise ... from ...`',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            self.__cause__ = orig_exc
+
+    @property
+    def orig_exc(self):
+        """The underlying exception object.
+
+        If the exception cause is undefined, it's set to :py:data:`None`.
+        """
+        return self.__cause__
+
+    @orig_exc.setter
+    def orig_exc(self, underlying_exception):
+        """Set the underlying exception as cause of the current one."""
+        self.__cause__ = underlying_exception
 
     @property
     def message(self):
@@ -78,6 +111,8 @@ class AnsibleError(Exception):
                 message.append(
                     '\n\n%s' % to_native(extended_error)
                 )
+        elif self.__cause__:
+            message.append('. %s' % to_native(self.__cause__))
 
         return ''.join(message)
 
@@ -294,7 +329,16 @@ class AnsibleUndefinedVariable(AnsibleTemplateError):
 class AnsibleFileNotFound(AnsibleRuntimeError):
     """ a file missing failure """
 
-    def __init__(self, message="", obj=None, show_content=True, suppress_extended_error=False, orig_exc=None, paths=None, file_name=None):
+    def __init__(
+        self,
+        message="",
+        obj=None,
+        show_content=True,
+        suppress_extended_error=False,
+        orig_exc=_UNDERLYING_EXC_SENTINEL,
+        paths=None,
+        file_name=None,
+    ):
 
         self.file_name = file_name
         self.paths = paths
@@ -324,7 +368,15 @@ class AnsibleFileNotFound(AnsibleRuntimeError):
 class AnsibleAction(AnsibleRuntimeError):
     """ Base Exception for Action plugin flow control """
 
-    def __init__(self, message="", obj=None, show_content=True, suppress_extended_error=False, orig_exc=None, result=None):
+    def __init__(
+        self,
+        message="",
+        obj=None,
+        show_content=True,
+        suppress_extended_error=False,
+        orig_exc=_UNDERLYING_EXC_SENTINEL,
+        result=None,
+    ):
 
         super(AnsibleAction, self).__init__(message=message, obj=obj, show_content=show_content,
                                             suppress_extended_error=suppress_extended_error, orig_exc=orig_exc)
@@ -337,7 +389,15 @@ class AnsibleAction(AnsibleRuntimeError):
 class AnsibleActionSkip(AnsibleAction):
     """ an action runtime skip"""
 
-    def __init__(self, message="", obj=None, show_content=True, suppress_extended_error=False, orig_exc=None, result=None):
+    def __init__(
+        self,
+        message="",
+        obj=None,
+        show_content=True,
+        suppress_extended_error=False,
+        orig_exc=_UNDERLYING_EXC_SENTINEL,
+        result=None,
+    ):
         super(AnsibleActionSkip, self).__init__(message=message, obj=obj, show_content=show_content,
                                                 suppress_extended_error=suppress_extended_error, orig_exc=orig_exc, result=result)
         self.result.update({'skipped': True, 'msg': message})
@@ -345,7 +405,15 @@ class AnsibleActionSkip(AnsibleAction):
 
 class AnsibleActionFail(AnsibleAction):
     """ an action runtime failure"""
-    def __init__(self, message="", obj=None, show_content=True, suppress_extended_error=False, orig_exc=None, result=None):
+    def __init__(
+        self,
+        message="",
+        obj=None,
+        show_content=True,
+        suppress_extended_error=False,
+        orig_exc=_UNDERLYING_EXC_SENTINEL,
+        result=None,
+    ):
         super(AnsibleActionFail, self).__init__(message=message, obj=obj, show_content=show_content,
                                                 suppress_extended_error=suppress_extended_error, orig_exc=orig_exc, result=result)
         self.result.update({'failed': True, 'msg': message, 'exception': traceback.format_exc()})

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -36,10 +36,6 @@ from ansible.errors.yaml_strings import (
 from ansible.module_utils.common.text.converters import to_native, to_text
 
 
-_UNDERLYING_EXC_SENTINEL = Exception()
-"""A sentinel object for use as a default for arguments in callables."""
-
-
 class AnsibleError(Exception):
     """
     This is the base class for all errors raised from Ansible code,
@@ -55,21 +51,14 @@ class AnsibleError(Exception):
     which should be returned by the DataLoader() class.
     """
 
-    def __init__(
-        self,
-        message="",
-        obj=None,
-        show_content=True,
-        suppress_extended_error=False,
-        orig_exc=_UNDERLYING_EXC_SENTINEL,
-    ):
+    def __init__(self, message="", obj=None, show_content=True, suppress_extended_error=False, orig_exc=None):
         super(AnsibleError, self).__init__(message)
 
         self._show_content = show_content
         self._suppress_extended_error = suppress_extended_error
         self._message = to_native(message)
         self.obj = obj
-        if orig_exc is not _UNDERLYING_EXC_SENTINEL:
+        if orig_exc is not None:
             _emit_warning(
                 'Passing the underlying error through the `orig_exc` argument '
                 'is deprecated. Instead, use native Python 3 exception cause '
@@ -329,16 +318,7 @@ class AnsibleUndefinedVariable(AnsibleTemplateError):
 class AnsibleFileNotFound(AnsibleRuntimeError):
     """ a file missing failure """
 
-    def __init__(
-        self,
-        message="",
-        obj=None,
-        show_content=True,
-        suppress_extended_error=False,
-        orig_exc=_UNDERLYING_EXC_SENTINEL,
-        paths=None,
-        file_name=None,
-    ):
+    def __init__(self, message="", obj=None, show_content=True, suppress_extended_error=False, orig_exc=None, paths=None, file_name=None):
 
         self.file_name = file_name
         self.paths = paths
@@ -368,15 +348,7 @@ class AnsibleFileNotFound(AnsibleRuntimeError):
 class AnsibleAction(AnsibleRuntimeError):
     """ Base Exception for Action plugin flow control """
 
-    def __init__(
-        self,
-        message="",
-        obj=None,
-        show_content=True,
-        suppress_extended_error=False,
-        orig_exc=_UNDERLYING_EXC_SENTINEL,
-        result=None,
-    ):
+    def __init__(self, message="", obj=None, show_content=True, suppress_extended_error=False, orig_exc=None, result=None):
 
         super(AnsibleAction, self).__init__(message=message, obj=obj, show_content=show_content,
                                             suppress_extended_error=suppress_extended_error, orig_exc=orig_exc)
@@ -389,15 +361,7 @@ class AnsibleAction(AnsibleRuntimeError):
 class AnsibleActionSkip(AnsibleAction):
     """ an action runtime skip"""
 
-    def __init__(
-        self,
-        message="",
-        obj=None,
-        show_content=True,
-        suppress_extended_error=False,
-        orig_exc=_UNDERLYING_EXC_SENTINEL,
-        result=None,
-    ):
+    def __init__(self, message="", obj=None, show_content=True, suppress_extended_error=False, orig_exc=None, result=None):
         super(AnsibleActionSkip, self).__init__(message=message, obj=obj, show_content=show_content,
                                                 suppress_extended_error=suppress_extended_error, orig_exc=orig_exc, result=result)
         self.result.update({'skipped': True, 'msg': message})
@@ -405,15 +369,7 @@ class AnsibleActionSkip(AnsibleAction):
 
 class AnsibleActionFail(AnsibleAction):
     """ an action runtime failure"""
-    def __init__(
-        self,
-        message="",
-        obj=None,
-        show_content=True,
-        suppress_extended_error=False,
-        orig_exc=_UNDERLYING_EXC_SENTINEL,
-        result=None,
-    ):
+    def __init__(self, message="", obj=None, show_content=True, suppress_extended_error=False, orig_exc=None, result=None):
         super(AnsibleActionFail, self).__init__(message=message, obj=obj, show_content=show_content,
                                                 suppress_extended_error=suppress_extended_error, orig_exc=orig_exc, result=result)
         self.result.update({'failed': True, 'msg': message, 'exception': traceback.format_exc()})

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -69,7 +69,7 @@ class AnsibleError(Exception):
             self.__cause__ = orig_exc
 
     @property
-    def orig_exc(self):
+    def orig_exc(self) -> BaseException | None:
         """The underlying exception object.
 
         If the exception cause is undefined, it's set to :py:data:`None`.
@@ -77,7 +77,7 @@ class AnsibleError(Exception):
         return self.__cause__
 
     @orig_exc.setter
-    def orig_exc(self, underlying_exception):
+    def orig_exc(self, underlying_exception: BaseException | None) -> None:
         """Set the underlying exception as cause of the current one."""
         self.__cause__ = underlying_exception
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -516,7 +516,7 @@ class TaskExecutor:
                 # Display the error from the conditional as well to prevent
                 # losing information useful for debugging.
                 display.v(to_text(e))
-                raise self._loop_eval_error  # pylint: disable=raising-bad-type
+                raise self._loop_eval_error from e  # pylint: disable=raising-bad-type
             raise
 
         # Not skipping, if we had loop error raised earlier we need to raise it now to halt the execution of this task
@@ -532,7 +532,7 @@ class TaskExecutor:
                     raiseit = False
                 elif isinstance(context_validation_error, AnsibleParserError):
                     # parser error, might be cause by undef too
-                    orig_exc = getattr(context_validation_error, 'orig_exc', None)
+                    orig_exc = context_validation_error.__cause__
                     if isinstance(orig_exc, AnsibleUndefinedVariable):
                         raiseit = False
             if raiseit:

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -487,6 +487,8 @@
 - assert:
     that:
       - "'msdcc is not in the list of supported passlib algorithms' in unsupported_hash_type.msg"
+  vars:
+    msg: "msdcc is not in the list of supported passlib algorithms: md5, blowfish, sha256, sha512. user must be unicode or bytes, not None"
 
 - name: Verify to_uuid throws on weird namespace
   set_fact:


### PR DESCRIPTION
This has the same effect as doing

    raise AnsibleError from UnderlyingError

The exception cause is then available for inspection and shows up in tracebacks.

##### SUMMARY

Here I'm exploring the possibility of using native Python 3 exception chaining.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Refactoring Pull Request

##### ADDITIONAL INFORMATION

N/A