### PR TITLE
Use capath instead of cafile for http tests

### DIFF
--- a/test/integration/targets/prepare_http_tests/handlers/main.yml
+++ b/test/integration/targets/prepare_http_tests/handlers/main.yml
@@ -10,3 +10,9 @@
 
 - name: Unregister cacert
   command: openssl rehash {{ capath.stdout }}
+
+- name: Remove cacert from cafile
+  blockinfile:
+    path: "{{ capaths.cafile }}"
+    block: "{{ cacert_pem.content }}"
+    state: absent

--- a/test/integration/targets/prepare_http_tests/handlers/main.yml
+++ b/test/integration/targets/prepare_http_tests/handlers/main.yml
@@ -2,3 +2,11 @@
   pip:
     name: gssapi
     state: absent
+
+- name: Remove cacert from capath
+  file:
+    state: absent
+    path: "{{ capath.stdout }}/ansible-http-test.pem"
+
+- name: Unregister cacert
+  command: openssl rehash {{ capath.stdout }}

--- a/test/integration/targets/prepare_http_tests/tasks/default.yml
+++ b/test/integration/targets/prepare_http_tests/tasks/default.yml
@@ -45,11 +45,20 @@
         return_content: true
       register: cacert_pem
 
-    - name: Locate cacert
-      command: '{{ ansible_python_interpreter }} -c "import ssl; print(ssl.get_default_verify_paths().cafile)"'
-      register: cafile_path
+    - name: Locate capath
+      command: '{{ ansible_python_interpreter }} -c "import ssl; print(ssl.get_default_verify_paths().capath)"'
+      register: capath
 
-    - name: Update cacert
-      blockinfile:
-        path: "{{ cafile_path.stdout_lines|first }}"
-        block: "{{ cacert_pem.content }}"
+    - name: Assert capath is set
+      assert:
+        that: capath.stdout
+
+    - name: Add cacert to capath
+      copy:
+        content: "{{ cacert_pem.content }}"
+        dest: "{{ capath.stdout }}/ansible-http-test.pem"
+      notify: Remove cacert from capath
+
+    - name: Register cacert
+      command: openssl rehash {{ capath.stdout }}
+      notify: Unregister cacert

--- a/test/integration/targets/prepare_http_tests/tasks/default.yml
+++ b/test/integration/targets/prepare_http_tests/tasks/default.yml
@@ -45,20 +45,29 @@
         return_content: true
       register: cacert_pem
 
-    - name: Locate capath
-      command: '{{ ansible_python_interpreter }} -c "import ssl; print(ssl.get_default_verify_paths().capath)"'
-      register: capath
+    - name: Get cafile and capath
+      command: '{{ ansible_python_interpreter }} -c "import ssl, json; paths = ssl.get_default_verify_paths(); print(json.dumps(dict(cafile=paths.cafile, capath=paths.capath)));"'
+      register: capaths
 
-    - name: Assert capath is set
-      assert:
-        that: capath.stdout
+    - name: Parse cafile and capath
+      set_fact:
+        capaths: "{{ capaths.stdout | from_json }}"
 
     - name: Add cacert to capath
       copy:
         content: "{{ cacert_pem.content }}"
-        dest: "{{ capath.stdout }}/ansible-http-test.pem"
+        dest: "{{ capaths.capath }}/ansible-http-test.pem"
       notify: Remove cacert from capath
+      when: capaths.capath is not none
 
     - name: Register cacert
-      command: openssl rehash {{ capath.stdout }}
+      command: openssl rehash {{ capaths.capath }}
       notify: Unregister cacert
+      when: capaths.capath is not none
+
+    - name: Add cacert to cafile
+      blockinfile:
+        path: "{{ capaths.cafile }}"
+        block: "{{ cacert_pem.content }}"
+      notify: Remove cacert from cafile
+      when: capaths.capath is none


### PR DESCRIPTION
##### SUMMARY

Use capath instead of cafile for http tests.

##### ISSUE TYPE

Test Pull Request
