### PR TITLE
module_utils, move out file functions from AnsibleModule to common to enable better reuse

### DIFF
--- a/changelogs/fragments/module_utils_file_reorg.yml
+++ b/changelogs/fragments/module_utils_file_reorg.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - moved several file related functions out of AnsibleModule to a common area, so plugin
+    developers can now use several file related functions without instanciating AnsibleModule.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -599,7 +599,7 @@ class AnsibleModule(object):
     # If selinux fails to find a default, return an array of None
     def selinux_default_context(self, path, mode=0):
         context = None
-        if self.selinux_enabled():
+        if is_selinux_enabled():
             try:
                 context = get_path_default_selinux_context(path, mode)
             except OSError:
@@ -611,7 +611,7 @@ class AnsibleModule(object):
 
     def selinux_context(self, path):
         context = None
-        if self.selinux_enabled():
+        if is_selinux_enabled():
             try:
                 context = get_path_selinux_context(path, context)
             except OSError as e:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -101,7 +101,7 @@ def _get_available_hash_algorithms():
                 # For example, md5 is not available in FIPS mode.
                 algorithm_func()
             except Exception as e:
-                self.debug(f"Skipping failure to get available hash algos: {e}")
+                pass
             else:
                 algorithms[algorithm_name] = algorithm_func
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -121,12 +121,22 @@ from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.common.file import (
     _PERM_BITS as PERM_BITS,
     _DEFAULT_PERM as DEFAULT_PERM,
+    DEFAULT_SELINUX_CONTEXT,
+    atomic_move,
     is_executable,
+    is_selinux_enabled,
+    is_selinux_mls_enabled,
+    is_special_selinux_path,
+    find_mount_point,
     format_attributes,
     get_flags_from_attributes,
     FILE_ATTRIBUTES,
     S_IXANY,
     S_IRWU_RWG_RWO,
+    get_path_selinux_context,
+    get_path_default_selinux_context,
+    set_selinux_context,
+    write_unsafely,
 )
 from ansible.module_utils.common.sys_info import (
     get_distribution,
@@ -572,57 +582,42 @@ class AnsibleModule(object):
 
     def selinux_mls_enabled(self):
         if self._selinux_mls_enabled is None:
-            self._selinux_mls_enabled = HAVE_SELINUX and selinux.is_selinux_mls_enabled() == 1
-
+            self._selinux_mls_enabled = is_selinux_mls_enabled()
         return self._selinux_mls_enabled
 
     def selinux_enabled(self):
         if self._selinux_enabled is None:
-            self._selinux_enabled = HAVE_SELINUX and selinux.is_selinux_enabled() == 1
-
+            self._selinux_enabled = is_selinux_enabled()
         return self._selinux_enabled
 
     # Determine whether we need a placeholder for selevel/mls
     def selinux_initial_context(self):
         if self._selinux_initial_context is None:
-            self._selinux_initial_context = [None, None, None]
-            if self.selinux_mls_enabled():
-                self._selinux_initial_context.append(None)
-
+            self._selinux_initial_context = DEFAULT_SELINUX_CONTEXT
         return self._selinux_initial_context
 
     # If selinux fails to find a default, return an array of None
     def selinux_default_context(self, path, mode=0):
-        context = self.selinux_initial_context()
-        if not self.selinux_enabled():
-            return context
-        try:
-            ret = selinux.matchpathcon(to_native(path, errors='surrogate_or_strict'), mode)
-        except OSError:
-            return context
-        if ret[0] == -1:
-            return context
-        # Limit split to 4 because the selevel, the last in the list,
-        # may contain ':' characters
-        context = ret[1].split(':', 3)
+        context = None
+        if self.selinux_enabled():
+            try:
+                context = get_path_default_selinux_context(path, mode)
+            except OSError:
+                # unable to read context, but we don't care, fallback to initial.
+                pass
+        if context is None:
+            context = self.selinux_initial_context()
         return context
 
     def selinux_context(self, path):
-        context = self.selinux_initial_context()
-        if not self.selinux_enabled():
-            return context
-        try:
-            ret = selinux.lgetfilecon_raw(to_native(path, errors='surrogate_or_strict'))
-        except OSError as e:
-            if e.errno == errno.ENOENT:
-                self.fail_json(path=path, msg='path %s does not exist' % path)
-            else:
-                self.fail_json(path=path, msg='failed to retrieve selinux context')
-        if ret[0] == -1:
-            return context
-        # Limit split to 4 because the selevel, the last in the list,
-        # may contain ':' characters
-        context = ret[1].split(':', 3)
+        context = None
+        if self.selinux_enabled():
+            try:
+                context = get_path_selinux_context(path, context)
+            except OSError as e:
+                self.fail_json(msg=f'{e}', exception=traceback.format_exc())
+        if context is None:
+            context = self.selinux_initial_context()
         return context
 
     def user_and_group(self, path, expand=True):
@@ -635,42 +630,10 @@ class AnsibleModule(object):
         return (uid, gid)
 
     def find_mount_point(self, path):
-        '''
-            Takes a path and returns its mount point
-
-        :param path: a string type with a filesystem path
-        :returns: the path to the mount point as a text type
-        '''
-
-        b_path = os.path.realpath(to_bytes(os.path.expanduser(os.path.expandvars(path)), errors='surrogate_or_strict'))
-        while not os.path.ismount(b_path):
-            b_path = os.path.dirname(b_path)
-
-        return to_text(b_path, errors='surrogate_or_strict')
+        return find_mount_point(path)
 
     def is_special_selinux_path(self, path):
-        """
-        Returns a tuple containing (True, selinux_context) if the given path is on a
-        NFS or other 'special' fs  mount point, otherwise the return will be (False, None).
-        """
-        try:
-            f = open('/proc/mounts', 'r')
-            mount_data = f.readlines()
-            f.close()
-        except Exception:
-            return (False, None)
-
-        path_mount_point = self.find_mount_point(path)
-
-        for line in mount_data:
-            (device, mount_point, fstype, options, rest) = line.split(' ', 4)
-            if to_bytes(path_mount_point) == to_bytes(mount_point):
-                for fs in self._selinux_special_fs:
-                    if fs in fstype:
-                        special_context = self.selinux_context(path_mount_point)
-                        return (True, special_context)
-
-        return (False, None)
+        return is_special_selinux_path(path, self._selinux_special_fs)
 
     def set_default_selinux_context(self, path, changed):
         if not self.selinux_enabled():
@@ -680,47 +643,25 @@ class AnsibleModule(object):
 
     def set_context_if_different(self, path, context, changed, diff=None):
 
-        if not self.selinux_enabled():
-            return changed
-
         if self.check_file_absent_if_check_mode(path):
-            return True
-
-        cur_context = self.selinux_context(path)
-        new_context = list(cur_context)
-        # Iterate over the current context instead of the
-        # argument context, which may have selevel.
-
-        (is_special_se, sp_context) = self.is_special_selinux_path(path)
-        if is_special_se:
-            new_context = sp_context
-        else:
-            for i in range(len(cur_context)):
-                if len(context) > i:
-                    if context[i] is not None and context[i] != cur_context[i]:
-                        new_context[i] = context[i]
-                    elif context[i] is None:
-                        new_context[i] = cur_context[i]
-
-        if cur_context != new_context:
-            if diff is not None:
-                if 'before' not in diff:
-                    diff['before'] = {}
-                diff['before']['secontext'] = cur_context
-                if 'after' not in diff:
-                    diff['after'] = {}
-                diff['after']['secontext'] = new_context
-
-            try:
-                if self.check_mode:
-                    return True
-                rc = selinux.lsetfilecon(to_native(path), ':'.join(new_context))
-            except OSError as e:
-                self.fail_json(path=path, msg='invalid selinux context: %s' % to_native(e),
-                               new_context=new_context, cur_context=cur_context, input_was=context)
-            if rc != 0:
-                self.fail_json(path=path, msg='set selinux context failed')
             changed = True
+        elif is_selinux_enabled():
+            cur_context = DEFAULT_SELINUX_CONTEXT
+            new_context = context
+            try:
+                cur_context, new_context = set_selinux_context(path, context, special_fs=self._selinux_special_fs, simulate=self.check_mode)
+            except OSError as e:
+                self.fail_json(path=path, msg=f'{e}', new_context=new_context, cur_context=cur_context, input_was=context)
+
+            if cur_context != new_context:
+                changed = True
+                if diff is not None:
+                    if 'before' not in diff:
+                        diff['before'] = {}
+                    diff['before']['secontext'] = cur_context
+                    if 'after' not in diff:
+                        diff['after'] = {}
+                    diff['after']['secontext'] = new_context
         return changed
 
     def set_owner_if_different(self, path, owner, changed, diff=None, expand=True):
@@ -1150,7 +1091,9 @@ class AnsibleModule(object):
             else:
                 kwargs['state'] = 'file'
             if self.selinux_enabled():
-                kwargs['secontext'] = ':'.join(self.selinux_context(path))
+                context = self.selinux_context(path)
+                if context is not None and None not in context:
+                    kwargs['secontext'] = ':'.join(context)
             kwargs['size'] = st[stat.ST_SIZE]
         return kwargs
 
@@ -1547,7 +1490,9 @@ class AnsibleModule(object):
             try:
                 os.unlink(tmpfile)
             except OSError as e:
-                sys.stderr.write("could not cleanup %s: %s" % (tmpfile, to_native(e)))
+                msg = f"Could not cleanup '{tmpfile}': {e}"
+                self.warn(msg)
+                sys.stderr.write(msg)
 
     def preserved_copy(self, src, dest):
         """Copy a file with preserved ownership, permissions and context"""
@@ -1585,134 +1530,16 @@ class AnsibleModule(object):
         self.set_attributes_if_different(dest, current_attribs, True)
 
     def atomic_move(self, src, dest, unsafe_writes=False, keep_dest_attrs=True):
-        '''atomically move src to dest, copying attributes from dest, returns true on success
-        it uses os.rename to ensure this as it is an atomic operation, rest of the function is
-        to work around limitations, corner cases and ensure selinux context is saved if possible'''
-        context = None
-        dest_stat = None
-        b_src = to_bytes(src, errors='surrogate_or_strict')
-        b_dest = to_bytes(dest, errors='surrogate_or_strict')
-        if os.path.exists(b_dest) and keep_dest_attrs:
-            try:
-                dest_stat = os.stat(b_dest)
-                os.chown(b_src, dest_stat.st_uid, dest_stat.st_gid)
-                shutil.copystat(b_dest, b_src)
-            except OSError as e:
-                if e.errno != errno.EPERM:
-                    raise
-            if self.selinux_enabled():
-                context = self.selinux_context(dest)
-        else:
-            if self.selinux_enabled():
-                context = self.selinux_default_context(dest)
-
-        creating = not os.path.exists(b_dest)
-
         try:
-            # Optimistically try a rename, solves some corner cases and can avoid useless work, throws exception if not atomic.
-            os.rename(b_src, b_dest)
-        except (IOError, OSError) as e:
-            if e.errno not in [errno.EPERM, errno.EXDEV, errno.EACCES, errno.ETXTBSY, errno.EBUSY]:
-                # only try workarounds for errno 18 (cross device), 1 (not permitted),  13 (permission denied)
-                # and 26 (text file busy) which happens on vagrant synced folders and other 'exotic' non posix file systems
-                self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, to_native(e)), exception=traceback.format_exc())
-            else:
-                # Use bytes here.  In the shippable CI, this fails with
-                # a UnicodeError with surrogateescape'd strings for an unknown
-                # reason (doesn't happen in a local Ubuntu16.04 VM)
-                b_dest_dir = os.path.dirname(b_dest)
-                b_suffix = os.path.basename(b_dest)
-                error_msg = None
-                tmp_dest_name = None
-                try:
-                    tmp_dest_fd, tmp_dest_name = tempfile.mkstemp(prefix=b'.ansible_tmp', dir=b_dest_dir, suffix=b_suffix)
-                except (OSError, IOError) as e:
-                    error_msg = 'The destination directory (%s) is not writable by the current user. Error was: %s' % (os.path.dirname(dest), to_native(e))
-                finally:
-                    if error_msg:
-                        if unsafe_writes:
-                            self._unsafe_writes(b_src, b_dest)
-                        else:
-                            self.fail_json(msg=error_msg, exception=traceback.format_exc())
-
-                if tmp_dest_name:
-                    b_tmp_dest_name = to_bytes(tmp_dest_name, errors='surrogate_or_strict')
-
-                    try:
-                        try:
-                            # close tmp file handle before file operations to prevent text file busy errors on vboxfs synced folders (windows host)
-                            os.close(tmp_dest_fd)
-                            # leaves tmp file behind when sudo and not root
-                            try:
-                                shutil.move(b_src, b_tmp_dest_name, copy_function=shutil.copy if keep_dest_attrs else shutil.copy2)
-                            except OSError:
-                                # cleanup will happen by 'rm' of tmpdir
-                                # copy2 will preserve some metadata
-                                if keep_dest_attrs:
-                                    shutil.copy(b_src, b_tmp_dest_name)
-                                else:
-                                    shutil.copy2(b_src, b_tmp_dest_name)
-
-                            if self.selinux_enabled():
-                                self.set_context_if_different(
-                                    b_tmp_dest_name, context, False)
-                            try:
-                                tmp_stat = os.stat(b_tmp_dest_name)
-                                if keep_dest_attrs and dest_stat and (tmp_stat.st_uid != dest_stat.st_uid or tmp_stat.st_gid != dest_stat.st_gid):
-                                    os.chown(b_tmp_dest_name, dest_stat.st_uid, dest_stat.st_gid)
-                            except OSError as e:
-                                if e.errno != errno.EPERM:
-                                    raise
-                            try:
-                                os.rename(b_tmp_dest_name, b_dest)
-                            except (shutil.Error, OSError, IOError) as e:
-                                if unsafe_writes and e.errno == errno.EBUSY:
-                                    self._unsafe_writes(b_tmp_dest_name, b_dest)
-                                else:
-                                    self.fail_json(msg='Unable to make %s into to %s, failed final rename from %s: %s' %
-                                                       (src, dest, b_tmp_dest_name, to_native(e)), exception=traceback.format_exc())
-                        except (shutil.Error, OSError, IOError) as e:
-                            if unsafe_writes:
-                                self._unsafe_writes(b_src, b_dest)
-                            else:
-                                self.fail_json(msg='Failed to replace file: %s to %s: %s' % (src, dest, to_native(e)), exception=traceback.format_exc())
-                    finally:
-                        self.cleanup(b_tmp_dest_name)
-
-        if creating:
-            # make sure the file has the correct permissions
-            # based on the current value of umask
-            umask = os.umask(0)
-            os.umask(umask)
-            os.chmod(b_dest, S_IRWU_RWG_RWO & ~umask)
-            try:
-                os.chown(b_dest, os.geteuid(), os.getegid())
-            except OSError:
-                # We're okay with trying our best here.  If the user is not
-                # root (or old Unices) they won't be able to chown.
-                pass
-
-        if self.selinux_enabled():
-            # rename might not preserve context
-            self.set_context_if_different(dest, context, False)
+            atomic_move(src, dest, unsafe_writes, keep_dest_attrs, self._selinux_special_fs)
+        except OSError as e:
+            self.fail_json(msg=f'{e}', src=src, dest=dest)
 
     def _unsafe_writes(self, src, dest):
