### PR TITLE
The extension returned by the splitext contains the dot

### DIFF
--- a/lib/ansible/plugins/filter/splitext.yml
+++ b/lib/ansible/plugins/filter/splitext.yml
@@ -14,14 +14,14 @@ DOCUMENTATION:
 
 EXAMPLES: |
 
-  # gobble => [ '/etc/make', 'conf' ]
+  # gobble => [ '/etc/make', '.conf' ]
   gobble: "{{ '/etc/make.conf' | splitext }}"
 
-  # file_n_ext => [ 'ansible', 'cfg' ]
+  # file_n_ext => [ 'ansible', '.cfg' ]
   file_n_ext: "{{ 'ansible.cfg' | splitext }}"
 
-  # hoax => ['/etc/hoasdf', '']
-  hoax: '{{ "/etc//hoasdf/" | splitext }}'
+  # hoax => [ '/etc/hoasdf', '' ]
+  hoax: "{{ '/etc/hoasdf' | splitext }}"
 
 RETURN:
   _value:


### PR DESCRIPTION
The documentation page of the filter `splitext` is currently not accurate.  
The filter is stated to return the extension without the dot, in the documentation, when, in reality, it does return it with the dot, i.e. documented as `['foo', 'ext']`; when in truth we have `('foo', '.ext')`.

Lastly, the last example was inconsistent, in syntax and in-between what the comment stands it returns versus was is passed to it.

This would also align the documentation to what is provided here: https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_filters.html#managing-file-names-and-path-names

##### SUMMARY

Closes #82801

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

Examples before
```yaml
# gobble => [ '/etc/make', 'conf' ]
gobble: "{{ '/etc/make.conf' | splitext }}"

# file_n_ext => [ 'ansible', 'cfg' ]
file_n_ext: "{{ 'ansible.cfg' | splitext }}"

# hoax => ['/etc/hoasdf', '']
hoax: '{{ "/etc//hoasdf/" | splitext }}'
```
Examples after:
```yaml
# gobble => [ '/etc/make', '.conf' ]
gobble: "{{ '/etc/make.conf' | splitext }}"

# file_n_ext => [ 'ansible', '.cfg' ]
file_n_ext: "{{ 'ansible.cfg' | splitext }}"

# hoax => [ '/etc/hoasdf', '' ]
hoax: "{{ '/etc/hoasdf' | splitext }}"
```