### PR TITLE
[WIP]Handle missing remote-tracking branch when switching version

### DIFF
--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -1012,7 +1012,11 @@ def set_remote_branch(git_path, module, dest, remote, version, depth):
 
     branchref = "+refs/heads/%s:refs/heads/%s" % (version, version)
     branchref += ' +refs/heads/%s:refs/remotes/%s/%s' % (version, remote, version)
-    cmd = "%s fetch --depth=%s %s %s" % (git_path, depth, remote, branchref)
+
+    cmd = "%s fetch" % git_path
+    if depth is not None:
+        cmd += " --depth=%s" % depth
+    cmd += " %s %s" % (remote, branchref)
     (rc, out, err) = module.run_command(cmd, cwd=dest)
     if rc != 0:
         module.fail_json(msg="Failed to fetch branch from remote: %s" % version, stdout=out, stderr=err, rc=rc)
@@ -1030,7 +1034,7 @@ def switch_version(git_path, module, dest, remote, version, verify_commit, depth
     else:
         # FIXME check for local_branch first, should have been fetched already
         if is_remote_branch(git_path, module, dest, remote, version):
-            if depth and not is_local_branch(git_path, module, dest, version):
+            if not is_local_branch(git_path, module, dest, version):
                 # git clone --depth implies --single-branch, which makes
                 # the checkout fail if the version changes
                 # fetch the remote branch, to be able to check it out next


### PR DESCRIPTION
Fixes #82007

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

If using `single_branch` parameter in `ansible.builtin.git` module, git will only track the specific revision, which cause the next different revision checkout failed.
Since ansible git module use `git branch --no-color -a` to list local branch(is_local_branch -> get_branches), which will display all local and remote-tracking branches. If we ensure the branch is in remote repo and is not in local or tracked, it's safe to fetch remote without checking the `depth` parameter.
The limitation of checking the `depth` parameter is that it count not correctly handle a `--single-branch` clone repo.


##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

reproduce.yml
```yml
- hosts: localhost
  tasks:
    - name: Remove git repo if required
      file:
        path: /tmp/test_clone_repo
        state: absent

    - name: Clone the git repo with only a single branch
      ansible.builtin.git:
        repo: https://github.com/ansible/ansible-examples.git
        version: master
        dest: /tmp/test_clone_repo
        single_branch: true

    - name: Attempt to change the branch
      ansible.builtin.git:
        repo: https://github.com/ansible/ansible-examples.git
        version: provisioning
        dest: /tmp/test_clone_repo
```

###### Before change

```sh
$ ansible-playbook reproduce.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development.
This is a rapidly changing source of code and can become unstable at any point.
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ***************************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************************
ok: [localhost]

TASK [Remove git repo if required] *********************************************************************************************************************************************************
changed: [localhost]

TASK [Clone the git repo with only a single branch] ****************************************************************************************************************************************
changed: [localhost]

TASK [Attempt to change the branch] ********************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/git checkout --track -b provisioning origin/provisioning", "msg": "Failed to checkout provisioning", "rc": 128, "stderr": "fatal: 'origin/provisioning' is not a commit and a branch 'provisioning' cannot be created from it\n", "stderr_lines": ["fatal: 'origin/provisioning' is not a commit and a branch 'provisioning' cannot be created from it"], "stdout": "", "stdout_lines": []}

PLAY RECAP *********************************************************************************************************************************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

###### After change

```sh
$ ansible-playbook reproduce.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development.
This is a rapidly changing source of code and can become unstable at any point.
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ***************************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************************
ok: [localhost]

TASK [Remove git repo if required] *********************************************************************************************************************************************************
changed: [localhost]

TASK [Clone the git repo with only a single branch] ****************************************************************************************************************************************
changed: [localhost]

TASK [Attempt to change the branch] ********************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP *********************************************************************************************************************************************************************************
localhost                  : ok=4    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```