### PR TITLE
remove ignore clauses for module uri

### DIFF
--- a/changelogs/fragments/83642-fix-sanity-ignore-for-uri.yml
+++ b/changelogs/fragments/83642-fix-sanity-ignore-for-uri.yml
@@ -1,2 +1,2 @@
-minor_changes:
-  - uri - minor refactor (https://github.com/ansible/ansible/pull/83642).
+bugfixes:
+  - uri - mark ``url`` as required (https://github.com/ansible/ansible/pull/83642).

--- a/changelogs/fragments/83642-fix-sanity-ignore-for-uri.yml
+++ b/changelogs/fragments/83642-fix-sanity-ignore-for-uri.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - uri - minor refactor (https://github.com/ansible/ansible/pull/83642).

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -606,6 +606,7 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout, c
 def main():
     argument_spec = url_argument_spec()
     argument_spec.update(
+        url=dict(type='str', required=True),
         dest=dict(type='path'),
         url_username=dict(type='str', aliases=['user']),
         url_password=dict(type='str', aliases=['password'], no_log=True),

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -605,8 +605,8 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout, c
 
 def main():
     argument_spec = url_argument_spec()
+    argument_spec['url']['required'] = True
     argument_spec.update(
-        url=dict(type='str', required=True),
         dest=dict(type='path'),
         url_username=dict(type='str', aliases=['user']),
         url_password=dict(type='str', aliases=['password'], no_log=True),

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -27,7 +27,6 @@ lib/ansible/modules/service.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/service.py validate-modules:use-run-command-not-popen
 lib/ansible/modules/stat.py validate-modules:parameter-invalid
 lib/ansible/modules/systemd_service.py validate-modules:parameter-invalid
-lib/ansible/modules/uri.py validate-modules:doc-required-mismatch
 lib/ansible/modules/user.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/user.py validate-modules:use-run-command-not-popen
 lib/ansible/module_utils/basic.py no-get-exception  # only referenced in deprecation code


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove the cases in `ignore.txt` for the module `uri`.

Case 1: doc-required-mismatch
Add parameter `url` in the module, overriding the one from `url_argument_spec()`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
