### PR TITLE
dnf: stop filtering exceptions by matching on text

### DIFF
--- a/changelogs/fragments/dnf-exceptions-vs-text.yml
+++ b/changelogs/fragments/dnf-exceptions-vs-text.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - dnf - minor internal changes in how the errors from the dnf API are handled; rely solely on the exceptions rather than inspecting text embedded in them


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
* Rely on dnf.base.remove, no special handling isn't needed,
  let the dnf internals figure out what is needed to be done.
  This is more in line with what dnf cli does.

* "already installed" in Exception (if it is even a thing) should be
  caught by special exceptions like MarkingError or CompsError. This
  appears to be a historic check that is no longer needed.

Supersedes: https://github.com/ansible/ansible/pull/83295
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
