### PR TITLE
Update password.py : use errno instead of strerror in _get_lock exception

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -130,6 +130,7 @@ import os
 import string
 import time
 import hashlib
+import errno
 
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
@@ -276,7 +277,7 @@ def _get_lock(b_path):
             os.close(fd)
             first_process = True
         except OSError as e:
-            if e.strerror != 'File exists':
+            if e.errno != errno.EEXIST:
                 raise
 
     counter = 0


### PR DESCRIPTION
##### SUMMARY

`_get_lock` function is using `strerror` in exception. `strerror` is a localized string so it depends of user language (ie: 'File exists' with LANG=C is 'Le fichier existe' with LANG=fr_FR). `errno` is used in all ansible code and the best way to test error type.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION
