### PR TITLE
Auto-inject coverage defaults through a plugin

### DIFF
--- a/test/integration/targets/pip/tasks/no_setuptools.yml
+++ b/test/integration/targets/pip/tasks/no_setuptools.yml
@@ -8,8 +8,9 @@
   pip:
     name:
       - packaging
-      # coverage is needed when ansible-test is invoked with --coverage
+      # coverage deps are needed when ansible-test is invoked with --coverage
       # and using a custom ansible_python_interpreter below
+      - '{{ pip_coverage.stdout_lines|select("match", "covdefaults")|first }}'
       - '{{ pip_coverage.stdout_lines|select("match", "coverage==")|first }}'
     virtualenv: "{{ remote_tmp_dir }}/no_setuptools"
 

--- a/test/lib/ansible_test/_data/requirements/ansible-test.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible-test.txt
@@ -1,2 +1,3 @@
 # The test-constraints sanity test verifies this file, but changes must be made manually to keep it in up-to-date.
+covdefaults == 2.3.0
 coverage == 7.6.1 ; python_version >= '3.8' and python_version <= '3.13'

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -1,5 +1,6 @@
 # do not add a cryptography or pyopenssl constraint to this file, they require special handling, see get_cryptography_requirements in python_requirements.py
 # do not add a coverage constraint to this file, it is handled internally by ansible-test
+covdefaults >= 2.3.0 # sane default configuration for coveragepy
 pypsrp < 1.0.0  # in case the next major version is too big of a change
 pywinrm >= 0.5.0  # support for WSManFaultError and type annotation
 pytest >= 4.5.0  # pytest 4.5.0 added support for --strict-markers

--- a/test/lib/ansible_test/_internal/coverage_util.py
+++ b/test/lib/ansible_test/_internal/coverage_util.py
@@ -63,14 +63,25 @@ class CoverageVersion:
     """Details about a coverage version and its supported Python versions."""
 
     coverage_version: str
+    covdefaults_version: str
     schema_version: int
     min_python: tuple[int, int]
     max_python: tuple[int, int]
 
+    @property
+    def covdefaults_spec(self) -> str:
+        """Return a pip-consumable pinned ``covdefaults`` spec."""
+        return f'covdefaults == {self.covdefaults_version !s}'
+
+    @property
+    def coverage_spec(self) -> str:
+        """Return a pip-consumable pinned ``coverage`` spec."""
+        return f'coverage == {self.coverage_version !s}'
+
 
 COVERAGE_VERSIONS = (
     # IMPORTANT: Keep this in sync with the ansible-test.txt requirements file.
-    CoverageVersion('7.6.1', 7, (3, 8), (3, 13)),
+    CoverageVersion('7.6.1', '2.3.0', 7, (3, 8), (3, 13)),
 )
 """
 This tuple specifies the coverage version to use for Python version ranges.
@@ -254,6 +265,7 @@ concurrency =
     multiprocessing
     thread
 parallel = True
+plugins = covdefaults
 
 omit =
     */python*/dist-packages/*
@@ -277,8 +289,10 @@ concurrency =
     multiprocessing
     thread
 parallel = True
+plugins = covdefaults
 disable_warnings =
     no-data-collected
+source =
 """
 
     if isinstance(args, IntegrationConfig):

--- a/test/lib/ansible_test/_internal/python_requirements.py
+++ b/test/lib/ansible_test/_internal/python_requirements.py
@@ -200,7 +200,13 @@ def collect_requirements(
     commands: list[PipCommand] = []
 
     if coverage:
-        commands.extend(collect_package_install(packages=[f'coverage=={get_coverage_version(python.version).coverage_version}'], constraints=False))
+        commands.extend(collect_package_install(
+            packages=[
+                get_coverage_version(python.version).coverage_spec,
+                get_coverage_version(python.version).covdefaults_spec,
+            ],
+            constraints=False,
+        ))
 
     if ansible or command:
         commands.extend(collect_general_install(command, ansible))

--- a/test/sanity/code-smell/test-constraints.py
+++ b/test/sanity/code-smell/test-constraints.py
@@ -72,10 +72,10 @@ def check_ansible_test(path: str, requirements: list[tuple[int, str, re.Match]])
     from ansible_test._internal.coverage_util import COVERAGE_VERSIONS
     from ansible_test._internal.util import version_to_str
 
-    expected_lines = set((
-        f"coverage == {item.coverage_version} ; python_version >= '{version_to_str(item.min_python)}' and python_version <= '{version_to_str(item.max_python)}'"
+    expected_lines = {
+        f"{item.coverage_spec} ; python_version >= '{version_to_str(item.min_python)}' and python_version <= '{version_to_str(item.max_python)}'"
         for item in COVERAGE_VERSIONS
-    ))
+    } | {next(iter(COVERAGE_VERSIONS)).covdefaults_spec}
 
     for idx, requirement in enumerate(requirements):
         lineno, line, match = requirement


### PR DESCRIPTION
The `covdefaults` plugin sets up the configuration of coveragepy with settings that are often copy-pasted across projects, being considered good defaults in general.

Ref: https://pypi.org/p/covdefaults

ci_complete

##### SUMMARY

N/A

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Maintenance Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

N/A