### PR TITLE
[DNM] Add mount_facts module

### DIFF
--- a/changelogs/fragments/83508_mount_facts.yml
+++ b/changelogs/fragments/83508_mount_facts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add a new mount_facts module to support gathering information about mounts that are excluded by default fact gathering.

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -37,6 +37,17 @@ from ansible.module_utils.six import iteritems
 # import this as a module to ensure we get the same module instance
 from ansible.module_utils.facts import timeout
 
+_OCTAL_ESCAPE_RE = re.compile(r'\\[0-9]{3}')
+
+
+def _replace_octal_escapes(value):
+
+    def _replace_octal_escapes_helper(match):
+        # Convert to integer using base8 and then convert to character
+        return chr(int(match.group()[1:], 8))
+
+    return _OCTAL_ESCAPE_RE.sub(_replace_octal_escapes_helper, value)
+
 
 def get_partition_uuid(partname):
     try:
@@ -80,7 +91,7 @@ class LinuxHardware(Hardware):
     MTAB_BIND_MOUNT_RE = re.compile(r'.*bind.*"')
 
     # regex used for replacing octal escape sequences
-    OCTAL_ESCAPE_RE = re.compile(r'\\[0-9]{3}')
+    OCTAL_ESCAPE_RE = _OCTAL_ESCAPE_RE
 
     def populate(self, collected_facts=None):
         hardware_facts = {}
@@ -547,13 +558,8 @@ class LinuxHardware(Hardware):
             mtab_entries.append(fields)
         return mtab_entries
 
-    @staticmethod
-    def _replace_octal_escapes_helper(match):
-        # Convert to integer using base8 and then convert to character
-        return chr(int(match.group()[1:], 8))
-
     def _replace_octal_escapes(self, value):
-        return self.OCTAL_ESCAPE_RE.sub(self._replace_octal_escapes_helper, value)
+        return _replace_octal_escapes(value)
 
     def get_mount_info(self, mount, device, uuids):
 

--- a/lib/ansible/module_utils/facts/timeout.py
+++ b/lib/ansible/module_utils/facts/timeout.py
@@ -48,7 +48,7 @@ def timeout(seconds=None, error_message="Timer expired"):
                 return res.get(timeout_value)
             except multiprocessing.TimeoutError:
                 # This is an ansible.module_utils.common.facts.timeout.TimeoutError
-                raise TimeoutError('Timer expired after %s seconds' % timeout_value)
+                raise TimeoutError(f'{error_message} after {timeout_value} seconds')
             finally:
                 pool.terminate()
 

--- a/lib/ansible/modules/mount_facts.py
+++ b/lib/ansible/modules/mount_facts.py
@@ -1,0 +1,434 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+
+DOCUMENTATION = """
+---
+module: mount_facts
+version_added: 2.18
+short_description: Retrieve mount information.
+description:
+  - Retrieve information about mounts from preferred sources and filter the results based on the filesystem type and device.
+options:
+  devices:
+    description: A list of fnmatch patterns to filter mounts by the special device or remote file system.
+    default:
+      - "*"
+    type: list
+    elements: str
+  fstypes:
+    description: A list of fnmatch patterns to filter mounts by the type of the file system.
+    default:
+      - "*"
+    type: list
+    elements: str
+  sources:
+    default:
+      - all
+    description:
+      - A list of files to use when collecting mount information, or the special values V(all), V(static), and V(dynamic).
+      - V(dynamic) contains V(/etc/mtab), V(/proc/mounts), V(/etc/mnttab), and if none are found, falls back to O(mount_binary).
+      - V(static) contains V(/etc/fstab), V(/etc/vfstab), and V(/etc/filesystems).
+      - Note that V(/etc/filesystems) is AIX-specific and the Linux file by this name will be ignored.
+    type: list
+    elements: str
+  mount_binary:
+    description:
+      - The O(mount_binary) is used if O(sources) contain the same value, or if O(sources) contains a dynamic
+        source, and none were found (as can be expected on BSD or AIX hosts).
+      - Set to V(null) to stop after no dynamic file source is found instead.
+    type: raw
+    default: mount
+  timeout:
+    description:
+      - This is the maximum number of seconds to query for each mount. When this is V(null), wait indefinitely.
+      - Configure in conjunction with O(on_timeout) to try to skip unresponsive mounts.
+      - This timeout also applies to the O(mount_binary) command to list mounts.
+      - If the module is configured to run during the play's fact gathering stage, set a timeout using module_defaults to prevent a hang (see example).
+    type: int
+  on_timeout:
+    description:
+      - The action to take when listing mounts or mount information exceeds O(timeout).
+    type: str
+    default: error
+    choices:
+      - error
+      - warn
+      - ignore
+extends_documentation_fragment:
+  - action_common_attributes
+attributes:
+  check_mode:
+    support: full
+  diff_mode:
+    support: none
+  platform:
+    platforms: posix
+author:
+  - Ansible Core Team
+  - Sloane Hertel (@s-hertel)
+"""
+
+EXAMPLES = """
+- name: Get non-local devices
+  mount_facts:
+    devices: "[!/]*"
+
+- name: Get FUSE subtype mounts
+  mount_facts:
+    fstypes:
+      - "fuse.*"
+
+- name: Get NFS mounts during gather_facts with timeout
+  hosts: all
+  gather_facts: true
+  vars:
+    ansible_facts_modules:
+      - ansible.builtin.mount_facts
+  module_default:
+    ansible.builtin.mount_facts:
+      timeout: 10
+      fstypes:
+        - nfs
+        - nfs4
+
+- name: Get mounts from a non-default location
+  mount_facts:
+    sources:
+      - /usr/etc/fstab
+
+- name: Get mounts from the mount binary
+  mount_facts:
+    sources:
+      - /sbin/mount
+    mount_binary: /sbin/mount
+"""
+
+RETURN = """
+ansible_facts:
+    description:
+      - An ansible_facts dictionary containing the key C(extended_mounts), and value matching the default structure of C(ansible_facts[mount_facts]).
+    returned: always
+    type: dict
+    sample:
+      extended_mounts:
+        /mnt/mount:
+          source: /proc/mounts
+          info:
+            block_available: 3242510
+            block_size: 4096
+            block_total: 3789825
+            block_used: 547315
+            device: hostname:/srv/sshfs
+            fstype: fuse.sshfs
+            inode_available: 1875503
+            inode_total: 1966080
+            mount: /mnt/mount
+            options: "rw,nosuid,nodev,relatime,user_id=0,group_id=0"
+            size_available: 13281320960
+            size_total: 15523123200
+          uuid: N/A
+"""
+
+from ansible.module_utils.basic import AnsibleModule as _AnsibleModule
+from ansible.module_utils.facts import timeout as _timeout
+from ansible.module_utils.facts.hardware.linux import LinuxHardware as _LinuxHardware, _replace_octal_escapes
+from ansible.module_utils.facts.utils import get_mount_size as _get_mount_size, get_file_content as _get_file_content
+
+from fnmatch import fnmatch as _fnmatch
+from collections.abc import Callable as _Callable
+from contextlib import suppress as _suppress
+from fnmatch import fnmatch as _fnmatch
+from functools import wraps as _wraps
+
+import re as _re
+import subprocess as _subprocess
+
+_STATIC_SOURCES = ["/etc/fstab", "/etc/vfstab", "/etc/filesystems"]
+_DYNAMIC_SOURCES = ["/etc/mtab", "/proc/mounts", "/etc/mnttab"]
+
+# AIX and BSD don't have a file-based dynamic source, so the module also supports running a mount binary to collect these.
+# Pattern for Linux, including OpenBSD and NetBSD
+_LINUX_MOUNT_RE = _re.compile(r"^(?P<device>\S+) on (?P<mount>\S+) type (?P<fstype>\S+) \((?P<options>.+)\)$")
+# Pattern for other BSD including FreeBSD, DragonFlyBSD, and MacOS
+_BSD_MOUNT_RE = _re.compile(r"^(?P<device>\S+) on (?P<mount>\S+) \((?P<fstype>.+)\)$")
+# Pattern for AIX, example in https://www.ibm.com/docs/en/aix/7.2?topic=m-mount-command
+_AIX_MOUNT_RE = _re.compile(r"^(?P<node>\S+)?\s+(?P<mounted>\S+)\s+(?P<mount>\S+)\s+(?P<fstype>\S+)\s+(?P<time>\S+\s+\d+\s+\d+:\d+)\s+(?P<options>.*)$")
+
+
+def _handle_timeout(module, default=None):
+    """Decorator to catch timeout exceptions and handle failing, warning, and ignoring the timeout."""
+    def decorator(func):
+        @_wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except (_subprocess.TimeoutExpired, _timeout.TimeoutError) as e:
+                if module.params["on_timeout"] == "error":
+                    module.fail_json(msg=str(e))
+                elif module.params["on_timeout"] == "warn":
+                    module.warn(str(e))
+                return default
+        return wrapper
+    return decorator
+
+
+def _run_mount_bin(module: _AnsibleModule, mount_bin: str) -> str:  # type: ignore # Missing return statement
+    """Execute the specified mount binary with optional timeout."""
+    mount_bin = module.get_bin_path(mount_bin, required=True)
+    try:
+        return _handle_timeout(module, default="")(_subprocess.check_output)(
+            mount_bin, text=True, timeout=module.params["timeout"]
+        )
+    except _subprocess.CalledProcessError as e:
+        module.fail_json(msg=f"Failed to execute {mount_bin}: {str(e)}")
+
+
+def _list_mounts_from_mount_stdout(stdout) -> list[dict[str, str]]:
+    """List mount dictionaries from mount stdout."""
+    lines = stdout.splitlines()
+    if any(_LINUX_MOUNT_RE.match(line) for line in lines):
+        pattern = _LINUX_MOUNT_RE
+    elif any(_BSD_MOUNT_RE.match(line) for line in lines):
+        pattern = _BSD_MOUNT_RE
+    elif any(_AIX_MOUNT_RE.match(line) for line in lines):
+        # AIX has a couple header lines for some reason
+        pattern = _AIX_MOUNT_RE
+    else:
+        return []
+
+    results: list[dict[str, str]] = []
+    for line in lines:
+        if not (match := pattern.match(line)):
+            continue
+
+        if pattern is _LINUX_MOUNT_RE:
+            results.append(match.groupdict())
+        elif pattern == _BSD_MOUNT_RE:
+            # the group containing fstype is comma separated, and may include whitespace
+            fields = match.groupdict()
+            parts = _re.split(r"\s*,\s*", match.group("fstype"), 1)
+            if len(parts) == 1:
+                fields["fstype"] = parts[0]
+            else:
+                fields.update({"fstype": parts[0], "options": parts[1]})
+            results.append(fields)
+        elif pattern == _AIX_MOUNT_RE:
+            fields = match.groupdict()
+            device = fields.pop("mounted")
+            node = fields.pop("node")
+            if node:
+                device = f"{node}:{device}"
+            fields["device"] = device
+            results.append(fields)
+
+    return results
+
+
+def _list_fstab_entries(lines: list[str]) -> list[dict[str, str]]:
+    """List dictionaries from https://man7.org/linux/man-pages/man5/fstab.5.html."""
+    entries: list[dict[str, str]] = []
+    for line in lines:
+        if not (line := line.strip()) or line.startswith("#"):
+            continue
+        fields = [_replace_octal_escapes(field) for field in line.split()]
+        entries.append({
+            "device": fields[0],
+            "mount": fields[1],
+            "fstype": fields[2],
+            "options": fields[3],
+        })
+        with _suppress(IndexError):
+            # the last two fields are optional
+            entries[-1]["dump"] = fields[4]
+            entries[-1]["passno"] = fields[5]
+    return entries
+
+
+def _list_vfstab_entries(lines: list[str]) -> list[dict[str, str]]:
+    """List dictionaries from /etc/vfstab https://docs.oracle.com/cd/E36784_01/html/E36882/vfstab-4.html."""
+    return [
+        {
+            "device": fields[0],
+            "device_to_fsck": fields[1],
+            "mount": fields[2],
+            "fstype": fields[3],
+            "passno": fields[4],
+            "mount_at_boot": fields[5],
+            "options": fields[6],
+        }
+        for line in lines
+        if line.strip() and not line.strip().startswith("#")
+        for fields in [line.split()]
+    ]
+
+
+def _list_aix_filesystem_entries(lines: list[str]) -> list[dict[str, str | dict[str, str]]]:
+    """List dictionaries from /etc/filesystems https://www.ibm.com/docs/hu/aix/7.2?topic=files-filesystems-file."""
+    # AIX comments start with *
+    lines = [line for line in lines if not line.startswith("*")]
+
+    results: list[dict[str, str | dict[str, str]]] = []
+    for stanza in _re.split(r"\n\s*\n", "\n".join(lines)):
+        stanza_lines = stanza.splitlines()
+        header = stanza_lines.pop(0).strip()
+        if any("=" not in line for line in stanza_lines):
+            # Expected for Linux, return an empty list since this doesn't appear to be AIX /etc/filesystems
+            results = []
+            break
+
+        mount_attrs: dict[str, str] = {
+            mount_attr.strip().rstrip(): mount_attr_value.strip().rstrip()
+            for line in stanza_lines
+            for mount_attr, mount_attr_value in [line.split("=", 1)]
+        }
+
+        device = ""
+        if "nodename" in mount_attrs:
+            device = mount_attrs["nodename"]
+        if "dev" in mount_attrs:
+            if device:
+                device += ":"
+            device += mount_attrs["dev"]
+
+        results.append({
+            "mount": header[:-1],  # snip trailing :
+            "fstype": mount_attrs.get("vfs") or "unknown",
+            "device": device or "unknown",
+            # return attrs as a value since it contains "mount" with a different value (automatic|true|false|removable|readonly)
+            "attributes": mount_attrs,
+        })
+    return results
+
+
+def _list_mnttab_entries(lines: list[str]) -> list[dict[str, str]]:
+    """List dictionaries from /etc/mnttab columns https://docs.oracle.com/cd/E36784_01/html/E36882/mnttab-4.html."""
+    if not any(len(fields[4]) == 10 for line in lines for fields in [line.split()]):
+        # best effort to distinguish between mnttab timestamp and mtab dump fields
+        # if none of these look like a UNIX timestamp, assume it's the latter
+        # TODO: check any are a valid datetime.date.fromtimestamp for good measure, or is there a better approach?
+        return []
+    return [
+        {
+            "device": fields[0],
+            "mount": fields[1],
+            "fstype": fields[2],
+            "options": fields[3],
+            "time": fields[4],
+        }
+        for line in lines
+        for fields in [line.split()]
+    ]
+
+
+def _get_mounts_by_source(module: _AnsibleModule):
+    """Enumerate the requested sources and return a dictionary containing the parsed sources."""
+    sources: list[str] = []
+    use_mount_bin_explicit = False
+    for source in module.params["sources"]:
+        if not source:
+            module.fail_json(msg="sources contains an empty string")
+
+        if source in {"static", "all"}:
+            sources.extend(_STATIC_SOURCES)
+        if source in {"dynamic", "all"}:
+            sources.extend(_DYNAMIC_SOURCES)
+
+        if source == module.params["mount_binary"]:
+            use_mount_bin_explicit = True
+        elif source not in {"static", "dynamic", "all"}:
+            sources.append(source)
+
+    if len(set(sources)) < len(sources):
+        module.warn(f"mount_facts option 'sources' contains duplicate entries, repeat sources will be ignored: {sources}")
+
+    collected = {}
+    for file in sources:
+        if file in collected:
+            continue
+        if not (lines := _get_file_content(file, "").splitlines()):
+            continue
+
+        for list_mount_func in [_list_vfstab_entries, _list_mnttab_entries, _list_fstab_entries, _list_aix_filesystem_entries]:
+            try:
+                mounts = list_mount_func(lines)
+            except IndexError:
+                continue
+            if mounts:
+                collected[file] = mounts
+                break
+        else:
+            module.debug(f"mount_facts source {file} exists, but contains an unsupported format.")
+
+    mount_binary = module.params["mount_binary"]
+    use_mount_bin_implicit = set(sources).intersection(_DYNAMIC_SOURCES) and not any(collected.get(src, []) for src in _DYNAMIC_SOURCES) and mount_binary
+    if use_mount_bin_explicit or use_mount_bin_implicit:
+        stdout = _run_mount_bin(module, mount_binary)
+        mounts = _list_mounts_from_mount_stdout(stdout)
+        if mounts:
+            collected[mount_binary] = mounts
+
+    return collected
+
+
+def _get_mount_facts(module: _AnsibleModule, uuids: dict, udevadm_uuid: _Callable) -> dict[str, dict[str, str | dict[str, str]]]:
+    """List and filter mounts, returning a dictionary containing mount points as the keys (last listed wins)."""
+    seconds = module.params["timeout"]
+    on_timeout = module.params["on_timeout"]
+
+    facts = {}
+    for source, mounts in _get_mounts_by_source(module).items():
+        for fields in mounts:
+            device = fields["device"]
+            fstype = fields["fstype"]
+
+            if not any(_fnmatch(device, pattern) for pattern in module.params["devices"]):
+                continue
+            if not any(_fnmatch(fstype, pattern) for pattern in module.params["fstypes"]):
+                continue
+
+            mount = fields["mount"]
+
+            timed_func = _timeout.timeout(seconds, f"Timed out getting mount size for mount {mount} (type {fstype})")(_get_mount_size)
+            if mount_size := _handle_timeout(module)(timed_func)(mount):
+                fields.update(mount_size)
+
+            timed_func = _timeout.timeout(seconds, f"Timed out getting uuid for mount {mount} (type {fstype})")(udevadm_uuid)
+            uuid = uuids.get(device, _handle_timeout(module)(timed_func)(device))
+
+            facts[mount] = {"info": fields, "uuid": uuid or "N/A", "source": source}
+    return facts
+
+
+def _get_argument_spec():
+    """Helper returning the argument spec."""
+    return dict(
+        sources=dict(type="list", elements="str", default=["all"]),
+        mount_binary=dict(default="mount", type="raw"),
+        devices=dict(type="list", elements="str", default=["*"]),
+        fstypes=dict(type="list", elements="str", default=["*"]),
+        timeout=dict(type="int"),
+        on_timeout=dict(choices=["error", "warn", "ignore"], default="error"),
+    )
+
+
+def main():
+    module = _AnsibleModule(
+        argument_spec=_get_argument_spec(),
+        supports_check_mode=True,
+    )
+    if (seconds := module.params["timeout"]) is not None and seconds <= 0:
+        module.fail_json(msg="argument 'timeout' must be a positive integer or null, not {seconds}")
+    if (mount_binary := module.params["mount_binary"]) is not None and not isinstance(mount_binary, str):
+        module.fail_json(msg=f"argument 'mount_binary' must be a string or null, not {mount_binary}")
+
+    hardware = _LinuxHardware(module)
+    mounts = _get_mount_facts(module, hardware._lsblk_uuid(), hardware._udevadm_uuid)
+    module.exit_json(ansible_facts={"extended_mounts": mounts})
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/targets/mount_facts/aliases
+++ b/test/integration/targets/mount_facts/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group1
+context/target
+needs/root
+skip/docker

