### PR TITLE
[2.17] fix any_errors_fatal tests (#83389)

### DIFF
--- a/test/integration/targets/any_errors_fatal/80981.yml
+++ b/test/integration/targets/any_errors_fatal/80981.yml
@@ -11,7 +11,7 @@
       rescue:
         - name: Rescues both hosts
           debug:
-            msg: rescue
+            msg: rescuedd
     - name: You can recover from fatal errors by adding a rescue section to the block.
       debug:
         msg: recovered

--- a/test/integration/targets/any_errors_fatal/runme.sh
+++ b/test/integration/targets/any_errors_fatal/runme.sh
@@ -15,8 +15,6 @@ if [ "${res}" -eq 0 ] ; then
     exit 1
 fi
 
-set -ux
-
 ansible-playbook -i inventory "$@" always_block.yml | tee out.txt | grep 'any_errors_fatal_always_block_start'
 res=$?
 cat out.txt
@@ -24,8 +22,6 @@ cat out.txt
 if [ "${res}" -ne 0 ] ; then
     exit 1
 fi
-
-set -ux
 
 for test_name in test_include_role test_include_tasks; do
   ansible-playbook -i inventory "$@" -e test_name=$test_name 50897.yml | tee out.txt | grep 'any_errors_fatal_this_should_never_be_reached'
@@ -35,6 +31,8 @@ for test_name in test_include_role test_include_tasks; do
       exit 1
   fi
 done
+
+set -e
 
 ansible-playbook -i inventory "$@" 31543.yml | tee out.txt
 [ "$(grep -c 'SHOULD NOT HAPPEN' out.txt)" -eq 0 ]
@@ -47,5 +45,5 @@ ansible-playbook -i inventory "$@" 73246.yml | tee out.txt
 
 ansible-playbook -i inventory "$@" 80981.yml | tee out.txt
 [ "$(grep -c 'SHOULD NOT HAPPEN' out.txt)" -eq 0 ]
-[ "$(grep -c 'rescue' out.txt)" -eq 2 ]
+[ "$(grep -c 'rescuedd' out.txt)" -eq 2 ]
 [ "$(grep -c 'recovered' out.txt)" -eq 2 ]


### PR DESCRIPTION
##### SUMMARY

* fix any_errors_fatal test to exit on non-zero rc

Use a typo in the debug msg to avoid matching play recap

* remove duplicate 'set -ux'

(cherry picked from commit 68638f47109c555812bd1a70477f995ebe8f1d21)

##### ISSUE TYPE

- Bugfix Pull Request
