### PR TITLE
Make apt_repository PPA repos use gpg instead of apt-key

### DIFF
--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -554,7 +554,7 @@ class UbuntuSourcesList(SourcesList):
                 keyfile = ''
                 if not self.module.check_mode:
                     if self.apt_key_bin:
-                        command = [self.apt_key_bin, 'adv', '--recv-keys', '--no-tty', '--keyserver', 'hkp://keyserver.ubuntu.com:80',
+                        command = [self.apt_key_bin, 'adv', '--recv-keys', '--no-tty', '--keyserver', 'hkps://keyserver.ubuntu.com:443',
                                    info['signing_key_fingerprint']]
                     else:
                         # use first available key dir, in order of preference
@@ -565,7 +565,7 @@ class UbuntuSourcesList(SourcesList):
                             self.module.fail_json("Unable to find any existing apt gpgp repo directories, tried the following: %s" % ', '.join(APT_KEY_DIRS))
 
                         keyfile = '%s/%s-%s-%s.gpg' % (keydir, os.path.basename(source).replace(' ', '-'), ppa_owner, ppa_name)
-                        command = [self.gpg_bin, '--no-tty', '--keyserver', 'hkp://keyserver.ubuntu.com:80', '--export', info['signing_key_fingerprint']]
+                        command = [self.gpg_bin, '--no-tty', '--keyserver', 'hkps://keyserver.ubuntu.com:443', '--export', info['signing_key_fingerprint']]
 
                     rc, stdout, stderr = self.module.run_command(command, check_rc=True, encoding=None)
                     if keyfile:

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -187,8 +187,6 @@ from ansible.module_utils.common.respawn import has_respawned, probe_interpreter
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.urls import fetch_file, fetch_url
 
-from ansible.module_utils.common.locale import get_best_parsable_locale
-
 try:
     import apt
     import apt_pkg
@@ -529,7 +527,6 @@ class UbuntuSourcesList(SourcesList):
         # TODO: report file that would have been added if not check_mode
         if not self.module.check_mode:
             # use first available key dir, in order of preference
-
 
             keyserver_url = "https://keyserver.ubuntu.com/pks/lookup?{}".format(
                 urlencode({"op": "get", "search": "0x" + info['signing_key_fingerprint']})

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -608,7 +608,7 @@ class UbuntuSourcesList(SourcesList):
                 if source_line.startswith('ppa:'):
                     source, ppa_owner, ppa_name = self._expand_ppa(source_line)
                     _repositories.append(source)
-                    source = self._expand_ppa(source_line, legacy=True)
+                    source = self._expand_ppa(source_line, legacy=True)[0]
                     _repositories.append(source)
                 else:
                     _repositories.append(source_line)


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Make `apt_repository` PPA repos use gpg instead of apt-key as this is now deprecated.

Also, the `--keyserver` GPG option is also deprecated, so this part of the functionality has been replaced with Ansible's `fetch_file`

Finally, the GPG key is now pulled from the Ubuntu keyserver over HTTPS instead of HTTP.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

This follows these [instructions](https://www.digitalocean.com/community/tutorials/how-to-handle-apt-key-and-add-apt-repository-deprecation-using-gpg-to-add-external-repositories-on-ubuntu-22-04) for adding external repositories
