### PR TITLE
[stable-2.16] Unarchive get zipinfo on more OS/distros (#82873)

### DIFF
--- a/changelogs/fragments/unarchive_fix.yml
+++ b/changelogs/fragments/unarchive_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unarchive modules now uses zipinfo options without relying on implementation defaults, making it more compatible with all OS/distributions.

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -969,7 +969,7 @@ class TarZstdArchive(TgzArchive):
 class ZipZArchive(ZipArchive):
     def __init__(self, src, b_dest, file_args, module):
         super(ZipZArchive, self).__init__(src, b_dest, file_args, module)
-        self.zipinfoflag = '-Z'
+        self.zipinfoflag = '-Zl'
         self.binaries = (
             ('unzip', 'cmd_path'),
             ('unzip', 'zipinfo_cmd_path'),


### PR DESCRIPTION
Not all implementations use -l as default for -Z on unzip

(cherry picked from commit 481d8bdc1edae1a02f6201174fe344ac9fa8968a)

##### ISSUE TYPE

- Bugfix Pull Request
