### PR TITLE
Add present state to systemd_service

### DIFF
--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -580,12 +580,12 @@ def main():
                             (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, action, unit))
                             if rc != 0:
                                 module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, err))
-        # check for chroot
-        elif is_chroot(module) or os.environ.get('SYSTEMD_OFFLINE') == '1':
-            module.warn("Target is a chroot or systemd is offline. This can lead to false positives or prevent the init system tools from working.")
-        else:
-            # this should not happen?
-            module.fail_json(msg="Service is in unknown state", status=result['status'])
+                # check for chroot
+                elif is_chroot(module) or os.environ.get('SYSTEMD_OFFLINE') == '1':
+                    module.warn("Target is a chroot or systemd is offline. This can lead to false positives or prevent the init system tools from working.")
+                else:
+                    # this should not happen?
+                    module.fail_json(msg="Service is in unknown state", status=result['status'])
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -557,7 +557,7 @@ def main():
             if module.params['state'] != 'present':
                 # default to desired state
                 result['state'] = module.params['state']
-    
+
                 # What is current service state?
                 if 'ActiveState' in result['status']:
                     action = None
@@ -573,7 +573,7 @@ def main():
                         else:
                             action = module.params['state'][:-2]  # remove 'ed' from restarted/reloaded
                         result['state'] = 'started'
-    
+
                     if action:
                         result['changed'] = True
                         if not module.check_mode:


### PR DESCRIPTION
##### SUMMARY

Add present state to systemd_service. This allows using this module to check for the existence of a unit without making any statement about it's state besides existing. This furthermore allows using the systemd_service module to get the "systemctl show" output into a variable without changing the state of the unit. This can be used e.g. for checking the last execution time before restarting a unit.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

```yaml
- name: Make sure a service unit is present
  ansible.builtin.systemd_service:
    name: httpd
    state: present
  register: foo_bar
- name: Print last unit start timestamp
  ansible.builtin.debug:
    msg: '{{ foo_bar.ExecMainStartTimestamp }}'
```
