### PR TITLE
Install crun from Alpine 3.19 for known musl compatibility

### DIFF
--- a/test/integration/targets/ansible-test-container/runme.py
+++ b/test/integration/targets/ansible-test-container/runme.py
@@ -1077,9 +1077,9 @@ class ApkBootstrapper(Bootstrapper):
         packages = ['docker', 'podman', 'openssl', 'crun', 'ip6tables']
 
         run_command('apk', 'add', *packages)
-        # 3.18 only contains crun 1.8.4, to get 1.9.2 to resolve the run/shm issue, install crun from edge
+        # 3.18 only contains crun 1.8.4, to get 1.9.2 to resolve the run/shm issue, install crun from 3.19
         # Remove once we update to 3.19
-        run_command('apk', 'upgrade', '-U', '--repository=http://dl-cdn.alpinelinux.org/alpine/edge/community', 'crun')
+        run_command('apk', 'upgrade', '-U', '--repository=http://dl-cdn.alpinelinux.org/alpine/v3.19/community', 'crun')
         run_command('service', 'docker', 'start')
         run_command('modprobe', 'tun')
 


### PR DESCRIPTION
##### SUMMARY

Installing crun from newer versions is potentially problematic which I knew at the time, because there may be incompatibilities.  We accepted this risk, but unfortunately when crun 1.14.4 was compiled for Alpine Edge, against a version of musl that deviates from what is available in Alpine 3.16-3.19, `crun` stopped being functional in those older versions.

This resulted in:

```
Error: OCI runtime error: crun: Error relocating /usr/bin/crun: statx: symbol not found
```

Now that 3.19 is released, and contains a version of `crun` that fixes the following issue, and has enough musl compatibility, I think it's safe-ish enough for us for now:

```
Error: OCI runtime error: crun: chmod `run/shm`: Not supported
```

Our alternative would be to use the `APKBUILD` for a specific `crun` version from our maximum in use Alpine stable release, and maintain our own builds of `crun` compiled directly against each version of Alpine we support in CI.  I have done some preliminary work on this with success, but it adds additional complexity that I'm not ready to handle yet.

##### ISSUE TYPE

- Test Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
