### PR TITLE
[stable-2.16]  powershell - Improve CLIXML parsing (#83847)

### DIFF
--- a/changelogs/fragments/fetch-filename.yml
+++ b/changelogs/fragments/fetch-filename.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - psrp - Fix bug when attempting to fetch a file path that contains special glob characters like ``[]``
+  - ssh - Fix bug when attempting to fetch a file path with characters that should be quoted when using the ``piped`` transfer method

--- a/changelogs/fragments/powershell-clixml.yml
+++ b/changelogs/fragments/powershell-clixml.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - powershell - Improve CLIXML decoding to decode all control characters and
+    unicode characters that are encoded as surrogate pairs.

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -633,39 +633,41 @@ end {
         buffer_size = max_b64_size - (max_b64_size % 1024)
 
         # setup the file stream with read only mode
-        setup_script = '''$ErrorActionPreference = "Stop"
-$path = '%s'
+        setup_script = '''param([string]$Path)
+$ErrorActionPreference = "Stop"
 
-if (Test-Path -Path $path -PathType Leaf) {
+if (Test-Path -LiteralPath $path -PathType Leaf) {
     $fs = New-Object -TypeName System.IO.FileStream -ArgumentList @(
         $path,
         [System.IO.FileMode]::Open,
         [System.IO.FileAccess]::Read,
         [System.IO.FileShare]::Read
     )
-    $buffer_size = %d
 } elseif (Test-Path -Path $path -PathType Container) {
     Write-Output -InputObject "[DIR]"
 } else {
     Write-Error -Message "$path does not exist"
     $host.SetShouldExit(1)
-}''' % (self._shell._escape(in_path), buffer_size)
+}'''
 
         # read the file stream at the offset and return the b64 string
-        read_script = '''$ErrorActionPreference = "Stop"
-$fs.Seek(%d, [System.IO.SeekOrigin]::Begin) > $null
-$buffer = New-Object -TypeName byte[] -ArgumentList $buffer_size
-$bytes_read = $fs.Read($buffer, 0, $buffer_size)
+        read_script = '''param([int64]$Offset, [int]$BufferSize)
+$ErrorActionPreference = "Stop"
+$fs.Seek($Offset, [System.IO.SeekOrigin]::Begin) > $null
+$buffer = New-Object -TypeName byte[] -ArgumentList $BufferSize
+$read = $fs.Read($buffer, 0, $buffer.Length)
 
-if ($bytes_read -gt 0) {
-    $bytes = $buffer[0..($bytes_read - 1)]
-    Write-Output -InputObject ([System.Convert]::ToBase64String($bytes))
+if ($read -gt 0) {
+    [System.Convert]::ToBase64String($buffer, 0, $read)
 }'''
 
         # need to run the setup script outside of the local scope so the
         # file stream stays active between fetch operations
-        rc, stdout, stderr = self._exec_psrp_script(setup_script,
-                                                    use_local_scope=False)
+        rc, stdout, stderr = self._exec_psrp_script(
+            setup_script,
+            use_local_scope=False,
+            arguments=[in_path],
+        )
         if rc != 0:
             raise AnsibleError("failed to setup file stream for fetch '%s': %s"
                                % (out_path, to_native(stderr)))
@@ -680,7 +682,10 @@ if ($bytes_read -gt 0) {
             while True:
                 display.vvvvv("PSRP FETCH %s to %s (offset=%d" %
                               (in_path, out_path, offset), host=self._psrp_host)
-                rc, stdout, stderr = self._exec_psrp_script(read_script % offset)
+                rc, stdout, stderr = self._exec_psrp_script(
+                    read_script,
+                    arguments=[offset, buffer_size],
+                )
                 if rc != 0:
                     raise AnsibleError("failed to transfer file to '%s': %s"
                                        % (out_path, to_native(stderr)))
@@ -814,7 +819,7 @@ if ($bytes_read -gt 0) {
         script: str,
         input_data: bytes | str | t.Iterable | None = None,
         use_local_scope: bool = True,
-        arguments: t.Iterable[str] | None = None,
+        arguments: t.Iterable[t.Any] | None = None,
     ) -> tuple[int, bytes, bytes]:
         # Check if there's a command on the current pipeline that still needs to be closed.
         if self._last_pipeline:

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1286,7 +1286,7 @@ class Connection(ConnectionBase):
                 if sftp_action == 'get':
                     # we pass sudoable=False to disable pty allocation, which
                     # would end up mixing stdout/stderr and screwing with newlines
-                    (returncode, stdout, stderr) = self.exec_command('dd if=%s bs=%s' % (in_path, BUFSIZE), sudoable=False)
+                    (returncode, stdout, stderr) = self.exec_command('dd if=%s bs=%s' % (self._shell.quote(in_path), BUFSIZE), sudoable=False)
                     with open(to_bytes(out_path, errors='surrogate_or_strict'), 'wb+') as out_file:
                         out_file.write(stdout)
                 else:

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -26,35 +26,70 @@ import ntpath
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.plugins.shell import ShellBase
 
+# This is weird, we are matching on byte sequences that match the utf-16-be
+# matches for '_x(a-fA-F0-9){4}_'. The \x00 and {8} will match the hex sequence
+# when it is encoded as utf-16-be.
+_STRING_DESERIAL_FIND = re.compile(rb"\x00_\x00x([\x00(a-fA-F0-9)]{8})\x00_")
 
 _common_args = ['PowerShell', '-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Unrestricted']
 
 
-def _parse_clixml(data, stream="Error"):
+def _parse_clixml(data: bytes, stream: str = "Error") -> bytes:
     """
     Takes a byte string like '#< CLIXML\r\n<Objs...' and extracts the stream
     message encoded in the XML data. CLIXML is used by PowerShell to encode
     multiple objects in stderr.
     """
-    lines = []
+    lines: list[str] = []
+
+    # A serialized string will serialize control chars and surrogate pairs as
+    # _xDDDD_ values where DDDD is the hex representation of a big endian
+    # UTF-16 code unit. As a surrogate pair uses 2 UTF-16 code units, we need
+    # to operate our text replacement on the utf-16-be byte encoding of the raw
+    # text. This allows us to replace the _xDDDD_ values with the actual byte
+    # values and then decode that back to a string from the utf-16-be bytes.
+    def rplcr(matchobj: re.Match) -> bytes:
+        match_hex = matchobj.group(1)
+        hex_string = match_hex.decode("utf-16-be")
+        return base64.b16decode(hex_string.upper())
 
     # There are some scenarios where the stderr contains a nested CLIXML element like
     # '<# CLIXML\r\n<# CLIXML\r\n<Objs>...</Objs><Objs>...</Objs>'.
     # Parse each individual <Objs> element and add the error strings to our stderr list.
     # https://github.com/ansible/ansible/issues/69550
     while data:
-        end_idx = data.find(b"</Objs>") + 7
-        current_element = data[data.find(b"<Objs "):end_idx]
+        start_idx = data.find(b"<Objs ")
+        end_idx = data.find(b"</Objs>")
+        if start_idx == -1 or end_idx == -1:
+            break
+
+        end_idx += 7
+        current_element = data[start_idx:end_idx]
         data = data[end_idx:]
 
         clixml = ET.fromstring(current_element)
         namespace_match = re.match(r'{(.*)}', clixml.tag)
-        namespace = "{%s}" % namespace_match.group(1) if namespace_match else ""
+        namespace = f"{{{namespace_match.group(1)}}}" if namespace_match else ""
 
-        strings = clixml.findall("./%sS" % namespace)
-        lines.extend([e.text.replace('_x000D__x000A_', '') for e in strings if e.attrib.get('S') == stream])
+        entries = clixml.findall("./%sS" % namespace)
+        if not entries:
+            continue
 
-    return to_bytes('\r\n'.join(lines))
+        # If this is a new CLIXML element, add a newline to separate the messages.
+        if lines:
+            lines.append("\r\n")
+
+        for string_entry in entries:
+            actual_stream = string_entry.attrib.get('S', None)
+            if actual_stream != stream:
+                continue
+
+            b_line = (string_entry.text or "").encode("utf-16-be")
+            b_escaped = re.sub(_STRING_DESERIAL_FIND, rplcr, b_line)
+
+            lines.append(b_escaped.decode("utf-16-be", errors="surrogatepass"))
+
+    return to_bytes(''.join(lines), errors="surrogatepass")
 
 
 class ShellModule(ShellBase):

--- a/test/integration/targets/connection/test_connection.yml
+++ b/test/integration/targets/connection/test_connection.yml
@@ -3,6 +3,25 @@
   serial: 1
   tasks:
 
+  # SSH with scp has troubles with using complex filenames that require quoting
+  # or escaping. The more complex filename scenario is skipped in this mode.
+  # The default of sftp has no problems with these filenames.
+  - name: check if ssh with the scp file transfer is being tested
+    set_fact:
+      skip_complex_filename: >-
+        {{
+            ansible_connection == "ssh" and
+            lookup("ansible.builtin.config",
+                "ssh_transfer_method",
+                plugin_name=ansible_connection,
+                plugin_type="connection",
+            ) == "scp"
+        }}
+
+  - name: set test filename
+    set_fact:
+      test_filename: 汉语-{{ skip_complex_filename | ternary("file", "['foo bar']") }}.txt
+
   ### raw with unicode arg and output
 
   - name: raw with unicode arg and output
@@ -17,20 +36,20 @@
   ### copy local file with unicode filename and content
 
   - name: create local file with unicode filename and content
-    local_action: lineinfile dest={{ local_tmp }}-汉语/汉语.txt create=true line=汉语
+    local_action: lineinfile dest={{ local_tmp }}-汉语/{{ test_filename }} create=true line=汉语
   - name: remove remote file with unicode filename and content
-    action: "{{ action_prefix }}file path={{ remote_tmp }}-汉语/汉语.txt state=absent"
+    action: "{{ action_prefix }}file path={{ remote_tmp }}-汉语/{{ test_filename }} state=absent"
   - name: create remote directory with unicode name
     action: "{{ action_prefix }}file path={{ remote_tmp }}-汉语 state=directory"
   - name: copy local file with unicode filename and content
-    action: "{{ action_prefix }}copy src={{ local_tmp }}-汉语/汉语.txt dest={{ remote_tmp }}-汉语/汉语.txt"
+    action: "{{ action_prefix }}copy src={{ local_tmp }}-汉语/{{ test_filename }} dest={{ remote_tmp }}-汉语/{{ test_filename }}"
 
   ### fetch remote file with unicode filename and content
 
   - name: remove local file with unicode filename and content
-    local_action: file path={{ local_tmp }}-汉语/汉语.txt state=absent
+    local_action: file path={{ local_tmp }}-汉语/{{ test_filename }} state=absent
   - name: fetch remote file with unicode filename and content
-    fetch: src={{ remote_tmp }}-汉语/汉语.txt dest={{ local_tmp }}-汉语/汉语.txt fail_on_missing=true validate_checksum=true flat=true
+    fetch: src={{ remote_tmp }}-汉语/{{ test_filename }} dest={{ local_tmp }}-汉语/{{ test_filename }} fail_on_missing=true validate_checksum=true flat=true
 
   ### remove local and remote temp files
 

--- a/test/integration/targets/connection_winrm/tests.yml
+++ b/test/integration/targets/connection_winrm/tests.yml
@@ -55,3 +55,12 @@
       ansible_port: 5986
       ansible_winrm_scheme: https
       ansible_winrm_server_cert_validation: ignore
+
+  - name: emit raw CLIXML on stderr with special chars
+    raw: $host.UI.WriteErrorLine("Test 🎵 _x005F_ _x005Z_.")
+    register: stderr_clixml
+
+  - name: assert emit raw CLIXML on stderr with special chars
+    assert:
+      that:
+      - stderr_clixml.stderr_lines == ['Test 🎵 _x005F_ _x005Z_.']

--- a/test/integration/targets/win_fetch/aliases
+++ b/test/integration/targets/win_fetch/aliases
@@ -1,1 +1,2 @@
 shippable/windows/group1
+shippable/windows/smoketest

--- a/test/units/plugins/shell/test_powershell.py
+++ b/test/units/plugins/shell/test_powershell.py
@@ -1,6 +1,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import pytest
+
 from ansible.plugins.shell.powershell import _parse_clixml, ShellModule
 
 
@@ -28,7 +30,8 @@ def test_parse_clixml_single_stream():
                     b'<S S="Error">At line:1 char:1_x000D__x000A_</S>' \
                     b'<S S="Error">+ fake cmdlet_x000D__x000A_</S><S S="Error">+ ~~~~_x000D__x000A_</S>' \
                     b'<S S="Error">    + CategoryInfo          : ObjectNotFound: (fake:String) [], CommandNotFoundException_x000D__x000A_</S>' \
-                    b'<S S="Error">    + FullyQualifiedErrorId : CommandNotFoundException_x000D__x000A_</S><S S="Error"> _x000D__x000A_</S>' \
+                    b'<S S="Error">    + FullyQualifiedErrorId : CommandNotFoundException_x000D__x000A_</S>' \
+                    b'<S S="Error"> _x000D__x000A_</S>' \
                     b'</Objs>'
     expected = b"fake : The term 'fake' is not recognized as the name of a cmdlet. Check \r\n" \
                b"the spelling of the name, or if a path was included.\r\n" \
@@ -36,7 +39,8 @@ def test_parse_clixml_single_stream():
                b"+ fake cmdlet\r\n" \
                b"+ ~~~~\r\n" \
                b"    + CategoryInfo          : ObjectNotFound: (fake:String) [], CommandNotFoundException\r\n" \
-               b"    + FullyQualifiedErrorId : CommandNotFoundException\r\n "
+               b"    + FullyQualifiedErrorId : CommandNotFoundException\r\n" \
+               b" \r\n"
     actual = _parse_clixml(single_stream)
     assert actual == expected
 
@@ -50,8 +54,9 @@ def test_parse_clixml_multiple_streams():
                       b'<S S="Error">    + CategoryInfo          : ObjectNotFound: (fake:String) [], CommandNotFoundException_x000D__x000A_</S>' \
                       b'<S S="Error">    + FullyQualifiedErrorId : CommandNotFoundException_x000D__x000A_</S><S S="Error"> _x000D__x000A_</S>' \
                       b'<S S="Info">hi info</S>' \
+                      b'<S S="Info">other</S>' \
                       b'</Objs>'
-    expected = b"hi info"
+    expected = b"hi infoother"
     actual = _parse_clixml(multiple_stream, stream="Info")
     assert actual == expected
 
@@ -73,6 +78,32 @@ def test_parse_clixml_multiple_elements():
     expected = b"Error 1\r\nError 2"
     actual = _parse_clixml(multiple_elements)
     assert actual == expected
+
+
+@pytest.mark.parametrize('clixml, expected', [
+    ('', ''),
+    ('just newline _x000A_', 'just newline \n'),
+    ('surrogate pair _xD83C__xDFB5_', 'surrogate pair 🎵'),
+    ('null char _x0000_', 'null char \0'),
+    ('normal char _x0061_', 'normal char a'),
+    ('escaped literal _x005F_x005F_', 'escaped literal _x005F_'),
+    ('underscope before escape _x005F__x000A_', 'underscope before escape _\n'),
+    ('surrogate high _xD83C_', 'surrogate high \uD83C'),
+    ('surrogate low _xDFB5_', 'surrogate low \uDFB5'),
+    ('lower case hex _x005f_', 'lower case hex _'),
+    ('invalid hex _x005G_', 'invalid hex _x005G_'),
+])
+def test_parse_clixml_with_comlex_escaped_chars(clixml, expected):
+    clixml_data = (
+        '<# CLIXML\r\n'
+        '<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">'
+        f'<S S="Error">{clixml}</S>'
+        '</Objs>'
+    ).encode()
+    b_expected = expected.encode(errors="surrogatepass")
+
+    actual = _parse_clixml(clixml_data)
+    assert actual == b_expected
 
 
 def test_join_path_unc():


### PR DESCRIPTION
##### SUMMARY
Improves the logic used when parsing CLIXML to support all escaped character sequences and not just newlines.

Backport of https://github.com/ansible/ansible/pull/83847

(cherry picked from commit b5e0293645570f3f404ad1dbbe5f006956ada0df)

##### ISSUE TYPE
- Bugfix Pull Request