### PR TITLE
docs: remove common return values from individual modules' docs

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -340,21 +340,6 @@ cache_update_time:
     returned: success, in some cases
     type: int
     sample: 1425828348000
-stdout:
-    description: output from apt
-    returned: success, when needed
-    type: str
-    sample: |-
-        Reading package lists...
-        Building dependency tree...
-        Reading state information...
-        The following extra packages will be installed:
-          apache2-bin ...
-stderr:
-    description: error output from apt
-    returned: success, when needed
-    type: str
-    sample: "AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 127.0.1.1. Set the 'ServerName' directive globally to ..."
 '''  # NOQA
 
 # added to stave off future warnings about apt api

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -177,11 +177,6 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-msg:
-  description: changed
-  returned: always
-  type: bool
-  sample: True
 start:
   description: The command execution start time.
   returned: always
@@ -197,16 +192,6 @@ delta:
   returned: always
   type: str
   sample: '0:00:00.001529'
-stdout:
-  description: The command standard output.
-  returned: always
-  type: str
-  sample: 'Clustering node rabbit@slave1 with rabbit@master …'
-stderr:
-  description: The command standard error.
-  returned: always
-  type: str
-  sample: 'ls cannot access foo: No such file or directory'
 cmd:
   description: The command executed by the task.
   returned: always
@@ -214,21 +199,6 @@ cmd:
   sample:
   - echo
   - hello
-rc:
-  description: The command return code (0 means success).
-  returned: always
-  type: int
-  sample: 0
-stdout_lines:
-  description: The command standard output split in lines.
-  returned: always
-  type: list
-  sample: [u'Clustering node rabbit@slave1 with rabbit@master …']
-stderr_lines:
-  description: The command standard error split in lines.
-  returned: always
-  type: list
-  sample: [u'ls cannot access foo: No such file or directory', u'ls …']
 '''
 
 import datetime

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -273,11 +273,6 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-backup_file:
-    description: name of backup file created after download
-    returned: changed and if backup=yes
-    type: str
-    sample: /path/to/file.txt.2015-02-12@22:09~
 checksum_dest:
     description: sha1 checksum of the file after copy
     returned: success

--- a/lib/ansible/modules/shell.py
+++ b/lib/ansible/modules/shell.py
@@ -153,11 +153,6 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-msg:
-    description: changed
-    returned: always
-    type: bool
-    sample: True
 start:
     description: The command execution start time.
     returned: always
@@ -173,34 +168,9 @@ delta:
     returned: always
     type: str
     sample: '0:00:00.325771'
-stdout:
-    description: The command standard output.
-    returned: always
-    type: str
-    sample: 'Clustering node rabbit@slave1 with rabbit@master …'
-stderr:
-    description: The command standard error.
-    returned: always
-    type: str
-    sample: 'ls: cannot access foo: No such file or directory'
 cmd:
     description: The command executed by the task.
     returned: always
     type: str
     sample: 'rabbitmqctl join_cluster rabbit@master'
-rc:
-    description: The command return code (0 means success).
-    returned: always
-    type: int
-    sample: 0
-stdout_lines:
-    description: The command standard output split in lines.
-    returned: always
-    type: list
-    sample: [u'Clustering node rabbit@slave1 with rabbit@master …']
-stderr_lines:
-    description: The command standard error split in lines.
-    returned: always
-    type: list
-    sample: [u'ls cannot access foo: No such file or directory', u'ls …']
 '''

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -437,16 +437,6 @@ ssh_public_key:
     'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC95opt4SPEC06tOYsJQJIuN23BbLMGmYo8ysVZQc4h2DZE9ugbjWWGS1/pweUGjVstgzMkBEeBCByaEf/RJKNecKRPeGd2Bw9DCj/bn5Z6rGfNENKBmo
     618mUJBvdlEgea96QGjOwSB7/gmonduC7gsWDMNcOdSE3wJMTim4lddiBx4RgC9yXsJ6Tkz9BHD73MXPpT5ETnse+A3fw3IGVSjaueVnlUyUmOBf7fzmZbhlFVXf2Zi2rFTXqvbdGHKkzpw1U8eB8xFPP7y
     d5u1u0e6Acju/8aZ/l17IDFiLke5IzlqIMRTEbDwLNeO84YQKWTm9fODHzhYe0yvxqLiK07 ansible-generated on host'
-stderr:
-  description: Standard error from running commands.
-  returned: When stderr is returned by a command that is run
-  type: str
-  sample: Group wheels does not exist
-stdout:
-  description: Standard output from running commands.
-  returned: When standard output is returned by the command that is run
-  type: str
-  sample:
 system:
   description: Whether or not the account is a system account.
   returned: When O(system) is passed to the module and the account does not exist


### PR DESCRIPTION
##### SUMMARY

Remove documentation of [common return values](https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values) from documentation of individual modules.

In the rendered module documentation, the Return Values section reads 

> Common return values are documented [here](https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values), the following are the fields unique to this module:

therefore I believe Return section of module's documentation should not contain common return values, unless the return value is significantly different from what would one expect based on the common documentation.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

compare eg [find module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/find_module.html#return-values) and [shell module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/shell_module.html#return-values) documentation.

Both implement 4 return values specific to that module, but the difference in readability is very visible.
