### PR TITLE
Fix gather_facts for Windows and shell dirname

### DIFF
--- a/changelogs/fragments/gather_facts-windows-parallel.yml
+++ b/changelogs/fragments/gather_facts-windows-parallel.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- gather_facts - Fix up parallel fact gathering for Windows modules - https://github.com/ansible/ansible/issues/83219

--- a/changelogs/fragments/shell-dirname.yml
+++ b/changelogs/fragments/shell-dirname.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- shell - Added ``dirname`` method to provide a shell specific function for getting the directory path from the provided path.

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1068,8 +1068,24 @@ def _add_module_to_zip(zf, date_time, remote_module_fqn, b_module_data):
         )
 
 
-def _find_module_utils(module_name, b_module_data, module_path, module_args, task_vars, templar, module_compression, async_timeout, become,
-                       become_method, become_user, become_password, become_flags, environment, remote_is_local=False):
+def _find_module_utils(
+    module_name,
+    b_module_data,
+    module_path,
+    module_args,
+    task_vars,
+    templar,
+    module_compression,
+    async_timeout: int,
+    wrap_async: bool,
+    become,
+    become_method,
+    become_user,
+    become_password,
+    become_flags,
+    environment,
+    remote_is_local=False,
+):
     """
     Given the source of the module, convert it to a Jinja2 template to insert
     module code and return whether it's a new or old style module.
@@ -1287,9 +1303,20 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         # create the common exec wrapper payload and set that as the module_data
         # bytes
         b_module_data = ps_manifest._create_powershell_wrapper(
-            b_module_data, module_path, module_args, environment,
-            async_timeout, become, become_method, become_user, become_password,
-            become_flags, module_substyle, task_vars, remote_module_fqn
+            b_module_data,
+            module_path,
+            module_args,
+            environment,
+            async_timeout,
+            wrap_async,
+            become,
+            become_method,
+            become_user,
+            become_password,
+            become_flags,
+            module_substyle,
+            task_vars,
+            remote_module_fqn,
         )
 
     elif module_substyle == 'jsonargs':
@@ -1337,8 +1364,23 @@ def _extract_interpreter(b_module_data):
     return interpreter, args
 
 
-def modify_module(module_name, module_path, module_args, templar, task_vars=None, module_compression='ZIP_STORED', async_timeout=0, become=False,
-                  become_method=None, become_user=None, become_password=None, become_flags=None, environment=None, remote_is_local=False):
+def modify_module(
+    module_name,
+    module_path,
+    module_args,
+    templar,
+    task_vars=None,
+    module_compression='ZIP_STORED',
+    async_timeout: int = 0,
+    wrap_async: bool = False,
+    become=False,
+    become_method=None,
+    become_user=None,
+    become_password=None,
+    become_flags=None,
+    environment=None,
+    remote_is_local=False,
+):
     """
     Used to insert chunks of code into modules before transfer rather than
     doing regular python imports.  This allows for more efficient transfer in
