### PR TITLE
Add fact about physical memory size on linux

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -154,7 +154,7 @@ class LinuxHardware(Hardware):
                         if size.endswith("GB"):
                             memstats['real:physical'] += int(size.split()[0]) * 1024
                         else:
-                            physical_memory_mb += int(size)
+                            memstats['real:physical'] += int(size)
 
 
         memory_facts['memory_mb'] = {

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -156,7 +156,6 @@ class LinuxHardware(Hardware):
                         else:
                             memstats['real:physical'] += int(size[0])
 
-
         memory_facts['memory_mb'] = {
             'real': {
                 'physical': memstats.get('real:physical'),

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -151,10 +151,10 @@ class LinuxHardware(Hardware):
                 if rc == 0:
                     dimm_size_list = re.findall(r'^\s+Size: (\d+( GB)?)$', out, re.MULTILINE)
                     for size in dimm_size_list:
-                        if size.endswith("GB"):
-                            memstats['real:physical'] += int(size.split()[0]) * 1024
+                        if size[0].endswith("GB"):
+                            memstats['real:physical'] += int(size[0].split()[0]) * 1024
                         else:
-                            memstats['real:physical'] += int(size)
+                            memstats['real:physical'] += int(size[0])
 
 
         memory_facts['memory_mb'] = {

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -138,8 +138,16 @@ class LinuxHardware(Hardware):
         if None not in (memstats.get('swaptotal'), memstats.get('swapfree')):
             memstats['swap:used'] = memstats['swaptotal'] - memstats['swapfree']
 
+        if os.path.isdir('/sys/devices/system/edac/mc'):
+            memstats['real:physical'] = 0
+            for file in glob.glob('/sys/devices/system/edac/mc/*/dimm*/size'):
+                dimm_size_mb = get_file_content(file)
+                if dimm_size_mb is not None:
+                    memstats['real:physical'] += int(dimm_size_mb)
+
         memory_facts['memory_mb'] = {
             'real': {
+                'physical': memstats.get('real:physical'),
                 'total': memstats.get('memtotal'),
                 'used': memstats.get('real:used'),
                 'free': memstats.get('memfree'),

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -149,7 +149,7 @@ class LinuxHardware(Hardware):
             if dmi_bin is not None:
                 (rc, out, err) = self.module.run_command('%s -t memory' % dmi_bin)
                 if rc == 0:
-                    dimm_size_list = re.findall(r'^\s+Size: (.*)$', out, re.MULTILINE)
+                    dimm_size_list = re.findall(r'^\s+Size: (\d+( GB)?)$', out, re.MULTILINE)
                     for size in dimm_size_list:
                         if size.endswith("GB"):
                             memstats['real:physical'] += int(size.split()[0]) * 1024


### PR DESCRIPTION
##### SUMMARY
I would like to add a fact that shows the actualy physical memory of a server. This gets calculated via sysfs (edac).

Kernel doc:
https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-devices-edac
```
What:		/sys/devices/system/edac/mc/mc*/(dimm|rank)*/size
Date:		April 2012
Contact:	Mauro Carvalho Chehab <mchehab+samsung@kernel.org>
		linux-edac@vger.kernel.org
Description:	This attribute file will display the size of dimm or rank.
		For dimm*/size, this is the size, in MB of the DIMM memory
		stick. For rank*/size, this is the size, in MB for one rank
		of the DIMM memory stick. On single rank memories (1R), this
		is also the total size of the dimm. On dual rank (2R) memories,
		this is half the size of the total DIMM memories.
```

<!--- Describe the change below, including rationale and design decisions -->

So what I am doing is creating a new memory fact
ansible_memory_mb.real.physical

it will show 0 if neither the sysfs edac path exists or dmidecode is not working (no root)

<!--- HINT: Include "Resolves #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
example output of ansible_memory_mb with the new physical mem value:
```paste below
        "ansible_memory_mb": {
            "nocache": {
                "free": 60313,
                "used": 3689
            },
            "real": {
                "free": 53755,
                "physical": 65536,
                "total": 64002,
                "used": 10247
            },
            "swap": {
                "cached": 0,
                "free": 8191,
                "total": 8191,
                "used": 0
            }
        },
```
