### PR TITLE
delay keyword changed from int to float

### DIFF
--- a/changelogs/fragments/delay_type.yml
+++ b/changelogs/fragments/delay_type.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - delay keyword is now a float, matching the underlying 'time' API and user expectations.

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -72,7 +72,7 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
 
     async_val = NonInheritableFieldAttribute(isa='int', default=0, alias='async')
     changed_when = NonInheritableFieldAttribute(isa='list', default=list)
-    delay = NonInheritableFieldAttribute(isa='int', default=5)
+    delay = NonInheritableFieldAttribute(isa='float', default=5)
     failed_when = NonInheritableFieldAttribute(isa='list', default=list)
     loop = NonInheritableFieldAttribute(isa='list')
     loop_control = NonInheritableFieldAttribute(isa='class', class_type=LoopControl, default=LoopControl)

--- a/test/units/playbook/test_task.py
+++ b/test/units/playbook/test_task.py
@@ -92,7 +92,7 @@ class TestTask(unittest.TestCase):
             (12, 12),
             (1.2, 1.2),
             ('1.2', 1.2),
-            ('1', 1),
+            ('1.0', 1),
         ]
         for delay, expected in good_params:
             with self.subTest(f'type "{type(delay)}" was not cast to float', delay=delay, expected=expected):

--- a/test/units/playbook/test_task.py
+++ b/test/units/playbook/test_task.py
@@ -1,30 +1,15 @@
-# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
+# Copyright: (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import annotations
 
 import unittest
 
 from unittest.mock import patch
 
+from ansible import errors
+from ansible.parsing.yaml import objects
 from ansible.playbook.task import Task
 from ansible.plugins.loader import init_plugin_loader
-from ansible.parsing.yaml import objects
-from ansible import errors
 
 
 basic_command_task = dict(
@@ -115,6 +100,7 @@ class TestTask(unittest.TestCase):
                 p.update(self._task_base)
                 t = Task().load_data(p)
                 self.assertEqual(t.get_validated_value('delay', t.fattributes.get('delay'), delay, None), expected)
+
         bad_params = [
             ('E', ValueError),
             ('1.E', ValueError),


### PR DESCRIPTION
It uses python's `time.sleep()` which accepts decimals, but the current `int` type would truncate, so `delay: 0.5` is the same as setting `delay: 0`.

##### ISSUE TYPE

- Bugfix Pull Request