### PR TITLE
delay keyword changed from int to float (#83901)

### DIFF
--- a/changelogs/fragments/delay_type.yml
+++ b/changelogs/fragments/delay_type.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - delay keyword is now a float, matching the underlying 'time' API and user expectations.

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -72,7 +72,7 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
 
     async_val = NonInheritableFieldAttribute(isa='int', default=0, alias='async')
     changed_when = NonInheritableFieldAttribute(isa='list', default=list)
-    delay = NonInheritableFieldAttribute(isa='int', default=5)
+    delay = NonInheritableFieldAttribute(isa='float', default=5)
     failed_when = NonInheritableFieldAttribute(isa='list', default=list)
     loop = NonInheritableFieldAttribute(isa='list')
     loop_control = NonInheritableFieldAttribute(isa='class', class_type=LoopControl, default=LoopControl)


### PR DESCRIPTION
Changed to match underlying API and user expectations, now 0.5 works instead of making the delay 0

(cherry picked from commit 9c49fdd86d0f555dd1bef0d117e095ca1287047f)

##### ISSUE TYPE

- Bugfix Pull Request
