### PR TITLE
apt: Install recommended packages while installing deb files

### DIFF
--- a/changelogs/fragments/apt_recommends.yml
+++ b/changelogs/fragments/apt_recommends.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - apt - install recommended packages when installing package via deb file (https://github.com/ansible/ansible/issues/29726).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -886,6 +886,11 @@ def install_deb(
         except Exception as e:
             m.fail_json(msg="Unable to install package: %s" % to_native(e))
 
+        # Install 'Recommends' of this deb file
+        if install_recommends:
+            pkg_recommends = get_field_of_deb(m, deb_file, "Recommends")
+            deps_to_install.extend([pkg_name.strip() for pkg_name in pkg_recommends.split()])
+
         # and add this deb to the list of packages to install
         pkgs_to_install.append(deb_file)
 

--- a/test/integration/targets/apt/tasks/url-with-deps.yml
+++ b/test/integration/targets/apt/tasks/url-with-deps.yml
@@ -48,9 +48,37 @@
         - dpkg_result is successful
         - dpkg_result.rc == 0
 
-  always:
-    - name: uninstall echo-hello with apt
+    - name: Install package from local repo
       apt:
-        pkg: echo-hello
+        deb: "{{ repodir }}/dists/stable/main/binary-all/baz_1.0.0_all.deb"
+        install_recommends: yes
+      register: apt_url_deps
+
+    - name: check to make sure we installed the package
+      shell: dpkg -l | grep baz
+      failed_when: False
+      register: baz_dpkg_result
+
+    - name: check to make sure we installed the package's recommends
+      shell: dpkg -l | grep rolldice
+      failed_when: False
+      register: rolldice_dpkg_result
+
+    - name: verify real installation of bar
+      assert:
+        that:
+        - apt_url_deps is changed
+        - baz_dpkg_result is successful
+        - baz_dpkg_result.rc == 0
+        - rolldice_dpkg_result is successful
+        - rolldice_dpkg_result.rc == 0
+
+  always:
+    - name: uninstall packages with apt
+      apt:
+        pkg:
+          - echo-hello
+          - rolldice
+          - baz
         state: absent
         purge: yes

--- a/test/integration/targets/setup_deb_repo/files/package_specs/stable/baz-1.0.0
+++ b/test/integration/targets/setup_deb_repo/files/package_specs/stable/baz-1.0.0
@@ -1,0 +1,11 @@
+Section: misc
+Priority: optional
+Standards-Version: 2.3.3
+
+Package: baz
+Version: 1.0.0
+Section: system
+Maintainer: John Doe <john@doe.com>
+Architecture: all
+Description: Dummy package
+Recommends: rolldice


### PR DESCRIPTION
##### SUMMARY

* install recommended packages while installing deb files and
  install_recommends is set to true.

Fixes: #29726

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


