### PR TITLE
modules/apt: add support for apt-patterns

### DIFF
--- a/changelogs/fragments/83070-add-support-for-apt-patterns.yml
+++ b/changelogs/fragments/83070-add-support-for-apt-patterns.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apt - add support for apt-patterns (https://github.com/ansible/ansible/pull/83070)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -637,8 +637,11 @@ def expand_pkgspec_from_fnmatches(m, pkgspec, cache):
 
             pkgname_pattern, version_cmp, version = package_split(pkgspec_pattern)
 
+            if pkgname_pattern.startswith(('?', '~', '(?', '(~')):
+                # this is an apt-pattern (https://manpages.debian.org/bookworm/apt/apt-patterns.7.en.html)
+                new_pkgspec.append(pkgspec_pattern)
             # note that none of these chars is allowed in a (debian) pkgname
-            if frozenset('*?[]!').intersection(pkgname_pattern):
+            elif frozenset('*?[]!').intersection(pkgname_pattern):
                 # handle multiarch pkgnames, the idea is that "apt*" should
                 # only select native packages. But "apt*:i386" should still work
                 if ":" not in pkgname_pattern:
@@ -964,7 +967,7 @@ def remove(m, pkgspec, cache, purge=False, force=False,
     for package in pkgspec:
         name, version_cmp, version = package_split(package)
         installed, installed_version, upgradable, has_files = package_status(m, name, version_cmp, version, None, cache, state='remove')
-        if installed_version or (has_files and purge):
+        if installed_version or (has_files and purge) or package.startswith(('?', '~', '(?', '(~')):
             pkg_list.append("'%s'" % package)
     packages = ' '.join(pkg_list)
 

--- a/test/units/modules/test_apt.py
+++ b/test/units/modules/test_apt.py
@@ -38,6 +38,11 @@ fake_cache = [
             ["apt", "apt-utils"],
             id="pkgname-expands",
         ),
+        pytest.param(
+            ["?config-files"],
+            ["?config-files"],
+            id="apt-pattern",
+        ),
     ],
 )
 def test_expand_pkgspec_from_fnmatches(test_input, expected):


### PR DESCRIPTION
##### SUMMARY

This small patch adds support for [apt-patterns](https://manpages.debian.org/bookworm/apt/apt-patterns.7.en.html). 

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

Support for apt-patterns makes it possible e.g. to express `apt purge ?config-files` using the `apt` module in contrast to working around using `shell`.

Only when using `state=absent`, the apt-pattern will end up as-is in the final call to apt on the remote machine as this is the most relevant use case for us and also in the examples of the apt-patterns man page. It is certainly possible to generalize for other packages states if required.

Example call: `ansible -m apt -a "name=?config-files state=absent autoremove=yes purge=yes" ...` will purge remnant configuration files from removed packages as well as unused packages in one call.