### PR TITLE
Use a PyPI CDN URL in `unarchive` integration test

### DIFF
--- a/test/integration/targets/unarchive/tasks/test_download.yml
+++ b/test/integration/targets/unarchive/tasks/test_download.yml
@@ -19,7 +19,7 @@
       - not ansible_facts.python.has_sslcontext
   - name: unarchive a tar from an URL
     unarchive:
-      src: "https://releases.ansible.com/ansible/ansible-latest.tar.gz"
+      src: https://files.pythonhosted.org/packages/source/a/ansible-core/ansible-core-2.16.5rc1.tar.gz
       dest: "{{ remote_tmp_dir }}/test-unarchive-tar-gz"
       mode: "0700"
       remote_src: yes


### PR DESCRIPTION
This fixes a TLS problem that manifested itself as Cloudflare updated the Let's Encrypt TLS certificate for `releases.ansible.com` [[1]][[2]] on March 15, 2024.

It started failing the stable-2.12 CI as follows:
```console
Failed to validate the SSL certificate for releases.ansible.com:443. Make sure your managed systems have a valid CA certificate installed. If the website serving the url uses SNI you need python >= 2.7.9 on your managed machine  (the python executable used (/usr/bin/python2.6) is version: 2.6.6 (r266:84292, Jun 20 2019, 14:14:55) [GCC 4.4.7 20120313 (Red Hat 4.4.7-23)]) to perform SNI verification in python >= 2.6. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible. The exception msg was: [Errno bad handshake] [('SSL routines', 'SSL3_GET_SERVER_CERTIFICATE', 'certificate verify failed')].
```

[1]: https://blog.cloudflare.com/upcoming-lets-encrypt-certificate-chain-change-and-impact-for-cloudflare-customers
[2]: https://letsencrypt.org/2023/07/10/cross-sign-expiration.html

##### SUMMARY

$sbj.

##### ISSUE TYPE

- Bugfix Pull Request
- Testing Pull Request

##### ADDITIONAL INFORMATION

$sbj.