### PR TITLE
Add SL-Micro to Suse family list

### DIFF
--- a/changelogs/fragments/83541-add-sl-micro-suse-family.yaml
+++ b/changelogs/fragments/83541-add-sl-micro-suse-family.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- distribution.py - Added SL-Micro in Suse OS Family. (https://github.com/ansible/ansible/pull/83541)

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -517,7 +517,7 @@ class Distribution(object):
                                 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux',
                                 'Pop!_OS', 'Parrot', 'Pardus GNU/Linux', 'Uos', 'Deepin', 'OSMC'],
                      'Suse': ['SuSE', 'SLES', 'SLED', 'openSUSE', 'openSUSE Tumbleweed',
-                              'SLES_SAP', 'SUSE_LINUX', 'openSUSE Leap', 'ALP-Dolomite'],
+                              'SLES_SAP', 'SUSE_LINUX', 'openSUSE Leap', 'ALP-Dolomite', 'SL-Micro'],
                      'Archlinux': ['Archlinux', 'Antergos', 'Manjaro'],
                      'Mandrake': ['Mandrake', 'Mandriva'],
                      'Solaris': ['Solaris', 'Nexenta', 'OmniOS', 'OpenIndiana', 'SmartOS'],

--- a/test/units/module_utils/facts/system/distribution/fixtures/sl-micro.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/sl-micro.json
@@ -1,9 +1,5 @@
 {
-    "platform.dist": [
-        "",
-        "",
-        ""
-    ],
+    "platform.dist": [ "", "", ""],
     "distro": {
         "codename": "",
         "id": "sl-micro",

--- a/test/units/module_utils/facts/system/distribution/fixtures/sl-micro.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/sl-micro.json
@@ -1,0 +1,27 @@
+{
+    "platform.dist": [
+        "",
+        "",
+        ""
+    ],
+    "distro": {
+        "codename": "",
+        "id": "sl-micro",
+        "name": "SUSE Linux Micro",
+        "version": "6.0",
+        "version_best": "6.0",
+        "os_release_info": {},
+        "lsb_release_info": {}
+    },
+    "input": {
+        "/etc/os-release": "NAME=\"SL-Micro\"\nVERSION=\"6.0\"\nID=sl-micro\nID_LIKE=\"suse\"\nVERSION_ID=\"6.0\"\nPRETTY_NAME=\"SUSE Linux Micro 6.0\"\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:suse:sl-micro:6.0\"\nHOME_URL=\"https://www.suse.com/products/micro/\"\nDOCUMENTATION_URL=\"https://documentation.suse.com/sl-micro/6.0/\"\nLOGO=\"distributor-logo\"\n"
+    },
+    "name": "SUSE Linux Micro 6.0",
+    "result": {
+        "distribution_release": "NA",
+        "distribution": "SL-Micro",
+        "distribution_major_version": "6",
+        "os_family": "Suse",
+        "distribution_version": "6.0"
+    }
+}


### PR DESCRIPTION
##### SUMMARY
This pull request addresses the issue of adding SUSE Linux Micro to the list of SUSE family operating systems in Ansible. Currently, SUSE Linux Micro is not recognized as a part of the SUSE OS family in Ansible. The proposed changes aim to update the distribution.py file to include SUSE Linux Micro under the SUSE OS family.

ISSUE TYPE: Bugfix Pull Request

##### ADDITIONAL INFORMATION

The SUSE Linux Micro reference can be found in the SUSE Linux Micro Documentation.: https://www.suse.com/download/sle-micro/

Before the change:

~~~
ansible -m setup -c local -i playbooks/inventory/localhost localhost | grep os_fam
    "ansible_os_family": "SL-Micro",
~~~

After the change:

~~~
ansible -m setup -c local -i playbooks/inventory/localhost localhost | grep os_fam
    "ansible_os_family": "Suse",
~~~