### PR TITLE
Remove reliance on `sshpass` and utilize `SSH_ASKPASS`

### DIFF
--- a/changelogs/fragments/83936-ssh-askpass.yml
+++ b/changelogs/fragments/83936-ssh-askpass.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ssh connection plugin - Support ``SSH_ASKPASS`` mechanism to provide passwords, making it the default, but still offering an explicit choice to use ``sshpass``
+  (https://github.com/ansible/ansible/pull/83936)

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -10,10 +10,13 @@ import os
 import sys
 
 
-# as the SSH_ASKPASS script can only be invoked as a singular command
-# python -m doesn't work here, so assume that if we are executing
-# and there is only a single item in argv plus the executable, and the
-# env var is set we are in SSH_ASKPASS mode
+# We overload the ``ansible`` adhoc command to provide the functionality for
+# ``SSH_ASKPASS``. This code is here, and not in ``adhoc.py`` to bypass
+# unnecessary code. The program provided to ``SSH_ASKPASS`` can only be invoked
+# as a singular command, ``python -m`` doesn't work for that use case, and we
+# aren't adding a new entrypoint at this time. Assume that if we are executing
+# and there is only a single item in argv plus the executable, and the env var
+# is set we are in ``SSH_ASKPASS`` mode
 if 1 <= len(sys.argv) <= 2 and os.path.basename(sys.argv[0]) == "ansible" and os.getenv('_ANSIBLE_SSH_ASKPASS_SHM'):
     from ansible.cli import _ssh_askpass
     _ssh_askpass.main()

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -9,6 +9,16 @@ import locale
 import os
 import sys
 
+
+# as the SSH_ASKPASS script can only be invoked as a singular command
+# python -m doesn't work here, so assume that if we are executing
+# and there is only a single item in argv plus the executable, and the
+# env var is set we are in SSH_ASKPASS mode
+if 1 <= len(sys.argv) <= 2 and os.path.basename(sys.argv[0]) == "ansible" and os.getenv('_ANSIBLE_SSH_ASKPASS_SHM'):
+    from ansible.cli import _ssh_askpass
+    _ssh_askpass.main()
+
+
 # Used for determining if the system is running a new enough python version
 # and should only restrict on our documented minimum versions
 if sys.version_info < (3, 11):

--- a/lib/ansible/cli/_ssh_askpass.py
+++ b/lib/ansible/cli/_ssh_askpass.py
@@ -1,0 +1,40 @@
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import typing as t
+from multiprocessing.shared_memory import SharedMemory
+
+HOST_KEY_RE = re.compile(
+    r'(The authenticity of host |differs from the key for the IP address)',
+)
+
+
+def main() -> t.Never:
+    try:
+        if HOST_KEY_RE.search(sys.argv[1]):
+            sys.stdout.buffer.write(b'no')
+            sys.stdout.flush()
+            sys.exit(0)
+    except IndexError:
+        pass
+
+    kwargs: dict[str, bool] = {}
+    if sys.version_info[:2] >= (3, 13):
+        # deprecated: description='unneeded due to track argument for SharedMemory' python_version='3.12'
+        kwargs['track'] = False
+    try:
+        shm = SharedMemory(name=os.environ['_ANSIBLE_SSH_ASKPASS_SHM'], **kwargs)
+    except FileNotFoundError:
+        # We must be running after the ansible fork is shutting down
+        sys.exit(1)
+    cfg = json.loads(shm.buf.tobytes().rstrip(b'\x00'))
+    sys.stdout.buffer.write(cfg['password'].encode('utf-8'))
+    sys.stdout.flush()
+    shm.buf[:] = b'\x00' * shm.size
+    shm.close()
+    sys.exit(0)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -62,6 +62,21 @@ DOCUMENTATION = """
               - name: ansible_password
               - name: ansible_ssh_pass
               - name: ansible_ssh_password
+      password_mechanism:
+          description: Mechanism to use for handling ssh password prompt
+          type: string
+          default: ssh_askpass
+          choices:
+              - ssh_askpass
+              - sshpass
+              - disable
+          version_added: '2.19'
+          env:
+              - name: ANSIBLE_SSH_PASSWORD_MECHANISM
+          ini:
+              - {key: password_mechanism, section: ssh_connection}
+          vars:
+              - name: ansible_ssh_password_mechanism
       sshpass_prompt:
           description:
               - Password prompt that sshpass should search for. Supported by sshpass 1.06 and up.
@@ -357,7 +372,6 @@ DOCUMENTATION = """
         type: string
         description:
           - "PKCS11 SmartCard provider such as opensc, example: /usr/local/lib/opensc-pkcs11.so"
-          - Requires sshpass version 1.06+, sshpass must support the -P option.
         env: [{name: ANSIBLE_PKCS11_PROVIDER}]
         ini:
           - {key: pkcs11_provider, section: ssh_connection}
@@ -367,26 +381,32 @@ DOCUMENTATION = """
 
 import collections.abc as c
 import errno
+import contextlib
 import fcntl
 import hashlib
 import io
+import json
 import os
+import pathlib
 import pty
 import re
 import selectors
 import shlex
+import shutil
 import subprocess
+import sys
 import time
 import typing as t
-
 from functools import wraps
+from multiprocessing.shared_memory import SharedMemory
+
 from ansible.errors import (
     AnsibleAuthenticationFailure,
     AnsibleConnectionFailure,
     AnsibleError,
     AnsibleFileNotFound,
 )
-from ansible.module_utils.six import PY3, text_type, binary_type
+from ansible.module_utils.six import text_type, binary_type
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.plugins.shell.powershell import _replace_stderr_clixml
@@ -407,6 +427,8 @@ b_NOT_SSH_ERRORS = (b'Traceback (most recent call last):',  # Python-2.6 when th
 
 SSHPASS_AVAILABLE = None
 SSH_DEBUG = re.compile(r'^debug\d+: .*')
+
+_HAS_RESOURCE_TRACK = sys.version_info[:2] >= (3, 13)
 
 
 class AnsibleControlPersistBrokenPipeError(AnsibleError):
@@ -497,9 +519,10 @@ def _ssh_retry(
         remaining_tries = int(self.get_option('reconnection_retries')) + 1
         cmd_summary = u"%s..." % to_text(args[0])
         conn_password = self.get_option('password') or self._play_context.password
+        is_sshpass = self.get_option('password_mechanism') == 'sshpass'
         for attempt in range(remaining_tries):
             cmd = t.cast(list[bytes], args[0])
-            if attempt != 0 and conn_password and isinstance(cmd, list):
+            if attempt != 0 and is_sshpass and conn_password and isinstance(cmd, list):
                 # If this is a retry, the fd/pipe for sshpass is closed, and we need a new one
                 self.sshpass_pipe = os.pipe()
                 cmd[1] = b'-d' + to_bytes(self.sshpass_pipe[0], nonstring='simplerepr', errors='surrogate_or_strict')
@@ -518,7 +541,7 @@ def _ssh_retry(
                 except (AnsibleControlPersistBrokenPipeError):
                     # Retry one more time because of the ControlPersist broken pipe (see #16731)
                     cmd = t.cast(list[bytes], args[0])
-                    if conn_password and isinstance(cmd, list):
+                    if is_sshpass and conn_password and isinstance(cmd, list):
                         # This is a retry, so the fd/pipe for sshpass is closed, and we need a new one
                         self.sshpass_pipe = os.pipe()
                         cmd[1] = b'-d' + to_bytes(self.sshpass_pipe[0], nonstring='simplerepr', errors='surrogate_or_strict')
@@ -559,6 +582,24 @@ def _ssh_retry(
     return wrapped
 
 
+def _clean_shm(func):
+    def inner(self, *args, **kwargs):
+        try:
+            ret = func(self, *args, **kwargs)
+        finally:
+            if self.shm:
+                self.shm.close()
+                with contextlib.suppress(FileNotFoundError):
+                    self.shm.unlink()
+                if not _HAS_RESOURCE_TRACK:
+                    # deprecated: description='unneeded due to track argument for SharedMemory' python_version='3.12'
+                    # There is a resource tracking issue where the resource is deleted, but tracking still has a record
+                    # This will effectively overwrite the record and remove it
+                    SharedMemory(name=self.shm.name, create=True, size=1).unlink()
+        return ret
+    return inner
+
+
 class Connection(ConnectionBase):
     """ ssh based connections """
 
@@ -574,6 +615,8 @@ class Connection(ConnectionBase):
         self.user = self._play_context.remote_user
         self.control_path: str | None = None
         self.control_path_dir: str | None = None
+        self.shm: SharedMemory | None = None
+        self.sshpass_pipe: tuple[int, int] | None = None
 
         # Windows operates differently from a POSIX connection/shell plugin,
         # we need to set various properties to ensure SSH on Windows continues
@@ -615,17 +658,10 @@ class Connection(ConnectionBase):
     def _sshpass_available() -> bool:
         global SSHPASS_AVAILABLE
 
-        # We test once if sshpass is available, and remember the result. It
-        # would be nice to use distutils.spawn.find_executable for this, but
-        # distutils isn't always available; shutils.which() is Python3-only.
+        # We test once if sshpass is available, and remember the result.
 
         if SSHPASS_AVAILABLE is None:
-            try:
-                p = subprocess.Popen(["sshpass"], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                p.communicate()
-                SSHPASS_AVAILABLE = True
-            except OSError:
-                SSHPASS_AVAILABLE = False
+            SSHPASS_AVAILABLE = shutil.which('sshpass') is not None
 
         return SSHPASS_AVAILABLE
 
@@ -678,17 +714,18 @@ class Connection(ConnectionBase):
 
         b_command = []
         conn_password = self.get_option('password') or self._play_context.password
+        pkcs11_provider = self.get_option("pkcs11_provider")
+        password_mechanism = self.get_option('password_mechanism')
 
         #
         # First, the command to invoke
         #
 
-        # If we want to use password authentication, we have to set up a pipe to
+        # If we want to use sshpass for password authentication, we have to set up a pipe to
         # write the password to sshpass.
-        pkcs11_provider = self.get_option("pkcs11_provider")
-        if conn_password or pkcs11_provider:
+        if password_mechanism == 'sshpass' and (conn_password or pkcs11_provider):
             if not self._sshpass_available():
-                raise AnsibleError("to use the 'ssh' connection type with passwords or pkcs11_provider, you must install the sshpass program")
+                raise AnsibleError("to use the password_mechanism=sshpass, you must install the sshpass program")
             if not conn_password and pkcs11_provider:
                 raise AnsibleError("to use pkcs11_provider you must specify a password/pin")
 
@@ -721,12 +758,12 @@ class Connection(ConnectionBase):
         # sftp batch mode allows us to correctly catch failed transfers, but can
         # be disabled if the client side doesn't support the option. However,
         # sftp batch mode does not prompt for passwords so it must be disabled
-        # if not using controlpersist and using sshpass
+        # if not using controlpersist and using password auth
         b_args: t.Iterable[bytes]
         if subsystem == 'sftp' and self.get_option('sftp_batch_mode'):
             if conn_password:
                 b_args = [b'-o', b'BatchMode=no']
-                self._add_args(b_command, b_args, u'disable batch mode for sshpass')
+                self._add_args(b_command, b_args, u'disable batch mode for password auth')
             b_command += [b'-b', b'-']
 
         if display.verbosity:
@@ -907,6 +944,50 @@ class Connection(ConnectionBase):
 
         return b''.join(output), remainder
 
+    def _init_shm(self) -> dict[str, t.Any]:
+        env = os.environ.copy()
+        popen_kwargs: dict[str, t.Any] = {}
+
+        if self.get_option('password_mechanism') != 'ssh_askpass':
+            return popen_kwargs
+
+        conn_password = self.get_option('password') or self._play_context.password
+        pkcs11_provider = self.get_option("pkcs11_provider")
+        if not conn_password and pkcs11_provider:
+            raise AnsibleError("to use pkcs11_provider you must specify a password/pin")
+
+        if not conn_password:
+            return popen_kwargs
+
+        kwargs = {}
+        if _HAS_RESOURCE_TRACK:
+            # deprecated: description='track argument for SharedMemory always available' python_version='3.12'
+            kwargs['track'] = False
+        self.shm = shm = SharedMemory(create=True, size=16384, **kwargs)  # type: ignore[arg-type]
+
+        data = json.dumps(
+            {'password': conn_password},
+        ).encode('utf-8')
+        shm.buf[:len(data)] = bytearray(data)
+        shm.close()
+
+        env['_ANSIBLE_SSH_ASKPASS_SHM'] = str(self.shm.name)
+        adhoc = pathlib.Path(sys.argv[0]).with_name('ansible')
+        env['SSH_ASKPASS'] = str(adhoc) if adhoc.is_file() else 'ansible'
+
+        # SSH_ASKPASS_REQUIRE was added in openssh 8.4, prior to 8.4 there must be no tty, and DISPLAY must be set
+        env['SSH_ASKPASS_REQUIRE'] = 'force'
+        if not env.get('DISPLAY'):
+            # If the user has DISPLAY set, assume it is there for a reason
+            env['DISPLAY'] = '-'
+
+        popen_kwargs['env'] = env
+        # start_new_session runs setsid which detaches the tty to support the use of ASKPASS prior to openssh 8.4
+        popen_kwargs['start_new_session'] = True
+
+        return popen_kwargs
+
+    @_clean_shm
     def _bare_run(self, cmd: list[bytes], in_data: bytes | None, sudoable: bool = True, checkrc: bool = True) -> tuple[int, bytes, bytes]:
         """
         Starts the command and communicates with it until it ends.
@@ -915,6 +996,9 @@ class Connection(ConnectionBase):
         # We don't use _shell.quote as this is run on the controller and independent from the shell plugin chosen
         display_cmd = u' '.join(shlex.quote(to_text(c)) for c in cmd)
         display.vvv(u'SSH: EXEC {0}'.format(display_cmd), host=self.host)
+
+        conn_password = self.get_option('password') or self._play_context.password
+        password_mechanism = self.get_option('password_mechanism')
 
         # Start the given command. If we don't need to pipeline data, we can try
         # to use a pseudo-tty (ssh will have been invoked with -tt). If we are
@@ -928,17 +1012,16 @@ class Connection(ConnectionBase):
         else:
             cmd = list(map(to_bytes, cmd))
 
-        conn_password = self.get_option('password') or self._play_context.password
+        popen_kwargs = self._init_shm()
+
+        if self.sshpass_pipe:
+            popen_kwargs['pass_fds'] = self.sshpass_pipe
 
         if not in_data:
             try:
                 # Make sure stdin is a proper pty to avoid tcgetattr errors
                 master, slave = pty.openpty()
-                if PY3 and conn_password:
-                    # pylint: disable=unexpected-keyword-arg
-                    p = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=self.sshpass_pipe)
-                else:
-                    p = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                p = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **popen_kwargs)
                 stdin = os.fdopen(master, 'wb', 0)
                 os.close(slave)
             except (OSError, IOError):