-        # sadly there are some situations where we cannot ensure atomicity, but only if
-        # the user insists and we get the appropriate error we update the file unsafely
         try:
-            out_dest = in_src = None
-            try:
-                out_dest = open(dest, 'wb')
-                in_src = open(src, 'rb')
-                shutil.copyfileobj(in_src, out_dest)
-            finally:  # assuring closed files in 2.4 compatible way
-                if out_dest:
-                    out_dest.close()
-                if in_src:
-                    in_src.close()
-        except (shutil.Error, OSError, IOError) as e:
-            self.fail_json(msg='Could not write data to file (%s) from (%s): %s' % (dest, src, to_native(e)),
-                           exception=traceback.format_exc())
+            write_unsafely(src, dest)
+        except OSError as e:
+            self.fail_json(msg=f'{e}', exception=traceback.format_exc())
 
     def _clean_args(self, args):
 

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -3,16 +3,32 @@
 
 from __future__ import annotations
 
+import errno
 import os
-import stat
 import re
+import shutil
+import stat
+import sys
+import tempfile
+
+import typing as t
+
+from pathlib import Path
 
 try:
-    import selinux  # pylint: disable=unused-import
+    import selinux
     HAVE_SELINUX = True
 except ImportError:
     HAVE_SELINUX = False
 
