### PR TITLE
command module `modifies` option

### DIFF
--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -155,6 +155,7 @@ EXAMPLES = r'''
     cmd: /usr/bin/make_database.sh db_user db_name
     modifies:
       - /path/to/database
+    diff_mode: true
 
 - name: Change the working directory to somedir/ and run the command as db_owner if /path/to/database does not exist
   ansible.builtin.command: /usr/bin/make_database.sh db_user db_name

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -258,15 +258,17 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native, to_bytes, to_text
 from ansible.module_utils.common.collections import is_iterable
 
+
 def _get_diff_data(before_path, after_path) -> dict:
-  with open(before_path, "rb") as before_file:
-    before_contents = before_file.read()
-  with open(after_path, "rb") as after_file:
-    after_contents = after_file.read()
-  return {
-    "before": before_contents,
-    "after": after_contents
-  }
+    with open(before_path, "rb") as before_file:
+        before_contents = before_file.read()
+    with open(after_path, "rb") as after_file:
+        after_contents = after_file.read()
+    return {
+        "before": before_contents,
+        "after": after_contents
+    }
+
 
 def _create_copy_or_empty_tempfile(path:str, tempfile_dir:str) -> str:
     '''
@@ -281,6 +283,7 @@ def _create_copy_or_empty_tempfile(path:str, tempfile_dir:str) -> str:
             os.remove(tempfile_path)
             raise Exception(err)
     return tempfile_path
+
 
 def main():
 

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -155,7 +155,7 @@ EXAMPLES = r'''
     cmd: /usr/bin/make_database.sh db_user db_name
     modifies:
       - /path/to/database
-    diff_mode: true
+    diff: true
 
 - name: Change the working directory to somedir/ and run the command as db_owner if /path/to/database does not exist
   ansible.builtin.command: /usr/bin/make_database.sh db_user db_name

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -254,29 +254,26 @@ import shlex
 import tempfile
 import shutil
 
-# from ansible import constants as C
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native, to_bytes, to_text
 from ansible.module_utils.common.collections import is_iterable
 
 def _get_diff_data(before_path, after_path) -> dict:
-  with open(before_path) as before_file:
+  with open(before_path, "rb") as before_file:
     before_contents = before_file.read()
-  with open(after_path) as after_file:
+  with open(after_path, "rb") as after_file:
     after_contents = after_file.read()
   return {
     "before": before_contents,
     "after": after_contents
   }
 
-def _create_copy_or_empty_tempfile(path:str):
+def _create_copy_or_empty_tempfile(path:str, tempfile_dir:str) -> str:
     '''
     Create a tempfile containing a copy of the file at `path`.
     If `path` does not point to a file, create an empty tempfile.
     '''
-    # TODO get temp dir
-    # fd, tempfile_path = tempfile.mkstemp(dir=C.DEFAULT_LOCAL_TMP)
-    fd, tempfile_path = tempfile.mkstemp(dir="/tmp")
+    fd, tempfile_path = tempfile.mkstemp(dir=tempfile_dir)
     if os.path.isfile(path):
         try:
             shutil.copy(path, tempfile_path)
@@ -387,7 +384,7 @@ def main():
     if len(modifies) > 0:
         file_copy_paths_before = dict()
         for path in modifies:
-            file_copy_paths_before[path] = _create_copy_or_empty_tempfile(path)
+            file_copy_paths_before[path] = _create_copy_or_empty_tempfile(path, module.tmpdir)
 
     # actually executes command (or not ...)
     if not module.check_mode:

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -270,7 +270,7 @@ def _get_diff_data(before_path, after_path) -> dict:
     }
 
 
-def _create_copy_or_empty_tempfile(path:str, tempfile_dir:str) -> str:
+def _create_copy_or_empty_tempfile(path: str, tempfile_dir: str) -> str:
     '''
     Create a tempfile containing a copy of the file at `path`.
     If `path` does not point to a file, create an empty tempfile.

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -32,7 +32,8 @@ attributes:
         details: while the command itself is arbitrary and cannot be subject to the check mode semantics it adds O(creates)/O(removes) options as a workaround
         support: partial
     diff_mode:
-        support: none
+        details: the `modifies` option shows a diff before/after command execution.
+        support: partial
     platform:
       support: full
       platforms: posix
@@ -74,6 +75,13 @@ options:
       - A filename or (since 2.0) glob pattern. If a matching file exists, this step B(will) be run.
       - This is checked after O(creates) is checked.
     version_added: "0.8"
+  modifies:
+    type: list
+    description:
+      - A list of file paths. A tempfile copy is made of each file before command execution,
+      - and then `results['changed']` `results['diff']` are set by comparing after command execution.
+      - Plain text files only.
+    version_added: "2.14"
   chdir:
     type: path
     description:
@@ -141,6 +149,12 @@ EXAMPLES = r'''
   ansible.builtin.command:
     cmd: /usr/bin/make_database.sh db_user db_name
     creates: /path/to/database
+
+- name: Run command and show changes in /path/to/database file
+  ansible.builtin.command:
+    cmd: /usr/bin/make_database.sh db_user db_name
+    modifies:
+      - /path/to/database
 
 - name: Change the working directory to somedir/ and run the command as db_owner if /path/to/database does not exist
   ansible.builtin.command: /usr/bin/make_database.sh db_user db_name
@@ -256,6 +270,7 @@ def main():
             expand_argument_vars=dict(type='bool', default=True),
             creates=dict(type='path'),
             removes=dict(type='path'),
+            modifies=dict(type='list', elements='str'),
             # The default for this really comes from the action plugin
             stdin=dict(required=False),
             stdin_add_newline=dict(type='bool', default=True),

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -384,7 +384,7 @@ def main():
     r['changed'] = True
 
     # make copies of files before command execution so that we can compare later
-    if len(modifies) > 0:
+    if modifies is not None and len(modifies) > 0:
         file_copy_paths_before = dict()
         for path in modifies:
             file_copy_paths_before[path] = _create_copy_or_empty_tempfile(path, module.tmpdir)
@@ -406,7 +406,7 @@ def main():
             r['changed'] = False
 
     # compare current state of files to their before-command tempfile copies
-    if len(modifies) > 0:
+    if modifies is not None and len(modifies) > 0:
         r['diff'] = []
         r['changed'] = False
         for path in modifies:

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -82,7 +82,7 @@ options:
       - A list of file paths. A tempfile copy is made of each file before command execution,
       - and then `results['changed']` `results['diff']` are set by comparing after command execution.
       - Plain text files only.
-    version_added: "2.14"
+    version_added: "2.18"
   chdir:
     type: path
     description:

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -77,6 +77,7 @@ options:
     version_added: "0.8"
   modifies:
     type: list
+    elements: str
     description:
       - A list of file paths. A tempfile copy is made of each file before command execution,
       - and then `results['changed']` `results['diff']` are set by comparing after command execution.

--- a/lib/ansible/modules/shell.py
+++ b/lib/ansible/modules/shell.py
@@ -105,6 +105,13 @@ EXAMPLES = r'''
 - name: Execute the command in remote shell; stdout goes to the specified file on the remote
   ansible.builtin.shell: somescript.sh >> somelog.txt
 
+- name: Execute the command in remote shell, append to file, show changes
+  ansible.builtin.shell:
+    cmd: somescript.sh >> somelog.txt
+    modifies:
+      - somelog.txt
+  diff: true
+
 - name: Change the working directory to somedir/ before executing the command
   ansible.builtin.shell: somescript.sh >> somelog.txt
   args:

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-__metaclass__ = type
-
 import os
 import tempfile
 import shutil

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -9,7 +9,6 @@ import os
 import tempfile
 import shutil
 
-from ansible import constants as C
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import merge_hash
 from ansible.module_utils.common.text.converters import to_bytes

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -3,9 +3,28 @@
 
 from __future__ import annotations
 
+__metaclass__ = type
+
+import os
+import tempfile
+import shutil
+
+from ansible import constants as C
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import merge_hash
+from ansible.module_utils.common.text.converters import to_bytes
+from ansible.module_utils.parsing.convert_bool import boolean
 
