### PR TITLE
Add explicit winrm/psrp tests for HTTP and HTTPS

### DIFF
--- a/test/integration/targets/connection_psrp/tests.yml
+++ b/test/integration/targets/connection_psrp/tests.yml
@@ -126,3 +126,16 @@
         path: /tmp/empty.txt
         state: absent
       delegate_to: localhost
+
+  - name: Test PSRP HTTP connection
+    win_ping:
+    vars:
+      ansible_port: 5985
+      ansible_psrp_protocol: http
+
+  - name: Test PSRP HTTPS connection
+    win_ping:
+    vars:
+      ansible_port: 5986
+      ansible_psrp_protocol: https
+      ansible_psrp_cert_validation: ignore

--- a/test/integration/targets/connection_winrm/tests.yml
+++ b/test/integration/targets/connection_winrm/tests.yml
@@ -42,6 +42,20 @@
       that:
       - timeout_cmd.msg == 'The win_shell action failed to execute in the expected time frame (5) and was terminated'
 
+  - name: Test WinRM HTTP connection
+    win_ping:
+    vars:
+      ansible_port: 5985
+      ansible_winrm_scheme: http
+      ansible_winrm_transport: ntlm  # Verifies message encryption over HTTP
+
+  - name: Test WinRM HTTPS connection
+    win_ping:
+    vars:
+      ansible_port: 5986
+      ansible_winrm_scheme: https
+      ansible_winrm_server_cert_validation: ignore
+
   - name: get WinRM quota value
     win_shell: (Get-Item WSMan:\localhost\Service\MaxConcurrentOperationsPerUser).Value
     changed_when: false


### PR DESCRIPTION
##### SUMMARY
Make sure the `winrm` and `psrp` connection tests actually test out a connection over both HTTP and HTTPS. This verifies the message encryption behaviour over HTTP works and there are no quirks in the HTTPS setup.

##### ISSUE TYPE
- Test Pull Request

##### ADDITIONAL INFORMATION
The `winrm` connection plugin right now defaults to HTTPS over all hosts except for 2016 which uses HTTP + NTLM. Instead of running all tests in this configuration this PR limits the different scenario to just the connection specific tests making our matrix simpler.