### PR TITLE
release.py - Auto-update setuptools upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools >= 66.1.0"]  # minimum setuptools version supporting Python 3.12
+requires = ["setuptools >= 66.1.0, <= 72.1.0"]  # lower bound to support controller Python versions, upper bound for latest version tested at release
 build-backend = "setuptools.build_meta"

--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -95,7 +95,7 @@ def clean_repository(complete_file_list: list[str]) -> t.Generator[str, None, No
 def build(source_dir: str, tmp_dir: str) -> tuple[pathlib.Path, pathlib.Path]:
     """Create a sdist and wheel."""
     create = subprocess.run(
-        [sys.executable, '-m', 'build', '--no-isolation', '--outdir', tmp_dir],
+        [sys.executable, '-m', 'build', '--outdir', tmp_dir],
         stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,


### PR DESCRIPTION
##### SUMMARY

When releases are prepared, the upper bound on setuptools in pyproject.toml will be automatically updated to the latest version available on PyPI. This version will then be tested by the package-data sanity test during the release process and will be used to build the release.

This change ensures that a released version of ansible-core can be built in the future if a new setuptools release includes breaking changes that would prevent building a functional package. If a downstream package maintainer requires a newer setuptools version than the upper bound permits, they can patch pyproject.toml as needed. Since ansible-core releases support specific Python versions, lack of support for new setuptools releases will have no effect on support for future Python versions.

##### ISSUE TYPE

Feature Pull Request
