### PR TITLE
Added docstrings to V2 methods in the CallbackBase Class (4 & 5 of 27)

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -508,9 +508,10 @@ class CallbackBase(AnsiblePlugin):
     def v2_runner_on_failed(self, result: TaskResult, ignore_errors: bool = False) -> None:
         """Process details of a failed task.
 
-        Customization note: Review and format the contents of the
-        TaskResult object here, then output, log, or notify as required
-        by the callback plugin.
+        Customization note: Ansible uses only one console stdout
+        callback at a time. However, you can override this method in a
+        separate callback to add output to stdout or forward details
+        to a log, etc.
 
         Note: The value of 'ignore_errors' tells Ansible whether or not
         to continue running tasks on the host where a failure occurred.
@@ -533,9 +534,10 @@ class CallbackBase(AnsiblePlugin):
     def v2_runner_on_ok(self, result: TaskResult) -> None:
         """Process details of a successful task.
 
-        Customization note: Review and format the contents of the
-        TaskResult object here, then output, log, or notify as required
-        by the callback plugin.
+        Customization note: Ansible uses only one console stdout
+        callback at a time. However, you can override this method in a
+        separate callback to add output to stdout or forward details
+        to a log, etc.
 
         :param result: An object that contains details about the task
         :type result: TaskResult
@@ -548,9 +550,10 @@ class CallbackBase(AnsiblePlugin):
     def v2_runner_on_skipped(self, result: TaskResult) -> None:
         """Get details about a skipped task.
 
-        Customization note: Review and format the contents of the
-        TaskResult object here, then output, log, or notify as required
-        by the callback plugin.
+        Customization note: Ansible uses only one console stdout
+        callback at a time. However, you can override this method in a
+        separate callback to add output to stdout or forward details
+        to a log, etc.
 
         :param result: An object that contains details about the task
         :type result: TaskResult
@@ -562,11 +565,12 @@ class CallbackBase(AnsiblePlugin):
             self.runner_on_skipped(host, self._get_item_label(getattr(result._result, 'results', {})))
 
     def v2_runner_on_unreachable(self, result: TaskResult) -> None:
-        """Process details of a task when the target host is unreachable.
+        """Process details of a task if a target node is unreachable.
 
-        Customization note: Review and format the contents of the
-        TaskResult object here, then output, log, or notify as required
-        by the callback plugin.
+        Customization note: Ansible uses only one console stdout
+        callback at a time. However, you can override this method in a
+        separate callback to add output to stdout or forward details
+        to a log, etc.
 
         :param result: An object that contains details about the task
         :type result: TaskResult
@@ -579,9 +583,10 @@ class CallbackBase(AnsiblePlugin):
     def v2_runner_on_async_poll(self, result: TaskResult) -> None:
         """Process details of a task running in asynchronous mode.
 
-        Customization note: Review and format the contents of the
-        TaskResult object here, then output, log, or notify as required
-        by the callback plugin.
+        Customization note: Ansible uses only one console stdout
+        callback at a time. However, you can override this method in a
+        separate callback to add output to stdout or forward details
+        to a log, etc.
 
         :param result: An object that contains details about the task
         :type result: TaskResult

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -555,11 +555,32 @@ class CallbackBase(AnsiblePlugin):
             host = result._host.get_name()
             self.runner_on_skipped(host, self._get_item_label(getattr(result._result, 'results', {})))
 
-    def v2_runner_on_unreachable(self, result):
+    def v2_runner_on_unreachable(self, result: TaskResult) -> None:
+        """Get details about a task that Ansible could not perform because it could not reach a
+        targeted host, then process the details as required by the callback (output, profiling,
+        logging, notifications, etc.)
+
+        Customization note: For more information about the attributes and methods of the
+        TaskResult class, see lib/ansible/executor/task_result.py.
+
+        :param TaskResult result: An object that contains details about the task
+
+        :return: None
+        """
         host = result._host.get_name()
         self.runner_on_unreachable(host, result._result)
 