@@ -946,21 +1029,13 @@ class Connection(ConnectionBase):
 
         if not p:
             try:
-                if PY3 and conn_password:
-                    # pylint: disable=unexpected-keyword-arg
-                    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                         stderr=subprocess.PIPE, pass_fds=self.sshpass_pipe)
-                else:
-                    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                         stderr=subprocess.PIPE)
+                p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE, **popen_kwargs)
                 stdin = p.stdin  # type: ignore[assignment] # stdin will be set and not None due to the calls above
             except (OSError, IOError) as e:
                 raise AnsibleError('Unable to execute ssh command line on a controller due to: %s' % to_native(e))
 
-        # If we are using SSH password authentication, write the password into
-        # the pipe we opened in _build_command.
-
-        if conn_password:
+        if password_mechanism == 'sshpass' and conn_password:
             os.close(self.sshpass_pipe[0])
             try:
                 os.write(self.sshpass_pipe[1], to_bytes(conn_password) + b'\n')
@@ -1179,10 +1254,15 @@ class Connection(ConnectionBase):
             p.stdout.close()
             p.stderr.close()
 
-        if self.get_option('host_key_checking'):
-            if cmd[0] == b"sshpass" and p.returncode == 6:
-                raise AnsibleError('Using a SSH password instead of a key is not possible because Host Key checking is enabled and sshpass does not support '
-                                   'this.  Please add this host\'s fingerprint to your known_hosts file to manage this host.')
+        conn_password = self.get_option('password') or self._play_context.password
+        hostkey_fail = any((
+            (cmd[0] == b"sshpass" and p.returncode == 6),
+            b"read_passphrase: can't open /dev/tty" in b_stderr,
+            b"Host key verification failed" in b_stderr,
+        ))
+        if password_mechanism and self.get_option('host_key_checking') and conn_password and hostkey_fail:
+            raise AnsibleError('Using a SSH password instead of a key is not possible because Host Key checking is enabled. '
+                               'Please add this host\'s fingerprint to your known_hosts file to manage this host.')
 
         controlpersisterror = b'Bad configuration option: ControlPersist' in b_stderr or b'unknown configuration option: ControlPersist' in b_stderr
         if p.returncode != 0 and controlpersisterror:

