### PR TITLE
debconf: allow a list for value when vtype is multiselect

### DIFF
--- a/changelogs/fragments/debconf_multiselect.yml
+++ b/changelogs/fragments/debconf_multiselect.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - debconf - allow user to specify a list for value when vtype is multiselect (https://github.com/ansible/ansible/issues/81345).

--- a/lib/ansible/modules/debconf.py
+++ b/lib/ansible/modules/debconf.py
@@ -125,7 +125,7 @@ EXAMPLES = r'''
 
 RETURN = r'''#'''
 
-from ansible.module_utils.common.text.converters import to_text
+from ansible.module_utils.common.text.converters import to_text, to_native
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -222,7 +222,10 @@ def main():
             elif vtype == 'password':
                 existing = get_password_value(module, pkg, question, vtype)
             elif vtype == 'multiselect' and isinstance(value, list):
-                value = sorted(value)
+                try:
+                    value = sorted(value)
+                except TypeError as exc:
+                    module.fail_json(msg="Invalid value provided for 'multiselect': %s" % to_native(exc))
                 existing = sorted([i.strip() for i in existing.split(",")])
 
             if value != existing:
@@ -231,7 +234,10 @@ def main():
     if changed:
         if not module.check_mode:
             if vtype == 'multiselect' and isinstance(value, list):
-                value = ", ".join(value)
+                try:
+                    value = ", ".join(value)
+                except TypeError as exc:
+                    module.fail_json(msg="Invalid value provided for 'multiselect': %s" % to_native(exc))
             rc, msg, e = set_selection(module, pkg, question, vtype, value, unseen)
             if rc:
                 module.fail_json(msg=e)

--- a/test/integration/targets/debconf/tasks/main.yml
+++ b/test/integration/targets/debconf/tasks/main.yml
@@ -99,7 +99,7 @@
         that:
           - not debconf_multiselect_test_idem.changed
 
-    - name: Multiselect value again to check if ordered value
+    - name: Multiselect value to check if ordered value
       debconf:
         name: libnss-ldapd
         question: libnss-ldapd/nsswitch
@@ -115,7 +115,7 @@
         that:
           - not debconf_multiselect_test_idem_2.changed
 
-    - name: Multiselect value again to check backward compatibility
+    - name: Multiselect value to check backward compatibility
       debconf:
         name: libnss-ldapd
         question: libnss-ldapd/nsswitch
@@ -127,6 +127,24 @@
       assert:
         that:
           - debconf_multiselect_test_idem_3.changed
+
+    - name: Multiselect value to check if value contains invalid user input
+      debconf:
+        name: libnss-ldapd
+        question: libnss-ldapd/nsswitch
+        vtype: multiselect
+        value:
+          - group
+          - 1
+          - passwd
+      register: debconf_multiselect_test_idem_4
+      ignore_errors: yes
+
+    - name: validate results for multiselect test for invalid value
+      assert:
+        that:
+          - not debconf_multiselect_test_idem_4.changed
+          - '"Invalid value provided" in debconf_multiselect_test_idem_4.msg'
 
   always:
     - name: uninstall debconf-utils

--- a/test/integration/targets/debconf/tasks/main.yml
+++ b/test/integration/targets/debconf/tasks/main.yml
@@ -66,6 +66,68 @@
       assert:
           that:
               - not debconf_test2.changed
+
+    - name: Multiselect value
+      debconf:
+        name: libnss-ldapd
+        question: libnss-ldapd/nsswitch
+        vtype: multiselect
+        value:
+          - passwd
+          - group
+          - shadow
+      register: debconf_multiselect_test
+
+    - name: validate results for multiselect test
+      assert:
+        that:
+          - debconf_multiselect_test.changed
+
+    - name: Multiselect value again (idempotency)
+      debconf:
+        name: libnss-ldapd
+        question: libnss-ldapd/nsswitch
+        vtype: multiselect
+        value:
+          - passwd
+          - group
+          - shadow
+      register: debconf_multiselect_test_idem
+
+    - name: validate results for multiselect test (idempotency)
+      assert:
+        that:
+          - not debconf_multiselect_test_idem.changed
+
+    - name: Multiselect value again to check if ordered value
+      debconf:
+        name: libnss-ldapd
+        question: libnss-ldapd/nsswitch
+        vtype: multiselect
+        value:
+          - group
+          - shadow
+          - passwd
+      register: debconf_multiselect_test_idem_2
+
+    - name: validate results for multiselect test for ordered value
+      assert:
+        that:
+          - not debconf_multiselect_test_idem_2.changed
+
+    - name: Multiselect value again to check backward compatibility
+      debconf:
+        name: libnss-ldapd
+        question: libnss-ldapd/nsswitch
+        vtype: multiselect
+        value: group, shadow, passwd
+      register: debconf_multiselect_test_idem_3
+
+    - name: validate results for multiselect test for backward compatibility
+      assert:
+        that:
+          - debconf_multiselect_test_idem_3.changed
+
   always:
     - name: uninstall debconf-utils
       apt:


### PR DESCRIPTION
##### SUMMARY

* allow user to specify a list for value when vtype is multiselect

Fixes: #81345

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


