### PR TITLE
Clarify galaxy CLI --help about install locations

### DIFF
--- a/changelogs/fragments/ansible-galaxy-install-help.yml
+++ b/changelogs/fragments/ansible-galaxy-install-help.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- >-
+  Add descriptions for ``ansible-galaxy install --help` and ``ansible-galaxy role|collection install --help``.
+- >-
+  ``ansible-galaxy install --help`` - Fix the usage text and document that the requirements file passed to ``-r`` can include collections and roles.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -468,11 +468,7 @@ class GalaxyCLI(CLI):
             ignore_errors_help = 'Ignore errors during installation and continue with the next specified ' \
                                  'collection. This will not ignore dependency conflict errors.'
         else:
-            args_kwargs['help'] = 'Role name, URL or tar file'
-            if self._implicit_role:
-                args_kwargs['help'] += '. This is mutually exclusive with --requirements-file.'
-            else:
-                args_kwargs['help'] += '. This is mutually exclusive with --role-file.'
+            args_kwargs['help'] = 'Role name, URL or tar file. This is mutually exclusive with -r.'
             ignore_errors_help = 'Ignore errors and continue with the next specified role.'
 
         if self._implicit_role:
@@ -549,12 +545,8 @@ class GalaxyCLI(CLI):
                                              'This does not apply to collections in remote Git repositories or URLs to remote tarballs.'
                                         )
         else:
-            if self._implicit_role:
-                install_parser.add_argument('-r', '--requirements-file', '--role-file', dest='requirements',
-                                            help='A file containing a list of collections and roles to be installed.')
-            else:
-                install_parser.add_argument('-r', '--role-file', dest='requirements',
-                                            help='A file containing a list of roles to be installed.')
+            install_parser.add_argument('-r', '--role-file', dest='requirements',
+                                        help='A file containing a list of roles to be installed.')
 
             r_re = re.compile(r'^(?<!-)-[a-zA-Z]*r[a-zA-Z]*')  # -r, -fr
             contains_r = bool([a for a in self._raw_args if r_re.match(a)])

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -257,7 +257,7 @@ class GalaxyCLI(CLI):
         collections_path = opt_help.ArgumentParser(add_help=False)
         collections_path.add_argument('-p', '--collections-path', dest='collections_path', type=opt_help.unfrack_path(pathsep=True),
                                       action=opt_help.PrependListAction,
-                                      help="One or more directories to search for collections (or install to) in addition "
+                                      help="One or more directories to search for collections in addition "
                                       "to the default COLLECTIONS_PATHS. Separate multiple paths "
                                       "with '{0}'.".format(os.path.pathsep))
 
@@ -472,22 +472,28 @@ class GalaxyCLI(CLI):
             ignore_errors_help = 'Ignore errors and continue with the next specified role.'
 
         if self._implicit_role:
-            # installing both roles and collections
+            # might install both roles and collections
             description_text = (
                 'Install roles and collections from file(s), URL(s) or Ansible '
                 'Galaxy to the first entry in the config COLLECTIONS_PATH for collections '
-                'and first entry in the config ROLES_PATH for roles.'
+                'and first entry in the config ROLES_PATH for roles. '
+                'The first entry in the config ROLES_PATH can be overridden by --roles-path '
+                'or -p. This will result in only roles being installed.'
+                'Only role requirements can be passed as positional arguments.'
             )
+            prog = 'ansible-galaxy install '
         else:
+            prog = parser._prog_prefix
             description_text = (
                 'Install {0}(s) from file(s), URL(s) or Ansible '
                 'Galaxy to the first entry in the config {1}S_PATH '
-                'unless overridden by --{0}s-path'.format(galaxy_type, galaxy_type.upper())
+                'unless overridden by --{0}s-path.'.format(galaxy_type, galaxy_type.upper())
             )
         install_parser = parser.add_parser('install', parents=parents,
                                            help='Install {0}(s) from file(s), URL(s) or Ansible '
                                                 'Galaxy'.format(galaxy_type),
-                                           description=description_text)
+                                           description=description_text,
+                                           prog=prog,)
         install_parser.set_defaults(func=self.execute_install)
 
         install_parser.add_argument('args', metavar='{0}_name'.format(galaxy_type), nargs='*', **args_kwargs)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -482,7 +482,7 @@ class GalaxyCLI(CLI):
                 'Galaxy to the first entry in the config COLLECTIONS_PATH for collections '
                 'and first entry in the config ROLES_PATH for roles. '
                 'The first entry in the config ROLES_PATH can be overridden by --roles-path '
-                'or -p. This will result in only roles being installed.'
+                'or -p, but this will result in only roles being installed.'
             )
             prog = 'ansible-galaxy install '
         else:

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -545,8 +545,12 @@ class GalaxyCLI(CLI):
                                              'This does not apply to collections in remote Git repositories or URLs to remote tarballs.'
                                         )
         else:
-            install_parser.add_argument('-r', '--role-file', dest='requirements',
-                                        help='A file containing a list of roles to be installed.')
+            if self._implicit_role:
+                install_parser.add_argument('-r', '--role-file', dest='requirements',
+                                            help='A file containing a list of collections and roles to be installed.')
+            else:
+                install_parser.add_argument('-r', '--role-file', dest='requirements',
+                                            help='A file containing a list of roles to be installed.')
 
             r_re = re.compile(r'^(?<!-)-[a-zA-Z]*r[a-zA-Z]*')  # -r, -fr
             contains_r = bool([a for a in self._raw_args if r_re.match(a)])

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -257,7 +257,7 @@ class GalaxyCLI(CLI):
         collections_path = opt_help.ArgumentParser(add_help=False)
         collections_path.add_argument('-p', '--collections-path', dest='collections_path', type=opt_help.unfrack_path(pathsep=True),
                                       action=opt_help.PrependListAction,
-                                      help="One or more directories to search for collections in addition "
+                                      help="One or more directories to search for collections (or install to) in addition "
                                       "to the default COLLECTIONS_PATHS. Separate multiple paths "
                                       "with '{0}'.".format(os.path.pathsep))
 
@@ -471,9 +471,23 @@ class GalaxyCLI(CLI):
             args_kwargs['help'] = 'Role name, URL or tar file'
             ignore_errors_help = 'Ignore errors and continue with the next specified role.'
 
+        if self._implicit_role:
+            # installing both roles and collections
+            description_text = (
+                'Install roles and collections from file(s), URL(s) or Ansible '
+                'Galaxy to the first entry in the config COLLECTIONS_PATH for collections '
+                'and first entry in the config ROLES_PATH for roles.'
+            )
+        else:
+            description_text = (
+                'Install {0}(s) from file(s), URL(s) or Ansible '
+                'Galaxy to the first entry in the config {1}S_PATH '
+                'unless overriden by --{0}s-path'.format(galaxy_type, galaxy_type.upper())
+            )
         install_parser = parser.add_parser('install', parents=parents,
                                            help='Install {0}(s) from file(s), URL(s) or Ansible '
-                                                'Galaxy'.format(galaxy_type))
+                                                'Galaxy'.format(galaxy_type),
+                                           description=description_text)
         install_parser.set_defaults(func=self.execute_install)
 
         install_parser.add_argument('args', metavar='{0}_name'.format(galaxy_type), nargs='*', **args_kwargs)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -482,7 +482,7 @@ class GalaxyCLI(CLI):
             description_text = (
                 'Install {0}(s) from file(s), URL(s) or Ansible '
                 'Galaxy to the first entry in the config {1}S_PATH '
-                'unless overriden by --{0}s-path'.format(galaxy_type, galaxy_type.upper())
+                'unless overridden by --{0}s-path'.format(galaxy_type, galaxy_type.upper())
             )
         install_parser = parser.add_parser('install', parents=parents,
                                            help='Install {0}(s) from file(s), URL(s) or Ansible '

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -484,7 +484,7 @@ class GalaxyCLI(CLI):
                 'The first entry in the config ROLES_PATH can be overridden by --roles-path '
                 'or -p, but this will result in only roles being installed.'
             )
-            prog = 'ansible-galaxy install '
+            prog = 'ansible-galaxy install'
         else:
             prog = parser._prog_prefix
             description_text = (

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -469,6 +469,10 @@ class GalaxyCLI(CLI):
                                  'collection. This will not ignore dependency conflict errors.'
         else:
             args_kwargs['help'] = 'Role name, URL or tar file'
+            if self._implicit_role:
+                args_kwargs['help'] += '. This is mutually exclusive with --requirements-file.'
+            else:
+                args_kwargs['help'] += '. This is mutually exclusive with --role-file.'
             ignore_errors_help = 'Ignore errors and continue with the next specified role.'
 
         if self._implicit_role:
@@ -479,7 +483,6 @@ class GalaxyCLI(CLI):
                 'and first entry in the config ROLES_PATH for roles. '
                 'The first entry in the config ROLES_PATH can be overridden by --roles-path '
                 'or -p. This will result in only roles being installed.'
-                'Only role requirements can be passed as positional arguments.'
             )
             prog = 'ansible-galaxy install '
         else:
@@ -546,8 +549,12 @@ class GalaxyCLI(CLI):
                                              'This does not apply to collections in remote Git repositories or URLs to remote tarballs.'
                                         )
         else:
-            install_parser.add_argument('-r', '--role-file', dest='requirements',
-                                        help='A file containing a list of roles to be installed.')
+            if self._implicit_role:
+                install_parser.add_argument('-r', '--requirements-file', '--role-file', dest='requirements',
+                                            help='A file containing a list of collections and roles to be installed.')
+            else:
+                install_parser.add_argument('-r', '--role-file', dest='requirements',
+                                            help='A file containing a list of roles to be installed.')
 
             r_re = re.compile(r'^(?<!-)-[a-zA-Z]*r[a-zA-Z]*')  # -r, -fr
             contains_r = bool([a for a in self._raw_args if r_re.match(a)])


### PR DESCRIPTION
##### SUMMARY

Updated #81159 with requested changes

```diff
$ ansible-galaxy install --help
-usage: ansible-galaxy role install [-h] [-s API_SERVER] [--token API_KEY] [-c] [--timeout TIMEOUT] [-v] [-f] [-p ROLES_PATH] [-i] [-n | --force-with-deps] [-r REQUIREMENTS] [-g] [role_name ...]
+usage: ansible-galaxy install  [-h] [-s API_SERVER] [--token API_KEY] [-c] [--timeout TIMEOUT] [-v] [-f] [-p ROLES_PATH] [-i] [-n | --force-with-deps] [-r REQUIREMENTS] [-g] [role_name ...]

