### PR TITLE
new ansible_parent_block_name for current task

### DIFF
--- a/changelogs/fragments/block_name.yml
+++ b/changelogs/fragments/block_name.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - new constant 'ansible_parent_block_name' contains the 'name' of the current explicit block a task is in, it won't work with implicit/generated blocks.
+  - new constant 'ansible_parent_block_name' contains the 'name' of the current explicit block a task is in.

--- a/changelogs/fragments/block_name.yml
+++ b/changelogs/fragments/block_name.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - new constant 'ansible_block_name' contains the 'name' of the current explicit block a task is in, it won't work with implicit/generated blocks.

--- a/changelogs/fragments/block_name.yml
+++ b/changelogs/fragments/block_name.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - new constant 'ansible_block_name' contains the 'name' of the current explicit block a task is in, it won't work with implicit/generated blocks.
+  - new constant 'ansible_parent_block_name' contains the 'name' of the current explicit block a task is in, it won't work with implicit/generated blocks.

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -462,13 +462,8 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
             self._parent.set_loader(loader)
 
     def get_parent_block_name(self):
-
-        name = ''
         parent_block = self.get_first_parent_block(static=True)
-        if parent_block:
-            name = getattr(parent_block, 'name', '')
-
-        return name
+        return getattr(parent_block, 'name', '')
 
     def _get_parent_attribute(self, attr, omit=False):
         """

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -461,6 +461,15 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
         if self._parent:
             self._parent.set_loader(loader)
 
+    def get_parent_block_name(self):
+
+        name = ''
+        parent_block = self.get_first_parent_block(static=True)
+        if parent_block:
+            name = getattr(parent_block, 'name', '')
+
+        return name
+
     def _get_parent_attribute(self, attr, omit=False):
         """
         Generic logic to get the attribute or parent attribute for a task value.
@@ -513,6 +522,21 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
                 return self._parent
             return self._parent.get_first_parent_include()
         return None
+
+    def get_first_parent_block(self, static=False):
+        parent = None
+        if self._parent:
+            if isinstance(self._parent, Block):
+                if static:
+                    if getattr(self._parent, 'statically_loaded', True):
+                        parent = self._parent
+                    else:
+                        parent = self._parent.get_first_parent_block()
+                else:
+                    parent = self._parent
+            else:
+                parent = self._parent.get_first_parent_block()
+        return parent
 
     def get_play(self):
         parent = self._parent

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -465,7 +465,10 @@ class VariableManager:
             variables['ansible_play_name'] = play.get_name()
 
         if task:
+            variables['ansible_parent_block_name'] = task.get_parent_block_name()
+
             if task._role:
+                # TODO: (data tagging!!) eventually deprecate 'non' ansible_ prefixed
                 variables['role_name'] = task._role.get_name(include_role_fqcn=False)
                 variables['role_path'] = task._role._role_path
                 variables['role_uuid'] = text_type(task._role._uuid)
@@ -490,7 +493,7 @@ class VariableManager:
                 variables['ansible_play_hosts'] = [x for x in variables['ansible_play_hosts_all'] if x not in play._removed_hosts]
                 variables['ansible_play_batch'] = [x for x in _hosts if x not in play._removed_hosts]
 
-                # DEPRECATED: play_hosts should be deprecated in favor of ansible_play_batch,
+                # TODO: DEPRECATE! (data tagging!!) play_hosts should be deprecated in favor of ansible_play_batch,
                 # however this would take work in the templating engine, so for now we'll add both
                 variables['play_hosts'] = variables['ansible_play_batch']
 

--- a/test/integration/targets/special_vars/tasks/main.yml
+++ b/test/integration/targets/special_vars/tasks/main.yml
@@ -110,4 +110,4 @@
   assert:
     that:
       - ansible_parent_block_name is defined
-      - "ansible_parent_block_name is None"
+      - "ansible_parent_block_name is none"

--- a/test/integration/targets/special_vars/tasks/main.yml
+++ b/test/integration/targets/special_vars/tasks/main.yml
@@ -98,3 +98,16 @@
 - name: ansible_parent_role_names - test functionality by importing another role
   import_role:
     name: include_parent_role_vars
+
+- name: test block name
+  block:
+    - assert:
+        that:
+          - ansible_block_name is defined
+          - "ansible_block_name == 'test block name'"
+
+- name: test no block name
+  assert:
+    that:
+      - ansible_block_name is defined
+      - "ansible_block_name is None"

--- a/test/integration/targets/special_vars/tasks/main.yml
+++ b/test/integration/targets/special_vars/tasks/main.yml
@@ -110,4 +110,4 @@
   assert:
     that:
       - ansible_parent_block_name is defined
-      - "ansible_parent_block_name is none"
+      - "ansible_parent_block_name == ''"

--- a/test/integration/targets/special_vars/tasks/main.yml
+++ b/test/integration/targets/special_vars/tasks/main.yml
@@ -103,11 +103,11 @@
   block:
     - assert:
         that:
-          - ansible_block_name is defined
-          - "ansible_block_name == 'test block name'"
+          - ansible_parent_block_name is defined
+          - "ansible_parent_block_name == 'test block name'"
 
 - name: test no block name
   assert:
     that:
-      - ansible_block_name is defined
-      - "ansible_block_name is None"
+      - ansible_parent_block_name is defined
+      - "ansible_parent_block_name is None"


### PR DESCRIPTION
So you can add to the task's own templating the name of the block that encapsulates it.

fixes #33581

##### ISSUE TYPE

- Feature Pull Request
