### PR TITLE
validate-modules: fix require_only_one

### DIFF
--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -89,7 +89,7 @@ def require_only_one(keys):
         found = None
         for k in obj.keys():
             if k in keys:
-                if k is None:
+                if found is None:
                     found = k
                 else:
                     raise Invalid('Found conflicting keys, must contain only one of {}'.format(keys))


### PR DESCRIPTION
##### SUMMARY
validate-modules is now broken and will flag every plugin/module that deprecates anything and uses either `alternative` or `alternatives` (but not both).

Ref: https://github.com/ansible/ansible/pull/82593/files#r1661893959

##### ISSUE TYPE
- Bugfix Pull Request
