### PR TITLE
Remove explicit shell environment docs

### DIFF
--- a/changelogs/fragments/shell-environment.yml
+++ b/changelogs/fragments/shell-environment.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - Removed the shell ``environment`` config entry as this is already covered by the play/task directives documentation
+    and the value itself is not used in the shell plugins. This should remove any confusion around how people set the
+    environment for a task.

--- a/lib/ansible/plugins/doc_fragments/shell_common.py
+++ b/lib/ansible/plugins/doc_fragments/shell_common.py
@@ -59,14 +59,6 @@ options:
         key: async_dir
     vars:
       - name: ansible_async_dir
-  environment:
-    type: list
-    elements: dictionary
-    default: [{}]
-    description:
-      - List of dictionaries of environment variables and their values to use when executing commands.
-    keyword:
-      - name: environment
   admin_users:
     type: list
     elements: string

--- a/lib/ansible/plugins/doc_fragments/shell_windows.py
+++ b/lib/ansible/plugins/doc_fragments/shell_windows.py
@@ -38,13 +38,4 @@ options:
     type: bool
     default: 'no'
     choices: ['no', False]
-  environment:
-    description:
-    - List of dictionaries of environment variables and their values to use when
-      executing commands.
-    keyword:
-      - name: environment
-    type: list
-    elements: dictionary
-    default: [{}]
 """

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -38,6 +38,9 @@ class ShellBase(AnsiblePlugin):
 
         super(ShellBase, self).__init__()
 
+        # Not used but here for backwards compatibility.
+        # ansible.posix.fish uses (but does not actually use) this value.
+        # https://github.com/ansible-collections/ansible.posix/blob/f41f08e9e3d3129e709e122540b5ae6bc19932be/plugins/shell/fish.py#L38-L39
         self.env = {}
         self.tmpdir = None
         self.executable = None
@@ -59,18 +62,6 @@ class ShellBase(AnsiblePlugin):
     def set_options(self, task_keys=None, var_options=None, direct=None):
 
         super(ShellBase, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
-
-        # set env if needed, deal with environment's 'dual nature' list of dicts or dict
-        # TODO: config system should already resolve this so we should be able to just iterate over dicts
-        env = self.get_option('environment')
-        if isinstance(env, string_types):
-            raise AnsibleError('The "environment" keyword takes a list of dictionaries or a dictionary, not a string')
-        if not isinstance(env, Sequence):
-            env = [env]
-        for env_dict in env:
-            if not isinstance(env_dict, Mapping):
-                raise AnsibleError('The "environment" keyword takes a list of dictionaries (or single dictionary), but got a "%s" instead' % type(env_dict))
-            self.env.update(env_dict)
 
         # We can remove the try: except in the future when we make ShellBase a proper subset of
         # *all* shells.  Right now powershell and third party shells which do not use the


### PR DESCRIPTION
##### SUMMARY
Removes the docs for the environment keyword in the shell base plugins as they are a no-op in the plugins themselves. The environment value is provided by the action base which gets it from the action base on the task.environment value. This should avoid confusion around how its being set and removes some code that is not used at all.

The `environment` keyword is documented under https://docs.ansible.com/ansible/latest/reference_appendices/playbooks_keywords.html.

Fixes: https://github.com/ansible/ansible/issues/83646

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request
