### PR TITLE
ansible-test - Use stable-2.17 default containers

### DIFF
--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,6 +1,6 @@
 base image=quay.io/ansible/base-test-container:6.2.0 python=3.12,3.7,3.8,3.9,3.10,3.11
-default image=quay.io/ansible/default-test-container:9.5.0 python=3.12,3.7,3.8,3.9,3.10,3.11 context=collection
-default image=quay.io/ansible/ansible-core-test-container:9.5.0 python=3.12,3.7,3.8,3.9,3.10,3.11 context=ansible-core
+default image=quay.io/ansible/default-test-container:9.6.0 python=3.12,3.7,3.8,3.9,3.10,3.11 context=collection
+default image=quay.io/ansible/ansible-core-test-container:9.6.0 python=3.12,3.7,3.8,3.9,3.10,3.11 context=ansible-core
 alpine319 image=quay.io/ansible/alpine319-test-container:7.1.0 python=3.11 cgroup=none audit=none
 fedora39 image=quay.io/ansible/fedora39-test-container:7.1.0 python=3.12
 ubuntu2004 image=quay.io/ansible/ubuntu2004-test-container:7.1.0 python=3.8


### PR DESCRIPTION
##### SUMMARY

ansible-test - Use stable-2.17 default containers.

##### ISSUE TYPE

Feature Pull Request
