### PR TITLE
increase timeout downloading galaxy role URLs

### DIFF
--- a/changelogs/fragments/ansible-galaxy-install-archive-url-timeout.yml
+++ b/changelogs/fragments/ansible-galaxy-install-archive-url-timeout.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- >-
+  ``ansible-galaxy role install`` - update the default timeout to download
+  archive URLs from 20 seconds to 60 (https://github.com/ansible/ansible/issues/83521).

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -256,7 +256,7 @@ class GalaxyRole(object):
             display.display("- downloading role from %s" % archive_url)
 
             try:
-                url_file = open_url(archive_url, validate_certs=self._validate_certs, http_agent=user_agent())
+                url_file = open_url(archive_url, validate_certs=self._validate_certs, http_agent=user_agent(), timeout=60)
                 temp_file = tempfile.NamedTemporaryFile(delete=False)
                 data = url_file.read()
                 while data:


### PR DESCRIPTION
##### SUMMARY

Update the timeout to download role .tar.gz to 60 seconds, to match the hardcoded default for collection artifacts here https://github.com/ansible/ansible/blob/devel/lib/ansible/galaxy/collection/concrete_artifact_manager.py#L224 (ConcreteArtifactManager isn't instantiated with the user specified `--timeout`, so I didn't make it configurable for roles either).

Fixes #83521

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