-    def v2_runner_on_async_poll(self, result):
+    def v2_runner_on_async_poll(self, result: TaskResult) -> None:
+        """Get details about a task that is running in asynchronous mode and process them as
+        required by the callback (output, profiling, logging, notifications, etc.)
+
+        Customization note: For more information about the attributes and methods of the
+        TaskResult class, see lib/ansible/executor/task_result.py.
+
+        :param TaskResult result: An object that contains details about the task
+
+        :return: None
+        """
         host = result._host.get_name()
         jid = result._result.get('ansible_job_id')
         # FIXME, get real clock

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -527,6 +527,7 @@ class CallbackBase(AnsiblePlugin):
         :type ignore_errors: bool
 
         :return: None
+        :rtype: None
         """
         host = result._host.get_name()
         self.runner_on_failed(host, result._result, ignore_errors)
@@ -543,6 +544,7 @@ class CallbackBase(AnsiblePlugin):
         :type result: TaskResult
 
         :return: None
+        :rtype: None
         """
         host = result._host.get_name()
         self.runner_on_ok(host, result._result)
@@ -559,6 +561,7 @@ class CallbackBase(AnsiblePlugin):
         :type result: TaskResult
 
         :return: None
+        :rtype: None
         """
         if C.DISPLAY_SKIPPED_HOSTS:
             host = result._host.get_name()
@@ -576,6 +579,7 @@ class CallbackBase(AnsiblePlugin):
         :type result: TaskResult
 
         :return: None
+        :rtype: None
         """
         host = result._host.get_name()
         self.runner_on_unreachable(host, result._result)
@@ -592,6 +596,7 @@ class CallbackBase(AnsiblePlugin):
         :type result: TaskResult
 
         :return: None
+        :rtype: None
         """
         host = result._host.get_name()
         jid = result._result.get('ansible_job_id')

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -573,7 +573,7 @@ class CallbackBase(AnsiblePlugin):
         :param result: The parameters of the task and its status.
         :type result: TaskResult
 
-        :return: None
+        :rtype: None
         :rtype: None
         """
         host = result._host.get_name()

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -506,20 +506,24 @@ class CallbackBase(AnsiblePlugin):
         self.on_any(args, kwargs)
 
     def v2_runner_on_failed(self, result: TaskResult, ignore_errors: bool = False) -> None:
-        """Get details about a failed task and whether or not Ansible should continue
-        running tasks on the host where the failure occurred, then process the details
-        as required by the callback (output, profiling, logging, notifications, etc.)
+        """Process details of a failed task.
 
-        Note: The 'ignore_errors' directive only works when the task can run and returns
-        a value of 'failed'. It does not make Ansible ignore undefined variable errors,
-        connection failures, execution issues (for example, missing packages), or syntax errors.
+        Customization note: Review and format the contents of the
+        TaskResult object here, then output, log, or notify as required
+        by the callback plugin.
+        
+        Note: The value of 'ignore_errors' tells Ansible whether or not
+        to continue running tasks on the host where a failure occurred.
+        But the 'ignore_errors' directive only works when the task can
+        run and returns a value of 'failed'. It does not make Ansible
+        ignore undefined variable errors, connection failures, execution
+        issues (for example, missing packages), or syntax errors.
 
-        Customization note: For more information about the attributes and methods of the
-        TaskResult class, see lib/ansible/executor/task_result.py.
-
-        :param TaskResult result: An object that contains details about the task
-        :param bool ignore_errors: Whether or not Ansible should continue running tasks on the host
-        where the failure occurred
+        :param result: An object that contains details about the task
+        :type result: TaskResult
+        :param ignore_errors: Whether or not Ansible should continue \
+            running tasks on the host where the failure occurred
+        :type ignore_errors: bool        
 
         :return: None
         """
@@ -527,13 +531,14 @@ class CallbackBase(AnsiblePlugin):
         self.runner_on_failed(host, result._result, ignore_errors)
 
     def v2_runner_on_ok(self, result: TaskResult) -> None:
-        """Get details about a successful task and process them as required by the callback
-        (output, profiling, logging, notifications, etc.)
+        """Process details of a successful task.
+        
+        Customization note: Review and format the contents of the
+        TaskResult object here, then output, log, or notify as required
+        by the callback plugin.
 
-        Customization note: For more information about the attributes and methods of the
-        TaskResult class, see lib/ansible/executor/task_result.py.
-
-        :param TaskResult result: An object that contains details about the task
+        :param result: An object that contains details about the task
+        :type result: TaskResult
 
         :return: None
         """
