### PR TITLE
Optimize the get_ini_entries method

### DIFF
--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -75,12 +75,9 @@ def _get_evar_list(settings):
 
 def _get_ini_entries(settings):
     data = {}
-    for setting in settings:
-        if 'ini' in settings[setting] and settings[setting]['ini']:
-            for kv in settings[setting]['ini']:
-                if not kv['section'] in data:
-                    data[kv['section']] = set()
-                data[kv['section']].add(kv['key'])
+    for values in settings.values():
+        for kv in values.get('ini', []):
+            data.setdefault(kv['section'], set()).add(kv['key'])
     return data
 
 


### PR DESCRIPTION
SUMMARY

1.Use the values () method to directly iterate through the values in the settings dictionary, without the need to retrieve keys and values every time. 2.Use the get() method to retrieve the value corresponding to the 'ini' key from the subdictionary, and if it does not exist, return an empty list to avoid additional conditional judgments. 3.Directly using the setdefault() method to create or retrieve partial corresponding collections and adding key value pairs simplifies the logic

 ISSUE TYPE

Feature Pull Request