### PR TITLE
Disable ansible-test podman container tests on Ubuntu 22.04

### DIFF
--- a/test/integration/targets/ansible-test-container/runme.py
+++ b/test/integration/targets/ansible-test-container/runme.py
@@ -1015,7 +1015,7 @@ class AptBootstrapper(Bootstrapper):
     @classmethod
     def install_podman(cls) -> bool:
         """Return True if podman will be installed."""
-        return not (os_release.id == 'ubuntu' and os_release.version_id == '20.04')
+        return not (os_release.id == 'ubuntu' and os_release.version_id in {'20.04', '22.04'})
 
     @classmethod
     def install_docker(cls) -> bool:


### PR DESCRIPTION
##### SUMMARY

Disable ansible-test podman container tests on Ubuntu 22.04 due to old crun that cannot handle kernel change for disallowing permission changes on symlinks.

##### ISSUE TYPE

- Test Pull Request

##### ADDITIONAL INFORMATION

Ref: https://dev.azure.com/ansible/ansible/_build/results?buildId=105223&view=logs&j=36c8ace0-2222-5f24-d698-6369bfa76572&t=43d9ab83-cfe0-5b30-9a70-e51b6f129dbd
