### PR TITLE
selinux compat - add ignore, proper ex chaining

### DIFF
--- a/lib/ansible/module_utils/compat/selinux.py
+++ b/lib/ansible/module_utils/compat/selinux.py
@@ -11,8 +11,8 @@ from ctypes import CDLL, c_char_p, c_int, byref, POINTER, get_errno
 
 try:
     _selinux_lib = CDLL('libselinux.so.1', use_errno=True)
-except OSError:
-    raise ImportError('unable to load libselinux.so')
+except OSError as ex:
+    raise ImportError('unable to load libselinux.so') from ex
 
 
 def _module_setup():

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -43,6 +43,7 @@ lib/ansible/module_utils/compat/selinux.py import-3.9!skip # pass/fail depends o
 lib/ansible/module_utils/compat/selinux.py import-3.10!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.11!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.12!skip # pass/fail depends on presence of libselinux.so
+lib/ansible/module_utils/compat/selinux.py import-3.13!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py pylint:unidiomatic-typecheck
 lib/ansible/module_utils/distro/_distro.py no-assert
 lib/ansible/module_utils/distro/__init__.py empty-init # breaks namespacing, bundled, do not override


### PR DESCRIPTION
##### SUMMARY

selinux compat - add ignore, proper ex chaining.

##### ISSUE TYPE

Bugfix Pull Request
