### PR TITLE
[stable-2.17] package_facts: ignore warnings by apk on stderr

### DIFF
--- a/changelogs/fragments/package_facts_apk.yml
+++ b/changelogs/fragments/package_facts_apk.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - package_facts - ignore warnings sent by apk on stderr (https://github.com/ansible/ansible/issues/83501).

--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -440,7 +440,7 @@ class APK(CLIMgr):
 
     def list_installed(self):
         rc, out, err = module.run_command([self._cli, 'info', '-v'])
-        if rc != 0 or err:
+        if rc != 0:
             raise Exception("Unable to list packages rc=%s : %s" % (rc, err))
         return out.splitlines()
 

--- a/test/integration/targets/package_facts/tasks/main.yml
+++ b/test/integration/targets/package_facts/tasks/main.yml
@@ -65,6 +65,19 @@
         that: ansible_facts.packages is defined
   when: (ansible_os_family == "openSUSE Leap") or (ansible_os_family == "Suse")
 
+- name: Same as those above, but based on pkg_mgr, tests aliases
+  block:
+    - name: Gather package facts
+      package_facts:
+        manager: '{{ ansible_facts["pkg_mgr"] }}'
+
+    - name: check for ansible_facts.packages exists
+      assert:
+        that:
+          - ansible_facts.packages is defined
+          - ansible_facts.packages | length > 1
+  when: ansible_facts['os_family'] in ["openSUSE Leap", "Suse", "RedHat", "Debian"]
+
 # Check that auto detection works also
 - name: Gather package facts
   package_facts:

--- a/test/integration/targets/package_facts/tasks/main.yml
+++ b/test/integration/targets/package_facts/tasks/main.yml
@@ -65,7 +65,7 @@
         that: ansible_facts.packages is defined
   when: (ansible_os_family == "openSUSE Leap") or (ansible_os_family == "Suse")
 
-- name: Same as those above, but based on pkg_mgr, tests aliases
+- name: Same as those above, but based on pkg_mgr
   block:
     - name: Gather package facts
       package_facts:
@@ -76,7 +76,7 @@
         that:
           - ansible_facts.packages is defined
           - ansible_facts.packages | length > 1
-  when: ansible_facts['os_family'] in ["openSUSE Leap", "Suse", "RedHat", "Debian"]
+  when: ansible_facts['os_family'] in ["openSUSE Leap", "Suse", "Debian"]
 
 # Check that auto detection works also
 - name: Gather package facts


### PR DESCRIPTION
##### SUMMARY

Ignore warnings sent by apk cli on stderr

Partial backport of https://github.com/ansible/ansible/pull/83149

Fixes: #83501

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


