### PR TITLE
Added docstrings to V2 methods in the CallbackBase Class (2 & 3 of 27)

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -522,11 +522,35 @@ class CallbackBase(AnsiblePlugin):
         host = result._host.get_name()
         self.runner_on_failed(host, result._result, ignore_errors)
 
-    def v2_runner_on_ok(self, result):
+    def v2_runner_on_ok(self, result: TaskResult) -> None:
+        """Show result, output, and optional information, based on verbosity level and
+        ansible.cfg settings, if a task passed.
+
+        Customization Notes - In this method:
+        - You can access TaskResult class methods and attributes like result.is_changed()
+          and result.task_name
+        - The ansible.executor.task_result.TaskResult class is defined in
+          lib/ansible/executor/task_result.py
+
+        :param TaskResult result: The result and output of a task
+        :return: None
+        """
         host = result._host.get_name()
         self.runner_on_ok(host, result._result)
 
-    def v2_runner_on_skipped(self, result):
+    def v2_runner_on_skipped(self, result: TaskResult) -> None:
+        """Show result, output, and optional information, based on verbosity level and
+        ansible.cfg settings, if a task is skipped.
+
+        Customization Notes - In this method:
+        - You can access TaskResult class methods and attributes like result.is_changed()
+          and result.task_name
+        - The ansible.executor.task_result.TaskResult class is defined in
+          lib/ansible/executor/task_result.py
+
+        :param TaskResult result: The result and output of a task
+        :return: None
+        """
         if C.DISPLAY_SKIPPED_HOSTS:
             host = result._host.get_name()
             self.runner_on_skipped(host, self._get_item_label(getattr(result._result, 'results', {})))

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -506,49 +506,58 @@ class CallbackBase(AnsiblePlugin):
         self.on_any(args, kwargs)
 
     def v2_runner_on_failed(self, result: TaskResult, ignore_errors: bool = False) -> None:
-        """Show result, output, and optional information, based on verbosity level, vars, and
-        ansible.cfg settings, if a task failed.
+        """Get details about a failed task and whether or not Ansible should continue running
+        tasks on the host where the failure occurred. Process the details for output, profiling,
+        logging, etc., as needed for the callback.
 
-        Customization notes - In this method:
-        - You can access TaskResult class methods and attributes like result.is_changed()
-          and result.task_name
+        Note: The 'ignore_errors' directive only works when the task can run and returns
+        a value of 'failed'. It does not make Ansible ignore undefined variable errors,
+        connection failures, execution issues (for example, missing packages), or syntax errors.
+
+        Customization notes:
+        - You can access and use other TaskResult class attributes and methods like
+          result._task, result._task_fields, result.task_name(), or result.is_failed()
         - The ansible.executor.task_result.TaskResult class is defined in
           lib/ansible/executor/task_result.py
 
-        :param TaskResult result: The result and output of a task
-        :param bool ignore_errors: The value of the ignore_errors vars
+        :param TaskResult result: An object that contains details about the task
+        :param bool ignore_errors: Whether or not Ansible should continue running tasks on the host
+        where the failure occurred
+
         :return: None
         """
         host = result._host.get_name()
         self.runner_on_failed(host, result._result, ignore_errors)
 
     def v2_runner_on_ok(self, result: TaskResult) -> None:
-        """Show result, output, and optional information, based on verbosity level and
-        ansible.cfg settings, if a task passed.
+        """Get details about a successful task and process them for output, profiling,
+        logging, etc., as needed for the callback.
 
-        Customization Notes - In this method:
-        - You can access TaskResult class methods and attributes like result.is_changed()
-          and result.task_name
+        Customization notes:
+        - You can access and use other TaskResult class attributes and methods like
+          result._task, result._task_fields, result.task_name(), or result.is_changed()
         - The ansible.executor.task_result.TaskResult class is defined in
           lib/ansible/executor/task_result.py
 
-        :param TaskResult result: The result and output of a task
+        :param TaskResult result: An object that contains details about the task
+
         :return: None
         """
         host = result._host.get_name()
         self.runner_on_ok(host, result._result)
 
     def v2_runner_on_skipped(self, result: TaskResult) -> None:
-        """Show result, output, and optional information, based on verbosity level and
-        ansible.cfg settings, if a task is skipped.
+        """Get details about a skipped task and process them for output, profiling,
+        logging, etc., as needed for the callback.
 
