### PR TITLE
[stable-2.16] Add the task info for tombstoned module/action plugins (#82451)

### DIFF
--- a/changelogs/fragments/improve-tombstone-error.yml
+++ b/changelogs/fragments/improve-tombstone-error.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Include the task location when a module or action plugin is deprecated (https://github.com/ansible/ansible/issues/82450).
+  - Give the tombstone error for ``include`` pre-fork like other tombstoned action/module plugins.

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -48,7 +48,6 @@ RAW_PARAM_MODULES = FREEFORM_ACTIONS.union(add_internal_fqcns((
 
 BUILTIN_TASKS = frozenset(add_internal_fqcns((
     'meta',
-    'include',
     'include_tasks',
     'include_role',
     'import_tasks',
@@ -304,9 +303,14 @@ class ModuleArgsParser:
             elif skip_action_validation:
                 is_action_candidate = True
             else:
-                context = action_loader.find_plugin_with_context(item, collection_list=self._collection_list)
-                if not context.resolved:
-                    context = module_loader.find_plugin_with_context(item, collection_list=self._collection_list)
+                try:
+                    context = action_loader.find_plugin_with_context(item, collection_list=self._collection_list)
+                    if not context.resolved:
+                        context = module_loader.find_plugin_with_context(item, collection_list=self._collection_list)
+                except AnsibleError as e:
+                    if e.obj is None:
+                        e.obj = self._task_ds
+                    raise e
 
                 is_action_candidate = context.resolved and bool(context.redirect_list)
 

--- a/test/integration/targets/collections/runme.sh
+++ b/test/integration/targets/collections/runme.sh
@@ -148,3 +148,12 @@ fi
 ./vars_plugin_tests.sh
 
 ./test_task_resolved_plugin.sh
+
+# Test tombstoned module/action plugins include the location of the fatal task
+cat <<EOF > test_dead_ping_error.yml
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - dead_ping:
+EOF
+ansible-playbook test_dead_ping_error.yml 2>&1 >/dev/null | grep -e 'line 4, column 5'

--- a/test/units/playbook/test_included_file.py
+++ b/test/units/playbook/test_included_file.py
@@ -318,9 +318,6 @@ def test_empty_raw_params():
 
     task_ds_list = [
         {
-            'include': ''
-        },
-        {
             'include_tasks': ''
         },
         {


### PR DESCRIPTION
##### SUMMARY
Backport for #82451

* Add the task info for tombstoned plugins

* Fix deprecation for 'include' by removing it from BUILTIN_TASKS which skip the plugin loader lookup

* changelog

remove obsolete unit test using 'include'

* Update changelogs/fragments/improve-tombstone-error.yml

(cherry picked from commit caa86cc4dfc3d1825158396bb2e5017b35131fa3)

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
