### PR TITLE
ansible-test - Reduce scope of empty-init test

### DIFF
--- a/changelogs/fragments/ansible-test-sanity-empty-init.yml
+++ b/changelogs/fragments/ansible-test-sanity-empty-init.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - The ``empty-init`` sanity test no longer applies to ``module_utils`` packages.

--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/empty-init.json
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/empty-init.json
@@ -1,9 +1,7 @@
 {
     "prefixes": [
         "lib/ansible/modules/",
-        "lib/ansible/module_utils/",
         "plugins/modules/",
-        "plugins/module_utils/",
         "test/units/",
         "tests/unit/"
     ],

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -39,8 +39,6 @@ lib/ansible/module_utils/compat/selinux.py import-3.12!skip # pass/fail depends 
 lib/ansible/module_utils/compat/selinux.py import-3.13!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py pylint:unidiomatic-typecheck
 lib/ansible/module_utils/distro/_distro.py no-assert
-lib/ansible/module_utils/distro/__init__.py empty-init # breaks namespacing, bundled, do not override
-lib/ansible/module_utils/facts/__init__.py empty-init # breaks namespacing, deprecate and eventually remove
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.ArgvParser.psm1 pslint:PSUseApprovedVerbs
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CommandUtil.psm1 pslint:PSProvideCommentHelp # need to agree on best format for comment location
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CommandUtil.psm1 pslint:PSUseApprovedVerbs
@@ -50,7 +48,6 @@ lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1 pslint:PSCus
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1 pslint:PSUseApprovedVerbs
 lib/ansible/module_utils/powershell/Ansible.ModuleUtils.LinkUtil.psm1 pslint:PSUseApprovedVerbs
 lib/ansible/module_utils/pycompat24.py no-get-exception
-lib/ansible/module_utils/six/__init__.py empty-init # breaks namespacing, bundled, do not override
 lib/ansible/module_utils/six/__init__.py pylint:self-assigning-variable
 lib/ansible/module_utils/six/__init__.py pylint:trailing-comma-tuple
 lib/ansible/module_utils/six/__init__.py pylint:unidiomatic-typecheck


### PR DESCRIPTION
##### SUMMARY

The ``empty-init`` sanity test no longer applies to ``module_utils`` packages.

##### ISSUE TYPE

Feature Pull Request
