### PR TITLE
[stable-2.16] linear strategy, show templated task name on start (#83473)

### DIFF
--- a/changelogs/fragments/linear_started_name.yml
+++ b/changelogs/fragments/linear_started_name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - linear strategy now provides a properly templated task name to the v2_runner_on_started callback event.

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -213,30 +213,21 @@ class StrategyModule(StrategyBase):
                                 skip_rest = True
                                 break
 
-                        run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
+                        run_once = action and getattr(action, 'BYPASS_HOST_LOOP', False) or templar.template(task.run_once)
+                        try:
+                            task.name = to_text(templar.template(task.name, fail_on_undefined=False), nonstring='empty')
+                        except Exception as e:
+                            display.debug(f"Failed to templalte task name ({task.name}), ignoring error and continuing: {e}")
 
                         if (task.any_errors_fatal or run_once) and not task.ignore_errors:
                             any_errors_fatal = True
 
                         if not callback_sent:
-                            display.debug("sending task start callback, copying the task so we can template it temporarily")
-                            saved_name = task.name
-                            display.debug("done copying, going to template now")
-                            try:
-                                task.name = to_text(templar.template(task.name, fail_on_undefined=False), nonstring='empty')
-                                display.debug("done templating")
-                            except Exception:
-                                # just ignore any errors during task name templating,
-                                # we don't care if it just shows the raw name
-                                display.debug("templating failed for some reason")
-                            display.debug("here goes the callback...")
                             if isinstance(task, Handler):
                                 self._tqm.send_callback('v2_playbook_on_handler_task_start', task)
                             else:
                                 self._tqm.send_callback('v2_playbook_on_task_start', task, is_conditional=False)
-                            task.name = saved_name
                             callback_sent = True
-                            display.debug("sending task start callback")
 
                         self._blocked_hosts[host.get_name()] = True
                         self._queue_task(host, task, task_vars, play_context)

--- a/test/integration/targets/retry_task_name_in_callback/runme.sh
+++ b/test/integration/targets/retry_task_name_in_callback/runme.sh
@@ -11,3 +11,8 @@ EXPECTED_REGEX="^.*TASK.*18236 callback task template fix OUTPUT 2"
 ansible-playbook "$@" -i ../../inventory test.yml | tee "${OUTFILE}"
 echo "Grepping for ${EXPECTED_REGEX} in stdout."
 grep -e "${EXPECTED_REGEX}" "${OUTFILE}"
+
+# check variables are interpolated in 'started'
+UNTEMPLATED_STARTED="^.*\[started .*{{.*}}.*$"
+echo "Checking we dont have untemplated started in stdout."
+grep -e "${UNTEMPLATED_STARTED}" "${OUTFILE}" || exit 0


### PR DESCRIPTION
we only templated in some cases but when queueing we could get an untemplated name for the 'on start' event.

(cherry picked from commit 0d28705ce5c6a4048645e919efd218a4ba8e5da1)

##### ISSUE TYPE

- Bugfix Pull Request
