### PR TITLE
[stable-2.16] Fixes permission for cache json file to 644

### DIFF
--- a/changelogs/fragments/82683-ansible-fact_cache-permissions-changed-after-ansible-coreupdate.yml
+++ b/changelogs/fragments/82683-ansible-fact_cache-permissions-changed-after-ansible-coreupdate.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fixes permission for cache json file from 600 to 644 (https://github.com/ansible/ansible/issues/82683).

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -29,6 +29,7 @@ from collections.abc import MutableMapping
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
+from ansible.module_utils.common.file import S_IRWU_RG_RO
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.plugins import AnsiblePlugin
 from ansible.plugins.loader import cache_loader
@@ -165,6 +166,7 @@ class BaseFileCacheModule(BaseCacheModule):
                 display.warning("error in '%s' cache plugin while trying to write to '%s' : %s" % (self.plugin_name, tmpfile_path, to_bytes(e)))
             try:
                 os.rename(tmpfile_path, cachefile)
+                os.chmod(cachefile, mode=S_IRWU_RG_RO)
             except (OSError, IOError) as e:
                 display.warning("error in '%s' cache plugin while trying to move '%s' to '%s' : %s" % (self.plugin_name, tmpfile_path, cachefile, to_bytes(e)))
         finally:

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -29,7 +29,6 @@ from collections.abc import MutableMapping
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
-from ansible.module_utils.common.file import S_IRWU_RG_RO
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.plugins import AnsiblePlugin
 from ansible.plugins.loader import cache_loader
@@ -166,7 +165,7 @@ class BaseFileCacheModule(BaseCacheModule):
                 display.warning("error in '%s' cache plugin while trying to write to '%s' : %s" % (self.plugin_name, tmpfile_path, to_bytes(e)))
             try:
                 os.rename(tmpfile_path, cachefile)
-                os.chmod(cachefile, mode=S_IRWU_RG_RO)
+                os.chmod(cachefile, mode=0o644)
             except (OSError, IOError) as e:
                 display.warning("error in '%s' cache plugin while trying to move '%s' to '%s' : %s" % (self.plugin_name, tmpfile_path, cachefile, to_bytes(e)))
         finally:


### PR DESCRIPTION
##### SUMMARY

Until ansible-core 2.12 the facts cache file created by this module, have permission set as 644 which allows the other users to read the cache, since ansible-core 2.13, we create the temporary file, but we do not set the permission after renaming the temporary file.  Adding the line to set the permission to allow other users/groups to read this file.

##### ISSUE TYPE
- Bugfix Pull Request


