### PR TITLE
Fix TypeError: NoneType when using `import_tasks` within `include_tasks` 

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -169,7 +169,11 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                             parent_include = parent_include._parent
                             continue
                         try:
-                            parent_include_dir = os.path.dirname(templar.template(parent_include.args.get('_raw_params')))
+                            if isinstance(parent_include, IncludeRole):
+                                task_path = os.path.join(parent_include._role_path, 'tasks')
+                            else:
+                                task_path = parent_include.args.get('_raw_params')
+                            parent_include_dir = os.path.dirname(templar.template(task_path))
                         except AnsibleUndefinedVariable as e:
                             if not parent_include.statically_loaded:
                                 raise AnsibleParserError(


### PR DESCRIPTION
##### SUMMARY

> This PR is on behalf of [mkrizek](https://github.com/mkrizek) from his comment over here https://github.com/ansible/ansible/issues/69882#issuecomment-642564666


Fixes #83852
Fixes #69882 

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

This PR fixes old issue, when using `import_tasks` within `include_tasks` within an `include_role` results in `TypeError: NoneType`

Full steps on how to reproduce provided in #83852.

Here is the output before the patch:
```yml
PLAY [Reproduce the issue] *******************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************
ok: [localhost]

TASK [foo : Print the role message] **********************************************************************************
ok: [localhost] =>
  msg: Hello from the inner role.

TASK [foo : First include] *******************************************************************************************
included: /Users/username/git/ansible-issue/roles/foo/tasks/first-include.yml for localhost

TASK [foo : Debug this task] *****************************************************************************************
ok: [localhost] =>
  msg: 'Current task file is: first-include.yml'

TASK [foo : Debug additional tasks yml] ******************************************************************************
ok: [localhost] =>
  msg: second_import.yml

TASK [foo : Debug inner additional tasks yml] ************************************************************************
ok: [localhost] =>
  msg: Inner additional tasks yml

TASK [Import the inner role] *****************************************************************************************
included: foo for localhost

TASK [foo : Print the role message] **********************************************************************************
ok: [localhost] =>
  msg: Hello from the inner role.

TASK [foo : First include] *******************************************************************************************
ERROR! Unexpected Exception, this is probably a bug: expected str, bytes or os.PathLike object, not NoneType
to see the full traceback, use -vvv
```
Here is the output after the patch:
```yml
ansible-playbook playbook.yml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Reproduce the issue] *******************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************
ok: [localhost]

TASK [foo : Print the role message] **********************************************************************************
ok: [localhost] =>
  msg: Hello from the inner role.

TASK [foo : First include] *******************************************************************************************
included: /Users/username/git/roles/role_solana/playbooks/ansible-issue/roles/foo/tasks/first-include.yml for localhost

TASK [foo : Debug this task] *****************************************************************************************
ok: [localhost] =>
  msg: 'Current task file is: first-include.yml'

TASK [foo : Debug additional tasks yml] ******************************************************************************
ok: [localhost] =>
  msg: second_import.yml

TASK [foo : Debug inner additional tasks yml] ************************************************************************
ok: [localhost] =>
  msg: Inner additional tasks yml

TASK [Import the inner role] *****************************************************************************************
included: foo for localhost

TASK [foo : Print the role message] **********************************************************************************
ok: [localhost] =>
  msg: Hello from the inner role.

TASK [foo : First include] *******************************************************************************************
included: /Users/username/git/roles/role_solana/playbooks/ansible-issue/roles/foo/tasks/first-include.yml for localhost

TASK [foo : Debug this task] *****************************************************************************************
ok: [localhost] =>
  msg: 'Current task file is: first-include.yml'

TASK [foo : Debug additional tasks yml] ******************************************************************************
ok: [localhost] =>
  msg: second_import.yml

TASK [foo : Debug inner additional tasks yml] ************************************************************************
ok: [localhost] =>
  msg: Inner additional tasks yml

PLAY RECAP ***********************************************************************************************************
localhost                  : ok=12   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```