### PR TITLE
Remove extraneous get_bin_path call

### DIFF
--- a/changelogs/fragments/linux_network_get.yml
+++ b/changelogs/fragments/linux_network_get.yml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
+bugfixes:
   - linux - remove extraneous get_bin_path API call.

--- a/changelogs/fragments/linux_network_get.yml
+++ b/changelogs/fragments/linux_network_get.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - linux - remove extraneous get_bin_path API call.

--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -295,8 +295,6 @@ class LinuxNetwork(Network):
                         if not address == '::1':
                             ips['all_ipv6_addresses'].append(address)
 
-            ip_path = self.module.get_bin_path("ip")
-
             args = [ip_path, 'addr', 'show', 'primary', 'dev', device]
             rc, primary_data, stderr = self.module.run_command(args, errors='surrogate_then_replace')
             if rc == 0:


### PR DESCRIPTION
##### SUMMARY

ip_path is already calculated befor calling get_interfaces_info

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