--- a/test/integration/targets/connection_ssh/aliases
+++ b/test/integration/targets/connection_ssh/aliases
@@ -1,3 +1,5 @@
 needs/ssh
 shippable/posix/group3
 needs/target/connection
+needs/target/setup_test_user
+setup/always/setup_passlib_controller  # required for setup_test_user

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -19,6 +19,7 @@ if command -v sshpass > /dev/null; then
         # that the flag gets passed to sshpass.
         timeout 5 ansible -m ping \
             -e ansible_connection=ssh \
+            -e ansible_ssh_password_mechanism=sshpass \
             -e ansible_sshpass_prompt=notThis: \
             -e ansible_password=foo \
             -e ansible_user=definitelynotroot \
@@ -34,6 +35,7 @@ if command -v sshpass > /dev/null; then
     else
         ansible -m ping \
             -e ansible_connection=ssh \
+            -e ansible_ssh_password_mechanism=sshpass \
             -e ansible_sshpass_prompt=notThis: \
             -e ansible_password=foo \
             -e ansible_user=definitelynotroot \
@@ -82,3 +84,5 @@ ANSIBLE_SSH_CONTROL_PATH='/tmp/ssh cp with spaces' ansible -m ping all -e ansibl
 
 # Test that timeout on waiting on become is an unreachable error
 ansible-playbook test_unreachable_become_timeout.yml "$@"
