### PR TITLE
unarchive: use native zipfile bindings

### DIFF
--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -441,6 +441,17 @@ class ZipArchive(object):
         except (KeyError, ValueError, OverflowError):
             return None
 
+    def _valid_time_stamp(self, timestamp):
+        """ Return a valid time tuple from the given time tuple """
+        epoch_date_time = (1980, 1, 1, 0, 0, 0)
+        if len(timestamp) < 6:
+            return epoch_date_time
+        if timestamp[0] < 1980 or timestamp[1] == 0 or timestamp[2] == 0:
+            return epoch_date_time
+        if timestamp[0] > 2107:
+            return (2107, 12, 31, 23, 59, 59)
+        return timestamp
+
     def is_unarchived(self):
         err = ''
         diff = ''
@@ -572,7 +583,8 @@ class ZipArchive(object):
 
             itemized = list('.%s.......??' % ftype)
 
-            timestamp = datetime(*(file_info.date_time)).timestamp()
+            date_time = self._valid_time_stamp(file_info.date_time)
+            timestamp = datetime(*date_time).timestamp()
 
             # Compare file timestamps
             if stat.S_ISREG(st.st_mode):

--- a/test/units/modules/test_unarchive.py
+++ b/test/units/modules/test_unarchive.py
@@ -2,8 +2,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import annotations
 
-
-import time
 import pytest
 
 from ansible.modules.unarchive import ZipArchive, TgzArchive
@@ -47,56 +45,6 @@ class TestCaseZipArchive:
         assert can_handle is False
         assert expected_reason in reason
         assert z.cmd_path is None
-
-    @pytest.mark.parametrize(
-        ("test_input", "expected"),
-        [
-            pytest.param(
-                "19800000.000000",
-                time.mktime(time.struct_time((1980, 0, 0, 0, 0, 0, 0, 0, 0))),
-                id="invalid-month-1980",
-            ),
-            pytest.param(
-                "19791231.000000",
-                time.mktime(time.struct_time((1980, 1, 1, 0, 0, 0, 0, 0, 0))),
-                id="invalid-year-1979",
-            ),
-            pytest.param(
-                "19810101.000000",
-                time.mktime(time.struct_time((1981, 1, 1, 0, 0, 0, 0, 0, 0))),
-                id="valid-datetime",
-            ),
-            pytest.param(
-                "21081231.000000",
-                time.mktime(time.struct_time((2107, 12, 31, 23, 59, 59, 0, 0, 0))),
-                id="invalid-year-2108",
-            ),
-            pytest.param(
-                "INVALID_TIME_DATE",
-                time.mktime(time.struct_time((1980, 1, 1, 0, 0, 0, 0, 0, 0))),
-                id="invalid-datetime",
-            ),
-        ],
-    )
-    def test_valid_time_stamp(self, mocker, fake_ansible_module, test_input, expected):
-        mocker.patch(
-            "ansible.modules.unarchive.get_bin_path",
-            side_effect=["/bin/unzip", "/bin/zipinfo"],
-        )
-        fake_ansible_module.params = {
-            "extra_opts": "",
-            "exclude": "",
-            "include": "",
-            "io_buffer_size": 65536,
-        }
-
-        z = ZipArchive(
-            src="",
-            b_dest="",
-            file_args="",
-            module=fake_ansible_module,
-        )
-        assert z._valid_time_stamp(test_input) == expected
 
 
 class TestCaseTgzArchive:

--- a/test/units/modules/test_unarchive.py
+++ b/test/units/modules/test_unarchive.py
@@ -46,6 +46,56 @@ class TestCaseZipArchive:
         assert expected_reason in reason
         assert z.cmd_path is None
 
+    @pytest.mark.parametrize(
+        ("test_input", "expected"),
+        [
+            pytest.param(
+                (1980, 0, 0, 0, 0, 0),
+                (1980, 1, 1, 0, 0, 0),
+                id="invalid-month-1980",
+            ),
+            pytest.param(
+                (1980, 1, 1, 0, 0, 0),
+                (1980, 1, 1, 0, 0, 0),
+                id="invalid-year-1979",
+            ),
+            pytest.param(
+                (1981, 1, 1, 0, 0, 0),
+                (1981, 1, 1, 0, 0, 0),
+                id="valid-datetime",
+            ),
+            pytest.param(
+                (2108, 12, 31, 23, 59, 59),
+                (2107, 12, 31, 23, 59, 59),
+                id="invalid-year-2108",
+            ),
+            pytest.param(
+                (0,),
+                (1980, 1, 1, 0, 0, 0),
+                id="invalid-length-datetime",
+            ),
+        ],
+    )
+    def test_valid_time_stamp(self, mocker, fake_ansible_module, test_input, expected):
+        mocker.patch(
+            "ansible.modules.unarchive.get_bin_path",
+            side_effect=["/bin/unzip", "/bin/zipinfo"],
+        )
+        fake_ansible_module.params = {
+            "extra_opts": "",
+            "exclude": "",
+            "include": "",
+            "io_buffer_size": 65536,
+        }
+
+        z = ZipArchive(
+            src="",
+            b_dest="",
+            file_args="",
+            module=fake_ansible_module,
+        )
+        assert z._valid_time_stamp(test_input) == expected
+
 
 class TestCaseTgzArchive:
     def test_no_tar_binary(self, mocker, fake_ansible_module):


### PR DESCRIPTION
##### SUMMARY

Instead of zipinfo command use zipfile Python interface

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


