### PR TITLE
Revert bool filter booleanization strategy option

### DIFF
--- a/changelogs/fragments/normalize_booleanization.yml
+++ b/changelogs/fragments/normalize_booleanization.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - bool filter now has new strategy option and by default equates YAML 1.1 booleanization, before it just aproximated it.

--- a/lib/ansible/plugins/filter/bool.yml
+++ b/lib/ansible/plugins/filter/bool.yml
@@ -10,31 +10,17 @@ DOCUMENTATION:
       description: Data to cast.
       type: raw
       required: true
-    strategy:
-      description: Evaluation engine to use while evaluating boolean.
-      default: yaml
-      choices:
-        yaml: Use YAML 1.1 allowed booleans
-        python: Pass through the Python C(bool) function
-        truthy: Just let Python evaluate in an C(if) statement
-      version_added: '2.18'
-  notes:
-    - Before adding the 'strategy' option, evaluation approximated the 'yaml' strategy.
-    - if the value is already a boolean or C(None), this filter returns the original value.
 
 EXAMPLES: |
 
   # in vars
   vars:
     isbool: "{{ (a == b) | bool }} "
-    otherbool: "{{ anothervar | bool('yaml') }} "
-    yetanotherbool: "{{ pythonbool | bool(strategy='python') }} "
+    otherbool: "{{ anothervar | bool }} "
 
   # in a task
   ...
-  when:
-    - some_string_value | bool
-    - other != notsame
+  when: some_string_value | bool
 
 RETURN:
   _value:

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -28,7 +28,6 @@ from ansible.module_utils.six import string_types, integer_types, reraise, text_
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.common.yaml import yaml_load, yaml_load_all
-from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.parsing.ajson import AnsibleJSONEncoder
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.template import recursive_check_defined
@@ -81,28 +80,14 @@ def to_nice_json(a, indent=4, sort_keys=True, *args, **kw):
     return to_json(a, indent=indent, sort_keys=sort_keys, separators=(',', ': '), *args, **kw)
 
 
-def to_bool(a, strategy='yaml'):
+def to_bool(a):
     ''' return a bool for the arg '''
-
-    # nothing to do
     if a is None or isinstance(a, bool):
         return a
-
-    valid_choices = ('yaml', 'python', 'truthy')
-    if strategy not in valid_choices:
-        raise AnsibleFilterError(f"Invalid strategy provided ({strategy}), valid choices are: {', '.join(valid_choices)}")
-
-    try:
-        if strategy == 'yaml':
-            # make it lower case for easier matching
-            return boolean(a)
-        if strategy == 'python':
-            return bool(a)
-        if strategy == 'truthy':
-            if a:
-                return True
-    except TypeError as e:
-        raise AnsibleFilterTypeError(f"Could not convert to boolean using strategy {strategy}: {e}", orig_exc=e)
+    if isinstance(a, string_types):
+        a = a.lower()
+    if a in ('yes', 'on', '1', 'true', 1):
+        return True
     return False
 
 

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -301,28 +301,14 @@
       - no_match_is_none_inline
       - failure is failed
 
-- name: to_bool
-  tags:
-    - to_bool
-  block:
-  - name: Verify to_bool, using default 'yaml' strategy
-    assert:
-      that:
-        - 'None|bool == None'
-        - 'False|bool == False'
-        - '"TrUe"|bool == True'
-        - '"FalSe"|bool == False'
-
-  - name: non valid bool should fail
-    set_fact:
-      failbool: '{{7|bool}}'
-    register: should_fail
-    ignore_errors: true
-
-  - name: ensure we failed
-    assert:
-      that:
-          - should_fail is failed
+- name: Verify to_bool
+  assert:
+    that:
+      - 'None|bool == None'
+      - 'False|bool == False'
+      - '"TrUe"|bool == True'
+      - '"FalSe"|bool == False'
+      - '7|bool == False'
 
 - name: Verify to_datetime
   assert:


### PR DESCRIPTION
##### SUMMARY
Fixes https://dev.azure.com/ansible/ansible/_build/results?buildId=114073&view=logs&j=0de013c3-539b-5408-ba9a-bdc827b0cb32&t=4b19883a-28c0-54ce-f1f9-895636b71fa8&l=8921

The `conditionals` tests are failing because an invalid YAML boolean was previously false.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
