### PR TITLE
ansible-test - Fix Alpine libexpat bootstrapping

### DIFF
--- a/changelogs/fragments/ansible-test-alpine-libexpat.yml
+++ b/changelogs/fragments/ansible-test-alpine-libexpat.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - The ``libexpat`` package is automatically upgraded during remote bootstrapping to maintain compatibility with newer Python packages.

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -106,6 +106,15 @@ bootstrap_remote_alpine()
         echo "Failed to install packages. Sleeping before trying again..."
         sleep 10
     done
+
+    # Upgrade the `libexpat` package to ensure that an upgraded Python (`pyexpat`) continues to work.
+    while true; do
+        # shellcheck disable=SC2086
+        apk upgrade -q libexpat \
+        && break
+        echo "Failed to upgrade libexpat. Sleeping before trying again..."
+        sleep 10
+    done
 }
 
 bootstrap_remote_fedora()


### PR DESCRIPTION
##### SUMMARY

An upgraded Python package in Alpine requires a newer `libexpat` package than is installed by default. Upgrading the package ensures it continues to function.

This issue currently affects Alpine 3.16 and 3.17 (tested on stable-2.14 and stable-2.15, respectively), which saw Python package updates today. This fix is being applied to other branches in anticipation of Python updates there as well.

##### ISSUE TYPE

Bugfix Pull Request

##### ADDITIONAL INFORMATION

The issue can be seen simply by trying to import the `pyexpat' module:

```
$ python -c 'import pyexpat'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: Error relocating /usr/lib/python3.10/lib-dynload/pyexpat.cpython-310-x86_64-linux-gnu.so: XML_SetReparseDeferralEnabled: symbol not found
```

The issue is resolved by upgrading the `libexpat` package:

```
$ apk upgrade libexpat
(1/1) Upgrading libexpat (2.5.0-r0 -> 2.6.2-r0)
OK: 354 MiB in 146 packages
```
