### PR TITLE
facts/hardware: Fix support_discard block device fact

### DIFF
--- a/changelogs/fragments/83480-fix-support-discard.yml
+++ b/changelogs/fragments/83480-fix-support-discard.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - facts - `support_discard` now returns `0` if either `discard_granularity`
+    or `discard_max_hw_bytes` is zero; otherwise it returns the value of
+    `discard_granularity`, as before
+    (https://github.com/ansible/ansible/pull/83480).


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Previously, `support_discard` simply returned the value of `/sys/block/{device}/queue/discard_granularity`. When its value is `0`, then the block device doesn't support discards; _however_, it being greater than zero doesn't necessarily mean that the block device _does_ support discards.

But another indication that a block device doesn't support discards is `/sys/block/{device}/queue/discard_max_hw_bytes` being equal to `0` (with the same caveat as above). So if either of those are `0`, set `support_discard` to zero, otherwise set it to the value of `discard_granularity` for backwards compatibility.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

If you run

```
$ ansible -m setup all
```

targeting servers with HDDs, chances are that you'll get `ansible_facts.devices.sda.support_discard` greater than zero, which supposedly indicates that they support discards. However, if you run (don't do it on a disk that contains data, just in case it works, because it would wipe it out) `blkdiscard /dev/sda`, you will likely get an error because the HDD doesn't actually support discards.

But if you check `/sys/block/sda/queue/discard_max_hw_bytes`, you'll likely see that it contains `0`, hence this PR.