--- a/test/integration/targets/mount_facts/meta/main.yml
+++ b/test/integration/targets/mount_facts/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_remote_tmp_dir

--- a/test/integration/targets/mount_facts/tasks/main.yml
+++ b/test/integration/targets/mount_facts/tasks/main.yml
@@ -1,0 +1,137 @@
+- name: Setup a NFS mount and test getting extended mount facts
+  become: yes
+  become_user: root
+  vars:
+    os_nfs_root:
+      Darwin: /opt  # TODO: can remote_tmp_dir (in /private) work?
+    nfs_root: "{{ os_nfs_root[ansible_os_family] | default(remote_tmp_dir) }}"
+    nfs_source: "{{ [nfs_root, 'nfs_src'] | path_join }}"
+    nfs_mount: "{{ [nfs_root, 'nfs_mnt'] | path_join }}"
+  block:
+    - name: Setup - install NFS server and client packages (Debian)
+      package:
+        state: present
+        name:
+          - nfs-kernel-server
+          - nfs-common
+      when: ansible_os_family == 'Debian'
+
+    - name: Setup - install NFS server package (RedHat)
+      package:
+        name: nfs-utils
+        state: present
+      when: ansible_os_family == 'RedHat'
+
+    - name: Setup - install NFS server package (Alpine)
+      command: apk add nfs-utils
+      when: ansible_os_family == 'Alpine'
+
+    - name: Setup - create export directory on server
+      file:
+        path: "{{ nfs_source }}"
+        state: directory
+        mode: '0755'
+
+    - name: Setup - configure NFS exports (Linux)
+      copy:
+        dest: /etc/exports
+        content: |
+          {{ nfs_source }} 127.0.0.1(rw,no_root_squash)
+      when: ansible_os_family not in ('FreeBSD', 'Darwin')
+
+    - name: Setup - configure NFS exports (FreeBSD)
+      copy:
+        dest: /etc/exports
+        content: |
+          {{ nfs_source }} -alldirs -maproot=root localhost
+          V4: /
+      when: ansible_os_family == 'FreeBSD'
+
+    - name: Setup - configure NFS exports (Darwin)
+      copy:
+        dest: /etc/exports
+        content: |
+          {{ nfs_source }} -alldirs -maproot=root localhost
+      when: ansible_os_family == 'Darwin'
+
+    # https://docs.freebsd.org/en/books/handbook/network-servers/#network-nfs
+    - name: Setup - configure NFS server (FreeBSD)
+      lineinfile:
+        line: "{{ item.option }}={{ item.value }}"
+        regexp: "^{{ item.option }}=.+$"
+        path: /etc/rc.conf
+      loop:
+        - option: rpcbind_enable
+          value: "YES"
+        - option: nfs_server_enable
+          value: "YES"
+        - option: nfsv4_server_enable
+          value: "YES"
+      when: ansible_os_family == 'FreeBSD'
+
+    - name: Setup - restart nfs-server (Linux)
+      service:
+        name: nfs-server
+        state: restarted
+      when: ansible_os_family == 'Debian' or ansible_os_family == 'RedHat'
+
+    - name: Setup - restart nfsd (Darwin)
+      command: nfsd restart  # log show --predicate 'process == "nfsd"' --info --last 5m
+      when: ansible_os_family == 'Darwin'
+
+    - name: Setup - start mountd and nfsd (FreeBSD)
+      shell: "service {{ item }} onestart || service {{ item }} onerestart"
+      loop:
+        - mountd
+        - nfsd
+      when: ansible_os_family == 'FreeBSD'
+      ignore_errors: true
+
+    # https://wiki.alpinelinux.org/wiki/Setting_up_an_NFS_server
+    - name: Setup - start nfs (Alpine)
+      command: rc-service nfs start
+      when: ansible_os_family == 'Alpine'
+
+    - name: Setup - reload NFS exports (Alpine)
+      command: exportfs -ra
+      when: ansible_os_family == 'Alpine'
+
+    - name: Setup - create mount point for the NFS client
+      file:
+        path: "{{ nfs_mount }}"
+        state: directory
+        mode: '0755'
+
+    - name: Setup - mount the NFS source with a timeout to prevent a hang
+      timeout: 2
+      block:
+        - name: Setup - mount the NFS source (Linux)
+          command: "mount -t nfs localhost:{{ nfs_source }} {{ nfs_mount}}"
+          when: ansible_os_family not in ('FreeBSD', 'Darwin')
+
+        - name: Setup - mount the NFS source (FreeBSD)
+          command: "mount -t nfs -o nfsv4 localhost:{{ nfs_source }} {{ nfs_mount }}"
+          when: ansible_os_family == 'FreeBSD'
+
+        - name: Setup - mount the NFS source (Darwin)
+          # TODO this syntax is deprecated, but adding '-o vers=4' to use nfsv4 fails with:
+          # mount_nfs: can't mount /opt/nfs from localhost onto /opt/nfs_mnt: RPC prog. not avail
+          # mount: /opt/nfs_mnt failed with 74
+          command: "mount -t nfs localhost:{{ nfs_source }} {{ nfs_mount }}"
+          when: ansible_os_family == 'Darwin'
+
+    - name: Test gathering NFS mount facts
+      mount_facts:
+        mount_binary: "mount"
+        devices: "[!/]*"
+        fstypes:
+          - nfs
+          - nfs4
+
+    - assert:
+        that:
+          - nfs_mount in extended_mounts
+          - 'extended_mounts[nfs_mount]["info"]["device"] == ("localhost:" ~ nfs_source)'
+
+  always:
+    - command: "umount {{ nfs_mount }}"

