### PR TITLE
[2.17] Fix task-adjacent search path in roles (#83621)

### DIFF
--- a/changelogs/fragments/dwim_is_role_fix_task_relative.yml
+++ b/changelogs/fragments/dwim_is_role_fix_task_relative.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix using the current task's directory for looking up relative paths within roles (https://github.com/ansible/ansible/issues/82695).

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -329,11 +329,10 @@ class DataLoader:
                 if (is_role or self._is_role(path)) and b_pb_base_dir.endswith(b'/tasks'):
                     search.append(os.path.join(os.path.dirname(b_pb_base_dir), b_dirname, b_source))
                     search.append(os.path.join(b_pb_base_dir, b_source))
-                else:
-                    # don't add dirname if user already is using it in source
-                    if b_source.split(b'/')[0] != dirname:
-                        search.append(os.path.join(b_upath, b_dirname, b_source))
-                    search.append(os.path.join(b_upath, b_source))
+                # don't add dirname if user already is using it in source
+                if b_source.split(b'/')[0] != dirname:
+                    search.append(os.path.join(b_upath, b_dirname, b_source))
+                search.append(os.path.join(b_upath, b_source))
 
             # always append basedir as last resort
             # don't add dirname if user already is using it in source

--- a/test/integration/targets/lookup_first_found/roles/a/tasks/main.yml
+++ b/test/integration/targets/lookup_first_found/roles/a/tasks/main.yml
@@ -1,0 +1,1 @@
+- include_tasks: subdir/main.yml

--- a/test/integration/targets/lookup_first_found/roles/a/tasks/subdir/main.yml
+++ b/test/integration/targets/lookup_first_found/roles/a/tasks/subdir/main.yml
@@ -1,0 +1,7 @@
+- assert:
+    that:
+      - "lookup('first_found', task_adjacent) is is_file"
+  vars:
+    task_adjacent:
+      - files:
+          - relative

--- a/test/integration/targets/lookup_first_found/tasks/main.yml
+++ b/test/integration/targets/lookup_first_found/tasks/main.yml
@@ -152,3 +152,7 @@
   assert:
     that:
       - q('first_found', ['/nonexistant'], skip=True) == []
+
+- name: Test relative paths in roles
+  include_role:
+    role: "{{ role_path }}/roles/a"


### PR DESCRIPTION
##### SUMMARY
Backport for #83621

* Restore search path in the current task file’s directory for roles

(cherry picked from commit 0be66ed6dcb9f499488df5c93168a8400b43cdac)

##### ISSUE TYPE

- Bugfix Pull Request
