### PR TITLE
Update subset.yml

### DIFF
--- a/lib/ansible/plugins/test/subset.yml
+++ b/lib/ansible/plugins/test/subset.yml
@@ -19,7 +19,7 @@ DOCUMENTATION:
       required: True
 EXAMPLES: |
   big: [1,2,3,4,5]
-  sml: [3,4]
+  small: [3,4]
   issmallinbig: '{{ small is subset(big) }}'
 RETURN:
   _value:


### PR DESCRIPTION
Typo error in examples

##### Typo in documentation 

<!--- In subset filter plugin documentation, example is having typo -->

<!--- HINT: Include "Closes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Changed from 
```
big: [1,2,3,4,5]
sml: [3,4]
issmallinbig: '{{ small is subset(big) }}'

```
to 
```
big: [1,2,3,4,5]
small: [3,4]
issmallinbig: '{{ small is subset(big) }}'

```