--- a/test/integration/targets/mount_facts/tasks/main.yml
+++ b/test/integration/targets/mount_facts/tasks/main.yml
@@ -119,6 +119,7 @@
           # mount: /opt/nfs_mnt failed with 74
           command: "mount -t nfs localhost:{{ nfs_source }} {{ nfs_mount }}"
           when: ansible_os_family == 'Darwin'
+          timeout: 4  # 2 isn't cutting it
 
     - name: Test gathering NFS mount facts
       mount_facts:
@@ -131,7 +132,7 @@
     - assert:
         that:
           - nfs_mount in extended_mounts
-          - 'extended_mounts[nfs_mount]["info"]["device"] == ("localhost:" ~ nfs_source)'
+          - extended_mounts[nfs_mount]["device"] == ("localhost:" ~ nfs_source)
 
   always:
     - command: "umount {{ nfs_mount }}"

--- a/test/units/modules/_mount_facts_data.py
+++ b/test/units/modules/_mount_facts_data.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-
 from dataclasses import dataclass as _dataclass
 
 
@@ -37,46 +36,72 @@ _freebsd_fstab = """# Custom /etc/fstab for FreeBSD VM images
 /dev/gpt/rootfs / ufs rw,acls 1 1
 /dev/gpt/efiesp    /boot/efi       msdosfs     rw      2       2"""
 
-
 _freebsd_fstab_parsed = [
-    {
-        "device": "/dev/gpt/rootfs",
-        "fstype": "ufs",
-        "mount": "/",
-        "options": "rw,acls",
-        "dump": "1",
-        "passno": "1",
-    },
-    {
-        "device": "/dev/gpt/efiesp",
-        "fstype": "msdosfs",
-        "mount": "/boot/efi",
-        "options": "rw",
-        "dump": "2",
-        "passno": "2",
-    },
+    (
+        "/etc/fstab",
+        "/",
+        "/dev/gpt/rootfs / ufs rw,acls 1 1",
+        {
+            "device": "/dev/gpt/rootfs",
+            "fstype": "ufs",
+            "mount": "/",
+            "options": "rw,acls",
+            "dump": 1,
+            "passno": 1,
+        },
+    ),
+    (
+        "/etc/fstab",
+        "/boot/efi",
+        "/dev/gpt/efiesp    /boot/efi       msdosfs     rw      2       2",
+        {
+            "device": "/dev/gpt/efiesp",
+            "fstype": "msdosfs",
+            "mount": "/boot/efi",
+            "options": "rw",
+            "dump": 2,
+            "passno": 2,
+        },
+    ),
 ]
-
 
 _freebsd_mount = """/dev/gpt/rootfs on / (ufs, local, soft-updates, acls)
 devfs on /dev (devfs)
 /dev/gpt/efiesp on /boot/efi (msdosfs, local)"""
 
-
 _freebsd_mount_parsed = [
-    {
-        "device": "/dev/gpt/rootfs",
-        "mount": "/",
-        "fstype": "ufs",
-        "options": "local, soft-updates, acls",
-    },
-    {"device": "devfs", "mount": "/dev", "fstype": "devfs"},
-    {
-        "device": "/dev/gpt/efiesp",
-        "mount": "/boot/efi",
-        "fstype": "msdosfs",
-        "options": "local",
-    },
+    (
+        "mount",
+        "/",
+        "/dev/gpt/rootfs on / (ufs, local, soft-updates, acls)",
+        {
+            "device": "/dev/gpt/rootfs",
+            "mount": "/",
+            "fstype": "ufs",
+            "options": "local, soft-updates, acls",
+        },
+    ),
+    (
+        "mount",
+        "/dev",
+        "devfs on /dev (devfs)",
+        {
+            "device": "devfs",
+            "mount": "/dev",
+            "fstype": "devfs",
+        },
+    ),
+    (
+        "mount",
+        "/boot/efi",
+        "/dev/gpt/efiesp on /boot/efi (msdosfs, local)",
+        {
+            "device": "/dev/gpt/efiesp",
+            "mount": "/boot/efi",
+            "fstype": "msdosfs",
+            "options": "local",
+        },
+    ),
 ]
 
 _freebsd14_1 = _LinuxData(_freebsd_fstab, _freebsd_fstab_parsed, "", [], _freebsd_mount, _freebsd_mount_parsed)
@@ -88,30 +113,45 @@ UUID=7B77-95E7  /boot/efi   vfat    defaults,uid=0,gid=0,umask=077,shortname=win
 """
 
 _rhel_fstab_parsed = [
-    {
-        "device": "UUID=6b8b920d-f334-426e-a440-1207d0d8725b",
-        "mount": "/",
-        "fstype": "xfs",
-        "options": "defaults",
-        "dump": "0",
-        "passno": "0",
-    },
-    {
-        "device": "UUID=3ecd4b07-f49a-410c-b7fc-6d1e7bb98ab9",
-        "mount": "/boot",
-        "fstype": "xfs",
-        "options": "defaults",
-        "dump": "0",
-        "passno": "0",
-    },
-    {
-        "device": "UUID=7B77-95E7",
-        "mount": "/boot/efi",
-        "fstype": "vfat",
-        "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
-        "dump": "0",
-        "passno": "2",
-    },
+    (
+        "/etc/fstab",
+        "/",
+        "UUID=6b8b920d-f334-426e-a440-1207d0d8725b   /   xfs defaults    0   0",
+        {
+            "device": "UUID=6b8b920d-f334-426e-a440-1207d0d8725b",
+            "mount": "/",
+            "fstype": "xfs",
+            "options": "defaults",
+            "dump": 0,
+            "passno": 0,
+        },
+    ),
+    (
+        "/etc/fstab",
+        "/boot",
+        "UUID=3ecd4b07-f49a-410c-b7fc-6d1e7bb98ab9   /boot   xfs defaults    0   0",
+        {
+            "device": "UUID=3ecd4b07-f49a-410c-b7fc-6d1e7bb98ab9",
+            "mount": "/boot",
+            "fstype": "xfs",
+            "options": "defaults",
+            "dump": 0,
+            "passno": 0,
+        },
+    ),
+    (
+        "/etc/fstab",
+        "/boot/efi",
+        "UUID=7B77-95E7  /boot/efi   vfat    defaults,uid=0,gid=0,umask=077,shortname=winnt  0   2",
+        {
+            "device": "UUID=7B77-95E7",
+            "mount": "/boot/efi",
+            "fstype": "vfat",
+            "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+            "dump": 0,
+            "passno": 2,
+        },
+    ),
 ]
 
 _rhel_mtab = """proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
@@ -119,30 +159,45 @@ sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0
 devtmpfs /dev devtmpfs rw,seclabel,nosuid,size=4096k,nr_inodes=445689,mode=755,inode64 0 0"""
 
 _rhel_mtab_parsed = [
-    {
-        "device": "proc",
-        "mount": "/proc",
-        "fstype": "proc",
-        "options": "rw,nosuid,nodev,noexec,relatime",
-        "dump": "0",
-        "passno": "0",
-    },
-    {
-        "device": "sysfs",
-        "mount": "/sys",
-        "fstype": "sysfs",
-        "options": "rw,seclabel,nosuid,nodev,noexec,relatime",
-        "dump": "0",
-        "passno": "0",
-    },
-    {
-        "device": "devtmpfs",
-        "mount": "/dev",
-        "fstype": "devtmpfs",
-        "options": "rw,seclabel,nosuid,size=4096k,nr_inodes=445689,mode=755,inode64",
-        "dump": "0",
-        "passno": "0",
-    },
+    (
+        "/etc/mtab",
+        "/proc",
+        "proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0",
+        {
+            "device": "proc",
+            "mount": "/proc",
+            "fstype": "proc",
+            "options": "rw,nosuid,nodev,noexec,relatime",
+            "dump": 0,
+            "passno": 0,
+        },
+    ),
+    (
+        "/etc/mtab",
+        "/sys",
+        "sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0",
+        {
+            "device": "sysfs",
+            "mount": "/sys",
+            "fstype": "sysfs",
+            "options": "rw,seclabel,nosuid,nodev,noexec,relatime",
+            "dump": 0,
+            "passno": 0,
+        },
+    ),
+    (
+        "/etc/mtab",
+        "/dev",
+        "devtmpfs /dev devtmpfs rw,seclabel,nosuid,size=4096k,nr_inodes=445689,mode=755,inode64 0 0",
+        {
+            "device": "devtmpfs",
+            "mount": "/dev",
+            "fstype": "devtmpfs",
+            "options": "rw,seclabel,nosuid,size=4096k,nr_inodes=445689,mode=755,inode64",
+            "dump": 0,
+            "passno": 0,
+        },
+    ),
 ]
 
 _rhel_mount = """proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
