### PR TITLE
ignore additional dnf error when removing packages by wildcard

### DIFF
--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -443,7 +443,8 @@ class DnfModule(YumDnf):
         """
         if (
             'no package matched' in to_native(error) or
-            'No match for argument:' in to_native(error)
+            'No match for argument:' in to_native(error) or
+            'All matches were filtered out by exclude filtering for argument:' in to_native(error)
         ):
             return (False, "{0} is not installed".format(spec))
 


### PR DESCRIPTION
##### SUMMARY

Ignore additional dnf error when removing packages by wildcard.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

fixes,

```
$ ansible all -i "localhost," -c local -m yum -a 'state=absent name=xorg-x11* '

localhost | FAILED! => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/libexec/platform-python"
    },
    "changed": false,
    "failures": [
        "xorg-x11* - All matches were filtered out by exclude filtering for argument: xorg-x11*"
    ],
    "msg": "Failed to install some of the specified packages",
    "rc": 1,
    "results": []
}
```

```
$ dnf --version
4.7.0
  Installed: dnf-0:4.7.0-19.el8.noarch at Thu 16 May 2024 10:51:25 AM GMT
  Built    : Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla> at Wed 28 Jun 2023 08:49:12 AM GMT
```

similar to https://github.com/ansible/ansible/pull/69241
