### PR TITLE
Fix task-adjacent search path in roles

### DIFF
--- a/changelogs/fragments/dwim_is_role_fix_task_relative.yml
+++ b/changelogs/fragments/dwim_is_role_fix_task_relative.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix using the current task's directory for looking up relative paths within roles (https://github.com/ansible/ansible/issues/82695).

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -329,11 +329,10 @@ class DataLoader:
                 if (is_role or self._is_role(path)) and b_pb_base_dir.endswith(b'/tasks'):
                     search.append(os.path.join(os.path.dirname(b_pb_base_dir), b_dirname, b_source))
                     search.append(os.path.join(b_pb_base_dir, b_source))
-                else:
-                    # don't add dirname if user already is using it in source
-                    if b_source.split(b'/')[0] != dirname:
-                        search.append(os.path.join(b_upath, b_dirname, b_source))
-                    search.append(os.path.join(b_upath, b_source))
+                # don't add dirname if user already is using it in source
+                if b_source.split(b'/')[0] != dirname:
+                    search.append(os.path.join(b_upath, b_dirname, b_source))
+                search.append(os.path.join(b_upath, b_source))
 
             # always append basedir as last resort
             # don't add dirname if user already is using it in source

--- a/test/integration/targets/lookup_first_found/roles/a/tasks/main.yml
+++ b/test/integration/targets/lookup_first_found/roles/a/tasks/main.yml
@@ -1,0 +1,1 @@
+- include_tasks: subdir/main.yml

--- a/test/integration/targets/lookup_first_found/roles/a/tasks/subdir/main.yml
+++ b/test/integration/targets/lookup_first_found/roles/a/tasks/subdir/main.yml
@@ -1,0 +1,7 @@
+- assert:
+    that:
+      - "lookup('first_found', task_adjacent) is is_file"
+  vars:
+    task_adjacent:
+      - files:
+          - relative

--- a/test/integration/targets/lookup_first_found/tasks/main.yml
+++ b/test/integration/targets/lookup_first_found/tasks/main.yml
@@ -152,3 +152,7 @@
   assert:
     that:
       - q('first_found', ['/nonexistant'], skip=True) == []
+
+- name: Test relative paths in roles
+  include_role:
+    role: "{{ role_path }}/roles/a"


### PR DESCRIPTION
##### SUMMARY

Fixes #82695

Fix searching relative to the current task file's directory for as documented in https://docs.ansible.com/ansible/latest/playbook_guide/playbook_pathing.html#resolving-local-relative-paths (item 3):

```
Specifically, Ansible tries to find the file in the following order:
  1. In the current role.
      1. In its appropriate subdirectory: “files”, “vars”, “templates”, or “tasks”; depending on the kind of file Ansible is searching for.
      2. Directly in its directory.
  2. Like 1, in the parent role that called into this current role with include_role, import_role, or with a role dependency. If the parent role has its own parent role, Ansible will repeat this step with that role.
  3. Like 1, in the current task file’s directory.
  4. Like 1, in the current play file’s directory.
```

##### ISSUE TYPE

- Bugfix Pull Request
