### PR TITLE
cidr host list inventory plugin

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1643,7 +1643,7 @@ INVENTORY_ANY_UNPARSED_IS_FAILED:
   version_added: "2.7"
 INVENTORY_ENABLED:
   name: Active Inventory plugins
-  default: ['host_list', 'script', 'auto', 'yaml', 'ini', 'toml']
+  default: ['script', 'auto', 'yaml', 'ini', 'toml']
   description: List of enabled inventory plugins, it also determines the order in which they are used.
   env: [{name: ANSIBLE_INVENTORY_ENABLED}]
   ini:

--- a/lib/ansible/plugins/inventory/auto.py
+++ b/lib/ansible/plugins/inventory/auto.py
@@ -32,7 +32,7 @@ from ansible.plugins.loader import inventory_loader
 class InventoryModule(BaseInventoryPlugin):
 
     NAME = 'auto'
-    TOKEN = re.compile('@(\w+):.+')
+    TOKEN = re.compile(r'@(\w+):.+')
 
     def verify_file(self, path):
         if os.path.exists(path):

--- a/lib/ansible/plugins/inventory/cidr.py
+++ b/lib/ansible/plugins/inventory/cidr.py
@@ -62,5 +62,4 @@ class InventoryModule(BaseInventoryPlugin):
 
                 for ip in hostnames.hosts():
                     host = ip.exploded
-                    if host not in self.inventory.hosts:
-                        self.inventory.add_host(host, group='ungrouped')
+                    self.inventory.add_host(host, group='ungrouped')

--- a/lib/ansible/plugins/inventory/cidr.py
+++ b/lib/ansible/plugins/inventory/cidr.py
@@ -37,11 +37,13 @@ class InventoryModule(BaseInventoryPlugin):
 
     NAME = 'cidr'
 
+    _TOKEN = '@cidr:'
+
     def verify_file(self, path):
 
         valid = False
         b_path = to_bytes(path, errors='surrogate_or_strict')
-        if not os.path.exists(b_path) and ',' in path and path.startswith('@cidr:'):
+        if not os.path.exists(b_path) and ',' in path and path.startswith(self._TOKEN):
             valid = True
         return valid
 
@@ -54,7 +56,7 @@ class InventoryModule(BaseInventoryPlugin):
         host_list = path
 
         for h in host_list.split(','):
-            if h == '@CIDR':
+            if h == self._TOKEN:
                 # skip marker
                 continue
 

--- a/lib/ansible/plugins/inventory/cidr.py
+++ b/lib/ansible/plugins/inventory/cidr.py
@@ -10,8 +10,8 @@ DOCUMENTATION = '''
     description:
         - Parses a host list string as a comma separated values of CIDR notations to generate an IP range of hosts
     notes:
-        - To ensure addresses are parsed as CIDR, make sure this plugin is before
-          host_list and advance_host_list in enabled inventory plugins.
+        - To ensure addresses are parsed as CIDR, make sure this plugin is enabled before
+          host_list and advance_host_list and other 'less discerning' host list inventory plugins.
         - This is not meant to handle big ranges, specially with IPV6. Generating
           the range is quick but adding all those hosts to inventory can take a
           long time.
@@ -19,10 +19,10 @@ DOCUMENTATION = '''
 
 EXAMPLES = '''
     # simple range
-    # ansible -i '@CIDR, 192.168.0.1/24,' -m ping
+    # ansible -i '@cidr: 192.168.0.1/24,' -m ping
 
     # still supports w/o ranges also
-    # ansible-playbook -i '@CIDR, 192.168.0.1, 192.168.0.23,' myplay.yml
+    # ansible-playbook -i '@cidr: 192.168.0.1, 192.168.0.23,' myplay.yml
 '''
 
 import os
@@ -41,7 +41,7 @@ class InventoryModule(BaseInventoryPlugin):
 
         valid = False
         b_path = to_bytes(path, errors='surrogate_or_strict')
-        if not os.path.exists(b_path) and ',' in path and path.startswith('@CIDR,'):
+        if not os.path.exists(b_path) and ',' in path and path.startswith('@cidr:'):
             valid = True
         return valid
 

--- a/lib/ansible/plugins/inventory/cidr.py
+++ b/lib/ansible/plugins/inventory/cidr.py
@@ -65,6 +65,7 @@ class InventoryModule(BaseInventoryPlugin):
                 except ValueError as e:
                     raise AnsibleParserError(f"Unable to parse address from '{h}'") from e
 
+                self.display.debug(f"CIDR: adding {hostnames.num_addresses} hosts from {h}")
                 for ip in hostnames.hosts():
                     host = ip.exploded
                     self.inventory.add_host(host, group='ungrouped')

