### PR TITLE
Fix file changed detection for get_url in check mode

### DIFF
--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -610,7 +610,7 @@ def main():
 
     # download to tmpsrc
     start = utcnow()
-    method = 'HEAD' if module.check_mode else 'GET'
+    method = 'GET'
     tmpsrc, info = url_get(module, url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest, method,
                            unredirected_headers=unredirected_headers, decompress=decompress, ciphers=ciphers, use_netrc=use_netrc)
     result['elapsed'] = (utcnow() - start).seconds

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -66,7 +66,7 @@
     that:
       - result is failed
 
-- name: test HTTP HEAD request for file in check mode
+- name: test HTTP GET request for file in check mode
   get_url:
     url: "https://{{ httpbin_host }}/get"
     dest: "{{ remote_tmp_dir }}/get_url_check.txt"
@@ -74,13 +74,13 @@
   check_mode: True
   register: result
 
-- name: assert that the HEAD request was successful in check mode
+- name: assert that the GET request was successful in check mode
   assert:
     that:
     - result is changed
     - '"OK" in result.msg'
 
-- name: test HTTP HEAD for nonexistent URL in check mode
+- name: test HTTP GET for nonexistent URL in check mode
   get_url:
     url: "https://{{ httpbin_host }}/DOESNOTEXIST"
     dest: "{{ remote_tmp_dir }}/shouldnotexist.html"
@@ -89,7 +89,7 @@
   register: result
   ignore_errors: True
 
-- name: assert that HEAD request for nonexistent URL failed
+- name: assert that GET request for nonexistent URL failed
   assert:
     that:
       - result is failed


### PR DESCRIPTION
##### SUMMARY

This pr revives https://github.com/ansible/ansible/pull/65703 and fixes https://github.com/ansible/ansible/issues/65687

Actually preforming the get request, even in check mode, results in the correct checksums being compared.

I prefer this solution over only checking if the file exists, as for our use case it is also important that the new file has the same content as the file on the remote url.
I can also compromise on making both those options available, depending on a variable. But that will make the code more complex.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION

I have removed the mentions off `HEAD` in the integration tests. The tests themselves did not seem to require a change.

It would be useful to also add a test on the actual issue: should not report changed when dest and source file are already the same. But I wasn't completely sure on how to write that.

```paste below
None
```
