### PR TITLE
Handle error raised when argument validation

### DIFF
--- a/changelogs/fragments/check_arguments.yml
+++ b/changelogs/fragments/check_arguments.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - handle exception raised while validating with elements='int' and value is not within choices (https://github.com/ansible/ansible/issues/82776).

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -665,7 +665,7 @@ def _validate_argument_values(argument_spec, parameters, options_context=None, e
                     diff_list = [item for item in parameters[param] if item not in choices]
                     if diff_list:
                         choices_str = ", ".join([to_native(c) for c in choices])
-                        diff_str = ", ".join(diff_list)
+                        diff_str = ", ".join([to_native(c) for c in diff_list])
                         msg = "value of %s must be one or more of: %s. Got no match for: %s" % (param, choices_str, diff_str)
                         if options_context:
                             msg = "{0} found in {1}".format(msg, " -> ".join(options_context))

--- a/test/units/module_utils/common/parameters/test_check_arguments.py
+++ b/test/units/module_utils/common/parameters/test_check_arguments.py
@@ -7,7 +7,11 @@ from __future__ import annotations
 
 import pytest
 
-from ansible.module_utils.common.parameters import _get_unsupported_parameters
+from ansible.module_utils.common.parameters import (
+    _get_unsupported_parameters,
+    _validate_argument_values,
+)
+from ansible.module_utils.errors import AnsibleValidationErrorMultiple
 
 
 @pytest.fixture
@@ -35,3 +39,13 @@ def test_check_arguments(argument_spec, module_parameters, legal_inputs, expecte
     result = _get_unsupported_parameters(argument_spec, module_parameters, legal_inputs)
 
     assert result == expected
+
+
+def test_validate_argument_values(mocker):
+    argument_spec = {
+        "foo": {"type": "list", "elements": "int", "choices": [1]},
+    }
+    module_parameters = {"foo": [2]}
+    errors = AnsibleValidationErrorMultiple()
+    result = _validate_argument_values(argument_spec, module_parameters, errors=errors)
+    assert "value of foo must be one" in errors[0].msg


### PR DESCRIPTION
##### SUMMARY

* Handle error raised when argument validation with elements=int
  and value is not within choices

Fixes: #82776

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


