### PR TITLE
fix module_defaults group incorrectly giving deprecation warnings

### DIFF
--- a/changelogs/fragments/fix-module-defaults-deprecations.yml
+++ b/changelogs/fragments/fix-module-defaults-deprecations.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_defaults - do not display action/module deprecation warnings when using an action_group that contains a deprecated plugin (https://github.com/ansible/ansible/issues/83490).

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -386,13 +386,13 @@ class FieldAttributeBase:
         return fq_group_name, resolved_actions
 
     def _resolve_action(self, action_name, mandatory=True):
-        context = module_loader.find_plugin_with_context(action_name, ignore_deprecated=not mandatory)
+        context = module_loader.find_plugin_with_context(action_name, ignore_deprecated=(not mandatory))
         if context.resolved and not context.action_plugin:
-            prefer = action_loader.find_plugin_with_context(action_name, ignore_deprecated=not mandatory)
+            prefer = action_loader.find_plugin_with_context(action_name, ignore_deprecated=(not mandatory))
             if prefer.resolved:
                 context = prefer
         elif not context.resolved:
-            context = action_loader.find_plugin_with_context(action_name, ignore_deprecated=not mandatory)
+            context = action_loader.find_plugin_with_context(action_name, ignore_deprecated=(not mandatory))
 
         if context.resolved:
             return context.resolved_fqcn

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -386,13 +386,13 @@ class FieldAttributeBase:
         return fq_group_name, resolved_actions
 
     def _resolve_action(self, action_name, mandatory=True):
-        context = module_loader.find_plugin_with_context(action_name)
+        context = module_loader.find_plugin_with_context(action_name, ignore_deprecated=not mandatory)
         if context.resolved and not context.action_plugin:
-            prefer = action_loader.find_plugin_with_context(action_name)
+            prefer = action_loader.find_plugin_with_context(action_name, ignore_deprecated=not mandatory)
             if prefer.resolved:
                 context = prefer
         elif not context.resolved:
-            context = action_loader.find_plugin_with_context(action_name)
+            context = action_loader.find_plugin_with_context(action_name, ignore_deprecated=not mandatory)
 
         if context.resolved:
             return context.resolved_fqcn

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
@@ -44,12 +44,19 @@ plugin_routing:
     ios_facts:
       action_plugin: testns.testcoll.redirected_action
 
+    old_ping:
+      deprecation:
+        removal_date: 2020-12-31
+        warning_text: old_ping will be removed in a future release of this collection. Use ping instead.
+        redirect: ping
+
 action_groups:
   testgroup:
     # Test metadata 'extend_group' feature does not get stuck in a recursive loop
     - metadata:
         extend_group: othergroup
     - metadata
+    - old_ping
     - ping
     - testns.testcoll.echo1
     - testns.testcoll.echo2

--- a/test/integration/targets/module_defaults/runme.sh
+++ b/test/integration/targets/module_defaults/runme.sh
@@ -5,7 +5,8 @@ set -eux
 # Symlink is test for backwards-compat (only workaround for https://github.com/ansible/ansible/issues/77059)
 sudo ln -s "${PWD}/collections/ansible_collections/testns/testcoll/plugins/action/vyos.py" ./collections/ansible_collections/testns/testcoll/plugins/action/vyosfacts.py
 
-ansible-playbook test_defaults.yml "$@"
+ANSIBLE_DEPRECATION_WARNINGS=true ansible-playbook test_defaults.yml "$@" 2> err.txt
+test "$(grep -c 'testns.testcoll.old_ping has been deprecated' err.txt || 0)" -eq 0
 
 sudo rm ./collections/ansible_collections/testns/testcoll/plugins/action/vyosfacts.py
 


### PR DESCRIPTION
##### SUMMARY

Fixes #83490

don't display deprecation warnings for actions/modules as a result of using an action_group containing a deprecated plugin

##### ISSUE TYPE

- Bugfix Pull Request