### PR TITLE
remove nonexistent url from role templates

### DIFF
--- a/changelogs/fragments/rm-obsolete-url-role-template.yml
+++ b/changelogs/fragments/rm-obsolete-url-role-template.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Remove link to https://galaxy.ansible.com/api/v1/platforms/ from the role templates (https://github.com/ansible/ansible/issues/82453).
+  - Remove the galaxy_info field ``platforms`` from the role templates (https://github.com/ansible/ansible/issues/82453).

--- a/changelogs/fragments/rm-obsolete-url-role-template.yml
+++ b/changelogs/fragments/rm-obsolete-url-role-template.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Remove link to https://galaxy.ansible.com/api/v1/platforms/ from the role templates (https://github.com/ansible/ansible/issues/82453).

--- a/lib/ansible/galaxy/data/container/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/meta/main.yml.j2
@@ -24,8 +24,6 @@ galaxy_info:
   #
   # Provide a list of supported platforms, and for each platform a list of versions.
   # If you don't wish to enumerate all versions for a particular platform, use 'all'.
-  # To view available platforms and versions (or releases), visit:
-  # https://galaxy.ansible.com/api/v1/platforms/
   #
   # platforms:
   # - name: Fedora

--- a/lib/ansible/galaxy/data/container/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/meta/main.yml.j2
@@ -21,22 +21,6 @@ galaxy_info:
   # If Ansible is required outside of the build container, provide the minimum version:
   # min_ansible_version:
 
-  #
-  # Provide a list of supported platforms, and for each platform a list of versions.
-  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
-
   galaxy_tags:
     - container
     # List tags for your role here, one per line. A tag is a keyword that describes

--- a/lib/ansible/galaxy/data/default/role/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/role/meta/main.yml.j2
@@ -24,8 +24,6 @@ galaxy_info:
   #
   # Provide a list of supported platforms, and for each platform a list of versions.
   # If you don't wish to enumerate all versions for a particular platform, use 'all'.
-  # To view available platforms and versions (or releases), visit:
-  # https://galaxy.ansible.com/api/v1/platforms/
   #
   # platforms:
   # - name: Fedora

--- a/lib/ansible/galaxy/data/default/role/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/role/meta/main.yml.j2
@@ -21,22 +21,6 @@ galaxy_info:
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
 
-  #
-  # Provide a list of supported platforms, and for each platform a list of versions.
-  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
-
   galaxy_tags: []
     # List tags for your role here, one per line. A tag is a keyword that describes
     # and categorizes the role. Users find roles by searching for tags. Be sure to

--- a/test/units/cli/test_data/role_skeleton/meta/main.yml.j2
+++ b/test/units/cli/test_data/role_skeleton/meta/main.yml.j2
@@ -26,22 +26,6 @@ galaxy_info:
   # (usually master) will be used.
   #github_branch:
 
-  #
-  # Provide a list of supported platforms, and for each platform a list of versions.
-  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
-
   galaxy_tags: []
     # List tags for your role here, one per line. A tag is
     # a keyword that describes and categorizes the role.

--- a/test/units/cli/test_data/role_skeleton/meta/main.yml.j2
+++ b/test/units/cli/test_data/role_skeleton/meta/main.yml.j2
@@ -29,8 +29,6 @@ galaxy_info:
   #
   # Provide a list of supported platforms, and for each platform a list of versions.
   # If you don't wish to enumerate all versions for a particular platform, use 'all'.
-  # To view available platforms and versions (or releases), visit:
-  # https://galaxy.ansible.com/api/v1/platforms/
   #
   # platforms:
   # - name: Fedora


### PR DESCRIPTION
##### SUMMARY

Fixes #82453

I'm partial to keeping `platforms:` for documentation purposes since it's still possible to publish, just not search for roles by platform. But on the other hand, there is no documentation now about the valid choices, causing issues like [this](https://forum.ansible.com/t/role-meta-data-platform-key-broken/4651), so maybe this convention should be moved outside of the galaxy_info key. Any opinions if I should do that, or delete the `platforms:` block entirely?

##### ISSUE TYPE

- Bugfix Pull Request