### PR TITLE
[2.16] atomic_move - fix preserving extended acls (#82818)

### DIFF
--- a/changelogs/fragments/atomic-move-fix-extended-attrs.yml
+++ b/changelogs/fragments/atomic-move-fix-extended-attrs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - AnsibleModule.atomic_move - fix preserving extended ACLs of the destination when it exists (https://github.com/ansible/ansible/issues/72929).

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -291,7 +291,6 @@ import filecmp
 import grp
 import os
 import os.path
-import platform
 import pwd
 import shutil
 import stat
@@ -300,33 +299,11 @@ import traceback
 
 from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.common.process import get_bin_path
-from ansible.module_utils.common.locale import get_best_parsable_locale
-from ansible.module_utils.six import PY3
-
-
-# The AnsibleModule object
-module = None
 
 
 class AnsibleModuleError(Exception):
     def __init__(self, results):
         self.results = results
-
-
-# Once we get run_command moved into common, we can move this into a common/files module.  We can't
-# until then because of the module.run_command() method.  We may need to move it into
-# basic::AnsibleModule() until then but if so, make it a private function so that we don't have to
-# keep it for backwards compatibility later.
-def clear_facls(path):
-    setfacl = get_bin_path('setfacl')
-    # FIXME "setfacl -b" is available on Linux and FreeBSD. There is "setfacl -D e" on z/OS. Others?
-    acl_command = [setfacl, '-b', path]
-    b_acl_command = [to_bytes(x) for x in acl_command]
-    locale = get_best_parsable_locale(module)
-    rc, out, err = module.run_command(b_acl_command, environ_update=dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale))
-    if rc != 0:
-        raise RuntimeError('Error running "{0}": stdout: "{1}"; stderr: "{2}"'.format(' '.join(b_acl_command), out, err))
 
 
 def split_pre_existing_dir(dirname):
@@ -529,8 +506,6 @@ def copy_common_dirs(src, dest, module):
 
 def main():
 
-    global module
-
     module = AnsibleModule(
         # not checking because of daisy chain to file module
         argument_spec=dict(
@@ -705,54 +680,8 @@ def main():
                         else:
                             raise
 
-                # might be needed below
-                if PY3 and hasattr(os, 'listxattr'):
-                    try:
-                        src_has_acls = 'system.posix_acl_access' in os.listxattr(src)
-                    except Exception as e:
-                        # assume unwanted ACLs by default
-                        src_has_acls = True
-
                 # at this point we should always have tmp file
-                module.atomic_move(b_mysrc, dest, unsafe_writes=module.params['unsafe_writes'])
-
-                if PY3 and hasattr(os, 'listxattr') and platform.system() == 'Linux' and not remote_src:
-                    # atomic_move used above to copy src into dest might, in some cases,
-                    # use shutil.copy2 which in turn uses shutil.copystat.
-                    # Since Python 3.3, shutil.copystat copies file extended attributes:
-                    # https://docs.python.org/3/library/shutil.html#shutil.copystat
-                    # os.listxattr (along with others) was added to handle the operation.
-
-                    # This means that on Python 3 we are copying the extended attributes which includes
-                    # the ACLs on some systems - further limited to Linux as the documentation above claims
-                    # that the extended attributes are copied only on Linux. Also, os.listxattr is only
-                    # available on Linux.
-
-                    # If not remote_src, then the file was copied from the controller. In that
-                    # case, any filesystem ACLs are artifacts of the copy rather than preservation
-                    # of existing attributes. Get rid of them:
-
-                    if src_has_acls:
-                        # FIXME If dest has any default ACLs, there are not applied to src now because
-                        # they were overridden by copystat. Should/can we do anything about this?
-                        # 'system.posix_acl_default' in os.listxattr(os.path.dirname(b_dest))
-
-                        try:
-                            clear_facls(dest)
-                        except ValueError as e:
-                            if 'setfacl' in to_native(e):
-                                # No setfacl so we're okay.  The controller couldn't have set a facl
-                                # without the setfacl command
-                                pass
-                            else:
-                                raise
-                        except RuntimeError as e:
-                            # setfacl failed.
-                            if 'Operation not supported' in to_native(e):
-                                # The file system does not support ACLs.
-                                pass
-                            else:
-                                raise
+                module.atomic_move(b_mysrc, dest, unsafe_writes=module.params['unsafe_writes'], keep_dest_attrs=not remote_src)
 
             except (IOError, OSError):
                 module.fail_json(msg="failed to copy: %s to %s" % (src, dest), traceback=traceback.format_exc())

--- a/test/integration/targets/copy/tasks/acls.yml
+++ b/test/integration/targets/copy/tasks/acls.yml
@@ -20,7 +20,9 @@
   - name: Check that there are no ACLs leftovers
     assert:
       that:
-        - "'user:{{ remote_unprivileged_user }}:r-x\t#effective:r--' not in acls.stdout_lines"
+        - leftovers not in acls.stdout_lines
+    vars:
+      leftovers: 'user:{{ remote_unprivileged_user }}:r-x\t#effective:r--'
 
   - name: Check that permissions match with what was set in the mode param
     assert:

--- a/test/integration/targets/lineinfile/aliases
+++ b/test/integration/targets/lineinfile/aliases
@@ -1,1 +1,3 @@
 shippable/posix/group2
+destructive
+needs/target/setup_nobody

--- a/test/integration/targets/lineinfile/tasks/acls.yml
+++ b/test/integration/targets/lineinfile/tasks/acls.yml
@@ -1,0 +1,59 @@
+- block:
+  - name: Install the acl package on Ubuntu
+    apt:
+      name: acl
+    when: ansible_distribution in ('Ubuntu')
+    register: setup_acl
+
+  - name: Create file
+    copy:
+      content: "TEST"
+      mode: 0644
+      dest: "~/test.txt"
+
+  - name: create user for openSUSE
+    include_role:
+      name: setup_nobody
+    when: '"openSUSE" in ansible_distribution'
+
+  - shell: setfacl -m nobody:rwx ~/test.txt
+
+  - shell: getfacl ~/test.txt
+    register: acls
+
+  - name: Check that permissions match with the copy mode and setfacl command
+    assert:
+      that:
+        - "'user::rw-' in acls.stdout_lines"
+        - "'user:nobody:rwx' in acls.stdout_lines"
+        - "'group::r--' in acls.stdout_lines"
+        - "'other::r--' in acls.stdout_lines"
+
+  - name: test atomic_move via lineinfile doesn't delete extended acls
+    lineinfile:
+      path: "~/test.txt"
+      regexp: "TEST"
+      line: "UPDATE"
+
+  - shell: getfacl ~/test.txt
+    register: acls
+
+  - name: Validate the acls are unmodified
+    assert:
+      that:
+        - "'user::rw-' in acls.stdout_lines"
+        - "'user:nobody:rwx' in acls.stdout_lines"
+        - "'group::r--' in acls.stdout_lines"
+        - "'other::r--' in acls.stdout_lines"
+
+  always:
+    - name: Remove the acl package on Ubuntu
+      apt:
+        name: acl
+        state: absent
+      when: setup_acl is changed
+
+    - name: Clean up
+      file:
+        path: "~/test.txt"
+        state: absent

--- a/test/integration/targets/lineinfile/tasks/main.yml
+++ b/test/integration/targets/lineinfile/tasks/main.yml
@@ -944,9 +944,6 @@
       The search string is an empty string, which will match every line in the file.
       This may have unintended consequences, such as replacing the last line in the file rather than appending.
 
-- name: meta
-  meta: end_play
-
 ###################################################################
 ## Issue #58923
 ## Using firstmatch with insertafter and ensure multiple lines are not inserted
@@ -1397,3 +1394,7 @@
       - testend1 is changed
       - testend2 is changed
       - testend_file.stat.checksum == 'ef36116966836ce04f6b249fd1837706acae4e19'
+
+- name: Integration test for issue 72929
+  import_tasks: acls.yml
+  when: ansible_system == 'Linux'


### PR DESCRIPTION
##### SUMMARY

Not sure if this will be merged, but testing a Python 2 port for #82818

Fixes #72929

* use getfacl/setfacl to copy extended attributes possible before os.rename

update unit test mocks for updated method of attribute preservation

add integration test for lineinfile case

remove erroneous `- meta: end_play` from lineinfile test suite

Only the integration test is cherry-picked from 2bb09bfd12e42e7be6f39ab0e45a992512c240f9

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
