### PR TITLE
uri: deprecate 'yes' or 'no' value in follow_redirects param

### DIFF
--- a/changelogs/fragments/uri_follow_redirect.yml
+++ b/changelogs/fragments/uri_follow_redirect.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - uri - deprecate 'yes' and 'no' value for 'follow_redirects' parameter.

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -107,12 +107,14 @@ options:
     default: no
   follow_redirects:
     description:
-      - Whether or not the URI module should follow redirects. V(all) will follow all redirects.
-        V(safe) will follow only "safe" redirects, where "safe" means that the client is only
-        doing a GET or HEAD on the URI to which it is being redirected. V(none) will not follow
-        any redirects. Note that V(true) and V(false) choices are accepted for backwards compatibility,
-        where V(true) is the equivalent of V(all) and V(false) is the equivalent of V(safe). V(true) and V(false)
-        are deprecated and will be removed in some future version of Ansible.
+      - Whether or not the URI module should follow redirects.
+      - V(all) will follow all redirects.
+      - V(safe) will follow only "safe" redirects, where "safe" means that the client is only
+        doing a GET or HEAD on the URI to which it is being redirected.
+      - V(none) will not follow any redirects.
+      - Note that V(true) and V(false) choices are accepted for backwards compatibility,
+        where V(true) is the equivalent of V(all) and V(false) is the equivalent of V(safe).
+        V(true) and V(false) are deprecated and will be removed in Ansible 2.22.
     type: str
     choices: ['all', 'no', 'none', 'safe', 'urllib2', 'yes']
     default: safe
@@ -579,6 +581,12 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout, c
     if dest is not None and os.path.isfile(dest):
         # if destination file already exist, only download if file newer
         kwargs['last_mod_time'] = utcfromtimestamp(os.path.getmtime(dest))
+
+    if module.params.get('follow_redirects') in ('no', 'yes'):
+        module.deprecate(
+            "Using 'yes' or 'no' for 'follow_redirects' parameter is deprecated.",
+            version='2.22'
+        )
 
     resp, info = fetch_url(module, url, data=data, headers=headers,
                            method=method, timeout=socket_timeout, unix_socket=module.params['unix_socket'],

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -115,8 +115,8 @@ options:
       none: Will not follow any redirects.
       safe: Only redirects doing GET or HEAD requests will be followed.
       urllib2: Automatically follows HTTP redirects.
-      no: (DEPRECATED, removed in 2.22) alias of V(none).
-      yes: (DEPRECATED, removed in 2.22) alias of V(all).
+      'no': (DEPRECATED, removed in 2.22) alias of V(none).
+      'yes': (DEPRECATED, removed in 2.22) alias of V(all).
   creates:
     description:
       - A filename, when it already exists, this step will not be run.

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -114,7 +114,7 @@ options:
       all: Will follow all redirects.
       none: Will not follow any redirects.
       safe: Only redirects doing GET or HEAD requests will be followed.
-      urllib2: Automatically follows HTTP redirects.
+      urllib2: Defer to urllib2 behavior (As of writing this follows HTTP redirects).
       'no': (DEPRECATED, removed in 2.22) alias of V(none).
       'yes': (DEPRECATED, removed in 2.22) alias of V(all).
   creates:

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -108,16 +108,15 @@ options:
   follow_redirects:
     description:
       - Whether or not the URI module should follow redirects.
-      - V(all) will follow all redirects.
-      - V(safe) will follow only "safe" redirects, where "safe" means that the client is only
-        doing a GET or HEAD on the URI to which it is being redirected.
-      - V(none) will not follow any redirects.
-      - Note that V(true) and V(false) choices are accepted for backwards compatibility,
-        where V(true) is the equivalent of V(all) and V(false) is the equivalent of V(safe).
-        V(true) and V(false) are deprecated and will be removed in Ansible 2.22.
     type: str
-    choices: ['all', 'no', 'none', 'safe', 'urllib2', 'yes']
     default: safe
+    choices:
+      all: Will follow all redirects.
+      none: Will not follow any redirects.
+      safe: Only redirects doing GET or HEAD requests will be followed.
+      urllib2: Automatically follows HTTP redirects.
+      no: (DEPRECATED, removed in 2.22) alias of V(none).
+      yes: (DEPRECATED, removed in 2.22) alias of V(all).
   creates:
     description:
       - A filename, when it already exists, this step will not be run.

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -103,8 +103,8 @@ options:
       none: Will not follow any redirects.
       safe: Only redirects doing GET or HEAD requests will be followed.
       urllib2: Automatically follows HTTP redirects.
-      no: (DEPRECATED, removed in 2.22) alias of V(none).
-      yes: (DEPRECATED, removed in 2.22) alias of V(all).
+      'no': (DEPRECATED, removed in 2.22) alias of V(none).
+      'yes': (DEPRECATED, removed in 2.22) alias of V(all).
   use_gssapi:
     description:
     - Use GSSAPI handler of requests

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -102,7 +102,7 @@ options:
       all: Will follow all redirects.
       none: Will not follow any redirects.
       safe: Only redirects doing GET or HEAD requests will be followed.
-      urllib2: Automatically follows HTTP redirects.
+      urllib2: Defer to urllib2 behavior (As of writing this follows HTTP redirects).
       'no': (DEPRECATED, removed in 2.22) alias of V(none).
       'yes': (DEPRECATED, removed in 2.22) alias of V(all).
   use_gssapi:

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -99,12 +99,12 @@ options:
         - section: url_lookup
           key: follow_redirects
     choices:
-        - urllib2
-        - all
-        - 'yes'
-        - safe
-        - none
-        - 'no'
+      all: Will follow all redirects.
+      none: Will not follow any redirects.
+      safe: Only redirects doing GET or HEAD requests will be followed.
+      urllib2: Automatically follows HTTP redirects.
+      no: (DEPRECATED, removed in 2.22) alias of V(none).
+      yes: (DEPRECATED, removed in 2.22) alias of V(all).
   use_gssapi:
     description:
     - Use GSSAPI handler of requests
@@ -234,6 +234,11 @@ class LookupModule(LookupBase):
         ret = []
         for term in terms:
             display.vvvv("url lookup connecting to %s" % term)
+            if self.get_option('follow_redirects') in ('yes', 'no'):
+                display.deprecated(
+                    "Using 'yes' or 'no' for 'follow_redirects' parameter is deprecated.",
+                    version='2.22'
+                )
             try:
                 response = open_url(
                     term, validate_certs=self.get_option('validate_certs'),


### PR DESCRIPTION
##### SUMMARY

* 'yes' or 'no' value deprecated and set to removal in version 2.22

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


