### PR TITLE
2.17: handlers: fix executing in lockstep using linear (#83030)

### DIFF
--- a/changelogs/fragments/82307-handlers-lockstep-linear-fix.yml
+++ b/changelogs/fragments/82307-handlers-lockstep-linear-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix handlers not being executed in lockstep using the linear strategy in some cases (https://github.com/ansible/ansible/issues/82307)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -427,13 +427,13 @@ class PlayIterator:
                     # might be there from previous flush
                     state.handlers = self.handlers[:]
                     state.update_handlers = False
-                    state.cur_handlers_task = 0
 
                 while True:
                     try:
                         task = state.handlers[state.cur_handlers_task]
                     except IndexError:
                         task = None
+                        state.cur_handlers_task = 0
                         state.run_state = state.pre_flushing_run_state
                         state.update_handlers = True
                         break

--- a/test/integration/targets/handlers/handlers_lockstep_82307.yml
+++ b/test/integration/targets/handlers/handlers_lockstep_82307.yml
@@ -1,0 +1,25 @@
+- hosts: A,B
+  gather_facts: false
+  tasks:
+    - block:
+        - command: echo
+          notify:
+            - handler1
+            - handler2
+
+        - fail:
+          when: inventory_hostname == "B"
+
+        - meta: flush_handlers
+      always:
+        - name: always
+          debug:
+            msg: always
+  handlers:
+    - name: handler1
+      debug:
+        msg: handler1
+
+    - name: handler2
+      debug:
+        msg: handler2

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -216,3 +216,6 @@ ansible-playbook nested_flush_handlers_failure_force.yml -i inventory.handlers "
 
 ansible-playbook 82241.yml -i inventory.handlers "$@" 2>&1 | tee out.txt
 [ "$(grep out.txt -ce 'included_task_from_tasks_dir')" = "1" ]
+
+ansible-playbook handlers_lockstep_82307.yml -i inventory.handlers "$@" 2>&1 | tee out.txt
+[ "$(grep out.txt -ce 'TASK \[handler2\]')" = "0" ]


### PR DESCRIPTION
##### SUMMARY
Backport of #83030

(cherry picked from commit a3cdd831b35b17338a4b8f8a1c3851f4aaeb1f00)
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
