### PR TITLE
Modify the captured exception type

### DIFF
--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -325,7 +325,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
             try:
                 display.verbosity = int(arg)
                 display.v('verbosity level set to %s' % arg)
-            except (TypeError, ValueError) as e:
+            except ValueError as e:
                 display.error('The verbosity must be a valid integer: %s' % to_text(e))
 
     def help_verbosity(self):


### PR DESCRIPTION
SUMMARY

The int() function takes a string and attempts to convert it to an integer. TypeError is unlikely to occur while Value Error is more suitable for describing situations where the int() function cannot parse the given string into a valid integer

ISSUE TYPE

Feature Pull Request