### PR TITLE
apt: handle options while installing python3-apt

### DIFF
--- a/changelogs/fragments/apt_install.yml
+++ b/changelogs/fragments/apt_install.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - apt - honor install_recommends and dpkg_options while installing python3-apt library (https://github.com/ansible/ansible/issues/40608).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1254,6 +1254,15 @@ def main():
     )
     module.run_command_environ_update = APT_ENV_VARS
 
+    global APTITUDE_CMD
+    APTITUDE_CMD = module.get_bin_path("aptitude", False)
+    global APT_GET_CMD
+    APT_GET_CMD = module.get_bin_path("apt-get")
+
+    p = module.params
+    install_recommends = p['install_recommends']
+    dpkg_options = expand_dpkg_options(p['dpkg_options'])
+
     if not HAS_PYTHON_APT:
         # This interpreter can't see the apt Python library- we'll do the following to try and fix that:
         # 1) look in common locations for system-owned interpreters that can see it; if we find one, respawn under it
@@ -1292,10 +1301,16 @@ def main():
             module.warn("Auto-installing missing dependency without updating cache: %s" % apt_pkg_name)
         else:
             module.warn("Updating cache and auto-installing missing dependency: %s" % apt_pkg_name)
-            module.run_command(['apt-get', 'update'], check_rc=True)
+            module.run_command([APT_GET_CMD, 'update'], check_rc=True)
 
         # try to install the apt Python binding
-        module.run_command(['apt-get', 'install', '--no-install-recommends', apt_pkg_name, '-y', '-q'], check_rc=True)
+        apt_pkg_cmd = [APT_GET_CMD, 'install', apt_pkg_name, '-y', '-q', dpkg_options]
+        if install_recommends:
+            apt_pkg_cmd.append('--install-recommends')
+        else:
+            apt_pkg_cmd.append('--no-install-recommends')
+
+        module.run_command(apt_pkg_cmd, check_rc=True)
 
         # try again to find the bindings in common places
         interpreter = probe_interpreters_for_module(interpreters, 'apt')
@@ -1308,13 +1323,6 @@ def main():
         else:
             # we've done all we can do; just tell the user it's busted and get out
             module.fail_json(msg="{0} must be installed and visible from {1}.".format(apt_pkg_name, sys.executable))
-
-    global APTITUDE_CMD
-    APTITUDE_CMD = module.get_bin_path("aptitude", False)
-    global APT_GET_CMD
-    APT_GET_CMD = module.get_bin_path("apt-get")
-
-    p = module.params
 
     if p['clean'] is True:
         aptclean_stdout, aptclean_stderr, aptclean_diff = aptclean(module)
@@ -1339,11 +1347,9 @@ def main():
 
     updated_cache = False
     updated_cache_time = 0
-    install_recommends = p['install_recommends']
     allow_unauthenticated = p['allow_unauthenticated']
     allow_downgrade = p['allow_downgrade']
     allow_change_held_packages = p['allow_change_held_packages']
-    dpkg_options = expand_dpkg_options(p['dpkg_options'])
     autoremove = p['autoremove']
     fail_on_autoremove = p['fail_on_autoremove']
     autoclean = p['autoclean']

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1305,10 +1305,12 @@ def main():
 
         # try to install the apt Python binding
         apt_pkg_cmd = [APT_GET_CMD, 'install', apt_pkg_name, '-y', '-q', dpkg_options]
-        if install_recommends:
-            apt_pkg_cmd.append('--install-recommends')
-        else:
-            apt_pkg_cmd.append('--no-install-recommends')
+
+        if install_recommends is False:
+            apt_pkg_cmd.extend(["-o", "APT::Install-Recommends=no"])
+        elif install_recommends is True:
+            apt_pkg_cmd.extend(["-o", "APT::Install-Recommends=yes"])
+        # install_recommends is None uses the OS default
 
         module.run_command(apt_pkg_cmd, check_rc=True)
 


### PR DESCRIPTION
##### SUMMARY

* While installing python3-apt library, honor parameter
  such as install_recommends and dpkg_options

Fixes: #40608

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


