### PR TITLE
Fix package manager determination when delegate_to is unsafe

### DIFF
--- a/changelogs/fragments/82598-package-safe-delegate-template.yml
+++ b/changelogs/fragments/82598-package-safe-delegate-template.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- package - Resolve issue of determining the package manager for ``use=auto`` when ``delegate_to``
+  is derived from an unsafe data source (https://github.com/ansible/ansible/issues/82598)

--- a/test/integration/targets/package/tasks/main.yml
+++ b/test/integration/targets/package/tasks/main.yml
@@ -240,3 +240,21 @@
           - "result is changed"
 
   when: ansible_distribution == "Fedora"
+
+# Verify unsafe delegate_to is functional
+- block:
+    - command: echo {{ inventory_hostname }}
+      register: unsafe_host
+
+    - name: install at
+      package:
+        name: at
+        state: present
+        use: auto
+      delegate_to: '{{ unsafe_host.stdout_lines|first }}'
+  always:
+    - name: remove apt
+      package:
+        name: at
+        state: absent
+  when: ansible_distribution in package_distros


### PR DESCRIPTION
##### SUMMARY

Fix package manager determination when delegate_to is unsafe. Fixes #82598

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Technically as of now devel is not affected, but 2.14-2.16 are, and 2.17 will be after we cut the stable-2.17 branch.

This new method roughly mirrors a new `Templar` method being added in data tagging for achieving this same goal.  It's private to this action, to not cause conflicts with DT.