### PR TITLE
Fix display to log severity mapping

### DIFF
--- a/changelogs/fragments/display_fix_log_severity.yml
+++ b/changelogs/fragments/display_fix_log_severity.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - display now does a better job of mapping warnings/errors to the proper log severity when using ansible.log. We still use color as a fallback mapping (now prioritiezed by severity) but mostly rely on it beind directly set by warnning/errors calls.

--- a/changelogs/fragments/display_fix_log_severity.yml
+++ b/changelogs/fragments/display_fix_log_severity.yml
@@ -1,2 +1,4 @@
 bugfixes:
   - display now does a better job of mapping warnings/errors to the proper log severity when using ansible.log. We still use color as a fallback mapping (now prioritiezed by severity) but mostly rely on it beind directly set by warnning/errors calls.
+minor_changes:
+  - ansible.log now also shows log severity field

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -401,6 +401,7 @@ class Display(metaclass=Singleton):
         screen_only: bool = False,
         log_only: bool = False,
         newline: bool = True,
+        caplevel: int | None = None,
     ) -> None:
         """ Display a message to the user
 
@@ -450,7 +451,7 @@ class Display(metaclass=Singleton):
             #         raise
 
         if logger and not screen_only:
-            self._log(nocolor, color)
+            self._log(nocolor, color, caplevel)
 
     def _log(self, msg: str, color: str | None = None, caplevel: int | None = None):
 

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -168,16 +168,16 @@ if getattr(C, 'DEFAULT_LOG_PATH'):
     else:
         print(f"[WARNING]: log file at '{path}' is not writeable and we cannot create it, aborting\n", file=sys.stderr)
 
-# map color to log levels
-color_to_log_level = {C.COLOR_ERROR: logging.ERROR,
-                      C.COLOR_UNREACHABLE: logging.ERROR,
-                      C.COLOR_WARN: logging.WARNING,
-                      C.COLOR_DEPRECATE: logging.WARNING,
-                      C.COLOR_SKIP: logging.WARNING,
+# map color to log levels, in order of priority (low to high)
+color_to_log_level = {C.COLOR_DEBUG: logging.DEBUG,
+                      C.COLOR_VERBOSE: logging.INFO,
                       C.COLOR_OK: logging.INFO,
                       C.COLOR_CHANGED: logging.INFO,
-                      C.COLOR_VERBOSE: logging.INFO,
-                      C.COLOR_DEBUG: logging.DEBUG}
+                      C.COLOR_SKIP: logging.WARNING,
+                      C.COLOR_DEPRECATE: logging.WARNING,
+                      C.COLOR_WARN: logging.WARNING,
+                      C.COLOR_UNREACHABLE: logging.ERROR,
+                      C.COLOR_ERROR: logging.ERROR}
 
 b_COW_PATHS = (
     b"/usr/bin/cowsay",

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -157,7 +157,7 @@ if getattr(C, 'DEFAULT_LOG_PATH'):
         if not os.path.isdir(path):
             # NOTE: level is kept at INFO to avoid security disclosures caused by certain libraries when using DEBUG
             logging.basicConfig(filename=path, level=logging.INFO,  # DO NOT set to logging.DEBUG
-                                format='%(asctime)s p=%(process)d u=%(user)s n=%(name)s | %(message)s')
+                                format='%(asctime)s p=%(process)d u=%(user)s n=%(name)s %(levelname)s| %(message)s')
 
             logger = logging.getLogger('ansible')
             for handler in logging.root.handlers:

--- a/test/integration/targets/ansible_log/logit.yml
+++ b/test/integration/targets/ansible_log/logit.yml
@@ -1,4 +1,12 @@
 - hosts: localhost
   gather_facts: false
   tasks:
-    - ping:
+    - name: normal task
+      ping:
+
+    - name: force warning
+      ping:
+      when: "{{pepe}} == 1"
+      vars:
+        lola: 1
+        pepe: lola

--- a/test/integration/targets/ansible_log/runme.sh
+++ b/test/integration/targets/ansible_log/runme.sh
@@ -14,9 +14,9 @@ ANSIBLE_LOG_PATH=${ALOG} ansible-playbook logit.yml
 # ensure log file is created
 [ -f "${ALOG}" ]
 # Ensure tasks and log levels appear
-grep -q '[normal task]' "${ALOG}"
-grep -q 'INFO| TASK [force warning]' "${ALOG}"
-grep -q 'WARNING| [WARNING]: conditional statements' "${ALOG}"
+grep -q '\[normal task\]' "${ALOG}"
+grep -q 'INFO| TASK \[force warning\]' "${ALOG}"
+grep -q 'WARNING| \[WARNING\]: conditional statements' "${ALOG}"
 rm "${ALOG}"
 
 # inline grep should fail if EXEC was present

--- a/test/integration/targets/ansible_log/runme.sh
+++ b/test/integration/targets/ansible_log/runme.sh
@@ -4,14 +4,22 @@ set -eux
 
 ALOG=${OUTPUT_DIR}/ansible_log_test.log
 
+# no log enabled
 ansible-playbook logit.yml
+# ensure file is not created
 [ ! -f "${ALOG}" ]
 
+# log enabled
 ANSIBLE_LOG_PATH=${ALOG} ansible-playbook logit.yml
+# ensure log file is created
 [ -f "${ALOG}" ]
+# has ping task as content
 grep -q 'ping' "${ALOG}"
-
+# Ensure log levels appear
+grep -q 'INFO| TASK [force warning]' ${ALOG}
+grep -q 'WARNING| [WARNING]: conditional statements' ${ALOG}
 rm "${ALOG}"
+
 # inline grep should fail if EXEC was present
 set +e
 ANSIBLE_LOG_PATH=${ALOG} ANSIBLE_LOG_VERBOSITY=3 ansible-playbook -v logit.yml | tee /dev/stderr | grep -q EXEC

--- a/test/integration/targets/ansible_log/runme.sh
+++ b/test/integration/targets/ansible_log/runme.sh
@@ -13,9 +13,8 @@ ansible-playbook logit.yml
 ANSIBLE_LOG_PATH=${ALOG} ansible-playbook logit.yml
 # ensure log file is created
 [ -f "${ALOG}" ]
-# has ping task as content
-grep -q 'ping' "${ALOG}"
-# Ensure log levels appear
+# Ensure tasks and log levels appear
+grep -q '[normal task]' "${ALOG}"
 grep -q 'INFO| TASK [force warning]' "${ALOG}"
 grep -q 'WARNING| [WARNING]: conditional statements' "${ALOG}"
 rm "${ALOG}"

--- a/test/integration/targets/ansible_log/runme.sh
+++ b/test/integration/targets/ansible_log/runme.sh
@@ -16,8 +16,8 @@ ANSIBLE_LOG_PATH=${ALOG} ansible-playbook logit.yml
 # has ping task as content
 grep -q 'ping' "${ALOG}"
 # Ensure log levels appear
-grep -q 'INFO| TASK [force warning]' ${ALOG}
-grep -q 'WARNING| [WARNING]: conditional statements' ${ALOG}
+grep -q 'INFO| TASK [force warning]' "${ALOG}"
+grep -q 'WARNING| [WARNING]: conditional statements' "${ALOG}"
 rm "${ALOG}"
 
 # inline grep should fail if EXEC was present


### PR DESCRIPTION
Use caplevel for better mapping than 'color value'
sort color/value mapping to favor/fail on the log severity precedence

Also ... actually show severity in logs, was not there and we did all this work to ignore it?

##### ISSUE TYPE

- Bugfix Pull Request
