### PR TITLE
release.py - Use --force to remove temp worktree

### DIFF
--- a/packaging/release.py
+++ b/packaging/release.py
@@ -1321,7 +1321,7 @@ def build(allow_dirty: bool = False) -> None:
             create_reproducible_sdist(get_sdist_path(version, dist_dir), sdist_file, commit_time)
             get_wheel_path(version, dist_dir).rename(wheel_file)
         finally:
-            git("worktree", "remove", temp_dir)
+            git("worktree", "remove", "--force", temp_dir)
 
 
 @command


### PR DESCRIPTION
##### SUMMARY

Avoid an error when removing the temporary worktree due to generated files being present that were not ignored by git. This can happen with `pyproject.toml` based builds, which create an `ansible_core.egg-info` directory in the worktree.

##### ISSUE TYPE

Bugfix Pull Request