+Install roles and collections from file(s), URL(s) or Ansible Galaxy to the first entry in the config COLLECTIONS_PATH for collections and first entry in the config ROLES_PATH for roles. The
+first entry in the config ROLES_PATH can be overridden by --roles-path or -p. This will result in only roles being installed.

positional arguments:
-  role_name             Role name, URL or tar file
+  role_name             Role name, URL or tar file. This is mutually exclusive with --requirements-file.

options:
  -h, --help            show this help message and exit
  -s API_SERVER, --server API_SERVER
                        The Galaxy API server URL
  --token API_KEY, --api-key API_KEY
                        The Ansible Galaxy API key which can be found at https://galaxy.ansible.com/me/preferences.
  -c, --ignore-certs    Ignore SSL certificate validation errors.
  --timeout TIMEOUT     The time to wait for operations against the galaxy server, defaults to 60s.
  -v, --verbose         Causes Ansible to print more debug messages. Adding multiple -v will increase the verbosity, the builtin plugins currently evaluate up to -vvvvvv. A reasonable level to
                        start is -vvv, connection debugging might require -vvvv. This argument may be specified multiple times.
  -f, --force           Force overwriting an existing role or collection
  -p ROLES_PATH, --roles-path ROLES_PATH
                        The path to the directory containing your roles. The default is the first writable one configured via DEFAULT_ROLES_PATH: {{ ANSIBLE_HOME ~
                        "/roles:/usr/share/ansible/roles:/etc/ansible/roles" }} . This argument may be specified multiple times.
  -i, --ignore-errors   Ignore errors and continue with the next specified role.
  -n, --no-deps         Don't download roles listed as dependencies.
  --force-with-deps     Force overwriting an existing role and its dependencies.
