### PR TITLE
Add initial support for multiple become passwords

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1119,7 +1119,7 @@ class Connection(ConnectionBase):
                     elif self._flags['become_prompt']:
                         display.debug(u'Sending become_password in response to prompt')
                         become_pass = self.become.get_option('become_pass', playcontext=self._play_context)
-                        become_pass = [become_pass] if type(become_pass) != list else become_pass
+                        become_pass = [become_pass] if not isinstance(become_pass, list) else become_pass
                         if self._become_attempts >= len(become_pass):
                             self._terminate_process(p)
                             raise AnsibleError('Incorrect %s password' % self.become.name)


### PR DESCRIPTION
##### SUMMARY

This adds the ability to enter multiple passwords during become when using the ssh connection plugin.

We are seeing more and more multi factor authentication set up. With SSH we can work around this
by using pubkey authentication but no such workaround is available for sudo, su, and other become
methods. Even if we use a service account without mfa setup we still get two password prompts where
we have to enter an empty password the second time.

This patch allows you to set `ansible_become_pass` to a list of passwords, possibly empty. Every time
a password prompt is issued we send the next password in this list to the server until we are out of
passwords or we have successfully escalated our privileges. Existing inventories that sets it to a string
works just as before making this feature fully backwards compatible.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

example inventory
```
[mfa]
mfatest.example.com

[mfa:vars]
ansible_ssh_pass=password
ansible_become_pass=["password", "{{ lookup('ansible.builtin.pipe', 'oathtool --totp -d 6 12345678909876543210') }}"]

```
Before this patch:
```
$ ansible mfa -m raw -a id -i hosts.ini --become
mfatest.example.com | FAILED | rc=-1 >>
Incorrect sudo password
```
After this patch:
```
$ ansible mfa -m raw -a id -i hosts.ini --become
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can become unstable at any point.
mfatest.example.com | CHANGED | rc=0 >>


uid=0(root) gid=0(root) groups=0(root)
Shared connection to mfatest.example.com closed.
```