@@ -1367,10 +1409,24 @@ def modify_module(module_name, module_path, module_args, templar, task_vars=None
         # read in the module source
         b_module_data = f.read()
 
-    (b_module_data, module_style, shebang) = _find_module_utils(module_name, b_module_data, module_path, module_args, task_vars, templar, module_compression,
-                                                                async_timeout=async_timeout, become=become, become_method=become_method,
-                                                                become_user=become_user, become_password=become_password, become_flags=become_flags,
-                                                                environment=environment, remote_is_local=remote_is_local)
+    (b_module_data, module_style, shebang) = _find_module_utils(
+        module_name,
+        b_module_data,
+        module_path,
+        module_args,
+        task_vars,
+        templar,
+        module_compression,
+        async_timeout=async_timeout,
+        wrap_async=wrap_async,
+        become=become,
+        become_method=become_method,
+        become_user=become_user,
+        become_password=become_password,
+        become_flags=become_flags,
+        environment=environment,
+        remote_is_local=remote_is_local,
+    )
 
     if module_style == 'binary':
         return (b_module_data, module_style, to_text(shebang, nonstring='passthru'))

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -282,10 +282,22 @@ def _strip_comments(source):
     return b'\n'.join(buf)
 
 
-def _create_powershell_wrapper(b_module_data, module_path, module_args,
-                               environment, async_timeout, become,
-                               become_method, become_user, become_password,
-                               become_flags, substyle, task_vars, module_fqn):
+def _create_powershell_wrapper(
+    b_module_data,
+    module_path,
+    module_args,
+    environment,
+    async_timeout: int,
+    wrap_async: bool,
+    become,
+    become_method,
+    become_user,
+    become_password,
+    become_flags,
+    substyle,
+    task_vars,
+    module_fqn,
+):
     # creates the manifest/wrapper used in PowerShell/C# modules to enable
     # things like become and async - this is also called in action/script.py
 
@@ -311,7 +323,7 @@ def _create_powershell_wrapper(b_module_data, module_path, module_args,
     )
     finder.scan_exec_script(module_wrapper)
 
-    if async_timeout > 0:
+    if wrap_async or async_timeout > 0:
         finder.scan_exec_script('exec_wrapper')
         finder.scan_exec_script('async_watchdog')
         finder.scan_exec_script('async_wrapper')

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -218,7 +218,7 @@ class ActionBase(ABC):
             return True
         return False
 
-    def _configure_module(self, module_name, module_args, task_vars):
+    def _configure_module(self, module_name, module_args, task_vars, wrap_async: bool = False):
         '''
         Handles the loading and templating of the module code through the
         modify_module() function.
@@ -298,6 +298,7 @@ class ActionBase(ABC):
                                                                             module_compression=C.config.get_config_value('DEFAULT_MODULE_COMPRESSION',
                                                                                                                          variables=task_vars),
                                                                             async_timeout=self._task.async_val,
+                                                                            wrap_async=wrap_async,
                                                                             environment=final_environment,
                                                                             remote_is_local=bool(getattr(self._connection, '_remote_is_local', False)),
                                                                             **become_kwargs)
@@ -1047,7 +1048,12 @@ class ActionBase(ABC):
             self._task.environment.append({"ANSIBLE_ASYNC_DIR": async_dir})
 
         # FUTURE: refactor this along with module build process to better encapsulate "smart wrapper" functionality
-        (module_style, shebang, module_data, module_path) = self._configure_module(module_name=module_name, module_args=module_args, task_vars=task_vars)
+        (module_style, shebang, module_data, module_path) = self._configure_module(
+            module_name=module_name,
+            module_args=module_args,
+            task_vars=task_vars,
+            wrap_async=wrap_async,
+        )
         display.vvv("Using module file %s" % module_path)
         if not shebang and module_style != 'binary':
             raise AnsibleError("module (%s) is missing interpreter line" % module_name)

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -276,7 +276,7 @@ class ActionBase(ABC):
             raise AnsibleError("The module %s was not found in configured module paths" % (module_name))
 
         # insert shared code and arguments into the module
-        final_environment = dict()
+        final_environment: dict = dict()
         self._compute_environment_string(final_environment)
 
         become_kwargs = {}

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 import time
 import typing as t
 

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -135,7 +135,8 @@ class ActionModule(ActionBase):
 
             while jobs:
                 for module in jobs:
-                    poll_args = {'jid': jobs[module]['ansible_job_id'], '_async_dir': os.path.dirname(jobs[module]['results_file'])}
+                    async_dir = self._connection._shell.dirname(jobs[module]['results_file'])
+                    poll_args = {'jid': jobs[module]['ansible_job_id'], '_async_dir': async_dir}
                     res = self._execute_module(module_name='ansible.legacy.async_status', module_args=poll_args, task_vars=task_vars, wrap_async=False)
                     if res.get('finished', 0) == 1:
                         if res.get('failed', False):

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -152,7 +152,7 @@ class ActionModule(ActionBase):
                 # FUTURE: use a more public method to get the exec payload
                 pc = self._task
                 exec_data = ps_manifest._create_powershell_wrapper(
-                    to_bytes(script_cmd), source, {}, env_dict, self._task.async_val,
+                    to_bytes(script_cmd), source, {}, env_dict, self._task.async_val, False,
                     pc.become, pc.become_method, pc.become_user,
                     self._play_context.become_pass, pc.become_flags, "script", task_vars, None
                 )

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -87,6 +87,10 @@ class ShellBase(AnsiblePlugin):
     def env_prefix(self, **kwargs):
         return ' '.join(['%s=%s' % (k, shlex.quote(text_type(v))) for k, v in kwargs.items()])
 
+    def dirname(self, path: str) -> str:
+        """Gets the parent directory for the provided path."""
+        return os.path.dirname(path)
+
     def join_path(self, *args):
         return os.path.join(*args)
 

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -77,6 +77,11 @@ class ShellModule(ShellBase):
         # powershell/winrm env handling is handled in the exec wrapper
         return ""
 
+    def dirname(self, path: str) -> str:
+        # Using os.path.dirname will return an empty string when path uses
+        # backslashes. Using ntpath can handle both cases for Windows.
+        return ntpath.dirname(path)
+
     def join_path(self, *args):
         # use normpath() to remove doubled slashed and convert forward to backslashes
         parts = [ntpath.normpath(self._unquote(arg)) for arg in args]

--- a/test/integration/targets/gather_facts_windows/aliases
+++ b/test/integration/targets/gather_facts_windows/aliases
@@ -1,0 +1,5 @@
+gather_facts
+shippable/windows/group1
+shippable/windows/minimal
+shippable/windows/smoketest
+windows

--- a/test/integration/targets/gather_facts_windows/library/win_other_facts.ps1
+++ b/test/integration/targets/gather_facts_windows/library/win_other_facts.ps1
@@ -1,0 +1,9 @@
+#!powershell
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{ supports_check_mode = $true }
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$module.Result.ansible_facts = @{ other = 'foo' }
+
+$module.ExitJson()

--- a/test/integration/targets/gather_facts_windows/tasks/main.yml
+++ b/test/integration/targets/gather_facts_windows/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: gather multiple facts
+  ansible.builtin.gather_facts:
+  vars:
+    ansible_facts_modules:
+    - smart
+    - win_other_facts
+
+- name: assert gather multiple facts
+  assert:
+    that:
+    - ansible_facts['other'] == 'foo'


### PR DESCRIPTION
##### SUMMARY
Fix parallel fact gather in gather_facts when targeting Windows by ensuring the modules are run in async mode.

Also added the dirname method to shell plugins to allow callers to get a shell specific parent directory path.

Fixes: https://github.com/ansible/ansible/issues/83219

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request