### PR TITLE
rpm_key: Added handler for ftp keys

### DIFF
--- a/changelogs/fragments/83336_handler_rpm_key_ftp.yml
+++ b/changelogs/fragments/83336_handler_rpm_key_ftp.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rpm_key FTP - Change conditional for ftp support fetch keys (https://github.com/ansible/ansible/issues/83321)

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -151,7 +151,7 @@ class RpmKey(object):
     def fetch_key(self, url):
         """Downloads a key from url, returns a valid path to a gpg key"""
         rsp, info = fetch_url(self.module, url)
-        if info['status'] != 200:
+        if info['status'] != 200 or ( url.startswith("ftp://") and info['status'] == None):
             self.module.fail_json(msg="failed to fetch key at %s , error was: %s" % (url, info['msg']))
 
         key = rsp.read()

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -6,7 +6,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-__metaclass__ = type
 
 
 DOCUMENTATION = '''
@@ -153,7 +152,7 @@ class RpmKey(object):
         """Downloads a key from url, returns a valid path to a gpg key"""
         rsp, info = fetch_url(self.module, url)
         if info['status'] != 200 and not url.startswith('file:/') and not (url.startswith('ftp:/') and info.get('msg', '').startswith('OK')):
-            self.module.fail_json(msg="failed to fetch key at %s , error was: %s" % (url, info ))
+            self.module.fail_json(msg="failed to fetch key at %s , error was: %s" % (url, info['msg']))
 
         key = rsp.read()
         if not is_pubkey(key):

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -5,7 +5,8 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import annotations
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 
 DOCUMENTATION = '''
@@ -151,8 +152,8 @@ class RpmKey(object):
     def fetch_key(self, url):
         """Downloads a key from url, returns a valid path to a gpg key"""
         rsp, info = fetch_url(self.module, url)
-        if info['status'] != 200 or (url.startswith("ftp://") and info['status'] is None):
-            self.module.fail_json(msg="failed to fetch key at %s , error was: %s" % (url, info['msg']))
+        if info['status'] != 200 and not url.startswith('file:/') and not (url.startswith('ftp:/') and info.get('msg', '').startswith('OK')):
+            self.module.fail_json(msg="failed to fetch key at %s , error was: %s" % (url, info ))
 
         key = rsp.read()
         if not is_pubkey(key):

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -20,7 +20,7 @@ version_added: "1.3"
 options:
     key:
       description:
-        - Key that will be modified. Can be a url, a file on the managed node, or a keyid if the key
+        - Key that will be modified. Can be a http https or ftp url, a file on the managed node, or a keyid if the key
           already exists in the database.
       type: str
       required: true

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -151,7 +151,7 @@ class RpmKey(object):
     def fetch_key(self, url):
         """Downloads a key from url, returns a valid path to a gpg key"""
         rsp, info = fetch_url(self.module, url)
-        if info['status'] != 200 or ( url.startswith("ftp://") and info['status'] is None):
+        if info['status'] != 200 or (url.startswith("ftp://") and info['status'] is None):
             self.module.fail_json(msg="failed to fetch key at %s , error was: %s" % (url, info['msg']))
 
         key = rsp.read()

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -20,7 +20,7 @@ version_added: "1.3"
 options:
     key:
       description:
-        - Key that will be modified. Can be a http https or ftp url, a file on the managed node, or a keyid if the key
+        - Key that will be modified. Can be an HTTP, HTTPS or FTP URL, a file on the managed node, or a keyid if the key
           already exists in the database.
       type: str
       required: true

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -5,7 +5,8 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, annotations
+
 
 
 DOCUMENTATION = '''

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -151,7 +151,7 @@ class RpmKey(object):
     def fetch_key(self, url):
         """Downloads a key from url, returns a valid path to a gpg key"""
         rsp, info = fetch_url(self.module, url)
-        if info['status'] != 200 and not url.startswith('file:/') and not (url.startswith('ftp:/') and info.get('msg', '').startswith('OK')):
+        if info['status'] != 200 and not (url.startswith('ftp:/') and info.get('msg', '').startswith('OK')):
             self.module.fail_json(msg="failed to fetch key at %s , error was: %s" % (url, info['msg']))
 
         key = rsp.read()

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 
-
 DOCUMENTATION = '''
 ---
 module: rpm_key

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -5,7 +5,7 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function, annotations
+from __future__ import annotations
 
 
 

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -151,7 +151,7 @@ class RpmKey(object):
     def fetch_key(self, url):
         """Downloads a key from url, returns a valid path to a gpg key"""
         rsp, info = fetch_url(self.module, url)
-        if info['status'] != 200 or ( url.startswith("ftp://") and info['status'] == None):
+        if info['status'] != 200 or ( url.startswith("ftp://") and info['status'] is None):
             self.module.fail_json(msg="failed to fetch key at %s , error was: %s" % (url, info['msg']))
 
         key = rsp.read()


### PR DESCRIPTION
Status code for fetch_url for ftp:// urls is None, this conditional change will allow to rpm_key for ftp urls usage

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

Changed the conditional check when fetch a key, since fetch_url function sets a status == None for ftp urls.
fetch_keys uses the function fetch_url to retrieve the target file.
This conditional change will allow to check the url and when the url is ftp, will allow the return code none in order to retrieve the key, without disrupting the http/s retrieves

Fixes #83321 


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Issue refer to ansible 2.15, but still persisting in latest 
