### PR TITLE
clarify ansible.builtin.success documentation

### DIFF
--- a/lib/ansible/plugins/test/failed.yml
+++ b/lib/ansible/plugins/test/failed.yml
@@ -5,7 +5,7 @@ DOCUMENTATION:
   short_description: did the task fail
   aliases: [failure]
   description:
-    - Tests if task finished in failure, opposite of C(succeeded).
+    - Tests if task finished in failure, opposite of P(ansible.builtin.succeeded#test).
     - This test checks for the existence of a C(failed) key in the input dictionary and that it is V(True) if present.
     - Tasks that get skipped or not executed due to other failures (syntax, templating, unreachable host, etc) do not return a 'failed' status.
   options:

--- a/lib/ansible/plugins/test/success.yml
+++ b/lib/ansible/plugins/test/success.yml
@@ -5,8 +5,10 @@ DOCUMENTATION:
   short_description: check task success
   aliases: [succeeded, successful]
   description:
-    - Tests if task finished successfully, opposite of C(failed).
-    - This test checks for the existence of a C(failed) key in the input dictionary and that it is V(False) if present
+    - Tests if task finished successfully, opposite of P(ansible.builtin.failed#test).
+    - This test checks for the existence of a C(failed) key in the input dictionary and that it is V(False) if present.
+    - Tasks that get skipped or not executed due to other failures (syntax, templating, unreachable host, etc) do not return a 'failed' status.
+    - To test if a successful task executed an action, see P(ansible.builtin.skippeded#test) and P(ansible.builtin.unreachable#test).
   options:
     _input:
       description: registered result from an Ansible task

--- a/lib/ansible/plugins/test/success.yml
+++ b/lib/ansible/plugins/test/success.yml
@@ -8,7 +8,7 @@ DOCUMENTATION:
     - Tests if task finished successfully, opposite of P(ansible.builtin.failed#test).
     - This test checks for the existence of a C(failed) key in the input dictionary and that it is V(False) if present.
     - Tasks that get skipped or not executed due to other failures (syntax, templating, unreachable host, etc) do not return a 'failed' status.
-    - To test if a successful task executed an action, see P(ansible.builtin.skippeded#test) and P(ansible.builtin.unreachable#test).
+    - To test if a successful task executed an action, see P(ansible.builtin.skipped#test) and P(ansible.builtin.unreachable#test).
   options:
     _input:
       description: registered result from an Ansible task


### PR DESCRIPTION
##### SUMMARY

Alternative to #83705

* Link to the succeeded Jinja2 test from the failed test and vice versa

* Copy line about skipped/unreachable to the succeeded test

* Add a line linking to the skipped and unreachable tests from the succeeded test

##### ISSUE TYPE

- Docs Pull Request