### PR TITLE
Fix Creating user directory using tilde always reports "changed"

### DIFF
--- a/changelogs/fragments/82490_creating_user_dir_using_tilde_always_reports_changed.yml
+++ b/changelogs/fragments/82490_creating_user_dir_using_tilde_always_reports_changed.yml
@@ -1,3 +1,2 @@
 bugfixes:
   - fixed the issue of creating user directory using tilde(~) always reported "changed".(https://github.com/ansible/ansible/issues/82490)
-

--- a/changelogs/fragments/82490_creating_user_dir_using_tilde_always_reports_changed.yml
+++ b/changelogs/fragments/82490_creating_user_dir_using_tilde_always_reports_changed.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - fixed the issue of creating user directory using tilde(~) always reported "changed".(https://github.com/ansible/ansible/issues/82490)
+

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -74,6 +74,7 @@ options:
               Since Ansible 2.5, the default shell for non-system users on macOS is V(/bin/bash).
             - On other operating systems, the default shell is determined by the underlying tool
               invoked by this module. See Notes for a per platform list of invoked tools.
+            - From Ansible 2.18, the type is changed to I(path) from I(str).
         type: path
     home:
         description:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -74,7 +74,7 @@ options:
               Since Ansible 2.5, the default shell for non-system users on macOS is V(/bin/bash).
             - On other operating systems, the default shell is determined by the underlying tool
               invoked by this module. See Notes for a per platform list of invoked tools.
-        type: str
+        type: path
     home:
         description:
             - Optionally set the user's home directory.
@@ -3115,7 +3115,7 @@ def main():
             groups=dict(type='list', elements='str'),
             comment=dict(type='str'),
             home=dict(type='path'),
-            shell=dict(type='str'),
+            shell=dict(type='path'),
             password=dict(type='str', no_log=True),
             login_class=dict(type='str'),
             password_expire_max=dict(type='int', no_log=False),

--- a/test/integration/targets/user/tasks/test_create_user.yml
+++ b/test/integration/targets/user/tasks/test_create_user.yml
@@ -77,3 +77,22 @@
     that:
       - "'RealName: ansibulluser' in user_test2.stdout_lines "
       - "'PrimaryGroupID: 20' in user_test2.stdout_lines "
+
+#https://github.com/ansible/ansible/issues/82490
+- name: Create a new user with custom shell to test ~ expansion
+  user:
+    name: bob
+    shell: ~/custom_shell
+
+- name: Create a new user with custom shell to test ~ expansion second time should show ok not changed
+  user:
+    name: bob
+    shell: ~/custom_shell
+  register: user_creation_result
+
+- name: Assert that the user was not changed on subsequent runs
+  assert:
+    that:
+      - user_creation_result is not changed
+    fail_msg: "Failure: User state was changed, We expect it to be same."
+

--- a/test/integration/targets/user/tasks/test_create_user.yml
+++ b/test/integration/targets/user/tasks/test_create_user.yml
@@ -81,13 +81,13 @@
 #https://github.com/ansible/ansible/issues/82490
 - name: Create a new user with custom shell to test ~ expansion
   user:
-    name: doesnotmatter
+    name: randomuserthomas
     shell: ~/custom_shell
   register: user_create_result
 
 - name: Create a new user with custom shell to test ~ expansion second time should show ok not changed
   user:
-    name: doesnotmatter
+    name: randomuserthomas
     shell: ~/custom_shell
   register: user_creation_result
 
@@ -96,3 +96,9 @@
     that:
       - user_creation_result is not changed
       - user_create_result is changed
+
+- name: remove the randomuserthomas user to clean up
+  user:
+    name: randomuserthomas
+    state: absent
+    force: true

--- a/test/integration/targets/user/tasks/test_create_user.yml
+++ b/test/integration/targets/user/tasks/test_create_user.yml
@@ -81,13 +81,13 @@
 #https://github.com/ansible/ansible/issues/82490
 - name: Create a new user with custom shell to test ~ expansion
   user:
-    name: bob
+    name: doesnotmatter
     shell: ~/custom_shell
   register: user_create_result
 
 - name: Create a new user with custom shell to test ~ expansion second time should show ok not changed
   user:
-    name: bob
+    name: doesnotmatter
     shell: ~/custom_shell
   register: user_creation_result
 

--- a/test/integration/targets/user/tasks/test_create_user.yml
+++ b/test/integration/targets/user/tasks/test_create_user.yml
@@ -83,6 +83,7 @@
   user:
     name: bob
     shell: ~/custom_shell
+  register: user_create_result
 
 - name: Create a new user with custom shell to test ~ expansion second time should show ok not changed
   user:
@@ -90,8 +91,8 @@
     shell: ~/custom_shell
   register: user_creation_result
 
-- name: Assert that the user was not changed on subsequent runs
+- name: Assert that the user with a tilde in the shell path is created
   assert:
     that:
       - user_creation_result is not changed
-    fail_msg: "Failure: User state was changed, We expect it to be same."
+      - user_create_result is changed

--- a/test/integration/targets/user/tasks/test_create_user.yml
+++ b/test/integration/targets/user/tasks/test_create_user.yml
@@ -95,4 +95,3 @@
     that:
       - user_creation_result is not changed
     fail_msg: "Failure: User state was changed, We expect it to be same."
-


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Fixes the issue of when Creating user directory using tilde, ansible always reports "changed"(https://github.com/ansible/ansible/issues/82490). along with an integration test to prevent regression. Fixed this issue through changing the spec from 'string' to 'path' for shell. This allowed for auto expansion of the tilde in user provided shell variable.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #82490 
##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION
