### PR TITLE
Add version ceiling for pypsrp

### DIFF
--- a/changelogs/fragments/psrp-version-req.yml
+++ b/changelogs/fragments/psrp-version-req.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Add a version ceiling constraint for pypsrp to avoid potential breaking changes in the 1.0.0 release.

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -13,7 +13,7 @@ description:
   underlying transport but instead runs in a PowerShell interpreter.
 version_added: "2.7"
 requirements:
-- pypsrp>=0.4.0 (Python library)
+- pypsrp>=0.4.0, <1.0.0 (Python library)
 extends_documentation_fragment:
     - connection_pipelining
 options:

--- a/test/lib/ansible_test/_data/requirements/constraints.txt
+++ b/test/lib/ansible_test/_data/requirements/constraints.txt
@@ -1,5 +1,6 @@
 # do not add a cryptography or pyopenssl constraint to this file, they require special handling, see get_cryptography_requirements in python_requirements.py
 # do not add a coverage constraint to this file, it is handled internally by ansible-test
+pypsrp < 1.0.0  # in case the next major version is too big of a change
 pywinrm >= 0.3.0 ; python_version < '3.11' # message encryption support
 pywinrm >= 0.4.3 ; python_version >= '3.11' # support for Python 3.11
 pytest >= 4.5.0  # pytest 4.5.0 added support for --strict-markers

--- a/test/lib/ansible_test/_data/requirements/windows-integration.txt
+++ b/test/lib/ansible_test/_data/requirements/windows-integration.txt
@@ -1,5 +1,5 @@
 ntlm-auth
 requests-ntlm
 requests-credssp
-pypsrp
+pypsrp>=0.4.0, <1.0.0
 pywinrm[credssp]

--- a/test/lib/ansible_test/_data/requirements/windows-integration.txt
+++ b/test/lib/ansible_test/_data/requirements/windows-integration.txt
@@ -1,5 +1,5 @@
 ntlm-auth
 requests-ntlm
 requests-credssp
-pypsrp>=0.4.0, <1.0.0
+pypsrp
 pywinrm[credssp]


### PR DESCRIPTION
##### SUMMARY
Add a version ceiling for the pypsrp requirements. This ensures that the future v1.0.0 release won't impact existing users who install the library using the version range specified.

##### ISSUE TYPE
- Docs Pull Request