### PR TITLE
[stable-2.17] The extension returned by the splitext contains the dot

### DIFF
--- a/lib/ansible/plugins/filter/splitext.yml
+++ b/lib/ansible/plugins/filter/splitext.yml
@@ -14,14 +14,14 @@ DOCUMENTATION:
 
 EXAMPLES: |
 
-  # gobble => [ '/etc/make', 'conf' ]
+  # gobble => [ '/etc/make', '.conf' ]
   gobble: "{{ '/etc/make.conf' | splitext }}"
 
-  # file_n_ext => [ 'ansible', 'cfg' ]
+  # file_n_ext => [ 'ansible', '.cfg' ]
   file_n_ext: "{{ 'ansible.cfg' | splitext }}"
 
-  # hoax => ['/etc/hoasdf', '']
-  hoax: '{{ "/etc//hoasdf/" | splitext }}'
+  # hoax => [ '/etc/hoasdf', '' ]
+  hoax: "{{ '/etc/hoasdf' | splitext }}"
 
 RETURN:
   _value:


### PR DESCRIPTION
##### SUMMARY

Fixed examples for splitext filter plugin

(cherry picked from commit 454dd9e91d6c42a674415274011b1115a375cc49)

##### ISSUE TYPE

- Docs Pull Request

