### PR TITLE
Make sure that none is not accepted for required module options

### DIFF
--- a/changelogs/fragments/argspec-required-mutually_exclusive.yml
+++ b/changelogs/fragments/argspec-required-mutually_exclusive.yml
@@ -1,5 +1,8 @@
 breaking_changes:
 - For Python modules, ``required_by`` no longer treats ``none`` as "not specified". It now behaves like all other required checks.
-- "For Python modules, the checks for ``required``, ``required_if``, ``required_together``, ``required_one_of``, and ``required_by`` no longer allow an explicitly specified value ``none``.
-   The old behavior (explicit ``none`` counts as specified) can be explicitly allowed by setting ``allow_none_value=True`` in the argument spec for that option
+- "For Python modules, the checks for ``required``, ``required_if``, ``required_together``, ``required_one_of``, and ``required_by`` warn when an explicit ``none`` value is passed for them, but still accept that value.
+   This behavior will be deprecated in ansible-base 2.12 and disabled in ansible-base 2.16.
+
+   Module authors can explicitly request the old behavior (explicit ``none`` counts as specified) by setting ``allow_none_value=True`` in the argument spec for that option,
+   and can explicitly request the new behavior  from ansible-base 2.16 (explicit ``none`` counts as error) by setting ``allow_none_value=False`` in the argument spec for that option
    (https://github.com/ansible/ansible/issues/69190)."

--- a/changelogs/fragments/argspec-required-mutually_exclusive.yml
+++ b/changelogs/fragments/argspec-required-mutually_exclusive.yml
@@ -1,5 +1,5 @@
 breaking_changes:
-- For Python modules, ``required_by`` no longer treats ``none` as "not specified'. It now behaves like all other required checks.
-- For Python modules, the checks for ``required``, ``required_if``, ``required_together``, ``required_one_of``, and ``required_by`` no longer allow an explicitly specified value ``none``.
-  The old behavior (explicit ``none`` counts as specified) can be explicitly allowed by setting ``allow_none_value=True`` in the argument spec for that option
-  (https://github.com/ansible/ansible/issues/69190).
+- For Python modules, ``required_by`` no longer treats ``none`` as "not specified". It now behaves like all other required checks.
+- "For Python modules, the checks for ``required``, ``required_if``, ``required_together``, ``required_one_of``, and ``required_by`` no longer allow an explicitly specified value ``none``.
+   The old behavior (explicit ``none`` counts as specified) can be explicitly allowed by setting ``allow_none_value=True`` in the argument spec for that option
+   (https://github.com/ansible/ansible/issues/69190)."

--- a/changelogs/fragments/argspec-required-mutually_exclusive.yml
+++ b/changelogs/fragments/argspec-required-mutually_exclusive.yml
@@ -1,0 +1,5 @@
+breaking_changes:
+- For Python modules, ``required_by`` no longer treats ``none` as "not specified'. It now behaves like all other required checks.
+- For Python modules, the checks for ``required``, ``required_if``, ``required_together``, ``required_one_of``, and ``required_by`` no longer allow an explicitly specified value ``none``.
+  The old behavior (explicit ``none`` counts as specified) can be explicitly allowed by setting ``allow_none_value=True`` in the argument spec for that option
+  (https://github.com/ansible/ansible/issues/69190).

--- a/changelogs/fragments/argspec-required-mutually_exclusive.yml
+++ b/changelogs/fragments/argspec-required-mutually_exclusive.yml
@@ -1,5 +1,7 @@
 breaking_changes:
 - For Python modules, ``required_by`` no longer treats ``none`` as "not specified". It now behaves like all other required checks.
+
+minor_changes:
 - "For Python modules, the checks for ``required``, ``required_if``, ``required_together``, ``required_one_of``, and ``required_by`` warn when an explicit ``none`` value is passed for them, but still accept that value.
    This behavior will be deprecated in ansible-base 2.12 and disabled in ansible-base 2.16.
 

--- a/changelogs/fragments/argspec-required-mutually_exclusive.yml
+++ b/changelogs/fragments/argspec-required-mutually_exclusive.yml
@@ -1,12 +1,12 @@
 deprecated_features:
-- "For Python modules, the behavior of ``required_by`` to treat an explicit value of ``none`` as 'not specified' is deprecated.
-   From ansible-base 2.15 on, an explicit ``none`` will no longer be treated as 'not specified'. Then the behavior of ``required_by``
-   will be the same as for all other ``required`` and ``required_*`` checks."
+- >-
+  The ``required_by`` feature for Python modules treats an explicit parameter passed in as ``None`` as "not specified".
+  This is deprecated because it is inconsistent with the other ``required`` and ``required_*`` checks.
+- >-
+  The ``required``, ``required_if``, ``required_together``, ``required_one_of``, and ``required_by`` checks for Python modules
+  warn when a module parameter is passed in as ``None``, but still accept that value.
 
-minor_changes:
-- "For Python modules, the checks for ``required``, ``required_if``, ``required_together``, ``required_one_of``, and ``required_by`` warn when an explicit ``none`` value is passed for them, but still accept that value.
-   This behavior will be deprecated in ansible-base 2.12 and disabled in ansible-base 2.16.
-
-   Module authors can explicitly request the old behavior (explicit ``none`` counts as specified) by setting ``allow_none_value=True`` in the argument spec for that option,
-   and can explicitly request the new behavior  from ansible-base 2.16 (explicit ``none`` counts as error) by setting ``allow_none_value=False`` in the argument spec for that option
-   (https://github.com/ansible/ansible/issues/69190)."
+  The module can opt into the intended behavior by setting ``allow_none_value`` to ``True`` or ``False`` for the option in the
+  argument spec.
+  
+  (https://github.com/ansible/ansible/issues/69190)

--- a/changelogs/fragments/argspec-required-mutually_exclusive.yml
+++ b/changelogs/fragments/argspec-required-mutually_exclusive.yml
@@ -1,5 +1,7 @@
-breaking_changes:
-- For Python modules, ``required_by`` no longer treats ``none`` as "not specified". It now behaves like all other required checks.
+deprecated_features:
+- "For Python modules, the behavior of ``required_by`` to treat an explicit value of ``none`` as 'not specified' is deprecated.
+   From ansible-base 2.15 on, an explicit ``none`` will no longer be treated as 'not specified'. Then the behavior of ``required_by``
+   will be the same as for all other ``required`` and ``required_*`` checks."
 
 minor_changes:
 - "For Python modules, the checks for ``required``, ``required_if``, ``required_together``, ``required_one_of``, and ``required_by`` warn when an explicit ``none`` value is passed for them, but still accept that value.

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -57,6 +57,7 @@ from ansible.module_utils.common.validation import (
     check_required_one_of,
     check_required_if,
     check_required_by,
+    check_required_none,
     check_type_bits,
     check_type_bool,
     check_type_bytes,
@@ -805,8 +806,9 @@ def _validate_sub_spec(
 
                 no_log_values.update(_set_defaults(sub_spec, sub_parameters, False))
 
+                required_options = []
                 try:
-                    check_required_arguments(sub_spec, sub_parameters, options_context)
+                    check_required_arguments(sub_spec, sub_parameters, options_context, add_required=required_options)
                 except TypeError as e:
                     errors.append(RequiredError(to_native(e)))
 
@@ -815,9 +817,13 @@ def _validate_sub_spec(
 
                 for check in _ADDITIONAL_CHECKS:
                     try:
-                        check['func'](value.get(check['attr']), sub_parameters, options_context)
+                        check['func'](value.get(check['attr']), sub_parameters, options_context, add_required=required_options)
                     except TypeError as e:
                         errors.append(check['err'](to_native(e)))
+                try:
+                    check_required_none(required_options, sub_spec, sub_parameters, options_context)
+                except TypeError as e:
+                    errors.append(RequiredError(to_native(e)))
 
                 no_log_values.update(_set_defaults(sub_spec, sub_parameters))
 

--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -13,7 +13,7 @@ from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.common.collections import is_iterable
 from ansible.module_utils.common.text.converters import jsonify
 from ansible.module_utils.common.text.formatters import human_to_bytes
-from ansible.module_utils.common.warnings import warn, deprecate
+from ansible.module_utils.common.warnings import deprecate
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six import (
     binary_type,
@@ -387,7 +387,7 @@ def check_required_none(required_options, argument_spec, parameters, options_con
         if allow_none_value is False:
             raise TypeError(to_native(msg))
         else:
-            warn(msg)
+            deprecate(msg, version='2.20')
 
 
 def check_missing_parameters(parameters, required_parameters=None):

--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -195,11 +195,8 @@ def check_required_by(requirements, parameters, options_context=None, add_requir
     if requirements is None:
         return result
 
-    deprecation_fmt = (
-        'The explicit none (null) value specified to %s' +
-        (' found in {0}'.format(' -> '.join(options_context)) if options_context else '') +
-        ' will not be treated as "not specified" in the future'
-    )
+    found_in = " found in %s" % " -> ".join(options_context) if options_context else ''
+    deprecation_fmt = f'The explicit none (null) value specified to %s{found_in} will not be treated as "not specified" in the future'
 
     for (key, value) in requirements.items():
         if key not in parameters or parameters[key] is None:
@@ -377,13 +374,8 @@ def check_required_none(required_options, argument_spec, parameters, options_con
         if allow_none_value:
             continue
 
-        if allow_none_value is False:
-            msg = "required parameter %s cannot be none (null)" % (required_option, )
-        else:
-            msg = "required parameter %s is none (null)" % (required_option, )
-        if options_context:
-            msg += " found in %s" % " -> ".join(options_context)
-
+        found_in = " found in %s" % " -> ".join(options_context) if options_context else ''
+        msg = f"required parameter {required_option}{found_in} {'cannot be' if allow_none_value is False else 'is'} none (null)"
         if allow_none_value is False:
             raise TypeError(to_native(msg))
         else:

--- a/test/integration/targets/argspec/library/argspec.py
+++ b/test/integration/targets/argspec/library/argspec.py
@@ -12,11 +12,15 @@ def main():
         {
             'required': {
                 'required': True,
+                'type': 'raw',
             },
             'required_one_of_one': {},
             'required_one_of_two': {},
             'required_one_of_three': {
                 'allow_none_value': True,
+            },
+            'required_one_of_four': {
+                'allow_none_value': False,
             },
             'required_by_one': {},
             'required_by_two': {},
@@ -255,7 +259,7 @@ def main():
             ('path', 'content', 'default_value',),
         ),
         required_one_of=(
-            ('required_one_of_one', 'required_one_of_two', 'required_one_of_three'),
+            ('required_one_of_one', 'required_one_of_two', 'required_one_of_three', 'required_one_of_four'),
         ),
         required_by={
             'required_by_one': ('required_by_two', 'required_by_three'),

--- a/test/integration/targets/argspec/library/argspec.py
+++ b/test/integration/targets/argspec/library/argspec.py
@@ -15,6 +15,9 @@ def main():
             },
             'required_one_of_one': {},
             'required_one_of_two': {},
+            'required_one_of_three': {
+                'allow_none_value': True,
+            },
             'required_by_one': {},
             'required_by_two': {},
             'required_by_three': {},
@@ -252,7 +255,7 @@ def main():
             ('path', 'content', 'default_value',),
         ),
         required_one_of=(
-            ('required_one_of_one', 'required_one_of_two'),
+            ('required_one_of_one', 'required_one_of_two', 'required_one_of_three'),
         ),
         required_by={
             'required_by_one': ('required_by_two', 'required_by_three'),

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -19,6 +19,11 @@
 
 - argspec:
     required: value
+    # Explicit None is allowed for 'required_one_of_three'
+    required_one_of_three:
+
+- argspec:
+    required: value
   register: argspec_required_one_of_fail
   ignore_errors: true
 

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -59,10 +59,28 @@
 - argspec:
     required: value
     required_one_of_two: value
+    required_by_one:
+    required_by_two:
+    required_by_three: value
+  register: argspec_required_by_fail_none_1
+  ignore_errors: true
+
+- argspec:
+    required: value
+    required_one_of_two: value
     required_by_one: value
     required_by_two:
     required_by_three: value
-  register: argspec_required_by_fail_none
+  register: argspec_required_by_fail_none_2
+  ignore_errors: true
+
+- argspec:
+    required: value
+    required_one_of_two: value
+    required_by_one:
+    required_by_two:
+    required_by_three: value
+  register: argspec_required_by_fail_none_3
   ignore_errors: true
 
 - argspec:
@@ -275,7 +293,25 @@
         other:
     required: value
     required_one_of_one: value
-  register: argspec_required_by_fail_2_none
+  register: argspec_required_by_fail_2_none_1
+  ignore_errors: true
+
+- argspec:
+    required_by:
+      - thing:
+        other: bar
+    required: value
+    required_one_of_one: value
+  register: argspec_required_by_fail_2_none_2
+  ignore_errors: true
+
+- argspec:
+    required_by:
+      - thing:
+        other:
+    required: value
+    required_one_of_one: value
+  register: argspec_required_by_fail_2_none_3
   ignore_errors: true
 
 - argspec:
@@ -599,8 +635,14 @@
       - argspec_required_one_of_explicitly_disallowed.msg == 'required parameter required_one_of_four cannot be none (null)'
 
       - argspec_required_by_fail is failed
-      - argspec_required_by_fail_none is succeeded
-      - "'required parameter required_by_two is none (null)' in argspec_required_by_fail_none.warnings"
+      - argspec_required_by_fail_none_1 is succeeded
+      - argspec_required_by_fail_none_1.deprecations | length == 1
+      - argspec_required_by_fail_none_1.deprecations[0].msg == 'The explicit none (null) value specified to required_by_one will not be treated as "not specified" in the future'
+      - argspec_required_by_fail_none_2 is failed
+      - argspec_required_by_fail_none_2.msg == "missing parameter(s) required by 'required_by_one': required_by_two"
+      - argspec_required_by_fail_none_3 is succeeded
+      - argspec_required_by_fail_none_3.deprecations | length == 1
+      - argspec_required_by_fail_none_3.deprecations[0].msg == 'The explicit none (null) value specified to required_by_one will not be treated as "not specified" in the future'
 
       - argspec_required_if_fail is failed
       - argspec_required_if_fail_none is succeeded
@@ -638,8 +680,14 @@
       - "'required parameter thing is none (null) found in required_one_of' in argspec_required_one_of_fail_2_none.warnings"
 
       - argspec_required_by_fail_2 is failed
-      - argspec_required_by_fail_2_none is succeeded
-      - "'required parameter other is none (null) found in required_by' in argspec_required_by_fail_2_none.warnings"
+      - argspec_required_by_fail_2_none_1 is failed
+      - argspec_required_by_fail_2_none_1.msg == "missing parameter(s) required by 'thing': other"
+      - argspec_required_by_fail_2_none_2 is succeeded
+      - argspec_required_by_fail_2_none_2.deprecations | length == 1
+      - argspec_required_by_fail_2_none_2.deprecations[0].msg == 'The explicit none (null) value specified to thing found in required_by will not be treated as "not specified" in the future'
+      - argspec_required_by_fail_2_none_3 is succeeded
+      - argspec_required_by_fail_2_none_3.deprecations | length == 1
+      - argspec_required_by_fail_2_none_3.deprecations[0].msg == 'The explicit none (null) value specified to thing found in required_by will not be treated as "not specified" in the future'
 
       - argspec_good_json_string is successful
       - >-

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -623,13 +623,13 @@
     that:
       - argspec_required_fail is failed
       - argspec_required_fail_none is succeeded
-      - "'required parameter required is none (null)' in argspec_required_fail_none.warnings"
+      - "'required parameter required is none (null)' == argspec_required_fail_none.deprecations[0]['msg']"
 
       - argspec_required_one_of_fail is failed
       - argspec_required_one_of_fail_none is succeeded
-      - "'required parameter required_one_of_one is none (null)' in argspec_required_one_of_fail_none.warnings"
+      - "'required parameter required_one_of_one is none (null)' == argspec_required_one_of_fail_none.deprecations[0]['msg']"
 
-      - "'Module did not set no_log for maybe_password' in argspec_required_one_of_explicitly_allowed.warnings and argspec_required_one_of_explicitly_allowed.warnings | length == 1"
+      - argspec_required_one_of_explicitly_allowed.deprecations is undefined
       - argspec_required_one_of_explicitly_disallowed is failed
       - argspec_required_one_of_explicitly_disallowed.msg == 'required parameter required_one_of_four cannot be none (null)'
 
@@ -645,7 +645,7 @@
 
       - argspec_required_if_fail is failed
       - argspec_required_if_fail_none is succeeded
-      - "'required parameter path is none (null)' in argspec_required_if_fail_none.warnings"
+      - "'required parameter path is none (null)' == argspec_required_if_fail_none.deprecations[0]['msg']"
 
       - argspec_mutually_exclusive_fail is failed
       - argspec_mutually_exclusive_fail_none is failed
@@ -668,15 +668,15 @@
 
       - argspec_required_together_fail is failed
       - argspec_required_together_fail_none is succeeded
-      - "'required parameter other is none (null) found in required_together' in argspec_required_together_fail_none.warnings"
+      - "'required parameter other is none (null) found in required_together' == argspec_required_together_fail_none.deprecations[0]['msg']"
 
       - argspec_required_if_fail_2 is failed
       - argspec_required_if_fail_2_none is succeeded
-      - "'required parameter other is none (null) found in required_if' in argspec_required_if_fail_2_none.warnings"
+      - "'required parameter other is none (null) found in required_if' == argspec_required_if_fail_2_none.deprecations[0]['msg']"
 
       - argspec_required_one_of_fail_2 is failed
       - argspec_required_one_of_fail_2_none is succeeded
-      - "'required parameter thing is none (null) found in required_one_of' in argspec_required_one_of_fail_2_none.warnings"
+      - "'required parameter thing is none (null) found in required_one_of' == argspec_required_one_of_fail_2_none.deprecations[0]['msg']"
 
       - argspec_required_by_fail_2 is failed
       - argspec_required_by_fail_2_none_1 is failed
@@ -700,7 +700,7 @@
 
       - argspec_fail_required_together_2 is failed
       - argspec_fail_required_together_2_none is succeeded
-      - "'required parameter required_together_two is none (null)' in argspec_fail_required_together_2_none.warnings"
+      - "'required parameter required_together_two is none (null)' == argspec_fail_required_together_2_none.deprecations[0]['msg']"
 
       - >-
         argspec_suboptions_list_no_elements.suboptions_list_no_elements.0 == {'thing': 'foo'}

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -668,15 +668,15 @@
 
       - argspec_required_together_fail is failed
       - argspec_required_together_fail_none is succeeded
-      - "'required parameter other is none (null) found in required_together' == argspec_required_together_fail_none.deprecations[0]['msg']"
+      - "'required parameter other found in required_together is none (null)' == argspec_required_together_fail_none.deprecations[0]['msg']"
 
       - argspec_required_if_fail_2 is failed
       - argspec_required_if_fail_2_none is succeeded
-      - "'required parameter other is none (null) found in required_if' == argspec_required_if_fail_2_none.deprecations[0]['msg']"
+      - "'required parameter other found in required_if is none (null)' == argspec_required_if_fail_2_none.deprecations[0]['msg']"
 
       - argspec_required_one_of_fail_2 is failed
       - argspec_required_one_of_fail_2_none is succeeded
-      - "'required parameter thing is none (null) found in required_one_of' == argspec_required_one_of_fail_2_none.deprecations[0]['msg']"
+      - "'required parameter thing found in required_one_of is none (null)' == argspec_required_one_of_fail_2_none.deprecations[0]['msg']"
 
       - argspec_required_by_fail_2 is failed
       - argspec_required_by_fail_2_none_1 is failed

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -8,12 +8,24 @@
   ignore_errors: true
 
 - argspec:
+    required:
+    required_one_of_one: value
+  register: argspec_required_fail_none
+  ignore_errors: true
+
+- argspec:
     required: value
     required_one_of_two: value
 
 - argspec:
     required: value
   register: argspec_required_one_of_fail
+  ignore_errors: true
+
+- argspec:
+    required: value
+    required_one_of_one:
+  register: argspec_required_one_of_fail_none
   ignore_errors: true
 
 - argspec:
@@ -32,6 +44,15 @@
   ignore_errors: true
 
 - argspec:
+    required: value
+    required_one_of_two: value
+    required_by_one: value
+    required_by_two:
+    required_by_three: value
+  register: argspec_required_by_fail_none
+  ignore_errors: true
+
+- argspec:
     state: absent
     required: value
     required_one_of_one: value
@@ -41,6 +62,14 @@
     required: value
     required_one_of_one: value
   register: argspec_required_if_fail
+  ignore_errors: true
+
+- argspec:
+    state: present
+    path:
+    required: value
+    required_one_of_one: value
+  register: argspec_required_if_fail_none
   ignore_errors: true
 
 - argspec:
@@ -62,6 +91,15 @@
     required: value
     required_one_of_one: value
   register: argspec_mutually_exclusive_fail
+  ignore_errors: true
+
+- argspec:
+    state: present
+    content: foo
+    path:
+    required: value
+    required_one_of_one: value
+  register: argspec_mutually_exclusive_fail_none
   ignore_errors: true
 
 - argspec:
@@ -137,6 +175,15 @@
 - argspec:
     required_together:
       - thing: foo
+        other:
+    required: value
+    required_one_of_one: value
+  register: argspec_required_together_fail_none
+  ignore_errors: true
+
+- argspec:
+    required_together:
+      - thing: foo
         other: bar
     required: value
     required_one_of_one: value
@@ -163,6 +210,15 @@
   ignore_errors: true
 
 - argspec:
+    required_if:
+      - thing: foo
+        other:
+    required: value
+    required_one_of_one: value
+  register: argspec_required_if_fail_2_none
+  ignore_errors: true
+
+- argspec:
     required_one_of:
       - thing: foo
         other: bar
@@ -178,6 +234,14 @@
   ignore_errors: true
 
 - argspec:
+    required_one_of:
+      - thing:
+    required: value
+    required_one_of_one: value
+  register: argspec_required_one_of_fail_2_none
+  ignore_errors: true
+
+- argspec:
     required_by:
       - thing: foo
         other: bar
@@ -190,6 +254,15 @@
     required: value
     required_one_of_one: value
   register: argspec_required_by_fail_2
+  ignore_errors: true
+
+- argspec:
+    required_by:
+      - thing: foo
+        other:
+    required: value
+    required_one_of_one: value
+  register: argspec_required_by_fail_2_none
   ignore_errors: true
 
 - argspec:
@@ -238,6 +311,14 @@
     required: value
     required_one_of_one: value
   register: argspec_fail_required_together_2
+  ignore_errors: true
+
+- argspec:
+    required_together_one: foo
+    required_together_two:
+    required: value
+    required_one_of_one: value
+  register: argspec_fail_required_together_2_none
   ignore_errors: true
 
 - argspec:
@@ -493,14 +574,19 @@
 - assert:
     that:
       - argspec_required_fail is failed
+      - argspec_required_fail_none is failed
 
       - argspec_required_one_of_fail is failed
+      - argspec_required_one_of_fail_none is failed
 
       - argspec_required_by_fail is failed
+      - argspec_required_by_fail_none is failed
 
       - argspec_required_if_fail is failed
+      - argspec_required_if_fail_none is failed
 
       - argspec_mutually_exclusive_fail is failed
+      - argspec_mutually_exclusive_fail_none is failed
 
       - argspec_good_mapping is successful
       - >-
@@ -519,12 +605,16 @@
       - argspec_bad_mapping_list is failed
 
       - argspec_required_together_fail is failed
+      - argspec_required_together_fail_none is failed
 
       - argspec_required_if_fail_2 is failed
+      - argspec_required_if_fail_2_none is failed
 
       - argspec_required_one_of_fail_2 is failed
+      - argspec_required_one_of_fail_2_none is failed
 
       - argspec_required_by_fail_2 is failed
+      - argspec_required_by_fail_2_none is failed
 
       - argspec_good_json_string is successful
       - >-
@@ -537,6 +627,7 @@
       - argspec_fail_on_missing_params_bad is failed
 
       - argspec_fail_required_together_2 is failed
+      - argspec_fail_required_together_2_none is failed
 
       - >-
         argspec_suboptions_list_no_elements.suboptions_list_no_elements.0 == {'thing': 'foo'}

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -11,7 +11,6 @@
     required:
     required_one_of_one: value
   register: argspec_required_fail_none
-  ignore_errors: true
 
 - argspec:
     required: value
@@ -630,7 +629,7 @@
       - argspec_required_one_of_fail_none is succeeded
       - "'required parameter required_one_of_one is none (null)' in argspec_required_one_of_fail_none.warnings"
 
-      - argspec_required_one_of_explicitly_allowed.warnings is not defined or argspec_required_one_of_explicitly_allowed.warnings | length == 0
+      - "'Module did not set no_log for maybe_password' in argspec_required_one_of_explicitly_allowed.warnings and argspec_required_one_of_explicitly_allowed.warnings | length == 1"
       - argspec_required_one_of_explicitly_disallowed is failed
       - argspec_required_one_of_explicitly_disallowed.msg == 'required parameter required_one_of_four cannot be none (null)'
 

--- a/test/integration/targets/argspec/tasks/main.yml
+++ b/test/integration/targets/argspec/tasks/main.yml
@@ -21,6 +21,14 @@
     required: value
     # Explicit None is allowed for 'required_one_of_three'
     required_one_of_three:
+  register: argspec_required_one_of_explicitly_allowed
+
+- argspec:
+    required: value
+    # Explicit None is not allowed for 'required_one_of_four'
+    required_one_of_four:
+  register: argspec_required_one_of_explicitly_disallowed
+  ignore_errors: true
 
 - argspec:
     required: value
@@ -579,16 +587,24 @@
 - assert:
     that:
       - argspec_required_fail is failed
-      - argspec_required_fail_none is failed
+      - argspec_required_fail_none is succeeded
+      - "'required parameter required is none (null)' in argspec_required_fail_none.warnings"
 
       - argspec_required_one_of_fail is failed
-      - argspec_required_one_of_fail_none is failed
+      - argspec_required_one_of_fail_none is succeeded
+      - "'required parameter required_one_of_one is none (null)' in argspec_required_one_of_fail_none.warnings"
+
+      - argspec_required_one_of_explicitly_allowed.warnings is not defined or argspec_required_one_of_explicitly_allowed.warnings | length == 0
+      - argspec_required_one_of_explicitly_disallowed is failed
+      - argspec_required_one_of_explicitly_disallowed.msg == 'required parameter required_one_of_four cannot be none (null)'
 
       - argspec_required_by_fail is failed
-      - argspec_required_by_fail_none is failed
+      - argspec_required_by_fail_none is succeeded
+      - "'required parameter required_by_two is none (null)' in argspec_required_by_fail_none.warnings"
 
       - argspec_required_if_fail is failed
-      - argspec_required_if_fail_none is failed
+      - argspec_required_if_fail_none is succeeded
+      - "'required parameter path is none (null)' in argspec_required_if_fail_none.warnings"
 
       - argspec_mutually_exclusive_fail is failed
       - argspec_mutually_exclusive_fail_none is failed
@@ -610,16 +626,20 @@
       - argspec_bad_mapping_list is failed
 
       - argspec_required_together_fail is failed
-      - argspec_required_together_fail_none is failed
+      - argspec_required_together_fail_none is succeeded
+      - "'required parameter other is none (null) found in required_together' in argspec_required_together_fail_none.warnings"
 
       - argspec_required_if_fail_2 is failed
-      - argspec_required_if_fail_2_none is failed
+      - argspec_required_if_fail_2_none is succeeded
+      - "'required parameter other is none (null) found in required_if' in argspec_required_if_fail_2_none.warnings"
 
       - argspec_required_one_of_fail_2 is failed
-      - argspec_required_one_of_fail_2_none is failed
+      - argspec_required_one_of_fail_2_none is succeeded
+      - "'required parameter thing is none (null) found in required_one_of' in argspec_required_one_of_fail_2_none.warnings"
 
       - argspec_required_by_fail_2 is failed
-      - argspec_required_by_fail_2_none is failed
+      - argspec_required_by_fail_2_none is succeeded
+      - "'required parameter other is none (null) found in required_by' in argspec_required_by_fail_2_none.warnings"
 
       - argspec_good_json_string is successful
       - >-
@@ -632,7 +652,8 @@
       - argspec_fail_on_missing_params_bad is failed
 
       - argspec_fail_required_together_2 is failed
-      - argspec_fail_required_together_2_none is failed
+      - argspec_fail_required_together_2_none is succeeded
+      - "'required parameter required_together_two is none (null)' in argspec_fail_required_together_2_none.warnings"
 
       - >-
         argspec_suboptions_list_no_elements.suboptions_list_no_elements.0 == {'thing': 'foo'}

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -299,6 +299,7 @@ def argument_spec_schema(for_collection):
             'choices': Any([object], (object,)),
             'context': dict,
             'required': bool,
+            'allow_none_value': bool,
             'no_log': bool,
             'aliases': Any(list_string_types, tuple(list_string_types)),
             'apply_defaults': bool,


### PR DESCRIPTION
##### SUMMARY

Rebase/port of #72248 to add a new check for `None` for required module/role argument spec options and deprecate treating explicitly specified `None` options as "not specified" implicitly by default.

Fixes #82724
Fixes #83314

##### ISSUE TYPE

- Feature Pull Request
