### PR TITLE
service_facts on OpenBSD: Don't crash on '=' in rcctl flags.

### DIFF
--- a/changelogs/fragments/83457-service_facts-openbsd-dont-crash-in-equals.yml
+++ b/changelogs/fragments/83457-service_facts-openbsd-dont-crash-in-equals.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - service_facts - don't crash if OpenBSD rcctl variable contains '=' character (https://github.com/ansible/ansible/issues/83457)

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -377,7 +377,7 @@ class OpenBSDScanService(BaseService):
                 if variable == '' or '=' not in variable:
                     continue
                 else:
-                    k, v = variable.replace(undy, '', 1).split('=')
+                    k, v = variable.replace(undy, '', 1).split('=', 1)
                     info[k] = v
         return info
 


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible/ansible/issues/83457

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Split was splitting on  all '=' characters, but only need to split on the first one to get key and value.