### PR TITLE
linear strategy, show templated task name on start

### DIFF
--- a/changelogs/fragments/linear_started_name.yml
+++ b/changelogs/fragments/linear_started_name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - linear strategy now provides a properly templated task name to the v2_runner_on_started callback event.

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -11,7 +11,7 @@ import sys
 
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 11):
     raise SystemExit(
         'ERROR: Ansible requires Python 3.11 or newer on the controller. '
         'Current version: %s' % ''.join(sys.version.splitlines())

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -11,7 +11,7 @@ import sys
 
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions
-if sys.version_info < (3, 11):
+if sys.version_info < (3, 10):
     raise SystemExit(
         'ERROR: Ansible requires Python 3.11 or newer on the controller. '
         'Current version: %s' % ''.join(sys.version.splitlines())

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -211,30 +211,21 @@ class StrategyModule(StrategyBase):
                                 skip_rest = True
                                 break
 
-                        run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
+                        run_once = action and getattr(action, 'BYPASS_HOST_LOOP', False) or templar.template(task.run_once)
+                        try:
+                            task.name = to_text(templar.template(task.name, fail_on_undefined=False), nonstring='empty')
+                        except Exception as e:
+                            display.debug(f"Failed to templalte task name ({task.name}), ignoring error and continuing: {e}")
 
                         if (task.any_errors_fatal or run_once) and not task.ignore_errors:
                             any_errors_fatal = True
 
                         if not callback_sent:
-                            display.debug("sending task start callback, copying the task so we can template it temporarily")
-                            saved_name = task.name
-                            display.debug("done copying, going to template now")
-                            try:
-                                task.name = to_text(templar.template(task.name, fail_on_undefined=False), nonstring='empty')
-                                display.debug("done templating")
-                            except Exception:
-                                # just ignore any errors during task name templating,
-                                # we don't care if it just shows the raw name
-                                display.debug("templating failed for some reason")
-                            display.debug("here goes the callback...")
                             if isinstance(task, Handler):
                                 self._tqm.send_callback('v2_playbook_on_handler_task_start', task)
                             else:
                                 self._tqm.send_callback('v2_playbook_on_task_start', task, is_conditional=False)
-                            task.name = saved_name
                             callback_sent = True
-                            display.debug("sending task start callback")
 
                         self._blocked_hosts[host.get_name()] = True
                         self._queue_task(host, task, task_vars, play_context)

--- a/test/integration/targets/callback_results/runme.sh
+++ b/test/integration/targets/callback_results/runme.sh
@@ -16,5 +16,11 @@ grep -e "${EXPECTED_REGEX}" "${OUTFILE}"
 # test connection tracking
 EXPECTED_CONNECTION='{"testhost":{"ssh":4}}'
 OUTPUT_TAIL=$(tail -n5 ${OUTFILE} | tr -d '[:space:]')
+echo "Checking for connection strin ${OUTPUT_TAIL} in stdout."
 [ "${EXPECTED_CONNECTION}" == "${OUTPUT_TAIL}" ]
 echo $?
+
+# check variables are interpolated in 'started'
+UNTEMPLATED_STARTED="^.*\[started .*{{.*}}.*$"
+echo "Checking we dont have untemplated started in stdout."
+grep -e "${UNTEMPLATED_STARTED}" "${OUTFILE}" || exit 0


### PR DESCRIPTION
currently we only template in some cases but when queueing we can get an untemplated name for the 'on start' event.


##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATIONA
repro:
```yaml
- hosts: localhost
  gather_facts: false
  tasks:
        - name: '{{test_name}}: for this task'
          debug:

```
run `ansible-playbook play.yml -e 'test_name=yolo'`

without PR:
```console
_____________________________
< TASK [yolo: for this task] >
 ---------------------------------------

 [started TASK: {{test_name}}: for this task on localhost]
ok: [localhost] => {
    "msg": "Hello world!"
}
```
with PR:
```console
_____________________________
< TASK [yolo: for this task] >
 ---------------------------------------

 [started TASK: yolo: for this task on localhost]
ok: [localhost] => {
    "msg": "Hello world!"
}
```