@@ -150,24 +205,39 @@ sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime,seclabel)
 devtmpfs on /dev type devtmpfs (rw,nosuid,seclabel,size=4096k,nr_inodes=445689,mode=755,inode64)"""
 
 _rhel_mount_parsed = [
-    {
-        "device": "proc",
-        "mount": "/proc",
-        "fstype": "proc",
-        "options": "rw,nosuid,nodev,noexec,relatime",
-    },
-    {
-        "device": "sysfs",
-        "mount": "/sys",
-        "fstype": "sysfs",
-        "options": "rw,nosuid,nodev,noexec,relatime,seclabel",
-    },
-    {
-        "device": "devtmpfs",
-        "mount": "/dev",
-        "fstype": "devtmpfs",
-        "options": "rw,nosuid,seclabel,size=4096k,nr_inodes=445689,mode=755,inode64",
-    },
+    (
+        "mount",
+        "/proc",
+        "proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)",
+        {
+            "device": "proc",
+            "mount": "/proc",
+            "fstype": "proc",
+            "options": "rw,nosuid,nodev,noexec,relatime",
+        },
+    ),
+    (
+        "mount",
+        "/sys",
+        "sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime,seclabel)",
+        {
+            "device": "sysfs",
+            "mount": "/sys",
+            "fstype": "sysfs",
+            "options": "rw,nosuid,nodev,noexec,relatime,seclabel",
+        },
+    ),
+    (
+        "mount",
+        "/dev",
+        "devtmpfs on /dev type devtmpfs (rw,nosuid,seclabel,size=4096k,nr_inodes=445689,mode=755,inode64)",
+        {
+            "device": "devtmpfs",
+            "mount": "/dev",
+            "fstype": "devtmpfs",
+            "options": "rw,nosuid,seclabel,size=4096k,nr_inodes=445689,mode=755,inode64",
+        },
+    ),
 ]
 
 _rhel9_4 = _LinuxData(_rhel_fstab, _rhel_fstab_parsed, _rhel_mtab, _rhel_mtab_parsed, _rhel_mount, _rhel_mount_parsed)
@@ -201,44 +271,75 @@ default:
          vfs        = nfs
 """
 
