### PR TITLE
winrm - Remove extras lookups

### DIFF
--- a/changelogs/fragments/winrm-extras.yaml
+++ b/changelogs/fragments/winrm-extras.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - winrm - Documented all valid winrm connection plugin options instead of relying on the extras var lookup.

--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -233,13 +233,13 @@ class TestWinRMKerbAuth(object):
     @pytest.mark.parametrize('options, expected', [
         [{},
          (["kinit", "user@domain"],)],
-        [{ 'ansible_winrm_kinit_cmd': 'kinit2'},
+        [{'ansible_winrm_kinit_cmd': 'kinit2'},
          (["kinit2", "user@domain"],)],
         [{'ansible_winrm_kerberos_delegation': True},
          (["kinit", "-f", "user@domain"],)],
-        [{ 'ansible_winrm_kinit_args': '-f -p'},
+        [{'ansible_winrm_kinit_args': '-f -p'},
          (["kinit", "-f", "-p", "user@domain"],)],
-        [{ 'ansible_winrm_kerberos_delegation': True, 'ansible_winrm_kinit_args': '-p'},
+        [{'ansible_winrm_kerberos_delegation': True, 'ansible_winrm_kinit_args': '-p'},
          (["kinit", "-p", "user@domain"],)]
     ])
     def test_kinit_success_subprocess(self, monkeypatch, options, expected):
@@ -270,13 +270,13 @@ class TestWinRMKerbAuth(object):
     @pytest.mark.parametrize('options, expected', [
         [{},
          ("kinit", ["user@domain"],)],
-        [{ 'ansible_winrm_kinit_cmd': 'kinit2'},
+        [{'ansible_winrm_kinit_cmd': 'kinit2'},
          ("kinit2", ["user@domain"],)],
         [{'ansible_winrm_kerberos_delegation': True},
          ("kinit", ["-f", "user@domain"],)],
-        [{ 'ansible_winrm_kinit_args': '-f -p'},
+        [{'ansible_winrm_kinit_args': '-f -p'},
          ("kinit", ["-f", "-p", "user@domain"],)],
-        [{ 'ansible_winrm_kerberos_delegation': True, 'ansible_winrm_kinit_args': '-p'},
+        [{'ansible_winrm_kerberos_delegation': True, 'ansible_winrm_kinit_args': '-p'},
          ("kinit", ["-p", "user@domain"],)]
     ])
     def test_kinit_success_pexpect(self, monkeypatch, options, expected):
@@ -318,7 +318,7 @@ class TestWinRMKerbAuth(object):
         pc = PlayContext()
         new_stdin = StringIO()
         conn = connection_loader.get('winrm', pc, new_stdin)
-        options = { "ansible_winrm_kinit_cmd": "/fake/kinit"}
+        options = {"ansible_winrm_kinit_cmd": "/fake/kinit"}
         conn.set_options(var_options=options)
         conn._build_winrm_kwargs()
 
@@ -341,7 +341,7 @@ class TestWinRMKerbAuth(object):
         pc = PlayContext()
         new_stdin = StringIO()
         conn = connection_loader.get('winrm', pc, new_stdin)
-        options = { "ansible_winrm_kinit_cmd": "/fake/kinit"}
+        options = {"ansible_winrm_kinit_cmd": "/fake/kinit"}
         conn.set_options(var_options=options)
         conn._build_winrm_kwargs()
 


### PR DESCRIPTION
##### SUMMARY
Removed the extras variable lookups for the winrm connection plugin. All valid options are explicitly documented and will no longer be looked up with the ansible_winrm_* variable names. This should have no impact on people using these variables as all existing options have been explicitly defined and will continue to work as before.

##### ISSUE TYPE
- Feature Pull Request

##### ADDITIONAL INFORMATION
The aim of this PR is to remove the usage of `_extras` functionality so it can be deprecated and eventually removed.