### PR TITLE
[stable-2.16] dnf - arches must be the same in the is_newer_installed check (#83417)

### DIFF
--- a/changelogs/fragments/83406-dnf-fix-arch-cmp.yml
+++ b/changelogs/fragments/83406-dnf-fix-arch-cmp.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf - fix an issue where two packages of the same ``evr`` but different arch failed to install (https://github.com/ansible/ansible/issues/83406)

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -739,7 +739,7 @@ class DnfModule(YumDnf):
             installed = sorted(self.base.sack.query().installed().filter(name=available.name).run())[-1]
         except IndexError:
             return False
-        return installed > available
+        return installed.evr_gt(available) and installed.arch == available.arch
 
     def _mark_package_install(self, pkg_spec, upgrade=False):
         """Mark the package for install."""

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -414,3 +414,23 @@
       dnf:
         name: provides_foo*
         state: absent
+
+- name: test that only evr is compared, avoiding a situation when a specific arch would be considered as a "newer" package
+  block:
+    - dnf:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - "dinginessentail-1.0-1.x86_64"
+        - "dinginessentail-1.0-1.i686"
+      register: dnf_results
+
+    - assert:
+        that:
+          - dnf_results["results"][0] is changed
+          - dnf_results["results"][1] is changed
+  always:
+    - name: Clean up
+      dnf:
+        name: dinginessentail
+        state: absent


### PR DESCRIPTION
##### SUMMARY
Backport of #83417

(cherry picked from commit 2930a4664c2b4ac3c8b1127c91d98d53644e61cf)
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
