### PR TITLE
[stable-2.17] Update sdist path in release tool

### DIFF
--- a/packaging/release.py
+++ b/packaging/release.py
@@ -856,7 +856,7 @@ def test_built_artifact(path: pathlib.Path) -> None:
 
 def get_sdist_path(version: Version, dist_dir: pathlib.Path = DIST_DIR) -> pathlib.Path:
     """Return the path to the sdist file."""
-    return dist_dir / f"ansible-core-{version}.tar.gz"
+    return dist_dir / f"ansible_core-{version}.tar.gz"
 
 
 def get_wheel_path(version: Version, dist_dir: pathlib.Path = DIST_DIR) -> pathlib.Path:


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/83055

The latest setuptools package uses a normalized package name for the sdist.

(cherry picked from commit 8bc0d809a6f35dc8cc16ff3c8fbe1eb93778b3ad)

##### ISSUE TYPE

Bugfix Pull Request
