### PR TITLE
[stable-2.16] - Add location on include_tasks fail inside include (#83876)

### DIFF
--- a/changelogs/fragments/83874-include-parse-error-location.yml
+++ b/changelogs/fragments/83874-include-parse-error-location.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    include_tasks - Display location when attempting to load a task list where ``include_*`` did not specify any value -
+    https://github.com/ansible/ansible/issues/83874

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -76,7 +76,7 @@ class TaskInclude(Task):
         if not task.args.get('_raw_params'):
             task.args['_raw_params'] = task.args.pop('file', None)
             if not task.args['_raw_params']:
-                raise AnsibleParserError('No file specified for %s' % task.action)
+                raise AnsibleParserError('No file specified for %s' % task.action, obj=data)
 
         apply_attrs = task.args.get('apply', {})
         if apply_attrs and task.action not in C._ACTION_INCLUDE_TASKS:

--- a/test/integration/targets/include_import/null_filename/tasks.yml
+++ b/test/integration/targets/include_import/null_filename/tasks.yml
@@ -1,0 +1,5 @@
+- name: ping task
+  ansible.builtin.ping:
+
+- name: invalid include_task definition
+  ansible.builtin.include_tasks:

--- a/test/integration/targets/include_import/runme.sh
+++ b/test/integration/targets/include_import/runme.sh
@@ -148,3 +148,9 @@ test "$(grep out.txt -ce 'In imported role')" = 3
 # https://github.com/ansible/ansible/issues/73657
 ansible-playbook issue73657.yml 2>&1 | tee issue73657.out
 test "$(grep -c 'SHOULD_NOT_EXECUTE' issue73657.out)" = 0
+
+# https://github.com/ansible/ansible/issues/83874
+ansible-playbook test_null_include_filename.yml 2>&1 | tee test_null_include_filename.out
+test "$(grep -c 'ERROR! No file specified for ansible.builtin.include_tasks' test_null_include_filename.out)" = 1
+test "$(grep -c 'The error appears to be in '\''.*/include_import/null_filename/tasks.yml'\'': line 4, column 3.*' test_null_include_filename.out)" = 1
+test "$(grep -c '\- name: invalid include_task definition' test_null_include_filename.out)" = 1

--- a/test/integration/targets/include_import/test_null_include_filename.yml
+++ b/test/integration/targets/include_import/test_null_include_filename.yml
@@ -1,0 +1,7 @@
+- name: Test include failure with invalid included include_task
+  hosts: localhost
+  gather_facts: false
+
+  tasks:
+  - ansible.builtin.include_tasks:
+      file: null_filename/tasks.yml


### PR DESCRIPTION
##### SUMMARY
Adds the datastore details to the parser error when attempting to include tasks that contain include_tasks without a filename set. This change will now display the exact location of the include_tasks that failed like any normal syntax error.

Backport of https://github.com/ansible/ansible/pull/83876

(cherry picked from commit 1503805b703787aba06111f67e7dc564e3420cad)

##### ISSUE TYPE
- Bugfix Pull Request