### PR TITLE
to_nice_json: document the indent option

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -75,6 +75,8 @@ def to_json(a, *args, **kw):
 
 def to_nice_json(a, indent=4, sort_keys=True, *args, **kw):
     '''Make verbose, human-readable JSON'''
+    # TODO separators can be potentially exposed to the user as well
+    kw.pop('separators', None)
     return to_json(a, indent=indent, sort_keys=sort_keys, separators=(',', ': '), *args, **kw)
 
 

--- a/lib/ansible/plugins/filter/to_nice_json.yml
+++ b/lib/ansible/plugins/filter/to_nice_json.yml
@@ -40,12 +40,16 @@ DOCUMENTATION:
       default: False
       type: bool
     sort_keys:
-      description: Affects sorting of dictionary keys.
+      description: Affects sorting of dictionary keys. Passed to an underlying C(json.dumps) call.
       default: True
-      type: bool      
+      type: bool
+    indent:
+      description: Specifies an indentation level. Passed to an underlying C(json.dumps) call.
+      default: 4
+      type: int
   notes:
     - Both O(vault_to_text) and O(preprocess_unsafe) defaulted to V(False) between Ansible 2.9 and 2.12.
-    - 'These parameters to C(json.dumps) will be ignored, they are overridden for internal use: I(cls), I(default), I(indent), I(separators), I(sort_keys).'
+    - 'These parameters to C(json.dumps) will be ignored, they are overridden for internal use: I(cls), I(default), I(separators).'
 
 EXAMPLES: |
   # dump variable in a template to create a nicely formatted JSON document


### PR DESCRIPTION
##### SUMMARY
Specifying indent as an option to `to_nice_json` has been possible in contrary to what documentation states.

Follow-up to https://github.com/ansible/ansible/pull/82912
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
