### PR TITLE
Correct code comment in the PlaybookExecutor class to reflect current behavior

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -195,10 +195,7 @@ class PlaybookExecutor:
                                 result = self._tqm.RUN_FAILED_HOSTS
                                 break_play = True
 
-                            # check the number of failures here, to see if they're above the maximum
-                            # failure percentage allowed, or if any errors are fatal. If either of those
-                            # conditions are met, we break out, otherwise we only break out if the entire
-                            # batch failed
+                            # check the number of failures here and break out if the entire batch failed
                             failed_hosts_count = len(self._tqm._failed_hosts) + len(self._tqm._unreachable_hosts) - \
                                 (previously_failed + previously_unreachable)
 


### PR DESCRIPTION


##### SUMMARY

Correct a code comment in the PlaybookExecutor class that explains the host failure condition under which the PBE breaks out of the run. This comment previously stated that the maximum failure percentage was checked by the PHE. However, that logic has been refactored into the linear strategy plugin. The new comment reflects the actual behavior.

##### ISSUE TYPE

- Bugfix Pull Request


##### ADDITIONAL INFORMATION

This change does not make any code changes aside from comments for readability. I found this while reading the source code while working on an issue with an ansible playbook failing and trying to understand under what conditions the PlaybookExecutor would halt the run. I believe that this was an small oversight from a much earlier refactoring into strategy plugins.
