### PR TITLE
utilize pathlib.Path instead of os.path.join()

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import ntpath
 import os.path
+from pathlib import Path
 import re
 import shlex
 import time
@@ -610,9 +611,9 @@ def path_join(paths):
     """ takes a sequence or a string, and return a concatenation
         of the different members """
     if isinstance(paths, string_types):
-        return os.path.join(paths)
+        return Path(paths).as_posix()
     if is_sequence(paths):
-        return os.path.join(*paths)
+        return Path(*paths).as_posix()
     raise AnsibleTypeError("|path_join expects string or sequence, got %s instead." % type(paths))
 
 

--- a/test/integration/targets/filter_core/files/foo.txt
+++ b/test/integration/targets/filter_core/files/foo.txt
@@ -56,6 +56,7 @@ files to exist and are passthrus to the python os.path functions
 path_join_simple = /etc/subdir/test
 path_join_with_slash = /test
 path_join_relative = etc/subdir/test
+path_join_merged = /etc/subdir/test
 
 TODO: realpath follows symlinks.  There isn't a test for this just now.
 

--- a/test/integration/targets/filter_core/templates/foo.j2
+++ b/test/integration/targets/filter_core/templates/foo.j2
@@ -49,6 +49,7 @@ files to exist and are passthrus to the python os.path functions
 path_join_simple = {{ ('/etc', 'subdir', 'test') | path_join }}
 path_join_with_slash = {{ ('/etc', 'subdir', '/test') | path_join }}
 path_join_relative = {{ ('etc', 'subdir', 'test') | path_join }}
+path_join_merged = {{ ('/etc', 'subdir//test') | path_join }}
 
 TODO: realpath follows symlinks.  There isn't a test for this just now.
 


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Call `pathlib.Path()` instead of `os.path.join()` from `path_join` filter because of better handle of subdirectories.

It is now possible to call `{{ path1~'/'~path2 | path_join }}` to merge multiple path fragments without need to sanitize occasion slash characters.

Result converted to posix path to keep compatibility and old behavior.
e.g.
```
{{ ('c:', 'fsff') | path_join  }} -> c:/fsff
```


##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Currently to merge multiple path fragments with a nice single delimiter we need to do something like this:
```
{{ ('/opt', app, subpath | string | trim('/')) | path_join }}
```
Assuming `app = 'myapp'` and subpath anything good to be a path.
For example `/var/lib/myapp/data`

After this change it is safe to write
```
{{ '/opt/'~app~'/'~subpath | path_join }}
# or
{{ ('/opt', app~'/'~subpath) | path_join }}
```

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below
# simple concatenation of strings ('/opt/'~app~'/'~subpath)
/opt/myapp//var/lib/myapp/data

# old path_join with trim or just new path_join
/opt/myapp/var/lib/myapp/data

```
