### PR TITLE
Add note for validate in blockinfile.py

### DIFF
--- a/lib/ansible/modules/blockinfile.py
+++ b/lib/ansible/modules/blockinfile.py
@@ -111,6 +111,7 @@ notes:
   - Option O(ignore:follow) has been removed in Ansible 2.5, because this module modifies the contents of the file
     so O(ignore:follow=no) does not make sense.
   - When more than one block should be handled in one file you must change the O(marker) per task.
+  - Option O(validate) is not considered when C(backup) is set to C(no).
 extends_documentation_fragment:
     - action_common_attributes
     - action_common_attributes.files


### PR DESCRIPTION
The `backup` option has to be enabled for `validate` to work.

##### SUMMARY

We used your example:
``` ansible
- name: Insert/Update configuration using a local file and validate it
  ansible.builtin.blockinfile:
    block: "{{ lookup('ansible.builtin.file', './local/sshd_config') }}"
    path: /etc/ssh/sshd_config
    backup: yes
    validate: /usr/sbin/sshd -T -f %s
```

but forgot to enable `backup`. This way the task did not fail even for wrong sshd configurations.

##### ISSUE TYPE

- Docs Pull Request

