### PR TITLE
[stable-2.16] csvfile lookup - fix giving an error when no search term is provided (#83710)

### DIFF
--- a/changelogs/fragments/fix-inconsistent-csvfile-missing-search-error.yml
+++ b/changelogs/fragments/fix-inconsistent-csvfile-missing-search-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - csvfile lookup - give an error when no search term is provided using modern config syntax (https://github.com/ansible/ansible/issues/83689).

--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -13,6 +13,7 @@ DOCUMENTATION = r"""
       - The csvfile lookup reads the contents of a file in CSV (comma-separated value) format.
         The lookup looks for the row where the first column matches keyname (which can be multiple words)
         and returns the value in the O(col) column (default 1, which indexed from 0 means the second column in the file).
+      - At least one keyname is required, provided as a positional argument(s) to the lookup.
     options:
       col:
         description:  column to return (0 indexed).
@@ -59,6 +60,22 @@ EXAMPLES = """
   vars:
     csvline: "{{ lookup('ansible.builtin.csvfile', bgp_neighbor_ip, file='bgp_neighbors.csv', delimiter=',') }}"
   delegate_to: localhost
+
+# Contents of debug.csv
+# test1 ret1.1 ret2.1
+# test2 ret1.2 ret2.2
+# test3 ret1.3 ret2.3
+
+- name: "Lookup multiple keynames in the first column (index 0), returning the values from the second column (index 1)"
+  debug:
+    msg: "{{ lookup('csvfile', 'test1', 'test2', file='debug.csv', delimiter=' ') }}"
+
+- name: Lookup multiple keynames using old style syntax
+  debug:
+    msg: "{{ lookup('csvfile', term1, term2) }}"
+  vars:
+    term1: "test1 file=debug.csv delimiter=' '"
+    term2: "test2 file=debug.csv delimiter=' '"
 """
 
 RETURN = """
@@ -145,6 +162,9 @@ class LookupModule(LookupBase):
 
         # populate options
         paramvals = self.get_options()
+
+        if not terms:
+            raise AnsibleError('Search key is required but was not found')
 
         for term in terms:
             kv = parse_kv(term)

--- a/test/integration/targets/lookup_csvfile/tasks/main.yml
+++ b/test/integration/targets/lookup_csvfile/tasks/main.yml
@@ -4,6 +4,12 @@
   ignore_errors: yes
   register: no_keyword
 
+- name: using modern syntax but missing keyword
+  set_fact:
+    this_will_error: "{{ lookup('csvfile', file=people.csv, delimiter=' ', col=1) }}"
+  ignore_errors: yes
+  register: modern_no_keyword
+
 - name: extra arg in k=v syntax (deprecated)
   set_fact:
     this_will_error: "{{ lookup('csvfile', 'foo file=people.csv delimiter=, col=1 thisarg=doesnotexist') }}"
@@ -27,6 +33,9 @@
       - no_keyword is failed
       - >
         "Search key is required but was not found" in no_keyword.msg
+      - modern_no_keyword is failed
+      - >
+        "Search key is required but was not found" in modern_no_keyword.msg
       - invalid_arg is failed
       - invalid_arg2 is failed
       - >

--- a/test/integration/targets/lookup_csvfile/tasks/main.yml
+++ b/test/integration/targets/lookup_csvfile/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: using modern syntax but missing keyword
   set_fact:
-    this_will_error: "{{ lookup('csvfile', file=people.csv, delimiter=' ', col=1) }}"
+    this_will_error: "{{ lookup('csvfile', file='people.csv', delimiter=' ', col=1) }}"
   ignore_errors: yes
   register: modern_no_keyword
 


### PR DESCRIPTION
##### SUMMARY
Backport for #83710

(cherry picked from commit 26c8a28d050422553df229743ffc86380dc50b81)

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