+
+ANSIBLE_ROLES_PATH=../ ansible-playbook "$@" -i ../../inventory test_ssh_askpass.yml

--- a/test/integration/targets/connection_ssh/test_ssh_askpass.yml
+++ b/test/integration/targets/connection_ssh/test_ssh_askpass.yml
@@ -1,0 +1,57 @@
+- hosts: all
+  tasks:
+    - import_role:
+        role: setup_test_user
+
+    # macos currently allows password auth, and macos/15.3 prevents restarting sshd
+    - when: ansible_facts.system != 'Darwin'
+      block:
+        - find:
+            paths: /etc/ssh
+            recurse: true
+            contains: 'PasswordAuthentication'
+          register: sshd_confs
+
+        - lineinfile:
+            path: '{{ item }}'
+            regexp: '^PasswordAuthentication'
+            line: PasswordAuthentication yes
+          loop: '{{ sshd_confs.files|default([{"path": "/etc/ssh/sshd_config"}], true)|map(attribute="path") }}'
+
+    - service:
+        name: ssh{{ '' if ansible_facts.os_family == 'Debian' else 'd' }}
+        state: restarted
+      when: ansible_facts.system != 'Darwin'
+
+    - command:
+        argv:
+          - ansible
+          - localhost
+          - -m
+          - command
+          - -a
+          - id
+          - -vvv
+          - -e
+          - ansible_pipelining=yes
+          - -e
+          - ansible_connection=ssh
+          - -e
+          - ansible_ssh_password_mechanism=ssh_askpass
+          - -e
+          - ansible_user={{ test_user_name }}
+          - -e
+          - ansible_password={{ test_user_plaintext_password }}
+      environment:
+        ANSIBLE_NOCOLOR: "1"
+        ANSIBLE_FORCE_COLOR: "0"
+      register: askpass_out
+
+    - debug:
+        var: askpass_out
+
+    - assert:
+        that:
+          - '"EXEC ssh " in askpass_out.stdout'
+          - '"sshpass" not in askpass_out.stdout'
+          - askpass_out.stdout is search('uid=\d+\(' ~ test_user_name ~ '\)')

