### PR TITLE
DRAFT: Add YAML tags for controlling variable merge behavior

### DIFF
--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -50,6 +50,15 @@ class AnsibleBaseYAMLObject(object):
         self._line_number = line
         self._column_number = col
 
+    def copy(self):
+        copy = self.__class__(self)
+        copy._data_source = self._data_source
+        copy._line_number = self._line_number
+        copy._column_number = self._column_number
+        if hasattr(self, 'merge_behavior'):
+            copy.merge_behavior = self.merge_behavior
+        return copy
+
     ansible_pos = property(_get_ansible_position, _set_ansible_position)
 
 

--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -74,7 +74,32 @@ class AnsibleUnicode(AnsibleBaseYAMLObject, text_type):
 
 class AnsibleSequence(AnsibleBaseYAMLObject, list):
     ''' sub class for lists '''
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._sources = set()
+
+    def __add__(self, other):
+        added = self.__class__(super().__add__(other))
+        if isinstance(other, AnsibleSequence):
+            added.sources = self.sources | other.sources
+        else:
+            added.sources = self.sources.copy()
+        return added
+
+    def copy(self):
+        copy = self.__class__(super().copy())
+        copy._sources = self._sources
+        return copy
+
+    @property
+    def sources(self):
+        if self.ansible_pos[0] is not None:
+            return {self.ansible_pos} | self._sources
+        return self._sources
+
+    @sources.setter
+    def sources(self, value):
+        self._sources = value
 
 
 class AnsibleVaultEncryptedUnicode(Sequence, AnsibleBaseYAMLObject):

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -29,6 +29,7 @@ from ansible.playbook.notifiable import Notifiable
 from ansible.playbook.role import Role
 from ansible.playbook.taggable import Taggable
 from ansible.utils.sentinel import Sentinel
+from ansible.utils.vars import merge_hash
 
 
 class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatable):
@@ -77,11 +78,9 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
         all_vars = {}
 
         if self._parent:
-            all_vars |= self._parent.get_vars()
+            all_vars = self._parent.get_vars()
 
-        all_vars |= self.vars.copy()
-
-        return all_vars
+        return merge_hash(all_vars, self.vars)
 
     @staticmethod
     def load(data, play=None, parent_block=None, role=None, task_include=None, use_handlers=False, variable_manager=None, loader=None):

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -41,6 +41,8 @@ from ansible.utils.vars import isidentifier
 
 __all__ = ['Task']
 
+from ansible.utils.vars import merge_hash
+
 display = Display()
 
 
@@ -365,9 +367,9 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
     def get_vars(self):
         all_vars = dict()
         if self._parent:
-            all_vars |= self._parent.get_vars()
+            all_vars = self._parent.get_vars()
 
-        all_vars |= self.vars
+        all_vars = merge_hash(all_vars, self.vars)
 
         if 'tags' in all_vars:
             del all_vars['tags']

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -86,8 +86,7 @@ def combine_vars(a, b, merge=None):
 
     # HASH_BEHAVIOUR == 'replace'
     _validate_mutable_mappings(a, b)
-    result = a | b
-    return result
+    return merge_hash(a, b, recursive=False)
 
 
 def merge_hash(x, y, recursive=True, list_merge='replace'):
@@ -114,13 +113,6 @@ def merge_hash(x, y, recursive=True, list_merge='replace'):
     # we don't want to modify x, so we create a copy of it
     x = x.copy()
 
-    # to speed things up: use dict.update if possible
-    # (this `if` can be remove without impact on the function
-    #  except performance)
-    if not recursive and list_merge == 'replace':
-        x.update(y)
-        return x
-
     # insert each element of y in x, overriding the one in x
     # (as y has higher priority)
     # we copy elements from y to x instead of x to y because
@@ -142,7 +134,11 @@ def merge_hash(x, y, recursive=True, list_merge='replace'):
         # depending on the `recursive` argument
         # and move on to the next element of y
         if isinstance(x_value, MutableMapping) and isinstance(y_value, MutableMapping):
-            if recursive:
+            if hasattr(y_value, 'merge_behavior'):
+                recursive_cur = y_value.merge_behavior
+            else:
+                recursive_cur = recursive
+            if recursive_cur:
                 x[key] = merge_hash(x_value, y_value, recursive, list_merge)
             else:
                 x[key] = y_value


### PR DESCRIPTION
##### SUMMARY

This adds a few YAML tags for controlling how variables are merged when there are duplicate names across multiple sources.

There are 2 commits in the PR. The first commit adds a `!merge` tag, and is for controlling merge behavior of maps/hashes/dictionaries/whatever_you_want_to_call_them. The second commit adds `!append` and `!prepend` for controlling merging of lists/arrays. This is a bit more complex of a change, as Ansible sometimes will merge the same variables multiple times, resulting in a list being (pre/ap)pended multiple times. Maps don't have this issue as it'll just result in a key overwrite with the same value. So for lists we have to track where the list came from to prevent duplicate entries.  
Note that the merge behaviors are not automatically recursive. The tag must be applied at each level to merge that level (otherwise it replaces).

This is definitely a draft, as there are things I would probably clean up and re-arrange. However with the code as it is, it makes it clearer what's going on. There also would need to be tests, addressing the linter, etc. Right now it's just up so it can be reviewed conceptually before proceeding.

I've tested this with group_vars, host_vars, playbook vars, block vars, task vars, & role vars.

Closes #83903 

While `DEFAULT_HASH_BEHAVIOUR` is also deprecated-but-not-quite, and has a messy history (#72021, #72669, #73089, #73328, #74215), this change will hopefully provide an actionable replacement for the functionality, and allow it to truly be deprecated.

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```yaml
# group_vars/all
foo:
  one: one
  two:
    two_dot_one: two dot one
  three:
    - three dot one
    - three dot two
```
```yaml
# host_vars/localhost
foo: !merge
  one: hostvars one
  three: !prepend
    - three dot zero
```
```yaml
# playbook.yml
- hosts: localhost
  roles:
    - test
  vars:
    foo: !merge
      four: four
```
```yaml
# roles/test/defaults/main.yml
foo: !merge
  five: five
```
<sup>^Note, this is not shown in the output below because it's a default, and thus overridden. Just showing to demo the behavior that defaults are not merged if override is present.</sup>
```yaml
# roles/test/tasks/main.yml
- block:
  - debug: var=foo
    vars:
      foo: !merge
        six: six
      blockvar: blockvar
  vars:
    foo: !merge
      seven: seven
    taskvar: taskvar
```

```
TASK [test : debug] ************************************************************
task path: /tmp/at/roles/test/tasks/main.yml:2
ok: [localhost] => {
    "foo": {
        "four": "four",
        "one": "hostvars one",
        "seven": "seven",
        "six": "six",
        "three": [
            "three dot zero",
            "three dot one",
            "three dot two"
        ],
        "two": {
            "two_dot_one": "two dot one"
        }
    }
}
```

##### Review
A few questions that need answering:
* Should maps & lists functionality be separate? Meaning should this PR focus on map merges only, and list merges be a separate future change? Maybe use suffixes for lists, like `!merge:append`.
* What should things be named? Should the merge tag names be something else?