### PR TITLE
[2.14] 🧪 Switch CentOS 7 yum repo mirrors to the vault

### DIFF
--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -410,6 +410,15 @@ bootstrap_docker()
 {
     # Required for newer mysql-server packages to install/upgrade on Ubuntu 16.04.
     rm -f /usr/sbin/policy-rc.d
+
+    # CentOS 7 is EoL and its official repos are down; we need to the archived ones.
+    if grep -q '^CENTOS_MANTISBT_PROJECT="CentOS-7"$' /etc/os-release
+    then
+        sed -i \
+            -e 's/mirrorlist/#mirrorlist/g' \
+            -e 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' \
+            /etc/yum.repos.d/CentOS-*
+    fi
 }
 
 bootstrap_remote()


### PR DESCRIPTION
The distro itself reached EoL on June 30, 2024, but these repository archives live on and should remain usable for testing.

Refs:
* https://www.redhat.com/en/topics/linux/centos-linux-eol
* https://github.com/ansible/pylibssh/commit/01d3442f
* https://gist.github.com/hkneptune/4961532c2df691db79a1c6b72c251b25
* https://vault.centos.org/7.9.2009/

(cherry picked from commit c8c45cdfb4af35a6c7f289c364fc49e3814c246d)

(PR #83523)

##### SUMMARY

$sbj

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Maintenance Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

N/A