### PR TITLE
Fix up raw_params for ansible.windows modules

### DIFF
--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -359,8 +359,8 @@ class ModuleArgsParser:
             if templar.is_template(raw_params):
                 args['_variable_params'] = raw_params
             else:
-                raise AnsibleParserError("this task '%s' has extra params, which is only allowed in the following modules: %s" % (action,
-                                                                                                                                  ", ".join(RAW_PARAM_MODULES_SIMPLE)),
-                                         obj=self._task_ds)
+                raise AnsibleParserError(
+                    "this task '%s' has extra params, which is only allowed in the following modules: %s" % (action, ", ".join(RAW_PARAM_MODULES_SIMPLE)),
+                    obj=self._task_ds)
 
         return (action, args, delegate_to)

--- a/test/integration/targets/windows-minimal/tasks/main.yml
+++ b/test/integration/targets/windows-minimal/tasks/main.yml
@@ -65,3 +65,23 @@
       - win_ping_crash_result is not changed
       - 'win_ping_crash_result.msg == "Unhandled exception while executing module: boom"'
       - '"throw \"boom\"" in win_ping_crash_result.exception'
+
+- name: verify that shortname _raw_params works
+  win_shell: echo "name=foo"
+  register: win_shell_short_res
+  failed_when: win_shell_short_res.stdout | trim != 'name=foo'
+
+- name: verify that legacy _raw_params works
+  ansible.legacy.win_shell: echo "name=foo"
+  register: win_shell_legacy_res
+  failed_when: win_shell_legacy_res.stdout | trim != 'name=foo'
+
+- name: verify that builtin _raw_params works
+  ansible.builtin.win_shell: echo "name=foo"
+  register: win_shell_builtin_res
+  failed_when: win_shell_builtin_res.stdout | trim != 'name=foo'
+
+- name: verify that collection _raw_params works
+  ansible.windows.win_shell: echo "name=foo"
+  register: win_shell_collection_res
+  failed_when: win_shell_collection_res.stdout | trim != 'name=foo'


### PR DESCRIPTION
##### SUMMARY
Fixes up the logic for detecting if using ansible.windows.win_command or ansible.windows.win_shell with _raw_params. These two modules are special in that they can be referenced in 4 different ways but the ansible.windows collection specific prefix needs to be manually added to the list.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
A bugfix changelog is not needed as this was broken by https://github.com/ansible/ansible/commit/885e3766a8d637c00254d25ea91e77733cc904b8 which is only in devel.

cc @felixfontein as I know you were looking at this space due to the same change.