### PR TITLE
[stable-2.16] find: do not fail on PermissionError

### DIFF
--- a/changelogs/fragments/82027_find.yml
+++ b/changelogs/fragments/82027_find.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - find - do not fail on Permission errors (https://github.com/ansible/ansible/issues/82027).

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -258,6 +258,7 @@ skipped_paths:
     version_added: '2.12'
 '''
 
+import errno
 import fnmatch
 import grp
 import os
@@ -434,10 +435,6 @@ def statinfo(st):
     }
 
 
-def handle_walk_errors(e):
-    raise e
-
-
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -481,6 +478,12 @@ def main():
 
     filelist = []
     skipped = {}
+
+    def handle_walk_errors(e):
+        if e.errno in (errno.EPERM, errno.EACCES):
+            skipped[e.filename] = to_text(e)
+            return
+        raise e
 
     if params['age'] is None:
         age = None

--- a/test/integration/targets/find/aliases
+++ b/test/integration/targets/find/aliases
@@ -1,1 +1,3 @@
 shippable/posix/group1
+destructive
+needs/root

--- a/test/integration/targets/find/meta/main.yml
+++ b/test/integration/targets/find/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
+  - setup_test_user
   - setup_remote_tmp_dir

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -375,5 +375,61 @@
       - '"{{ remote_tmp_dir_test }}/astest/.hidden.txt" in astest_list'
       - '"checksum" in result.files[0]'
 
+# Test permission error is correctly handled by find module
+- vars:
+    test_dir: /tmp/permission_test
+  block:
+    - name: Set up content
+      file:
+        path: "{{ test_dir }}/{{ item.name }}"
+        state: "{{ item.state }}"
+        mode: "{{ item.mode }}"
+        owner: "{{ item.owner | default(omit) }}"
+        group: "{{ item.group | default(omit) }}"
+      loop:
+        - name: readable
+          state: directory
+          owner: "{{ test_user_name }}"
+          mode: "1711"
+        - name: readable/1-unreadable
+          state: directory
+          mode: "0700"
+        - name: readable/2-readable
+          state: touch
+          owner: "{{ test_user_name }}"
+          mode: "0777"
+
+    - name: Find a file in readable directory
+      find:
+        paths: "{{ test_dir }}/readable/"
+        patterns: "*"
+        recurse: true
+      register: permission_issue
+      become_user: "{{ test_user_name }}"
+
+    - name: Find a file in readable directory
+      find:
+        paths: "{{ test_dir }}/readable/"
+        patterns: "*"
+        recurse: true
+      register: permission_issue
+      become_user: "{{ test_user_name }}"
+      become: yes
+
+    - name: Check if the skipped_paths are populated correctly with permission error
+      assert:
+        that:
+          - permission_issue is success
+          - not permission_issue.changed
+          - permission_issue.skipped_paths|length == 1
+          - "'{{ test_dir }}/readable/1-unreadable' in permission_issue.skipped_paths"
+          - "'Permission denied' in permission_issue.skipped_paths['{{ test_dir }}/readable/1-unreadable']"
+          - permission_issue.matched == 1
+  always:
+    - name: cleanup test directory
+      file:
+        dest: "{{ test_dir }}"
+        state: absent
+
 - name: Run mode tests
   import_tasks: mode.yml


### PR DESCRIPTION
##### SUMMARY

* Log and skip permission errors on files and directories

Fixes: #82027

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit f73d72e8306244701b720586c28b11bbc1661af4)

##### ISSUE TYPE
- Bugfix Pull Request