--- a/test/integration/targets/setup_test_user/tasks/macosx.yml
+++ b/test/integration/targets/setup_test_user/tasks/macosx.yml
@@ -1,6 +1,8 @@
 - name: set variables
   set_fact:
     test_user_group: staff
+    test_user_groups:
+      - com.apple.access_ssh
 
 - name: set plaintext password
   no_log: yes


### PR DESCRIPTION
##### SUMMARY

Instead of attempting to match prompts, and respond to prompts with `sshpass`, which brings along some additional complexities, rely on `SSH_ASKPASS` to respond with passwords.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

**Why does this use shared memory and not a pipe for communication?**

OpenSSH almost immediately on invocation closes all FDs above stderr (2):

https://github.com/openssh/openssh-portable/blob/1bc426f51b0a5cfdcfbd205218f0b6839ffe91e9/ssh.c#L688-L692

This means, that regardless of having an inhertiable pipe, without `CLOEXEC` the FDs of the pipe are closed, and are thus unusable.

Additionally, through testing various mechanisms, such as named pipes, I determined the use of shared memory was more simplisitic, and pushed concerns into the Python SharedMemory implementation, instead of needing to roll many protections myself.

##### TO DO

- [x] The location of the `ssh_askpass.py` script currently causes a sanity failure because it has a shebang and is executable. There are some ideas and concerns to explore. Because we simply use `#!/usr/bin/env python3` in the script, it could attempt to execute on a python interpreter without `SharedMemory`.  However, `SSH_ASKPASS` must be a singular command, not a command with args, so we cannot execute `f'{sys.executable} -m ansible.ssh_askpass'`. This leaves us with another alternative of exposing as an entrypoint, although we could make it "private".
- [x] `sshpass` use in ansible has been around forever (Nov 2012) and obviously works in a set of broad scenarios. Will `SSH_ASKPASS` be as reliable?  Should we keep `sshpass` support, and allow it to be toggled back on?