-        Customization Notes - In this method:
-        - You can access TaskResult class methods and attributes like result.is_changed()
-          and result.task_name
+        Customization notes:
+        - You can access and use other TaskResult class attributes and methods like
+          result._task, result._task_fields, result.task_name(), or result.is_skipped()
         - The ansible.executor.task_result.TaskResult class is defined in
           lib/ansible/executor/task_result.py
 
-        :param TaskResult result: The result and output of a task
+        :param TaskResult result: An object that contains details about the task
+
         :return: None
         """
         if C.DISPLAY_SKIPPED_HOSTS:

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -506,9 +506,9 @@ class CallbackBase(AnsiblePlugin):
         self.on_any(args, kwargs)
 
     def v2_runner_on_failed(self, result: TaskResult, ignore_errors: bool = False) -> None:
-        """Get details about a failed task and whether or not Ansible should continue running
-        tasks on the host where the failure occurred. Process the details for output, profiling,
-        logging, etc., as needed for the callback.
+        """Get details about a failed task and whether or not Ansible should continue
+        running tasks on the host where the failure occurred, then process the details
+        as required by the callback (output, profiling, logging, notifications, etc.)
 
         Note: The 'ignore_errors' directive only works when the task can run and returns
         a value of 'failed'. It does not make Ansible ignore undefined variable errors,
@@ -516,7 +516,7 @@ class CallbackBase(AnsiblePlugin):
 
         Customization notes:
         - You can access and use other TaskResult class attributes and methods like
-          result._task, result._task_fields, result.task_name(), or result.is_failed()
+          result._task, result._task_fields, result.task_name(), and result.is_failed()
         - The ansible.executor.task_result.TaskResult class is defined in
           lib/ansible/executor/task_result.py
 
@@ -530,12 +530,12 @@ class CallbackBase(AnsiblePlugin):
         self.runner_on_failed(host, result._result, ignore_errors)
 
     def v2_runner_on_ok(self, result: TaskResult) -> None:
-        """Get details about a successful task and process them for output, profiling,
-        logging, etc., as needed for the callback.
+        """Get details about a successful task and process them as required by the callback
+        (output, profiling, logging, notifications, etc.)
 
         Customization notes:
         - You can access and use other TaskResult class attributes and methods like
-          result._task, result._task_fields, result.task_name(), or result.is_changed()
+          result._task, result._task_fields, result.task_name(), and result.is_changed()
         - The ansible.executor.task_result.TaskResult class is defined in
           lib/ansible/executor/task_result.py
 
@@ -547,12 +547,12 @@ class CallbackBase(AnsiblePlugin):
         self.runner_on_ok(host, result._result)
 
     def v2_runner_on_skipped(self, result: TaskResult) -> None:
-        """Get details about a skipped task and process them for output, profiling,
-        logging, etc., as needed for the callback.
+        """Get details about a skipped task and process them as required by the callback
+        (output, profiling, logging, notifications, etc.)
 
         Customization notes:
         - You can access and use other TaskResult class attributes and methods like
-          result._task, result._task_fields, result.task_name(), or result.is_skipped()
+          result._task, result._task_fields, result.task_name(), and result.is_skipped()
         - The ansible.executor.task_result.TaskResult class is defined in
           lib/ansible/executor/task_result.py
 

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -514,11 +514,8 @@ class CallbackBase(AnsiblePlugin):
         a value of 'failed'. It does not make Ansible ignore undefined variable errors,
         connection failures, execution issues (for example, missing packages), or syntax errors.
 
-        Customization notes:
-        - You can access and use other TaskResult class attributes and methods like
-          result._task, result._task_fields, result.task_name(), and result.is_failed()
-        - The ansible.executor.task_result.TaskResult class is defined in
-          lib/ansible/executor/task_result.py
+        Customization note: For more information about the attributes and methods of the
+        TaskResult class, see lib/ansible/executor/task_result.py.
 
         :param TaskResult result: An object that contains details about the task
         :param bool ignore_errors: Whether or not Ansible should continue running tasks on the host
@@ -533,11 +530,8 @@ class CallbackBase(AnsiblePlugin):
         """Get details about a successful task and process them as required by the callback
         (output, profiling, logging, notifications, etc.)
 
-        Customization notes:
-        - You can access and use other TaskResult class attributes and methods like
-          result._task, result._task_fields, result.task_name(), and result.is_changed()
-        - The ansible.executor.task_result.TaskResult class is defined in
-          lib/ansible/executor/task_result.py
+        Customization note: For more information about the attributes and methods of the
+        TaskResult class, see lib/ansible/executor/task_result.py.
 
         :param TaskResult result: An object that contains details about the task
 
