### PR TITLE
docs: fix wrong return value name

### DIFF
--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -177,8 +177,8 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-msg:
-  description: changed
+changed:
+  description: False if skipped due to O(creates)/O(removes) options, otherwise True
   returned: always
   type: bool
   sample: True

--- a/lib/ansible/modules/shell.py
+++ b/lib/ansible/modules/shell.py
@@ -153,8 +153,8 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-msg:
-    description: changed
+changed:
+    description: False if skipped due to O(creates)/O(removes) options, otherwise True
     returned: always
     type: bool
     sample: True


### PR DESCRIPTION
##### SUMMARY

fix wrong return value name in command and shell module docs.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

