### PR TITLE
Provide filename and line number of variable which triggered the deprecation warning

### DIFF
--- a/changelogs/fragments/82528summary.yml
+++ b/changelogs/fragments/82528summary.yml
@@ -1,3 +1,3 @@
-bug fixes:
+bugfixes:
 - Warning now includes filename and line number of variable 
   when specifying a list of dictionaries for vars (https://github.com/ansible/ansible/issues/82528).

--- a/changelogs/fragments/82528summary.yml
+++ b/changelogs/fragments/82528summary.yml
@@ -1,0 +1,3 @@
+bug fixes:
+- Warning now includes filename and line number of variable 
+  when specifying a list of dictionaries for vars (https://github.com/ansible/ansible/issues/82528).

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import itertools
 import operator
 import os
-import inspect
+
 
 from copy import copy as shallowcopy
 from functools import cache
@@ -590,12 +590,12 @@ class FieldAttributeBase:
                 _validate_variable_keys(ds)
                 return combine_vars(self.vars, ds)
             elif isinstance(ds, list):
-                yml_filename = ds._data_source
-                line_number = ds._line_number
+
+                line_file = getattr(ds, 'ansible_pos', ("unknown", 0))
                 display.deprecated(
                     (
                         'Specifying a list of dictionaries for vars is deprecated in favor of '
-                        'specifying a dictionary. Error occurred in the file: %s, line: %d'  % (yml_filename, line_number)
+                        'specifying a dictionary. Error occurred in the file: %s, line: %d' % (line_file[0], line_file[1])
                     ),
                     version='2.18'
                 )

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -8,7 +8,6 @@ import itertools
 import operator
 import os
 
-
 from copy import copy as shallowcopy
 from functools import cache
 
@@ -590,7 +589,6 @@ class FieldAttributeBase:
                 _validate_variable_keys(ds)
                 return combine_vars(self.vars, ds)
             elif isinstance(ds, list):
-
                 line_file = getattr(ds, 'ansible_pos', ("unknown", 0))
                 display.deprecated(
                     (

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -590,12 +590,12 @@ class FieldAttributeBase:
                 _validate_variable_keys(ds)
                 return combine_vars(self.vars, ds)
             elif isinstance(ds, list):
-                frame_info = inspect.stack()[1]
-                line_number = frame_info.lineno
+                yml_filename = ds._data_source
+                line_number = ds._line_number
                 display.deprecated(
                     (
                         'Specifying a list of dictionaries for vars is deprecated in favor of '
-                        'specifying a dictionary. Error occurred in file: %s, line: %d' % (__file__, line_number)
+                        'specifying a dictionary. Error occurred in the file: %s, line: %d'  % (yml_filename, line_number)
                     ),
                     version='2.18'
                 )

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import itertools
 import operator
 import os
+import inspect
 
 from copy import copy as shallowcopy
 from functools import cache
@@ -589,10 +590,12 @@ class FieldAttributeBase:
                 _validate_variable_keys(ds)
                 return combine_vars(self.vars, ds)
             elif isinstance(ds, list):
+                frame_info = inspect.stack()[1]
+                line_number = frame_info.lineno
                 display.deprecated(
                     (
                         'Specifying a list of dictionaries for vars is deprecated in favor of '
-                        'specifying a dictionary.'
+                        'specifying a dictionary. Error occurred in file: %s, line: %d' % (__file__, line_number)
                     ),
                     version='2.18'
                 )


### PR DESCRIPTION
bug fixes:
- Warning now includes filename and line number of variable 
  when specifying a list of dictionaries for vars (https://github.com/ansible/ansible/issues/82528).

ISSUE TYPE: 
- Bugfix Pull Request

