### PR TITLE
[stable-2.15] Use build instead of pep517 for integration test

### DIFF
--- a/test/integration/targets/collections_runtime_pythonpath/ansible-collection-python-dist-boo/pyproject.toml
+++ b/test/integration/targets/collections_runtime_pythonpath/ansible-collection-python-dist-boo/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
   "setuptools >= 44",
-  "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/test/integration/targets/collections_runtime_pythonpath/runme.sh
+++ b/test/integration/targets/collections_runtime_pythonpath/runme.sh
@@ -25,11 +25,11 @@ ansible \
     === Test that the module \
     gets picked up if installed \
     into site-packages ===
-python -m pip install pep517
-( # Build a binary Python dist (a wheel) using PEP517:
+python -m pip install build
+( # Build a binary Python dist (a wheel) using build:
   cp -r ansible-collection-python-dist-boo "${OUTPUT_DIR}/"
   cd "${OUTPUT_DIR}/ansible-collection-python-dist-boo"
-  python -m pep517.build --binary --out-dir dist .
+  python -m build -w -o dist .
 )
 # Install a pre-built dist with pip:
 python -m pip install \


### PR DESCRIPTION
##### SUMMARY

Partial backport of https://github.com/ansible/ansible/pull/83637

(cherry picked from commit f261a6142f2f56f69ee2896229c07814b3880095)

##### ISSUE TYPE

Test Pull Request
