### PR TITLE
[stable-2.15] ansible-test - Use PyPI proxy for centos7 (#83226)

### DIFF
--- a/changelogs/fragments/ansible-test-centos7-pypi-proxy.yml
+++ b/changelogs/fragments/ansible-test-centos7-pypi-proxy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Automatically enable the PyPI proxy for the ``centos7`` container to restore the ability to use ``pip`` in that container.

--- a/test/lib/ansible_test/_internal/pypi_proxy.py
+++ b/test/lib/ansible_test/_internal/pypi_proxy.py
@@ -14,6 +14,7 @@ from .config import (
 
 from .host_configs import (
     PosixConfig,
+    DockerConfig,
 )
 
 from .util import (
@@ -55,8 +56,14 @@ def run_pypi_proxy(args: EnvironmentConfig, targets_use_pypi: bool) -> None:
         return  # user has overridden the proxy endpoint, there is nothing to provision
 
     versions_needing_proxy: tuple[str, ...] = tuple()  # preserved for future use, no versions currently require this
+    containers_needing_proxy: set[str] = {'centos7'}
     posix_targets = [target for target in args.targets if isinstance(target, PosixConfig)]
-    need_proxy = targets_use_pypi and any(target.python.version in versions_needing_proxy for target in posix_targets)
+    need_proxy = targets_use_pypi and any(
+        target.python.version in versions_needing_proxy or
+        (isinstance(target, DockerConfig) and target.name in containers_needing_proxy)
+        for target in posix_targets
+    )
+
     use_proxy = args.pypi_proxy or need_proxy
 
     if not use_proxy:


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/83226

(cherry picked from commit c0f7e9cc2c3cd30b9c9ad6649f6a5010fe1e7896)

##### ISSUE TYPE

Bugfix Pull Request
