### PR TITLE
Fix unable to find pip in the virtualenv when using relative path

### DIFF
--- a/changelogs/fragments/81522_unable_to_find_pip_in_virutalenv_with_relative_path.yml
+++ b/changelogs/fragments/81522_unable_to_find_pip_in_virutalenv_with_relative_path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fix unable to find pip in the virtualenv when using relative path

--- a/changelogs/fragments/81522_unable_to_find_pip_in_virutalenv_with_relative_path.yml
+++ b/changelogs/fragments/81522_unable_to_find_pip_in_virutalenv_with_relative_path.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - fix unable to find pip in the virtualenv when using relative path
+  - pip - consider the relative path for chdir is specified with virutalenv path (https://github.com/ansible/ansible/issues/81522).

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -721,8 +721,10 @@ def main():
     env = module.params['virtualenv']
 
     venv_created = False
-    if env and chdir:
-        env = os.path.join(chdir, env)
+    if env:
+        if chdir:
+            env = os.path.join(chdir, env)
+        env = os.path.abspath(env)
 
     if umask and not isinstance(umask, int):
         try:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -628,7 +628,7 @@
     chdir: checkout-dir # a relative path
     requirements: "{{ remote_tmp_dir}}/pipreq.txt" #we dont care about what we are trying to install here
     virtualenv: venv
-    virtualenv_command: python3 -m venv
+    virtualenv_command: "{{ ansible_python_interpreter }} -m venv"
   register: pip_output  # Registering the output of the pip task
 
 - assert:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -621,3 +621,17 @@
         - pip_prereleases is successful
         - pip_prereleases is not changed
         - '"fallible==0.0.1a2" in pip_prereleases.stdout_lines'
+
+#https://github.com/ansible/ansible/issues/81522
+- name: Unable to find pip in the virtualenv when using relative path
+  pip:
+    chdir: checkout-dir # a relative path
+    requirements: "{{ remote_tmp_dir}}/pipreq.txt" #we dont care about what we are trying to install here
+    virtualenv: venv
+    virtualenv_command: python3 -m venv
+  register: pip_output  # Registering the output of the pip task
+
+- assert:
+    that:
+      - pip_output is successful
+      - '"checkout-dir/venv" in pip_output.virtualenv'

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -634,4 +634,4 @@
 - assert:
     that:
       - pip_output is successful
-      - '"checkout-dir/venv" in pip_output.virtualenv'
+      - '"{{ playbook_dir }}/checkout-dir/venv" == pip_output.virtualenv'

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -634,4 +634,4 @@
 - assert:
     that:
       - pip_output is successful
-      - '"{{ playbook_dir }}/checkout-dir/venv" == pip_output.virtualenv'
+      - '"checkout-dir/venv" in pip_output.virtualenv'


### PR DESCRIPTION
##### SUMMARY
The bug identified in #81522  was regarding Unable to find pip in the virtualenv when a relative path was fed into chdir. This PR aims to fix this issue along with an integration test to prevent regression.
Fixes #81522

##### ISSUE TYPE

- Bugfix Pull Request


