### PR TITLE
Update communication links for the forum

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Hi! Nice to see you here!
 If you have questions about anything related to Ansible, get in touch with us!
 See [Communicating with the Ansible community](https://docs.ansible.com/ansible/devel/community/communication.html) to find out how.
 
-The [Community Guide](https://docs.ansible.com/ansible/latest/community/index.html) also explains how to contribute
+The [Community Guide](https://docs.ansible.com/ansible/devel/community/index.html) also explains how to contribute
 and interact with the project, including how to submit bug reports and code to Ansible.
 
 Please note that the GitHub issue tracker is not the best place to ask questions for several reasons.
@@ -20,11 +20,11 @@ By contributing to this project you agree to the [Developer Certificate of Origi
 The Ansible project is licensed under the [GPL-3.0](COPYING) or later. Some portions of the code fall under other licenses as noted in individual files.
 
 The Ansible project accepts contributions through GitHub pull requests.
-Please review the [Community Guide](https://docs.ansible.com/ansible/latest/community/index.html) for more information on contributing to Ansible.
+Please review the [Community Guide](https://docs.ansible.com/ansible/devel/community/index.html) for more information on contributing to Ansible.
 
 ## BUG TO REPORT ?
 
-First and foremost, also check the [Community Guide](https://docs.ansible.com/ansible/latest/community/index.html).
+First and foremost, also check the [Community Guide](https://docs.ansible.com/ansible/devel/community/index.html).
 
 You can report bugs or make enhancement requests at
 the [Ansible GitHub issue page](http://github.com/ansible/ansible/issues/new/choose) by filling out the issue template that will be presented.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,11 +4,14 @@ Hi! Nice to see you here!
 
 ## QUESTIONS ?
 
-Please see the [Community Guide](https://docs.ansible.com/ansible/latest/community/index.html) for information on
-how to ask questions on the [mailing lists](https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information) and IRC.
+If you have questions about anything related to Ansible, get in touch with us!
+See [Communicating with the Ansible community](https://docs.ansible.com/ansible/devel/community/communication.html) to find out how.
 
-The GitHub issue tracker is not the best place for questions for various reasons,
-but both IRC and the mailing list are very helpful places for those things, as the community page explains best.
+The [Community Guide](https://docs.ansible.com/ansible/latest/community/index.html) also explains how to contribute
+and interact with the project, including how to submit bug reports and code to Ansible.
+
+Please note that the GitHub issue tracker is not the best place to ask questions for several reasons.
+You'll get more helpful, and quicker, responses in the forum.
 
 ## CONTRIBUTING ?
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,13 +19,14 @@ body:
       Also test if the latest release and devel branch are affected too.
 
 
-      **Tip:** If you are seeking community support, please consider
-      [starting a mailing list thread or chatting in IRC][ML||IRC].
+      **Tip:** If you are seeking community support, please see
+      [Communicating with the Ansible community][communication] to
+      get in touch and ask questions.
 
 
 
-      [ML||IRC]:
-      https://docs.ansible.com/ansible-core/devel/community/communication.html?utm_medium=github&utm_source=issue_form--bug_report.yml#mailing-list-information
+      [communication]:
+      https://docs.ansible.com/ansible/devel/community/communication.html
 
       [issue search]: ../search?q=is%3Aissue&type=issues
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -259,7 +259,7 @@ body:
     description: |
       Read the [Ansible Code of Conduct][CoC] first.
 
-      [CoC]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--bug_report.yml
+      [CoC]: https://docs.ansible.com/ansible/devel/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--bug_report.yml
     options:
     - label: I agree to follow the Ansible Code of Conduct
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@
 blank_issues_enabled: false  # default: true
 contact_links:
 - name: 🔐 Security bug report 🔥
-  url: https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html?utm_medium=github&utm_source=issue_template_chooser
+  url: https://docs.ansible.com/ansible/devel/community/reporting_bugs_and_features.html?utm_medium=github&utm_source=issue_template_chooser
   about: |
     Please learn how to report security vulnerabilities here.
 
@@ -11,12 +11,12 @@ contact_links:
     a prompt response.
 
     For more information, see
-    https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html
+    https://docs.ansible.com/ansible/devel/community/reporting_bugs_and_features.html
 - name: 📝 Ansible Code of Conduct
-  url: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_template_chooser
+  url: https://docs.ansible.com/ansible/devel/community/code_of_conduct.html?utm_medium=github&utm_source=issue_template_chooser
   about: ❤ Be nice to other members of the community. ☮ Behave.
 - name: 💬 Talk to the community
-  url: https://docs.ansible.com/ansible/latest/community/communication.html?utm_medium=github&utm_source=issue_template_chooser#mailing-list-information
+  url: https://docs.ansible.com/ansible/devel/community/communication.html?utm_medium=github&utm_source=issue_template_chooser#mailing-list-information
   about: Please ask and answer usage questions here
 - name: ⚡ Working groups
   url: https://github.com/ansible/community/wiki

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -15,7 +15,7 @@ contact_links:
 - name: 📝 Ansible Code of Conduct
   url: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_template_chooser
   about: ❤ Be nice to other members of the community. ☮ Behave.
-- name: 💬 Talks to the community
+- name: 💬 Talk to the community
   url: https://docs.ansible.com/ansible/latest/community/communication.html?utm_medium=github&utm_source=issue_template_chooser#mailing-list-information
   about: Please ask and answer usage questions here
 - name: ⚡ Working groups

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -22,12 +22,14 @@ body:
       Also test if the latest release and devel branch are affected too.
 
 
-      **Tip:** If you are seeking community support, please consider
-      [starting a mailing list thread or chatting in IRC][ML||IRC].
+      **Tip:** If you are seeking community support, please see
+      [Communicating with the Ansible community][communication] to
+      get in touch and ask questions.
 
 
-      [ML||IRC]:
-      https://docs.ansible.com/ansible-core/devel/community/communication.html?utm_medium=github&utm_source=issue_form--documentation_report.yml#mailing-list-information
+
+      [communication]:
+      https://docs.ansible.com/ansible/devel/community/communication.html
 
       [issue search]: ../search?q=is%3Aissue&type=issues
 

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -207,7 +207,7 @@ body:
     description: |
       Read the [Ansible Code of Conduct][CoC] first.
 
-      [CoC]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--documentation_report.yml
+      [CoC]: https://docs.ansible.com/ansible/devel/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--documentation_report.yml
     options:
     - label: I agree to follow the Ansible Code of Conduct
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -185,7 +185,7 @@ body:
     description: |
       Read the [Ansible Code of Conduct][CoC] first.
 
-      [CoC]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--feature_request.yml
+      [CoC]: https://docs.ansible.com/ansible/devel/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--feature_request.yml
     options:
     - label: I agree to follow the Ansible Code of Conduct
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -21,8 +21,7 @@ body:
 
       If unsure, consider filing a [new proposal] instead outlining your
       use-cases, the research and implementation considerations. Then,
-      start a discussion on one of the public [IRC meetings] we have just
-      for this.
+      start a discussion in the [Ansible forum][forum].
 
 
       <details>
@@ -44,21 +43,22 @@ body:
       Also test if the devel branch does not already implement this.
 
 
-      **Tip:** If you are seeking community support, please consider
-      [starting a mailing list thread or chatting in IRC][ML||IRC].
+      **Tip:** If you are seeking community support, please see
+      [Communicating with the Ansible community][communication] to
+      get in touch and ask questions.
 
 
 
       [contribute to collections]:
       https://docs.ansible.com/ansible-core/devel/community/contributing_maintained_collections.html?utm_medium=github&utm_source=issue_form--feature_request.yml
 
-      [IRC meetings]:
-        https://docs.ansible.com/ansible-core/devel/community/communication.html?utm_medium=github&utm_source=issue_form--feature_request.yml#irc-meetings
+      [communication]:
+      https://docs.ansible.com/ansible/devel/community/communication.html
 
       [issue search]: ../search?q=is%3Aissue&type=issues
 
-      [ML||IRC]:
-      https://docs.ansible.com/ansible-core/devel/community/communication.html?utm_medium=github&utm_source=issue_form--feature_request.yml#mailing-list-information
+      [forum help]:
+      https://forum.ansible.com/c/help/6
 
       [new proposal]: ../../proposals/issues/new
 

--- a/README.md
+++ b/README.md
@@ -40,21 +40,32 @@ features and fixes, directly. Although it is reasonably stable, you are more lik
 breaking changes when running the `devel` branch. We recommend getting involved
 in the Ansible community if you want to run the `devel` branch.
 
-## Get Involved
+## Communication
+
+Join the Ansible forum to ask questions, get help, and interact with the
+community.
+
+* [Get Help](https://forum.ansible.com/c/help/6): Find help or share your Ansible knowledge to help others.
+  Use tags to filter and subscribe to posts, such as the following:
+  * Posts tagged with [ansible](https://forum.ansible.com/tag/ansible)
+  * Posts tagged with [ansible-core](https://forum.ansible.com/tag/ansible-core)
+  * Posts tagged with [playbook](https://forum.ansible.com/tag/playbook)
+* [Social Spaces](https://forum.ansible.com/c/chat/4): Meet and interact with fellow enthusiasts.
+* [News & Announcements](https://forum.ansible.com/c/news/5): Track project-wide announcements including social events.
+* [Bullhorn newsletter](https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn): Get release announcements and important changes.
+
+For more ways to get in touch, see [Communicating with the Ansible community](https://docs.ansible.com/ansible/devel/community/communication.html).
+
+## Contribute to Ansible
 
 * Read [Community Information](https://docs.ansible.com/ansible/latest/community) for all
   kinds of ways to contribute to and interact with the project,
-  including mailing list information and how to submit bug reports and
-  code to Ansible.
-* Join a [Working Group](https://docs.ansible.com/ansible/devel/community/communication.html#working-groups),
-  an organized community devoted to a specific technology domain or platform.
+  including how to submit bug reports and code to Ansible.
 * Submit a proposed code update through a pull request to the `devel` branch.
 * Talk to us before making larger changes
   to avoid duplicate efforts. This not only helps everyone
   know what is going on, but it also helps save time and effort if we decide
   some changes are needed.
-* For a list of email lists, IRC channels and Working Groups, see the
-  [Communication page](https://docs.ansible.com/ansible/devel/community/communication.html)
 
 ## Coding Guidelines
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For more ways to get in touch, see [Communicating with the Ansible community](ht
 
 ## Contribute to Ansible
 
+* Check out the [Contributor's Guide](./.github/CONTRIBUTING.md).
 * Read [Community Information](https://docs.ansible.com/ansible/latest/community) for all
   kinds of ways to contribute to and interact with the project,
   including how to submit bug reports and code to Ansible.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![PyPI version](https://img.shields.io/pypi/v/ansible-core.svg)](https://pypi.org/project/ansible-core)
 [![Docs badge](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://docs.ansible.com/ansible/latest/)
-[![Chat badge](https://img.shields.io/badge/chat-IRC-brightgreen.svg)](https://docs.ansible.com/ansible/latest/community/communication.html)
+[![Chat badge](https://img.shields.io/badge/chat-IRC-brightgreen.svg)](https://docs.ansible.com/ansible/devel/community/communication.html)
 [![Build Status](https://dev.azure.com/ansible/ansible/_apis/build/status/CI?branchName=devel)](https://dev.azure.com/ansible/ansible/_build/latest?definitionId=20&branchName=devel)
-[![Ansible Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-Ansible-silver.svg)](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html)
-[![Ansible mailing lists](https://img.shields.io/badge/mailing%20lists-Ansible-orange.svg)](https://docs.ansible.com/ansible/latest/community/communication.html#mailing-list-information)
+[![Ansible Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-Ansible-silver.svg)](https://docs.ansible.com/ansible/devel/community/code_of_conduct.html)
+[![Ansible mailing lists](https://img.shields.io/badge/mailing%20lists-Ansible-orange.svg)](https://docs.ansible.com/ansible/devel/community/communication.html#mailing-list-information)
 [![Repository License](https://img.shields.io/badge/license-GPL%20v3.0-brightgreen.svg)](COPYING)
 [![Ansible CII Best Practices certification](https://bestpractices.coreinfrastructure.org/projects/2372/badge)](https://bestpractices.coreinfrastructure.org/projects/2372)
 
@@ -59,7 +59,7 @@ For more ways to get in touch, see [Communicating with the Ansible community](ht
 ## Contribute to Ansible
 
 * Check out the [Contributor's Guide](./.github/CONTRIBUTING.md).
-* Read [Community Information](https://docs.ansible.com/ansible/latest/community) for all
+* Read [Community Information](https://docs.ansible.com/ansible/devel/community) for all
   kinds of ways to contribute to and interact with the project,
   including how to submit bug reports and code to Ansible.
 * Submit a proposed code update through a pull request to the `devel` branch.
@@ -79,7 +79,7 @@ We document our Coding Guidelines in the [Developer Guide](https://docs.ansible.
 
 * The `devel` branch corresponds to the release actively under development.
 * The `stable-2.X` branches correspond to stable releases.
-* Create a branch based on `devel` and set up a [dev environment](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_general.html#common-environment-setup) if you want to open a PR.
+* Create a branch based on `devel` and set up a [dev environment](https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_general.html#common-environment-setup) if you want to open a PR.
 * See the [Ansible release and maintenance](https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html) page for information about active branches.
 
 ## Roadmap


### PR DESCRIPTION
##### SUMMARY

As a part of the [Consolidating Ansible discussion platforms initiative](https://forum.ansible.com/t/proposal-consolidating-ansible-discussion-platforms/6812), this PR updates communication links to point to the forum and de-emphasize IRC and mailing lists. Similar PRs are being raised across all Ansible ecosystem projects. Thanks!

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

n/a
