### PR TITLE
ansible-test: update http-test-container to 3.2.0

### DIFF
--- a/changelogs/fragments/83469-http-test-container.yml
+++ b/changelogs/fragments/83469-http-test-container.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ansible-test - update HTTP test container to 3.1.0 (https://github.com/ansible/ansible/pull/83469)."

--- a/changelogs/fragments/83469-http-test-container.yml
+++ b/changelogs/fragments/83469-http-test-container.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "ansible-test - update HTTP test container to 3.1.0 (https://github.com/ansible/ansible/pull/83469)."
+  - "ansible-test - update HTTP test container to 3.2.0 (https://github.com/ansible/ansible/pull/83469)."

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/httptester.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/httptester.py
@@ -31,7 +31,7 @@ class HttptesterProvider(CloudProvider):
     def __init__(self, args: IntegrationConfig) -> None:
         super().__init__(args)
 
-        self.image = os.environ.get('ANSIBLE_HTTP_TEST_CONTAINER', 'quay.io/ansible/http-test-container:3.0.0')
+        self.image = os.environ.get('ANSIBLE_HTTP_TEST_CONTAINER', 'quay.io/ansible/http-test-container:3.1.0')
 
         self.uses_docker = True
 

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/httptester.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/httptester.py
@@ -31,7 +31,7 @@ class HttptesterProvider(CloudProvider):
     def __init__(self, args: IntegrationConfig) -> None:
         super().__init__(args)
 
-        self.image = os.environ.get('ANSIBLE_HTTP_TEST_CONTAINER', 'quay.io/ansible/http-test-container:3.1.0')
+        self.image = os.environ.get('ANSIBLE_HTTP_TEST_CONTAINER', 'quay.io/ansible/http-test-container:3.2.0')
 
         self.uses_docker = True
 


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/http-test-container/releases/tag/3.1.0

Ref: https://github.com/ansible-collections/community.crypto/pull/768#issuecomment-2166653041

##### ISSUE TYPE
- Feature Pull Request
- Test Pull Request
