### PR TITLE
remove ignore clauses for module blockinfile

### DIFF
--- a/lib/ansible/modules/blockinfile.py
+++ b/lib/ansible/modules/blockinfile.py
@@ -50,12 +50,10 @@ options:
     description:
     - If specified and no begin/ending O(marker) lines are found, the block will be inserted after the last match of specified regular expression.
     - A special value is available; V(EOF) for inserting the block at the end of the file.
-    - If specified regular expression has no matches, V(EOF) will be used instead.
+    - If specified regular expression has no matches or no value is passed, V(EOF) will be used instead.
     - The presence of the multiline flag (?m) in the regular expression controls whether the match is done line by line or with multiple lines.
       This behaviour was added in ansible-core 2.14.
     type: str
-    choices: [ EOF, '*regex*' ]
-    default: EOF
   insertbefore:
     description:
     - If specified and no begin/ending O(marker) lines are found, the block will be inserted before the last match of specified regular expression.
@@ -64,7 +62,6 @@ options:
     - The presence of the multiline flag (?m) in the regular expression controls whether the match is done line by line or with multiple lines.
       This behaviour was added in ansible-core 2.14.
     type: str
-    choices: [ BOF, '*regex*' ]
   create:
     description:
     - Create a new file if it does not exist.

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -9,8 +9,6 @@ lib/ansible/modules/async_status.py validate-modules!skip
 lib/ansible/modules/async_wrapper.py ansible-doc!skip  # not an actual module
 lib/ansible/modules/async_wrapper.py pylint:ansible-bad-function # ignore, required
 lib/ansible/modules/async_wrapper.py use-argspec-type-path
-lib/ansible/modules/blockinfile.py validate-modules:doc-choices-do-not-match-spec
-lib/ansible/modules/blockinfile.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/command.py validate-modules:doc-default-does-not-match-spec  # _uses_shell is undocumented
 lib/ansible/modules/command.py validate-modules:doc-missing-type
 lib/ansible/modules/command.py validate-modules:nonexistent-parameter-documented


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove the cases in `ignore.txt` for the module `blockinfile`.

Case 1: validate-modules:doc-choices-do-not-match-spec
The specification `choices` did not represent an actual choice in the code, it seems it was used to generate the idea of this choice in the documentation. This is not consistent with most of the modules in core and/or collections, and it is arguably better expressed as `str` option with a special value (`BOF` or `EOF` depending on the option) that has a distinct semantic.

Case 2: validate-modules:doc-default-does-not-match-spec
The parameter does not actually has that default value. In fact, if adding the default value to the module arg_spec the integration test fails. The documentation description already describes the behavior when nothing is passed.

Not sure what Issue Type to use in this PR, marked all that made any sense in this context.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Test Pull Request
