### PR TITLE
Update collections_runtime_pythonpath test

### DIFF
--- a/test/integration/targets/collections_runtime_pythonpath/ansible-collection-python-dist-boo/pyproject.toml
+++ b/test/integration/targets/collections_runtime_pythonpath/ansible-collection-python-dist-boo/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
   "setuptools >= 44",
-  "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/test/integration/targets/collections_runtime_pythonpath/ansible-collection-python-dist-boo/pyproject.toml
+++ b/test/integration/targets/collections_runtime_pythonpath/ansible-collection-python-dist-boo/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = [
-  "setuptools [core] >= 44",
+  "setuptools >= 44",
+  "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/test/integration/targets/collections_runtime_pythonpath/runme.sh
+++ b/test/integration/targets/collections_runtime_pythonpath/runme.sh
@@ -19,11 +19,11 @@ ansible \
 
 
 >&2 echo '=== Test that the module gets picked up if installed into site-packages ==='
-python -m pip install pep517
-( # Build a binary Python dist (a wheel) using PEP517:
+python -m pip install build
+( # Build a binary Python dist (a wheel) using build:
   cp -r ansible-collection-python-dist-boo "${OUTPUT_DIR}/"
   cd "${OUTPUT_DIR}/ansible-collection-python-dist-boo"
-  python -m pep517.build --binary --out-dir dist .
+  python -m build -w -o dist .
 )
 # Install a pre-built dist with pip:
 python -m pip install \


### PR DESCRIPTION
##### SUMMARY

Update the `collections_runtime_pythonpath` integration test to use `build` instead of the deprecated `pep517.build` tool.

This also reverts the previous change to use `setuptools [core]` instead of `setuptools` in the test.

##### ISSUE TYPE

Test Pull Request
