### PR TITLE
document return values (#82796)

### DIFF
--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -134,6 +134,9 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-none:
-    description: This module does not return anything except tasks to execute.  In a loop, the return value includes loop variables not valid after the loop.
+# This module does not return anything except tasks to execute.
+include_args:
+    description:   Args passed to the included role.  May be contain invalid references after this module is called in a loop.
+    returned: nothing except tasks to execute
+    type: dict
 '''

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -134,6 +134,6 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-n/a:
+none:
     description: This module does not return anything except tasks to execute.  In a loop, the return value includes loop variables not valid after the loop.
 '''

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -135,5 +135,5 @@ EXAMPLES = r'''
 
 RETURN = r'''
 n/a:
-    description: This module does not return anything except tasks to execute.
+    description: This module does not return anything except tasks to execute.  In a loop, the return value includes loop variables not valid after the end of the loop, so attempting to register and enumerate the return value from include_role in a loop will cause errors.
 '''

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -136,7 +136,7 @@ EXAMPLES = r'''
 RETURN = r'''
 # This module does not return anything except tasks to execute.
 include_args:
-    description:   Args passed to the included role.  May contain invalid references to loop variables after this module is called in a loop.
+    description: Args passed to the included role.  May contain invalid references to loop variables after this module is called in a loop.
     returned: nothing except tasks to execute
     type: dict
 '''

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -135,5 +135,5 @@ EXAMPLES = r'''
 
 RETURN = r'''
 n/a:
-    description: This module does not return anything except tasks to execute.  In a loop, the return value includes loop variables not valid after the end of the loop, so attempting to register and enumerate the return value from include_role in a loop will cause errors.
+    description: This module does not return anything except tasks to execute.  In a loop, the return value includes loop variables not valid after the loop.
 '''

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -136,7 +136,7 @@ EXAMPLES = r'''
 RETURN = r'''
 # This module does not return anything except tasks to execute.
 include_args:
-    description:   Args passed to the included role.  May be contain invalid references after this module is called in a loop.
+    description:   Args passed to the included role.  May contain invalid references to loop variables after this module is called in a loop.
     returned: nothing except tasks to execute
     type: dict
 '''

--- a/lib/ansible/modules/include_role.py
+++ b/lib/ansible/modules/include_role.py
@@ -134,5 +134,6 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-# This module does not return anything except tasks to execute.
+n/a:
+    description: This module does not return anything except tasks to execute.
 '''


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale -->

State that this module breaks expectations for the return value.  Start with the formerly commented-out explanation, and explain a known case where expectations need to be modified.

<!--- HINT: Include "Closes #nnn" if you are fixing an existing issue -->

Closes #82796.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->

I'm not 100% sure that "invalid references" is the correct terminology.  I know if you try to enumerate the contents in a debug statement, you get errors about an undefined variable.

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before (RETURN VALUES section absent):
```paste below

```

After (RETURN VALUES section present):
```
RETURN VALUES:

   include_args  Args passed to the included role.  May contain invalid references to loop variables after this module is called in a loop.
        returned: nothing except tasks to execute
        type: dict
```
