### PR TITLE
paramiko_ssh: remove deprecated ssh_*_args parameters

### DIFF
--- a/changelogs/fragments/82941.yml
+++ b/changelogs/fragments/82941.yml
@@ -1,0 +1,5 @@
+---
+removed_features:
+  - paramiko_ssh - removed deprecated ssh_extra_args from the paramiko_ssh connection plugin (https://github.com/ansible/ansible/issues/82941).
+  - paramiko_ssh - removed deprecated ssh_common_args from the paramiko_ssh connection plugin (https://github.com/ansible/ansible/issues/82940).
+  - paramiko_ssh - removed deprecated ssh_args from the paramiko_ssh connection plugin (https://github.com/ansible/ansible/issues/82939).


### PR DESCRIPTION
##### SUMMARY

* removed ssh_args parameter
* removed ssh_extra_args parameter
* removed ssh_common_args parameter

Fixes: #82939
Fixes: #82940
Fixes: #82941

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


