### PR TITLE
module compression is now again settable via var (#83573)

### DIFF
--- a/changelogs/fragments/mc_fix.yml
+++ b/changelogs/fragments/mc_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - config, restored the ability to set module compression via a variable

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -855,8 +855,8 @@ DEFAULT_MODULE_COMPRESSION:
   env: []
   ini:
   - {key: module_compression, section: defaults}
-# vars:
-#   - name: ansible_module_compression
+  vars:
+    - name: ansible_module_compression
 DEFAULT_MODULE_NAME:
   name: Default adhoc module
   default: command


### PR DESCRIPTION
Previous change overlooked 'uncommenting' the variable entry as a way to update this  to keep the functionality.

Co-authored-by: Glandos <bugs-github@antipoul.fr>
Co-authored-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 0eeb9332389d1e1742d40b9b8d2d3f85ca023a10)


##### ISSUE TYPE

- Bugfix Pull Request

