### PR TITLE
Adds `limit` parameter to `ansible.builtin.find` 

### DIFF
--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -154,9 +154,9 @@ options:
             - When doing a C(contains) search, determine the encoding of the files to be searched.
         type: str
         version_added: "2.17"
-    max_matches:
+    limit:
         description:
-            - Set the maximum number of matches to make before returning.
+            - Limit the maximum number of matches to make before returning.
             - Matches are made from the top, down (i.e. shallowest directory first).
             - Set to V(None) for unlimited matches.
             - Default is unlimited matches.
@@ -245,7 +245,7 @@ EXAMPLES = r'''
     patterns: "^.*\\.log$"
     use_regex: true
     recurse: true
-    max_matches: 1
+    limit: 1
 '''
 
 RETURN = r'''
@@ -487,7 +487,7 @@ def main():
             mode=dict(type='raw'),
             exact_mode=dict(type='bool', default=True),
             encoding=dict(type='str'),
-            max_matches=dict(type='int', default=None)
+            limit=dict(type='int', default=None)
         ),
         supports_check_mode=True,
     )
@@ -540,8 +540,8 @@ def main():
         else:
             module.fail_json(size=params['size'], msg="failed to process size")
 
-    if params['max_matches'] is None or params['max_matches'] <= 0:
-        module.fail_json(msg="max_matches cannot be %d (use None for unlimited)" % params['max_matches'])
+    if params['limit'] is None or params['limit'] <= 0:
+        module.fail_json(msg="limit cannot be %d (use None for unlimited)" % params['limit'])
 
     now = time.time()
     msg = 'All paths examined'
@@ -620,11 +620,11 @@ def main():
                             r.update(statinfo(st))
                             filelist.append(r)
 
-                    if len(filelist) == params["max_matches"]:
+                    if len(filelist) == params["limit"]:
                         # Breaks out of directory files loop only
                         break
 
-                if not params['recurse'] or len(filelist) == params["max_matches"]:
+                if not params['recurse'] or len(filelist) == params["limit"]:
                     break
         except Exception as e:
             skipped[npath] = to_text(e)

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -487,7 +487,7 @@ def main():
             mode=dict(type='raw'),
             exact_mode=dict(type='bool', default=True),
             encoding=dict(type='str'),
-            limit=dict(type='int', default=None)
+            limit=dict(type='int')
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -161,7 +161,6 @@ options:
             - Set to V(None) for unlimited matches.
             - Default is unlimited matches.
         type: int
-        default: None
         version_added: "2.18"
 extends_documentation_fragment: action_common_attributes
 attributes:

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -154,6 +154,14 @@ options:
             - When doing a C(contains) search, determine the encoding of the files to be searched.
         type: str
         version_added: "2.17"
+    max_matches:
+        description:
+            - Set the maximum number of matches to make before returning.
+            - Set to V(-1) for unlimited matches.
+            - Default is unlimited matches.
+        type: int
+        default: -1
+        version_added: "2.17"
 extends_documentation_fragment: action_common_attributes
 attributes:
     check_mode:

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -157,7 +157,7 @@ options:
     max_matches:
         description:
             - Set the maximum number of matches to make before returning.
-            - Matches are made from the top down (i.e. shallowest directory first).
+            - Matches are made from the top, down (i.e. shallowest directory first).
             - Set to V(-1) for unlimited matches.
             - Default is unlimited matches.
         type: int

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -622,6 +622,7 @@ def main():
 
                     if len(filelist) == params["limit"]:
                         # Breaks out of directory files loop only
+                        msg = "Limit of matches reached"
                         break
 
                 if not params['recurse'] or len(filelist) == params["limit"]:

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -467,7 +467,8 @@ def main():
             depth=dict(type='int'),
             mode=dict(type='raw'),
             exact_mode=dict(type='bool', default=True),
-            encoding=dict(type='str')
+            encoding=dict(type='str'),
+            max_matches=dict(type='int', default=-1)
         ),
         supports_check_mode=True,
     )
@@ -519,6 +520,11 @@ def main():
             size = int(m.group(1)) * bytes_per_unit.get(m.group(2), 1)
         else:
             module.fail_json(size=params['size'], msg="failed to process size")
+
+    if params['max_matches'] == 0:
+        module.fail_json(msg="max_matches cannot be 0 (use -1 for unlimited)")
+    elif params['max_matches'] < -1:
+        module.fail_json(msg="max_matches cannot be %d (use -1 for unlimited)" % params['max_matches'])
 
     now = time.time()
     msg = 'All paths examined'
@@ -596,7 +602,7 @@ def main():
                             r.update(statinfo(st))
                             filelist.append(r)
 
-                if not params['recurse']:
+                if not params['recurse'] or len(filelist) == params["max_matches"]:
                     break
         except Exception as e:
             skipped[npath] = to_text(e)

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -158,7 +158,7 @@ options:
         description:
             - Limit the maximum number of matching paths returned. After finding this many, the find action will stop looking.
             - Matches are made from the top, down (i.e. shallowest directory first).
-            - Set to V(None) for unlimited matches.
+            - If not set, or set to v(null), it will do unlimited matches
             - Default is unlimited matches.
         type: int
         version_added: "2.18"

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -236,6 +236,16 @@ EXAMPLES = r'''
       - '^_[0-9]{2,4}_.*.log$'
       - '^[a-z]{1,5}_.*log$'
 