@@ -541,13 +546,14 @@ class CallbackBase(AnsiblePlugin):
         self.runner_on_ok(host, result._result)
 
     def v2_runner_on_skipped(self, result: TaskResult) -> None:
-        """Get details about a skipped task and process them as required by the callback
-        (output, profiling, logging, notifications, etc.)
+        """Get details about a skipped task.
+        
+        Customization note: Review and format the contents of the
+        TaskResult object here, then output, log, or notify as required
+        by the callback plugin.
 
-        Customization note: For more information about the attributes and methods of the
-        TaskResult class, see lib/ansible/executor/task_result.py.
-
-        :param TaskResult result: An object that contains details about the task
+        :param result: An object that contains details about the task
+        :type result: TaskResult
 
         :return: None
         """
@@ -556,14 +562,14 @@ class CallbackBase(AnsiblePlugin):
             self.runner_on_skipped(host, self._get_item_label(getattr(result._result, 'results', {})))
 
     def v2_runner_on_unreachable(self, result: TaskResult) -> None:
-        """Get details about a task that Ansible could not perform because it could not reach a
-        targeted host, then process the details as required by the callback (output, profiling,
-        logging, notifications, etc.)
+        """Process details of a task when the target host is unreachable.
 
-        Customization note: For more information about the attributes and methods of the
-        TaskResult class, see lib/ansible/executor/task_result.py.
+        Customization note: Review and format the contents of the
+        TaskResult object here, then output, log, or notify as required
+        by the callback plugin.
 
-        :param TaskResult result: An object that contains details about the task
+        :param result: An object that contains details about the task
+        :type result: TaskResult
 
         :return: None
         """
@@ -571,13 +577,14 @@ class CallbackBase(AnsiblePlugin):
         self.runner_on_unreachable(host, result._result)
 
     def v2_runner_on_async_poll(self, result: TaskResult) -> None:
-        """Get details about a task that is running in asynchronous mode and process them as
-        required by the callback (output, profiling, logging, notifications, etc.)
+        """Process details of a task running in asynchronous mode.
+        
+        Customization note: Review and format the contents of the
+        TaskResult object here, then output, log, or notify as required
+        by the callback plugin.
 
