### PR TITLE
Fix "No such file or directory" error with local modules in macOS venv #82535

### DIFF
--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -207,19 +207,15 @@ class ShellBase(AnsiblePlugin):
         return 'echo %spwd%s' % (self._SHELL_SUB_LEFT, self._SHELL_SUB_RIGHT)
 
     def build_module_command(self, env_string, shebang, cmd, arg_path=None):
-        # don't quote the cmd if it's an empty string, because this will break pipelining mode
-        if cmd.strip() != '':
-            cmd = shlex.quote(cmd)
-
         cmd_parts = []
         if shebang:
             shebang = shebang.replace("#!", "").strip()
         else:
             shebang = ""
-        cmd_parts.extend([env_string.strip(), shebang, cmd])
+        cmd_parts.extend([env_string, shebang, cmd])
         if arg_path is not None:
             cmd_parts.append(arg_path)
-        new_cmd = " ".join(cmd_parts)
+        new_cmd = shlex.join(cps for cp in cmd_parts if cp and (cps := cp.strip()))
         return new_cmd
 
     def append_command(self, cmd, cmd_to_append):


### PR DESCRIPTION
##### SUMMARY

Resolves #82535

Local modules in Library/Application Support venvs(macOS) were failing with 'No such file or directory' error due to incorrect handling of spaces in the Python interpreter path. This fix uses “shlex.join” to properly quote and join command parts and removes empty strings from “cmd_path”, preventing the error.

Thanks to @sivel for the insightful suggestion to switch to shlex.join().

##### ISSUE TYPE

- Bugfix Pull Request

