### PR TITLE
add continue_on_batch_failure playbook parameter

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -199,7 +199,7 @@ class PlaybookExecutor:
                             failed_hosts_count = len(self._tqm._failed_hosts) + len(self._tqm._unreachable_hosts) - \
                                 (previously_failed + previously_unreachable)
 
-                            if len(batch) == failed_hosts_count:
+                            if len(batch) == failed_hosts_count and not play.continue_on_batch_failure:
                                 break_play = True
                                 break
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -80,6 +80,7 @@ class Play(Base, Taggable, CollectionSearch):
     serial = NonInheritableFieldAttribute(isa='list', default=list, always_post_validate=True)
     strategy = NonInheritableFieldAttribute(isa='string', default=C.DEFAULT_STRATEGY, always_post_validate=True)
     order = NonInheritableFieldAttribute(isa='string', always_post_validate=True)
+    continue_on_batch_failure = NonInheritableFieldAttribute(isa='bool', default=False, always_post_validate=True)
 
     # =================================================================================
 


### PR DESCRIPTION
##### SUMMARY

ansible is used to run playbook on a set of hosts and there's the need to ensure the playbook is run on all hosts even if some fails during the process. This is especially true when serial is set to 1 as the whole playbook stops as soon as 1 host fails.

We have a use case where we want to run a complex playbook on all hosts 1 by 1 and ensure that it's run on all hosts even if some fails in between (because of unreachabled host or other hardware problems).

by adding the `continue_on_batch_failure` parameter at the playbook level we can have the option to ensure the playbook is run on all hosts.

Resolves #82267 #14665

<!--- HINT: Include "Resolves #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION
Here is a simple playbook to show the change:
```yaml
---
- hosts: all
  gather_facts: false
#  continue_on_batch_failure: true
  serial: 1
  tasks:

    - vars:
        is_even: "{{ inventory_hostname | int % 2 == 0 }}"
      fail:
        msg: failure
      when: is_even

    - command: /bin/true
...
```

when run without the `continue_on_batch_failure` playbook parameter, the run stop when host number 2 fails:
```
#:~/ansible# ansible-playbook -i 1,2,3,4 -c local playbook.yml

PLAY [all] *****************************************************************************************************************************

TASK [fail] ****************************************************************************************************************************
skipping: [1]

TASK [command] *************************************************************************************************************************
changed: [1]

PLAY [all] *****************************************************************************************************************************

TASK [fail] ****************************************************************************************************************************
fatal: [2]: FAILED! => changed=false
  msg: failure

PLAY RECAP *****************************************************************************************************************************
1                          : ok=1    changed=1    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
2                          : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```

And the same run with `continue_on_batch_failure` set to `true`, the run continues and show all hosts with 2 failures and 2 success:
```
#:~/ansible# ansible-playbook -i 1,2,3,4 -c local playbook.yml

PLAY [all] *****************************************************************************************************************************

TASK [fail] ****************************************************************************************************************************
skipping: [1]

TASK [command] *************************************************************************************************************************
changed: [1]

PLAY [all] *****************************************************************************************************************************

TASK [fail] ****************************************************************************************************************************
fatal: [2]: FAILED! => changed=false
  msg: failure

PLAY [all] *****************************************************************************************************************************

TASK [fail] ****************************************************************************************************************************
skipping: [3]

TASK [command] *************************************************************************************************************************
changed: [3]

PLAY [all] *****************************************************************************************************************************

TASK [fail] ****************************************************************************************************************************
fatal: [4]: FAILED! => changed=false
  msg: failure

PLAY RECAP *****************************************************************************************************************************
1                          : ok=1    changed=1    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
2                          : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
3                          : ok=1    changed=1    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0
4                          : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```