### PR TITLE
systemd_service - Add the machine parameter (#82958)

### DIFF
--- a/changelogs/fragments/82958-systemd_service-machine-parameter.yml
+++ b/changelogs/fragments/82958-systemd_service-machine-parameter.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - |-
+    systemd_service - Add the `machine` parameter to connect systemd to the
+    session bus of a specific user in a local container or on the local host.

--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -78,6 +78,14 @@ options:
         type: bool
         default: no
         version_added: "2.3"
+    machine:
+        description:
+            - Specify a container name to connect to, optionally prefixed by a user name to connect as and a separating `@` character.
+            - If the special string `.host` is used in place of the container name, a connection to the local system is made.
+            - If the `@` syntax is used either the left hand side or the right hand side may be omitted (but not both) in which case
+              the local user name and `.host` are implied.
+        type: str
+        version_added: "2.17"
 extends_documentation_fragment: action_common_attributes
 attributes:
     check_mode:
@@ -147,6 +155,13 @@ EXAMPLES = '''
     scope: user
   environment:
     XDG_RUNTIME_DIR: "/run/user/{{ myuid }}"
+
+- name: Run from within a specific user session
+  ansible.builtin.systemd_service:
+    name: myservice
+    state: started
+    scope: user
+    machine: myuser@.host
 '''
 
 RETURN = '''
@@ -350,6 +365,7 @@ def main():
             daemon_reexec=dict(type='bool', default=False, aliases=['daemon-reexec']),
             scope=dict(type='str', default='system', choices=['system', 'user', 'global']),
             no_block=dict(type='bool', default=False),
+            machine=dict(type='str'),
         ),
         supports_check_mode=True,
         required_one_of=[['state', 'enabled', 'masked', 'daemon_reload', 'daemon_reexec']],
@@ -376,6 +392,9 @@ def main():
     # The other choices match the corresponding switch
     if module.params['scope'] != 'system':
         systemctl += " --%s" % module.params['scope']
+
+    if module.params['machine']:
+        systemctl += " --machine=%s" % module.params['machine']
 
     if module.params['no_block']:
         systemctl += " --no-block"

--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -81,6 +81,17 @@ options:
         type: bool
         default: no
         version_added: "2.3"
+    machine:
+        description:
+            - Specify a container name to connect to, optionally prefixed by a
+              user name to connect as and a separating `@` character.
+            - If the special string `.host` is used in place of the container
+              name, a connection to the local system is made.
+            - If the `@` syntax is used either the left hand side or the right
+              hand side may be omitted (but not both) in which case the local
+              user name and `.host` are implied.
+        type: str
+        version_added: "2.22"
 extends_documentation_fragment: action_common_attributes
 attributes:
     check_mode:
@@ -149,6 +160,13 @@ EXAMPLES = """
     scope: user
   environment:
     XDG_RUNTIME_DIR: "/run/user/{{ myuid }}"
+
+- name: Run from within a specific user session
+  ansible.builtin.systemd_service:
+    name: myservice
+    state: started
+    scope: user
+    machine: "myuser@.host"
 """
 
 RETURN = """
@@ -282,6 +300,7 @@ status:
 """  # NOQA
 
 import os
+import shlex
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.facts.system.chroot import is_chroot
@@ -351,6 +370,7 @@ def main():
             daemon_reload=dict(type='bool', default=False, aliases=['daemon-reload']),
             daemon_reexec=dict(type='bool', default=False, aliases=['daemon-reexec']),
             scope=dict(type='str', default='system', choices=['system', 'user', 'global']),
+            machine=dict(type='str'),
             no_block=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
@@ -378,6 +398,10 @@ def main():
     # The other choices match the corresponding switch
     if module.params['scope'] != 'system':
         systemctl += " --%s" % module.params['scope']
+
+    if module.params['machine']:
+        machine = shlex.quote(module.params['machine'])
+        systemctl += f" --machine={machine}"
 
     if module.params['no_block']:
         systemctl += " --no-block"

--- a/test/integration/targets/systemd/tasks/main.yml
+++ b/test/integration/targets/systemd/tasks/main.yml
@@ -112,11 +112,27 @@
     enabled: true
   register: systemd_enable_ssh_2
 
+- name: Disable ssh 2 with machine
+  systemd:
+    name: '{{ ssh_service }}'
+    enabled: false
+    machine: '@.host'
+  register: systemd_disable_ssh_2_machine
+
+- name: Enable ssh 2 with machine
+  systemd:
+    name: '{{ ssh_service }}'
+    enabled: true
+    machine: '@.host'
+  register: systemd_enable_ssh_2_machine
+
 - assert:
     that:
       - systemd_disable_ssh_2 is not changed
       - systemd_enable_ssh_1 is changed
       - systemd_enable_ssh_2 is not changed
+      - systemd_disable_ssh_2_machine is changed
+      - systemd_enable_ssh_2_machine is changed
 
 - import_tasks: test_unit_template.yml
 - import_tasks: test_indirect_service.yml


### PR DESCRIPTION
Fixes #82958 

systemctl's `--machine` option execute the operation in the context of a local user session or a local container.

This provides a failsafe way to run systemd on behalf of another user than setting the `XDG_RUNTIME_DIR` variable.

##### SUMMARY

When trying to run systemd as another user, the following is advised: 

```yaml
- name: Run a user service when XDG_RUNTIME_DIR is not set on remote login
  ansible.builtin.systemd_service:
    name: myservice
    state: started
    scope: user
  environment:
    XDG_RUNTIME_DIR: "/run/user/{{ myuid }}"
```

However, this may not always work and can fail in various ways, typically:

```
Failed to connect to bus: Operation not permitted
```

Since [systemd 248](https://lists.freedesktop.org/archives/systemd-devel/2021-March/046289.html), the `--machine` option is available to to open a connection to the session bus of a specific user.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

```yaml
- name: Run from within a specific user session
  ansible.builtin.systemd_service:
    name: myservice
    state: started
    scope: user
    machine: myuser@.host
```

```json
"invocation": {
    "module_args": {
        "daemon_reexec": false,
        "daemon_reload": false,
        "enabled": true,
        "force": null,
        "machine": "myuser@.host",
        "masked": null,
        "name": "myservice",
        "no_block": false,
        "scope": "user",
        "state": "started"
    }
}
```
