### PR TITLE
Allow check mode async task disabling check_mode

### DIFF
--- a/changelogs/fragments/async-task-check-mode.yml
+++ b/changelogs/fragments/async-task-check-mode.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- >-
+  async - Fix bug that stopped running async task in ``--check`` when ``check_mode: False`` was set as a task attribute
+  - https://github.com/ansible/ansible/issues/82811

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -917,6 +917,7 @@ class TaskExecutor:
                         'jid': async_jid,
                         'mode': 'cleanup',
                     },
+                    'check_mode': self._task.check_mode,
                     'environment': self._task.environment,
                 }
             )

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -840,7 +840,12 @@ class TaskExecutor:
         # that (with a sleep for "poll" seconds between each retry) until the
         # async time limit is exceeded.
 
-        async_task = Task.load(dict(action='async_status', args={'jid': async_jid}, environment=self._task.environment))
+        async_task = Task.load(dict(
+            action='async_status',
+            args={'jid': async_jid},
+            check_mode=self._task.check_mode,
+            environment=self._task.environment,
+        ))
 
         # FIXME: this is no longer the case, normal takes care of all, see if this can just be generalized
         # Because this is an async task, the action handler is async. However,

--- a/test/integration/targets/async/check_task_test.yml
+++ b/test/integration/targets/async/check_task_test.yml
@@ -1,0 +1,8 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: Async in check mode task disabled test
+    command: sleep 5
+    async: 6
+    poll: 1
+    check_mode: False

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -298,3 +298,15 @@
 - assert:
     that:
       - '"ASYNC POLL on localhost" in callback_output.stdout'
+
+- name: run playbook in --check with task disabling check mode
+  command: ansible-playbook {{ role_path }}/check_task_test.yml --check
+  register: check_task_disabled_output
+  delegate_to: localhost
+  environment:
+     ANSIBLE_NOCOLOR: 'true'
+     ANSIBLE_FORCE_COLOR: 'false'
+
+- assert:
+    that:
+    - '"ASYNC OK on localhost" in check_task_disabled_output.stdout'


### PR DESCRIPTION
##### SUMMARY
Allows running an async task with check_mode: False when the playbook is being run in check mode.

Fixes: https://github.com/ansible/ansible/issues/82811

##### ISSUE TYPE
- Bugfix Pull Request