### PR TITLE
[stable-2.17] release.py - Add missing setuptools arg to prepare

### DIFF
--- a/packaging/release.py
+++ b/packaging/release.py
@@ -1243,7 +1243,7 @@ def check_state(allow_stale: bool = False) -> None:
 
 # noinspection PyUnusedLocal
 @command
-def prepare(final: bool = False, pre: str | None = None, version: str | None = None) -> None:
+def prepare(final: bool = False, pre: str | None = None, version: str | None = None, setuptools: bool | None = None) -> None:
     """Prepare a release."""
     command.run(
         update_version,


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/83887

release.py - Add missing setuptools arg to prepare

This allows the prepare command to accept the `--no-setuptools` argument.

It also fixes a traceback when using the `prepare` command.

##### ISSUE TYPE

Bugfix Pull Request
