### PR TITLE
add sftp_batch_mode description

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -296,7 +296,7 @@ DOCUMENTATION = '''
             version_added: '2.7'
       sftp_batch_mode:
         default: true
-        description: 'TODO: write it'
+        description: Determines if SSH disable batch mode for sshpass or not for a connection.
         env: [{name: ANSIBLE_SFTP_BATCH_MODE}]
         ini:
         - {key: sftp_batch_mode, section: ssh_connection}


### PR DESCRIPTION
##### SUMMARY

The updated description explains the purpose of the code logic of `sftp_batch_mode`.

##### ISSUE TYPE

- Docs Pull Request for issue: #83813

##### ADDITIONAL INFORMATION
```
# line 724 in lib/ansible/plugins/connection/ssh.py

        b_args: t.Iterable[bytes]
        if subsystem == 'sftp' and self.get_option('sftp_batch_mode'):
            if conn_password:
                b_args = [b'-o', b'BatchMode=no']
                self._add_args(b_command, b_args, u'disable batch mode for sshpass')
            b_command += [b'-b', b'-']
```
The `sftp_batch_mode` determines whether to enable or disable SSH batch mode for SFTP connections based on the presence of a password. Disables batch mode when using a password to ensure proper authentication, and enables it otherwise for efficiency. Constructs the SSH command accordingly.

Before Change:
```      
        sftp_batch_mode:
        default: true
        description: 'TODO: write it'
        env: [{name: ANSIBLE_SFTP_BATCH_MODE}]
        ini:
        - {key: sftp_batch_mode, section: ssh_connection}
        type: bool
        vars:
          - name: ansible_sftp_batch_mode
            version_added: '2.7'
``` 
After Change: 
```
        sftp_batch_mode:
        default: true
        description: Determines if SSH disable batch mode for sshpass or not for a connection.
        env: [{name: ANSIBLE_SFTP_BATCH_MODE}]
        ini:
        - {key: sftp_batch_mode, section: ssh_connection}
        type: bool
        vars:
          - name: ansible_sftp_batch_mode
            version_added: '2.7'
```

