### PR TITLE
additional timeout info

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -43,6 +43,11 @@ __all__ = ['TaskExecutor']
 
 class TaskTimeoutError(BaseException):
     def __init__(self, message="", frame=None):
+
+        root = pathlib.Path(ansible.__file__).parent
+        while not pathlib.Path(frame.f_code.co_filename).is_relative_to(root):
+            frame = frame.f_back
+
         self.frame = str(frame)
         super(TaskTimeoutError, self).__init__(message)
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -44,11 +44,14 @@ __all__ = ['TaskExecutor']
 class TaskTimeoutError(BaseException):
     def __init__(self, message="", frame=None):
 
-        root = pathlib.Path(__file__).parent
-        while not pathlib.Path(frame.f_code.co_filename).is_relative_to(root):
-            frame = frame.f_back
+        if frame is not None:
+            orig = frame
+            root = pathlib.Path(__file__).parent
+            while not pathlib.Path(frame.f_code.co_filename).is_relative_to(root):
+                frame = frame.f_back
 
-        self.frame = str(frame)
+            self.frame = 'Interrupted at %s called from %s' % (orig, frame)
+
         super(TaskTimeoutError, self).__init__(message)
 
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -44,7 +44,7 @@ __all__ = ['TaskExecutor']
 class TaskTimeoutError(BaseException):
     def __init__(self, message="", frame=None):
 
-        root = pathlib.Path(ansible.__file__).parent
+        root = pathlib.Path(__file__).parent
         while not pathlib.Path(frame.f_code.co_filename).is_relative_to(root):
             frame = frame.f_back
 


### PR DESCRIPTION
jumped gun, took wrong feedback, this should complete previous PR #83206

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFO

current content of timedout:
```
Interrupted at <frame at 0x738624874c40, file '/usr/lib/python3.10/selectors.py', line 416, code select> called from <frame at 0x61755921eb80, file '/home/bcoca/work/ansible/lib/ansible/executor/task_executor.py', line 647, code _execute>
```
