### PR TITLE
minor fix for misspelling

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -897,7 +897,7 @@ DEFAULT_PRIVATE_ROLE_VARS:
     - This was introduced as a way to reset role variables to default values if a role is used more than once
       in a playbook.
     - Starting in version '2.17' M(ansible.builtin.include_roles) and M(ansible.builtin.import_roles) can
-      indivudually override this via the C(public) parameter.
+      individually override this via the C(public) parameter.
     - Included roles only make their variables public at execution, unlike imported roles which happen at playbook compile time.
   env: [{name: ANSIBLE_PRIVATE_ROLE_VARS}]
   ini:


### PR DESCRIPTION
##### SUMMARY

This change fixes a minor spelling error, indivudually ==> individually.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

Very minor typo that was caught by a codespell check in the `ansible/ansible-documentation` repo.
