### PR TITLE
[stable-2.14] ansible-test - Update PyPI test container to 3.1.0

### DIFF
--- a/changelogs/fragments/ansible-test-pypi-test-container-update.yml
+++ b/changelogs/fragments/ansible-test-pypi-test-container-update.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Update ``pypi-test-container`` to version 3.1.0.

--- a/test/lib/ansible_test/_internal/pypi_proxy.py
+++ b/test/lib/ansible_test/_internal/pypi_proxy.py
@@ -76,7 +76,7 @@ def run_pypi_proxy(args: EnvironmentConfig, targets_use_pypi: bool) -> None:
         display.warning('Unable to use the PyPI proxy because Docker is not available. Installation of packages using `pip` may fail.')
         return
 
-    image = 'quay.io/ansible/pypi-test-container:2.0.0'
+    image = 'quay.io/ansible/pypi-test-container:3.1.0'
     port = 3141
 
     run_support_container(


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/83432

(cherry picked from commit 5af5b4b6c8697b8cdd68f9591beba16f5a1018e6)

##### ISSUE TYPE

Bugfix Pull Request
