### PR TITLE
user: create Buildroot subclass as alias to Busybox

### DIFF
--- a/changelogs/fragments/buildroot.yml
+++ b/changelogs/fragments/buildroot.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - user - Create Buildroot subclass as alias to Busybox (https://github.com/ansible/ansible/issues/83665).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3228,6 +3228,11 @@ class Alpine(BusyBox):
     distribution = 'Alpine'
 
 
+class Buildroot(BusyBox):
+    platform = 'Linux'
+    distribution = 'Buildroot'
+
+
 def main():
     ssh_defaults = dict(
         bits=0,


### PR DESCRIPTION
##### SUMMARY

Adds a alias subclass to match against Buidlroot (embedded distribution) for the `user module`

Fixes: #83665 

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

Buildroot defaults to using Busybox for user management which means that `useradd` isn't available.  The code for Busybox is there but there is no way to influence Ansible to use it with out a subclass to match on it.  So this adds a subclass.

The distibution name was retrieved from the device.

```
(.venv) # python
imPython 3.12.4 (main, Jul 13 2024, 22:33:31) [GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import distro
>>> distro.id()
'buildroot'
>>> distro.id().capitalize()
'Buildroot'
>>> ^D
```