### PR TITLE
Allow Python syntax playbooks

### DIFF
--- a/test/integration/targets/dataloader/main.py
+++ b/test/integration/targets/dataloader/main.py
@@ -1,0 +1,13 @@
+playbook = [
+    {
+        'hosts': 'localhost',
+        'gather_facts': 'no',
+        'tasks': [
+            {
+                'name': 'test item being present in the output',
+                'debug': 'var=item',
+                'loop': [1, 2, 3]
+            },
+        ],
+    },
+]

--- a/test/integration/targets/dataloader/main.yml
+++ b/test/integration/targets/dataloader/main.yml
@@ -1,0 +1,6 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: test item being present in the output
+      debug: var=item
+      loop: [1, 2, 3]

--- a/test/integration/targets/dataloader/runme.sh
+++ b/test/integration/targets/dataloader/runme.sh
@@ -4,3 +4,23 @@ set -eux
 
 # check if we get proper json error
 ansible-playbook -i ../../inventory attempt_to_load_invalid_json.yml "$@" 2>&1|grep 'JSON:'
+
+trap 'rm -f actually_yaml.py out-py out-yaml' EXIT
+
+# equivalent Python and YAML should yield same result
+ansible-playbook main.py -i ../../inventory | tee out-py
+ansible-playbook main.yml -i ../../inventory | tee out-yaml
+diff -u out-py out-yaml
+
+# Historically, all files, including *.py, have been loaded as YAML. In the
+# initial version of Python playbook support, if a .py file fails to import, a
+# warning message is emitted and the historical YAML loading is still
+# attempted. Erroring out immediately in the future seems simpler, but the path
+# of abundant caution probably includes deprecation warnings and reserving the
+# change for a major version bump.
+cp main.yml actually_yaml.py
+ansible-playbook actually_yaml.py -i ../../inventory | tee out-yaml
+for i in 1 2 3; do
+  grep "ok: \[localhost\] => (item=$i)" out-yaml
+  grep "\"item\": $i" out-yaml
+done


### PR DESCRIPTION
##### SUMMARY
Being able to reuse familiar tools and skills from Python programming for infrastructure would be wonderful. While generating YAML or JSON from Python does work (https://github.com/hashicorp/terraform-cdk is one example), in the specific case of Python syntax plabooks for Ansible, direct import is simpler.

##### ISSUE TYPE
- Feature Pull Request