### PR TITLE
first_found lookup; minor fixes (#82836)

### DIFF
--- a/changelogs/fragments/first_found_fixes.yml
+++ b/changelogs/fragments/first_found_fixes.yml
@@ -1,3 +1,5 @@
 bugfixes:
   - first found lookup has been updated to use the normalized argument parsing (pythonic) matching the documented examples.
   - first found lookup, fixed an issue with subsequent items clobbering information from previous ones.
+  - first_found lookup now always takes into account k=v options
+  - first_found lookup now always returns a full (absolute) and normalized path

--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -147,6 +147,7 @@ from jinja2.exceptions import UndefinedError
 from ansible.errors import AnsibleLookupError, AnsibleUndefinedVariable
 from ansible.module_utils.six import string_types
 from ansible.plugins.lookup import LookupBase
+from ansible.utils.path import unfrackpath
 
 
 def _splitter(value, chars):
@@ -218,8 +219,9 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables, **kwargs):
 
+        self.set_options(var_options=variables, direct=kwargs)
+
         if not terms:
-            self.set_options(var_options=variables, direct=kwargs)
             terms = self.get_option('files')
 
         total_search, skip = self._process_terms(terms, variables, kwargs)
@@ -246,7 +248,7 @@ class LookupModule(LookupBase):
 
             # exit if we find one!
             if path is not None:
-                return [path]
+                return [unfrackpath(path, follow=False)]
 
         # if we get here, no file was found
         if skip:

--- a/test/integration/targets/lookup_first_found/tasks/main.yml
+++ b/test/integration/targets/lookup_first_found/tasks/main.yml
@@ -147,3 +147,8 @@
           - ishouldnotbefound.yml
         paths:
           - "{{role_path}}/vars"
+
+- name: Make sure skip works in 'mixed' argument passing
+  assert:
+    that:
+      - q('first_found', ['/nonexistant'], skip=True) == []


### PR DESCRIPTION
Always process options no matter the combination
return a full normalized path (symlinks still not followed, should be specific option in future)

(cherry picked from commit ad0ec47fe9aca20be91081b9a2cc2d4ff130cc42)

##### ISSUE TYPE

- Bugfix Pull Request