### PR TITLE
Fix Test failure with cowsay installed/present

### DIFF
--- a/changelogs/fragments/83327.yml
+++ b/changelogs/fragments/83327.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fixed unit test test_borken_cowsay to address mock not been properly applied when existing unix system already have cowsay installed.

--- a/test/units/utils/display/test_broken_cowsay.py
+++ b/test/units/utils/display/test_broken_cowsay.py
@@ -10,13 +10,12 @@ from unittest.mock import MagicMock
 
 
 def test_display_with_fake_cowsay_binary(capsys, mocker):
-    display = Display()
 
     mocker.patch("ansible.constants.ANSIBLE_COW_PATH", "./cowsay.sh")
-
     mock_popen = MagicMock()
     mock_popen.return_value.returncode = 1
     mocker.patch("subprocess.Popen", mock_popen)
+    display = Display()
 
     assert not hasattr(display, "cows_available")
     assert display.b_cowsay is None


### PR DESCRIPTION
##### SUMMARY
Address the issue of test failure with cowsay installed/present(https://github.com/ansible/ansible/issues/83327) on unix through applying the mock of subprocess.open before the creation of Display .
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #83327 
##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
