### PR TITLE
Remove deprecated 'loader' argument

### DIFF
--- a/changelogs/fragments/listify.yml
+++ b/changelogs/fragments/listify.yml
@@ -1,0 +1,3 @@
+---
+removed_features:
+  - utils/listify - remove deprecated 'loader' argument from listify_lookup_plugin_terms API (https://github.com/ansible/ansible/issues/82949).

--- a/lib/ansible/utils/listify.py
+++ b/lib/ansible/utils/listify.py
@@ -27,11 +27,7 @@ display = Display()
 __all__ = ['listify_lookup_plugin_terms']
 
 
-def listify_lookup_plugin_terms(terms, templar, loader=None, fail_on_undefined=True, convert_bare=False):
-
-    if loader is not None:
-        display.deprecated('"listify_lookup_plugin_terms" does not use "dataloader" anymore, the ability to pass it in will be removed in future versions.',
-                           version='2.18')
+def listify_lookup_plugin_terms(terms, templar, fail_on_undefined=True, convert_bare=False):
 
     if isinstance(terms, string_types):
         terms = templar.template(terms.strip(), convert_bare=convert_bare, fail_on_undefined=fail_on_undefined)

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -203,5 +203,4 @@ lib/ansible/playbook/play_context.py pylint:ansible-deprecated-version  # 2.18 d
 lib/ansible/plugins/action/__init__.py pylint:ansible-deprecated-version  # 2.18 deprecation
 lib/ansible/plugins/loader.py pylint:ansible-deprecated-version  # 2.18 deprecation
 lib/ansible/template/__init__.py pylint:ansible-deprecated-version  # 2.18 deprecation
-lib/ansible/utils/listify.py pylint:ansible-deprecated-version  # 2.18 deprecation
 lib/ansible/vars/manager.py pylint:ansible-deprecated-version  # 2.18 deprecation

--- a/test/units/utils/test_listify.py
+++ b/test/units/utils/test_listify.py
@@ -1,0 +1,51 @@
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import pytest
+
+from ansible.template import Templar
+from ansible.utils.listify import listify_lookup_plugin_terms
+
+from units.mock.loader import DictDataLoader
+
+
+@pytest.mark.parametrize(
+    ("test_input", "expected"),
+    [
+        pytest.param(
+            [],
+            [],
+            id="empty-list",
+        ),
+        pytest.param(
+            "foo",
+            ["foo"],
+            id="string-types",
+        ),
+        pytest.param(
+            ["foo"],
+            ["foo"],
+            id="list-types",
+        ),
+    ],
+)
+def test_listify_lookup_plugin_terms(test_input, expected):
+    fake_loader = DictDataLoader({})
+    templar = Templar(loader=fake_loader)
+
+    terms = listify_lookup_plugin_terms(
+        test_input, templar=templar, fail_on_undefined=False
+    )
+    assert terms == expected
+
+
+def test_negative_listify_lookup_plugin_terms():
+    fake_loader = DictDataLoader({})
+    templar = Templar(loader=fake_loader)
+
+    with pytest.raises(TypeError, match=".*got an unexpected keyword argument 'loader'"):
+        listify_lookup_plugin_terms(
+            "foo", templar=templar, loader=fake_loader, fail_on_undefined=False
+        )


### PR DESCRIPTION
##### SUMMARY

* remove deprecated 'loader' argument from listify_lookup_plugin_terms API

Fixes: #82949

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


