### PR TITLE
galaxy-cli tasking polling interval from environment variable

### DIFF
--- a/changelogs/fragments/83803-collection-import-poll-interval.yml
+++ b/changelogs/fragments/83803-collection-import-poll-interval.yml
@@ -1,4 +1,4 @@
 minor_changes:
 - >-
-  ``ansible-galaxy collection import`` - add a configuration option for the initial poll interval
+  ``ansible-galaxy collection publish`` - add a configuration option for the initial poll interval
   used when checking the import status of a collection, since the default is relatively slow.

--- a/changelogs/fragments/83803-collection-import-poll-interval.yml
+++ b/changelogs/fragments/83803-collection-import-poll-interval.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- >-
+  ``ansible-galaxy collection import`` - add a configuration option for the initial poll interval
+  used when checking the import status of a collection, since the default is relatively slow.

--- a/changelogs/fragments/83803-collection-import-poll-interval.yml
+++ b/changelogs/fragments/83803-collection-import-poll-interval.yml
@@ -1,4 +1,4 @@
 minor_changes:
 - >-
-  ``ansible-galaxy collection publish`` - add a configuration option for the initial poll interval
-  used when checking the import status of a collection, since the default is relatively slow.
+  ``ansible-galaxy collection publish`` - add configuration options for the initial poll interval
+  and the exponential when checking the import status of a collection, since the default is relatively slow.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1530,13 +1530,21 @@ GALAXY_REQUIRED_VALID_SIGNATURE_COUNT:
   - Prepend + to the value to fail if no valid signatures are found for the collection.
 GALAXY_COLLECTION_IMPORT_POLL_INTERVAL:
   description:
-    - The initial interval in seconds for polling the import status of a collection, using exponential backoff with a factor of 1.5.
-    - The maximum total backoff is capped at 30 seconds.
+    - The initial interval in seconds for polling the import status of a collection.
+    - This interval increases exponentially based on the :ref:`galaxy_collection_import_poll_factor`, with a maximum delay of 30 seconds.
   type: float
   default: "2.0"
   env:
-    - name: ANSIBLE_GALAXY_SLEEP_SECONDS_POLLING
+    - name: ANSIBLE_GALAXY_COLLECTION_IMPORT_POLL_INTERVAL
   version_added: '2.18'
+GALAXY_COLLECTION_IMPORT_POLL_FACTOR:
+  description:
+    - The multiplier used to increase the :ref:`galaxy_collection_import_poll_interval` when checking the collection import status.
+  type: float
+  default: "1.5"
+  env:
+    - name: ANSIBLE_GALAXY_COLLECTION_IMPORT_POLL_FACTOR
+  version_added: "2.18"
 HOST_KEY_CHECKING:
   # NOTE: constant not in use by ssh/paramiko plugins anymore, but they do support the same configuration sources
   # TODO: check non ssh connection plugins for use/migration

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1528,6 +1528,14 @@ GALAXY_REQUIRED_VALID_SIGNATURE_COUNT:
   - The number of signatures that must be successful during GPG signature verification while installing or verifying collections.
   - This should be a positive integer or all to indicate all signatures must successfully validate the collection.
   - Prepend + to the value to fail if no valid signatures are found for the collection.
+GALAXY_COLLECTION_IMPORT_POLL_INTERVAL:
+  description:
+    - The initial interval in seconds for polling the import status of a collection, using exponential backoff with a factor of 1.5.
+    - The maximum total backoff is capped at 30 seconds.
+  type: float
+  default: "2.0"
+  env:
+    - name: ANSIBLE_GALAXY_SLEEP_SECONDS_POLLING
 HOST_KEY_CHECKING:
   # NOTE: constant not in use by ssh/paramiko plugins anymore, but they do support the same configuration sources
   # TODO: check non ssh connection plugins for use/migration

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1533,7 +1533,7 @@ GALAXY_COLLECTION_IMPORT_POLL_INTERVAL:
     - The initial interval in seconds for polling the import status of a collection.
     - This interval increases exponentially based on the :ref:`galaxy_collection_import_poll_factor`, with a maximum delay of 30 seconds.
   type: float
-  default: "2.0"
+  default: 2.0
   env:
     - name: ANSIBLE_GALAXY_COLLECTION_IMPORT_POLL_INTERVAL
   version_added: '2.18'
@@ -1541,7 +1541,7 @@ GALAXY_COLLECTION_IMPORT_POLL_FACTOR:
   description:
     - The multiplier used to increase the :ref:`galaxy_collection_import_poll_interval` when checking the collection import status.
   type: float
-  default: "1.5"
+  default: 1.5
   env:
     - name: ANSIBLE_GALAXY_COLLECTION_IMPORT_POLL_FACTOR
   version_added: "2.18"

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1536,6 +1536,7 @@ GALAXY_COLLECTION_IMPORT_POLL_INTERVAL:
   default: "2.0"
   env:
     - name: ANSIBLE_GALAXY_SLEEP_SECONDS_POLLING
+  version_added: '2.18'
 HOST_KEY_CHECKING:
   # NOTE: constant not in use by ssh/paramiko plugins anymore, but they do support the same configuration sources
   # TODO: check non ssh connection plugins for use/migration

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -719,7 +719,7 @@ class GalaxyAPI:
 
         display.display("Waiting until Galaxy import task %s has completed" % full_url)
         start = time.time()
-        wait = float(os.environ.get("ANSIBLE_GALAXY_SLEEP_SECONDS_POLLING", '2.0'))
+        wait = C.GALAXY_COLLECTION_IMPORT_POLL_INTERVAL
 
         while timeout == 0 or (time.time() - start) < timeout:
             try:

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -743,7 +743,7 @@ class GalaxyAPI:
             time.sleep(wait)
 
             # poor man's exponential backoff algo so we don't flood the Galaxy API, cap at 30 seconds.
-            wait = min(30, wait * 1.5)
+            wait = min(30, wait * C.GALAXY_COLLECTION_IMPORT_POLL_FACTOR)
         if state == 'waiting':
             raise AnsibleError("Timeout while waiting for the Galaxy import process to finish, check progress at '%s'"
                                % to_native(full_url))

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -719,7 +719,7 @@ class GalaxyAPI:
 
         display.display("Waiting until Galaxy import task %s has completed" % full_url)
         start = time.time()
-        wait = 2
+        wait = float(os.environ.get("ANSIBLE_GALAXY_SLEEP_SECONDS_POLLING", '2.0'))
 
         while timeout == 0 or (time.time() - start) < timeout:
             try:


### PR DESCRIPTION
##### SUMMARY

2 seconds is a long time relatively speaking for a battery of integration tests that call galaxy cli over and over.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

This is probably better done in the true ansible config structure and or via a cli arg, but I needed something right now.
