### PR TITLE
minor fix in error msg in case non-vowel

### DIFF
--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -560,8 +560,13 @@ class FieldAttributeBase:
                 setattr(self, name, value)
             except (TypeError, ValueError) as e:
                 value = getattr(self, name)
-                raise AnsibleParserError("the field '%s' has an invalid value (%s), and could not be converted to an %s. "
-                                         "The error was: %s" % (name, value, attribute.isa, e), obj=self.get_ds(), orig_exc=e)
+                msg = "the field '%s' has an invalid value (%s), and could not be converted to "
+                if value.lower().startswith(("a", "e", "i", "o", "u")):
+                    msg += "an %s."
+                else:
+                    msg += "a %s."
+                msg += " The error was: %s"
+                raise AnsibleParserError(msg % (name, value, attribute.isa, e), obj=self.get_ds(), orig_exc=e)
             except (AnsibleUndefinedVariable, UndefinedError) as e:
                 if templar._fail_on_undefined_errors and name != 'name':
                     if name == 'args':


### PR DESCRIPTION
##### SUMMARY
fix english for values not starting with a vowel, e.g. bool.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below
FAILED! => {"msg": "the field 'ignore_errors' has an invalid value ('VM with vmid {{ pve__vmid }} does not exist in cluster' == resp.msg), and could not be converted to an bool.The error was: The value ''VM with vmid 901 does not exist in cluster' == resp.msg' is not a valid boolean.  Valid booleans include: 0, 'yes', 1, 'false', 'f', '1', 'true', 't', 'n', 'on', '0', 'off', 'no', 'y'\n\n...."}
```
