### PR TITLE
Add ansible_win_rm_certificate_thumbprint to facts

### DIFF
--- a/test/support/windows-integration/plugins/modules/setup.ps1
+++ b/test/support/windows-integration/plugins/modules/setup.ps1
@@ -459,6 +459,10 @@ if($gather_subset.Contains('winrm')) {
         $winrm_cert_thumbprints += $https_listener | Where-Object {$_.Name -EQ "CertificateThumbprint" } | Select-Object Value
     }
 
+    if ($winrm_cert_thumbprints) {
+        $ansible_facts.Add("ansible_win_rm_certificate_thumbprint", $winrm_cert_thumbprints[0].Value)
+    }
+
     $winrm_cert_expiry = @()
     foreach ($winrm_cert_thumbprint in $winrm_cert_thumbprints) {
         Try {


### PR DESCRIPTION
##### SUMMARY

Adds `ansible_win_rm_certificate_thumbprint` to the facts collected as part of the WinRM facts.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

Seeing as we're already collecting this data, it would be handy to expose it as a fact for use later (for certificate renewals/updates). Would there be any objections to adding it to the facts like I have implemented below?

```
PLAY [Test playbook] **********************************************************************************************************************************************************************************************************************************************
TASK [Gathering Facts] ********************************************************************************************************************************************************************************************************************************************
ok: [test-win-vm]

TASK [Print WinRM certificate expiry] *****************************************************************************************************************************************************************************************************************************
ok: [test-win-vm] => {
    "ansible_win_rm_certificate_expires": "2021-11-22 13:17:09"
}

TASK [Print WinRM certificate thumbprint] *************************************************************************************************************************************************************************************************************************
ok: [test-win-vm] => {
    "ansible_win_rm_certificate_thumbprint": "D96A5DC19B1DC6A939BF418B3F48756B0ECC636E"
}

PLAY RECAP ********************************************************************************************************************************************************************************************************************************************************
test-win-vm                 : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
