### PR TITLE
Document now using FQCN

### DIFF
--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -368,7 +368,7 @@ EXAMPLES = r'''
   delay: 5 # Every 5 seconds
 
 - name: Provide SSL/TLS ciphers as a list
-  uri:
+  ansible.builtin.uri:
     url: https://example.org
     ciphers:
       - '@SECLEVEL=2'
@@ -383,7 +383,7 @@ EXAMPLES = r'''
       - '!AESCCM'
 
 - name: Provide SSL/TLS ciphers as an OpenSSL formatted cipher list
-  uri:
+  ansible.builtin.uri:
     url: https://example.org
     ciphers: '@SECLEVEL=2:ECDH+AESGCM:ECDH+CHACHA20:ECDH+AES:DHE+AES:!aNULL:!eNULL:!aDSS:!SHA1:!AESCCM'
 '''


### PR DESCRIPTION
##### SUMMARY

There were 2 occurrences where the non FQCN (`uri`) was used. As FQCNs should be used, update the documentation.

##### ISSUE TYPE

- Docs Pull Request