### PR TITLE
dnf - honor installroot and substitutes in paths

### DIFF
--- a/changelogs/fragments/dnf-installroot-substitutions.yml
+++ b/changelogs/fragments/dnf-installroot-substitutions.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - dnf - honor installroot for ``cachedir``, ``logdir`` and ``persistdir``
+  - dnf - perform variable substitutions in ``logdir`` and ``persistdir``

--- a/test/lib/ansible_test/_util/controller/sanity/mypy/ansible-core.ini
+++ b/test/lib/ansible_test/_util/controller/sanity/mypy/ansible-core.ini
@@ -58,9 +58,6 @@ ignore_missing_imports = True
 [mypy-dnf.*]
 ignore_missing_imports = True
 
-[mypy-libdnf.*]
-ignore_missing_imports = True
-
 [mypy-apt.*]
 ignore_missing_imports = True
 

--- a/test/lib/ansible_test/_util/controller/sanity/mypy/modules.ini
+++ b/test/lib/ansible_test/_util/controller/sanity/mypy/modules.ini
@@ -25,9 +25,6 @@ ignore_missing_imports = True
 [mypy-dnf.*]
 ignore_missing_imports = True
 
-[mypy-libdnf.*]
-ignore_missing_imports = True
-
 [mypy-apt.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
##### SUMMARY
In #80094 support for var substitution for cachedir was added but there are more options that should be supported. Using an API for prepend_installroot which should be done anyway provide that feature so use that. In addition, perform the operation once all substitutes are in place (releasever as well).
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
