### PR TITLE
Enable Ubuntu 24.04 group 6 in CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -114,9 +114,8 @@ stages:
               test: fedora/40
             - name: RHEL 9.4
               test: rhel/9.4
-# Temporarily disabled to unblock merging of other Ubuntu 24.04 changes.
-#            - name: Ubuntu 24.04
-#              test: ubuntu/24.04
+            - name: Ubuntu 24.04
+              test: ubuntu/24.04
           groups:
             - 6
   - stage: Docker

--- a/changelogs/fragments/ansible-test-platform-updates.yml
+++ b/changelogs/fragments/ansible-test-platform-updates.yml
@@ -5,3 +5,8 @@ minor_changes:
   - ansible-test - Add Ubuntu 24.04 remote.
   - ansible-test - Replace RHEL 9.3 remote with RHEL 9.4.
   - ansible-test - Replace FreeBSD 14.0 remote with FreeBSD 14.1.
+known_issues:
+  - ansible-test - When using the Fedora 40 container with Podman on a Ubuntu 24.04 host,
+    the ``unix-chkpwd`` AppArmor profile must be disabled on the host to allow SSH connections to the container.
+  - ansible-test - When using ansible-test containers with Podman on a Ubuntu 24.04 host,
+    ansible-test must be run as a non-root user to avoid permission issues caused by AppArmor.

--- a/test/integration/targets/ansible-test-container/runme.py
+++ b/test/integration/targets/ansible-test-container/runme.py
@@ -189,14 +189,17 @@ def get_test_scenarios() -> list[TestScenario]:
             ]
 
             if engine == 'podman':
-                user_scenarios.append(UserScenario(ssh=ROOT_USER))
+                if os_release.id not in ('ubuntu',):
+                    # rootfull podman is not supported by all systems
+                    user_scenarios.append(UserScenario(ssh=ROOT_USER))
 
                 # TODO: test podman remote on Alpine and Ubuntu hosts
                 # TODO: combine remote with ssh using different unprivileged users
                 if os_release.id not in ('alpine', 'ubuntu'):
                     user_scenarios.append(UserScenario(remote=unprivileged_user))
 
-                if LOGINUID_MISMATCH:
+                if LOGINUID_MISMATCH and os_release.id not in ('ubuntu',):
+                    # rootfull podman is not supported by all systems
                     user_scenarios.append(UserScenario())
 
             for user_scenario in user_scenarios:

--- a/test/integration/targets/ansible-test-container/runme.py
+++ b/test/integration/targets/ansible-test-container/runme.py
@@ -181,6 +181,11 @@ def get_test_scenarios() -> list[TestScenario]:
             # See: https://access.redhat.com/solutions/6816771
             enable_sha1 = os_release.id == 'rhel' and os_release.version_id.startswith('9.') and container_name == 'centos6'
 
+            # Starting with Fedora 40, use of /usr/sbin/unix-chkpwd fails under Ubuntu 24.04 due to AppArmor.
+            # This prevents SSH logins from completing due to unix-chkpwd failing to look up the user with getpwnam.
+            # Disabling the 'unix-chkpwd' profile works around the issue, but does not solve the underlying problem.
+            disable_apparmor_profile_unix_chkpwd = engine == 'podman' and os_release.id == 'ubuntu' and container_name == 'fedora40'
+
             cgroup_version = get_docker_info(engine).cgroup_version
 
             user_scenarios = [
@@ -228,6 +233,7 @@ def get_test_scenarios() -> list[TestScenario]:
                         enable_sha1=enable_sha1,
                         debug_systemd=debug_systemd,
                         probe_cgroups=probe_cgroups,
+                        disable_apparmor_profile_unix_chkpwd=disable_apparmor_profile_unix_chkpwd,
                     )
                 )
 
@@ -322,6 +328,10 @@ def run_test(scenario: TestScenario) -> TestResult:
         if scenario.enable_sha1:
             run_command('update-crypto-policies', '--set', 'DEFAULT:SHA1')
 
+        if scenario.disable_apparmor_profile_unix_chkpwd:
+            os.symlink('/etc/apparmor.d/unix-chkpwd', '/etc/apparmor.d/disable/unix-chkpwd')
+            run_command('apparmor_parser', '-R', '/etc/apparmor.d/unix-chkpwd')
+
         for test_command in test_commands:
             def run_test_command() -> SubprocessResult:
                 if os_release.id == 'alpine' and scenario.user_scenario.actual.name != 'root':
@@ -344,6 +354,10 @@ def run_test(scenario: TestScenario) -> TestResult:
         message = str(ex)
         display.error(f'{scenario} {message}')
     finally:
+        if scenario.disable_apparmor_profile_unix_chkpwd:
+            os.unlink('/etc/apparmor.d/disable/unix-chkpwd')
+            run_command('apparmor_parser', '/etc/apparmor.d/unix-chkpwd')
+
         if scenario.enable_sha1:
             run_command('update-crypto-policies', '--set', 'DEFAULT')
 
@@ -603,6 +617,7 @@ class TestScenario:
     enable_sha1: bool
     debug_systemd: bool
     probe_cgroups: bool
+    disable_apparmor_profile_unix_chkpwd: bool
 
     @property
     def tags(self) -> tuple[str, ...]:
@@ -622,6 +637,9 @@ class TestScenario:
 
         if self.enable_sha1:
             tags.append('sha1: enabled')
+
+        if self.disable_apparmor_profile_unix_chkpwd:
+            tags.append('apparmor(unix-chkpwd): disabled')
 
         return tuple(tags)
 


### PR DESCRIPTION
##### SUMMARY

Enable Ubuntu 24.04 group 6 in CI.

##### ISSUE TYPE

Test Pull Request
