### PR TITLE
Unsafe YAML dumping

### DIFF
--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -159,8 +159,8 @@ class InventoryCLI(CLI):
 
         if context.CLIARGS['yaml']:
             import yaml
-            from ansible.parsing.yaml.dumper import AnsibleDumper
-            results = to_text(yaml.dump(stuff, Dumper=AnsibleDumper, default_flow_style=False, allow_unicode=True))
+            from ansible.parsing.yaml.dumper import AnsibleUnsafeDumper
+            results = to_text(yaml.dump(stuff, Dumper=AnsibleUnsafeDumper, default_flow_style=False, allow_unicode=True))
         elif context.CLIARGS['toml']:
             from ansible.plugins.inventory.toml import toml_dumps
             try:

--- a/lib/ansible/parsing/yaml/constructor.py
+++ b/lib/ansible/parsing/yaml/constructor.py
@@ -130,6 +130,13 @@ class AnsibleConstructor(SafeConstructor):
 
         return wrap_var(value)
 
+    def construct_yaml_binary_unsafe(self, node):
+        constructor = self.construct_yaml_binary
+
+        value = constructor(node)
+
+        return wrap_var(value)
+
     def _node_position_info(self, node):
         # the line number where the previous token has ended (plus empty lines)
         # Add one so that the first line is line 1 rather than line 0
@@ -168,6 +175,10 @@ AnsibleConstructor.add_constructor(
 AnsibleConstructor.add_constructor(
     u'!unsafe',
     AnsibleConstructor.construct_yaml_unsafe)
+
+AnsibleConstructor.add_constructor(
+    u'!unsafe-binary',
+    AnsibleConstructor.construct_yaml_binary_unsafe)
 
 AnsibleConstructor.add_constructor(
     u'!vault',

--- a/lib/ansible/parsing/yaml/dumper.py
+++ b/lib/ansible/parsing/yaml/dumper.py
@@ -44,6 +44,10 @@ def represent_vault_encrypted_unicode(self, data):
     return self.represent_scalar(u'!vault', data._ciphertext.decode(), style='|')
 
 
+def represent_unsafe(self, data):
+    return self.represent_scalar(u'!unsafe', text_type(data))
+
+
 def represent_unicode(self, data):
     return yaml.representer.SafeRepresenter.represent_str(self, text_type(data))
 
@@ -117,4 +121,22 @@ AnsibleDumper.add_representer(
 AnsibleDumper.add_representer(
     NativeJinjaText,
     represent_unicode,
+)
+
+
+class AnsibleUnsafeDumper(AnsibleDumper):
+    '''
+    A simple stub class that allows us to add representers
+    for our overridden object types.
+    '''
+
+
+AnsibleUnsafeDumper.add_representer(
+    AnsibleUnsafeText,
+    represent_unsafe,
+)
+
+AnsibleUnsafeDumper.add_representer(
+    NativeJinjaUnsafeText,
+    represent_unsafe,
 )

--- a/lib/ansible/parsing/yaml/dumper.py
+++ b/lib/ansible/parsing/yaml/dumper.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import base64
+
 import yaml
 
 from ansible.module_utils.six import text_type, binary_type
@@ -54,6 +56,11 @@ def represent_unicode(self, data):
 
 def represent_binary(self, data):
     return yaml.representer.SafeRepresenter.represent_binary(self, binary_type(data))
+
+
+def represent_binary_unsafe(self, data):
+    data_b64 = base64.encodebytes(binary_type(data)).decode('ascii')
+    return self.represent_scalar(u'!unsafe-binary', data_b64, style='|')
 
 
 def represent_undefined(self, data):
@@ -134,6 +141,11 @@ class AnsibleUnsafeDumper(AnsibleDumper):
 AnsibleUnsafeDumper.add_representer(
     AnsibleUnsafeText,
     represent_unsafe,
+)
+
+AnsibleUnsafeDumper.add_representer(
+    AnsibleUnsafeBytes,
+    represent_binary_unsafe,
 )
 
 AnsibleUnsafeDumper.add_representer(


### PR DESCRIPTION
##### SUMMARY
Adds an `AnsibleUnsafeDumper` which dumps unsafe strings with the `!unsafe` tag.

The second commit adds a `!unsafe-binary` tag so that unsafe binary strings can also be dumped and survive a round-trip with `ansible-inventory --list --yaml`.

Ref: #82999.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request