@@ -550,11 +544,8 @@ class CallbackBase(AnsiblePlugin):
         """Get details about a skipped task and process them as required by the callback
         (output, profiling, logging, notifications, etc.)
 
-        Customization notes:
-        - You can access and use other TaskResult class attributes and methods like
-          result._task, result._task_fields, result.task_name(), and result.is_skipped()
-        - The ansible.executor.task_result.TaskResult class is defined in
-          lib/ansible/executor/task_result.py
+        Customization note: For more information about the attributes and methods of the
+        TaskResult class, see lib/ansible/executor/task_result.py.
 
         :param TaskResult result: An object that contains details about the task
 


### PR DESCRIPTION
##### SUMMARY

Added type declarations and docstrings to the `v2_runner_on_ok` and `v2_runner_on_skipped` methods of the `Callback` class, to explain the purpose of the methods and the parameters that the methods will accept. The docstrings also provide additional information for developers who want to use the methods in custom callback plugins. This PR incorporates feedback from @bcoca, @webknjaz, and PR 83267.

##### ISSUE TYPE

    Docs Pull Request

##### ADDITIONAL INFORMATION

These changes do not alter the output of either method. Tasks that passed or were skipped based on a condition ran with no issues. All tests in `test.units.plugins.callback.test_callback` passed

```bash
$ python3 -m unittest --verbose --buffer test.units.plugins.callback.test_callback
test_display (test.units.plugins.callback.test_callback.TestCallback.test_display) ... ok
test_display_verbose (test.units.plugins.callback.test_callback.TestCallback.test_display_verbose) ... ok
test_host_label (test.units.plugins.callback.test_callback.TestCallback.test_host_label) ... ok
test_host_label_delegated (test.units.plugins.callback.test_callback.TestCallback.test_host_label_delegated) ... ok
test_init (test.units.plugins.callback.test_callback.TestCallback.test_init) ... ok
test_clear_file (test.units.plugins.callback.test_callback.TestCallbackDiff.test_clear_file) ... ok
test_diff_after_none (test.units.plugins.callback.test_callback.TestCallbackDiff.test_diff_after_none) ... ok
test_diff_before_none (test.units.plugins.callback.test_callback.TestCallbackDiff.test_diff_before_none) ... ok
test_diff_dicts (test.units.plugins.callback.test_callback.TestCallbackDiff.test_diff_dicts) ... ok
test_difflist (test.units.plugins.callback.test_callback.TestCallbackDiff.test_difflist) ... ok
test_new_file (test.units.plugins.callback.test_callback.TestCallbackDiff.test_new_file) ... ok
test_no_trailing_newline_after (test.units.plugins.callback.test_callback.TestCallbackDiff.test_no_trailing_newline_after) ... ok
test_no_trailing_newline_before (test.units.plugins.callback.test_callback.TestCallbackDiff.test_no_trailing_newline_before) ... ok
test_no_trailing_newline_both (test.units.plugins.callback.test_callback.TestCallbackDiff.test_no_trailing_newline_both) ... ok
test_no_trailing_newline_both_with_some_changes (test.units.plugins.callback.test_callback.TestCallbackDiff.test_no_trailing_newline_both_with_some_changes) ... ok
test_simple_diff (test.units.plugins.callback.test_callback.TestCallbackDiff.test_simple_diff) ... ok
test_are_methods (test.units.plugins.callback.test_callback.TestCallbackOnMethods.test_are_methods) ... ok
test_on_any (test.units.plugins.callback.test_callback.TestCallbackOnMethods.test_on_any) ... ok
test_clean_results (test.units.plugins.callback.test_callback.TestCallbackResults.test_clean_results) ... ok
test_clean_results_debug_task (test.units.plugins.callback.test_callback.TestCallbackResults.test_clean_results_debug_task) ... ok
test_clean_results_debug_task_empty_results (test.units.plugins.callback.test_callback.TestCallbackResults.test_clean_results_debug_task_empty_results) ... ok
test_clean_results_debug_task_no_invocation (test.units.plugins.callback.test_callback.TestCallbackResults.test_clean_results_debug_task_no_invocation) ... ok
test_get_item_label (test.units.plugins.callback.test_callback.TestCallbackResults.test_get_item_label) ... ok
test_get_item_label_no_log (test.units.plugins.callback.test_callback.TestCallbackResults.test_get_item_label_no_log) ... ok

----------------------------------------------------------------------
Ran 24 tests in 0.004s

OK
```
