### PR TITLE
Add argon2 support to password_hash

### DIFF
--- a/lib/ansible/plugins/filter/password_hash.yml
+++ b/lib/ansible/plugins/filter/password_hash.yml
@@ -17,7 +17,7 @@ DOCUMENTATION:
       description: Hashing algorithm to use.
       type: string
       default: sha512
-      choices: [ md5, blowfish, sha256, sha512, bcrypt ]
+      choices: [ md5, blowfish, sha256, sha512, bcrypt, argon2 ]
     salt:
       description: Secret string used for the hashing. If none is provided a random one can be generated. Use only numbers and letters (characters matching V([./0-9A-Za-z]+)).
       type: string


### PR DESCRIPTION
Adding the argon2 algorithm for `password_hash` -- this is already supported in `passlib` and is now the default hashing algorithm on NetBSD 10.