### PR TITLE
Improve documentation for replace module

### DIFF
--- a/lib/ansible/modules/replace.py
+++ b/lib/ansible/modules/replace.py
@@ -74,6 +74,7 @@ options:
       - Uses Python regular expressions; see
         U(https://docs.python.org/3/library/re.html).
       - Uses DOTALL, which means the V(.) special character I(can match newlines).
+      - Does not use MULTILINE, so V(^) and V($) will only match the beginning and end of the file.
     type: str
     version_added: "2.4"
   before:
@@ -83,6 +84,7 @@ options:
       - Uses Python regular expressions; see
         U(https://docs.python.org/3/library/re.html).
       - Uses DOTALL, which means the V(.) special character I(can match newlines).
+      - Does not use MULTILINE, so V(^) and V($) will only match the beginning and end of the file.
     type: str
     version_added: "2.4"
   backup:
@@ -124,7 +126,7 @@ EXAMPLES = r'''
     regexp: '^(.+)$'
     replace: '# \1'
 
-- name: Replace before the expression till the begin of the file (requires Ansible >= 2.4)
+- name: Replace before the expression from the beginning of the file (requires Ansible >= 2.4)
   ansible.builtin.replace:
     path: /etc/apache2/sites-available/default.conf
     before: '# live site config'
@@ -133,11 +135,12 @@ EXAMPLES = r'''
 
 # Prior to Ansible 2.7.10, using before and after in combination did the opposite of what was intended.
 # see https://github.com/ansible/ansible/issues/31354 for details.
+# Note (?m) which turns on MULTILINE mode so ^ matches any line's beginning
 - name: Replace between the expressions (requires Ansible >= 2.4)
   ansible.builtin.replace:
     path: /etc/hosts
-    after: '<VirtualHost [*]>'
-    before: '</VirtualHost>'
+    after: '(?m)^<VirtualHost [*]>'
+    before: '(?m)^</VirtualHost>'
     regexp: '^(.+)$'
     replace: '# \1'
 


### PR DESCRIPTION
##### SUMMARY

* Make it clearer that the `before` and `after` regexp do NOT use `MULTILINE`, contrary to `regexp`.
* Give an example of turning on `MULTILINE` via embedded flags (`(?m)`)

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

I think all regexp should use the same flags for consistency. It is very unlikely that someone would use `^` or `$` in the `before`/`after` arguments and NOT mean beginning/end of a line... if you want to replace from the beginning of end of the *file*, why would you use those arguments at all?

In addition, Python re has an easy way to say beginning/end of file when using MULTILINE (`\A` and `\Z`) but no easy way to say beginning/end of line when not using MULTILINE.

I proposed changing the behavior but this was rejected: #82720