### PR TITLE
Clarify documentation for `INJECT_FACTS_AS_VARS`

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1740,7 +1740,7 @@ INJECT_FACTS_AS_VARS:
   default: True
   description:
     - Facts are available inside the `ansible_facts` variable, this setting also pushes them as their own vars in the main namespace.
-    - Unlike inside the `ansible_facts` dictionary, these will have an `ansible_` prefix.
+    - Unlike inside the `ansible_facts` dictionary where the prefix `ansible_` is removed from fact names, these will have the exact names that are returned by the module.
   env: [{name: ANSIBLE_INJECT_FACT_VARS}]
   ini:
   - {key: inject_facts_as_vars, section: defaults}


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale -->
The current description is a little confusing, since it implies that all injected variables will have an `ansible_` prefix. This is not the case.
<!--- HINT: Include "Closes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->