### PR TITLE
add support for inactive option

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -268,6 +268,11 @@ options:
             - Requires O(local) is omitted or V(False).
         type: str
         version_added: "2.12"
+    account_inactive:
+        description:
+            - Number of days after a password expires until the account is disabled.
+        type: int
+        version_added: "2.18"
 extends_documentation_fragment: action_common_attributes
 attributes:
     check_mode:
@@ -356,6 +361,11 @@ EXAMPLES = r'''
   ansible.builtin.user:
     name: jane157
     password_expire_warn: 30
+
+- name: Set number of days after password expires until account is disabled
+  ansible.builtin.user:
+    name: jimholden2016
+    account_inactive: 15
 '''
 
 RETURN = r'''
@@ -582,6 +592,7 @@ class User(object):
         self.password_expire_min = module.params['password_expire_min']
         self.password_expire_warn = module.params['password_expire_warn']
         self.umask = module.params['umask']
+        self.inactive = module.params['account_inactive']
 
         if self.umask is not None and self.local:
             module.fail_json(msg="'umask' can not be used with 'local'")
@@ -756,6 +767,10 @@ class User(object):
                 cmd.append('')
             else:
                 cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
+
+        if self.inactive is not None:
+            cmd.append('-f')
+            cmd.append(int(self.inactive))
 
         if self.password is not None:
             cmd.append('-p')
@@ -945,6 +960,10 @@ class User(object):
                     else:
                         cmd.append('-e')
                         cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
+
+        if self.inactive is not None:
+            cmd.append('-f')
+            cmd.append(self.inactive)
 
         # Lock if no password or unlocked, unlock only if locked
         if self.password_lock and not info[1].startswith('!'):
@@ -1444,6 +1463,10 @@ class FreeBsdUser(User):
             else:
                 cmd.append(str(calendar.timegm(self.expires)))
 
+        if self.inactive is not None:
+            cmd.append('-f')
+            cmd.append(str(self.inactive))
+
         # system cannot be handled currently - should we error if its requested?
         # create the user
         (rc, out, err) = self.execute_command(cmd)
@@ -1581,6 +1604,10 @@ class FreeBsdUser(User):
 
         (rc, out, err) = (None, '', '')
 
+        if self.inactive is not None:
+            cmd.append('-f')
+            cmd.append(str(self.inactive))
+
         # modify the user if cmd will do anything
         if cmd_len != len(cmd):
             (rc, _out, _err) = self.execute_command(cmd)
@@ -1694,6 +1721,10 @@ class OpenBSDUser(User):
                 cmd.append('-K')
                 cmd.append('UMASK=' + self.umask)
 
+        if self.inactive is not None:
+            cmd.append('-f')
+            cmd.append(self.inactive)
+
         cmd.append(self.name)
         return self.execute_command(cmd)
 
@@ -1763,6 +1794,10 @@ class OpenBSDUser(User):
         if self.shell is not None and info[6] != self.shell:
             cmd.append('-s')
             cmd.append(self.shell)
+
+        if self.inactive is not None:
+            cmd.append('-f')
+            cmd.append(self.inactive)
 
         if self.login_class is not None:
             # find current login class
@@ -1860,6 +1895,10 @@ class NetBSDUser(User):
             cmd.append('-p')
             cmd.append(self.password)
 
+        if self.inactive is not None:
+            cmd.append('-f')
+            cmd.append(self.inactive)
+
         if self.create_home:
             cmd.append('-m')
 
@@ -1945,6 +1984,10 @@ class NetBSDUser(User):
         if self.login_class is not None:
             cmd.append('-L')
             cmd.append(self.login_class)
+
+        if self.inactive is not None:
+            cmd.append('-f')
+            cmd.append(self.inactive)
 
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:
             cmd.append('-p')
@@ -2072,6 +2115,10 @@ class SunOS(User):
             cmd.append('-R')
             cmd.append(self.role)
 
+        if self.inactive is not None:
+            cmd.append('-f')
+            cmd.append(self.inactive)
+
         cmd.append(self.name)
 
         (rc, out, err) = self.execute_command(cmd)
@@ -2188,6 +2235,10 @@ class SunOS(User):
         if self.role is not None and info[9] != self.role:
             cmd.append('-R')
             cmd.append(self.role)
+
+        if self.inactive is not None:
+            cmd.append('-f')
+            cmd.append(self.inactive)
 
         # modify the user if cmd will do anything
         if cmd_len != len(cmd):
@@ -2674,6 +2725,10 @@ class AIX(User):
                 cmd.append('-K')
                 cmd.append('UMASK=' + self.umask)
 
+        if self.inactive is not None:
+            cmd.append('-f')
+            cmd.append(self.inactive)
+
         cmd.append(self.name)
         (rc, out, err) = self.execute_command(cmd)
 
@@ -2741,6 +2796,10 @@ class AIX(User):
         if self.shell is not None and info[6] != self.shell:
             cmd.append('-s')
             cmd.append(self.shell)
+
+        if self.inactive is not None:
+            cmd.append('-f')
+            cmd.append(self.inactive)
 
         # skip if no changes to be made
         if len(cmd) == 1:
@@ -3150,6 +3209,7 @@ def main():
             authorization=dict(type='str'),
             role=dict(type='str'),
             umask=dict(type='str'),
+            inactive=dict(type='int'),
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3209,7 +3209,7 @@ def main():
             authorization=dict(type='str'),
             role=dict(type='str'),
             umask=dict(type='str'),
-            inactive=dict(type='int'),
+            account_inactive=dict(type='int'),
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -271,6 +271,7 @@ options:
     account_inactive:
         description:
             - Number of days after a password expires until the account is disabled.
+            - Currently not supported on FreeBSD.
         type: int
         version_added: "2.18"
 extends_documentation_fragment: action_common_attributes
@@ -1462,10 +1463,6 @@ class FreeBsdUser(User):
                 cmd.append('0')
             else:
                 cmd.append(str(calendar.timegm(self.expires)))
-
-        if self.inactive is not None:
-            cmd.append('-f')
-            cmd.append(str(self.inactive))
 
         # system cannot be handled currently - should we error if its requested?
         # create the user

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -271,7 +271,7 @@ options:
     password_expire_account_disable:
         description:
             - Number of days after a password expires until the account is disabled.
-            - Currently not supported on FreeBSD.
+            - Currently supported on AIX, Linux, NetBSD, OpenBSD.
         type: int
         version_added: "2.18"
 extends_documentation_fragment: action_common_attributes
@@ -1600,10 +1600,6 @@ class FreeBsdUser(User):
                     cmd.append(str(calendar.timegm(self.expires)))
 
         (rc, out, err) = (None, '', '')
-
-        if self.inactive is not None:
-            cmd.append('-f')
-            cmd.append(str(self.inactive))
 
         # modify the user if cmd will do anything
         if cmd_len != len(cmd):

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -268,7 +268,7 @@ options:
             - Requires O(local) is omitted or V(False).
         type: str
         version_added: "2.12"
-    account_inactive:
+    password_expire_account_disable:
         description:
             - Number of days after a password expires until the account is disabled.
             - Currently not supported on FreeBSD.
@@ -366,7 +366,7 @@ EXAMPLES = r'''
 - name: Set number of days after password expires until account is disabled
   ansible.builtin.user:
     name: jimholden2016
