### PR TITLE
Remove deprecated fact gathering config options

### DIFF
--- a/changelogs/fragments/remove-deprecated-gather-facts-config.yml
+++ b/changelogs/fragments/remove-deprecated-gather-facts-config.yml
@@ -1,0 +1,11 @@
+bugfixes:
+- >-
+  Remove deprecated config options DEFAULT_FACT_PATH, DEFAULT_GATHER_SUBSET, and
+  DEFAULT_GATHER_TIMEOUT in favor of setting ``fact_path``, ``gather_subset``
+  and ``gather_timeout`` as ``module_defaults`` for ``ansible.builtin.setup``.
+
+  These will apply to both the ``gather_facts`` play keyword, and any
+  ``ansible.builtin.setup`` tasks.
+
+  To configure these options only for the ``gather_facts`` keyword, set these
+  options as play keywords also.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -582,24 +582,6 @@ DEFAULT_EXECUTABLE:
   env: [{name: ANSIBLE_EXECUTABLE}]
   ini:
   - {key: executable, section: defaults}
-DEFAULT_FACT_PATH:
-  name: local fact path
-  description:
-    - "This option allows you to globally configure a custom path for 'local_facts' for the implied :ref:`ansible_collections.ansible.builtin.setup_module` task when using fact gathering."
-    - "If not set, it will fall back to the default from the ``ansible.builtin.setup`` module: ``/etc/ansible/facts.d``."
-    - "This does **not** affect user defined tasks that use the ``ansible.builtin.setup`` module."
-    - The real action being created by the implicit task is currently ``ansible.legacy.gather_facts`` module, which then calls the configured fact modules,
-      by default this will be ``ansible.builtin.setup`` for POSIX systems but other platforms might have different defaults.
-  env: [{name: ANSIBLE_FACT_PATH}]
-  ini:
-  - {key: fact_path, section: defaults}
-  type: string
-  deprecated:
-    # TODO: when removing set playbook/play.py to default=None
-    why: the module_defaults keyword is a more generic version and can apply to all calls to the
-         M(ansible.builtin.gather_facts) or M(ansible.builtin.setup) actions
-    version: "2.18"
-    alternatives: module_defaults
 DEFAULT_FILTER_PLUGIN_PATH:
   name: Jinja2 Filter Plugins Path
   default: '{{ ANSIBLE_HOME ~ "/plugins/filter:/usr/share/ansible/plugins/filter" }}'
@@ -643,39 +625,6 @@ DEFAULT_GATHERING:
     implicit: "the cache plugin will be ignored and facts will be gathered per play unless 'gather_facts: False' is set."
     explicit: facts will not be gathered unless directly requested in the play.
     smart: each new host that has no facts discovered will be scanned, but if the same host is addressed in multiple plays it will not be contacted again in the run.
-DEFAULT_GATHER_SUBSET:
-  name: Gather facts subset
-  description:
-      - Set the `gather_subset` option for the :ref:`ansible_collections.ansible.builtin.setup_module` task in the implicit fact gathering.
-        See the module documentation for specifics.
-      - "It does **not** apply to user defined ``ansible.builtin.setup`` tasks."
-  env: [{name: ANSIBLE_GATHER_SUBSET}]
-  ini:
-    - key: gather_subset
-      section: defaults
-  version_added: "2.1"
-  type: list
-  deprecated:
-    # TODO: when removing set playbook/play.py to default=None
-    why: the module_defaults keyword is a more generic version and can apply to all calls to the
-         M(ansible.builtin.gather_facts) or M(ansible.builtin.setup) actions
-    version: "2.18"
-    alternatives: module_defaults
-DEFAULT_GATHER_TIMEOUT:
-  name: Gather facts timeout
-  description:
-    - Set the timeout in seconds for the implicit fact gathering, see the module documentation for specifics.
-    - "It does **not** apply to user defined :ref:`ansible_collections.ansible.builtin.setup_module` tasks."
-  env: [{name: ANSIBLE_GATHER_TIMEOUT}]
-  ini:
-  - {key: gather_timeout, section: defaults}
-  type: integer
-  deprecated:
-    # TODO: when removing set playbook/play.py to default=None
-    why: the module_defaults keyword is a more generic version and can apply to all calls to the
-         M(ansible.builtin.gather_facts) or M(ansible.builtin.setup) actions
-    version: "2.18"
-    alternatives: module_defaults
 DEFAULT_HASH_BEHAVIOUR:
   name: Hash merge behaviour
   default: replace

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -57,11 +57,9 @@ class Play(Base, Taggable, CollectionSearch):
 
     # Facts
     gather_facts = NonInheritableFieldAttribute(isa='bool', default=None, always_post_validate=True)
-
-    # defaults to be deprecated, should be 'None' in future
-    gather_subset = NonInheritableFieldAttribute(isa='list', default=(lambda: C.DEFAULT_GATHER_SUBSET), listof=string_types, always_post_validate=True)
-    gather_timeout = NonInheritableFieldAttribute(isa='int', default=C.DEFAULT_GATHER_TIMEOUT, always_post_validate=True)
-    fact_path = NonInheritableFieldAttribute(isa='string', default=C.DEFAULT_FACT_PATH)
+    gather_subset = NonInheritableFieldAttribute(isa='list', default=None, listof=string_types, always_post_validate=True)
+    gather_timeout = NonInheritableFieldAttribute(isa='int', default=None, always_post_validate=True)
+    fact_path = NonInheritableFieldAttribute(isa='string', default=None)
 
     # Variable Attributes
     vars_files = NonInheritableFieldAttribute(isa='list', default=list, priority=99)

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -4,7 +4,6 @@ set -eux
 
 export ANSIBLE_COLLECTIONS_PATH=$PWD/collection_root_user:$PWD/collection_root_sys
 export ANSIBLE_GATHERING=explicit
-export ANSIBLE_GATHER_SUBSET=minimal
 export ANSIBLE_HOST_PATTERN_MISMATCH=error
 export NO_COLOR=1
 unset ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH


### PR DESCRIPTION
##### SUMMARY

Remove deprecated configs for DEFAULT_FACT_PATH, DEFAULT_GATHER_SUBSET, and DEFAULT_GATHER_TIMEOUT

Fixes #82936
Fixes #82937
Fixes #82938

##### ISSUE TYPE

- Bugfix Pull Request
