### PR TITLE
[stable-2.17] facts: Add a generic detection for VMware product name

### DIFF
--- a/changelogs/fragments/vmware_facts.yml
+++ b/changelogs/fragments/vmware_facts.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - facts - add a generic detection for VMware in product name.

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -175,7 +175,7 @@ class LinuxVirtual(Virtual):
                     virtual_facts['virtualization_type'] = 'RHEV'
                     found_virt = True
 
-        if product_name in ('VMware Virtual Platform', 'VMware7,1', 'VMware20,1'):
+        if product_name and product_name.startswith(("VMware",)):
             guest_tech.add('VMware')
             if not found_virt:
                 virtual_facts['virtualization_type'] = 'VMware'


### PR DESCRIPTION
##### SUMMARY

* Use startswith instead of hardcoded values in VMWare product
  detction

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


