### PR TITLE
Update default.py

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -28,6 +28,7 @@ from collections.abc import MutableMapping
 from copy import deepcopy
 
 from ansible import constants as C
+from ansible.executor.task_result import TaskResult
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six import text_type
 from ansible.parsing.ajson import AnsibleJSONEncoder
@@ -502,6 +503,20 @@ class CallbackBase(AnsiblePlugin):
         self.on_any(args, kwargs)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
+        # type: (TaskResult, bool) -> None
+        """Show result, output, and optional information, based on verbosity level, vars, and
+        ansible.cfg settings, if a task failed.
+
+        Customization notes - In this method:
+        - You can access TaskResult class methods and attributes like result.is_changed()
+          and result.task_name
+        - The ansible.executor.task_result.TaskResult class is defined in
+          lib/ansible/executor/task_result.py
+
+        :param TaskResult result: The result and output of a task
+        :param bool ignore_errors: The value of the ignore_errors vars
+        :return: None
+        """
         host = result._host.get_name()
         self.runner_on_failed(host, result._result, ignore_errors)
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -21,6 +21,7 @@ DOCUMENTATION = '''
 
 from ansible import constants as C
 from ansible import context
+from ansible.executor.task_result import TaskResult
 from ansible.playbook.task_include import TaskInclude
 from ansible.plugins.callback import CallbackBase
 from ansible.utils.color import colorize, hostcolor
@@ -47,7 +48,20 @@ class CallbackModule(CallbackBase):
         super(CallbackModule, self).__init__()
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
+        # type: (TaskResult, bool) -> None
+        """Show result, output, and optional information, based on verbosity level, vars, and
+        ansible.cfg settings, if a task failed.
 
+        Customization notes - In this method:
+        - You can access TaskResult class methods and attributes like result.is_changed()
+          and result.task_name
+        - The ansible.executor.task_result.TaskResult class is defined in
+          lib/ansible/executor/task_result.py
+
+        :param TaskResult result: The result and output of a task
+        :param bool ignore_errors: The value of the ignore_errors vars
+        :return: None
+        """
         host_label = self.host_label(result)
         self._clean_results(result._result, result._task.action)
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -21,7 +21,6 @@ DOCUMENTATION = '''
 
 from ansible import constants as C
 from ansible import context
-from ansible.executor.task_result import TaskResult
 from ansible.playbook.task_include import TaskInclude
 from ansible.plugins.callback import CallbackBase
 from ansible.utils.color import colorize, hostcolor
@@ -48,20 +47,7 @@ class CallbackModule(CallbackBase):
         super(CallbackModule, self).__init__()
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
-        # type: (TaskResult, bool) -> None
-        """Show result, output, and optional information, based on verbosity level, vars, and
-        ansible.cfg settings, if a task failed.
 
-        Customization notes - In this method:
-        - You can access TaskResult class methods and attributes like result.is_changed()
-          and result.task_name
-        - The ansible.executor.task_result.TaskResult class is defined in
-          lib/ansible/executor/task_result.py
-
-        :param TaskResult result: The result and output of a task
-        :param bool ignore_errors: The value of the ignore_errors vars
-        :return: None
-        """
         host_label = self.host_label(result)
         self._clean_results(result._result, result._task.action)
 


### PR DESCRIPTION
##### SUMMARY

Added type hints and a docstring to the `v2_runner_on_failed` method in `lib/ansible/plugins/callback/default.py`. This change is meant to help others understand the purpose of the method and the parameters that the method will accept. The docstring also provides additional information for programmers who may want to use the method in a custom callback plugin.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

This change does not alter the method's output. All tests in test.units.plugins.callback.test_callback passed:

```text
test_display (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_display_verbose (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_host_label (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_host_label_delegated (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_init (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_clear_file (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_diff_after_none (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_diff_before_none (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_diff_dicts (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_difflist (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_new_file (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_no_trailing_newline_after (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_no_trailing_newline_before (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_no_trailing_newline_both (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_no_trailing_newline_both_with_some_changes (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_simple_diff (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_are_methods (test.units.plugins.callback.test_callback.TestCallbackOnMethods) ... ok
test_on_any (test.units.plugins.callback.test_callback.TestCallbackOnMethods) ... ok
test_clean_results (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_clean_results_debug_task (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_clean_results_debug_task_empty_results (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_clean_results_debug_task_no_invocation (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_get_item_label (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_get_item_label_no_log (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok

----------------------------------------------------------------------
Ran 24 tests in 0.012s

OK
```
