### PR TITLE
Fix tb for when env var contains %

### DIFF
--- a/changelogs/fragments/83498-command-tb-env.yml
+++ b/changelogs/fragments/83498-command-tb-env.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix a traceback when an environment variable contains certain special characters (https://github.com/ansible/ansible/issues/83498)

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -211,7 +211,11 @@ class ShellBase(AnsiblePlugin):
             arg_path,
         ]
 
-        return f'{env_string}{self.join(cps for cp in cmd_parts if cp and (cps := cp.strip()))}'
+        cleaned_up_cmd = self.join(
+            stripped_cmd_part for raw_cmd_part in cmd_parts
+            if raw_cmd_part and (stripped_cmd_part := raw_cmd_part.strip())
+        )
+        return ''.join((env_string, cleaned_up_cmd))
 
     def append_command(self, cmd, cmd_to_append):
         """Append an additional command if supported by the shell"""

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -211,7 +211,7 @@ class ShellBase(AnsiblePlugin):
             arg_path,
         ]
 
-        return f'{env_string}%s' % self.join(cps for cp in cmd_parts if cp and (cps := cp.strip()))
+        return f'{env_string}{self.join(cps for cp in cmd_parts if cp and (cps := cp.strip()))}'
 
     def append_command(self, cmd, cmd_to_append):
         """Append an additional command if supported by the shell"""

--- a/test/integration/targets/shell/tasks/command-building.yml
+++ b/test/integration/targets/shell/tasks/command-building.yml
@@ -28,6 +28,7 @@
         ANSIBLE_REMOTE_TMP: '{{ atd }}'
         ANSIBLE_NOCOLOR: "1"
         ANSIBLE_FORCE_COLOR: "0"
+        TEST: "foo%D"
       register: command_building
       delegate_to: localhost
 


### PR DESCRIPTION
##### SUMMARY
By constructing the string utilizing f-string only.

Fixes #83498
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
