### PR TITLE
Require UTF-8 module args

### DIFF
--- a/changelogs/fragments/require-utf8-args.yml
+++ b/changelogs/fragments/require-utf8-args.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- module arguments - Ensure that module arguments are utf-8 adhereing to JSON RFC and expectations of the core code.

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -292,6 +292,15 @@ class ActionBase(ABC):
             become_kwargs['become_flags'] = self._connection.become.get_option('become_flags',
                                                                                playcontext=self._play_context)
 
+        try:
+            _validate_utf8_json(module_args)
+        except UnicodeEncodeError as e:
+            display.deprecated(
+                f'Module arguments for "{self._task.resolved_action or self._task.action}" includes non-UTF8 '
+                'data. This will become an error in the future',
+                version='2.20',
+            )
+
         # modify_module will exit early if interpreter discovery is required; re-run after if necessary
         for dummy in (1, 2):
             try:


### PR DESCRIPTION
##### SUMMARY

This PR will validate the module args to ensure they can be encoded as UTF-8.

This goes along with the requirement of module responses.  This really should have been included in that PR, but it was overlooked, as such, it will have a different deprecation version.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
