### PR TITLE
remove ignore clauses for module find

### DIFF
--- a/changelogs/fragments/83575-fix-sanity-ignore-for-find.yml
+++ b/changelogs/fragments/83575-fix-sanity-ignore-for-find.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - find - change the datatype of ``elements`` to ``path`` in option ``paths`` (https://github.com/ansible/ansible/pull/83575).

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -75,6 +75,7 @@ options:
     paths:
         description:
             - List of paths of directories to search. All paths must be fully qualified.
+            - From ansible-core 2.18 and onwards, the data type has changed from C(str) to C(path).
         type: list
         required: true
         aliases: [ name, path ]
@@ -547,7 +548,6 @@ def main():
     looked = 0
     has_warnings = False
     for npath in params['paths']:
-        npath = os.path.expandvars(npath)
         try:
             if not os.path.isdir(npath):
                 raise Exception("'%s' is not a directory" % to_native(npath))

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -78,7 +78,7 @@ options:
         type: list
         required: true
         aliases: [ name, path ]
-        elements: str
+        elements: path
     file_type:
         description:
             - Type of file to select.
@@ -468,7 +468,7 @@ def statinfo(st):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            paths=dict(type='list', required=True, aliases=['name', 'path'], elements='str'),
+            paths=dict(type='list', required=True, aliases=['name', 'path'], elements='path'),
             patterns=dict(type='list', default=[], aliases=['pattern'], elements='str'),
             excludes=dict(type='list', aliases=['exclude'], elements='str'),
             contains=dict(type='str'),
@@ -547,7 +547,7 @@ def main():
     looked = 0
     has_warnings = False
     for npath in params['paths']:
-        npath = os.path.expanduser(os.path.expandvars(npath))
+        npath = os.path.expandvars(npath)
         try:
             if not os.path.isdir(npath):
                 raise Exception("'%s' is not a directory" % to_native(npath))

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -210,7 +210,7 @@
       that:
           - fail_to_read_wrong_encoding_file.msg == 'Not all paths examined, check warnings for details'
           - >-
-              fail_to_read_wrong_encoding_file.skipped_paths[remote_tmp_dir_test] == 
+              fail_to_read_wrong_encoding_file.skipped_paths[remote_tmp_dir_test] ==
               ("Failed to read the file %s/hello_world.gbk due to an encoding error. current encoding: utf-8" % (remote_tmp_dir_test))
 
 - name: read a gbk file by gbk
@@ -479,3 +479,31 @@
 
 - name: Run mode tests
   import_tasks: mode.yml
+
+- name: User block
+  become: true
+  become_user: "{{ test_user_name }}"
+  block:
+    - name: Create file in home dir
+      copy:
+        content: ""
+        dest: ~/wharevs.txt
+        mode: '0644'
+
+    - name: Find file in home dir with ~/
+      find:
+        paths: ~/
+        patterns: 'whar*'
+      register: homedir_search
+
+    - set_fact:
+        astest_list: "{{ homedir_search.files | map(attribute='path') }}"
+
+    - name: Check if found
+      assert:
+        that:
+          - homedir_search is success
+          - homedir_search.matched == 1
+          - '"{{ homedir }}/wharevs.txt" in astest_list'
+      vars:
+        homedir: "{{ test_user.home }}"

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -19,7 +19,6 @@ lib/ansible/modules/copy.py validate-modules:undocumented-parameter
 lib/ansible/modules/dnf.py validate-modules:parameter-invalid
 lib/ansible/modules/dnf5.py validate-modules:parameter-invalid
 lib/ansible/modules/file.py validate-modules:undocumented-parameter
-lib/ansible/modules/find.py use-argspec-type-path # fix needed
 lib/ansible/modules/git.py use-argspec-type-path
 lib/ansible/modules/git.py validate-modules:doc-required-mismatch
 lib/ansible/modules/package_facts.py validate-modules:doc-choices-do-not-match-spec


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove the cases in `ignore.txt` for the module `find`.

Case 1: use-argspec-type-path
Change the option `path` from `list[str]` to `list[path]` and removed the call to `expanduser()`.

Not sure what Issue Type to use in this PR, marked all that made any sense in this context.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Test Pull Request
