### PR TITLE
Updated the docstring for the v2_runner_on_failed method in the Callb…

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -28,6 +28,7 @@ from collections.abc import MutableMapping
 from copy import deepcopy
 
 from ansible import constants as C
+from ansible.executor.task_result import TaskResult
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six import text_type
 from ansible.parsing.ajson import AnsibleJSONEncoder
@@ -502,6 +503,20 @@ class CallbackBase(AnsiblePlugin):
         self.on_any(args, kwargs)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
+        # type: (TaskResult, bool) -> None
+        """Show result, output, and optional information, based on verbosity level, vars, and
+        ansible.cfg settings, if a task failed.
+
+        Customization notes - In this method:
+        - You can access TaskResult class methods and attributes like result.is_changed()
+          and result.task_name
+        - The ansible.executor.task_result.TaskResult class is defined in
+          lib/ansible/executor/task_result.py
+
+        :param TaskResult result: The result and output of a task
+        :param bool ignore_errors: The value of the ignore_errors vars
+        :return: None
+        """
         host = result._host.get_name()
         self.runner_on_failed(host, result._result, ignore_errors)
 


### PR DESCRIPTION
…ackBase class.

##### SUMMARY

Added type hints and a docstring to the `v2_runner_on_failed` method of the Callback class in `lib/ansible/plugins/callback/__init__.py`. This change is meant to help others understand the purpose of the method and the parameters that the method will accept. The docstring also provides additional information for programmers who may want to use the method in a custom callback plugin. I originally added this to `default.py`, but moved it to `__init__.py` as recommended by @bcoca.

I will update the remaining docstrings based on feedback from this PR.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

This change does not alter the method's output. All tests in test.units.plugins.callback.test_callback passed:

```text
$ python3 -m unittest --verbose --buffer test.units.plugins.callback.test_callback
test_display (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_display_verbose (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_host_label (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_host_label_delegated (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_init (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_clear_file (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_diff_after_none (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_diff_before_none (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_diff_dicts (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_difflist (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_new_file (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_no_trailing_newline_after (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_no_trailing_newline_before (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_no_trailing_newline_both (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_no_trailing_newline_both_with_some_changes (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_simple_diff (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_are_methods (test.units.plugins.callback.test_callback.TestCallbackOnMethods) ... ok
test_on_any (test.units.plugins.callback.test_callback.TestCallbackOnMethods) ... ok
test_clean_results (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_clean_results_debug_task (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_clean_results_debug_task_empty_results (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_clean_results_debug_task_no_invocation (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_get_item_label (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_get_item_label_no_log (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok

----------------------------------------------------------------------
Ran 24 tests in 0.012s

OK
```
