### PR TITLE
[stable-2.16] Use f38 official repo for libdnf5 package

### DIFF
--- a/test/integration/targets/dnf5/playbook.yml
+++ b/test/integration/targets/dnf5/playbook.yml
@@ -1,8 +1,6 @@
 - hosts: localhost
   tasks:
     - block:
-        - command: "dnf install -y 'dnf-command(copr)'"
-        - command: dnf copr enable -y rpmsoftwaremanagement/dnf5-unstable
         - command: dnf install -y python3-libdnf5
 
         - include_role:
@@ -13,7 +11,7 @@
               - /var/log/dnf5.log
       when:
         - ansible_distribution == 'Fedora'
-        - ansible_distribution_major_version is version('37', '>=')
+        - ansible_distribution_major_version is version('38', '>=')
       module_defaults:
         dnf:
           use_backend: dnf5


### PR DESCRIPTION
##### SUMMARY
This will make stable-2.16 testing more stable as the f38 copr repo is going away at some point. It suffices to test against the nightly repo in stable-2.17 and devel.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Test Pull Request
