### PR TITLE
Fix up to_datetime timedelta seconds docs

### DIFF
--- a/lib/ansible/plugins/filter/to_datetime.yml
+++ b/lib/ansible/plugins/filter/to_datetime.yml
@@ -4,9 +4,14 @@ DOCUMENTATION:
   short_description: Get C(datetime) from string
   description:
     - Using the input string attempt to create a matching Python C(datetime) object.
+    - Adding or Subtracting two datetime objects will result in a Python C(timedelta) object.
   notes:
     - For a full list of format codes for working with Python date format strings, see
       L(the Python documentation, https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior).
+    - The timedelta object produced by the difference of two datetimes store the days, seconds, and microseconds of
+      the delta. This results in the C(seconds) attribute being the total seconds of the minutes and hours of that
+      delta. See L(datatime.timedelta, https://docs.python.org/3/library/datetime.html#timedelta-objects) for more
+      information about how a timedelta works.
   positional: _input
   options:
     _input:
@@ -22,9 +27,9 @@ EXAMPLES: |
   # Get total amount of seconds between two dates. Default date format is %Y-%m-%d %H:%M:%S but you can pass your own format
   secsdiff: '{{ (("2016-08-14 20:00:12" | to_datetime) - ("2015-12-25" | to_datetime("%Y-%m-%d"))).total_seconds()  }}'
 
-  # Get remaining seconds after delta has been calculated. NOTE: This does NOT convert years, days, hours, and so on to seconds. For that, use total_seconds()
+  # Get remaining seconds after delta has been calculated. NOTE: This does NOT convert years and days to seconds. For that, use total_seconds()
   {{ (("2016-08-14 20:00:12" | to_datetime) - ("2016-08-14 18:00:00" | to_datetime)).seconds  }}
-  # This expression evaluates to "12" and not "132". Delta is 2 hours, 12 seconds
+  # This expression evaluates to "7212". Delta is 2 hours, 12 seconds
 
   # get amount of days between two dates. This returns only number of days and discards remaining hours, minutes, and seconds
   {{ (("2016-08-14 20:00:12" | to_datetime) - ("2015-12-25" | to_datetime('%Y-%m-%d'))).days  }}


### PR DESCRIPTION
##### SUMMARY
The docs for `to_datetime` incorrectly documents that a `timedelta` `seconds` attribute is only the seconds difference. This is incorrect as it is the number of seconds in the hour/minute/seconds delta. This PR updates the description to expand on this detail and update the example.

Fixes: https://github.com/ansible/ansible/issues/82813

##### ISSUE TYPE
- Docs Pull Request