### PR TITLE
Remove EXTERNALLY-MANAGED marker in apt test

### DIFF
--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -38,3 +38,16 @@
 
   when:
     - ansible_distribution in ('Ubuntu', 'Debian')
+
+  always:
+    - name: Check if the target is managed by ansible-test
+      stat:
+        path: /etc/ansible-test.bootstrap
+      register: marker
+
+    - name: Ensure the EXTERNALLY-MANAGED marker is not present on the target
+      command: |
+        {{ ansible_python_interpreter | quote }}
+        -c
+        'import sysconfig; import pathlib; (pathlib.Path(sysconfig.get_path("stdlib")) / "EXTERNALLY-MANAGED").unlink(missing_ok=True);'
+      when: marker.stat.exists


### PR DESCRIPTION
##### SUMMARY

The marker is removed in ansible-test managed environments, but the apt test restores it by installing/upgrading packages. To avoid breaking later tests, the marker needs to be removed again.

##### ISSUE TYPE

Test Pull Request
