### PR TITLE
Handle missing remote-tracking branch when switching version

### DIFF
--- a/changelogs/fragments/82007-git-fix-missing-remote-tracking-branch.yml
+++ b/changelogs/fragments/82007-git-fix-missing-remote-tracking-branch.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- git - Fixed the issue where fetching a specific branch would fail if the remote tracking branch was missing. This typically occurs when the initial git clone was performed using the --single-branch or --depth parameters." (https://github.com/ansible/ansible/issues/82007).

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -1018,6 +1018,30 @@ def set_remote_branch(git_path, module, dest, remote, version, depth):
         module.fail_json(msg="Failed to fetch branch from remote: %s" % version, stdout=out, stderr=err, rc=rc)
 
 
+def fix_remote_tracking_branch(git_path, module, dest, remote, version, single_branch):
+    """
+    Fix the remote tracking branch configuration for a Git repository.
+
+    When a Git repository is cloned with the --single-branch or --depth options, it may not fetch other branches.
+    This function checks if the current branch is not a local branch but exists on the remote.
+    If so, it updates the remote tracking branch configuration to allow fetching the specified branch.
+    """
+    if single_branch:
+        fetch_ref = '+refs/heads/%s:refs/remotes/origin/%s' % (version, version)
+    else:
+        fetch_ref = '+refs/heads/*:refs/remotes/origin/*'
+
+    cmd = [git_path, 'config', 'remote.origin.fetch', fetch_ref]
+    (rc, out, err) = module.run_command(cmd, cwd=dest)
+    if rc != 0:
+        module.fail_json(
+            msg='Failed to fix remote tracking branch.',
+            stdout=out,
+            stderr=err,
+            rc=rc,
+            cmd=cmd)
+
+
 def switch_version(git_path, module, dest, remote, version, verify_commit, depth, gpg_allowlist):
     cmd = ''
     if version == 'HEAD':
@@ -1381,6 +1405,9 @@ def main():
                     result['diff'] = diff
             module.exit_json(**result)
         else:
+            if not is_local_branch(git_path, module, dest, version) and is_remote_branch(git_path, module, dest, remote, version):
+                fix_remote_tracking_branch(git_path, module, dest, remote, version, single_branch)
+                result.update(changed=True)
             fetch(git_path, module, repo, dest, version, remote, depth, bare, refspec, git_version_used, force=force)
 
         result['after'] = get_version(module, git_path, dest)

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -1031,7 +1031,7 @@ def fix_remote_tracking_branch(git_path, module, dest, remote, version, single_b
     else:
         fetch_ref = '+refs/heads/*:refs/remotes/origin/*'
 
-    cmd = [git_path, 'config', 'remote.origin.fetch', fetch_ref]
+    cmd = [git_path, 'config', 'remote.%s.fetch' % remote, fetch_ref]
     (rc, out, err) = module.run_command(cmd, cwd=dest)
     if rc != 0:
         module.fail_json(


### PR DESCRIPTION
Fixes #82007

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

When a git repository is cloned with the `--single-branch` or `--depth` options, other branches may not be fetched. The Ansible git module uses `git branch --no-color -a` to list all local and remote-tracking branches. If a branch exists in the remote repository but not locally or as a remote-tracking branch, adjust the git remote tracking branch configuration accordingly.


##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

reproduce.yml
```yml
- hosts: localhost
  tasks:
    - name: Remove git repo if required
      ansible.builtin.file:
        path: /tmp/test_clone_repo
        state: absent

    - name: Clone the git repo with only a single branch
      ansible.builtin.git:
        repo: https://github.com/ansible/ansible-examples.git
        version: master
        dest: /tmp/test_clone_repo
        single_branch: true

    - name: Attempt to change the branch with single_branch
      ansible.builtin.git:
        repo: https://github.com/ansible/ansible-examples.git
        version: provisioning
        dest: /tmp/test_clone_repo
        single_branch: true
    
    - name: Execute git config command
      ansible.builtin.command: git config --get-all remote.origin.fetch
      args:
        chdir: /tmp/test_clone_repo
      register: git_config_output
    
    - name: Print git config output
      debug:
        msg: "{{ git_config_output.stdout_lines }}"
```

###### Before change

```sh
$ ansible-playbook reproduce.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development.
This is a rapidly changing source of code and can become unstable at any point.
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ***************************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************************
ok: [localhost]

TASK [Remove git repo if required] *********************************************************************************************************************************************************
changed: [localhost]

TASK [Clone the git repo with only a single branch] ****************************************************************************************************************************************
changed: [localhost]

TASK [Attempt to change the branch with single_branch] *************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/git checkout --track -b provisioning origin/provisioning", "msg": "Failed to checkout provisioning", "rc": 128, "stderr": "fatal: 'origin/provisioning' is not a commit and a branch 'provisioning' cannot be created from it\n", "stderr_lines": ["fatal: 'origin/provisioning' is not a commit and a branch 'provisioning' cannot be created from it"], "stdout": "", "stdout_lines": []}

PLAY RECAP *********************************************************************************************************************************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

###### After change

```sh
$ ansible-playbook reproduce.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development.
This is a rapidly changing source of code and can become unstable at any point.
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] ***************************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************************
ok: [localhost]

TASK [Remove git repo if required] *********************************************************************************************************************************************************
changed: [localhost]

TASK [Clone the git repo with only a single branch] ****************************************************************************************************************************************
changed: [localhost]

TASK [Attempt to change the branch with single_branch] *************************************************************************************************************************************
changed: [localhost]

TASK [Execute git config command] **********************************************************************************************************************************************************
changed: [localhost]

TASK [Print git config output] *************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": [
        "+refs/heads/provisioning:refs/remotes/origin/provisioning"
    ]
}

PLAY RECAP *********************************************************************************************************************************************************************************
localhost                  : ok=6    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```