### PR TITLE
Added submodule track for branch in .gitmodule file

### DIFF
--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -962,8 +962,7 @@ def submodules_fetch(git_path, module, remote, track_submodules, dest):
 
         if track_submodules:
             # Compare against submodule HEAD
-            # FIXME: determine this from .gitmodules
-            version = 'master'
+            version = '$(git config -f $toplevel/.gitmodules submodule.$name.branch || echo master)'
             after = get_submodule_versions(git_path, module, dest, '%s/%s' % (remote, version))
             if begin != after:
                 changed = True


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

Implemented the use of the branch tag in the .gitmodule file for submodule,
As for current release the git module only track and update the master branch of the submodule, and if other branch was tagged on the file, the module will only mark as change and update when the master revision change, but the repository branch update still is chose from the file, 
Now it is possible to use other branches, when comparing the HEAD with the branch, instead of the fixed master I added small command to check the value for the tag in the file, if fails returns the master (potentially change for "main", as new default).

TL;DR
If some submodule has the branch tag other than master, the ansible.builtin.git module will check the revision change for the master, and if changed, update the submodule for the tag branch in the .gitmodule file. 

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

My submodule use the branch "main" as it defaults, so when trying to use the track_submodule option on the ansible.builtin.git module, error return about no found the "origin/master" branch, so after look at the source code I found was fixed  the master branch as revision for the submodule, I've change the contente from `version = 'master'` to `version = '$(git config -f $toplevel/.gitmodules submodule.$name.branch || echo master)'`, which checks the file for the branch name, if fails return the master branch, It is passes as parameter concatenated with "origin/' for the function `get_submodule_versions()`

