### PR TITLE
remove ignore clauses for module lineinfile

### DIFF
--- a/lib/ansible/modules/lineinfile.py
+++ b/lib/ansible/modules/lineinfile.py
@@ -87,13 +87,11 @@ options:
       - If specified, the line will be inserted after the last match of specified regular expression.
       - If the first match is required, use(firstmatch=yes).
       - A special value is available; V(EOF) for inserting the line at the end of the file.
-      - If specified regular expression has no matches, EOF will be used instead.
+      - If specified regular expression has no matches or no value is passed, V(EOF) will be used instead.
       - If O(insertbefore) is set, default value V(EOF) will be ignored.
       - If regular expressions are passed to both O(regexp) and O(insertafter), O(insertafter) is only honored if no match for O(regexp) is found.
       - May not be used with O(backrefs) or O(insertbefore).
     type: str
-    choices: [ EOF, '*regex*' ]
-    default: EOF
   insertbefore:
     description:
       - Used with O(state=present).
@@ -104,7 +102,6 @@ options:
       - If regular expressions are passed to both O(regexp) and O(insertbefore), O(insertbefore) is only honored if no match for O(regexp) is found.
       - May not be used with O(backrefs) or O(insertafter).
     type: str
-    choices: [ BOF, '*regex*' ]
     version_added: "1.1"
   create:
     description:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -22,8 +22,6 @@ lib/ansible/modules/file.py validate-modules:undocumented-parameter
 lib/ansible/modules/find.py use-argspec-type-path # fix needed
 lib/ansible/modules/git.py use-argspec-type-path
 lib/ansible/modules/git.py validate-modules:doc-required-mismatch
-lib/ansible/modules/lineinfile.py validate-modules:doc-choices-do-not-match-spec
-lib/ansible/modules/lineinfile.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/package_facts.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/replace.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/replace.py pylint:used-before-assignment  # false positive detection by pylint


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove the cases in `ignore.txt` for the module `lineinfile`. This PR presents essentially the same changes as #83577 , only for a different module.

Case 1: validate-modules:doc-choices-do-not-match-spec
The specification `choices` did not represent an actual choice in the code, it seems it was used to generate the idea of this choice in the documentation. This is not consistent with most of the modules in core and/or collections, and it is arguably better expressed as `str` option with a special value (`BOF` or `EOF` depending on the option) that has a distinct semantic.

Case 2: validate-modules:doc-default-does-not-match-spec
The parameter does not actually has that default value. In fact, if adding the default value to the module arg_spec the integration test fails. The documentation description already describes the behavior when nothing is passed.

Not sure what Issue Type to use in this PR, marked all that made any sense in this context.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Test Pull Request
