### PR TITLE
Allow "role_name : " prefix for notifying handler listen topics

### DIFF
--- a/changelogs/fragments/fix-role-name-handler-prefix-listen.yml
+++ b/changelogs/fragments/fix-role-name-handler-prefix-listen.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fix notifying role handlers by listen keyword topics with the "role_name : " prefix (https://github.com/ansible/ansible/issues/82849).
+  - 'Fix notifying role handlers by listen keyword topics with the "role_name : " prefix (https://github.com/ansible/ansible/issues/82849).'

--- a/changelogs/fragments/fix-role-name-handler-prefix-listen.yml
+++ b/changelogs/fragments/fix-role-name-handler-prefix-listen.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix notifying role handlers by listen keyword topics with the "role_name : " prefix (https://github.com/ansible/ansible/issues/82849).

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -553,12 +553,19 @@ class StrategyBase:
         seen = []
         for handler in handlers:
             if listeners := handler.listen:
-                if notification in handler.get_validated_value(
+                listeners = handler.get_validated_value(
                     'listen',
                     handler.fattributes.get('listen'),
                     listeners,
                     templar,
-                ):
+                )
+                if handler._role is not None:
+                    for listener in listeners.copy():
+                        listeners.extend([
+                            handler._role.get_name(include_role_fqcn=True) + ' : ' + listener,
+                            handler._role.get_name(include_role_fqcn=False) + ' : ' + listener
+                        ])
+                if notification in listeners:
                     if handler.name and handler.name in seen:
                         continue
                     seen.append(handler.name)

--- a/test/integration/targets/handlers/collections/ansible_collections/ns/col/roles/test_handlers_listen/handlers/main.yml
+++ b/test/integration/targets/handlers/collections/ansible_collections/ns/col/roles/test_handlers_listen/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: test notifying listen namespaced by collection + role
+  set_fact:
+    notify_listen_in_specific_collection_role: True
+  listen: notify_specific_collection_role_listen

--- a/test/integration/targets/handlers/roles/test_handlers_listen/handlers/main.yml
+++ b/test/integration/targets/handlers/roles/test_handlers_listen/handlers/main.yml
@@ -8,3 +8,8 @@
   set_fact:
     notify_listen_in_role_4: True
   listen: notify_listen_in_role
+
+- name: test notifying listen namespaced by the role
+  set_fact:
+    notify_listen_in_specific_role: True
+  listen: notify_specific_role_listen

--- a/test/integration/targets/handlers/test_handlers_listen.yml
+++ b/test/integration/targets/handlers/test_handlers_listen.yml
@@ -99,6 +99,7 @@
   gather_facts: false
   roles:
     - role: test_handlers_listen
+    - role: ns.col.test_handlers_listen
   tasks:
     - name: test notify handlers listen in roles
       command: uptime
@@ -113,6 +114,20 @@
           - "notify_listen_ran_4_3 is defined"
           - "notify_listen_in_role_4 is defined"
           - "notify_listen_from_role_4 is defined"
+    - name: test notifying handlers using the role name prefix
+      command: /bin/true
+      notify:
+        - 'test_handlers_listen : notify_specific_role_listen'
+        - 'test_handlers_listen : notify_specific_collection_role_listen'
+    - meta: flush_handlers
+    - assert:
+        that:
+          - notify_listen_in_specific_collection_role is defined
+          - notify_listen_in_specific_role is defined
+    - name: test notifying the collection listener by the role's FQCN also works
+      command: /bin/true
+      notify:
+        - 'ns.col.test_handlers_listen : notify_specific_collection_role_listen'
   handlers:
     - name: notify_listen_ran_4_1
       set_fact:

--- a/test/integration/targets/handlers/test_handlers_listen.yml
+++ b/test/integration/targets/handlers/test_handlers_listen.yml
@@ -115,7 +115,7 @@
           - "notify_listen_in_role_4 is defined"
           - "notify_listen_from_role_4 is defined"
     - name: test notifying handlers using the role name prefix
-      command: /bin/true
+      command: uptime
       notify:
         - 'test_handlers_listen : notify_specific_role_listen'
         - 'test_handlers_listen : notify_specific_collection_role_listen'
@@ -125,7 +125,7 @@
           - notify_listen_in_specific_collection_role is defined
           - notify_listen_in_specific_role is defined
     - name: test notifying the collection listener by the role's FQCN also works
-      command: /bin/true
+      command: uptime
       notify:
         - 'ns.col.test_handlers_listen : notify_specific_collection_role_listen'
   handlers:


### PR DESCRIPTION
##### SUMMARY

Allow notifying handler listen topics more similarly to handler names.

This handler:
```yaml
- name: handler name
  debug:
  listen: topic1
```
can be now be notified using `topic1`, `role : topic1` if the handler is in a standalone or collection role, and `ns.col.role : topic1` if the role is in a collection.

Fixes #82849

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
