### PR TITLE
Allow a log file to be tailed and displayed by async_status

### DIFF
--- a/test/integration/targets/async/async-status-tail-test.yml
+++ b/test/integration/targets/async/async-status-tail-test.yml
@@ -1,0 +1,24 @@
+---
+- name: Test async_status tail
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Run long task
+      ansible.builtin.shell: |
+        for i in $(seq 1 30); do
+          echo $i | tee -a ~/long.log;
+          sleep 1
+        done
+      register: long_task
+      async: 120
+      poll: 0
+
+    - name: Check status
+      ansible.builtin.async_status:
+        jid: "{{ long_task.ansible_job_id }}"
+        log_file: ~/long.log
+        tail_length: 5
+      register: long_task_status
+      until: long_task_status.finished
+      retries: 10
+      delay: 5

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -337,3 +337,18 @@
       retries: 100
       delay: 10
       timeout: 30
+
+- name: run async status tail test playbook
+  command: ansible-playbook {{ role_path }}/async-status-tail-test.yml
+  delegate_to: localhost
+  register: async_status_output
+  environment:
+    ANSIBLE_NOCOLOR: 'true'
+    ANSIBLE_FORCE_COLOR: 'false'
+
+- name: Ensure that we have tailed output in ansible output
+  assert:
+    that:
+      - |
+        async_status_output.stdout is
+        search('tail --lines=5 .*/long.log\n\d+\n\d+\n\d+\n\d+\n\d+\n')


### PR DESCRIPTION
##### SUMMARY
This allows you to track the status of a long running async task.

Sometimes you need to run a long running task but want to understand the progress of that task.
This allows you to run that task as `async` and then when you request the status of that job it will print the last `x` lines of the specified log file to update you on the status of the task

Resolves #3887 

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

Example playbook

`async-status-test.yml`
```yml
---
- name: Test async_status tail
  hosts: localhost
  gather_facts: false
  tasks:
    - name: Run long task
      ansible.builtin.shell: |
        for i in $(seq 1 30); do
          echo $i | tee -a ~/long.log;
          sleep 1
        done
      register: long_task
      async: 120
      poll: 0

    - name: Check status
      ansible.builtin.async_status:
        jid: "{{ long_task.ansible_job_id }}"
        log_file: ~/long.log
        tail_length: 5
      register: long_task_status
      until: long_task_status.finished
      retries: 10
      delay: 5
```

```
ansible-playbook adhoc-test/async-status-test.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you
are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of
code and can become unstable at any point.
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not
match 'all'

PLAY [Test async] ***********************************************************************************************

TASK [Run long task] ********************************************************************************************
changed: [localhost]

TASK [Check status] *********************************************************************************************
tail --lines=5 ~/long.log
27
28
29
30
1
FAILED - RETRYING: [localhost]: Check status (10 retries left).
tail --lines=5 ~/long.log
2
3
4
5
6
FAILED - RETRYING: [localhost]: Check status (9 retries left).
tail --lines=5 ~/long.log
7
8
9
10
11
FAILED - RETRYING: [localhost]: Check status (8 retries left).
tail --lines=5 ~/long.log
12
13
14
15
16
FAILED - RETRYING: [localhost]: Check status (7 retries left).
tail --lines=5 ~/long.log
17
18
19
20
21
FAILED - RETRYING: [localhost]: Check status (6 retries left).
tail --lines=5 ~/long.log
22
23
24
25
26
FAILED - RETRYING: [localhost]: Check status (5 retries left).
changed: [localhost]

PLAY RECAP ******************************************************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```