### PR TITLE
fix error message when csvfile receives no search term

### DIFF
--- a/changelogs/fragments/fix-inconsistent-csvfile-missing-search-error.yml
+++ b/changelogs/fragments/fix-inconsistent-csvfile-missing-search-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - csvfile lookup - give an error when no search term is provided using modern config syntax (https://github.com/ansible/ansible/issues/83689).

--- a/test/integration/targets/lookup_csvfile/tasks/main.yml
+++ b/test/integration/targets/lookup_csvfile/tasks/main.yml
@@ -4,6 +4,12 @@
   ignore_errors: yes
   register: no_keyword
 
+- name: using modern syntax but missing keyword
+  set_fact:
+    this_will_error: "{{ lookup('csvfile', file=people.csv, delimiter=' ', col=1) }}"
+  ignore_errors: yes
+  register: modern_no_keyword
+
 - name: extra arg in k=v syntax (deprecated)
   set_fact:
     this_will_error: "{{ lookup('csvfile', 'foo file=people.csv delimiter=, col=1 thisarg=doesnotexist') }}"
@@ -27,6 +33,9 @@
       - no_keyword is failed
       - >
         "Search key is required but was not found" in no_keyword.msg
+      - modern_no_keyword is failed
+      - >
+        "Search key is required but was not found" in modern_no_keyword.msg
       - invalid_arg is failed
       - invalid_arg2 is failed
       - >


### PR DESCRIPTION
##### SUMMARY

Fixes #83689

Fix giving an error consistently for the csvfile lookup when no search term has been provided. This was the case for old-style syntax when the positional argument(s) contain only k=v values, now this is also the case when no positional arguments are given at all.

Also updated the documentation to indicate a positional argument is required and added an example looking up multiple terms.

##### ISSUE TYPE

- Bugfix Pull Request