### PR TITLE
ansible-test - Update http-test-container

### DIFF
--- a/changelogs/fragments/ansible-test-http-test-container-update.yml
+++ b/changelogs/fragments/ansible-test-http-test-container-update.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Update ``http-test-container`` to version 3.0.0.

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -672,6 +672,7 @@
 
 - name: Test ciphers
   import_tasks: ciphers.yml
+  when: false  # skipped until we have a way to disable TLS 1.3 on the client or server, since cipher suite selection won't break TLS 1.3
 
 - name: Test use_netrc=False
   import_tasks: use_netrc.yml

--- a/test/integration/targets/get_url/tasks/use_netrc.yml
+++ b/test/integration/targets/get_url/tasks/use_netrc.yml
@@ -6,31 +6,24 @@
       login foo
       password bar
 
-- name: Test Bearer authorization is failed with netrc
+- name: Test with netrc forced Basic auth
   get_url:
-    url: https://{{ httpbin_host }}/bearer
+    url: https://{{ httpbin_host }}/basic-auth/foo/bar
     headers:
       Authorization: Bearer foobar
     dest: "{{ remote_tmp_dir }}/msg.txt"
-  ignore_errors: yes
   environment:
     NETRC: "{{ remote_tmp_dir }}/netrc"
 
 - name: Read msg.txt file
   ansible.builtin.slurp:
     src: "{{ remote_tmp_dir }}/msg.txt"
-  register: response_failed
+  register: response
 
-- name: Parse token from msg.txt
-  set_fact:
-    token: "{{ (response_failed['content'] | b64decode | from_json).token }}"
-
-- name: assert Test Bearer authorization is failed with netrc
+- name: assert Test with netrc forced Basic auth
   assert:
     that:
-    - "token.find('v=' ~ 'Zm9vOmJhcg') == -1"
-    fail_msg: "Was expecting 'foo:bar' in base64, but received: {{ response_failed['content'] | b64decode | from_json }}"
-    success_msg: "Expected Basic authentication even Bearer headers were sent"
+     - (response['content'] | b64decode | from_json).user == 'foo'
 
 - name: Test Bearer authorization is successfull with use_netrc=False
   get_url:
@@ -47,16 +40,10 @@
     src: "{{ remote_tmp_dir }}/msg.txt"
   register: response
 
-- name: Parse token from msg.txt
-  set_fact:
-    token: "{{ (response['content'] | b64decode | from_json).token }}"
-
 - name: assert Test Bearer authorization is successfull with use_netrc=False
   assert:
     that:
-    - "token.find('v=' ~ 'foobar') == -1"
-    fail_msg: "Was expecting Bearer token 'foobar', but received: {{ response['content'] | b64decode | from_json }}"
-    success_msg: "Bearer authentication successfull without netrc"
+     - (response['content'] | b64decode | from_json).token == 'foobar'
 
 - name: Clean up
   file:

--- a/test/integration/targets/lookup_url/tasks/ciphers.yml
+++ b/test/integration/targets/lookup_url/tasks/ciphers.yml
@@ -1,0 +1,22 @@
+- vars:
+    url: https://{{ httpbin_host }}/get
+  block:
+    - name: test good cipher
+      debug:
+        msg: '{{ lookup("url", url) }}'
+      vars:
+        ansible_lookup_url_ciphers: ECDHE-RSA-AES128-SHA256
+      register: good_ciphers
+
+    - name: test bad cipher
+      debug:
+        msg: '{{ lookup("url", url) }}'
+      vars:
+        ansible_lookup_url_ciphers: ECDHE-ECDSA-AES128-SHA
+      ignore_errors: true
+      register: bad_ciphers
+
+    - assert:
+        that:
+          - good_ciphers is successful
+          - bad_ciphers is failed

--- a/test/integration/targets/lookup_url/tasks/main.yml
+++ b/test/integration/targets/lookup_url/tasks/main.yml
@@ -27,28 +27,9 @@
     that:
       - badssl_host_substring in web_data
 
-- vars:
-    url: https://{{ httpbin_host }}/get
-  block:
-    - name: test good cipher
-      debug:
-        msg: '{{ lookup("url", url) }}'
-      vars:
-        ansible_lookup_url_ciphers: ECDHE-RSA-AES128-SHA256
-      register: good_ciphers
-
-    - name: test bad cipher
-      debug:
-        msg: '{{ lookup("url", url) }}'
-      vars:
-        ansible_lookup_url_ciphers: ECDHE-ECDSA-AES128-SHA
-      ignore_errors: true
-      register: bad_ciphers
-
-    - assert:
-        that:
-          - good_ciphers is successful
-          - bad_ciphers is failed
+- name: Test ciphers
+  import_tasks: ciphers.yml
+  when: false  # skipped until we have a way to disable TLS 1.3 on the client or server, since cipher suite selection won't break TLS 1.3
 
 - name: Test use_netrc=False
   import_tasks: use_netrc.yml

--- a/test/integration/targets/lookup_url/tasks/use_netrc.yml
+++ b/test/integration/targets/lookup_url/tasks/use_netrc.yml
@@ -8,17 +8,14 @@
       password bar
     mode: "0600"
 
-- name: test Url lookup with ~/.netrc forced Basic auth
+- name: test Url lookup with netrc forced Basic auth
   set_fact:
