### PR TITLE
Add /opt/bin/python to python fallback list

### DIFF
--- a/changelogs/fragments/82821-interpreter-discovery-flatcar.yml
+++ b/changelogs/fragments/82821-interpreter-discovery-flatcar.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Python interpreter discovery now works out of the box on Flatcar hosts.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1570,6 +1570,7 @@ INTERPRETER_PYTHON_FALLBACK:
   - python3.7
   - /usr/bin/python3
   - python3
+  - /opt/bin/python
   vars:
     - name: ansible_interpreter_python_fallback
   type: list


### PR DESCRIPTION
Allows to support Flatcar hosts out of the box

This avoid the necessity of setting ansible_python_interpreter in group_vars for users, or hacking stuff with set_facts in downstream projects (for context, this is prompted partly by https://github.com/kubernetes-sigs/kubespray/pull/10983#issuecomment-1991524275 )

```yaml
# Hacky being this
set_fact:
  ansible_interpreter_python_fallback: "{{ ansible_interpreter_python_fallback + ['/opt/bin/python'] }}"

```
The main problem is that this drastically changes the precedence level for this variable
And I think we can't do it in a role defaults/ because the var would be lazy evaluated and cause an infinite recursion, if I'm not mistaken