### PR TITLE
Fallbacks for brand new APIs that don't exist in released dnf5

### DIFF
--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -562,7 +562,11 @@ class Dnf5Module(YumDnf):
             for repo in repo_query:
                 repo.enable()
 
-        sack.load_repos()
+        try:
+            sack.load_repos()
+        except AttributeError:
+            # dnf5 < 5.2.0.0
+            sack.update_and_load_enabled_repos(True)
 
         if self.update_cache and not self.names and not self.list:
             self.module.exit_json(
@@ -594,7 +598,11 @@ class Dnf5Module(YumDnf):
             self.module.exit_json(msg="", results=results, rc=0)
 
         settings = libdnf5.base.GoalJobSettings()
-        settings.set_group_with_name(True)
+        try:
+            settings.set_group_with_name(True)
+        except AttributeError:
+            # dnf5 < 5.2.0.0
+            settings.group_with_name = True
         if self.bugfix or self.security:
             advisory_query = libdnf5.advisory.AdvisoryQuery(base)
             types = []


### PR DESCRIPTION
##### SUMMARY

Fallbacks for brand new APIs that don't exist in released dnf5

Follow up to https://github.com/ansible/ansible/pull/83020

Without this, if we release the changes from the above PR, which technically we would do because we need to fix CI, and have releases coming up, the dnf5 module would be unusable until dnf 5.2.0.0 releases.  I don't know what that timeline is.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request


##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
