### PR TITLE
Ensure that we are handling `DownloadError` properly in the `dnf` module

### DIFF
--- a/changelogs/fragments/dnf_handle_downloaderror.yml
+++ b/changelogs/fragments/dnf_handle_downloaderror.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf - Ensure that we are handling DownloadError properly in the dnf module

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -1190,10 +1190,8 @@ class DnfModule(YumDnf):
 
                     self.base.download_packages(self.base.transaction.install_set)
                 except dnf.exceptions.DownloadError as e:
-                    self.module.fail_json(
-                        msg="Failed to download packages: {0}".format(to_text(e)),
-                        results=[],
-                    )
+                    failure_response['msg'] = "Failed to download packages: {0}".format(to_native(e))
+                    self.module.fail_json(**failure_response)
 
                 # Validate GPG. This is NOT done in dnf.Base (it's done in the
                 # upstream CLI subclass of dnf.Base)


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
When we are facing a `Download error` from the dnf module, it returns an error with an empty `results` list but omitting the `rc` field. This change will ensure that the module will returns a proper `rc` value in case of error.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Here's a testing playbook:
```---

- name: Test
  hosts: testhost
  tasks:
    - name: Install package
      become: true
      ansible.builtin.dnf:
        name: "tuned-profiles-cpu-partitioning"
        state: present
      register: packages_download
      until: packages_download.rc == 0
      retries: 3
      delay: 10
```

Verbose output of the task before the patch:
```
fatal: [testhost]: FAILED! => {
    "msg": "The conditional check 'packages_download.rc == 0' failed. The error was: error while evaluating conditional (packages_download.rc == 0): 'dict object' has no attribute 'rc'. 'dict object' has no attribute 'rc'"
}


```

Verbose output after patch:
```
The full traceback is:
  File "/tmp/ansible_ansible.legacy.dnf_payload_1bgijn7z/ansible_ansible.legacy.dnf_payload.zip/ansible/modules/dnf.py", line 1330, in ensure
  File "/usr/lib/python3.9/site-packages/dnf/base.py", line 1309, in download_packages
    self._download_remote_payloads(payloads, drpm, progress, callback_total)
  File "/usr/lib/python3.9/site-packages/dnf/base.py", line 1238, in _download_remote_payloads
    raise dnf.exceptions.DownloadError(errors._irrecoverable())
fatal: [testhost]: FAILED! => {
    "attempts": 3,
    "changed": false,
    "failures": [],
    "invocation": {
        "module_args": {
            "allow_downgrade": false,
            "allowerasing": false,
            "autoremove": false,
            "bugfix": false,
            "cacheonly": false,
            "conf_file": null,
            "disable_excludes": null,
            "disable_gpg_check": false,
            "disable_plugin": [],
            "disablerepo": [],
            "download_dir": null,
            "download_only": false,
            "enable_plugin": [],
            "enablerepo": [],
            "exclude": [],
            "install_repoquery": true,
            "install_weak_deps": true,
            "installroot": "/",
            "list": null,
            "lock_timeout": 30,
            "name": [
                "tuned-profiles-cpu-partitioning"
            ],
            "nobest": false,
            "releasever": null,
            "security": false,
            "skip_broken": false,
            "sslverify": true,
            "state": "present",
            "update_cache": false,
            "update_only": false,
            "use_backend": "auto",
            "validate_certs": true
        }
    },
    "msg": "Failed to download packages: tuned-profiles-cpu-partitioning-2.22.1-1.4.20240530git5385fa99.el9fdp.noarch: Cannot download, all mirrors were already tried without success",
    "rc": 1,
    "results": []
}
```