### PR TITLE
Add a --namespace option to ansible-galaxy role import

### DIFF
--- a/changelogs/fragments/ansible-galaxy-role-import-namespace.yml
+++ b/changelogs/fragments/ansible-galaxy-role-import-namespace.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- >-
+  ``ansible-galaxy role import`` - add ``--namespace`` to publish the role to
+  a namespace other than the Github user. This option takes precedence over the
+  ``namespace`` field in the ``galaxy_info`` field of the ``meta/main.yml``.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -419,6 +419,8 @@ class GalaxyCLI(CLI):
                                         '(usually master)')
         import_parser.add_argument('--role-name', dest='role_name',
                                    help='The name the role should have, if different than the repo name')
+        import_parser.add_argument('--namespace', dest='role_namespace',
+                                   help='The role namespace, if different than the user name')
         import_parser.add_argument('--status', dest='check_status', action='store_true', default=False,
                                    help='Check the status of the most recent import request for given github_'
                                         'user/github_repo.')
@@ -1805,7 +1807,8 @@ class GalaxyCLI(CLI):
             # Submit an import request
             task = self.api.create_import_task(github_user, github_repo,
                                                reference=context.CLIARGS['reference'],
-                                               role_name=context.CLIARGS['role_name'])
+                                               role_name=context.CLIARGS['role_name'],
+                                               namespace=context.CLIARGS['role_namespace'])
 
             if len(task) > 1:
                 # found multiple roles associated with github_user/github_repo

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -479,7 +479,7 @@ class GalaxyAPI:
         return data
 
     @g_connect(['v1'])
-    def create_import_task(self, github_user, github_repo, reference=None, role_name=None):
+    def create_import_task(self, github_user, github_repo, reference=None, role_name=None, namespace=None):
         """
         Post an import request
         """
@@ -491,6 +491,8 @@ class GalaxyAPI:
         }
         if role_name:
             args['alternate_role_name'] = role_name
+        if namespace:
+            args['alternate_namespace_name'] = namespace
         data = self._call_galaxy(url, args=urlencode(args), method="POST")
         if data.get('results', None):
             return data['results']


### PR DESCRIPTION
##### SUMMARY

Add `--namespace` to allow publishing roles to a alternate namespace without embedding that in the meta/main.yml `galaxy_info`, similarly to `--role-name`/`galaxy_info.role_name`.

Added to Galaxy in https://github.com/ansible/galaxy_ng/pull/2011

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
