### PR TITLE
file module fix attribute issues

### DIFF
--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+
 DOCUMENTATION = r'''
 ---
 module: file
@@ -539,16 +540,16 @@ def ensure_absent(path):
                 if '-a' in current_attributes:
                     # Attempt to remove the append-only attribute before deletion
                     try:
-                        module.set_attributes_if_different(path, current_attributes, changed, diff, expand=False)
+                        module.set_attributes_if_different(path, current_attributes, changed, 
+                                                           diff, expand=False)
                         changed = True  # Mark as changed if attributes were modified
                     except Exception as e:
-                        module.fail_json(msg="Failed to change attributes: %s" % to_native(e), path=to_native(b_path))            
+                        module.fail_json(msg="Failed to change attributes: %s" % to_native(e), 
+                                         path=to_native(b_path))            
                 try:
                     shutil.rmtree(b_path, ignore_errors=False)
                 except Exception as e:
-                    # raise AnsibleModuleError(results={'msg': "rmtree failed: %s" % to_native(e)})
-                    raise AnsibleModuleError(results={'msg': "rmtree failed: %s" % to_native(e),
-                                                      'details': "Attributes before removal: %s, Changed: %s" % (file_args.get('attributes', 'None'), changed)})
+                    raise AnsibleModuleError(results={'msg': "rmtree failed: %s" % to_native(e)})
             else:
                 try:
                     os.unlink(b_path)

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-
 DOCUMENTATION = r'''
 ---
 module: file
@@ -213,6 +212,12 @@ EXAMPLES = r'''
   ansible.builtin.file:
     path: /etc/foo
     state: absent
+
+- name: Remove file attributes and recursively remove directory
+  ansible.builtin.file:
+    path: /etc/foo
+    state: absent
+    attribute: -a
 
 '''
 RETURN = r'''
@@ -521,16 +526,29 @@ def ensure_absent(path):
     b_path = to_bytes(path, errors='surrogate_or_strict')
     prev_state = get_state(b_path)
     result = {}
+    file_args = module.load_file_common_arguments(module.params)
+    changed = False 
 
     if prev_state != 'absent':
         diff = initial_diff(path, 'absent', prev_state)
 
         if not module.check_mode:
             if prev_state == 'directory':
+                # Check if 'attributes' in file_args 
+                current_attributes = file_args.get('attributes', '')
+                if '-a' in current_attributes:
+                    # Attempt to remove the append-only attribute before deletion
+                    try:
+                        module.set_attributes_if_different(path, current_attributes, changed, diff, expand=False)
+                        changed = True  # Mark as changed if attributes were modified
+                    except Exception as e:
+                        module.fail_json(msg="Failed to change attributes: %s" % to_native(e), path=to_native(b_path))            
                 try:
                     shutil.rmtree(b_path, ignore_errors=False)
                 except Exception as e:
-                    raise AnsibleModuleError(results={'msg': "rmtree failed: %s" % to_native(e)})
+                    # raise AnsibleModuleError(results={'msg': "rmtree failed: %s" % to_native(e)})
+                    raise AnsibleModuleError(results={'msg': "rmtree failed: %s" % to_native(e),
+                                                      'details': "Attributes before removal: %s, Changed: %s" % (file_args.get('attributes', 'None'), changed)})
             else:
                 try:
                     os.unlink(b_path)

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -528,24 +528,24 @@ def ensure_absent(path):
     prev_state = get_state(b_path)
     result = {}
     file_args = module.load_file_common_arguments(module.params)
-    changed = False 
+    changed = False
 
     if prev_state != 'absent':
         diff = initial_diff(path, 'absent', prev_state)
 
         if not module.check_mode:
             if prev_state == 'directory':
-                # Check if 'attributes' in file_args 
+                # Check if 'attributes' in file_args
                 current_attributes = file_args.get('attributes', '')
                 if '-a' in current_attributes:
                     # Attempt to remove the append-only attribute before deletion
                     try:
-                        module.set_attributes_if_different(path, current_attributes, changed, 
+                        module.set_attributes_if_different(path, current_attributes, changed,
                                                            diff, expand=False)
                         changed = True  # Mark as changed if attributes were modified
                     except Exception as e:
-                        module.fail_json(msg="Failed to change attributes: %s" % to_native(e), 
-                                         path=to_native(b_path))            
+                        module.fail_json(msg="Failed to change attributes: %s" % to_native(e),
+                                         path=to_native(b_path))
                 try:
                     shutil.rmtree(b_path, ignore_errors=False)
                 except Exception as e:


### PR DESCRIPTION
##### SUMMARY

Fixes #79587 

This change ensures that directories with the +a (append-only) attribute can be removed by first clearing the attribute before attempting deletion. Previously, directories with the +a attribute could not be deleted when specified -a in the same task, causing errors in playbooks where directory removal was expected. This is inconsistent as we are able to specify +a in the same task as directory creation. 

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

The modification introduces checks and procedures to manage file attributes effectively, especially focusing on the append-only attribute to ensure that there are no other unwanted behavior. 

Steps to Reproduce:

Create a directory and set the +a attribute.
Try to remove the directory without changing attributes (Expected to fail).
Remove the +a attribute.
Successfully delete the directory.
