### PR TITLE
apt - remove extraneous quotes from package input

### DIFF
--- a/changelogs/fragments/apt_package_split.yml
+++ b/changelogs/fragments/apt_package_split.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - apt - remove extraneous single or double quotes from package names when gathering information about package name, version (https://github.com/ansible/ansible/issues/82763).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -484,7 +484,8 @@ class PolicyRcD(object):
 def package_split(pkgspec):
     parts = re.split(r'(>?=)', pkgspec, 1)
     if len(parts) > 1:
-        return parts
+        # Remove extraneous single or double quotes from the string before returning
+        return [i.strip('\'"') for i in parts]
     return parts[0], None, None
 
 

--- a/test/units/modules/test_apt.py
+++ b/test/units/modules/test_apt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import collections
 
-from ansible.modules.apt import expand_pkgspec_from_fnmatches
+from ansible.modules.apt import expand_pkgspec_from_fnmatches, package_split
 import pytest
 
 FakePackage = collections.namedtuple("Package", ("name",))
@@ -43,3 +43,33 @@ fake_cache = [
 def test_expand_pkgspec_from_fnmatches(test_input, expected):
     """Test positive cases of ``expand_pkgspec_from_fnmatches``."""
     assert expand_pkgspec_from_fnmatches(None, test_input, fake_cache) == expected
+
+
+@pytest.mark.parametrize(
+    ("test_input", "expected"),
+    [
+        pytest.param(
+            "apt",
+            ("apt", None, None),
+            id="trivial",
+        ),
+        pytest.param(
+            "base-files>=2.1.12",
+            ['base-files', '>=', '2.1.12'],
+            id="version-gt",
+        ),
+        pytest.param(
+            "docker-ce-cli='5:25.0.3-1~ubuntu.22.04~jammy'",
+            ['docker-ce-cli', '=', '5:25.0.3-1~ubuntu.22.04~jammy'],
+            id="with-extraneous-single-quote",
+        ),
+        pytest.param(
+            'docker-ce-cli="5:25.0.3-1~ubuntu.22.04~jammy"',
+            ['docker-ce-cli', '=', '5:25.0.3-1~ubuntu.22.04~jammy'],
+            id="with-extraneous-double-quote",
+        ),
+    ],
+)
+def test_package_split(test_input, expected):
+    """Test positive cases of ``package_split``."""
+    assert package_split(test_input) == expected


### PR DESCRIPTION
##### SUMMARY

* Remove extraneous single quote, double quotes from package name
  while gathering information about package version etc.

Fixes: #82763

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


