### PR TITLE
Follow fix for test_iptables

### DIFF
--- a/test/units/modules/test_iptables.py
+++ b/test/units/modules/test_iptables.py
@@ -135,7 +135,7 @@ def test_policy_table(mocker):
         )
     ]
 )
-def test_policy_table(mocker, test_input, commands_results):
+def test_policy_table_flush(mocker, test_input, commands_results):
     """Test flush without parameters and change == false."""
     set_module_args(test_input)
     run_command = mocker.patch(


### PR DESCRIPTION
##### SUMMARY

* rename 'test_policy_table' to 'test_policy_table_flush' to remove duplicate
  test case name.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE



- Test Pull Request