### PR TITLE
Changing validation task to use role's tags

### DIFF
--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -372,7 +372,8 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
                 },
             },
             'name': task_name,
-            'tags': ['always'],
+            # Unless role is specifically tagged, the tag is set to 'always'
+            'tags': ['always'] if not self.tags else self.tags,
         }
 
     def _load_role_yaml(self, subdir, main=None, allow_dir=False):


### PR DESCRIPTION
Changing the validation internal task  to check for tags on the role itself and use that if they exist, otherwise fallback to always

##### SUMMARY

Fixes #82505 


##### ISSUE TYPE

- Bugfix Pull Request