-        Customization note: For more information about the attributes and methods of the
-        TaskResult class, see lib/ansible/executor/task_result.py.
-
-        :param TaskResult result: An object that contains details about the task
+        :param result: An object that contains details about the task
+        :type result: TaskResult
 
         :return: None
         """

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -506,24 +506,19 @@ class CallbackBase(AnsiblePlugin):
         self.on_any(args, kwargs)
 
     def v2_runner_on_failed(self, result: TaskResult, ignore_errors: bool = False) -> None:
-        """Process details of a failed task.
+        """Process results of a failed task.
 
-        Customization note: Ansible uses only one console stdout
-        callback at a time. However, you can override this method in a
-        separate callback to add output to stdout or forward details
-        to a log, etc.
-
-        Note: The value of 'ignore_errors' tells Ansible whether or not
-        to continue running tasks on the host where a failure occurred.
+        Note: The value of 'ignore_errors' tells Ansible whether to
+        continue running tasks on the host where this task failed.
         But the 'ignore_errors' directive only works when the task can
         run and returns a value of 'failed'. It does not make Ansible
         ignore undefined variable errors, connection failures, execution
         issues (for example, missing packages), or syntax errors.
 
-        :param result: An object that contains details about the task
+        :param result: The parameters of the task and its results.
         :type result: TaskResult
-        :param ignore_errors: Whether or not Ansible should continue \
-            running tasks on the host where the failure occurred
+        :param ignore_errors: Whether Ansible should continue \
+            running tasks on the host where the task failed.
         :type ignore_errors: bool
 
         :return: None
@@ -533,14 +528,9 @@ class CallbackBase(AnsiblePlugin):
         self.runner_on_failed(host, result._result, ignore_errors)
 
     def v2_runner_on_ok(self, result: TaskResult) -> None:
-        """Process details of a successful task.
+        """Process results of a successful task.
 
-        Customization note: Ansible uses only one console stdout
-        callback at a time. However, you can override this method in a
-        separate callback to add output to stdout or forward details
-        to a log, etc.
-
-        :param result: An object that contains details about the task
+        :param result: The parameters of the task and its results.
         :type result: TaskResult
 
         :return: None
@@ -550,14 +540,9 @@ class CallbackBase(AnsiblePlugin):
         self.runner_on_ok(host, result._result)
 
     def v2_runner_on_skipped(self, result: TaskResult) -> None:
-        """Get details about a skipped task.
+        """Process results of a skipped task.
 
-        Customization note: Ansible uses only one console stdout
-        callback at a time. However, you can override this method in a
-        separate callback to add output to stdout or forward details
-        to a log, etc.
-
-        :param result: An object that contains details about the task
+        :param result: The parameters of the task and its results.
         :type result: TaskResult
 
         :return: None
@@ -568,14 +553,9 @@ class CallbackBase(AnsiblePlugin):
             self.runner_on_skipped(host, self._get_item_label(getattr(result._result, 'results', {})))
 
     def v2_runner_on_unreachable(self, result: TaskResult) -> None:
-        """Process details of a task if a target node is unreachable.
+        """Process results of a task if a target node is unreachable.
 
-        Customization note: Ansible uses only one console stdout
-        callback at a time. However, you can override this method in a
-        separate callback to add output to stdout or forward details
-        to a log, etc.
-
-        :param result: An object that contains details about the task
+        :param result: The parameters of the task and its results.
         :type result: TaskResult
 
         :return: None
@@ -585,14 +565,12 @@ class CallbackBase(AnsiblePlugin):
         self.runner_on_unreachable(host, result._result)
 
     def v2_runner_on_async_poll(self, result: TaskResult) -> None:
-        """Process details of a task running in asynchronous mode.
+        """Get details about an unfinished task running in async mode.
 
-        Customization note: Ansible uses only one console stdout
-        callback at a time. However, you can override this method in a
-        separate callback to add output to stdout or forward details
-        to a log, etc.
+        Note: The value of the `poll` keyword in the task determines
+        the interval at which polling occurs and this method is run.
 
-        :param result: An object that contains details about the task
+        :param result: The parameters of the task and its status.
         :type result: TaskResult
 
         :return: None
@@ -604,7 +582,15 @@ class CallbackBase(AnsiblePlugin):
         clock = 0
         self.runner_on_async_poll(host, result._result, jid, clock)
 
-    def v2_runner_on_async_ok(self, result):
+    def v2_runner_on_async_ok(self, result: TaskResult) -> None:
+        """Process results of a successful task that ran in async mode.
+
+        :param result: The parameters of the task and its results.
+        :type result: TaskResult
+
+        :return: None
+        :rtype: None
+        """
         host = result._host.get_name()
         jid = result._result.get('ansible_job_id')
         self.runner_on_async_ok(host, result._result, jid)

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -511,7 +511,7 @@ class CallbackBase(AnsiblePlugin):
         Customization note: Review and format the contents of the
         TaskResult object here, then output, log, or notify as required
         by the callback plugin.
-        
+
         Note: The value of 'ignore_errors' tells Ansible whether or not
         to continue running tasks on the host where a failure occurred.
         But the 'ignore_errors' directive only works when the task can
@@ -523,7 +523,7 @@ class CallbackBase(AnsiblePlugin):
         :type result: TaskResult
         :param ignore_errors: Whether or not Ansible should continue \
             running tasks on the host where the failure occurred
-        :type ignore_errors: bool        
+        :type ignore_errors: bool
 
         :return: None
         """
@@ -532,7 +532,7 @@ class CallbackBase(AnsiblePlugin):
 
     def v2_runner_on_ok(self, result: TaskResult) -> None:
         """Process details of a successful task.
-        
+
         Customization note: Review and format the contents of the
         TaskResult object here, then output, log, or notify as required
         by the callback plugin.
@@ -547,7 +547,7 @@ class CallbackBase(AnsiblePlugin):
 
     def v2_runner_on_skipped(self, result: TaskResult) -> None:
         """Get details about a skipped task.
-        
+
         Customization note: Review and format the contents of the
         TaskResult object here, then output, log, or notify as required
         by the callback plugin.
