### PR TITLE
Support terminals that implement `truecolor`

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 
 from string import ascii_letters, digits
@@ -59,6 +60,13 @@ COLOR_CODES = {
     'dark gray': u'1;30', 'bright yellow': u'1;33',
     'magenta': u'0;35', 'bright magenta': u'1;35',
     'normal': u'0',
+}
+COLOR_CODES = {
+    name:
+    str(int(re.search(r'1;(?P<color_code>3\d)', ansi_seq).group('color_code')) + 60)
+    if os.getenv('COLORTERM') == 'truecolor' and '1;3' in ansi_seq
+    else ansi_seq
+    for name, ansi_seq in COLOR_CODES.items()
 }
 REJECT_EXTS = ['.pyc', '.pyo', '.swp', '.bak', '~', '.rpm', '.md', '.txt', '.rst']  # this is concatenated with other config settings as lists; cannot be tuple
 BOOL_TRUE = BOOLEANS_TRUE

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -293,6 +293,13 @@ def generate_command(
         ANSIBLE_TEST_CONTENT_ROOT=content_root,
     )
 
+    if color_term := os.getenv('COLORTERM'):
+        # NOTE: The current terminal emulator may have this set to `truecolor`
+        # NOTE: which is important for setting different color defaults. This
+        # NOTE: may be evident in Kitty that does not interpret the bold ANSI
+        # NOTE: marker as bright like some of the others.
+        env_vars['COLORTERM'] = color_term
+
     if isinstance(args.controller, OriginConfig):
         # Expose the ansible and ansible_test library directories to the Python environment.
         # This is only required when delegation is used on the origin host.

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -733,6 +733,13 @@ def common_environment() -> dict[str, str]:
 
     env.update(pass_vars(required=required, optional=optional))
 
+    if color_term := os.getenv('COLORTERM'):
+        # NOTE: The current terminal emulator may have this set to `truecolor`
+        # NOTE: which is important for setting different color defaults. This
+        # NOTE: may be evident in Kitty that does not interpret the bold ANSI
+        # NOTE: marker as bright like some of the others.
+        env['COLORTERM'] = color_term
+
     return env
 
 


### PR DESCRIPTION
##### SUMMARY

$sbj. Basically, I want to make my Kitty terminal show invisible debug log lines properly.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
- Feature Pull Request

##### ADDITIONAL INFORMATION

* Bold/faint @ Kitty: https://sw.kovidgoyal.net/kitty/misc-protocol/#independent-control-of-bold-and-faint-sgr-properties.
* https://en.wikipedia.org/wiki/ANSI_escape_code#SGR uses 90–97 for bright colors.