### PR TITLE
Remove platforms from overlooked templates

### DIFF
--- a/lib/ansible/galaxy/data/apb/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/apb/meta/main.yml.j2
@@ -16,21 +16,6 @@ galaxy_info:
   # - CC-BY-4.0
   license: {{ license }}
 
-  #
-  # platforms is a list of platforms, and each platform has a name and a list of versions.
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
-
   galaxy_tags:
     - apb
     # List tags for your role here, one per line. A tag is a keyword that describes

--- a/lib/ansible/galaxy/data/network/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/network/meta/main.yml.j2
@@ -21,21 +21,6 @@ galaxy_info:
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
 
-  #
-  # platforms is a list of platforms, and each platform has a name and a list of versions.
-  #
-  # platforms:
-  # - name: VYOS
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
-
   galaxy_tags: []
     # List tags for your role here, one per line. A tag is a keyword that describes
     # and categorizes the role. Users find roles by searching for tags. Be sure to


### PR DESCRIPTION
##### SUMMARY

Missed these in https://github.com/ansible/ansible/pull/82933 since I was grepping for the URL (`https://galaxy.ansible.com/api/v1/platforms/`).

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
