### PR TITLE
systemd_service: handle failure when mask operation fails

### DIFF
--- a/changelogs/fragments/mask_me.yml
+++ b/changelogs/fragments/mask_me.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - systemd_service - handle mask operation failure (https://github.com/ansible/ansible/issues/81649).

--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -484,17 +484,17 @@ def main():
             masked = out.strip() == "masked"
 
             if masked != module.params['masked']:
-                result['changed'] = True
-                if module.params['masked']:
-                    action = 'mask'
-                else:
-                    action = 'unmask'
+                action = "mask" if module.params['masked'] else "unmask"
 
                 if not module.check_mode:
                     (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, action, unit))
                     if rc != 0:
                         # some versions of system CAN mask/unmask non existing services, we only fail on missing if they don't
                         fail_if_missing(module, found, unit, msg='host')
+                        if "Failed to mask" in err:
+                            module.fail_json(msg=err.strip())
+                    else:
+                        result['changed'] = True
 
         # Enable/disable service startup at boot if requested
         if module.params['enabled'] is not None:

--- a/test/integration/targets/systemd/handlers/main.yml
+++ b/test/integration/targets/systemd/handlers/main.yml
@@ -15,3 +15,8 @@
   file:
     path: /etc/systemd/system/baz.service
     state: absent
+
+- name: remove mask unit file
+  file:
+    path: /etc/systemd/system/mask_me.service
+    state: absent

--- a/test/integration/targets/systemd/tasks/main.yml
+++ b/test/integration/targets/systemd/tasks/main.yml
@@ -121,3 +121,4 @@
 - import_tasks: test_unit_template.yml
 - import_tasks: test_indirect_service.yml
 - import_tasks: test_enabled_runtime.yml
+- import_tasks: test_mask.yml

--- a/test/integration/targets/systemd/tasks/test_mask.yml
+++ b/test/integration/targets/systemd/tasks/test_mask.yml
@@ -1,0 +1,25 @@
+- name: Copy service file for mask operation
+  template:
+    src: mask_me.service
+    dest: /etc/systemd/system/mask_me.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify: remove unit file
+
+- name: Reload systemd
+  systemd:
+    daemon_reload: true
+
+- name: Try to mask already masked service
+  systemd:
+    name: mask_me.service
+    masked: true
+  register: mask_test_1
+  ignore_errors: true
+
+- name: Test mask service test
+  assert:
+    that:
+      - mask_test_1 is not changed
+      - "'Failed to mask' in mask_test_1.msg"

--- a/test/integration/targets/systemd/templates/mask_me.service
+++ b/test/integration/targets/systemd/templates/mask_me.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Mask Me Server
+Documentation=Mask
+
+[Service]
+ExecStart=/bin/yes
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
##### SUMMARY

* Handle the mask operation failure instead of just
  marking state changed.

Fixes: #81649

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


