### PR TITLE
Replace references to archived ansible/ansible-examples repository

### DIFF
--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -241,7 +241,7 @@ notes:
 EXAMPLES = '''
 - name: Git checkout
   ansible.builtin.git:
-    repo: git@github.com:ansible/ansible.git
+    repo: 'https://github.com/ansible/ansible.git'
     dest: /tmp/checkout
     version: release-0.22
 
@@ -252,7 +252,7 @@ EXAMPLES = '''
 
 - name: Just ensuring the repo checkout exists
   ansible.builtin.git:
-    repo: git@github.com:ansible/ansible.git
+    repo: 'https://github.com/ansible/ansible.git'
     dest: /tmp/checkout
     update: no
 
@@ -265,7 +265,7 @@ EXAMPLES = '''
 
 - name: Checkout a github repo and use refspec to fetch all pull requests
   ansible.builtin.git:
-    repo: git@github.com:ansible/ansible.git
+    repo: 'https://github.com/ansible/ansible.git'
     dest: /tmp/checkout
     refspec: '+refs/pull/*:refs/heads/*'
 
@@ -277,7 +277,7 @@ EXAMPLES = '''
 
 - name: Clone a repo with separate git directory
   ansible.builtin.git:
-    repo: git@github.com:ansible/ansible.git
+    repo: 'https://github.com/ansible/ansible.git'
     dest: /tmp/checkout
     separate_git_dir: /tmp/repo
 
@@ -290,7 +290,7 @@ EXAMPLES = '''
 
 - name: Avoid hanging when http(s) password is missing
   ansible.builtin.git:
-    repo: git@github.com:ansible/ansible.git
+    repo: 'https://github.com/ansible/ansible.git'
     dest: /tmp/checkout
   environment:
     GIT_TERMINAL_PROMPT: 0 # reports "terminal prompts disabled" on missing password

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -241,57 +241,57 @@ notes:
 EXAMPLES = '''
 - name: Git checkout
   ansible.builtin.git:
-    repo: 'https://foosball.example.org/path/to/repo.git'
-    dest: /srv/checkout
+    repo: git@github.com:ansible/ansible.git
+    dest: /tmp/checkout
     version: release-0.22
 
 - name: Read-write git checkout from github
   ansible.builtin.git:
-    repo: git@github.com:mylogin/hello.git
-    dest: /home/mylogin/hello
+    repo: git@github.com:ansible/ansible.git
+    dest: /tmp/checkout
 
 - name: Just ensuring the repo checkout exists
   ansible.builtin.git:
-    repo: 'https://foosball.example.org/path/to/repo.git'
-    dest: /srv/checkout
+    repo: git@github.com:ansible/ansible.git
+    dest: /tmp/checkout
     update: no
 
 - name: Just get information about the repository whether or not it has already been cloned locally
   ansible.builtin.git:
-    repo: 'https://foosball.example.org/path/to/repo.git'
-    dest: /srv/checkout
+    repo: git@github.com:ansible/ansible.git
+    dest: /tmp/checkout
     clone: no
     update: no
 
 - name: Checkout a github repo and use refspec to fetch all pull requests
   ansible.builtin.git:
-    repo: git@github.com:mylogin/hello.git
-    dest: /home/mylogin/hello
+    repo: git@github.com:ansible/ansible.git
+    dest: /tmp/checkout
     refspec: '+refs/pull/*:refs/heads/*'
 
 - name: Create git archive from repo
   ansible.builtin.git:
-    repo: git@github.com:mylogin/hello.git
-    dest: /home/mylogin/hello
-    archive: /home/mylogin/hello.zip
+    repo: git@github.com:ansible/ansible.git
+    dest: /tmp/checkout
+    archive: /tmp/ansible.zip
 
 - name: Clone a repo with separate git directory
   ansible.builtin.git:
-    repo: git@github.com:mylogin/hello.git
-    dest: /home/mylogin/hello
-    separate_git_dir: /home/mylogin/hello.git
+    repo: git@github.com:ansible/ansible.git
+    dest: /tmp/checkout
+    separate_git_dir: /tmp/repo
 
 - name: Example clone of a single branch
   ansible.builtin.git:
-    repo: git@github.com:mylogin/hello.git
-    dest: /home/mylogin/hello
+    repo: git@github.com:ansible/ansible.git
+    dest: /tmp/checkout
     single_branch: yes
     version: master
 
 - name: Avoid hanging when http(s) password is missing
   ansible.builtin.git:
-    repo: https://github.com/ansible/could-be-a-private-repo
-    dest: /src/from-private-repo
+    repo: git@github.com:ansible/ansible.git
+    dest: /tmp/checkout
   environment:
     GIT_TERMINAL_PROMPT: 0 # reports "terminal prompts disabled" on missing password
     # or GIT_ASKPASS: /bin/true # for git before version 2.3.0, reports "Authentication failed" on missing password

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -265,26 +265,26 @@ EXAMPLES = '''
 
 - name: Checkout a github repo and use refspec to fetch all pull requests
   ansible.builtin.git:
-    repo: https://github.com/ansible/ansible-examples.git
-    dest: /src/ansible-examples
+    repo: git@github.com:mylogin/hello.git
+    dest: /home/mylogin/hello
     refspec: '+refs/pull/*:refs/heads/*'
 
 - name: Create git archive from repo
   ansible.builtin.git:
-    repo: https://github.com/ansible/ansible-examples.git
-    dest: /src/ansible-examples
-    archive: /tmp/ansible-examples.zip
+    repo: git@github.com:mylogin/hello.git
+    dest: /home/mylogin/hello
+    archive: /home/mylogin/hello.zip
 
 - name: Clone a repo with separate git directory
   ansible.builtin.git:
-    repo: https://github.com/ansible/ansible-examples.git
-    dest: /src/ansible-examples
-    separate_git_dir: /src/ansible-examples.git
+    repo: git@github.com:mylogin/hello.git
+    dest: /home/mylogin/hello
+    separate_git_dir: /home/mylogin/hello.git
 
 - name: Example clone of a single branch
   ansible.builtin.git:
-    repo: https://github.com/ansible/ansible-examples.git
-    dest: /src/ansible-examples
+    repo: git@github.com:mylogin/hello.git
+    dest: /home/mylogin/hello
     single_branch: yes
     version: master
 


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
The [ansible-examples](https://github.com/ansible/ansible-examples) repository has been archived, and therefore examples in the `git` module referencing it are replaced.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

Initial [issue](https://github.com/ansible/ansible-documentation/issues/1640) in `ansible-documentation`.