### PR TITLE
[stable-2.17] dnf - arches must be the same in the is_newer_installed check

### DIFF
--- a/changelogs/fragments/83406-dnf-fix-arch-cmp.yml
+++ b/changelogs/fragments/83406-dnf-fix-arch-cmp.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf - fix an issue where two packages of the same ``evr`` but different arch failed to install (https://github.com/ansible/ansible/issues/83406)

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -754,7 +754,7 @@ class DnfModule(YumDnf):
             installed = sorted(self.base.sack.query().installed().filter(name=available.name).run())[-1]
         except IndexError:
             return False
-        return installed > available
+        return installed.evr_gt(available) and installed.arch == available.arch
 
     def _mark_package_install(self, pkg_spec, upgrade=False):
         """Mark the package for install."""

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -743,18 +743,25 @@ class DnfModule(YumDnf):
         else:
             return bool(installed_query)
 
-    def _is_newer_version_installed(self, pkg_name):
+    def _is_newer_version_installed(self, pkg_spec):
         try:
-            if isinstance(pkg_name, dnf.package.Package):
-                available = pkg_name
+            if isinstance(pkg_spec, dnf.package.Package):
+                installed = sorted(self.base.sack.query().installed().filter(name=pkg_spec.name, arch=pkg_spec.arch))[-1]
+                return installed.evr_gt(pkg_spec)
             else:
-                available = sorted(
-                    dnf.subject.Subject(pkg_name).get_best_query(sack=self.base.sack).available().run()
-                )[-1]
-            installed = sorted(self.base.sack.query().installed().filter(name=available.name).run())[-1]
+                available = dnf.subject.Subject(pkg_spec).get_best_query(sack=self.base.sack).available()
+                installed = self.base.sack.query().installed().filter(name=available[0].name)
+                for arch in sorted(set(p.arch for p in installed)):  # select only from already-installed arches for this case
+                    installed_pkg = sorted(installed.filter(arch=arch))[-1]
+                    try:
+                        available_pkg = sorted(available.filter(arch=arch))[-1]
+                    except IndexError:
+                        continue  # nothing currently available for this arch; keep going
+                    if installed_pkg.evr_gt(available_pkg):
+                        return True
+                return False
         except IndexError:
             return False
-        return installed.evr_gt(available) and installed.arch == available.arch
 
     def _mark_package_install(self, pkg_spec, upgrade=False):
         """Mark the package for install."""

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -562,3 +562,40 @@
       dnf:
         name: dinginessentail
         state: absent
+
+- block:
+  - name: make sure dinginessentail is not installed
+    dnf:
+      name: dinginessentail
+      state: absent
+
+  - name: install dinginessentail both archs
+    dnf:
+      name:
+        - "{{ repodir }}/dinginessentail-1.1-1.x86_64.rpm"
+        - "{{ repodir_i686 }}/dinginessentail-1.1-1.i686.rpm"
+      state: present
+      disable_gpg_check: true
+
+  - name: try to install lower version of dinginessentail from rpm file, without allow_downgrade, just one arch
+    dnf:
+      name: "{{ repodir_i686 }}/dinginessentail-1.0-1.i686.rpm"
+      state: present
+    register: dnf_result
+
+  - name: check dinginessentail with rpm
+    shell: rpm -q dinginessentail
+    register: rpm_result
+
+  - name: verify installation
+    assert:
+      that:
+          - "not dnf_result.changed"
+          - "rpm_result.stdout_lines[0].startswith('dinginessentail-1.1-1')"
+          - "rpm_result.stdout_lines[1].startswith('dinginessentail-1.1-1')"
+  always:
+    - name: Clean up
+      dnf:
+        name: dinginessentail
+        state: absent
+  when: ansible_architecture == "x86_64"

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -542,3 +542,23 @@
       dnf:
         name: provides_foo*
         state: absent
+
+- name: test that only evr is compared, avoiding a situation when a specific arch would be considered as a "newer" package
+  block:
+    - dnf:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - "dinginessentail-1.0-1.x86_64"
+        - "dinginessentail-1.0-1.i686"
+      register: dnf_results
+
+    - assert:
+        that:
+          - dnf_results["results"][0] is changed
+          - dnf_results["results"][1] is changed
+  always:
+    - name: Clean up
+      dnf:
+        name: dinginessentail
+        state: absent


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/83417
Backport of https://github.com/ansible/ansible/pull/83556
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
