### PR TITLE
ansible-test - Update PyPI test container to 3.1.0

### DIFF
--- a/changelogs/fragments/ansible-test-pypi-test-container-update.yml
+++ b/changelogs/fragments/ansible-test-pypi-test-container-update.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ansible-test - Update ``pypi-test-container`` to version 3.0.0.
+  - ansible-test - Update ``pypi-test-container`` to version 3.1.0.

--- a/test/lib/ansible_test/_internal/pypi_proxy.py
+++ b/test/lib/ansible_test/_internal/pypi_proxy.py
@@ -69,7 +69,7 @@ def run_pypi_proxy(args: EnvironmentConfig, targets_use_pypi: bool) -> None:
         display.warning('Unable to use the PyPI proxy because Docker is not available. Installation of packages using `pip` may fail.')
         return
 
-    image = 'quay.io/ansible/pypi-test-container:3.0.0'
+    image = 'quay.io/ansible/pypi-test-container:3.1.0'
     port = 3141
 
     run_support_container(


### PR DESCRIPTION
##### SUMMARY

ansible-test - Update PyPI test container to 3.1.0.

##### ISSUE TYPE

Feature Pull Request
