### PR TITLE
Fixes permission for cache json file from 600 to 644

### DIFF
--- a/changelogs/fragments/82683-ansible-fact_cache-permissions-changed-after-ansible-coreupdate.yml
+++ b/changelogs/fragments/82683-ansible-fact_cache-permissions-changed-after-ansible-coreupdate.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes permission for cache json file from 600 to 644 (https://github.com/ansible/ansible/issues/82683).

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -28,6 +28,7 @@ from collections.abc import MutableMapping
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
+from ansible.module_utils.common.file import S_IRWU_RG_RO
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.plugins import AnsiblePlugin
 from ansible.plugins.loader import cache_loader
@@ -164,6 +165,7 @@ class BaseFileCacheModule(BaseCacheModule):
                 display.warning("error in '%s' cache plugin while trying to write to '%s' : %s" % (self.plugin_name, tmpfile_path, to_bytes(e)))
             try:
                 os.rename(tmpfile_path, cachefile)
+                os.chmod(cachefile, mode=S_IRWU_RG_RO)
             except (OSError, IOError) as e:
                 display.warning("error in '%s' cache plugin while trying to move '%s' to '%s' : %s" % (self.plugin_name, tmpfile_path, cachefile, to_bytes(e)))
         finally:


### PR DESCRIPTION
##### SUMMARY

Until ansible-core 2.12 the facts cache file created by this module, have permission set as 644 which allow the other users to read the cache, since ansible-core 2.13, we create the temporary file, but we do not set the permission after renaming the temporary file.  Adding the line to set the permission to allow other users/groups read this file.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Permission when setting the cache to store in jsonfile `ANSIBLE_CACHE_PLUGIN=jsonfile` and `ANSIBLE_CACHE_PLUGIN_CONNECTION="$HOME/facts_cache"` at ansible-core-2.13+
```
facts_cache_2.14:
total 28K
-rw------- 1 root root 25K Feb 27 14:38 localhost
```

Permission when setting the cache to store in jsonfile `ANSIBLE_CACHE_PLUGIN=jsonfile` and `ANSIBLE_CACHE_PLUGIN_CONNECTION="$HOME/facts_cache"` at ansible-core-2.12
```
facts_cache_2.12:
total 24K
-rw-r--r-- 1 root root 24K Feb 27 14:35 localhost
```
