### PR TITLE
[stable-2.15] blockinfile: do not crash when filename has no path (#81638)

### DIFF
--- a/changelogs/fragments/81638-blockinfile.yml
+++ b/changelogs/fragments/81638-blockinfile.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "blockinfile - when ``create=true`` is used with a filename without path, the module crashed (https://github.com/ansible/ansible/pull/81638)."

--- a/lib/ansible/modules/blockinfile.py
+++ b/lib/ansible/modules/blockinfile.py
@@ -248,7 +248,7 @@ def main():
             module.fail_json(rc=257,
                              msg='Path %s does not exist !' % path)
         destpath = os.path.dirname(path)
-        if not os.path.exists(destpath) and not module.check_mode:
+        if destpath and not os.path.exists(destpath) and not module.check_mode:
             try:
                 os.makedirs(destpath)
             except Exception as e:

--- a/test/integration/targets/blockinfile/tasks/create_file.yml
+++ b/test/integration/targets/blockinfile/tasks/create_file.yml
@@ -30,3 +30,17 @@
       - empty_test_2 is changed
       - "'Block removed' in empty_test_2.msg"
       - empty_test_stat.stat.size == 0
+
+- block:
+  - name: Create file in current directory
+    blockinfile:
+      path: "empty.txt"
+      block: Hello.
+      state: present
+      create: yes
+
+  always:
+  - name: Remove file
+    file:
+      path: "empty.txt"
+      state: absent


### PR DESCRIPTION
##### SUMMARY
Backport of #81638 to stable-2.15.

When path has no `/` in it and `create=true`, the module calls `os.makedirs('')`, resulting in a crash.

Fixes https://github.com/ansible-collections/community.general/issues/7207.
Fixes #81767.

##### ISSUE TYPE
- Bugfix Pull Request