@@ -578,7 +578,7 @@ class CallbackBase(AnsiblePlugin):
 
     def v2_runner_on_async_poll(self, result: TaskResult) -> None:
         """Process details of a task running in asynchronous mode.
-        
+
         Customization note: Review and format the contents of the
         TaskResult object here, then output, log, or notify as required
         by the callback plugin.


### PR DESCRIPTION
##### SUMMARY

Added type declarations and docstrings to the `v2_runner_on_unreachable` and `v2_runner_on_async_poll` methods of the `Callback` class, to explain the purpose of the methods and the parameters that the methods will accept. The docstrings also provide additional information for developers who want to use the methods in custom callback plugins. This PR incorporates feedback from @bcoca, @webknjaz, and PR #83267.

*NOTE: Would like more information about the `# FIXME, get real clock` comment in the `v2_runner_on_async_poll` method for future development.*

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

These changes do not alter the output of either method. Tasks that passed or were skipped based on a condition ran with no issues. All tests in `test.units.plugins.callback.test_callback` passed

```console
$ python3 -m unittest --verbose --buffer test.units.plugins.callback.test_callback
test_display (test.units.plugins.callback.test_callback.TestCallback.test_display) ... ok
test_display_verbose (test.units.plugins.callback.test_callback.TestCallback.test_display_verbose) ... ok
test_host_label (test.units.plugins.callback.test_callback.TestCallback.test_host_label) ... ok
test_host_label_delegated (test.units.plugins.callback.test_callback.TestCallback.test_host_label_delegated) ... ok
test_init (test.units.plugins.callback.test_callback.TestCallback.test_init) ... ok
test_clear_file (test.units.plugins.callback.test_callback.TestCallbackDiff.test_clear_file) ... ok
test_diff_after_none (test.units.plugins.callback.test_callback.TestCallbackDiff.test_diff_after_none) ... ok
test_diff_before_none (test.units.plugins.callback.test_callback.TestCallbackDiff.test_diff_before_none) ... ok
test_diff_dicts (test.units.plugins.callback.test_callback.TestCallbackDiff.test_diff_dicts) ... ok
test_difflist (test.units.plugins.callback.test_callback.TestCallbackDiff.test_difflist) ... ok
test_new_file (test.units.plugins.callback.test_callback.TestCallbackDiff.test_new_file) ... ok
test_no_trailing_newline_after (test.units.plugins.callback.test_callback.TestCallbackDiff.test_no_trailing_newline_after) ... ok
test_no_trailing_newline_before (test.units.plugins.callback.test_callback.TestCallbackDiff.test_no_trailing_newline_before) ... ok
test_no_trailing_newline_both (test.units.plugins.callback.test_callback.TestCallbackDiff.test_no_trailing_newline_both) ... ok
test_no_trailing_newline_both_with_some_changes (test.units.plugins.callback.test_callback.TestCallbackDiff.test_no_trailing_newline_both_with_some_changes) ... ok
test_simple_diff (test.units.plugins.callback.test_callback.TestCallbackDiff.test_simple_diff) ... ok
test_are_methods (test.units.plugins.callback.test_callback.TestCallbackOnMethods.test_are_methods) ... ok
test_on_any (test.units.plugins.callback.test_callback.TestCallbackOnMethods.test_on_any) ... ok
test_clean_results (test.units.plugins.callback.test_callback.TestCallbackResults.test_clean_results) ... ok
test_clean_results_debug_task (test.units.plugins.callback.test_callback.TestCallbackResults.test_clean_results_debug_task) ... ok
test_clean_results_debug_task_empty_results (test.units.plugins.callback.test_callback.TestCallbackResults.test_clean_results_debug_task_empty_results) ... ok
test_clean_results_debug_task_no_invocation (test.units.plugins.callback.test_callback.TestCallbackResults.test_clean_results_debug_task_no_invocation) ... ok
test_get_item_label (test.units.plugins.callback.test_callback.TestCallbackResults.test_get_item_label) ... ok
test_get_item_label_no_log (test.units.plugins.callback.test_callback.TestCallbackResults.test_get_item_label_no_log) ... ok

----------------------------------------------------------------------
Ran 24 tests in 0.003s

OK
```
