### PR TITLE
[stable-2.17] ansible-doc: fix typo in output

### DIFF
--- a/changelogs/fragments/ansible-doc-inicate.yml
+++ b/changelogs/fragments/ansible-doc-inicate.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-doc - fixed "inicates" typo in output

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1303,7 +1303,7 @@ class DocCLI(CLI, RoleMixin):
                 text.append('')
 
             if doc.get('options'):
-                text.append(_format("Options", 'bold') + " (%s inicates it is required):" % ("=" if C.ANSIBLE_NOCOLOR else 'red'))
+                text.append(_format("Options", 'bold') + " (%s indicates it is required):" % ("=" if C.ANSIBLE_NOCOLOR else 'red'))
                 DocCLI.add_fields(text, doc.pop('options'), limit, opt_indent)
 
             if doc.get('attributes', False):
@@ -1385,7 +1385,7 @@ class DocCLI(CLI, RoleMixin):
 
         if doc.get('options', False):
             text.append("")
-            text.append(_format("OPTIONS", 'bold') + " (%s inicates it is required):" % ("=" if C.ANSIBLE_NOCOLOR else 'red'))
+            text.append(_format("OPTIONS", 'bold') + " (%s indicates it is required):" % ("=" if C.ANSIBLE_NOCOLOR else 'red'))
             DocCLI.add_fields(text, doc.pop('options'), limit, opt_indent, man=(display.verbosity == 0))
 
         if doc.get('attributes', False):

--- a/test/integration/targets/ansible-doc/fakecollrole.output
+++ b/test/integration/targets/ansible-doc/fakecollrole.output
@@ -5,7 +5,7 @@ ENTRY POINT: *alternate* - testns.testcol.testrole short description for alterna
           Longer description for testns.testcol.testrole alternate
           entry point.
 
-Options (= inicates it is required):
+Options (= indicates it is required):
 
 = altopt1   altopt1 description
           type: int

--- a/test/integration/targets/ansible-doc/fakemodule.output
+++ b/test/integration/targets/ansible-doc/fakemodule.output
@@ -2,7 +2,7 @@
 
   this is a fake module
 
-OPTIONS (= inicates it is required):
+OPTIONS (= indicates it is required):
 
 - _notreal  really not a real option
         default: null

--- a/test/integration/targets/ansible-doc/fakerole.output
+++ b/test/integration/targets/ansible-doc/fakerole.output
@@ -11,7 +11,7 @@ ENTRY POINT: *main* - test_role1 from roles subdir
           fat case left use. Match round scale now style far times.
           Your me past an much.
 
-Options (= inicates it is required):
+Options (= indicates it is required):
 
 = myopt1    First option.
           type: str

--- a/test/integration/targets/ansible-doc/randommodule-text-verbose.output
+++ b/test/integration/targets/ansible-doc/randommodule-text-verbose.output
@@ -7,7 +7,7 @@ DEPRECATED:
 	Will be removed in: Ansible 3.0.0
 	Alternatives: Use some other module
 
-OPTIONS (= inicates it is required):
+OPTIONS (= indicates it is required):
 
 - sub     Suboptions.
         set_via:

--- a/test/integration/targets/ansible-doc/randommodule-text.output
+++ b/test/integration/targets/ansible-doc/randommodule-text.output
@@ -13,7 +13,7 @@ DEPRECATED:
 	Will be removed in: Ansible 3.0.0
 	Alternatives: Use some other module
 
-OPTIONS (= inicates it is required):
+OPTIONS (= indicates it is required):
 
 - sub     Suboptions. Contains `sub.subtest', which can be set to `123'.
            You can use `TEST_ENV' to set this.

--- a/test/integration/targets/ansible-doc/test_docs_suboptions.output
+++ b/test/integration/targets/ansible-doc/test_docs_suboptions.output
@@ -1,6 +1,6 @@
   Test module
 
-OPTIONS (= inicates it is required):
+OPTIONS (= indicates it is required):
 
 - with_suboptions  An option with suboptions.
                     Use with care.

--- a/test/integration/targets/ansible-doc/test_docs_yaml_anchors.output
+++ b/test/integration/targets/ansible-doc/test_docs_yaml_anchors.output
@@ -1,6 +1,6 @@
   Test module
 
-OPTIONS (= inicates it is required):
+OPTIONS (= indicates it is required):
 
 - at_the_top  Short desc
         default: some string

--- a/test/integration/targets/ansible-doc/yolo-text.output
+++ b/test/integration/targets/ansible-doc/yolo-text.output
@@ -2,7 +2,7 @@
 
   This is always true
 
-OPTIONS (= inicates it is required):
+OPTIONS (= indicates it is required):
 
 = _input  does not matter
         type: raw


### PR DESCRIPTION
##### SUMMARY
Backport of #83205

(cherry picked from commit f5b945bf6a53c8a2b4c900f28d1790818d7b934f)

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->