### PR TITLE
core: raw params better error msg

### DIFF
--- a/changelogs/fragments/raw_clean_msg.yml
+++ b/changelogs/fragments/raw_clean_msg.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - the raw arguments error now just displays the short names of modules instead of every possible variation

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -176,10 +176,10 @@ INTERNAL_STATIC_VARS = frozenset(
     ]
 )
 LOCALHOST = ('127.0.0.1', 'localhost', '::1')
-MODULE_REQUIRE_ARGS = tuple(add_internal_fqcns(('command', 'win_command', 'ansible.windows.win_command', 'shell', 'win_shell',
-                                                'ansible.windows.win_shell', 'raw', 'script')))
-MODULE_NO_JSON = tuple(add_internal_fqcns(('command', 'win_command', 'ansible.windows.win_command', 'shell', 'win_shell',
-                                           'ansible.windows.win_shell', 'raw')))
+WIN_MOVED = ['ansible.windows.win_command', 'ansible.windows.win_shell']
+MODULE_REQUIRE_ARGS_SIMPLE = ['command', 'raw', 'script', 'shell', 'win_command', 'win_shell']
+MODULE_REQUIRE_ARGS = tuple(add_internal_fqcns(MODULE_REQUIRE_ARGS_SIMPLE) + WIN_MOVED)
+MODULE_NO_JSON = tuple(add_internal_fqcns(('command', 'win_command', 'shell', 'win_shell', 'raw')) + WIN_MOVED)
 RESTRICTED_RESULT_KEYS = ('ansible_rsync_path', 'ansible_playbook_python', 'ansible_facts')
 SYNTHETIC_COLLECTIONS = ('ansible.builtin', 'ansible.legacy')
 TREE_DIR = None

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -31,7 +31,6 @@ from ansible.utils.sentinel import Sentinel
 # modules formated for user msg
 FREEFORM_ACTIONS = set(C.MODULE_REQUIRE_ARGS_SIMPLE)
 RAW_PARAM_MODULES = FREEFORM_ACTIONS.union(set([
-    'include',
     'include_vars',
     'include_tasks',
     'include_role',

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -28,10 +28,9 @@ from ansible.utils.fqcn import add_internal_fqcns
 from ansible.utils.sentinel import Sentinel
 
 
-# For filtering out modules correctly below
-FREEFORM_ACTIONS = frozenset(C.MODULE_REQUIRE_ARGS)
-
-RAW_PARAM_MODULES = FREEFORM_ACTIONS.union(add_internal_fqcns((
+# modules formated for user msg
+FREEFORM_ACTIONS = set(C.MODULE_REQUIRE_ARGS_SIMPLE)
+RAW_PARAM_MODULES = FREEFORM_ACTIONS.union(set([
     'include',
     'include_vars',
     'include_tasks',
@@ -42,8 +41,9 @@ RAW_PARAM_MODULES = FREEFORM_ACTIONS.union(add_internal_fqcns((
     'group_by',
     'set_fact',
     'meta',
-)))
-
+]))
+# For filtering out modules correctly below, use all permutations
+RAW_PARAM_MODULES_MATCH = add_internal_fqcns(RAW_PARAM_MODULES) + C.WIN_MOVED
 BUILTIN_TASKS = frozenset(add_internal_fqcns((
     'meta',
     'include_tasks',
@@ -352,7 +352,7 @@ class ModuleArgsParser:
             else:
                 raise AnsibleParserError("no module/action detected in task.",
                                          obj=self._task_ds)
-        elif args.get('_raw_params', '') != '' and action not in RAW_PARAM_MODULES:
+        elif args.get('_raw_params', '') != '' and action not in RAW_PARAM_MODULES_MATCH:
             templar = Templar(loader=None)
             raw_params = args.pop('_raw_params')
             if templar.is_template(raw_params):


### PR DESCRIPTION
Also removed 'include' from the list, since that module does not exist anymore.

##### ISSUE TYPE

- Bugfix Pull Request


#### ADDITIONAL INFO
before:

ERROR! this task 'assert' has extra params, which is only allowed in the following modules: import_tasks, ansible.legacy.command, ansible.builtin.include_role, ansible.builtin.shell, ansible.legacy.script, include_role, ansible.builtin.win_shell, ansible.windows.win_shell, ansible.legacy.import_role, ansible.legacy.include_vars, ansible.builtin.include, ansible.legacy.win_command, ansible.legacy.group_by, include_tasks, ansible.builtin.command, ansible.builtin.script, win_shell, include_vars, ansible.legacy.add_host, ansible.legacy.import_tasks, set_fact, ansible.builtin.include_vars, script, ansible.builtin.import_role, include, ansible.windows.win_command, ansible.legacy.set_fact, ansible.legacy.win_shell, meta, ansible.legacy.include, ansible.builtin.include_tasks, ansible.builtin.meta, ansible.legacy.shell, ansible.builtin.add_host, command, ansible.builtin.import_tasks, win_command, raw, ansible.legacy.meta, group_by, ansible.builtin.win_command, ansible.builtin.raw, shell, add_host, ansible.legacy.include_role, ansible.legacy.raw, import_role, ansible.builtin.group_by, ansible.builtin.set_fact, ansible.legacy.include_tasks


after:

ERROR! this task 'assert' has extra params, which is only allowed in the following modules: include_role, include_tasks, include_vars, import_tasks, group_by, import_role, command, add_host, shell, set_fact, include, script, meta, win_command, win_shell, raw

