### PR TITLE
Update example to match docs

### DIFF
--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -140,7 +140,7 @@ EXAMPLES = r'''
 - name: Enable service httpd, and not touch the state
   ansible.builtin.service:
     name: httpd
-    enabled: yes
+    enabled: true
 
 - name: Start service foo, based on running process /usr/bin/foo
   ansible.builtin.service:


### PR DESCRIPTION
In the documentation for the "enabled" parameter, two choices are listed "true" or "false".  The example below uses "yes." I understand that both work, but IMO it's a bit more clear if the example matches the definition.

##### SUMMARY

In the documentation for the "enabled" parameter, two choices are listed "true" or "false".  The example below uses "yes." I understand that both work, but IMO it's a bit more clear if the example matches the definition.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION