### PR TITLE
Added info about MacOS targets for cron module

### DIFF
--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -131,6 +131,7 @@ options:
     version_added: "2.1"
 requirements:
   - cron (any 'vixie cron' conformant variant, like cronie)
+  - if used for newer MacOS targets, make sure to first enable these options under "Privacy" -> "Full Disk Access" - C(ssd-keygen-wrapper), C(Terminal) and C(cron).
 author:
   - Dane Summers (@dsummersl)
   - Mike Grozak (@rhaido)

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -131,7 +131,7 @@ options:
     version_added: "2.1"
 requirements:
   - cron (any 'vixie cron' conformant variant, like cronie)
-  - if used for newer MacOS targets, make sure to first enable these options under "Privacy" -> "Full Disk Access" - C(ssd-keygen-wrapper), C(Terminal) and C(cron).
+  - if used for newer MacOS targets, first enable these options under "Privacy" -> "Full Disk Access" - C(ssd-keygen-wrapper), C(Terminal) and C(cron).
 author:
   - Dane Summers (@dsummersl)
   - Mike Grozak (@rhaido)

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -131,7 +131,9 @@ options:
     version_added: "2.1"
 requirements:
   - cron (any 'vixie cron' conformant variant, like cronie)
-  - if used for newer MacOS targets, first enable these options under "Privacy" -> "Full Disk Access" - C(ssd-keygen-wrapper), C(Terminal) and C(cron).
+notes:
+  - If you are experiencing permissions issues with cron and MacOS,
+    you should see the official MacOS documentation for further information.
 author:
   - Dane Summers (@dsummersl)
   - Mike Grozak (@rhaido)


### PR DESCRIPTION


##### SUMMARY

<!--- Describe the change below, including rationale -->
If certain "full disk access" permissions are not given on a MacOS target, setting the cron will not be possible, so I've added a line explaining that.
<!--- HINT: Include "Closes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
Reference:
https://osxdaily.com/2020/04/27/fix-cron-permissions-macos-full-disk-access/#comment-9957102
<!--- Paste verbatim command output below, e.g. before and after your change -->