+- name: Find file containing "wally" without necessarily reading all files
+  ansible.builtin.find:
+    paths: /var/log
+    file_type: file
+    contains: wally
+    read_whole_file: true
+    patterns: "^.*\\.log$"
+    use_regex: true
+    recurse: true
+    max_matches: 1
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -521,9 +521,7 @@ def main():
         else:
             module.fail_json(size=params['size'], msg="failed to process size")
 
-    if params['max_matches'] == 0:
-        module.fail_json(msg="max_matches cannot be 0 (use -1 for unlimited)")
-    elif params['max_matches'] < -1:
+    if params['max_matches'] == 0 or params['max_matches'] < -1:
         module.fail_json(msg="max_matches cannot be %d (use -1 for unlimited)" % params['max_matches'])
 
     now = time.time()

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -540,7 +540,7 @@ def main():
         else:
             module.fail_json(size=params['size'], msg="failed to process size")
 
-    if params['limit'] is None or params['limit'] <= 0:
+    if params['limit'] is not None and params['limit'] <= 0:
         module.fail_json(msg="limit cannot be %d (use None for unlimited)" % params['limit'])
 
     now = time.time()

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -157,6 +157,7 @@ options:
     max_matches:
         description:
             - Set the maximum number of matches to make before returning.
+            - Matches are made from the top down (i.e. shallowest directory first).
             - Set to V(-1) for unlimited matches.
             - Default is unlimited matches.
         type: int
@@ -542,7 +543,8 @@ def main():
             if not os.path.isdir(npath):
                 raise Exception("'%s' is not a directory" % to_native(npath))
 
-            for root, dirs, files in os.walk(npath, onerror=handle_walk_errors, followlinks=params['follow']):
+            # Setting `topdown=True` to explicitly guarantee matches are made from the shallowest directory first
+            for root, dirs, files in os.walk(npath, onerror=handle_walk_errors, followlinks=params['follow'], topdown=True):
                 looked = looked + len(files) + len(dirs)
                 for fsobj in (files + dirs):
                     fsname = os.path.normpath(os.path.join(root, fsobj))

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -158,7 +158,7 @@ options:
         description:
             - Limit the maximum number of matching paths returned. After finding this many, the find action will stop looking.
             - Matches are made from the top, down (i.e. shallowest directory first).
-            - If not set, or set to v(null), it will do unlimited matches
+            - If not set, or set to v(null), it will do unlimited matches.
             - Default is unlimited matches.
         type: int
         version_added: "2.18"

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -156,7 +156,7 @@ options:
         version_added: "2.17"
     limit:
         description:
-            - Limit the maximum number of matches to make before returning.
+            - Limit the maximum number of matching paths returned. After finding this many, the find action will stop looking.
             - Matches are made from the top, down (i.e. shallowest directory first).
             - Set to V(None) for unlimited matches.
             - Default is unlimited matches.

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -602,6 +602,10 @@ def main():
                             r.update(statinfo(st))
                             filelist.append(r)
 
+                    if len(filelist) == params["max_matches"]:
+                        # Breaks out of directory files loop only
+                        break
+
                 if not params['recurse'] or len(filelist) == params["max_matches"]:
                     break
         except Exception as e:

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -158,10 +158,10 @@ options:
         description:
             - Set the maximum number of matches to make before returning.
             - Matches are made from the top, down (i.e. shallowest directory first).
-            - Set to V(-1) for unlimited matches.
+            - Set to V(None) for unlimited matches.
             - Default is unlimited matches.
         type: int
-        default: -1
+        default: None
         version_added: "2.18"
 extends_documentation_fragment: action_common_attributes
 attributes:
@@ -487,7 +487,7 @@ def main():
             mode=dict(type='raw'),
             exact_mode=dict(type='bool', default=True),
             encoding=dict(type='str'),
-            max_matches=dict(type='int', default=-1)
+            max_matches=dict(type='int', default=None)
         ),
         supports_check_mode=True,
     )
@@ -540,8 +540,8 @@ def main():
         else:
             module.fail_json(size=params['size'], msg="failed to process size")
 
-    if params['max_matches'] == 0 or params['max_matches'] < -1:
-        module.fail_json(msg="max_matches cannot be %d (use -1 for unlimited)" % params['max_matches'])
+    if params['max_matches'] is None or params['max_matches'] <= 0:
+        module.fail_json(msg="max_matches cannot be %d (use None for unlimited)" % params['max_matches'])
 
     now = time.time()
     msg = 'All paths examined'

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -162,7 +162,7 @@ options:
             - Default is unlimited matches.
         type: int
         default: -1
-        version_added: "2.17"
+        version_added: "2.18"
 extends_documentation_fragment: action_common_attributes
 attributes:
     check_mode:


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
`ansible.builtin.find` currently looks for matches in all non-filtered files.  When there is a very big file system in the search scope, and/or an expensive search is made (e.g. based off whole file contents), the operation can be very expensive. 

This PR adds the ability for the user to limit the number of matches that are made. Use cases that would benefit/be enabled with this functionality include:
- Determining if there are `> n` matching files in a directory.
- Finding the first directory in a nested tree with any files.
- Discovering where the file with matching content is (stopping once found!). 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Try the module using: 
```bash
# Can't run module in place due to import issues caused by other modules in directory
cp lib/ansible/modules/find.py /tmp/find.py && python /tmp/find.py <<EOF
{
    "ANSIBLE_MODULE_ARGS": {
        "paths": "/var/log",
        "file_type": "file",
        "contains": "wally",
        "read_whole_file": true,
        "patterns": "^.*\\\.log$",
        "use_regex": true,
        "recurse": true,
        "limit": 1
    }
}
EOF
```
