### PR TITLE
Address non-UTF8 module responses with `diff` in git module

### DIFF
--- a/changelogs/fragments/82820-git-diff-encoding.yml
+++ b/changelogs/fragments/82820-git-diff-encoding.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- git - Address non-UTF8 module responses in the ``diff`` parameter with repositories that contain non-UTF8 encoded data

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -668,7 +668,9 @@ def get_diff(module, git_path, dest, repo, remote, depth, bare, before, after):
         git_version_used = git_version(git_path, module)
         fetch(git_path, module, repo, dest, after, remote, depth, bare, '', git_version_used)
         cmd = '%s diff %s %s' % (git_path, before, after)
-        (rc, out, err) = module.run_command(cmd, cwd=dest)
+        # The actual file encodings in the repo may not be easily discernible, to avoid encoding issues later,
+        # replace chars that are not utf-8 encodable
+        (rc, out, err) = module.run_command(cmd, cwd=dest, errors='replace')
         if rc == 0 and out:
             return {'prepared': out}
         elif rc == 0:


### PR DESCRIPTION
##### SUMMARY

Address non-UTF8 module responses with `diff`

Fixes #82820

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
