### PR TITLE
2.16: Fix error when templating an unsafe string leading to a type error in Python (#82675)

### DIFF
--- a/changelogs/fragments/82675-fix-unsafe-templating-leading-to-type-error.yml
+++ b/changelogs/fragments/82675-fix-unsafe-templating-leading-to-type-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - template - Fix error when templating an unsafe string which corresponds to an invalid type in Python (https://github.com/ansible/ansible/issues/82600).

--- a/lib/ansible/template/native_helpers.py
+++ b/lib/ansible/template/native_helpers.py
@@ -67,7 +67,7 @@ def ansible_eval_concat(nodes):
                     )
                 )
             )
-        except (ValueError, SyntaxError, MemoryError):
+        except (TypeError, ValueError, SyntaxError, MemoryError):
             pass
 
     return out
@@ -129,7 +129,7 @@ def ansible_native_concat(nodes):
             # parse the string ourselves without removing leading spaces/tabs.
             ast.parse(out, mode='eval')
         )
-    except (ValueError, SyntaxError, MemoryError):
+    except (TypeError, ValueError, SyntaxError, MemoryError):
         return out
 
     if isinstance(evaled, string_types):

--- a/test/integration/targets/template/unsafe.yml
+++ b/test/integration/targets/template/unsafe.yml
@@ -3,6 +3,7 @@
   vars:
     nottemplated: this should not be seen
     imunsafe: !unsafe '{{ nottemplated }}'
+    unsafe_set: !unsafe '{{ "test" }}'
   tasks:
 
     - set_fact:
@@ -12,11 +13,15 @@
     - set_fact:
           this_always_safe: '{{ imunsafe }}'
 
+    - set_fact:
+        this_unsafe_set: "{{ unsafe_set }}"
+
     - name: ensure nothing was templated
       assert:
         that:
         - this_always_safe == imunsafe
         - imunsafe == this_was_unsafe.strip()
+        - unsafe_set == this_unsafe_set.strip()
 
 
 - hosts: localhost


### PR DESCRIPTION
##### SUMMARY

Backport of #82675
(cherry picked from commit 79ea21a39fbbb3be83de2a899f6228805bb33773)
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request