### PR TITLE
PR to update package module name option doc

### DIFF
--- a/lib/ansible/modules/package.py
+++ b/lib/ansible/modules/package.py
@@ -31,6 +31,9 @@ options:
       - Package names also vary with package manager; this module will not "translate" them per distribution. For example V(libyaml-dev), V(libyaml-devel).
       - To operate on several packages this can accept a comma separated string of packages or a list of packages, depending on the underlying package manager.
     required: true
+    type: list
+    elements: str
+    default: []
   state:
     description:
       - Whether to install (V(present)), or remove (V(absent)) a package.

--- a/lib/ansible/modules/package.py
+++ b/lib/ansible/modules/package.py
@@ -33,7 +33,6 @@ options:
     required: true
     type: list
     elements: str
-    default: []
   state:
     description:
       - Whether to install (V(present)), or remove (V(absent)) a package.


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
PR to update package module name option doc
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### ADDITIONAL INFORMATION
One of ARI(ansible risk insight) mutating rule checks if the argument type is `list` or not.
`yum` builtin module has correct type definition like: [this](https://github.com/ansible/ansible/blob/v2.16.6/lib/ansible/modules/yum.py#L33-L45), but `package` builtin module lacks type definition like [this](https://github.com/ansible/ansible/blob/v2.16.6/lib/ansible/modules/package.py#L28-L33). 

Even when `package` module does accepts parameters as list for option `name`([ref](https://github.com/ansible/ansible/blob/v2.16.6/lib/ansible/modules/package.py#L83)), similar to `yum` module `name` option
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
