### PR TITLE
[stable-2.17] config base: fix typo in option description

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -948,7 +948,7 @@ DEFAULT_PRIVATE_ROLE_VARS:
     - This was introduced as a way to reset role variables to default values if a role is used more than once
       in a playbook.
     - Starting in version '2.17' M(ansible.builtin.include_roles) and M(ansible.builtin.import_roles) can
-      indivudually override this via the C(public) parameter.
+      individually override this via the C(public) parameter.
     - Included roles only make their variables public at execution, unlike imported roles which happen at playbook compile time.
   env: [{name: ANSIBLE_PRIVATE_ROLE_VARS}]
   ini:


### PR DESCRIPTION
##### SUMMARY

config base: fix typo in option description

This error was caught by ansible-documentation's spell check linter.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

None