### PR TITLE
[stable-2.15] Use f38 official repo for libdnf5 package

### DIFF
--- a/test/integration/targets/dnf5/playbook.yml
+++ b/test/integration/targets/dnf5/playbook.yml
@@ -1,9 +1,7 @@
 - hosts: localhost
   tasks:
     - block:
-        - command: "dnf install -y 'dnf-command(copr)'"
-        - command: dnf copr enable -y rpmsoftwaremanagement/dnf5-unstable
-        - command: dnf install -y python3-libdnf5
+        - command: dnf install -y python3-libdnf5 --releasever 38
 
         - include_role:
             name: dnf


### PR DESCRIPTION
##### SUMMARY
The nightly copr repo for Fedora 37 is no longer available and python3-libdnf5 is not present in the official Fedora 37 repository, try and use Fedora 38 repo for installing python3-libdnf5 instead.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Test Pull Request
