### PR TITLE
Documented v2_runner_on_failed method in Callback class

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -22,7 +22,7 @@ import json
 import re
 import sys
 import textwrap
-import typing
+from typing import TYPE_CHECKING
 
 from collections import OrderedDict
 from collections.abc import MutableMapping
@@ -42,7 +42,7 @@ from ansible.vars.clean import strip_internal_keys, module_response_deepcopy
 
 import yaml
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from ansible.executor.task_result import TaskResult
 
 global_display = Display()
@@ -505,7 +505,7 @@ class CallbackBase(AnsiblePlugin):
     def v2_on_any(self, *args, **kwargs):
         self.on_any(args, kwargs)
 
-    def v2_runner_on_failed(self, result: 'TaskResult', ignore_errors: bool = False) -> None:
+    def v2_runner_on_failed(self, result: TaskResult, ignore_errors: bool = False) -> None:
         """Show result, output, and optional information, based on verbosity level, vars, and
         ansible.cfg settings, if a task failed.
 

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -22,6 +22,7 @@ import json
 import re
 import sys
 import textwrap
+import typing
 
 from collections import OrderedDict
 from collections.abc import MutableMapping
@@ -40,6 +41,9 @@ from ansible.utils.unsafe_proxy import AnsibleUnsafeText, NativeJinjaUnsafeText
 from ansible.vars.clean import strip_internal_keys, module_response_deepcopy
 
 import yaml
+
+if typing.TYPE_CHECKING:
+    from ansible.executor.task_result import TaskResult
 
 global_display = Display()
 
@@ -501,7 +505,20 @@ class CallbackBase(AnsiblePlugin):
     def v2_on_any(self, *args, **kwargs):
         self.on_any(args, kwargs)
 
-    def v2_runner_on_failed(self, result, ignore_errors=False):
+    def v2_runner_on_failed(self, result: 'TaskResult', ignore_errors: bool = False) -> None:
+        """Show result, output, and optional information, based on verbosity level, vars, and
+        ansible.cfg settings, if a task failed.
+
+        Customization notes - In this method:
+        - You can access TaskResult class methods and attributes like result.is_changed()
+          and result.task_name
+        - The ansible.executor.task_result.TaskResult class is defined in
+          lib/ansible/executor/task_result.py
+
+        :param TaskResult result: The result and output of a task
+        :param bool ignore_errors: The value of the ignore_errors vars
+        :return: None
+        """
         host = result._host.get_name()
         self.runner_on_failed(host, result._result, ignore_errors)
 


### PR DESCRIPTION
##### SUMMARY

Added type declarations and a docstring to the `v2_runner_on_failed` method of the Callback class to explain the purpose of the method and the parameters that the method will accept. The docstring also provides additional information for developers who want to use the method in custom callback plugins. This PR incorporates feedback from @bcoca and @webknjaz.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

This change does not alter the method's output. A `block-rescue` play using an `ansible.builtin.fail` module ran with no issues. All tests in test.units.plugins.callback.test_callback passed

```
$ python3 -m unittest --verbose --buffer test.units.plugins.callback.test_callback
test_display (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_display_verbose (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_host_label (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_host_label_delegated (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_init (test.units.plugins.callback.test_callback.TestCallback) ... ok
test_clear_file (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_diff_after_none (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_diff_before_none (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_diff_dicts (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_difflist (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_new_file (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_no_trailing_newline_after (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_no_trailing_newline_before (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_no_trailing_newline_both (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_no_trailing_newline_both_with_some_changes (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_simple_diff (test.units.plugins.callback.test_callback.TestCallbackDiff) ... ok
test_are_methods (test.units.plugins.callback.test_callback.TestCallbackOnMethods) ... ok
test_on_any (test.units.plugins.callback.test_callback.TestCallbackOnMethods) ... ok
test_clean_results (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_clean_results_debug_task (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_clean_results_debug_task_empty_results (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_clean_results_debug_task_no_invocation (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_get_item_label (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok
test_get_item_label_no_log (test.units.plugins.callback.test_callback.TestCallbackResults) ... ok

----------------------------------------------------------------------
Ran 24 tests in 0.003s

OK
```

