### PR TITLE
Add dinit as a service_mgr

### DIFF
--- a/changelogs/fragments/dinit.yml
+++ b/changelogs/fragments/dinit.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - service_mgr - add support for dinit service manager (https://github.com/ansible/ansible/pull/83489).

--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -144,6 +144,8 @@ class ServiceMgrFactCollector(BaseFactCollector):
                 service_mgr_name = 'systemd'
             elif os.path.exists('/etc/init.d/'):
                 service_mgr_name = 'sysvinit'
+            elif os.path.exists('/etc/dinit.d/'):
+                service_mgr_name = 'dinit'
 
         if not service_mgr_name:
             # if we cannot detect, fallback to generic 'service'


### PR DESCRIPTION
##### SUMMARY

Detect [dinit](https://davmac.org/projects/dinit/) as an init system / service manager / supervision suite. I'm using some [Chimera Linux](https://chimera-linux.org/) hosts and using ansible to manage them isn't working all that well yet, mostly due to dinit being neither recognized, nor supported in any way yet.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

