### PR TITLE
runtime-metadata sanity test: do not fail deprecation version checks if galaxy.yml has empty `version`

### DIFF
--- a/changelogs/fragments/83831-runtime-metadata-fix.yml
+++ b/changelogs/fragments/83831-runtime-metadata-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "runtime-metadata sanity test - do not crash on deprecations if ``galaxy.yml`` contains an empty ``version`` field (https://github.com/ansible/ansible/pull/83831)."

--- a/changelogs/fragments/83831-runtime-metadata-fix.yml
+++ b/changelogs/fragments/83831-runtime-metadata-fix.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - "runtime-metadata sanity test - do not crash on deprecations if ``galaxy.yml`` contains an empty ``version`` field (https://github.com/ansible/ansible/pull/83831)."
+  - "Fix ``SemanticVersion.parse()`` to store the version string so that ``__repr__`` reports it instead of ``None`` (https://github.com/ansible/ansible/pull/83831)."

--- a/lib/ansible/utils/version.py
+++ b/lib/ansible/utils/version.py
@@ -190,6 +190,7 @@ class SemanticVersion(Version):
             raise ValueError("invalid semantic version '%s'" % vstring)
 
         (major, minor, patch, prerelease, buildmetadata) = match.group(1, 2, 3, 4, 5)
+        self.vstring = vstring
         self.major = int(major)
         self.minor = int(minor)
         self.patch = int(patch)

--- a/test/integration/targets/ansible-test-sanity-runtime-metadata/aliases
+++ b/test/integration/targets/ansible-test-sanity-runtime-metadata/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group3  # runs in the distro test containers
+shippable/generic/group1  # runs in the default test container
+context/controller
+needs/target/collection

--- a/test/integration/targets/ansible-test-sanity-runtime-metadata/ansible_collections/ns/no_version/galaxy.yml
+++ b/test/integration/targets/ansible-test-sanity-runtime-metadata/ansible_collections/ns/no_version/galaxy.yml
@@ -1,0 +1,5 @@
+namespace: ns
+name: no_version
+version: null
+authors:
+  - Ansible

--- a/test/integration/targets/ansible-test-sanity-runtime-metadata/ansible_collections/ns/no_version/meta/runtime.yml
+++ b/test/integration/targets/ansible-test-sanity-runtime-metadata/ansible_collections/ns/no_version/meta/runtime.yml
@@ -1,0 +1,11 @@
+extra_key: true
+plugin_routing:
+  modules:
+    deprecated_module:
+      deprecation:
+        removal_version: 2.0.0
+        warning_text: Will no longer be there.
+    tombstoned_module:
+      tombstone:
+        removal_version: 1.0.0
+        warning_text: Is no longer there.

--- a/test/integration/targets/ansible-test-sanity-runtime-metadata/ansible_collections/ns/version/galaxy.yml
+++ b/test/integration/targets/ansible-test-sanity-runtime-metadata/ansible_collections/ns/version/galaxy.yml
@@ -1,0 +1,5 @@
+namespace: ns
+name: version
+version: 2.3.4
+authors:
+  - Ansible

--- a/test/integration/targets/ansible-test-sanity-runtime-metadata/ansible_collections/ns/version/meta/runtime.yml
+++ b/test/integration/targets/ansible-test-sanity-runtime-metadata/ansible_collections/ns/version/meta/runtime.yml
@@ -1,0 +1,18 @@
+plugin_routing:
+  modules:
+    deprecated_module:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Will no longer be there.
+    tombstoned_module:
+      tombstone:
+        removal_version: 2.0.0
+        warning_text: Is no longer there.
+    deprecated_module_wrong_version:
+      deprecation:
+        removal_version: 2.0.0
+        warning_text: Will no longer be there.
+    tombstoned_module_wrong_version:
+      tombstone:
+        removal_version: 3.0.0
+        warning_text: Is no longer there.

--- a/test/integration/targets/ansible-test-sanity-runtime-metadata/expected-no_version.txt
+++ b/test/integration/targets/ansible-test-sanity-runtime-metadata/expected-no_version.txt
@@ -1,0 +1,1 @@
+meta/runtime.yml:0:0: extra keys not allowed @ data['extra_key']. Got True

--- a/test/integration/targets/ansible-test-sanity-runtime-metadata/expected-version.txt
+++ b/test/integration/targets/ansible-test-sanity-runtime-metadata/expected-version.txt
@@ -1,0 +1,2 @@
+meta/runtime.yml:0:0: The deprecation removal_version ('2.0.0') must be after the current version (SemanticVersion('2.3.4')) for dictionary value @ data['plugin_routing']['modules']['deprecated_module_wrong_version']['deprecation']['removal_version']. Got '2.0.0'
+meta/runtime.yml:0:0: The tombstone removal_version ('3.0.0') must not be after the current version (SemanticVersion('2.3.4')) for dictionary value @ data['plugin_routing']['modules']['tombstoned_module_wrong_version']['tombstone']['removal_version']. Got '3.0.0'

--- a/test/integration/targets/ansible-test-sanity-runtime-metadata/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-runtime-metadata/runme.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+COLLECTION_NAME=version source ../collection/setup.sh
+
+set -eux
+
+cd ../version
+ansible-test sanity --test runtime-metadata --color --truncate 0 --failure-ok --lint "${@}" 1> actual-stdout.txt 2> actual-stderr.txt
+diff -u "${TEST_DIR}/expected-version.txt" actual-stdout.txt
+grep -F -f "${TEST_DIR}/expected-version.txt" actual-stderr.txt
+
+cd ../no_version
+ansible-test sanity --test runtime-metadata --color --truncate 0 --failure-ok --lint "${@}" 1> actual-stdout.txt 2> actual-stderr.txt
+diff -u "${TEST_DIR}/expected-no_version.txt" actual-stdout.txt
+grep -F -f "${TEST_DIR}/expected-no_version.txt" actual-stderr.txt

--- a/test/integration/targets/collection/setup.sh
+++ b/test/integration/targets/collection/setup.sh
@@ -24,6 +24,6 @@ WORK_DIR="$(mktemp -d)"
 trap 'rm -rf "${WORK_DIR}"' EXIT
 
 cp -a "${TEST_DIR}/ansible_collections" "${WORK_DIR}"
-cd "${WORK_DIR}/ansible_collections/ns/col"
+cd "${WORK_DIR}/ansible_collections/ns/${COLLECTION_NAME:-col}"
 
 "${TEST_DIR}/../collection/update-ignore.py"

--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
@@ -123,7 +123,9 @@ def get_collection_version():
     # noinspection PyBroadException
     try:
         result = collection_detail.read_manifest_json('.') or collection_detail.read_galaxy_yml('.')
-        return SemanticVersion(result['version'])
+        version = SemanticVersion()
+        version.parse(result['version'])
+        return version
     except Exception:  # pylint: disable=broad-except
         # We do not care why it fails, in case we cannot get the version
         # just return None to indicate "we don't know".


### PR DESCRIPTION
##### SUMMARY
Fixes #83822.
Closes #83823.

##### ISSUE TYPE
- Bugfix Pull Request
