### PR TITLE
[stable-2.14] ansible-test - Drop Windows 2012/2012-R2 support

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -70,8 +70,6 @@ stages:
           nameFormat: Server {0}
           testFormat: windows/{0}/1
           targets:
-            - test: 2012
-            - test: 2012-R2
             - test: 2016
             - test: 2019
             - test: 2022
@@ -191,8 +189,6 @@ stages:
           nameFormat: Server {0}
           testFormat: i/windows/{0}
           targets:
-            - test: 2012
-            - test: 2012-R2
             - test: 2016
             - test: 2019
             - test: 2022

--- a/changelogs/fragments/ansible-test-windows-2012.yml
+++ b/changelogs/fragments/ansible-test-windows-2012.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Removed support for provisioning remote Windows 2012 and 2012-R2 instances.

--- a/test/lib/ansible_test/_data/completion/windows.txt
+++ b/test/lib/ansible_test/_data/completion/windows.txt
@@ -1,5 +1,3 @@
-windows/2012 provider=azure arch=x86_64
-windows/2012-R2 provider=azure arch=x86_64
 windows/2016 provider=aws arch=x86_64
 windows/2019 provider=aws arch=x86_64
 windows/2022 provider=aws arch=x86_64


### PR DESCRIPTION
##### SUMMARY

ansible-test - Drop Windows 2012/2012-R2 support.

##### ISSUE TYPE

Test Pull Request
