### PR TITLE
env: update examples for setting default values to variable

### DIFF
--- a/lib/ansible/plugins/lookup/env.py
+++ b/lib/ansible/plugins/lookup/env.py
@@ -31,21 +31,21 @@ EXAMPLES = """
     msg: "'{{ lookup('ansible.builtin.env', 'HOME') }}' is the HOME environment variable."
 
 - name: Before 2.13, how to set default value if the variable is not defined.
-        This cannot distinguish between USR undefined and USR=''.
+        This cannot distinguish between USER undefined and USER=''.
   ansible.builtin.debug:
-    msg: "{{ lookup('ansible.builtin.env', 'USR')|default('nobody', True) }} is the user."
+    msg: "{{ lookup('ansible.builtin.env', 'USER')|default('nobody', True) }} is the user."
 
-- name: Example how to set default value if the variable is not defined, ignores USR=''
+- name: Example how to set default value if the variable is not defined, ignores USER=''
   ansible.builtin.debug:
-    msg: "{{ lookup('ansible.builtin.env', 'USR', default='nobody') }} is the user."
+    msg: "{{ lookup('ansible.builtin.env', 'USER', default='nobody') }} is the user."
 
 - name: Set default value to Undefined, if the variable is not defined
   ansible.builtin.debug:
-    msg: "{{ lookup('ansible.builtin.env', 'USR', default=Undefined) }} is the user."
+    msg: "{{ lookup('ansible.builtin.env', 'USER', default=Undefined) }} is the user."
 
 - name: Set default value to undef(), if the variable is not defined
   ansible.builtin.debug:
-    msg: "{{ lookup('ansible.builtin.env', 'USR', default=undef()) }} is the user."
+    msg: "{{ lookup('ansible.builtin.env', 'USER', default=undef()) }} is the user."
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/env.py
+++ b/lib/ansible/plugins/lookup/env.py
@@ -30,22 +30,21 @@ EXAMPLES = """
   ansible.builtin.debug:
     msg: "'{{ lookup('ansible.builtin.env', 'HOME') }}' is the HOME environment variable."
 
-- name: Before 2.13, how to set default value if the variable is not defined.
-        This cannot distinguish between USER undefined and USER=''.
+- name: Before 2.13, how to set default value if the variable is not defined
   ansible.builtin.debug:
-    msg: "{{ lookup('ansible.builtin.env', 'USER')|default('nobody', True) }} is the user."
+    msg: "Hello {{ lookup('ansible.builtin.env', 'UNDEFINED_VARIABLE') | default('World', True) }}"
 
-- name: Example how to set default value if the variable is not defined, ignores USER=''
+- name: Example how to set default value if the variable is not defined
   ansible.builtin.debug:
-    msg: "{{ lookup('ansible.builtin.env', 'USER', default='nobody') }} is the user."
+    msg: "Hello {{ lookup('ansible.builtin.env', 'UNDEFINED_VARIABLE', default='World') }}"
 
-- name: Set default value to Undefined, if the variable is not defined
+- name: Fail if the variable is not defined by setting default value to 'Undefined'
   ansible.builtin.debug:
-    msg: "{{ lookup('ansible.builtin.env', 'USER', default=Undefined) }} is the user."
+    msg: "Hello {{ lookup('ansible.builtin.env', 'UNDEFINED_VARIABLE', default=Undefined) }}"
 
-- name: Set default value to undef(), if the variable is not defined
+- name: Fail if the variable is not defined by setting default value to 'undef()'
   ansible.builtin.debug:
-    msg: "{{ lookup('ansible.builtin.env', 'USER', default=undef()) }} is the user."
+    msg: "Hello {{ lookup('ansible.builtin.env', 'UNDEFINED_VARIABLE', default=undef()) }}"
 """
 
 RETURN = """


### PR DESCRIPTION
The example should use USER rather than USR when lookup the env.

##### SUMMARY

In Linux and macos the environment variable USR is nothing, the correct variable name should be USER

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

