### PR TITLE
setup_rpm_repo/create_repo: "Arch dependent binaries in noarch package"

### DIFF
--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -448,7 +448,7 @@
         - present
 
     - dnf:
-        name: /foo.so
+        name: /foo.gif
         state: present
       register: dnf_result
 

--- a/test/integration/targets/setup_rpm_repo/library/create_repo.py
+++ b/test/integration/targets/setup_rpm_repo/library/create_repo.py
@@ -12,11 +12,11 @@ from ansible.module_utils.common.respawn import has_respawned, probe_interpreter
 HAS_RPMFLUFF = True
 can_use_rpm_weak_deps = None
 try:
-    from rpmfluff import SimpleRpmBuild, GeneratedSourceFile, make_elf
+    from rpmfluff import SimpleRpmBuild, GeneratedSourceFile, make_gif
     from rpmfluff import YumRepoBuild
 except ImportError:
     try:
-        from rpmfluff.make import make_elf
+        from rpmfluff.make import make_gif
         from rpmfluff.sourcefile import GeneratedSourceFile
         from rpmfluff.rpmbuild import SimpleRpmBuild
         from rpmfluff.yumrepobuild import YumRepoBuild
@@ -47,8 +47,8 @@ SPECS = [
     RPM('dinginessentail-with-weak-dep', '1.0', '1', None, ['dinginessentail-weak-dep'], None, None),
     RPM('dinginessentail-weak-dep', '1.0', '1', None, None, None, None),
     RPM('noarchfake', '1.0', '1', None, None, None, 'noarch'),
-    RPM('provides_foo_a', '1.0', '1', None, None, 'foo.so', 'noarch'),
-    RPM('provides_foo_b', '1.0', '1', None, None, 'foo.so', 'noarch'),
+    RPM('provides_foo_a', '1.0', '1', None, None, 'foo.gif', 'noarch'),
+    RPM('provides_foo_b', '1.0', '1', None, None, 'foo.gif', 'noarch'),
     RPM('number-11-name', '11.0', '1', None, None, None, None),
     RPM('number-11-name', '11.1', '1', None, None, None, None),
     RPM('epochone', '1.0', '1', '1', None, None, "noarch"),
@@ -74,7 +74,7 @@ def create_repo(arch='x86_64'):
             pkg.add_installed_file(
                 "/" + spec.file,
                 GeneratedSourceFile(
-                    spec.file, make_elf()
+                    spec.file, make_gif()
                 )
             )
 


### PR DESCRIPTION
##### SUMMARY
This fixes "Arch dependent binaries in noarch package" error cause by including files created by make_elf function in noarch packages. While the error only manifests itself on EL 7 and 8 it is better to use files suitable for noarch packages to prevent the error potentially re-occuring in the future.

Noticed while backporting some of the dnf fixes to 2.16: https://github.com/ansible/ansible/pull/83084.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Test Pull Request
