### PR TITLE
[stable-2.14] ansible-test - Fix Alpine libexpat bootstrapping 

### DIFF
--- a/changelogs/fragments/ansible-test-alpine-libexpat.yml
+++ b/changelogs/fragments/ansible-test-alpine-libexpat.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - The ``libexpat`` package is automatically upgraded during remote bootstrapping to maintain compatibility with newer Python packages.

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -112,12 +112,12 @@ bootstrap_remote_alpine()
         sleep 10
     done
 
-    # Upgrade the `libexpat` package to ensure that an upgraded Python (`pyexpat`) continues to work.
+    # Upgrade the `expat` package to ensure that an upgraded Python (`pyexpat`) continues to work.
     while true; do
         # shellcheck disable=SC2086
-        apk upgrade -q libexpat \
+        apk upgrade -q expat \
         && break
-        echo "Failed to upgrade libexpat. Sleeping before trying again..."
+        echo "Failed to upgrade expat. Sleeping before trying again..."
         sleep 10
     done
 }

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -111,6 +111,15 @@ bootstrap_remote_alpine()
         echo "Failed to install packages. Sleeping before trying again..."
         sleep 10
     done
+
+    # Upgrade the `libexpat` package to ensure that an upgraded Python (`pyexpat`) continues to work.
+    while true; do
+        # shellcheck disable=SC2086
+        apk upgrade -q libexpat \
+        && break
+        echo "Failed to upgrade libexpat. Sleeping before trying again..."
+        sleep 10
+    done
 }
 
 bootstrap_remote_fedora()


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/82895

(cherry picked from commit ca168eb3674a01d5fffccd6f237f0872eb386e46)

##### ISSUE TYPE

Bugfix Pull Request