-  -r REQUIREMENTS, --role-file REQUIREMENTS
+  -r REQUIREMENTS, --requirements-file REQUIREMENTS, --role-file REQUIREMENTS
-                        A file containing a list of roles to be installed.
+                        A file containing a list of collections and roles to be installed.
```

```diff
$ ansible-galaxy collection install --help
usage: ansible-galaxy collection [-h] [-s API_SERVER] [--token API_KEY] [-c] [--timeout TIMEOUT] [-v] [-f] [--clear-response-cache] [--no-cache] [-i] [-n | --force-with-deps]
                                 [-p COLLECTIONS_PATH] [-r REQUIREMENTS] [--pre] [-U] [--keyring KEYRING] [--disable-gpg-verify] [--signature SIGNATURES]
                                 [--required-valid-signature-count REQUIRED_VALID_SIGNATURE_COUNT]
                                 [--ignore-signature-status-code {EXPSIG,EXPKEYSIG,REVKEYSIG,BADSIG,ERRSIG,NO_PUBKEY,MISSING_PASSPHRASE,BAD_PASSPHRASE,NODATA,UNEXPECTED,ERROR,FAILURE,BADARMOR,KEYEXPIRED,KEYREVOKED,NO_SECKEY}]
                                 [--offline]
                                 [collection_name ...]

+Install collection(s) from file(s), URL(s) or Ansible Galaxy to the first entry in the config COLLECTIONS_PATH unless overridden by --collections-path.

positional arguments:
  collection_name       The collection(s) name or path/url to a tar.gz collection artifact. This is mutually exclusive with --requirements-file.
...
```

```diff
$ ansible-galaxy role install --help
usage: ansible-galaxy role [-h] [-s API_SERVER] [--token API_KEY] [-c] [--timeout TIMEOUT] [-v] [-f] [-p ROLES_PATH] [-i] [-n | --force-with-deps] [-r REQUIREMENTS] [-g] [role_name ...]

+Install role(s) from file(s), URL(s) or Ansible Galaxy to the first entry in the config ROLES_PATH unless overridden by --roles-path.

positional arguments:
-  role_name             Role name, URL or tar file
+  role_name             Role name, URL or tar file. This is mutually exclusive with --role-file.
...
```


##### ISSUE TYPE

- Bugfix Pull Request

