### PR TITLE
Document sort_keys option in to_nice_json() filter

### DIFF
--- a/lib/ansible/plugins/filter/to_nice_json.yml
+++ b/lib/ansible/plugins/filter/to_nice_json.yml
@@ -39,6 +39,10 @@ DOCUMENTATION:
       description: If V(True), keys that are not basic Python types will be skipped.
       default: False
       type: bool
+    sort_keys:
+      description: Affects sorting of dictionary keys.
+      default: True
+      type: bool      
   notes:
     - Both O(vault_to_text) and O(preprocess_unsafe) defaulted to V(False) between Ansible 2.9 and 2.12.
     - 'These parameters to C(json.dumps) will be ignored, they are overridden for internal use: I(cls), I(default), I(indent), I(separators), I(sort_keys).'


### PR DESCRIPTION
##### SUMMARY

the `to_nice_json()` filter can take an option `sort_keys`, but this isn't currently documented.  It *is* documented for `to_json()`.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

This option was added by https://github.com/ansible/ansible/pull/52341.
