### PR TITLE
Add support for extra vars in ansible.builtin.generator plugin

### DIFF
--- a/lib/ansible/plugins/inventory/generator.py
+++ b/lib/ansible/plugins/inventory/generator.py
@@ -77,6 +77,7 @@ from itertools import product
 from ansible import constants as C
 from ansible.errors import AnsibleParserError
 from ansible.plugins.inventory import BaseInventoryPlugin
+from ansible.utils.vars import load_extra_vars
 
 
 class InventoryModule(BaseInventoryPlugin):
@@ -124,9 +125,12 @@ class InventoryModule(BaseInventoryPlugin):
 
         config = self._read_config_data(path)
 
+        extra_vars = load_extra_vars(loader)
+
         template_inputs = product(*config['layers'].values())
         for item in template_inputs:
             template_vars = dict()
+            template_vars.update(extra_vars)
             for i, key in enumerate(config['layers'].keys()):
                 template_vars[key] = item[i]
             host = self.template(config['hosts']['name'], template_vars)


### PR DESCRIPTION
### Reference
This pull request addresses issue #83270 

### Summary

# Use Cases
##  VM Creation
- *Scenario:* Using Ansible to both create VMs and configure them. Consistency in hostname generation is critical to ensure seamless transitions between creation and configuration phases.
- *Solution:* By enabling the `ansible.builtin.generator` plugin to use extra vars, it will be possible to dynamically generate consistent hostnames based on variables provided at runtime. This ensures consistency across already existing virtual machines (that may be sourced from dynamic inventory plugin) and newly created virtual machines. This consistency is important for the use of `group_vars` and `host_vars` in the configuration phase.


### Issue Type

- Feature Pull Request


### Component Name

plugins/inventory/generator.py

### Additional Information

In `inventory.yaml` file:
```yaml
plugin: ansible.builtin.generator
hosts:
    # The `region` variable is provided at runtime
    name: "{{ region }}{{ machine_type }}"
layers:
    machine_type:
        - web
        - db
```
Running:
```sh
ansible-inventory -i inventory.yaml -e region=region10 --list
```
Should output:
```
@all:
  |--@ungrouped:
  |  |--region10web
  |  |--region10db
```


