### PR TITLE
[stable-2.17] setup_rpm_repo/create_repo: "Arch dependent binaries in noarch package (#83108)

### DIFF
--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -448,7 +448,7 @@
         - present
 
     - dnf:
-        name: /foo.so
+        name: /foo.gif
         state: present
       register: dnf_result
 

--- a/test/integration/targets/setup_rpm_repo/library/create_repo.py
+++ b/test/integration/targets/setup_rpm_repo/library/create_repo.py
@@ -12,11 +12,11 @@ from ansible.module_utils.common.respawn import has_respawned, probe_interpreter
 HAS_RPMFLUFF = True
 can_use_rpm_weak_deps = None
 try:
-    from rpmfluff import SimpleRpmBuild, GeneratedSourceFile, make_elf
+    from rpmfluff import SimpleRpmBuild, GeneratedSourceFile, make_gif
     from rpmfluff import YumRepoBuild
 except ImportError:
     try:
-        from rpmfluff.make import make_elf
+        from rpmfluff.make import make_gif
         from rpmfluff.sourcefile import GeneratedSourceFile
         from rpmfluff.rpmbuild import SimpleRpmBuild
         from rpmfluff.yumrepobuild import YumRepoBuild
@@ -47,8 +47,8 @@ SPECS = [
     RPM('dinginessentail-with-weak-dep', '1.0', '1', None, ['dinginessentail-weak-dep'], None, None),
     RPM('dinginessentail-weak-dep', '1.0', '1', None, None, None, None),
     RPM('noarchfake', '1.0', '1', None, None, None, 'noarch'),
-    RPM('provides_foo_a', '1.0', '1', None, None, 'foo.so', 'noarch'),
-    RPM('provides_foo_b', '1.0', '1', None, None, 'foo.so', 'noarch'),
+    RPM('provides_foo_a', '1.0', '1', None, None, 'foo.gif', 'noarch'),
+    RPM('provides_foo_b', '1.0', '1', None, None, 'foo.gif', 'noarch'),
     RPM('number-11-name', '11.0', '1', None, None, None, None),
     RPM('number-11-name', '11.1', '1', None, None, None, None),
     RPM('epochone', '1.0', '1', '1', None, None, "noarch"),
@@ -74,7 +74,7 @@ def create_repo(arch='x86_64'):
             pkg.add_installed_file(
                 "/" + spec.file,
                 GeneratedSourceFile(
-                    spec.file, make_elf()
+                    spec.file, make_gif()
                 )
             )
 


### PR DESCRIPTION
##### SUMMARY
Backport of #83108
<!--- Describe the change below, including rationale and design decisions -->
(cherry picked from commit 87bead3dcf9402f792e069e4ac68e15521c89493)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Test Pull Request