### PR TITLE
Use file name when content-disposition is inline

### DIFF
--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -444,7 +444,7 @@ def extract_filename_from_headers(headers):
 
     Looks for the content-disposition header and applies a regex.
     Returns the filename if successful, else None."""
-    cont_disp_regex = 'attachment; ?filename="?([^"]+)'
+    cont_disp_regex = 'attachment|inline; ?filename="?([^"]+)'
     res = None
 
     if 'content-disposition' in headers:


### PR DESCRIPTION
##### SUMMARY

Checks the content disposition header for either attachment or inline

Fixes https://github.com/ansible/ansible/issues/83690

##### ISSUE TYPE

- Bugfix Pull Request