+def _create_copy_tempfile(path:str):
+    ''' Create a tempfile containing a copy of the file at `path` '''
+    _, tempfile_path = tempfile.mkstemp(dir=C.DEFAULT_LOCAL_TMP)
+    if os.path.isfile(path):
+        try:
+            shutil.copy(path, tempfile_path)
+        except Exception as err:
+            os.remove(tempfile_path)
+            raise Exception(err)
+    return tempfile_path
 
 class ActionModule(ActionBase):
 
@@ -14,10 +33,33 @@ class ActionModule(ActionBase):
         results = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
+        raw = boolean(self._task.args.get('raw', 'no'), strict=False)
+
+        # make copies of files before command execution so that we can compare later
+        if "modifies" in self._task.args and not raw:
+            file_copy_paths_before = dict()
+            for path in self._task.args['modifies']:
+                file_copy_paths_before[path] = _create_copy_tempfile(path)
+
         wrap_async = self._task.async_val and not self._connection.has_native_async
         # explicitly call `ansible.legacy.command` for backcompat to allow library/ override of `command` while not allowing
         # collections search for an unqualified `command` module
         results = merge_hash(results, self._execute_module(module_name='ansible.legacy.command', task_vars=task_vars, wrap_async=wrap_async))
+
+        # compare current state of files to their before-command tempfile copies
+        if "modifies" in self._task.args and not raw:
+            if self._play_context.diff:
+                results['diff'] = []
+            results['changed'] = False
+            for path in self._task.args['modifies']:
+                copy_path_before = file_copy_paths_before[path]
+                diff = self._get_diff_data(copy_path_before, path, task_vars)
+                # TODO check value when there is no difference
+                if diff is not None:
+                    if self._play_context.diff:
+                        results['diff'].append(diff)
+                    results['changed'] = True
+                os.remove(copy_path_before)
 
         if not wrap_async:
             # remove a temporary path we created

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -3,29 +3,8 @@
 
 from __future__ import annotations
 
-import os
-import tempfile
-import shutil
-
-from ansible import constants as C
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import merge_hash
-from ansible.module_utils.parsing.convert_bool import boolean
-
-
-def _create_copy_or_empty_tempfile(path:str): 
-    '''
-    Create a tempfile containing a copy of the file at `path`.
-    If `path` does not point to a file, create an empty tempfile.
-    '''
-    fd, tempfile_path = tempfile.mkstemp(dir=C.DEFAULT_LOCAL_TMP)
-    if os.path.isfile(path):
-        try:
-            shutil.copy(path, tempfile_path)
-        except Exception as err:
-            os.remove(tempfile_path)
-            raise Exception(err)
-    return tempfile_path
 
 
 class ActionModule(ActionBase):
@@ -35,32 +14,10 @@ class ActionModule(ActionBase):
         results = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
-        raw = boolean(self._task.args.get('raw', 'no'), strict=False)
-
-        # make copies of files before command execution so that we can compare later
-        if "modifies" in self._task.args and not raw:
-            file_copy_paths_before = dict()
-            for path in self._task.args['modifies']:
-                file_copy_paths_before[path] = _create_copy_or_empty_tempfile(path)
-
         wrap_async = self._task.async_val and not self._connection.has_native_async
         # explicitly call `ansible.legacy.command` for backcompat to allow library/ override of `command` while not allowing
         # collections search for an unqualified `command` module
         results = merge_hash(results, self._execute_module(module_name='ansible.legacy.command', task_vars=task_vars, wrap_async=wrap_async))
-
-        # compare current state of files to their before-command tempfile copies
-        if "modifies" in self._task.args and not raw:
-            if self._play_context.diff:
-                results['diff'] = []
-            results['changed'] = False
-            for path in self._task.args['modifies']:
-                copy_path_before = file_copy_paths_before[path]
-                diff = self._get_diff_data(copy_path_before, path, task_vars)
-                if self._play_context.diff:
-                    results['diff'].append(diff)
-                if not results['changed'] and diff['before'] != diff['after']:
-                    results['changed'] = True
-                os.remove(copy_path_before)
 
         if not wrap_async:
             # remove a temporary path we created

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -12,12 +12,13 @@ from ansible.plugins.action import ActionBase
 from ansible.utils.vars import merge_hash
 from ansible.module_utils.parsing.convert_bool import boolean
 
