### PR TITLE
Update distro version in __init__.py

### DIFF
--- a/lib/ansible/module_utils/distro/__init__.py
+++ b/lib/ansible/module_utils/distro/__init__.py
@@ -22,7 +22,7 @@ Compat distro library.
 from __future__ import annotations
 
 # The following makes it easier for us to script updates of the bundled code
-_BUNDLED_METADATA = {"pypi_name": "distro", "version": "1.6.0"}
+_BUNDLED_METADATA = {"pypi_name": "distro", "version": "1.9.0"}
 
 # The following additional changes have been made:
 # * Remove optparse since it is not needed for our use.

--- a/lib/ansible/module_utils/distro/__init__.py
+++ b/lib/ansible/module_utils/distro/__init__.py
@@ -22,7 +22,7 @@ Compat distro library.
 from __future__ import annotations
 
 # The following makes it easier for us to script updates of the bundled code
-_BUNDLED_METADATA = {"pypi_name": "distro", "version": "1.9.0"}
+_BUNDLED_METADATA = {"pypi_name": "distro", "version": "1.8.0"}
 
 # The following additional changes have been made:
 # * Remove optparse since it is not needed for our use.


### PR DESCRIPTION
Update the bundled package distro from 1.6.0 to 1.9.0 in __init__.py (lib/ansible/module_utils/distro/__init__.py)

##### SUMMARY

Latest package of distro has been released and it has been changed from 1.6.0 to 1.9.0 in __init__.py file.

Fixes #83114

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Component Name: lib/ansible/module_utils/distro/__init__.py

```paste below

```
