### PR TITLE
assemble: update argument_spec with 'decrypt' option

### DIFF
--- a/changelogs/fragments/assemble.yml
+++ b/changelogs/fragments/assemble.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - assemble - update argument_spec with 'decrypt' option which is required by action plugin (https://github.com/ansible/ansible/issues/80840).

--- a/lib/ansible/modules/assemble.py
+++ b/lib/ansible/modules/assemble.py
@@ -205,6 +205,11 @@ def main():
             regexp=dict(type='str'),
             ignore_hidden=dict(type='bool', default=False),
             validate=dict(type='str'),
+
+            # Options that are for the action plugin, but ignored by the module itself.
+            # We have them here so that the tests pass without ignores, which
+            # reduces the likelihood of further bugs added.
+            decrypt=dict(type='bool', default=True),
         ),
         add_file_common_args=True,
     )

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -15,7 +15,6 @@ lib/ansible/parsing/yaml/constructor.py mypy-3.12:type-var  # too many occurrenc
 lib/ansible/keyword_desc.yml no-unwanted-files
 lib/ansible/modules/apt.py validate-modules:parameter-invalid
 lib/ansible/modules/apt_repository.py validate-modules:parameter-invalid
-lib/ansible/modules/assemble.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/async_status.py validate-modules!skip
 lib/ansible/modules/async_wrapper.py ansible-doc!skip  # not an actual module
 lib/ansible/modules/async_wrapper.py pylint:ansible-bad-function # ignore, required


### PR DESCRIPTION
##### SUMMARY

* decrypt option is used by assemble action plugin.
  Add this parameter to remove failure raised by
  validate-modules:nonexistent-parameter-documented

Fixes: #80840

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


