### PR TITLE
release.py - Use changelog requirements

### DIFF
--- a/packaging/release.py
+++ b/packaging/release.py
@@ -672,7 +672,7 @@ build
 twine
 """
 
-    requirements_file = CHECKOUT_DIR / "test/sanity/code-smell/package-data.requirements.txt"
+    requirements_file = CHECKOUT_DIR / "test/lib/ansible_test/_data/requirements/sanity.changelog.txt"
     requirements_content = requirements_file.read_text()
     requirements_content += ansible_requirements
     requirements_content += release_requirements

--- a/test/sanity/code-smell/package-data.requirements.in
+++ b/test/sanity/code-smell/package-data.requirements.in
@@ -1,6 +1,1 @@
 build  # required to build sdist
-jinja2
-pyyaml
-resolvelib < 1.1.0
-rstcheck < 6  # newer versions have too many dependencies
-antsibull-changelog

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -1,14 +1,4 @@
 # edit "package-data.requirements.in" and generate with: hacking/update-sanity-requirements.py --test package-data
-antsibull-changelog==0.29.0
-build==1.2.1
-docutils==0.18.1
-Jinja2==3.1.4
-MarkupSafe==2.1.5
+build==1.2.2
 packaging==24.1
 pyproject_hooks==1.1.0
-PyYAML==6.0.2
-resolvelib==1.0.1
-rstcheck==5.0.0
-semantic-version==2.10.0
-types-docutils==0.18.3
-typing_extensions==4.12.2


### PR DESCRIPTION
##### SUMMARY

Use the changelog sanity test requirements instead of the package-data sanity test requirements.

This enables removal of most package-data sanity test requirements, as they are no longer used by the test itself. The additional requirements were being maintained only to provide pinned requirements for building the changelog during a release.

##### ISSUE TYPE

Feature Pull Request
