### PR TITLE
Stop suggesting `easy_install` in hacking

### DIFF
--- a/hacking/README.md
+++ b/hacking/README.md
@@ -18,7 +18,7 @@ and do not wish to install them from your operating system package manager, you
 can install them from pip
 
 ```shell
-easy_install pip  # if pip is not already available
+python -Im ensurepip  # if pip is not already available
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
It's been discouraged for the past decade. And CPython actually ships with pip nowadays, that is bundled within the built-in `ensurepip` stdlib module.

##### SUMMARY

$sbj.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Maintenance Pull Request

##### ADDITIONAL INFORMATION

N/A
