### PR TITLE
[stable-2.15] 🧪 Use `setuptools [core]` @ collections_runtime_pythonpath (#83627)

### DIFF
--- a/test/integration/targets/collections_runtime_pythonpath/ansible-collection-python-dist-boo/pyproject.toml
+++ b/test/integration/targets/collections_runtime_pythonpath/ansible-collection-python-dist-boo/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
-  "setuptools >= 44",
-  "wheel",
+  "setuptools [core] >= 44",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This is now necessary since `setuptools >= 71` started preferring
externally present stdlib deps over the vendored ones.

Refs:
* https://github.com/pypa/setuptools/pull/4457
* https://github.com/pypa/setuptools/issues/4483
* https://github.com/pypa/setuptools/issues/2825

This additionally drops `wheel` from that test, as it was never needed, nor will it ever be.

(cherry picked from commit 0d5460d)

##### SUMMARY

$sbj.

##### ISSUE TYPE

- Maintenance Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

N/A