-
 _aix_filesystems_parsed = [
-    {
-        "mount": "default",
-        "fstype": "unknown",
-        "device": "unknown",
-        "attributes": {"vol": '"OS"', "mount": "false", "check": "false"},
-    },
-    {
-        "mount": "/",
-        "fstype": "unknown",
-        "device": "/dev/hd4",
-        "attributes": {
+    (
+        "/etc/filesystems",
+        "default",
+        'default:\n         vol        = "OS"\n         mount      = false\n         check      = false',
+        {
+            "fstype": "unknown",
+            "device": "unknown",
+            "mount": "false",
+            "vol": '"OS"',
+            "check": "false",
+
+        },
+    ),
+    (
+        "/etc/filesystems",
+        "/",
+        (
+            '/:'
+            '\n         dev        = /dev/hd4'
+            '\n         vol        = "root"'
+            '\n         mount      = automatic'
+            '\n         check      = true'
+            '\n         log        = /dev/hd8'
+        ),
+        {
+            "fstype": "unknown",
+            "device": "/dev/hd4",
+            "mount": "automatic",
             "dev": "/dev/hd4",
             "vol": '"root"',
-            "mount": "automatic",
             "check": "true",
             "log": "/dev/hd8",
+
         },
-    },
-    {
-        "mount": "/home",
-        "fstype": "unknown",
-        "device": "/dev/hd1",
-        "attributes": {
+    ),
+    (
+        "/etc/filesystems",
+        "/home",
+        (
+            '/home:'
+            '\n         dev        = /dev/hd1'
+            '\n         vol        = "u"'
+            '\n         mount      = true'
+            '\n         check      = true'
+            '\n         log        = /dev/hd8'
+        ),
+        {
+            "fstype": "unknown",
+            "device": "/dev/hd1",
             "dev": "/dev/hd1",
             "vol": '"u"',
             "mount": "true",
             "check": "true",
             "log": "/dev/hd8",
         },
-    },
-    {
-        "mount": "/home/joe/1",
-        "fstype": "nfs",
-        "device": "vance:/home/joe/1",
-        "attributes": {"dev": "/home/joe/1", "nodename": "vance", "vfs": "nfs"},
-    },
+    ),
+    (
+        "/etc/filesystems",
+        "/home/joe/1",
+        '/home/joe/1:\n         dev        = /home/joe/1\n         nodename   = vance\n         vfs        = nfs',
+        {
+            "fstype": "nfs",
+            "device": "vance:/home/joe/1",
+            "dev": "/home/joe/1",
+            "nodename": "vance",
+            "vfs": "nfs",
+        },
+    ),
 ]
 
 # https://www.ibm.com/docs/en/aix/7.2?topic=m-mount-command
@@ -249,27 +350,42 @@ _aix_mount = """node   mounted          mounted over  vfs    date              o
 sue    /home/local/src  /usr/code    nfs   Dec 17 08:06   ro, log  =/dev/hd8"""
 
 _aix_mount_parsed = [
-    {
-        "mount": "/",
-        "device": "/dev/hd0",
-        "fstype": "jfs",
-        "time": "Dec 17 08:04",
-        "options": "rw, log  =/dev/hd8",
-    },
-    {
-        "mount": "/usr",
-        "device": "/dev/hd2",
-        "fstype": "jfs",
-        "time": "Dec 17 08:06",
-        "options": "rw, log  =/dev/hd8",
-    },
-    {
-        "mount": "/usr/code",
-        "device": "sue:/home/local/src",
-        "fstype": "nfs",
-        "time": "Dec 17 08:06",
-        "options": "ro, log  =/dev/hd8",
-    },
+    (
+        "mount",
+        "/",
+        "       /dev/hd0         /            jfs   Dec 17 08:04   rw, log  =/dev/hd8",
+        {
+            "mount": "/",
+            "device": "/dev/hd0",
+            "fstype": "jfs",
+            "time": "Dec 17 08:04",
+            "options": "rw, log  =/dev/hd8",
+        },
+    ),
+    (
+        "mount",
+        "/usr",
+        "       /dev/hd2         /usr         jfs   Dec 17 08:06   rw, log  =/dev/hd8",
+        {
+            "mount": "/usr",
+            "device": "/dev/hd2",
+            "fstype": "jfs",
+            "time": "Dec 17 08:06",
+            "options": "rw, log  =/dev/hd8",
+        },
+    ),
+    (
+        "mount",
+        "/usr/code",
+        "sue    /home/local/src  /usr/code    nfs   Dec 17 08:06   ro, log  =/dev/hd8",
+        {
+            "mount": "/usr/code",
+            "device": "sue:/home/local/src",
+            "fstype": "nfs",
+            "time": "Dec 17 08:06",
+            "options": "ro, log  =/dev/hd8",
+        },
+    ),
 ]
 
 _aix7_2 = _AIXData(_aix_filesystems, _aix_filesystems_parsed, _aix_mount, _aix_mount_parsed)
@@ -279,28 +395,43 @@ _openbsd_fstab = """726d525601651a64.b none swap sw
 726d525601651a64.k /home ffs rw,nodev,nosuid 1 2"""
 
 _openbsd_fstab_parsed = [
-    {
-        "device": "726d525601651a64.b",
-        "fstype": "swap",
-        "mount": "none",
-        "options": "sw",
-    },
-    {
-        "device": "726d525601651a64.a",
-        "dump": "1",
-        "fstype": "ffs",
-        "mount": "/",
-        "options": "rw",
-        "passno": "1",
-    },
-    {
-        "device": "726d525601651a64.k",
-        "dump": "1",
-        "fstype": "ffs",
-        "mount": "/home",
-        "options": "rw,nodev,nosuid",
-        "passno": "2",
-    },
+    (
+        "/etc/fstab",
+        "none",
+        "726d525601651a64.b none swap sw",
+        {
+            "device": "726d525601651a64.b",
+            "fstype": "swap",
+            "mount": "none",
+            "options": "sw",
+        },
+    ),
+    (
+        "/etc/fstab",
+        "/",
+        "726d525601651a64.a / ffs rw 1 1",
+        {
+            "device": "726d525601651a64.a",
+            "dump": 1,
+            "fstype": "ffs",
+            "mount": "/",
+            "options": "rw",
+            "passno": 1,
+        },
+    ),
+    (
+        "/etc/fstab",
+        "/home",
+        "726d525601651a64.k /home ffs rw,nodev,nosuid 1 2",
+        {
+            "device": "726d525601651a64.k",
+            "dump": 1,
+            "fstype": "ffs",
+            "mount": "/home",
+            "options": "rw,nodev,nosuid",
+            "passno": 2,
+        },
+    ),
 ]
 
 # Note: matches Linux mount format, like NetBSD
@@ -309,24 +440,39 @@ _openbsd_mount = """/dev/sd0a on / type ffs (local)
 /dev/sd0e on /tmp type ffs (local, nodev, nosuid)"""
 
 _openbsd_mount_parsed = [
-    {
-        "device": "/dev/sd0a",
-        "mount": "/",
-        "fstype": "ffs",
-        "options": "local"
-    },
-    {
-        "device": "/dev/sd0k",
-        "mount": "/home",
-        "fstype": "ffs",
-        "options": "local, nodev, nosuid",
-    },
-    {
-        "device": "/dev/sd0e",
-        "mount": "/tmp",
-        "fstype": "ffs",
-        "options": "local, nodev, nosuid",
-    },
+    (
+        "mount",
+        "/",
+        "/dev/sd0a on / type ffs (local)",
+        {
+            "device": "/dev/sd0a",
+            "mount": "/",
+            "fstype": "ffs",
+            "options": "local"
+        },
+    ),
+    (
+        "mount",
+        "/home",
+        "/dev/sd0k on /home type ffs (local, nodev, nosuid)",
+        {
+            "device": "/dev/sd0k",
+            "mount": "/home",
+            "fstype": "ffs",
+            "options": "local, nodev, nosuid",
+        },
+    ),
+    (
+        "mount",
+        "/tmp",
+        "/dev/sd0e on /tmp type ffs (local, nodev, nosuid)",
+        {
+            "device": "/dev/sd0e",
+            "mount": "/tmp",
+            "fstype": "ffs",
+            "options": "local, nodev, nosuid",
+        },
+    ),
 ]
 
 _openbsd6_4 = _LinuxData(_openbsd_fstab, _openbsd_fstab_parsed, "", [], _openbsd_mount, _openbsd_mount_parsed)
@@ -339,33 +485,48 @@ example1:/usr/local - /usr/local nfs - yes ro
 mailsvr:/var/mail - /var/mail nfs - yes intr,bg"""
 
 _solaris_vfstab_parsed = [
-    {
-        "device": "/dev/dsk/c2t10d0s0",
-        "device_to_fsck": "/dev/rdsk/c2t10d0s0",
-        "mount": "/export/local",
-        "fstype": "ufs",
-        "passno": "3",
-        "mount_at_boot": "yes",
-        "options": "logging",
-    },
-    {
-        "device": "example1:/usr/local",
-        "device_to_fsck": "-",
-        "mount": "/usr/local",
-        "fstype": "nfs",
-        "passno": "-",
-        "mount_at_boot": "yes",
-        "options": "ro",
-    },
-    {
-        "device": "mailsvr:/var/mail",
-        "device_to_fsck": "-",
-        "mount": "/var/mail",
-        "fstype": "nfs",
-        "passno": "-",
-        "mount_at_boot": "yes",
-        "options": "intr,bg",
-    },
+    (
+        "/etc/vfstab",
+        "/export/local",
+        "/dev/dsk/c2t10d0s0 /dev/rdsk/c2t10d0s0 /export/local ufs 3 yes logging",
+        {
+            "device": "/dev/dsk/c2t10d0s0",
+            "device_to_fsck": "/dev/rdsk/c2t10d0s0",
+            "mount": "/export/local",
+            "fstype": "ufs",
+            "passno": 3,
+            "mount_at_boot": "yes",
+            "options": "logging",
+        },
+    ),
+    (
+        "/etc/vfstab",
+        "/usr/local",
+        "example1:/usr/local - /usr/local nfs - yes ro",
+        {
+            "device": "example1:/usr/local",
+            "device_to_fsck": "-",
+            "mount": "/usr/local",
+            "fstype": "nfs",
+            "passno": "-",
+            "mount_at_boot": "yes",
+            "options": "ro",
+        },
+    ),
+    (
+        "/etc/vfstab",
+        "/var/mail",
+        "mailsvr:/var/mail - /var/mail nfs - yes intr,bg",
+        {
+            "device": "mailsvr:/var/mail",
+            "device_to_fsck": "-",
+            "mount": "/var/mail",
+            "fstype": "nfs",
+            "passno": "-",
+            "mount_at_boot": "yes",
+            "options": "intr,bg",
+        },
+    ),
 ]
 
 _solaris_mnttab = """rpool/ROOT/solaris  /   zfs dev=4490002 0
@@ -373,27 +534,42 @@ _solaris_mnttab = """rpool/ROOT/solaris  /   zfs dev=4490002 0
 example.ansible.com:/export/nfs    /mnt/nfs    nfs xattr,dev=8e40010   1724055352"""
 
 _solaris_mnttab_parsed = [
-    {
-        "device": "rpool/ROOT/solaris",
-        "mount": "/",
-        "fstype": "zfs",
-        "options": "dev=4490002",
-        "time": "0",
-    },
-    {
-        "device": "-hosts",
-        "mount": "/net",
-        "fstype": "autofs",
-        "options": "ignore,indirect,nosuid,soft,nobrowse,dev=4000002",
-        "time": "1724055352",
-    },
-    {
-        "device": "example.ansible.com:/export/nfs",
-        "mount": "/mnt/nfs",
-        "fstype": "nfs",
-        "options": "xattr,dev=8e40010",
-        "time": "1724055352",
-    },
+    (
+        "/etc/mnttab",
+        "/",
+        "rpool/ROOT/solaris  /   zfs dev=4490002 0",
+        {
+            "device": "rpool/ROOT/solaris",
+            "mount": "/",
+            "fstype": "zfs",
+            "options": "dev=4490002",
+            "time": 0,
+        },
+    ),
+    (
+        "/etc/mnttab",
+        "/net",
+        "-hosts /net autofs ignore,indirect,nosuid,soft,nobrowse,dev=4000002 1724055352",
+        {
+            "device": "-hosts",
+            "mount": "/net",
+            "fstype": "autofs",
+            "options": "ignore,indirect,nosuid,soft,nobrowse,dev=4000002",
+            "time": 1724055352,
+        },
+    ),
+    (
+        "/etc/mnttab",
+        "/mnt/nfs",
+        "example.ansible.com:/export/nfs    /mnt/nfs    nfs xattr,dev=8e40010   1724055352",
+        {
+            "device": "example.ansible.com:/export/nfs",
+            "mount": "/mnt/nfs",
+            "fstype": "nfs",
+            "options": "xattr,dev=8e40010",
+            "time": 1724055352,
+        },
+    ),
 ]
 
 _solaris11_2 = _SolarisData(_solaris_vfstab, _solaris_vfstab_parsed, _solaris_mnttab, _solaris_mnttab_parsed)

--- a/test/units/modules/_mount_facts_data.py
+++ b/test/units/modules/_mount_facts_data.py
@@ -32,13 +32,20 @@ class _AIXData:
     mount_parsed: list[dict[str, str]]
 
 
+_mount = "mount"
+_fstab = "/etc/fstab"
+_mtab = "/etc/mtab"
+_mnttab = "/etc/mnttab"
+_vfstab = "/etc/vfstab"
+_filesystems = "/etc/filesystems"
+
 _freebsd_fstab = """# Custom /etc/fstab for FreeBSD VM images
 /dev/gpt/rootfs / ufs rw,acls 1 1
 /dev/gpt/efiesp    /boot/efi       msdosfs     rw      2       2"""
 
 _freebsd_fstab_parsed = [
     (
-        "/etc/fstab",
+        _fstab,
         "/",
         "/dev/gpt/rootfs / ufs rw,acls 1 1",
         {
@@ -51,7 +58,7 @@ _freebsd_fstab_parsed = [
         },
     ),
     (
-        "/etc/fstab",
+        _fstab,
         "/boot/efi",
         "/dev/gpt/efiesp    /boot/efi       msdosfs     rw      2       2",
         {
@@ -71,7 +78,7 @@ devfs on /dev (devfs)
 
 _freebsd_mount_parsed = [
     (
-        "mount",
+        _mount,
         "/",
         "/dev/gpt/rootfs on / (ufs, local, soft-updates, acls)",
         {
@@ -82,7 +89,7 @@ _freebsd_mount_parsed = [
         },
     ),
     (
-        "mount",
+        _mount,
         "/dev",
         "devfs on /dev (devfs)",
         {
@@ -92,7 +99,7 @@ _freebsd_mount_parsed = [
         },
     ),
     (
-        "mount",
+        _mount,
         "/boot/efi",
         "/dev/gpt/efiesp on /boot/efi (msdosfs, local)",
         {
@@ -114,7 +121,7 @@ UUID=7B77-95E7  /boot/efi   vfat    defaults,uid=0,gid=0,umask=077,shortname=win
 
 _rhel_fstab_parsed = [
     (
-        "/etc/fstab",
+        _fstab,
         "/",
         "UUID=6b8b920d-f334-426e-a440-1207d0d8725b   /   xfs defaults    0   0",
         {
@@ -127,7 +134,7 @@ _rhel_fstab_parsed = [
         },
     ),
     (
-        "/etc/fstab",
+        _fstab,
         "/boot",
         "UUID=3ecd4b07-f49a-410c-b7fc-6d1e7bb98ab9   /boot   xfs defaults    0   0",
         {
@@ -140,7 +147,7 @@ _rhel_fstab_parsed = [
         },
     ),
     (
-        "/etc/fstab",
+        _fstab,
         "/boot/efi",
         "UUID=7B77-95E7  /boot/efi   vfat    defaults,uid=0,gid=0,umask=077,shortname=winnt  0   2",
         {
@@ -160,7 +167,7 @@ devtmpfs /dev devtmpfs rw,seclabel,nosuid,size=4096k,nr_inodes=445689,mode=755,i
 
 _rhel_mtab_parsed = [
     (
-        "/etc/mtab",
+        _mtab,
         "/proc",
         "proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0",
         {
@@ -173,7 +180,7 @@ _rhel_mtab_parsed = [
         },
     ),
     (
-        "/etc/mtab",
+        _mtab,
         "/sys",
         "sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0",
         {
@@ -186,7 +193,7 @@ _rhel_mtab_parsed = [
         },
     ),
     (
-        "/etc/mtab",
+        _mtab,
         "/dev",
         "devtmpfs /dev devtmpfs rw,seclabel,nosuid,size=4096k,nr_inodes=445689,mode=755,inode64 0 0",
         {
@@ -206,7 +213,7 @@ devtmpfs on /dev type devtmpfs (rw,nosuid,seclabel,size=4096k,nr_inodes=445689,m
 
 _rhel_mount_parsed = [
     (
-        "mount",
+        _mount,
         "/proc",
         "proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)",
         {
@@ -217,7 +224,7 @@ _rhel_mount_parsed = [
         },
     ),
     (
-        "mount",
+        _mount,
         "/sys",
         "sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime,seclabel)",
         {
@@ -228,7 +235,7 @@ _rhel_mount_parsed = [
         },
     ),
     (
-        "mount",
+        _mount,
         "/dev",
         "devtmpfs on /dev type devtmpfs (rw,nosuid,seclabel,size=4096k,nr_inodes=445689,mode=755,inode64)",
         {
@@ -273,7 +280,7 @@ default:
 
 _aix_filesystems_parsed = [
     (
-        "/etc/filesystems",
+        _filesystems,
         "default",
         'default:\n         vol        = "OS"\n         mount      = false\n         check      = false',
         {
@@ -286,7 +293,7 @@ _aix_filesystems_parsed = [
         },
     ),
     (
-        "/etc/filesystems",
+        _filesystems,
         "/",
         (
             '/:'
@@ -308,7 +315,7 @@ _aix_filesystems_parsed = [
         },
     ),
     (
-        "/etc/filesystems",
+        _filesystems,
         "/home",
         (
             '/home:'
@@ -329,7 +336,7 @@ _aix_filesystems_parsed = [
         },
     ),
     (
-        "/etc/filesystems",
+        _filesystems,
         "/home/joe/1",
         '/home/joe/1:\n         dev        = /home/joe/1\n         nodename   = vance\n         vfs        = nfs',
         {
@@ -351,7 +358,7 @@ sue    /home/local/src  /usr/code    nfs   Dec 17 08:06   ro, log  =/dev/hd8"""
 
 _aix_mount_parsed = [
     (
-        "mount",
+        _mount,
         "/",
         "       /dev/hd0         /            jfs   Dec 17 08:04   rw, log  =/dev/hd8",
         {
@@ -363,7 +370,7 @@ _aix_mount_parsed = [
         },
     ),
     (
-        "mount",
+        _mount,
         "/usr",
         "       /dev/hd2         /usr         jfs   Dec 17 08:06   rw, log  =/dev/hd8",
         {
@@ -375,7 +382,7 @@ _aix_mount_parsed = [
         },
     ),
     (
-        "mount",
+        _mount,
         "/usr/code",
         "sue    /home/local/src  /usr/code    nfs   Dec 17 08:06   ro, log  =/dev/hd8",
         {
@@ -396,7 +403,7 @@ _openbsd_fstab = """726d525601651a64.b none swap sw
 
 _openbsd_fstab_parsed = [
     (
-        "/etc/fstab",
+        _fstab,
         "none",
         "726d525601651a64.b none swap sw",
         {
@@ -407,7 +414,7 @@ _openbsd_fstab_parsed = [
         },
     ),
     (
-        "/etc/fstab",
+        _fstab,
         "/",
         "726d525601651a64.a / ffs rw 1 1",
         {
@@ -420,7 +427,7 @@ _openbsd_fstab_parsed = [
         },
     ),
     (
-        "/etc/fstab",
+        _fstab,
         "/home",
         "726d525601651a64.k /home ffs rw,nodev,nosuid 1 2",
         {
@@ -437,11 +444,11 @@ _openbsd_fstab_parsed = [
 # Note: matches Linux mount format, like NetBSD
 _openbsd_mount = """/dev/sd0a on / type ffs (local)
 /dev/sd0k on /home type ffs (local, nodev, nosuid)
-/dev/sd0e on /tmp type ffs (local, nodev, nosuid)"""
+/dev/sd0e on /foo type ffs (local, nodev, nosuid)"""
 
 _openbsd_mount_parsed = [
     (
-        "mount",
+        _mount,
         "/",
         "/dev/sd0a on / type ffs (local)",
         {
@@ -452,7 +459,7 @@ _openbsd_mount_parsed = [
         },
     ),
     (
-        "mount",
+        _mount,
         "/home",
         "/dev/sd0k on /home type ffs (local, nodev, nosuid)",
         {
@@ -463,12 +470,12 @@ _openbsd_mount_parsed = [
         },
     ),
     (
-        "mount",
-        "/tmp",
-        "/dev/sd0e on /tmp type ffs (local, nodev, nosuid)",
+        _mount,
+        "/foo",
+        "/dev/sd0e on /foo type ffs (local, nodev, nosuid)",
         {
             "device": "/dev/sd0e",
-            "mount": "/tmp",
+            "mount": "/foo",
             "fstype": "ffs",
             "options": "local, nodev, nosuid",
         },
@@ -486,7 +493,7 @@ mailsvr:/var/mail - /var/mail nfs - yes intr,bg"""
 
 _solaris_vfstab_parsed = [
     (
-        "/etc/vfstab",
+        _vfstab,
         "/export/local",
         "/dev/dsk/c2t10d0s0 /dev/rdsk/c2t10d0s0 /export/local ufs 3 yes logging",
         {
@@ -500,7 +507,7 @@ _solaris_vfstab_parsed = [
         },
     ),
     (
-        "/etc/vfstab",
+        _vfstab,
         "/usr/local",
         "example1:/usr/local - /usr/local nfs - yes ro",
         {
@@ -514,7 +521,7 @@ _solaris_vfstab_parsed = [
         },
     ),
     (
-        "/etc/vfstab",
+        _vfstab,
         "/var/mail",
         "mailsvr:/var/mail - /var/mail nfs - yes intr,bg",
         {
@@ -535,7 +542,7 @@ example.ansible.com:/export/nfs    /mnt/nfs    nfs xattr,dev=8e40010   172405535
 
 _solaris_mnttab_parsed = [
     (
-        "/etc/mnttab",
+        _mnttab,
         "/",
         "rpool/ROOT/solaris  /   zfs dev=4490002 0",
         {
@@ -547,7 +554,7 @@ _solaris_mnttab_parsed = [
         },
     ),
     (
-        "/etc/mnttab",
+        _mnttab,
         "/net",
         "-hosts /net autofs ignore,indirect,nosuid,soft,nobrowse,dev=4000002 1724055352",
         {
@@ -559,7 +566,7 @@ _solaris_mnttab_parsed = [
         },
     ),
     (
-        "/etc/mnttab",
+        _mnttab,
         "/mnt/nfs",
         "example.ansible.com:/export/nfs    /mnt/nfs    nfs xattr,dev=8e40010   1724055352",
         {

--- a/test/units/modules/_mount_facts_data.py
+++ b/test/units/modules/_mount_facts_data.py
@@ -1,0 +1,399 @@
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+
+from dataclasses import dataclass as _dataclass
+
+
+@_dataclass
+class _LinuxData:
+    fstab: str
+    fstab_parsed: list[dict[str, str]]
+    mtab: str
+    mtab_parsed: list[dict[str, str]]
+    mount: str
+    mount_parsed: list[dict[str, str]]
+
+
+@_dataclass
+class _SolarisData:
+    vfstab: str
+    vfstab_parsed: list[dict[str, str]]
+    mnttab: str
+    mnttab_parsed: list[dict[str, str]]
+
+
+@_dataclass
+class _AIXData:
+    filesystems: str
+    filesystems_parsed: list[dict[str, str | dict[str, str]]]
+    mount: str
+    mount_parsed: list[dict[str, str]]
+
+
+_freebsd_fstab = """# Custom /etc/fstab for FreeBSD VM images
+/dev/gpt/rootfs / ufs rw,acls 1 1
+/dev/gpt/efiesp    /boot/efi       msdosfs     rw      2       2"""
+
+
+_freebsd_fstab_parsed = [
+    {
+        "device": "/dev/gpt/rootfs",
+        "fstype": "ufs",
+        "mount": "/",
+        "options": "rw,acls",
+        "dump": "1",
+        "passno": "1",
+    },
+    {
+        "device": "/dev/gpt/efiesp",
+        "fstype": "msdosfs",
+        "mount": "/boot/efi",
+        "options": "rw",
+        "dump": "2",
+        "passno": "2",
+    },
+]
+
+
+_freebsd_mount = """/dev/gpt/rootfs on / (ufs, local, soft-updates, acls)
+devfs on /dev (devfs)
+/dev/gpt/efiesp on /boot/efi (msdosfs, local)"""
+
+
+_freebsd_mount_parsed = [
+    {
+        "device": "/dev/gpt/rootfs",
+        "mount": "/",
+        "fstype": "ufs",
+        "options": "local, soft-updates, acls",
+    },
+    {"device": "devfs", "mount": "/dev", "fstype": "devfs"},
+    {
+        "device": "/dev/gpt/efiesp",
+        "mount": "/boot/efi",
+        "fstype": "msdosfs",
+        "options": "local",
+    },
+]
+
+_freebsd14_1 = _LinuxData(_freebsd_fstab, _freebsd_fstab_parsed, "", [], _freebsd_mount, _freebsd_mount_parsed)
+
+_rhel_fstab = """
+UUID=6b8b920d-f334-426e-a440-1207d0d8725b   /   xfs defaults    0   0
+UUID=3ecd4b07-f49a-410c-b7fc-6d1e7bb98ab9   /boot   xfs defaults    0   0
+UUID=7B77-95E7  /boot/efi   vfat    defaults,uid=0,gid=0,umask=077,shortname=winnt  0   2
+"""
+
+_rhel_fstab_parsed = [
+    {
+        "device": "UUID=6b8b920d-f334-426e-a440-1207d0d8725b",
+        "mount": "/",
+        "fstype": "xfs",
+        "options": "defaults",
+        "dump": "0",
+        "passno": "0",
+    },
+    {
+        "device": "UUID=3ecd4b07-f49a-410c-b7fc-6d1e7bb98ab9",
+        "mount": "/boot",
+        "fstype": "xfs",
+        "options": "defaults",
+        "dump": "0",
+        "passno": "0",
+    },
+    {
+        "device": "UUID=7B77-95E7",
+        "mount": "/boot/efi",
+        "fstype": "vfat",
+        "options": "defaults,uid=0,gid=0,umask=077,shortname=winnt",
+        "dump": "0",
+        "passno": "2",
+    },
+]
+
+_rhel_mtab = """proc /proc proc rw,nosuid,nodev,noexec,relatime 0 0
+sysfs /sys sysfs rw,seclabel,nosuid,nodev,noexec,relatime 0 0
+devtmpfs /dev devtmpfs rw,seclabel,nosuid,size=4096k,nr_inodes=445689,mode=755,inode64 0 0"""
+
+_rhel_mtab_parsed = [
+    {
+        "device": "proc",
+        "mount": "/proc",
+        "fstype": "proc",
+        "options": "rw,nosuid,nodev,noexec,relatime",
+        "dump": "0",
+        "passno": "0",
+    },
+    {
+        "device": "sysfs",
+        "mount": "/sys",
+        "fstype": "sysfs",
+        "options": "rw,seclabel,nosuid,nodev,noexec,relatime",
+        "dump": "0",
+        "passno": "0",
+    },
+    {
+        "device": "devtmpfs",
+        "mount": "/dev",
+        "fstype": "devtmpfs",
+        "options": "rw,seclabel,nosuid,size=4096k,nr_inodes=445689,mode=755,inode64",
+        "dump": "0",
+        "passno": "0",
+    },
+]
+
+_rhel_mount = """proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
+sysfs on /sys type sysfs (rw,nosuid,nodev,noexec,relatime,seclabel)
+devtmpfs on /dev type devtmpfs (rw,nosuid,seclabel,size=4096k,nr_inodes=445689,mode=755,inode64)"""
+
+_rhel_mount_parsed = [
+    {
+        "device": "proc",
+        "mount": "/proc",
+        "fstype": "proc",
+        "options": "rw,nosuid,nodev,noexec,relatime",
+    },
+    {
+        "device": "sysfs",
+        "mount": "/sys",
+        "fstype": "sysfs",
+        "options": "rw,nosuid,nodev,noexec,relatime,seclabel",
+    },
+    {
+        "device": "devtmpfs",
+        "mount": "/dev",
+        "fstype": "devtmpfs",
+        "options": "rw,nosuid,seclabel,size=4096k,nr_inodes=445689,mode=755,inode64",
+    },
+]
+
+_rhel9_4 = _LinuxData(_rhel_fstab, _rhel_fstab_parsed, _rhel_mtab, _rhel_mtab_parsed, _rhel_mount, _rhel_mount_parsed)
+
+# https://www.ibm.com/docs/en/aix/7.3?topic=files-filesystems-file
+_aix_filesystems = """*
+* File system information
+*
+default:
+         vol        = "OS"
+         mount      = false
+         check      = false
+
+/:
+         dev        = /dev/hd4
+         vol        = "root"
+         mount      = automatic
+         check      = true
+         log        = /dev/hd8
+
+/home:
+         dev        = /dev/hd1
+         vol        = "u"
+         mount      = true
+         check      = true
+         log        = /dev/hd8
+
+/home/joe/1:
+         dev        = /home/joe/1
+         nodename   = vance
+         vfs        = nfs
+"""
+
+
+_aix_filesystems_parsed = [
+    {
+        "mount": "default",
+        "fstype": "unknown",
+        "device": "unknown",
+        "attributes": {"vol": '"OS"', "mount": "false", "check": "false"},
+    },
+    {
+        "mount": "/",
+        "fstype": "unknown",
+        "device": "/dev/hd4",
+        "attributes": {
+            "dev": "/dev/hd4",
+            "vol": '"root"',
+            "mount": "automatic",
+            "check": "true",
+            "log": "/dev/hd8",
+        },
+    },
+    {
+        "mount": "/home",
+        "fstype": "unknown",
+        "device": "/dev/hd1",
+        "attributes": {
+            "dev": "/dev/hd1",
+            "vol": '"u"',
+            "mount": "true",
+            "check": "true",
+            "log": "/dev/hd8",
+        },
+    },
+    {
+        "mount": "/home/joe/1",
+        "fstype": "nfs",
+        "device": "vance:/home/joe/1",
+        "attributes": {"dev": "/home/joe/1", "nodename": "vance", "vfs": "nfs"},
+    },
+]
+
+# https://www.ibm.com/docs/en/aix/7.2?topic=m-mount-command
+_aix_mount = """node   mounted          mounted over  vfs    date              options\t
+----   -------          ------------ ---  ------------   -------------------
+       /dev/hd0         /            jfs   Dec 17 08:04   rw, log  =/dev/hd8
+       /dev/hd2         /usr         jfs   Dec 17 08:06   rw, log  =/dev/hd8
+sue    /home/local/src  /usr/code    nfs   Dec 17 08:06   ro, log  =/dev/hd8"""
+
+_aix_mount_parsed = [
+    {
+        "mount": "/",
+        "device": "/dev/hd0",
+        "fstype": "jfs",
+        "time": "Dec 17 08:04",
+        "options": "rw, log  =/dev/hd8",
+    },
+    {
+        "mount": "/usr",
+        "device": "/dev/hd2",
+        "fstype": "jfs",
+        "time": "Dec 17 08:06",
+        "options": "rw, log  =/dev/hd8",
+    },
+    {
+        "mount": "/usr/code",
+        "device": "sue:/home/local/src",
+        "fstype": "nfs",
+        "time": "Dec 17 08:06",
+        "options": "ro, log  =/dev/hd8",
+    },
+]
+
+_aix7_2 = _AIXData(_aix_filesystems, _aix_filesystems_parsed, _aix_mount, _aix_mount_parsed)
+
+_openbsd_fstab = """726d525601651a64.b none swap sw
+726d525601651a64.a / ffs rw 1 1
+726d525601651a64.k /home ffs rw,nodev,nosuid 1 2"""
+
+_openbsd_fstab_parsed = [
+    {
+        "device": "726d525601651a64.b",
+        "fstype": "swap",
+        "mount": "none",
+        "options": "sw",
+    },
+    {
+        "device": "726d525601651a64.a",
+        "dump": "1",
+        "fstype": "ffs",
+        "mount": "/",
+        "options": "rw",
+        "passno": "1",
+    },
+    {
+        "device": "726d525601651a64.k",
+        "dump": "1",
+        "fstype": "ffs",
+        "mount": "/home",
+        "options": "rw,nodev,nosuid",
+        "passno": "2",
+    },
+]
+
+# Note: matches Linux mount format, like NetBSD
+_openbsd_mount = """/dev/sd0a on / type ffs (local)
+/dev/sd0k on /home type ffs (local, nodev, nosuid)
+/dev/sd0e on /tmp type ffs (local, nodev, nosuid)"""
+
+_openbsd_mount_parsed = [
+    {
+        "device": "/dev/sd0a",
+        "mount": "/",
+        "fstype": "ffs",
+        "options": "local"
+    },
+    {
+        "device": "/dev/sd0k",
+        "mount": "/home",
+        "fstype": "ffs",
+        "options": "local, nodev, nosuid",
+    },
+    {
+        "device": "/dev/sd0e",
+        "mount": "/tmp",
+        "fstype": "ffs",
+        "options": "local, nodev, nosuid",
+    },
+]
+
+_openbsd6_4 = _LinuxData(_openbsd_fstab, _openbsd_fstab_parsed, "", [], _openbsd_mount, _openbsd_mount_parsed)
+
+_solaris_vfstab = """#device         device          mount           FS      fsck    mount   mount
+#to mount       to fsck         point           type    pass    at boot options
+#
+/dev/dsk/c2t10d0s0 /dev/rdsk/c2t10d0s0 /export/local ufs 3 yes logging
+example1:/usr/local - /usr/local nfs - yes ro
+mailsvr:/var/mail - /var/mail nfs - yes intr,bg"""
+
+_solaris_vfstab_parsed = [
+    {
+        "device": "/dev/dsk/c2t10d0s0",
+        "device_to_fsck": "/dev/rdsk/c2t10d0s0",
+        "mount": "/export/local",
+        "fstype": "ufs",
+        "passno": "3",
+        "mount_at_boot": "yes",
+        "options": "logging",
+    },
+    {
+        "device": "example1:/usr/local",
+        "device_to_fsck": "-",
+        "mount": "/usr/local",
+        "fstype": "nfs",
+        "passno": "-",
+        "mount_at_boot": "yes",
+        "options": "ro",
+    },
+    {
+        "device": "mailsvr:/var/mail",
+        "device_to_fsck": "-",
+        "mount": "/var/mail",
+        "fstype": "nfs",
+        "passno": "-",
+        "mount_at_boot": "yes",
+        "options": "intr,bg",
+    },
+]
+
+_solaris_mnttab = """rpool/ROOT/solaris  /   zfs dev=4490002 0
+-hosts /net autofs ignore,indirect,nosuid,soft,nobrowse,dev=4000002 1724055352
+example.ansible.com:/export/nfs    /mnt/nfs    nfs xattr,dev=8e40010   1724055352"""
+
+_solaris_mnttab_parsed = [
+    {
+        "device": "rpool/ROOT/solaris",
+        "mount": "/",
+        "fstype": "zfs",
+        "options": "dev=4490002",
+        "time": "0",
+    },
+    {
+        "device": "-hosts",
+        "mount": "/net",
+        "fstype": "autofs",
+        "options": "ignore,indirect,nosuid,soft,nobrowse,dev=4000002",
+        "time": "1724055352",
+    },
+    {
+        "device": "example.ansible.com:/export/nfs",
+        "mount": "/mnt/nfs",
+        "fstype": "nfs",
+        "options": "xattr,dev=8e40010",
+        "time": "1724055352",
+    },
+]
+
+_solaris11_2 = _SolarisData(_solaris_vfstab, _solaris_vfstab_parsed, _solaris_mnttab, _solaris_mnttab_parsed)

--- a/test/units/modules/test_mount_facts.py
+++ b/test/units/modules/test_mount_facts.py
@@ -108,8 +108,8 @@ def test_duplicate_source(monkeypatch, _set_file_content):
     ("_gen_aix_filesystems_entries", _aix7_2.filesystems, _aix7_2.filesystems_parsed),
 ])
 def test_list_mounts(function, data, expected_result_data):
-    function = getattr(_mount_facts, function)
-    result = list(function(data.splitlines()))
+    func = getattr(_mount_facts, function)
+    result = list(func(data.splitlines()))
     assert result == [(_mnt, _line, _info) for _src, _mnt, _line, _info in expected_result_data]
 
 

--- a/test/units/modules/test_mount_facts.py
+++ b/test/units/modules/test_mount_facts.py
@@ -1,0 +1,283 @@
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+from ansible.module_utils.basic import AnsibleModule as _AnsibleModule
+from ansible.modules import mount_facts as _mount_facts
+from units.modules.utils import (
+    AnsibleExitJson as _AnsibleExitJson,
+    AnsibleFailJson as _AnsibleFailJson,
+    exit_json as _exit_json,
+    fail_json as _fail_json,
+    set_module_args as _set_module_args
+)
+from units.modules._mount_facts_data import _aix7_2, _freebsd14_1, _openbsd6_4, _rhel9_4, _solaris11_2
+from unittest.mock import MagicMock
+
+import pytest
+import time
+
+_UUIDS = {}
+
+
+def _get_mock_module(invocation):
+    _set_module_args(invocation)
+    module = _AnsibleModule(
+        argument_spec=_mount_facts._get_argument_spec(),
+        supports_check_mode=True,
+    )
+    return module
+
+
+def _mock_callable(return_value=None):
+    def func(*args, **kwargs):
+        return return_value
+
+    return func
+
+
+@pytest.fixture
+def _set_file_content(monkeypatch):
+    def _set_file_content(data):
+        def mock_get_file_content(filename, default=None):
+            if filename in data:
+                return data[filename]
+            return default
+        monkeypatch.setattr(_mount_facts, "_get_file_content", mock_get_file_content)
+    return _set_file_content
+
+
+def test_invocation(monkeypatch, _set_file_content):
+    _set_file_content({})
+    _set_module_args({})
+    monkeypatch.setattr(_mount_facts, "_run_mount_bin", _mock_callable(return_value=""))
+    monkeypatch.setattr(_AnsibleModule, "exit_json", _exit_json)
+    with pytest.raises(_AnsibleExitJson, match="{'ansible_facts': {'extended_mounts': {}}}"):
+        _mount_facts.main()
+
+
+def test_invalid_timeout(monkeypatch):
+    _set_module_args({"timeout": 0})
+    monkeypatch.setattr(_AnsibleModule, "fail_json", _fail_json)
+    with pytest.raises(_AnsibleFailJson, match="argument 'timeout' must be a positive integer or null"):
+        _mount_facts.main()
+
+
+@pytest.mark.parametrize("invalid_binary, error", [
+    ("ansible_test_missing_binary", 'Failed to find required executable "ansible_test_missing_binary" in paths: .*'),
+    ("false", "Failed to execute .*false: Command '[^']*false' returned non-zero exit status 1"),
+    (["one", "two"], "argument 'mount_binary' must be a string or null, not \\['one', 'two'\\]"),
+])
+def test_invalid_mount_binary(monkeypatch, _set_file_content, invalid_binary, error):
+    _set_file_content({})
+    _set_module_args({"mount_binary": invalid_binary})
+    monkeypatch.setattr(_AnsibleModule, "fail_json", _fail_json)
+    with pytest.raises(_AnsibleFailJson, match=error):
+        _mount_facts.main()
+
+
+def test_invalid_source(monkeypatch):
+    _set_module_args({"sources": [""]})
+    monkeypatch.setattr(_AnsibleModule, "fail_json", _fail_json)
+    with pytest.raises(_AnsibleFailJson, match="sources contains an empty string"):
+        _mount_facts.main()
+
+
+def test_duplicate_source(monkeypatch, _set_file_content):
+    _set_file_content({"/etc/fstab": _rhel9_4.fstab})
+    mock_warn = MagicMock()
+    monkeypatch.setattr(_AnsibleModule, "warn", mock_warn)
+
+    user_sources = ["static", "/etc/fstab"]
+    resolved_sources = ["/etc/fstab", "/etc/vfstab", "/etc/filesystems", "/etc/fstab"]
+    expected_warning = "mount_facts option 'sources' contains duplicate entries, repeat sources will be ignored:"
+
+    module = _get_mock_module({"sources": user_sources})
+    _mount_facts._get_mounts_by_source(module)
+    assert mock_warn.called
+    assert len(mock_warn.call_args_list) == 1
+    assert mock_warn.call_args_list[0].args == (f"{expected_warning} {resolved_sources}",)
+
+
+@pytest.mark.parametrize("function, data, result", [
+    ("_list_fstab_entries", _rhel9_4.fstab, _rhel9_4.fstab_parsed),
+    ("_list_fstab_entries", _rhel9_4.mtab, _rhel9_4.mtab_parsed),
+    ("_list_fstab_entries", _freebsd14_1.fstab, _freebsd14_1.fstab_parsed),
+    ("_list_vfstab_entries", _solaris11_2.vfstab, _solaris11_2.vfstab_parsed),
+    ("_list_mnttab_entries", _solaris11_2.mnttab, _solaris11_2.mnttab_parsed),
+    ("_list_aix_filesystem_entries", _aix7_2.filesystems, _aix7_2.filesystems_parsed),
+])
+def test_list_mounts(function, data, result):
+    function = getattr(_mount_facts, function)
+    assert function(data.splitlines()) == result
+
+
+def test_etc_filesystems_linux(_set_file_content):
+    not_aix_data = (
+        "ext4\next3\next2\nnodev proc\nnodev devpts\niso9770\nvfat\nhfs\nhfsplus\n*"
+    )
+    _set_file_content({"/etc/filesystems": not_aix_data})
+    module = _get_mock_module({"sources": ["/etc/filesystems"]})
+    assert _mount_facts._get_mounts_by_source(module) == {}
+
+
+@pytest.mark.parametrize("mount_stdout, result", [
+    (_rhel9_4.mount, _rhel9_4.mount_parsed),
+    (_freebsd14_1.mount, _freebsd14_1.mount_parsed),
+    (_openbsd6_4.mount, _openbsd6_4.mount_parsed),
+    (_aix7_2.mount, _aix7_2.mount_parsed),
+])
+def test_parse_mount_bin_stdout(mount_stdout, result):
+    assert result == _mount_facts._list_mounts_from_mount_stdout(mount_stdout)
+
+
+def test_parse_mount_bin_stdout_unknown(monkeypatch, _set_file_content):
+    _set_file_content({})
+    _set_module_args({})
+    monkeypatch.setattr(_mount_facts, "_run_mount_bin", _mock_callable(return_value="nonsense"))
+    monkeypatch.setattr(_AnsibleModule, "exit_json", _exit_json)
+    with pytest.raises(_AnsibleExitJson, match="{'ansible_facts': {'extended_mounts': {}}}"):
+        _mount_facts.main()
+
+
+_rhel_mock_fs = {"/etc/fstab": _rhel9_4.fstab, "/etc/mtab": _rhel9_4.mtab}
+_freebsd_mock_fs = {"/etc/fstab": _freebsd14_1.fstab}
+_aix_mock_fs = {"/etc/filesystems": _aix7_2.filesystems}
+_openbsd_mock_fs = {"/etc/fstab": _openbsd6_4.fstab}
+_solaris_mock_fs = {"/etc/mnttab": _solaris11_2.mnttab, "/etc/vfstab": _solaris11_2.vfstab}
+
+
+@pytest.mark.parametrize("sources, file_data, mount_data, results", [
+    (["static"], _rhel_mock_fs, _rhel9_4.mount, {"/etc/fstab": _rhel9_4.fstab_parsed}),
+    (["/etc/fstab"], _rhel_mock_fs, _rhel9_4.mount, {"/etc/fstab": _rhel9_4.fstab_parsed}),
+    (["dynamic"], _rhel_mock_fs, _rhel9_4.mount, {"/etc/mtab": _rhel9_4.mtab_parsed}),
+    (["/etc/mtab"], _rhel_mock_fs, _rhel9_4.mount, {"/etc/mtab": _rhel9_4.mtab_parsed}),
+    (["all"], _rhel_mock_fs, _rhel9_4.mount, {"/etc/fstab": _rhel9_4.fstab_parsed, "/etc/mtab": _rhel9_4.mtab_parsed}),
+    (["mount"], _rhel_mock_fs, _rhel9_4.mount, {"mount": _rhel9_4.mount_parsed}),
+    (["all"], _freebsd_mock_fs, _freebsd14_1.mount, {"/etc/fstab": _freebsd14_1.fstab_parsed, "mount": _freebsd14_1.mount_parsed}),
+    (["static"], _freebsd_mock_fs, _freebsd14_1.mount, {"/etc/fstab": _freebsd14_1.fstab_parsed}),
+    (["dynamic"], _freebsd_mock_fs, _freebsd14_1.mount, {"mount": _freebsd14_1.mount_parsed}),
+    (["mount"], _freebsd_mock_fs, _freebsd14_1.mount, {"mount": _freebsd14_1.mount_parsed}),
+    (["all"], _aix_mock_fs, _aix7_2.mount, {"/etc/filesystems": _aix7_2.filesystems_parsed, "mount": _aix7_2.mount_parsed}),
+    (["all"], _openbsd_mock_fs, _openbsd6_4.mount, {"/etc/fstab": _openbsd6_4.fstab_parsed, "mount": _openbsd6_4.mount_parsed}),
+    (["all"], _solaris_mock_fs, "", {"/etc/mnttab": _solaris11_2.mnttab_parsed, "/etc/vfstab": _solaris11_2.vfstab_parsed}),
+])
+def test_get_mounts_by_sources(monkeypatch, _set_file_content, sources, file_data, mount_data, results):
+    _set_file_content(file_data)
+    mock_run_mount = _mock_callable(return_value=mount_data)
+    monkeypatch.setattr(_mount_facts, "_run_mount_bin", mock_run_mount)
+    module = _get_mock_module({"sources": sources})
+    actual_results = _mount_facts._get_mounts_by_source(module)
+    assert set(actual_results) == set(results)
+    assert actual_results == results
+
+
+@pytest.mark.parametrize("on_timeout, should_warn, should_raise", [
+    (None, False, True),
+    ("warn", True, False),
+    ("ignore", False, False),
+])
+def test_list_mounts_mount_timeout(monkeypatch, _set_file_content, on_timeout, should_warn, should_raise):
+    _set_file_content({})
+    monkeypatch.setattr(_AnsibleModule, "fail_json", _fail_json)
+    mock_warn = MagicMock()
+    monkeypatch.setattr(_AnsibleModule, "warn", mock_warn)
+
+    # hack to simulate a hang (module entrypoint requires >= 1 or None)
+    params = {"timeout": 0}
+    if on_timeout:
+        params["on_timeout"] = on_timeout
+
+    module = _get_mock_module(params)
+    if should_raise:
+        with pytest.raises(_AnsibleFailJson, match="Command '[^']*mount' timed out after 0 seconds"):
+            _mount_facts._get_mounts_by_source(module)
+    else:
+        assert _mount_facts._get_mounts_by_source(module) == {}
+    assert mock_warn.called == should_warn
+
+
+def test_get_mounts_facts_filtering(monkeypatch, _set_file_content):
+    _set_file_content({"/etc/mtab": _rhel9_4.mtab})
+    result = {"info": _rhel9_4.mtab_parsed[-1], "uuid": "N/A", "source": "/etc/mtab"}
+    module = _get_mock_module({"devices": [result["info"]["device"]]})
+    monkeypatch.setattr(_mount_facts, "_get_mount_size", _mock_callable(return_value=None))
+    assert _mount_facts._get_mount_facts(module, _UUIDS, _mock_callable()) == {result["info"]["mount"]: result}
+    module = _get_mock_module({"fstypes": [result["info"]["fstype"]]})
+    assert _mount_facts._get_mount_facts(module, _UUIDS, _mock_callable()) == {result["info"]["mount"]: result}
+
+
+def test_get_mounts_size(monkeypatch, _set_file_content):
+    def mock_get_mount_size(*args, **kwargs):
+        return {
+            "block_available": 3242510,
+            "block_size": 4096,
+            "block_total": 3789825,
+            "block_used": 547315,
+            "inode_available": 1875503,
+            "inode_total": 1966080,
+            "size_available": 13281320960,
+            "size_total": 15523123200,
+        }
+
+    expected_result = {
+        info["mount"]: {
+            "uuid": "N/A",
+            "info": dict(**mock_get_mount_size(), **info),
+            "source": "/etc/mtab",
+        }
+        for info in _rhel9_4.mtab_parsed
+    }
+
+    _set_file_content({"/etc/mtab": _rhel9_4.mtab})
+    monkeypatch.setattr(_mount_facts, "_get_mount_size", mock_get_mount_size)
+    module = _get_mock_module({})
+    result = _mount_facts._get_mount_facts(module, _UUIDS, _mock_callable())
+    assert result == expected_result
+
+
+@pytest.mark.parametrize("on_timeout, should_warn, should_raise, slow_function", [
+    (None, False, True, "_get_mount_size"),
+    ("error", False, True, "_get_mount_size"),
+    ("warn", True, False, "_get_mount_size"),
+    ("ignore", False, False, "_get_mount_size"),
+    ("error", False, True, "_udevadm_uuid"),
+    ("warn", True, False, "_udevadm_uuid"),
+    ("ignore", False, False, "_udevadm_uuid"),
+])
+def test_get_mount_facts_timeout(monkeypatch, _set_file_content, on_timeout, should_warn, should_raise, slow_function):
+    _set_file_content({"/etc/mtab": _rhel9_4.mtab})
+    monkeypatch.setattr(_AnsibleModule, "fail_json", _fail_json)
+    mock_warn = MagicMock()
+    monkeypatch.setattr(_AnsibleModule, "warn", mock_warn)
+
+    params = {"timeout": 1, "sources": ["dynamic"], "mount_binary": "mount"}
+    if on_timeout:
+        params["on_timeout"] = on_timeout
+
+    module = _get_mock_module(params)
+
+    def mock_slow_function(*args, **kwargs):
+        time.sleep(1.1)
+        raise Exception("Timeout failed")
+
+    if slow_function == "_get_mount_size":
+        monkeypatch.setattr(_mount_facts, "_get_mount_size", mock_slow_function)
+        match = "Timed out getting mount size .*"
+        mock_udevadm_uuid = _mock_callable()
+    else:
+        monkeypatch.setattr(_mount_facts, "_get_mount_size", _mock_callable())
+        match = "Timed out getting uuid for mount .+ \\(type .+\\) after 1 seconds"
+        mock_udevadm_uuid = mock_slow_function
+
+    if should_raise:
+        with pytest.raises(_AnsibleFailJson, match=match):
+            _mount_facts._get_mount_facts(module, _UUIDS, mock_udevadm_uuid)
+    else:
+        results = _mount_facts._get_mount_facts(module, _UUIDS, mock_udevadm_uuid)
+        assert len(results) == len(_rhel9_4.mtab_parsed)
+        assert results == {
+            info["mount"]: {"info": info, "uuid": "N/A", "source": "/etc/mtab"}
+            for info in _rhel9_4.mtab_parsed
+        }
+    assert mock_warn.called == should_warn


### PR DESCRIPTION
##### SUMMARY

Add a module to gather mount information, including devices that don't look like paths (which are excluded by default fact gathering). Renamed to `mount_facts` for less typing, since the module is more generic now.

Fixes #24644

Marked as draft until I've added:
* [x] Tests
* [x] Changelog

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```