-    account_inactive: 15
+    password_expire_account_disable: 15
 '''
 
 RETURN = r'''
@@ -593,7 +593,7 @@ class User(object):
         self.password_expire_min = module.params['password_expire_min']
         self.password_expire_warn = module.params['password_expire_warn']
         self.umask = module.params['umask']
-        self.inactive = module.params['account_inactive']
+        self.inactive = module.params['password_expire_account_disable']
 
         if self.umask is not None and self.local:
             module.fail_json(msg="'umask' can not be used with 'local'")
@@ -3206,7 +3206,7 @@ def main():
             authorization=dict(type='str'),
             role=dict(type='str'),
             umask=dict(type='str'),
-            account_inactive=dict(type='int'),
+            password_expire_account_disable=dict(type='int', no_log=False),
         ),
         supports_check_mode=True,
     )

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -42,3 +42,4 @@
   when: not (ansible_distribution == 'openSUSE Leap' and ansible_distribution_version is version('15.4', '>='))
 - import_tasks: test_umask.yml
   when: ansible_facts.system == 'Linux'
+- import_tasks: test_inactive_new_account.yml

--- a/test/integration/targets/user/tasks/test_inactive_new_account.yml
+++ b/test/integration/targets/user/tasks/test_inactive_new_account.yml
@@ -1,0 +1,74 @@
+# Test inactive setting when creating a new account
+- name: Remove ansibulluser
+  user:
+    name: ansibulluser
+    state: absent
+
+- name: Create user account with inactive set to 15
+  user:
+    name: ansibulluser
+    state: present
+    inactive: 15
+
+- name: Verify inactive setting for Linux
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
+  block:
+    - name: LINUX | Get inactive value for ansibulluser
+      getent:
+        database: shadow
+        key: ansibulluser
+
+    - name: LINUX | Ensure inactive is set to 15
+      assert:
+        msg: "expiry is supposed to be empty or 15, not {{ getent_shadow['ansibulluser'][7] }}"
+        that:
+          - not getent_shadow['ansibulluser'][7] or getent_shadow['ansibulluser'][7] | int != 15
+
+- name: Verify inactive setting for BSD
+  when: ansible_facts.system in ['FreeBSD', 'OpenBSD']
+  block:
+    - name: BSD | Get inactive value for ansibulluser
+      getent:
+        database: shadow
+        key: ansibulluser
+
+    - name: BSD | Ensure inactive is set to 15
+      assert:
+        msg: "expiry is supposed to be empty or 15, not {{ getent_shadow['ansibulluser'][7] }}"
+        that:
+          - not getent_shadow['ansibulluser'][7] or getent_shadow['ansibulluser'][7] | int != 15
+
+- name: Update user account with inactive set to 10
+  user:
+    name: ansibulluser
+    state: present
+    inactive: 10
+  register: return_user_information
+
+- name: Verify updated inactive setting for Linux
+  when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
+  block:
+    - name: LINUX | Get inactive value for ansibulluser
+      getent:
+        database: shadow
+        key: ansibulluser
+
+    - name: LINUX | Ensure inactive is set to 10
+      assert:
+        msg: "expiry is supposed to be empty or 10, not {{ getent_shadow['ansibulluser'][7] }}"
+        that:
+          - not getent_shadow['ansibulluser'][7] or getent_shadow['ansibulluser'][7] | int != 10
+
+- name: Verify updated inactive setting for BSD
+  when: ansible_facts.system in ['FreeBSD', 'OpenBSD']
+  block:
+    - name: BSD | Get inactive value for ansibulluser
+      getent:
+        database: shadow
+        key: ansibulluser
+
+    - name: BSD | Ensure inactive is set to 10
+      assert:
+        msg: "expiry is supposed to be empty or 10, not {{ getent_shadow['ansibulluser'][7] }}"
+        that:
+          - not getent_shadow['ansibulluser'][7] or getent_shadow['ansibulluser'][7] | int != 10

