### PR TITLE
expose play.strategy as ansible_play_strategy

### DIFF
--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -451,6 +451,8 @@ class VariableManager:
 
             variables['ansible_play_name'] = play.get_name()
 
+            variables['ansible_play_strategy'] = play.strategy
+
         if task:
             if task._role:
                 variables['role_name'] = task._role.get_name(include_role_fqcn=False)


### PR DESCRIPTION
##### SUMMARY

Create the magic variable `ansible_play_strategy` which makes the current play's strategy visible to tasks.

With this information, it becomes possible to take active precautions against the unexpected behavior `ansible-lint` warns about when combining `strategy: free` and `run_once: true`. For example, one could fail the play with a message like, "Don't run this play with `strategy: free` because it uses `run_once`." Or one could include a set of tasks more appropriate for the current strategy, a decision which isn't limited to the `strategy: free` case.

Without this info (i.e. currently), the only possible action is to ignore `ansible-lint`'s warning, either with a `noqa` or tweaking the `ansible-lint` config file. That gets past linting, but there's nothing more you can do. If someone subsequently sets `strategy: free`, then they'll suffer the consequences that would have been mentioned in the suppressed warnings.

Note: you'll have to suppress `ansible-lint`'s warnings in either case to pass linting. But at least with `ansible_play_strategy` exposed as a magic variable, you can take additional safeguards in the play itself, an option which isn't available to you without `ansible_play_strategy`.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

This change has an extremely small footprint. There's not much more to say about it.

Here's a simple playbook with two plays, the first with `strategy: free` and the second without specifying a strategy.

```yaml
---
# strategy.yml
- name: See if ansible_play_strategy is a variable
  hosts: localhost
  gather_facts: false
  strategy: free
  tasks:
    - name: Show the first play ansible_play_strategy
      ansible.builtin.debug:
        msg: 'ansible_play_strategy: {{ ansible_play_strategy }}'

- name: See if ansible_play_strategy changed
  hosts: localhost
  gather_facts: false
  tasks:
    - name: Show the second play ansible_play_strategy
      ansible.builtin.debug:
        msg: 'ansible_play_strategy: {{ ansible_play_strategy }}'
```
And here's the output:
```
utoddl@tango:~/ansible$ ansible-playbook strategy.yml -vv
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development.
This is a rapidly changing source of code and can become unstable at any point.
ansible-playbook [core 2.17.0.dev0] (devel 2b1a5dd7a0) last updated 2024/03/21 01:50:34 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/utoddl/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/utoddl/src/ansible-on-github/lib/ansible
  ansible collection location = /home/utoddl/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/utoddl/src/ansible-on-github/bin/ansible-playbook
  python version = 3.12.2 (main, Feb 21 2024, 00:00:00) [GCC 13.2.1 20231205 (Red Hat 13.2.1-6)] (/usr/bin/python)
  jinja version = 3.1.3
  libyaml = True
Using /etc/ansible/ansible.cfg as config file
redirecting (type: callback) ansible.builtin.yaml to community.general.yaml
redirecting (type: callback) ansible.builtin.yaml to community.general.yaml
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: strategy.yml *********************************************************************
2 plays in strategy.yml

PLAY [See if ansible_play_strategy is a variable] ******************************************

TASK [Show the first play ansible_play_strategy] *******************************************
task path: /home/utoddl/ansible/strategy.yml:8
ok: [localhost] => 
  msg: 'ansible_play_strategy: free'

PLAY [See if ansible_play_strategy changed] ************************************************

TASK [Show the second play ansible_play_strategy] ******************************************
task path: /home/utoddl/ansible/strategy.yml:16
ok: [localhost] => 
  msg: 'ansible_play_strategy: linear'

PLAY RECAP *********************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```