### PR TITLE
reset multiplexer only at connection failure

### DIFF
--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -81,16 +81,16 @@ class ActionModule(ActionBase):
             # re-run interpreter discovery if we ran it in the first iteration
             if self._discovered_interpreter_key:
                 task_vars['ansible_facts'].pop(self._discovered_interpreter_key, None)
-            # call connection reset between runs if it's there
-            try:
-                self._connection.reset()
-            except AttributeError:
-                pass
 
             ping_result = self._execute_module(module_name='ansible.legacy.ping', module_args=dict(), task_vars=task_vars)
 
             # Test module output
             if ping_result['ping'] != 'pong':
+                # call connection reset between runs if it's there
+                try:
+                    self._connection.reset()
+                except AttributeError:
+                    pass
                 raise Exception('ping test failed')
 
         start = datetime.now()


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
When using `wait_for_connection` module at the beginning of every Ansible run, it resets the multiplexed connection every time. It's not nice because triggers extra connection to `ssh-agent` which can be avoided

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

The patch makes `wait_for_connection` module reset the multiplexed connection only at failure for the next try. Successful connections will use existing multiplexed connection

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below
none
```
