### PR TITLE
[stable-2.15] Add explicit winrm/psrp tests for HTTP and HTTPS (#83769)

### DIFF
--- a/test/integration/targets/connection_psrp/tests.yml
+++ b/test/integration/targets/connection_psrp/tests.yml
@@ -126,3 +126,16 @@
         path: /tmp/empty.txt
         state: absent
       delegate_to: localhost
+
+  - name: Test PSRP HTTP connection
+    win_ping:
+    vars:
+      ansible_port: 5985
+      ansible_psrp_protocol: http
+
+  - name: Test PSRP HTTPS connection
+    win_ping:
+    vars:
+      ansible_port: 5986
+      ansible_psrp_protocol: https
+      ansible_psrp_cert_validation: ignore

--- a/test/integration/targets/connection_winrm/tests.yml
+++ b/test/integration/targets/connection_winrm/tests.yml
@@ -41,3 +41,17 @@
   - assert:
       that:
       - timeout_cmd.msg == 'The win_shell action failed to execute in the expected time frame (5) and was terminated'
+
+  - name: Test WinRM HTTP connection
+    win_ping:
+    vars:
+      ansible_port: 5985
+      ansible_winrm_scheme: http
+      ansible_winrm_transport: ntlm  # Verifies message encryption over HTTP
+
+  - name: Test WinRM HTTPS connection
+    win_ping:
+    vars:
+      ansible_port: 5986
+      ansible_winrm_scheme: https
+      ansible_winrm_server_cert_validation: ignore


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/83769
(cherry picked from commit dec49e62882b0f36f613a22ef8d07b8c13064cca)

##### ISSUE TYPE
- Test Pull Request