### PR TITLE
ansible-test - Linux/FreeBSD default to aarch64

### DIFF
--- a/changelogs/fragments/ansible-test-remote-aarch64.yml
+++ b/changelogs/fragments/ansible-test-remote-aarch64.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Managed remote Linux and FreeBSD instance provisioning now defaults to aarch64 instead of x86_64.

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -1,13 +1,13 @@
-alpine/3.19 python=3.11 become=doas_sudo provider=aws arch=x86_64
-alpine become=doas_sudo provider=aws arch=x86_64
-fedora/39 python=3.12 become=sudo provider=aws arch=x86_64
-fedora become=sudo provider=aws arch=x86_64
-freebsd/13.3 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
-freebsd/14.0 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
-freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
+alpine/3.19 python=3.11 become=doas_sudo provider=aws arch=aarch64
+alpine become=doas_sudo provider=aws arch=aarch64
+fedora/39 python=3.12 become=sudo provider=aws arch=aarch64
+fedora become=sudo provider=aws arch=aarch64
+freebsd/13.3 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=aarch64
+freebsd/14.0 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=aarch64
+freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=aarch64
 macos/14.3 python=3.11 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64
 macos python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64
-rhel/9.3 python=3.9,3.11 become=sudo provider=aws arch=x86_64
-rhel become=sudo provider=aws arch=x86_64
-ubuntu/22.04 python=3.10 become=sudo provider=aws arch=x86_64
-ubuntu become=sudo provider=aws arch=x86_64
+rhel/9.3 python=3.9,3.11 become=sudo provider=aws arch=aarch64
+rhel become=sudo provider=aws arch=aarch64
+ubuntu/22.04 python=3.10 become=sudo provider=aws arch=aarch64
+ubuntu become=sudo provider=aws arch=aarch64


### PR DESCRIPTION
##### SUMMARY

Managed remote Linux and FreeBSD instance provisioning now defaults to aarch64 instead of x86_64.

##### ISSUE TYPE

Feature Pull Request