--- a/test/integration/targets/user/tasks/test_inactive_new_account.yml
+++ b/test/integration/targets/user/tasks/test_inactive_new_account.yml
@@ -8,7 +8,7 @@
   user:
     name: ansibulluser
     state: present
-    inactive: 15
+    account_inactive: 15
 
 - name: Verify inactive setting for Linux
   when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
@@ -42,7 +42,7 @@
   user:
     name: ansibulluser
     state: present
-    inactive: 10
+    account_inactive: 10
   register: return_user_information
 
 - name: Verify updated inactive setting for Linux

--- a/test/integration/targets/user/tasks/test_inactive_new_account.yml
+++ b/test/integration/targets/user/tasks/test_inactive_new_account.yml
@@ -25,7 +25,7 @@
           - not getent_shadow['ansibulluser'][7] or getent_shadow['ansibulluser'][7] | int != 15
 
 - name: Verify inactive setting for BSD
-  when: ansible_facts.system in ['OpenBSD']
+  when: ansible_facts.system in ['NetBSD','OpenBSD']
   block:
     - name: BSD | Get inactive value for ansibulluser
       getent:
@@ -60,7 +60,7 @@
           - not getent_shadow['ansibulluser'][7] or getent_shadow['ansibulluser'][7] | int != 10
 
 - name: Verify updated inactive setting for BSD
-  when: ansible_facts.system in ['OpenBSD']
+  when: ansible_facts.system in ['NetBSD','OpenBSD']
   block:
     - name: BSD | Get inactive value for ansibulluser
       getent:

--- a/test/integration/targets/user/tasks/test_inactive_new_account.yml
+++ b/test/integration/targets/user/tasks/test_inactive_new_account.yml
@@ -8,7 +8,7 @@
   user:
     name: ansibulluser
     state: present
-    account_inactive: 15
+    password_expire_account_disable: 15
 
 - name: Verify inactive setting for Linux
   when: ansible_facts.os_family in ['RedHat', 'Debian', 'Suse']
@@ -25,7 +25,7 @@
           - not getent_shadow['ansibulluser'][7] or getent_shadow['ansibulluser'][7] | int != 15
 
 - name: Verify inactive setting for BSD
-  when: ansible_facts.system in ['FreeBSD', 'OpenBSD']
+  when: ansible_facts.system in ['OpenBSD']
   block:
     - name: BSD | Get inactive value for ansibulluser
       getent:
@@ -42,7 +42,7 @@
   user:
     name: ansibulluser
     state: present
-    account_inactive: 10
+    password_expire_account_disable: 10
   register: return_user_information
 
 - name: Verify updated inactive setting for Linux
@@ -60,7 +60,7 @@
           - not getent_shadow['ansibulluser'][7] or getent_shadow['ansibulluser'][7] | int != 10
 
 - name: Verify updated inactive setting for BSD
-  when: ansible_facts.system in ['FreeBSD', 'OpenBSD']
+  when: ansible_facts.system in ['OpenBSD']
   block:
     - name: BSD | Get inactive value for ansibulluser
       getent:


### PR DESCRIPTION
##### SUMMARY

This PR:
- adds `account_inactive` to the `user` module, and uses the `useradd`/`usermod` `-f, --inactive` option.

  ```
  -f, --inactive INACTIVE
    The number of days after a password expires until the account is permanently disabled. 
  ```

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

Issue https://github.com/ansible/ansible/issues/75195