-    web_data: "{{ lookup('ansible.builtin.url', 'https://' ~ httpbin_host ~ '/bearer', headers={'Authorization':'Bearer foobar'}) }}"
-  ignore_errors: yes
+    web_data: "{{ lookup('ansible.builtin.url', 'https://' ~ httpbin_host ~ '/basic-auth/foo/bar', headers={'Authorization':'Bearer foobar'}) }}"
 
-- name: assert test Url lookup with ~/.netrc forced Basic auth
+- name: assert test Url lookup with netrc forced Basic auth
   assert:
     that:
-    - "web_data.token.find('v=' ~ 'Zm9vOmJhcg==') == -1"
-    fail_msg: "Was expecting 'foo:bar' in base64, but received: {{ web_data }}"
-    success_msg: "Expected Basic authentication even Bearer headers were sent"
+     - web_data.user == 'foo'
 
 - name: test Url lookup with use_netrc=False
   set_fact:
@@ -27,9 +24,7 @@
 - name: assert test Url lookup with netrc=False used Bearer authentication
   assert:
     that:
-    - "web_data.token.find('v=' ~ 'foobar') == -1"
-    fail_msg: "Was expecting 'foobar' Bearer token, but received: {{ web_data }}"
-    success_msg: "Expected to ignore ~/.netrc and authorize with Bearer token"
+     - web_data.token == 'foobar'
 
 - name: Clean up. Removing ~/.netrc
   file:

--- a/test/integration/targets/prepare_http_tests/vars/httptester.yml
+++ b/test/integration/targets/prepare_http_tests/vars/httptester.yml
@@ -2,5 +2,5 @@
 badssl_host: fail.ansible.http.tests
 httpbin_host: ansible.http.tests
 sni_host: sni1.ansible.http.tests
-badssl_host_substring: HTTP Client Testing Service
+badssl_host_substring: httpbin.org
 self_signed_host: self-signed.ansible.http.tests

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -444,7 +444,7 @@
 - name: Assert multipart/form-data
   assert:
     that:
-      - multipart.json.files.file1 == '_multipart/form-data_\n'
+      - multipart.json.files.file1 | b64decode == '_multipart/form-data_\n'
       - multipart.json.files.file2 == 'text based file content'
       - multipart.json.form.text_form_field1 == 'value1'
       - multipart.json.form.text_form_field2 == 'value2'

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -720,6 +720,7 @@
 
 - name: Test ciphers
   import_tasks: ciphers.yml
+  when: false  # skipped until we have a way to disable TLS 1.3 on the client or server, since cipher suite selection won't break TLS 1.3
 
 - name: Test use_netrc.yml
   import_tasks: use_netrc.yml

--- a/test/integration/targets/uri/tasks/use_netrc.yml
+++ b/test/integration/targets/uri/tasks/use_netrc.yml
@@ -6,24 +6,20 @@
       login foo
       password bar
 
-- name: Test Bearer authorization is failed with netrc
+- name: Test with netrc forced Basic auth
   uri:
-    url: https://{{ httpbin_host }}/bearer
+    url: https://{{ httpbin_host }}/basic-auth/foo/bar
     return_content: yes
     headers:
       Authorization: Bearer foobar
-  ignore_errors: yes
   environment:
     NETRC: "{{ remote_tmp_dir }}/netrc"
-  register: response_failed
+  register: response
 
-- name: assert Test Bearer authorization is failed with netrc
+- name: assert Test with netrc forced Basic auth
   assert:
     that:
-    - response_failed.json.token != 'foobar'
-    - "'Zm9vOmJhcg==' in response_failed.json.token"
-    fail_msg: "Was expecting 'foo:bar' in base64, but received: {{ response_failed }}"
-    success_msg: "Expected to fail because netrc is using Basic authentication by default"
+     - response.json.user == 'foo'
 
 - name: Test Bearer authorization is successful with use_netrc=False
   uri:
@@ -39,11 +35,7 @@
 - name: assert Test Bearer authorization is successful with use_netrc=False
   assert:
     that:
-    - response.status == 200
-    - response.json.token == 'foobar'
-    - response.url == 'https://{{ httpbin_host }}/bearer'
-    fail_msg: "Was expecting successful Bearer authentication, but received: {{ response }}"
-    success_msg: "Bearer authentication successful when netrc is ignored."
+     - response.json.token == 'foobar'
 
 - name: Clean up
   file:

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/httptester.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/httptester.py
@@ -31,7 +31,7 @@ class HttptesterProvider(CloudProvider):
     def __init__(self, args: IntegrationConfig) -> None:
         super().__init__(args)
 
-        self.image = os.environ.get('ANSIBLE_HTTP_TEST_CONTAINER', 'quay.io/ansible/http-test-container:2.1.0')
+        self.image = os.environ.get('ANSIBLE_HTTP_TEST_CONTAINER', 'quay.io/ansible/http-test-container:3.0.0')
 
         self.uses_docker = True
 


### PR DESCRIPTION
##### SUMMARY

Update ``http-test-container`` to version 3.0.0.

##### ISSUE TYPE

Feature Pull Request

##### ADDITIONAL INFORMATION

This disables the cipher suite testing for get_url, lookup_url and uri because they're unable to function properly when both the client and server support TLS 1.3. Testing cipher suite support will require use of a client or server that has TLS 1.3 disabled.