### PR TITLE
Fix issue where using listen parameter for handlers in collections could lead to memory issues

### DIFF
--- a/changelogs/fragments/fix_listeners_mutable_array.yml
+++ b/changelogs/fragments/fix_listeners_mutable_array.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix issue where using ``listen`` parameter for handlers in collections could lead to memory issues (https://github.com/ansible/ansible/issues/83392).

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -558,7 +558,7 @@ class StrategyBase:
                     handler.fattributes.get('listen'),
                     listeners,
                     templar,
-                )
+                ).copy()
                 if handler._role is not None:
                     for listener in listeners.copy():
                         listeners.extend([


### PR DESCRIPTION
Fix issue where using `listen` parameter for handlers in collections could lead to memory issues on Ansible controller.

##### SUMMARY

Fixes https://github.com/ansible/ansible/issues/83392

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

See issue for more info.