+from ansible.module_utils.common.text.converters import to_bytes, to_text
+
+if t.TYPE_CHECKING:
+    Path_type = t.Union[bytes, str, os.PathLike]
+    SEEntry = t.Union[str, None]
+    SEContext = t.Union[t.List[SEEntry], None]
+
+DEFAULT_SELINUX_CONTEXT: SEContext = [None, None, None]
 
 FILE_ATTRIBUTES = {
     'A': 'noatime',
@@ -37,7 +53,6 @@ FILE_ATTRIBUTES = {
     'Z': 'compresseddirty',
 }
 
-
 # Used for parsing symbolic file perms
 MODE_OPERATOR_RE = re.compile(r'[+=-]')
 USERS_RE = re.compile(r'[^ugo]')
@@ -55,7 +70,45 @@ _EXEC_PERM_BITS = S_IXANY       # execute permission bits
 _DEFAULT_PERM = S_IRWU_RWG_RWO  # default file permission bits
 
 
-def is_executable(path):
+def unfrackpath(path: Path_type, follow: bool = True, basedir: Path_type | None = None) -> str:
+    '''
+    Returns a path that is free of symlinks (if follow=True), environment variables, relative path traversals and symbols (~)
+
+    :arg path: A byte or text string representing a path to be canonicalized
+    :arg follow: A boolean to indicate of symlinks should be resolved or not
+    :arg basedir: A byte string, text string, PathLike object, or `None`
+        representing where a relative path should be resolved from.
+        `None` will be substituted for the current working directory.
+    :raises UnicodeDecodeError: If the canonicalized version of the path
+        contains non-utf8 byte sequences.
+    :rtype: A text string (unicode on pyyhon2, str on python3).
+    :returns: An absolute path with symlinks, environment variables, and tilde
+        expanded.  Note that this does not check whether a path exists.
+
+    example::
+        '$HOME/../../var/mail' becomes '/var/spool/mail'
+    '''
+
+    if basedir is None:
+        basedir = Path.cwd()
+    else:
+        basedir = Path(to_text(basedir, errors='surrogate_or_strict'))
+        if basedir.is_file():
+            basedir = basedir.parent
+
+    final_path = Path(os.path.expandvars(to_text(path, errors='surrogate_or_strict'))).expanduser()
+
+    if not final_path.is_absolute():
+        final_path = basedir / final_path
+
+    if follow and final_path.is_symlink():
+        # TODO: move to Path.readlink() once python 3.8 is history
+        final_path = os.readlink(to_text(final_path, errors='surrogate_or_strict'))
+
+    return os.path.normpath(to_text(final_path, errors='surrogate_or_strict'))
+
+
+def is_executable(path: Path_type) -> bool:
     # This function's signature needs to be repeated
     # as the first line of its docstring.
     # This method is reused by the basic module,
@@ -76,21 +129,21 @@ def is_executable(path):
     # These are all bitfields so first bitwise-or all the permissions we're
     # looking for, then bitwise-and with the file's mode to determine if any
     # execute bits are set.
-    return ((stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH) & os.stat(path)[stat.ST_MODE])
+    return bool((stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH) & os.stat(path)[stat.ST_MODE])
 
 
-def format_attributes(attributes):
+def format_attributes(attributes: list) -> list:
     attribute_list = [FILE_ATTRIBUTES.get(attr) for attr in attributes if attr in FILE_ATTRIBUTES]
     return attribute_list
 
 
-def get_flags_from_attributes(attributes):
+def get_flags_from_attributes(attributes: list) -> str:
     flags = [key for key, attr in FILE_ATTRIBUTES.items() if attr in attributes]
     return ''.join(flags)
 
 
-def get_file_arg_spec():
-    arg_spec = dict(
+def get_file_arg_spec() -> dict:
+    return dict(
         mode=dict(type='raw'),
         owner=dict(),
         group=dict(),
@@ -100,4 +153,252 @@ def get_file_arg_spec():
         setype=dict(),
         attributes=dict(aliases=['attr']),
     )
-    return arg_spec
+
+
+def find_mount_point(path: Path_type) -> str:
+    '''
+        Takes a path and returns its mount point
+
+    :param path: a string type with a filesystem path
+    :returns: the path to the mount point as a text type
+    '''
+    b_path = to_bytes(unfrackpath(path, follow=True), errors='surrogate_or_strict')
+    while not os.path.ismount(b_path):
+        b_path = os.path.dirname(b_path)
+
+    return to_text(b_path, errors='surrogate_or_strict')
+
+
+def write_unsafely(src: Path_type, dest: Path_type):
+    '''
+        sadly there are some situations where we cannot ensure atomicity, but only if
+        the user insists and we get the appropriate error we update the file unsafely
+    '''
+    try:
+        with open(dest, 'wb') as out_dest, open(src, 'rb') as in_src:
+            shutil.copyfileobj(in_src, out_dest)
+    except (shutil.Error, OSError, IOError) as e:
+        raise OSError(f'Could not write data to file ({dest!r}) from ({src!r}): {e!r}')
+
+
+def atomic_move(src: Path_type, dest: Path_type, unsafe_writes: bool = False, keep_dest_attrs: bool = True, special_fs: list[str] | None = None):
+    '''atomically move src to dest, copying attributes from dest, returns true on success
+    it uses os.rename to ensure this as it is an atomic operation, rest of the function is
+    to work around limitations, corner cases and ensure selinux context is saved if possible'''
+    context = None
+    dest_stat = None
+    b_src = to_bytes(src, errors='surrogate_or_strict')
+    b_dest = to_bytes(dest, errors='surrogate_or_strict')
+    if os.path.exists(b_dest) and keep_dest_attrs:
+        try:
+            dest_stat = os.stat(b_dest)
+            os.chown(b_src, dest_stat.st_uid, dest_stat.st_gid)
+            shutil.copystat(b_dest, b_src)
+        except OSError as e:
+            if e.errno != errno.EPERM:
+                raise
+        if is_selinux_enabled():
+            context = get_path_selinux_context(dest)
+    else:
+        if is_selinux_enabled():
+            context = get_path_default_selinux_context(dest)
+
+    creating = not os.path.exists(b_dest)
+
+    try:
+        # Optimistically try a rename, solves some corner cases and can avoid useless work, throws exception if not atomic.
+        os.rename(b_src, b_dest)
+    except (IOError, OSError) as e:
+        if e.errno not in [errno.EPERM, errno.EXDEV, errno.EACCES, errno.ETXTBSY, errno.EBUSY]:
+            # only try workarounds for errno 18 (cross device), 1 (not permitted),  13 (permission denied)
+            # and 26 (text file busy) which happens on vagrant synced folders and other 'exotic' non posix file systems
+            raise OSError(f'Could not replace file "{src!r}" to "{dest!r}": {e!r}')
+        else:
+            # Use bytes here.  In the shippable CI, this fails with
+            # a UnicodeError with surrogateescape'd strings for an unknown
+            # reason (doesn't happen in a local Ubuntu16.04 VM)
+            b_dest_dir = os.path.dirname(b_dest)
+            b_suffix = os.path.basename(b_dest)
+            error_msg = None
+            tmp_dest_name = None
+            try:
+                tmp_dest_fd, tmp_dest_name = tempfile.mkstemp(prefix=b'.ansible_tmp', dir=b_dest_dir, suffix=b_suffix)
+            except (OSError, IOError) as e:
+                error_msg = 'The destination directory (%r) is not writable by the current user. Error was: %r' % (os.path.dirname(dest), e)
+            finally:
+                if error_msg:
+                    if unsafe_writes:
+                        write_unsafely(b_src, b_dest)
+                    else:
+                        raise OSError(error_msg)
+
+            if tmp_dest_name:
+                b_tmp_dest_name = to_bytes(tmp_dest_name, errors='surrogate_or_strict')
+
+                try:
+                    try:
+                        # close tmp file handle before file operations to prevent text file busy errors on vboxfs synced folders (windows host)
+                        os.close(tmp_dest_fd)
+                        # leaves tmp file behind when sudo and not root
+                        try:
+                            shutil.move(b_src, b_tmp_dest_name, copy_function=shutil.copy if keep_dest_attrs else shutil.copy2)
+                        except OSError:
+                            # cleanup will happen by 'rm' of tmpdir
+                            # copy2 will preserve some metadata
+                            if keep_dest_attrs:
+                                shutil.copy(b_src, b_tmp_dest_name)
+                            else:
+                                shutil.copy2(b_src, b_tmp_dest_name)
+
+                        if is_selinux_enabled():
+                            set_selinux_context(b_tmp_dest_name, context, special_fs, False)
+                        try:
+                            tmp_stat = os.stat(b_tmp_dest_name)
+                            if keep_dest_attrs and dest_stat and (tmp_stat.st_uid != dest_stat.st_uid or tmp_stat.st_gid != dest_stat.st_gid):
+                                os.chown(b_tmp_dest_name, dest_stat.st_uid, dest_stat.st_gid)
+                        except OSError as e:
+                            if e.errno != errno.EPERM:
+                                raise
+                        try:
+                            os.rename(b_tmp_dest_name, b_dest)
+                        except (shutil.Error, OSError, IOError) as e:
+                            if unsafe_writes and e.errno == errno.EBUSY:
+                                write_unsafely(b_tmp_dest_name, b_dest)
+                            else:
+                                raise OSError('Unable to make %r into to %r, failed final rename from %r: %r' %
+                                              (src, dest, b_tmp_dest_name, e))
+                    except (shutil.Error, OSError, IOError) as e:
+                        if unsafe_writes:
+                            write_unsafely(b_src, b_dest)
+                        else:
+                            raise OSError('Failed to replace file "%r" to "%r": %r' % (src, dest, e))
+                finally:
+                    if os.path.exists(b_tmp_dest_name):
+                        try:
+                            os.unlink(b_tmp_dest_name)
+                        except OSError as e:
+                            sys.stderr.write(f"Could not cleanup '{b_tmp_dest_name!r}': {e!r}")
+    if creating:
+        # make sure the file has the correct permissions
+        # based on the current value of umask
+        umask = os.umask(0)
+        os.umask(umask)
+        os.chmod(b_dest, S_IRWU_RWG_RWO & ~umask)
+        try:
+            os.chown(b_dest, os.geteuid(), os.getegid())
+        except OSError:
+            # We're okay with trying our best here.  If the user is not
+            # root (or old Unices) they won't be able to chown.
+            pass
+
+    if is_selinux_enabled():
+        # rename might not preserve context
+        set_selinux_context(dest, context, special_fs, False)
+
+
+# SELINUX ############
+def is_selinux_enabled() -> bool:
+    return bool(HAVE_SELINUX and selinux.is_selinux_enabled() == 1)
+
+
+def is_selinux_mls_enabled() -> bool:
+    return bool(HAVE_SELINUX and selinux.is_selinux_mls_enabled() == 1)
+
+
+if is_selinux_mls_enabled():
+    # mls adds security level/4th field
+    if DEFAULT_SELINUX_CONTEXT is not None:  # typechecking
+        DEFAULT_SELINUX_CONTEXT.append(None)
+
+
+def is_special_selinux_path(path: Path_type, special_fs: t.Union[list[str], None] = None) -> tuple[bool, SEContext]:
+    """
+    Returns a tuple containing (True, selinux_context) if the given path is on a
+    NFS or other 'special' fs  mount point, otherwise the return will be (False, None).
+    """
+    is_special = False
+    special_context = DEFAULT_SELINUX_CONTEXT
+    if special_fs is None:
+        special_fs = []
+
+    try:
+        with open('/proc/mounts', 'r') as f:
+            mount_data = f.readlines()
+
+        path_mount_point = Path(find_mount_point(path))
+
+        for line in mount_data:
+            if is_special:
+                break
+            (device, mount_point, fstype, options, rest) = line.split(' ', 4)
+            if path_mount_point.samefile(mount_point):
+                for fs in special_fs:
+                    if fs in fstype:
+                        special_context = get_path_selinux_context(path_mount_point)
+                        is_special = True
+                        break
+    except (OSError, IOError):
+        # can ignore fs errors, will just not flag as special
+        pass
+
+    return (is_special, special_context)
+
+
+def _seresult_to_context(ret: list[t.Any]) -> SEContext:
+    context = DEFAULT_SELINUX_CONTEXT
+    if ret[0] != -1:
+        # Limit split to 4 because the selevel, the last in the list,
+        # may contain ':' characters
+        context = ret[1].split(':', 3)
+    return context
+
+
+def get_path_default_selinux_context(path: Path_type, mode: int = 0) -> SEContext:
+
+    context = DEFAULT_SELINUX_CONTEXT
+    if is_selinux_enabled():
+        context = _seresult_to_context(selinux.matchpathcon(to_text(path, errors='surrogate_or_strict'), mode))
+    return context
+
+
+def get_path_selinux_context(path: Path_type) -> SEContext:
+
+    context = DEFAULT_SELINUX_CONTEXT
+    try:
+        context = _seresult_to_context(selinux.lgetfilecon_raw(to_text(path, errors='surrogate_or_strict')))
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            msg = f'path ({path!r}) does not exist'
+        else:
+            msg = f'failed to retrieve selinux context for "{path!r}"'
+        raise OSError(msg)
+
+    return context
+
+
+def set_selinux_context(path: Path_type, context: SEContext, special_fs: list[str] | None = None, simulate: bool = False) -> tuple[SEContext, SEContext]:
+
+    cur_context = get_path_selinux_context(path)
+    new_context = DEFAULT_SELINUX_CONTEXT
+
+    if is_selinux_enabled():
+        new_context = cur_context
+        # Iterate over the current context instead of the
+        # argument context, which may have selevel.
+        (is_special_se, sp_context) = is_special_selinux_path(path, special_fs)
+        if is_special_se:
+            new_context = sp_context
+        elif None not in (context, cur_context, new_context):
+            for i in range(len(cur_context)):  # type: ignore
+                if len(context) > i:  # type: ignore
+                    if context[i] is not None and context[i] != cur_context[i]:  # type: ignore
+                        new_context[i] = context[i]  # type: ignore
+                    elif context[i] is None:  # type: ignore
+                        new_context[i] = cur_context[i]  # type: ignore
+
+        if cur_context != new_context and not simulate:
+            rc = selinux.lsetfilecon(str(path), ':'.join([x or '' for x in new_context]))  # type: ignore
+            if rc != 0:
+                raise OSError('Settting selinux context to "{new_context!r}" failed')
+
+    return cur_context, new_context

--- a/lib/ansible/utils/path.py
+++ b/lib/ansible/utils/path.py
@@ -22,46 +22,10 @@ import shutil
 from errno import EEXIST
 from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
+from ansible.module_utils.common.file import unfrackpath
 
 
 __all__ = ['unfrackpath', 'makedirs_safe']
-
-
-def unfrackpath(path, follow=True, basedir=None):
-    '''
-    Returns a path that is free of symlinks (if follow=True), environment variables, relative path traversals and symbols (~)
-
-    :arg path: A byte or text string representing a path to be canonicalized
-    :arg follow: A boolean to indicate of symlinks should be resolved or not
-    :arg basedir: A byte string, text string, PathLike object, or `None`
-        representing where a relative path should be resolved from.
-        `None` will be substituted for the current working directory.
-    :raises UnicodeDecodeError: If the canonicalized version of the path
-        contains non-utf8 byte sequences.
-    :rtype: A text string (unicode on pyyhon2, str on python3).
-    :returns: An absolute path with symlinks, environment variables, and tilde
-        expanded.  Note that this does not check whether a path exists.
-
-    example::
-        '$HOME/../../var/mail' becomes '/var/spool/mail'
-    '''
-
-    b_basedir = to_bytes(basedir, errors='surrogate_or_strict', nonstring='passthru')
-
-    if b_basedir is None:
-        b_basedir = to_bytes(os.getcwd(), errors='surrogate_or_strict')
-    elif os.path.isfile(b_basedir):
-        b_basedir = os.path.dirname(b_basedir)
-
-    b_final_path = os.path.expanduser(os.path.expandvars(to_bytes(path, errors='surrogate_or_strict')))
-
-    if not os.path.isabs(b_final_path):
-        b_final_path = os.path.join(b_basedir, b_final_path)
-
-    if follow:
-        b_final_path = os.path.realpath(b_final_path)
-
-    return to_text(os.path.normpath(b_final_path), errors='surrogate_or_strict')
 
 
 def makedirs_safe(path, mode=None):

--- a/test/units/module_utils/basic/test_selinux.py
+++ b/test/units/module_utils/basic/test_selinux.py
@@ -97,17 +97,17 @@ class TestSELinuxMU:
         am = no_args_module(selinux_enabled=True, selinux_mls_enabled=True)
         with patch.object(file_common, 'selinux', create=True) as selinux:
             # matchpathcon success
-            file_common.selinux.matchpathcon.return_value = [0, 'unconfined_u:object_r:default_t:s0']
+            file_common.get_path_default_selinux_context.return_value = [0, 'unconfined_u:object_r:default_t:s0']
             assert am.selinux_default_context(path='/foo/bar') == ['unconfined_u', 'object_r', 'default_t', 's0']
 
         with patch.object(file_common, 'selinux', create=True) as selinux:
             # matchpathcon fail (return initial context value)
-            file_common.selinux.matchpathcon.return_value = [-1, '']
+            file_common.get_path_default_selinux_context.return_value = [-1, '']
             assert am.selinux_default_context(path='/foo/bar') == [None, None, None, None]
 
         with patch.object(file_common, 'selinux', create=True) as selinux:
             # matchpathcon OSError
-            file_common.selinux.matchpathcon.side_effect = OSError
+            file_common.get_path_default_selinux_context.side_effect = OSError
             assert am.selinux_default_context(path='/foo/bar') == [None, None, None, None]
 
     def test_selinux_context(self):
@@ -118,22 +118,22 @@ class TestSELinuxMU:
         am = no_args_module(selinux_enabled=True, selinux_mls_enabled=True)
         # lgetfilecon_raw passthru
         with patch.object(file_common, 'selinux', create=True) as selinux:
-            file_common.selinux.lgetfilecon_raw.return_value = [0, 'unconfined_u:object_r:default_t:s0']
+            file_common.get_path_selinux_context.return_value = [0, 'unconfined_u:object_r:default_t:s0']
             assert am.selinux_context(path='/foo/bar') == ['unconfined_u', 'object_r', 'default_t', 's0']
 
         # lgetfilecon_raw returned a failure
         with patch.object(file_common, 'selinux', create=True) as selinux:
-            file_common.selinux.lgetfilecon_raw.return_value = [-1, '']
+            file_common.get_path_selinux_context.return_value = [-1, '']
             assert am.selinux_context(path='/foo/bar') == [None, None, None, None]
 
         # lgetfilecon_raw OSError (should bomb the module)
         with patch.object(file_common, 'selinux', create=True) as selinux:
-            file_common.selinux.lgetfilecon_raw.side_effect = OSError(errno.ENOENT, 'NotFound')
+            file_common.get_path_selinux-context.side_effect = OSError(errno.ENOENT, 'NotFound')
             with pytest.raises(SystemExit):
                 am.selinux_context(path='/foo/bar')
 
         with patch.object(file_common, 'selinux', create=True) as selinux:
-            file_common.selinux.lgetfilecon_raw.side_effect = OSError()
+            file_common.get_path_selinux_context.side_effect = OSError()
             with pytest.raises(SystemExit):
                 am.selinux_context(path='/foo/bar')
 

--- a/test/units/module_utils/basic/test_selinux.py
+++ b/test/units/module_utils/basic/test_selinux.py
@@ -13,6 +13,7 @@ import pytest
 from unittest.mock import mock_open, patch
 
 from ansible.module_utils import basic
+from ansible.module_utils.common import file as file_common
 from ansible.module_utils.common.text.converters import to_bytes
 import builtins
 
@@ -27,9 +28,15 @@ def no_args_module(selinux_enabled=None, selinux_mls_enabled=None):
     am = basic.AnsibleModule(argument_spec={})
     # just dirty-patch the wrappers on the object instance since it's short-lived
     if isinstance(selinux_enabled, bool):
-        patch.object(am, 'selinux_enabled', return_value=selinux_enabled).start()
+        patch.object(file_common, 'is_selinux_enabled', return_value=selinux_enabled).start()
+    # reset to the default
+    context = [None, None, None]
     if isinstance(selinux_mls_enabled, bool):
-        patch.object(am, 'selinux_mls_enabled', return_value=selinux_mls_enabled).start()
+        patch.object(file_common, 'is_selinux_mls_enabled', return_value=selinux_mls_enabled).start()
+        if selinux_mls_enabled:
+            context = [None, None, None, None]
+    patch.object(file_common, 'DEFAULT_SELINUX_CONTEXT', context).start()
+    patch.object(am, '_selinux_initial_context', context).start()
     return am
 
 
@@ -39,12 +46,12 @@ class TestSELinuxMU:
     def test_selinux_enabled(self):
         # test selinux unavailable
         # selinux unavailable, should return false
-        with patch.object(basic, 'HAVE_SELINUX', False):
+        with patch.object(file_common, 'HAVE_SELINUX', False):
             assert no_args_module().selinux_enabled() is False
 
             # test selinux present/not-enabled
             disabled_mod = no_args_module()
-            with patch.object(basic, 'selinux', create=True) as selinux:
+            with patch.object(file_common, 'selinux', create=True) as selinux:
                 selinux.is_selinux_enabled.return_value = 0
                 assert disabled_mod.selinux_enabled() is False
 
@@ -52,9 +59,9 @@ class TestSELinuxMU:
         assert disabled_mod.selinux_enabled() is False
 
         # and present / enabled
-        with patch.object(basic, 'HAVE_SELINUX', True):
+        with patch.object(file_common, 'HAVE_SELINUX', True):
             enabled_mod = no_args_module()
-            with patch.object(basic, 'selinux', create=True) as selinux:
+            with patch.object(file_common, 'selinux', create=True) as selinux:
                 selinux.is_selinux_enabled.return_value = 1
                 assert enabled_mod.selinux_enabled() is True
         # ensure value is cached (same answer after unpatching)
@@ -62,16 +69,16 @@ class TestSELinuxMU:
 
     def test_selinux_mls_enabled(self):
         # selinux unavailable, should return false
-        with patch.object(basic, 'HAVE_SELINUX', False):
+        with patch.object(file_common, 'HAVE_SELINUX', False):
             assert no_args_module().selinux_mls_enabled() is False
             # selinux disabled, should return false
-            with patch.object(basic, 'selinux', create=True) as selinux:
+            with patch.object(file_common, 'selinux', create=True) as selinux:
                 selinux.is_selinux_mls_enabled.return_value = 0
                 assert no_args_module(selinux_enabled=False).selinux_mls_enabled() is False
 
-        with patch.object(basic, 'HAVE_SELINUX', True):
+        with patch.object(file_common, 'HAVE_SELINUX', True):
             # selinux enabled, should pass through the value of is_selinux_mls_enabled
-            with patch.object(basic, 'selinux', create=True) as selinux:
+            with patch.object(file_common, 'selinux', create=True) as selinux:
                 selinux.is_selinux_mls_enabled.return_value = 1
                 assert no_args_module(selinux_enabled=True).selinux_mls_enabled() is True
 
@@ -84,49 +91,49 @@ class TestSELinuxMU:
 
     def test_selinux_default_context(self):
         # selinux unavailable
-        with patch.object(basic, 'HAVE_SELINUX', False):
+        with patch.object(file_common, 'HAVE_SELINUX', False):
             assert no_args_module().selinux_default_context(path='/foo/bar') == [None, None, None]
 
         am = no_args_module(selinux_enabled=True, selinux_mls_enabled=True)
-        with patch.object(basic, 'selinux', create=True) as selinux:
+        with patch.object(file_common, 'selinux', create=True) as selinux:
             # matchpathcon success
-            selinux.matchpathcon.return_value = [0, 'unconfined_u:object_r:default_t:s0']
+            file_common.selinux.matchpathcon.return_value = [0, 'unconfined_u:object_r:default_t:s0']
             assert am.selinux_default_context(path='/foo/bar') == ['unconfined_u', 'object_r', 'default_t', 's0']
 
-        with patch.object(basic, 'selinux', create=True) as selinux:
+        with patch.object(file_common, 'selinux', create=True) as selinux:
             # matchpathcon fail (return initial context value)
-            selinux.matchpathcon.return_value = [-1, '']
+            file_common.selinux.matchpathcon.return_value = [-1, '']
             assert am.selinux_default_context(path='/foo/bar') == [None, None, None, None]
 
-        with patch.object(basic, 'selinux', create=True) as selinux:
+        with patch.object(file_common, 'selinux', create=True) as selinux:
             # matchpathcon OSError
-            selinux.matchpathcon.side_effect = OSError
+            file_common.selinux.matchpathcon.side_effect = OSError
             assert am.selinux_default_context(path='/foo/bar') == [None, None, None, None]
 
     def test_selinux_context(self):
         # selinux unavailable
-        with patch.object(basic, 'HAVE_SELINUX', False):
+        with patch.object(file_common, 'HAVE_SELINUX', False):
             assert no_args_module().selinux_context(path='/foo/bar') == [None, None, None]
 
         am = no_args_module(selinux_enabled=True, selinux_mls_enabled=True)
         # lgetfilecon_raw passthru
-        with patch.object(basic, 'selinux', create=True) as selinux:
-            selinux.lgetfilecon_raw.return_value = [0, 'unconfined_u:object_r:default_t:s0']
+        with patch.object(file_common, 'selinux', create=True) as selinux:
+            file_common.selinux.lgetfilecon_raw.return_value = [0, 'unconfined_u:object_r:default_t:s0']
             assert am.selinux_context(path='/foo/bar') == ['unconfined_u', 'object_r', 'default_t', 's0']
 
         # lgetfilecon_raw returned a failure
-        with patch.object(basic, 'selinux', create=True) as selinux:
-            selinux.lgetfilecon_raw.return_value = [-1, '']
+        with patch.object(file_common, 'selinux', create=True) as selinux:
+            file_common.selinux.lgetfilecon_raw.return_value = [-1, '']
             assert am.selinux_context(path='/foo/bar') == [None, None, None, None]
 
         # lgetfilecon_raw OSError (should bomb the module)
-        with patch.object(basic, 'selinux', create=True) as selinux:
-            selinux.lgetfilecon_raw.side_effect = OSError(errno.ENOENT, 'NotFound')
+        with patch.object(file_common, 'selinux', create=True) as selinux:
+            file_common.selinux.lgetfilecon_raw.side_effect = OSError(errno.ENOENT, 'NotFound')
             with pytest.raises(SystemExit):
                 am.selinux_context(path='/foo/bar')
 
-        with patch.object(basic, 'selinux', create=True) as selinux:
-            selinux.lgetfilecon_raw.side_effect = OSError()
+        with patch.object(file_common, 'selinux', create=True) as selinux:
+            file_common.selinux.lgetfilecon_raw.side_effect = OSError()
             with pytest.raises(SystemExit):
                 am.selinux_context(path='/foo/bar')
 
@@ -181,7 +188,7 @@ class TestSELinuxMU:
         am.selinux_context = lambda path: ['bar_u', 'bar_r', None, None]
         am.is_special_selinux_path = lambda path: (False, None)
 
-        with patch.object(basic, 'selinux', create=True) as selinux:
+        with patch.object(file_common, 'selinux', create=True) as selinux:
             selinux.lsetfilecon.return_value = 0
             assert am.set_context_if_different('/path/to/file', ['foo_u', 'foo_r', 'foo_t', 's0'], False) is True
             selinux.lsetfilecon.assert_called_with('/path/to/file', 'foo_u:foo_r:foo_t:s0')
@@ -191,19 +198,19 @@ class TestSELinuxMU:
             assert not selinux.lsetfilecon.called
             am.check_mode = False
 
-        with patch.object(basic, 'selinux', create=True) as selinux:
+        with patch.object(file_common, 'selinux', create=True) as selinux:
             selinux.lsetfilecon.return_value = 1
             with pytest.raises(SystemExit):
                 am.set_context_if_different('/path/to/file', ['foo_u', 'foo_r', 'foo_t', 's0'], True)
 
-        with patch.object(basic, 'selinux', create=True) as selinux:
+        with patch.object(file_common, 'selinux', create=True) as selinux:
             selinux.lsetfilecon.side_effect = OSError
             with pytest.raises(SystemExit):
                 am.set_context_if_different('/path/to/file', ['foo_u', 'foo_r', 'foo_t', 's0'], True)
 
         am.is_special_selinux_path = lambda path: (True, ['sp_u', 'sp_r', 'sp_t', 's0'])
 
-        with patch.object(basic, 'selinux', create=True) as selinux:
+        with patch.object(file_common, 'selinux', create=True) as selinux:
             selinux.lsetfilecon.return_value = 0
             assert am.set_context_if_different('/path/to/file', ['foo_u', 'foo_r', 'foo_t', 's0'], False) is True
             selinux.lsetfilecon.assert_called_with('/path/to/file', 'sp_u:sp_r:sp_t:s0')

--- a/test/units/module_utils/basic/test_selinux.py
+++ b/test/units/module_utils/basic/test_selinux.py
@@ -128,7 +128,7 @@ class TestSELinuxMU:
 
         # lgetfilecon_raw OSError (should bomb the module)
         with patch.object(file_common, 'selinux', create=True) as selinux:
-            file_common.get_path_selinux-context.side_effect = OSError(errno.ENOENT, 'NotFound')
+            file_common.get_path_selinux_context.side_effect = OSError(errno.ENOENT, 'NotFound')
             with pytest.raises(SystemExit):
                 am.selinux_context(path='/foo/bar')
 


### PR DESCRIPTION

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION
keep AnsibleModule methods as wrappers for backwards compat and specific AM expected behaviour