### PR TITLE
vault: Handle directory value to vault password file

### DIFF
--- a/changelogs/fragments/42960_vault_password.yml
+++ b/changelogs/fragments/42960_vault_password.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- vault - handle vault password file value when it is directory (https://github.com/ansible/ansible/issues/42960).

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -357,6 +357,9 @@ def get_file_vault_secret(filename=None, vault_id=None, encoding=None, loader=No
     if not os.path.exists(this_path):
         raise AnsibleError("The vault password file %s was not found" % this_path)
 
+    if os.path.isdir(this_path):
+        raise AnsibleError(f"The vault password file provided '{this_path}' can not be a directory")
+
     # it is a script?
     if loader.is_executable(this_path):
 

--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -185,6 +185,12 @@ WRONG_RC=$?
 echo "rc was $WRONG_RC (1 is expected)"
 [ $WRONG_RC -eq 1 ]
 
+# test if vault password file is not a directory
+ANSIBLE_VAULT_PASSWORD_FILE='' ansible-vault view "$@" format_1_1_AES.yml && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (1 is expected)"
+[ $WRONG_RC -eq 1 ]
+
 # new 1.2 format, view, using password script with vault-id, ENFORCE_IDENTITY_MATCH=true, 'test_vault_id' provided should work
 ANSIBLE_VAULT_ID_MATCH=1 ansible-vault view "$@" --vault-id=test_vault_id@password-script.py format_1_2_AES256.yml
 


### PR DESCRIPTION
##### SUMMARY

When vault password file env variable is set to blank,
this value is converted to CWD and passed for further
processing.
Check if ANSIBLE_VAULT_PASSWORD_FILE is not a directory.

Fixes: #42960

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


