### PR TITLE
distro: remove pep8 ignore

### DIFF
--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -56,7 +56,6 @@ lib/ansible/module_utils/compat/selinux.py import-3.11!skip # pass/fail depends 
 lib/ansible/module_utils/compat/selinux.py import-3.12!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py pylint:unidiomatic-typecheck
 lib/ansible/module_utils/distro/_distro.py no-assert
-lib/ansible/module_utils/distro/_distro.py pep8!skip # bundled code we don't want to modify
 lib/ansible/module_utils/distro/__init__.py empty-init # breaks namespacing, bundled, do not override
 lib/ansible/module_utils/facts/__init__.py empty-init # breaks namespacing, deprecate and eventually remove
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.ArgvParser.psm1 pslint:PSUseApprovedVerbs


### PR DESCRIPTION
##### SUMMARY

* Remove unnecessary pep8 from ignore.txt

Fixes: #80840

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


