### PR TITLE
Sequence query fix

### DIFF
--- a/changelogs/fragments/fix-lookup-sequence-keyword-args-only.yml
+++ b/changelogs/fragments/fix-lookup-sequence-keyword-args-only.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sequence lookup - sequence query/lookups without positional arguments now return a valid list if their kwargs comprise a valid sequence expression (https://github.com/ansible/ansible/issues/82921).

--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -210,6 +210,9 @@ class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
         results = []
 
+        if (not terms) and kwargs:
+            terms = ['']
+
         for term in terms:
             try:
                 # set defaults/global

--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -171,6 +171,12 @@ class LookupModule(LookupBase):
             setattr(self, f, self.get_option(f))
 
     def sanity_check(self):
+        """
+        Returns True if options comprise a valid sequence expression
+        Raises AnsibleError if options are an invalid expression
+        Returns false if options are valid but result in an empty sequence - these cases do not raise exceptions
+        in order to maintain historic behavior
+        """
         if self.count is None and self.end is None:
             raise AnsibleError("must specify count or end in with_sequence")
         elif self.count is not None and self.end is not None:
@@ -180,16 +186,17 @@ class LookupModule(LookupBase):
             if self.count != 0:
                 self.end = self.start + self.count * self.stride - 1
             else:
-                self.start = 0
-                self.end = 0
-                self.stride = 0
-            del self.count
+                return False
         if self.stride > 0 and self.end < self.start:
             raise AnsibleError("to count backwards make stride negative")
         if self.stride < 0 and self.end > self.start:
             raise AnsibleError("to count forward don't make stride negative")
+        if self.stride == 0:
+            return False
         if self.format.count('%') != 1:
             raise AnsibleError("bad formatting string: %s" % self.format)
+
+        return True
 
     def generate_sequence(self):
         if self.stride >= 0:
@@ -226,10 +233,9 @@ class LookupModule(LookupBase):
                     raise AnsibleError("unknown error parsing with_sequence arguments: %r. Error was: %s" % (term, e))
 
                 self.set_fields()
-                self.sanity_check()
-
-                if self.stride != 0:
+                if self.sanity_check():
                     results.extend(self.generate_sequence())
+
             except AnsibleError:
                 raise
             except Exception as e:

--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -217,7 +217,8 @@ class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
         results = []
 
-        if (not terms) and kwargs:
+        if kwargs and not terms:
+            # All of the necessary arguments can be provided as keywords, but we still need something to loop over
             terms = ['']
 
         for term in terms:

--- a/test/integration/targets/lookup_sequence/tasks/main.yml
+++ b/test/integration/targets/lookup_sequence/tasks/main.yml
@@ -196,3 +196,91 @@
           - ansible_failed_result.msg == expected
       vars:
         expected: "bad formatting string: d"
+
+# Tests for lookup()/plugin() jinja invocation:
+# Many of these tests check edge case behaviors that are only possible when invoking query/lookup sequence through jinja.
+# While they aren't particularly intuitive, these tests ensure playbooks that could be relying on these behaviors don't
+# break in future
+- name: Test that sequence can be invoked using query/lookup with keyword args only
+  ping:
+    data: '{{ item }}'
+  loop: '{{ query("ansible.builtin.sequence", count=5, start=10) }}'
+  register: results1
+
+- name: Assert that sequence can be invoked using query/lookup with keyword args only
+  assert:
+    that:
+      - 'results1["results"][0]["ping"] == "10"'
+      - 'results1["results"][1]["ping"] == "11"'
+      - 'results1["results"][2]["ping"] == "12"'
+      - 'results1["results"][3]["ping"] == "13"'
+      - 'results1["results"][4]["ping"] == "14"'
+
+- name: Test that multiple positional args produces concatenated sequence
+  ping:
+    data: '{{ item }}'
+  loop: '{{ query("ansible.builtin.sequence", "count=5 start=1", "count=3 start=10 stride=2") }}'
+  register: results2
+
+- name: Assert that multiple positional args produces concatenated sequence
+  assert:
+    that:
+      - 'results2["results"][0]["ping"] == "1"'
+      - 'results2["results"][1]["ping"] == "2"'
+      - 'results2["results"][2]["ping"] == "3"'
+      - 'results2["results"][3]["ping"] == "4"'
+      - 'results2["results"][4]["ping"] == "5"'
+      - 'results2["results"][5]["ping"] == "10"'
+      - 'results2["results"][6]["ping"] == "12"'
+      - 'results2["results"][7]["ping"] == "14"'
+
+- name: Test that keyword arguments are applied to all positional expressions
+  ping:
+    data: '{{ item }}'
+  loop: '{{ query("ansible.builtin.sequence", "count=5 start=0", "count=5 start=20", stride=2) }}'
+  register: results3
+
+- name: Assert that keyword arguments are applied to all positional expressions
+  assert:
+    that:
+      - 'results3["results"][0]["ping"] == "0"'
+      - 'results3["results"][1]["ping"] == "2"'
+      - 'results3["results"][2]["ping"] == "4"'
+      - 'results3["results"][3]["ping"] == "6"'
+      - 'results3["results"][4]["ping"] == "8"'
+      - 'results3["results"][5]["ping"] == "20"'
+      - 'results3["results"][6]["ping"] == "22"'
+      - 'results3["results"][7]["ping"] == "24"'
+      - 'results3["results"][8]["ping"] == "26"'
+      - 'results3["results"][9]["ping"] == "28"'
+
+- name: Test that keyword arguments do not overwrite parameters present in positional expressions
+  ping:
+    data: '{{ item }}'
+  loop: '{{ query("ansible.builtin.sequence", "count=5 start=0", "count=5", start=20) }}'
+  register: results4
+
+- name: Assert that keyword arguments do not overwrite parameters present in positional expressions
+  assert:
+    that:
+      - 'results4["results"][0]["ping"] == "0"'
+      - 'results4["results"][1]["ping"] == "1"'
+      - 'results4["results"][2]["ping"] == "2"'
+      - 'results4["results"][3]["ping"] == "3"'
+      - 'results4["results"][4]["ping"] == "4"'
+      - 'results4["results"][5]["ping"] == "20"'
+      - 'results4["results"][6]["ping"] == "21"'
+      - 'results4["results"][7]["ping"] == "22"'
+      - 'results4["results"][8]["ping"] == "23"'
+      - 'results4["results"][9]["ping"] == "24"'
+
+- name: Test that call with no arguments produces an empty list
+  ping:
+    data: '{{ item }}'
+  loop: '{{ query("ansible.builtin.sequence") }}'
+  register: results5
+
+- name: Assert that call with no arguments produces an empty list
+  assert:
+    that:
+      - 'results5["results"] == []'

--- a/test/integration/targets/lookup_sequence/tasks/main.yml
+++ b/test/integration/targets/lookup_sequence/tasks/main.yml
@@ -201,86 +201,27 @@
 # Many of these tests check edge case behaviors that are only possible when invoking query/lookup sequence through jinja.
 # While they aren't particularly intuitive, these tests ensure playbooks that could be relying on these behaviors don't
 # break in future
-- name: Test that sequence can be invoked using query/lookup with keyword args only
-  ping:
-    data: '{{ item }}'
-  loop: '{{ query("ansible.builtin.sequence", count=5, start=10) }}'
-  register: results1
-
-- name: Assert that sequence can be invoked using query/lookup with keyword args only
+- name: Test lookup with keyword args only
   assert:
     that:
-      - 'results1["results"][0]["ping"] == "10"'
-      - 'results1["results"][1]["ping"] == "11"'
-      - 'results1["results"][2]["ping"] == "12"'
-      - 'results1["results"][3]["ping"] == "13"'
-      - 'results1["results"][4]["ping"] == "14"'
+      - query("ansible.builtin.sequence", count=5, start=10) == ["10", "11", "12", "13", "14"]
 
 - name: Test that multiple positional args produces concatenated sequence
-  ping:
-    data: '{{ item }}'
-  loop: '{{ query("ansible.builtin.sequence", "count=5 start=1", "count=3 start=10 stride=2") }}'
-  register: results2
-
-- name: Assert that multiple positional args produces concatenated sequence
   assert:
     that:
-      - 'results2["results"][0]["ping"] == "1"'
-      - 'results2["results"][1]["ping"] == "2"'
-      - 'results2["results"][2]["ping"] == "3"'
-      - 'results2["results"][3]["ping"] == "4"'
-      - 'results2["results"][4]["ping"] == "5"'
-      - 'results2["results"][5]["ping"] == "10"'
-      - 'results2["results"][6]["ping"] == "12"'
-      - 'results2["results"][7]["ping"] == "14"'
+      - query("ansible.builtin.sequence", "count=5 start=1", "count=3 start=10 stride=2") == ["1", "2", "3", "4", "5", "10", "12", "14"]
 
 - name: Test that keyword arguments are applied to all positional expressions
-  ping:
-    data: '{{ item }}'
-  loop: '{{ query("ansible.builtin.sequence", "count=5 start=0", "count=5 start=20", stride=2) }}'
-  register: results3
-
-- name: Assert that keyword arguments are applied to all positional expressions
   assert:
     that:
-      - 'results3["results"][0]["ping"] == "0"'
-      - 'results3["results"][1]["ping"] == "2"'
-      - 'results3["results"][2]["ping"] == "4"'
-      - 'results3["results"][3]["ping"] == "6"'
-      - 'results3["results"][4]["ping"] == "8"'
-      - 'results3["results"][5]["ping"] == "20"'
-      - 'results3["results"][6]["ping"] == "22"'
-      - 'results3["results"][7]["ping"] == "24"'
-      - 'results3["results"][8]["ping"] == "26"'
-      - 'results3["results"][9]["ping"] == "28"'
+      - query("ansible.builtin.sequence", "count=5 start=0", "count=5 start=20", stride=2) == ["0", "2", "4", "6", "8", "20", "22", "24", "26", "28"]
 
 - name: Test that keyword arguments do not overwrite parameters present in positional expressions
-  ping:
-    data: '{{ item }}'
-  loop: '{{ query("ansible.builtin.sequence", "count=5 start=0", "count=5", start=20) }}'
-  register: results4
-
-- name: Assert that keyword arguments do not overwrite parameters present in positional expressions
   assert:
     that:
-      - 'results4["results"][0]["ping"] == "0"'
-      - 'results4["results"][1]["ping"] == "1"'
-      - 'results4["results"][2]["ping"] == "2"'
-      - 'results4["results"][3]["ping"] == "3"'
-      - 'results4["results"][4]["ping"] == "4"'
-      - 'results4["results"][5]["ping"] == "20"'
-      - 'results4["results"][6]["ping"] == "21"'
-      - 'results4["results"][7]["ping"] == "22"'
-      - 'results4["results"][8]["ping"] == "23"'
-      - 'results4["results"][9]["ping"] == "24"'
+      - query("ansible.builtin.sequence", "count=5 start=0", "count=5", start=20) == ["0", "1", "2", "3", "4", "20", "21", "22", "23", "24"]
 
 - name: Test that call with no arguments produces an empty list
-  ping:
-    data: '{{ item }}'
-  loop: '{{ query("ansible.builtin.sequence") }}'
-  register: results5
-
-- name: Assert that call with no arguments produces an empty list
   assert:
     that:
-      - 'results5["results"] == []'
+      - query("ansible.builtin.sequence") == []


### PR DESCRIPTION
#### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Fixes #82921

Fixes query/lookup jinja invocations of built_in.sequence returning an empty list if no positional string arguments are provided despite the provided kwargs comprising options that should produce a valid sequence.

Adds integration tests to test behaviors only possible through invoking query/lookup to ensure future playbook compatibility.

Slight refactoring of sequence's run and sanity_test functions for clarity.

#### ISSUE TYPE

- Bugfix Pull Request

#### ADDITIONAL INFORMATION

##### Added tests for historical behavior
While investigating the behavior of sequence, I discovered some idiosyncratic behaviors only possible when calling through query/lookup. For one example, keyword arguments will be applied to the evaluation of every sequence expression unless that option is already present in the string:
```
query("ansible.builtin.sequence", "count= 4", "count=4 start=10", "count=4 stride=2", start=20, stride=5)
```
This will result in the sequence [0,5,10,15,10,15,20,25,20,22,24,26]. 

These behaviors were easy to break through function modification while still passing all current integration tests, so I've added tests to ensure that any playbooks using these historic query/lookup quirks (however unlikely) will not be broken by modifications made to sequence in the future.

##### Refactoring

The sanity function was refactored to return a bool, with comments that more clearly communicate that sequences are only added to result[] upon passing a successful sanity check in the run function. It behaves identically as before - options that would result in nothing being added to the result will still do without raising an exception, while exceptions that would cause playbooks to halt still do so.

The original issue has been fixed as demonstrated below:

##### Original Steps to Reproduce
```
- name: Debug
  loop:
    - query("ansible.builtin.sequence", count=2)
    - query("ansible.builtin.sequence", "count=2")
    - query("ansible.builtin.sequence", count=count_variable)
    - query("ansible.builtin.sequence", "count=count_variable")
  vars:
    count_variable: 2
  ansible.builtin.debug:
    var: '{{ item }}'
```

##### New Output Matches Expected
```
ok: [localhost] => (item=query("ansible.builtin.sequence", count=2)) => {
    "ansible_loop_var": "item",
    "item": "query(\"ansible.builtin.sequence\", count=2)",
    "query(\"ansible.builtin.sequence\", count=2)": [
        "1",
        "2"
    ]
}
ok: [localhost] => (item=query("ansible.builtin.sequence", "count=2")) => {
    "ansible_loop_var": "item",
    "item": "query(\"ansible.builtin.sequence\", \"count=2\")",
    "query(\"ansible.builtin.sequence\", \"count=2\")": [
        "1",
        "2"
    ]
}
ok: [localhost] => (item=query("ansible.builtin.sequence", count=count_variable)) => {
    "ansible_loop_var": "item",
    "item": "query(\"ansible.builtin.sequence\", count=count_variable)",
    "query(\"ansible.builtin.sequence\", count=count_variable)": [
        "1",
        "2"
    ]
}
fatal: [localhost]: FAILED! => {"msg": "Invalid type for configuration option plugin_type: lookup plugin: ansible_collections.ansible.builtin.plugins.lookup.sequence setting: count (from Direct): invalid literal for int() with base 10: 'count_variable'"}
```
