### PR TITLE
debconf: handle boolean value representation consistently

### DIFF
--- a/changelogs/fragments/83601-debconf-normalize-bools.yml
+++ b/changelogs/fragments/83601-debconf-normalize-bools.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - debconf - fix normalization of value representation for boolean vtypes in new packages (https://github.com/ansible/ansible/issues/83594)

--- a/lib/ansible/modules/debconf.py
+++ b/lib/ansible/modules/debconf.py
@@ -173,8 +173,6 @@ def set_selection(module, pkg, question, vtype, value, unseen):
     if unseen:
         cmd.append('-u')
 
-    if vtype == 'boolean':
-        value = value.lower()
     data = ' '.join([pkg, question, vtype, value])
 
     return module.run_command(cmd, data=data)
@@ -209,15 +207,17 @@ def main():
         if vtype is None or value is None:
             module.fail_json(msg="when supplying a question you must supply a valid vtype and value")
 
+        # ensure we compare booleans supplied to the way debconf sees them (true/false strings)
+        if vtype == 'boolean':
+            value = to_text(value).lower()
+
         # if question doesn't exist, value cannot match
         if question not in prev:
             changed = True
         else:
             existing = prev[question]
 
-            # ensure we compare booleans supplied to the way debconf sees them (true/false strings)
             if vtype == 'boolean':
-                value = to_text(value).lower()
                 existing = to_text(prev[question]).lower()
             elif vtype == 'password':
                 existing = get_password_value(module, pkg, question, vtype)

--- a/test/integration/targets/debconf/tasks/main.yml
+++ b/test/integration/targets/debconf/tasks/main.yml
@@ -146,6 +146,32 @@
           - not debconf_multiselect_test_idem_4.changed
           - '"Invalid value provided" in debconf_multiselect_test_idem_4.msg'
 
+    - name: Boolean vtype from boolean value
+      debconf:
+        name: libnns-ldap
+        question: libnss-ldapd/clean_nsswitch
+        vtype: boolean
+        value: true
+      register: debconf_bool_test_bool_1
+
+    - name: validate results for boolean vtype from boolean value
+      assert:
+        that:
+          - debconf_bool_test_bool_1.changed
+
+    - name: Boolean vtype from string value
+      debconf:
+        name: libnns-ldap
+        question: libnss-ldapd/clean_nsswitch
+        vtype: boolean
+        value: "FALSE"
+      register: debconf_bool_test_bool_2
+
+    - name: validate results for boolean vtype from string value
+      assert:
+        that:
+          - debconf_bool_test_bool_2.changed
+
   always:
     - name: uninstall debconf-utils
       apt:


### PR DESCRIPTION
##### SUMMARY

A past commit normalized the representation of values for boolean vtype as string for consistency with debconf values, but only if the question had been seen before.   A different past commit updated a different normalization with an incorrect assumption that the value would be type string.   As  a result, a boolean setting for a question not seen before would attempt to invoke a non-existent `lower()` method.

* lift code that normalizes value type for boolean vtype to cover both branches of conditional.
* remove obsolete and incomplete conversion of type in set_selection.

Fixes: #83594

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
