### PR TITLE
[stable-2.16] Disable ansible-test podman container tests on Ubuntu 22.04 (#82748)

### DIFF
--- a/test/integration/targets/ansible-test-container/runme.py
+++ b/test/integration/targets/ansible-test-container/runme.py
@@ -996,7 +996,7 @@ class AptBootstrapper(Bootstrapper):
     @classmethod
     def install_podman(cls) -> bool:
         """Return True if podman will be installed."""
-        return not (os_release.id == 'ubuntu' and os_release.version_id == '20.04')
+        return not (os_release.id == 'ubuntu' and os_release.version_id in {'20.04', '22.04'})
 
     @classmethod
     def install_docker(cls) -> bool:


### PR DESCRIPTION
(cherry picked from commit 9a8be1e)


Co-authored-by: Matt Martz <matt@sivel.net>