-def _create_copy_or_empty_tempfile(path:str):
+
+def _create_copy_or_empty_tempfile(path:str): 
     '''
     Create a tempfile containing a copy of the file at `path`.
     If `path` does not point to a file, create an empty tempfile.
     '''
-    _, tempfile_path = tempfile.mkstemp(dir=C.DEFAULT_LOCAL_TMP)
+    fd, tempfile_path = tempfile.mkstemp(dir=C.DEFAULT_LOCAL_TMP)
     if os.path.isfile(path):
         try:
             shutil.copy(path, tempfile_path)
@@ -25,6 +26,7 @@ def _create_copy_or_empty_tempfile(path:str):
             os.remove(tempfile_path)
             raise Exception(err)
     return tempfile_path
+
 
 class ActionModule(ActionBase):
 

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -12,8 +12,11 @@ from ansible.utils.vars import merge_hash
 from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.parsing.convert_bool import boolean
 
-def _create_copy_tempfile(path:str):
-    ''' Create a tempfile containing a copy of the file at `path` '''
+def _create_copy_or_empty_tempfile(path:str):
+    '''
+    Create a tempfile containing a copy of the file at `path`.
+    If `path` does not point to a file, create an empty tempfile.
+    '''
     _, tempfile_path = tempfile.mkstemp(dir=C.DEFAULT_LOCAL_TMP)
     if os.path.isfile(path):
         try:
@@ -36,7 +39,7 @@ class ActionModule(ActionBase):
         if "modifies" in self._task.args and not raw:
             file_copy_paths_before = dict()
             for path in self._task.args['modifies']:
-                file_copy_paths_before[path] = _create_copy_tempfile(path)
+                file_copy_paths_before[path] = _create_copy_or_empty_tempfile(path)
 
         wrap_async = self._task.async_val and not self._connection.has_native_async
         # explicitly call `ansible.legacy.command` for backcompat to allow library/ override of `command` while not allowing

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 import shutil
 
+from ansible import constants as C
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import merge_hash
 from ansible.module_utils.parsing.convert_bool import boolean

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -9,7 +9,6 @@ import shutil
 
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import merge_hash
-from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.parsing.convert_bool import boolean
 
 def _create_copy_or_empty_tempfile(path:str):

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -54,10 +54,9 @@ class ActionModule(ActionBase):
             for path in self._task.args['modifies']:
                 copy_path_before = file_copy_paths_before[path]
                 diff = self._get_diff_data(copy_path_before, path, task_vars)
-                # TODO check value when there is no difference
-                if diff is not None:
-                    if self._play_context.diff:
-                        results['diff'].append(diff)
+                if self._play_context.diff:
+                    results['diff'].append(diff)
+                if diff["before"] != diff["after"]:
                     results['changed'] = True
                 os.remove(copy_path_before)
 

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -56,7 +56,7 @@ class ActionModule(ActionBase):
                 diff = self._get_diff_data(copy_path_before, path, task_vars)
                 if self._play_context.diff:
                     results['diff'].append(diff)
-                if diff["before"] != diff["after"]:
+                if not results['changed'] and diff['before'] != diff['after']:
                     results['changed'] = True
                 os.remove(copy_path_before)
 


### PR DESCRIPTION
##### SUMMARY

added a `modifies` option to the `command` module. This adds partial support for diff mode and improves support for `changed_when`.

```
  modifies:
    type: list
    description:
      - A list of file paths. A tempfile copy is made of each file before command execution,
      - and then `results['changed']` `results['diff']` are set by comparing after command execution.
      - Plain text files only.
```

##### ISSUE TYPE
- Feature Pull Request

##### ADDITIONAL INFORMATION

```yml
- name: play
  hosts: localhost
  tasks:
    - name: shell
      shell:
        cmd: date +%s > /tmp/date
        modifies:
          - /tmp/date 
          - /etc/hosts
      diff: true
```

```
PLAY [playbook] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [command] *****************************************************************
--- before: /home/simonleary_umass_edu/.ansible/tmp/ansible-local-345127uc3p904f/tmphgxmq5b6
+++ after: /tmp/date
@@ -0,0 +1 @@
+1713040735

changed: [localhost]
```