--- a/lib/ansible/plugins/inventory/cidr.py
+++ b/lib/ansible/plugins/inventory/cidr.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+DOCUMENTATION = '''
+    name: cidr
+    version_added: "2.18"
+    short_description: Parses CIDR expressions to generate inventory
+    description:
+        - Parses a host list string as a comma separated values of CIDR notations to generate an IP range of hosts
+    notes:
+        - To ensure addresses are parsed as CIDR, make sure this plugin is before
+          host_list and advance_host_list in enabled inventory plugins.
+'''
+
+EXAMPLES = '''
+    # simple range
+    ansible -i '@CIDR, 192.168.0.1/24,' -m ping
+
+    # still supports w/o ranges also
+    ansible-playbook -i '@CIDR, 192.168.0.1, 192.168.0.23,' myplay.yml
+'''
+
+import os
+import ipaddress
+
+from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.module_utils.common.text.converters import to_bytes
+from ansible.plugins.inventory import BaseInventoryPlugin
+
+
+class InventoryModule(BaseInventoryPlugin):
+
+    NAME = 'cidr'
+
+    def verify_file(self, host_list):
+
+        valid = False
+        b_path = to_bytes(host_list, errors='surrogate_or_strict')
+        if not os.path.exists(b_path) and ',' in host_list and host_list.startswith('@CIDR,'):
+            valid = True
+        return valid
+
+    def parse(self, inventory, loader, host_list, cache=True):
+        ''' parses the inventory string'''
+
+        super(InventoryModule, self).parse(inventory, loader, host_list)
+
+        for h in host_list.split(','):
+            if h == '@CIDR':
+                # skip marker
+                continue
+
+            h = h.strip()
+            if h:
+                try:
+                    hostnames = ipaddress.ip_network(h, False)
+                except ValueError as e:
+                    raise AnsibleError(f"Unable to parse address from '{h}'") from e
+
+                for ip in hostnames.hosts():
+                    host = ip.exploded
+                    if host not in self.inventory.hosts:
+                        self.inventory.add_host(host, group='ungrouped')

--- a/lib/ansible/plugins/inventory/cidr.py
+++ b/lib/ansible/plugins/inventory/cidr.py
@@ -52,13 +52,10 @@ class InventoryModule(BaseInventoryPlugin):
 
         super(InventoryModule, self).parse(inventory, loader, path)
 
-        # not really a path at this point
-        host_list = path
+        # not really a path at this point, also remove token
+        host_list = path.lstrip(self._TOKEN)
 
         for h in host_list.split(','):
-            if h == self._TOKEN:
-                # skip marker
-                continue
 
             h = h.strip()
             if h:

--- a/lib/ansible/plugins/inventory/cidr.py
+++ b/lib/ansible/plugins/inventory/cidr.py
@@ -16,10 +16,10 @@ DOCUMENTATION = '''
 
 EXAMPLES = '''
     # simple range
-    ansible -i '@CIDR, 192.168.0.1/24,' -m ping
+    # ansible -i '@CIDR, 192.168.0.1/24,' -m ping
 
     # still supports w/o ranges also
-    ansible-playbook -i '@CIDR, 192.168.0.1, 192.168.0.23,' myplay.yml
+    # ansible-playbook -i '@CIDR, 192.168.0.1, 192.168.0.23,' myplay.yml
 '''
 
 import os
@@ -34,11 +34,12 @@ class InventoryModule(BaseInventoryPlugin):
 
     NAME = 'cidr'
 
-    def verify_file(self, host_list):
+    def verify_file(self, path):
 
         valid = False
-        b_path = to_bytes(host_list, errors='surrogate_or_strict')
-        if not os.path.exists(b_path) and ',' in host_list and host_list.startswith('@CIDR,'):
+        b_path = to_bytes(path, errors='surrogate_or_strict')
+        if not os.path.exists(b_path) and ',' in path and path.startswith('@CIDR,'):
+            # not a path, but a hostlist with CIDR!
             valid = True
         return valid
 

--- a/lib/ansible/plugins/inventory/cidr.py
+++ b/lib/ansible/plugins/inventory/cidr.py
@@ -12,6 +12,9 @@ DOCUMENTATION = '''
     notes:
         - To ensure addresses are parsed as CIDR, make sure this plugin is before
           host_list and advance_host_list in enabled inventory plugins.
+        - This is not meant to handle big ranges, specially with IPV6. Generating
+          the range is quick but adding all those hosts to inventory can take a
+          long time.
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/plugins/inventory/cidr.py
+++ b/lib/ansible/plugins/inventory/cidr.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 DOCUMENTATION = '''
     name: cidr
-    version_added: "2.18"
-    short_description: Parses CIDR expressions to generate inventory
+    version_added: "2.19"
+    short_description: Parses CIDR expressions to generate inventory (not really adding to core, here to show usage of more generic inv plugin addressing).
     description:
         - Parses a host list string as a comma separated values of CIDR notations to generate an IP range of hosts
     notes:

--- a/lib/ansible/plugins/inventory/cidr.py
+++ b/lib/ansible/plugins/inventory/cidr.py
@@ -48,7 +48,7 @@ class InventoryModule(BaseInventoryPlugin):
         return valid
 
     def parse(self, inventory, loader, path, cache=True):
-        ''' parses the inventory string'''
+        """Extract hosts from the inventory string."""
 
         super().parse(inventory, loader, path)
 

--- a/lib/ansible/plugins/inventory/cidr.py
+++ b/lib/ansible/plugins/inventory/cidr.py
@@ -50,7 +50,7 @@ class InventoryModule(BaseInventoryPlugin):
     def parse(self, inventory, loader, path, cache=True):
         ''' parses the inventory string'''
 
-        super(InventoryModule, self).parse(inventory, loader, path)
+        super().parse(inventory, loader, path)
 
         # not really a path at this point, also remove token
         host_list = path.lstrip(self._TOKEN)


### PR DESCRIPTION
##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFO
```
$ ANSIBLE_INVENTORY_ENABLED=cidr ansible-inventory -i '@cidr: 10.10.1.23, 2001:db8::1, 192.168.1.25/30, 64:ff9b:1::/126' --list
{
    "_meta": {
        "hostvars": {}
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    },
    "ungrouped": {
        "hosts": [
            "10.10.1.23",
            "2001:0db8:0000:0000:0000:0000:0000:0001",
            "192.168.1.25",
            "192.168.1.26",
            "0064:ff9b:0001:0000:0000:0000:0000:0001",
            "0064:ff9b:0001:0000:0000:0000:0000:0002",
            "0064:ff9b:0001:0000:0000:0000:0000:0003"
        ]
    }
}
```

