### PR TITLE
remove ignore clauses for module replace

### DIFF
--- a/lib/ansible/modules/replace.py
+++ b/lib/ansible/modules/replace.py
@@ -93,10 +93,6 @@ options:
         get the original file back if you somehow clobbered it incorrectly.
     type: bool
     default: no
-  others:
-    description:
-      - All arguments accepted by the M(ansible.builtin.file) module also work here.
-    type: str
   encoding:
     description:
       - The character encoding for reading and writing the file.
@@ -246,6 +242,7 @@ def main():
     path = params['path']
     encoding = params['encoding']
     res_args = dict(rc=0)
+    contents = None
 
     params['after'] = to_text(params['after'], errors='surrogate_or_strict', nonstring='passthru')
     params['before'] = to_text(params['before'], errors='surrogate_or_strict', nonstring='passthru')

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -27,8 +27,6 @@ lib/ansible/modules/git.py validate-modules:doc-required-mismatch
 lib/ansible/modules/lineinfile.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/lineinfile.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/package_facts.py validate-modules:doc-choices-do-not-match-spec
-lib/ansible/modules/replace.py validate-modules:nonexistent-parameter-documented
-lib/ansible/modules/replace.py pylint:used-before-assignment  # false positive detection by pylint
 lib/ansible/modules/service.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/service.py validate-modules:use-run-command-not-popen
 lib/ansible/modules/stat.py validate-modules:parameter-invalid


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove the two cases in `ignore.txt` for the module `replace`.

Case 1: used-before-assignment
Juts had to initialize the variable `contents` with `None` by the beginning of the module. The `module.exit_with_json()` call will guarantee the `None` will never go further if it cannot read the file.

Case 2: nonexistent-parameter-documented
Documentation ponts to this parameter `others` which does not really exist. It looks like it was used only to document the fact that the module will accept `file` options as well, which is already provided by the documentation fragment.

Not sure what Issue Type to use in this PR, marked all that made any sense in this context.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Test Pull Request
