### PR TITLE
Feature: galaxy install path support

### DIFF
--- a/changelogs/CHANGELOG-v2.16.rst
+++ b/changelogs/CHANGELOG-v2.16.rst
@@ -1,0 +1,287 @@
+=============================================
+ansible-core 2.16 "All My Love" Release Notes
+=============================================
+
+.. contents:: Topics
+
+
+v2.16.0b1
+=========
+
+Release Summary
+---------------
+
+| Release Date: 2023-09-26
+| `Porting Guide <https://docs.ansible.com/ansible-core/2.16/porting_guides/porting_guide_core_2.16.html>`__
+
+
+Minor Changes
+-------------
+
+- Add Python type hints to the Display class (https://github.com/ansible/ansible/issues/80841)
+- Add ``GALAXY_COLLECTIONS_PATH_WARNING`` option to disable the warning given by ``ansible-galaxy collection install`` when installing a collection to a path that isn't in the configured collection paths.
+- Add ``python3.12`` to the default ``INTERPRETER_PYTHON_FALLBACK`` list.
+- Add ``utcfromtimestamp`` and ``utcnow`` to ``ansible.module_utils.compat.datetime`` to return fixed offset datetime objects.
+- Add a general ``GALAXY_SERVER_TIMEOUT`` config option for distribution servers (https://github.com/ansible/ansible/issues/79833).
+- Added Python type annotation to connection plugins
+- CLI argument parsing - Automatically prepend to the help of CLI arguments that support being specified multiple times. (https://github.com/ansible/ansible/issues/22396)
+- DEFAULT_TRANSPORT now defaults to 'ssh', the old 'smart' option is being deprecated as versions of OpenSSH without control persist are basically not present anymore.
+- Documentation for set filters ``intersect``, ``difference``, ``symmetric_difference`` and ``union`` now states that the returned list items are in arbitrary order.
+- Record ``removal_date`` in runtime metadata as a string instead of a date.
+- Remove the ``CleansingNodeVisitor`` class and its usage due to the templating changes that made it superfluous. Also simplify the ``Conditional`` class.
+- Removed ``exclude`` and ``recursive-exclude`` commands for generated files from the ``MANIFEST.in`` file. These excludes were unnecessary since releases are expected to be built with a clean worktree.
+- Removed ``exclude`` commands for sanity test files from the ``MANIFEST.in`` file. These tests were previously excluded because they did not pass when run from an sdist. However, sanity tests are not expected to pass from an sdist, so excluding some (but not all) of the failing tests makes little sense.
+- Removed redundant ``include`` commands from the ``MANIFEST.in`` file. These includes either duplicated default behavior or another command.
+- The ``ansible-core`` sdist no longer contains pre-generated man pages. Instead, a ``packaging/cli-doc/build.py`` script is included in the sdist. This script can generate man pages and standalone RST documentation for ``ansible-core`` CLI programs.
+- The ``docs`` and ``examples`` directories are no longer included in the ``ansible-core`` sdist. These directories have been moved to the https://github.com/ansible/ansible-documentation repository.
+- The minimum required ``setuptools`` version is now 66.1.0, as it is the oldest version to support Python 3.12.
+- Update ``ansible_service_mgr`` fact to include init system for SMGL OS family
+- Use ``ansible.module_utils.common.text.converters`` instead of ``ansible.module_utils._text``.
+- Use ``importlib.resources.abc.TraversableResources`` instead of deprecated ``importlib.abc.TraversableResources`` where available (https:/github.com/ansible/ansible/pull/81082).
+- Use ``include`` where ``recursive-include`` is unnecessary in the ``MANIFEST.in`` file.
+- Use ``package_data`` instead of ``include_package_data`` for ``setup.cfg`` to avoid ``setuptools`` warnings.
+- Utilize gpg check provided internally by the ``transaction.run`` method as oppose to calling it manually.
+- ``Templar`` - do not add the ``dict`` constructor to ``globals`` as all required Jinja2 versions already do so
+- ansible-doc - allow to filter listing of collections and metadata dump by more than one collection (https://github.com/ansible/ansible/pull/81450).
+- ansible-galaxy - Add a plural option to improve ignoring multiple signature error status codes when installing or verifying collections. A space-separated list of error codes can follow --ignore-signature-status-codes in addition to specifying --ignore-signature-status-code multiple times (for example, ``--ignore-signature-status-codes NO_PUBKEY UNEXPECTED``).
+- ansible-galaxy - Remove internal configuration argument ``v3`` (https://github.com/ansible/ansible/pull/80721)
+- ansible-galaxy - add note to the collection dependency resolver error message about pre-releases if ``--pre`` was not provided (https://github.com/ansible/ansible/issues/80048).
+- ansible-galaxy - used to crash out with a "Errno 20 Not a directory" error when extracting files from a role when hitting a file with an illegal name (https://github.com/ansible/ansible/pull/81553). Now it gives a warning identifying the culprit file and the rule violation (e.g., ``my$class.jar`` has a ``$`` in the name) before crashing out, giving the user a chance to remove the invalid file and try again. (https://github.com/ansible/ansible/pull/81555).
+- ansible-test - Add Alpine 3.18 to remotes
+- ansible-test - Add Fedora 38 container.
+- ansible-test - Add Fedora 38 remote.
+- ansible-test - Add FreeBSD 13.2 remote.
+- ansible-test - Add new pylint checker for new ``# deprecated:`` comments within code to trigger errors when time to remove code that has no user facing deprecation message. Only supported in ansible-core, not collections.
+- ansible-test - Add support for RHEL 8.8 remotes.
+- ansible-test - Add support for RHEL 9.2 remotes.
+- ansible-test - Add support for testing with Python 3.12.
+- ansible-test - Allow float values for the ``--timeout`` option to the ``env`` command. This simplifies testing.
+- ansible-test - Enable ``thread`` code coverage in addition to the existing ``multiprocessing`` coverage.
+- ansible-test - RHEL 8.8 provisioning can now be used with the ``--python 3.11`` option.
+- ansible-test - RHEL 9.2 provisioning can now be used with the ``--python 3.11`` option.
+- ansible-test - Refactored ``env`` command logic and timeout handling.
+- ansible-test - Remove Fedora 37 remote support.
+- ansible-test - Remove Fedora 37 test container.
+- ansible-test - Remove Python 3.8 and 3.9 from RHEL 8.8.
+- ansible-test - Remove obsolete embedded script for configuring WinRM on Windows remotes.
+- ansible-test - Removed Ubuntu 20.04 LTS image from the `--remote` option.
+- ansible-test - Removed `freebsd/12.4` remote.
+- ansible-test - Removed `freebsd/13.1` remote.
+- ansible-test - Removed test remotes: rhel/8.7, rhel/9.1
+- ansible-test - Removed the deprecated ``--docker-no-pull`` option.
+- ansible-test - Removed the deprecated ``--no-pip-check`` option.
+- ansible-test - Removed the deprecated ``foreman`` test plugin.
+- ansible-test - Removed the deprecated ``govcsim`` support from the ``vcenter`` test plugin.
+- ansible-test - Replace the ``pytest-forked`` pytest plugin with a custom plugin.
+- ansible-test - The ``no-get-exception`` sanity test is now limited to plugins in collections. Previously any Python file in a collection was checked for ``get_exception`` usage.
+- ansible-test - The ``replace-urlopen`` sanity test is now limited to plugins in collections. Previously any Python file in a collection was checked for ``urlopen`` usage.
+- ansible-test - The ``use-compat-six`` sanity test is now limited to plugins in collections. Previously any Python file in a collection was checked for ``six`` usage.
+- ansible-test - The openSUSE test container has been updated to openSUSE Leap 15.5.
+- ansible-test - Update pip to ``23.1.2`` and setuptools to ``67.7.2``.
+- ansible-test - Update the ``default`` containers.
+- ansible-test - Update the ``nios-test-container`` to version 2.0.0, which supports API version 2.9.
+- ansible-test - Update the logic used to detect when ``ansible-test`` is running from source.
+- ansible-test - Updated the CloudStack test container to version 1.6.1.
+- ansible-test - Use ``datetime.datetime.now`` with ``tz`` specified instead of ``datetime.datetime.utcnow``.
+- ansible-test - Use a context manager to perform cleanup at exit instead of using the built-in ``atexit`` module.
+- ansible-test - remove Alpine 3.17 from remotes
+- ansible-test — Python 3.8–3.12 will use ``coverage`` v7.3.0.
+- ansible-test — ``coverage`` v6.5.0 is to be used only under Python 3.7.
+- ansible-vault create: Now raises an error when opening the editor without tty. The flag --skip-tty-check restores previous behaviour.
+- ansible_user_module - tweaked macos user defaults to reflect expected defaults (https://github.com/ansible/ansible/issues/44316)
+- apt - return calculated diff while running apt clean operation.
+- blockinfile - add append_newline and prepend_newline options (https://github.com/ansible/ansible/issues/80835).
+- cli - Added short option '-J' for asking for vault password (https://github.com/ansible/ansible/issues/80523).
+- command - Add option ``expand_argument_vars`` to disable argument expansion and use literal values - https://github.com/ansible/ansible/issues/54162
+- config lookup new option show_origin to also return the origin of a configuration value.
+- display methods for warning and deprecation are now proxied to main process when issued from a fork. This allows for the deduplication of warnings and deprecations to work globally.
+- dnf5 - enable environment groups installation testing in CI as its support was added.
+- dnf5 - enable now implemented ``cacheonly`` functionality
+- executor now skips persistent connection when it detects an action that does not require a connection.
+- find module - Add ability to filter based on modes
+- gather_facts now will use gather_timeout setting to limit parallel execution of modules that do not themselves use gather_timeout.
+- group - remove extraneous warning shown when user does not exist (https://github.com/ansible/ansible/issues/77049).
+- include_vars - os.walk now follows symbolic links when traversing directories (https://github.com/ansible/ansible/pull/80460)
+- module compression is now sourced directly via config, bypassing play_context possibly stale values.
+- reboot - show last error message in verbose logs (https://github.com/ansible/ansible/issues/81574).
+- service_facts now returns more info for rcctl managed systesm (OpenBSD).
+- tasks - the ``retries`` keyword can be specified without ``until`` in which case the task is retried until it succeeds but at most ``retries`` times (https://github.com/ansible/ansible/issues/20802)
+- user - add new option ``password_expire_warn`` (supported on Linux only) to set the number of days of warning before a password change is required (https://github.com/ansible/ansible/issues/79882).
+- yum_repository - Align module documentation with parameters
+
+Breaking Changes / Porting Guide
+--------------------------------
+
+- Any plugin using the config system and the `cli` entry to use the `timeout` from the command line, will see the value change if the use had configured it in any of the lower precedence methods. If relying on this behaviour to consume the global/generic timeout from the DEFAULT_TIMEOUT constant, please consult the documentation on plugin configuration to add the overlaping entries.
+- ansible-test - Test plugins that rely on containers no longer support reusing running containers. The previous behavior was an undocumented, untested feature.
+- service module will not permanently configure variables/flags for openbsd when doing enable/disable operation anymore, this module was never meant to do this type of work, just to manage the service state itself. A rcctl_config or similar module should be created and used instead.
+
+Deprecated Features
+-------------------
+
+- Deprecated ini config option ``collections_paths``, use the singular form ``collections_path`` instead
+- Deprecated the env var ``ANSIBLE_COLLECTIONS_PATHS``, use the singular form ``ANSIBLE_COLLECTIONS_PATH`` instead
+- Support for Windows Server 2012 and 2012 R2 has been removed as the support end of life from Microsoft is October 10th 2023. These versions of Windows will no longer be tested in this Ansible release and it cannot be guaranteed that they will continue to work going forward.
+- ``STRING_CONVERSION_ACTION`` config option is deprecated as it is no longer used in the Ansible Core code base.
+- the 'smart' option for setting a connection plugin is being removed as it's main purpose (choosing between ssh and paramiko) is now irrelevant.
+- vault and unfault filters - the undocumented ``vaultid`` parameter is deprecated and will be removed in ansible-core 2.20. Use ``vault_id`` instead.
+- yum_repository - deprecated parameter 'keepcache' (https://github.com/ansible/ansible/issues/78693).
+
+Removed Features (previously deprecated)
+----------------------------------------
+
+- ActionBase - remove deprecated ``_remote_checksum`` method
+- PlayIterator - remove deprecated ``cache_block_tasks`` and ``get_original_task`` methods
+- Remove deprecated ``FileLock`` class
+- Removed Python 3.9 as a supported version on the controller. Python 3.10 or newer is required.
+- Removed ``include`` which has been deprecated in Ansible 2.12. Use ``include_tasks`` or ``import_tasks`` instead.
+- ``Templar`` - remove deprecated ``shared_loader_obj`` parameter of ``__init__``
+- ``fetch_url`` - remove auto disabling ``decompress`` when gzip is not available
+- ``get_action_args_with_defaults`` - remove deprecated ``redirected_names`` method parameter
+- ansible-test - Removed support for the remote Windows targets 2012 and 2012-R2
+- inventory_cache - remove deprecated ``default.fact_caching_prefix`` ini configuration option, use ``defaults.fact_caching_prefix`` instead.
+- module_utils/basic.py - Removed Python 3.5 as a supported remote version. Python 2.7 or Python 3.6+ is now required.
+- stat - removed unused `get_md5` parameter.
+
+Bugfixes
+--------
+
+- Allow for searching handler subdir for included task via include_role (https://github.com/ansible/ansible/issues/81722)
+- AnsibleModule.run_command - Only use selectors when needed, and rely on Python stdlib subprocess for the simple task of collecting stdout/stderr when prompt matching is not required.
+- Display - Defensively configure writing to stdout and stderr with a custom encoding error handler that will replace invalid characters while providing a deprecation warning that non-utf8 text will result in an error in a future version.
+- Exclude internal options from man pages and docs.
+- Fix ``ansible-config init`` man page option indentation.
+- Fix ``ast`` deprecation warnings for ``Str`` and ``value.s`` when using Python 3.12.
+- Fix exceptions caused by various inputs when performing arg splitting or parsing key/value pairs. Resolves issue https://github.com/ansible/ansible/issues/46379 and issue https://github.com/ansible/ansible/issues/61497
+- Fix incorrect parsing of multi-line Jinja2 blocks when performing arg splitting or parsing key/value pairs.
+- Fix post-validating looped task fields so the strategy uses the correct values after task execution.
+- Fixed `pip` module failure in case of usage quotes for `virtualenv_command` option for the venv command. (https://github.com/ansible/ansible/issues/76372)
+- From issue https://github.com/ansible/ansible/issues/80880, when notifying a handler from another handler, handler notifications must be registered immediately as the flush_handler call is not recursive.
+- Import ``FILE_ATTRIBUTES`` from ``ansible.module_utils.common.file`` in ``ansible.module_utils.basic`` instead of defining it twice.
+- Inventory scripts parser not treat exception when getting hostsvar (https://github.com/ansible/ansible/issues/81103)
+- On Python 3 use datetime methods ``fromtimestamp`` and ``now`` with UTC timezone instead of ``utcfromtimestamp`` and ``utcnow``, which are deprecated in Python 3.12.
+- PluginLoader - fix Jinja plugin performance issues (https://github.com/ansible/ansible/issues/79652)
+- PowerShell - Remove some code which is no longer valid for dotnet 5+
+- Prevent running same handler multiple times when included via ``include_role`` (https://github.com/ansible/ansible/issues/73643)
+- Prompting - add a short sleep between polling for user input to reduce CPU consumption (https://github.com/ansible/ansible/issues/81516).
+- Properly disable ``jinja2_native`` in the template module when jinja2 override is used in the template (https://github.com/ansible/ansible/issues/80605)
+- Remove unreachable parser error for removed ``static`` parameter of ``include_role``
+- Replace uses of ``configparser.ConfigParser.readfp()`` which was removed in Python 3.12 with ``configparser.ConfigParser.read_file()`` (https://github.com/ansible/ansible/issues/81656)
+- Set filters ``intersect``, ``difference``, ``symmetric_difference`` and ``union`` now always return a ``list``, never a ``set``. Previously, a ``set`` would be returned if the inputs were a hashable type such as ``str``, instead of a collection, such as a ``list`` or ``tuple``.
+- Set filters ``intersect``, ``difference``, ``symmetric_difference`` and ``union`` now use set operations when the given items are hashable. Previously, list operations were performed unless the inputs were a hashable type such as ``str``, instead of a collection, such as a ``list`` or ``tuple``.
+- Switch result queue from a ``multiprocessing.queues.Queue` to ``multiprocessing.queues.SimpleQueue``, primarily to allow properly handling pickling errors, to prevent an infinite hang waiting for task results
+- The ``ansible-config init`` command now has a documentation description.
+- The ``ansible-galaxy collection download`` command now has a documentation description.
+- The ``ansible-galaxy collection install`` command documentation is now visible (previously hidden by a decorator).
+- The ``ansible-galaxy collection verify`` command now has a documentation description.
+- The ``ansible-galaxy role install`` command documentation is now visible (previously hidden by a decorator).
+- The ``ansible-inventory`` command command now has a documentation description (previously used as the epilog).
+- The ``hostname`` module now also updates both current and permanent hostname on OpenBSD. Before it only updated the permanent hostname (https://github.com/ansible/ansible/issues/80520).
+- Update module_utils.urls unit test to work with cryptography >= 41.0.0.
+- When generating man pages, use ``func`` to find the command function instead of looking it up by the command name.
+- ``StrategyBase._process_pending_results`` - create a ``Templar`` on demand for templating ``changed_when``/``failed_when``.
+- ``ansible-galaxy`` now considers all collection paths when identifying which collection requirements are already installed. Use the ``COLLECTIONS_PATHS`` and ``COLLECTIONS_SCAN_SYS_PATHS`` config options to modify these. Previously only the install path was considered when resolving the candidates. The install path will remain the only one potentially modified. (https://github.com/ansible/ansible/issues/79767, https://github.com/ansible/ansible/issues/81163)
+- ``ansible.module_utils.service`` - ensure binary data transmission in ``daemonize()``
+- ``ansible.module_utils.service`` - fix inter-process communication in ``daemonize()``
+- ``pkg_mgr`` - fix the default dnf version detection
+- ansiballz - Prevent issue where the time on the control host could change part way through building the ansiballz file, potentially causing a pre-1980 date to be used during ansiballz unpacking leading to a zip file error (https://github.com/ansible/ansible/issues/80089)
+- ansible terminal color settings were incorrectly limited to 16 options via 'choices', removing so all 256 can be accessed.
+- ansible-console - fix filtering by collection names when a collection search path was set (https://github.com/ansible/ansible/pull/81450).
+- ansible-galaxy - Enabled the ``data`` tarfile filter during role installation for Python versions that support it. A probing mechanism is used to avoid Python versions with a broken implementation.
+- ansible-galaxy - Fix issue installing collections containing directories with more than 100 characters on python versions before 3.10.6
+- ansible-galaxy - Fix variable type error when installing subdir collections (https://github.com/ansible/ansible/issues/80943)
+- ansible-galaxy - fix installing collections from directories that have a trailing path separator (https://github.com/ansible/ansible/issues/77803).
+- ansible-galaxy - fix installing signed collections (https://github.com/ansible/ansible/issues/80648).
+- ansible-galaxy - reduce API calls to servers by fetching signatures only for final candidates.
+- ansible-galaxy - started allowing the use of pre-releases for collections that do not have any stable versions published. (https://github.com/ansible/ansible/pull/81606)
+- ansible-galaxy - started allowing the use of pre-releases for dependencies on any level of the dependency tree that specifically demand exact pre-release versions of collections and not version ranges. (https://github.com/ansible/ansible/pull/81606)
+- ansible-galaxy collection verify - fix verifying signed collections when the keyring is not configured.
+- ansible-test - Add support for ``argcomplete`` version 3.
+- ansible-test - All containers created by ansible-test now include the current test session ID in their name. This avoids conflicts between concurrent ansible-test invocations using the same container host.
+- ansible-test - Always use ansible-test managed entry points for ansible-core CLI tools when not running from source. This fixes issues where CLI entry points created during install are not compatible with ansible-test.
+- ansible-test - Fix a traceback that occurs when attempting to test Ansible source using a different ansible-test. A clear error message is now given when this scenario occurs.
+- ansible-test - Fix handling of timeouts exceeding one day.
+- ansible-test - Fix several possible tracebacks when using the ``-e`` option with sanity tests.
+- ansible-test - Fix various cases where the test timeout could expire without terminating the tests.
+- ansible-test - Pre-build a PyYAML wheel before installing requirements to avoid a potential Cython build failure.
+- ansible-test - Remove redundant warning about missing programs before attempting to execute them.
+- ansible-test - The ``import`` sanity test now checks the collection loader for remote-only Python support when testing ansible-core.
+- ansible-test - Unit tests now report warnings generated during test runs. Previously only warnings generated during test collection were reported.
+- ansible-test - Update ``pylint`` to 2.17.2 to resolve several possible false positives.
+- ansible-test - Update ``pylint`` to 2.17.3 to resolve several possible false positives.
+- ansible-test - Use ``raise ... from ...`` when raising exceptions from within an exception handler.
+- ansible-test - When bootstrapping remote FreeBSD instances, use the OS packaged ``setuptools`` instead of installing the latest version from PyPI.
+- ansible-test local change detection - use ``git merge-base <branch> HEAD`` instead of ``git merge-base --fork-point <branch>`` (https://github.com/ansible/ansible/pull/79734).
+- ansible-vault - fail when the destination file location is not writable before performing encryption (https://github.com/ansible/ansible/issues/81455).
+- apt - ignore fail_on_autoremove and allow_downgrade parameters when using aptitude (https://github.com/ansible/ansible/issues/77868).
+- blockinfile - avoid crash with Python 3 if creating the directory fails when ``create=true`` (https://github.com/ansible/ansible/pull/81662).
+- connection timeouts defined in ansible.cfg will now be properly used, the --timeout cli option was obscuring them by always being set.
+- copy - print correct destination filename when using `content` and `--diff` (https://github.com/ansible/ansible/issues/79749).
+- copy unit tests - Fixing "dir all perms" documentation and formatting for easier reading.
+- core will now also look at the connection plugin to force 'local' interpreter for networking path compatibility as just ansible_network_os could be misleading.
+- deb822_repository - use http-agent for receiving content (https://github.com/ansible/ansible/issues/80809).
+- debconf - idempotency in questions with type 'password' (https://github.com/ansible/ansible/issues/47676).
+- distribution facts - fix Source Mage family mapping
+- dnf - fix a failure when a package from URI was specified and ``update_only`` was set (https://github.com/ansible/ansible/issues/81376).
+- dnf5 - Update dnf5 module to handle API change for setting the download directory (https://github.com/ansible/ansible/issues/80887)
+- dnf5 - Use ``transaction.check_gpg_signatures`` API call to check package signatures AND possibly to recover from when keys are missing.
+- dnf5 - fix module and package names in the message following failed module respawn attempt
+- dnf5 - use the logs API to determine transaction problems
+- dpkg_selections - check if the package exists before performing the selection operation (https://github.com/ansible/ansible/issues/81404).
+- encrypt - deprecate passlib_or_crypt API (https://github.com/ansible/ansible/issues/55839).
+- fetch - Handle unreachable errors properly (https://github.com/ansible/ansible/issues/27816)
+- file modules - Make symbolic modes with X use the computed permission, not original file (https://github.com/ansible/ansible/issues/80128)
+- file modules - fix validating invalid symbolic modes.
+- first found lookup has been updated to use the normalized argument parsing (pythonic) matching the documented examples.
+- first found lookup, fixed an issue with subsequent items clobbering information from previous ones.
+- first_found lookup now gets 'untemplated' loop entries and handles templating itself as task_executor was removing even 'templatable' entries and breaking functionality. https://github.com/ansible/ansible/issues/70772
+- galaxy - check if the target for symlink exists (https://github.com/ansible/ansible/pull/81586).
+- galaxy - cross check the collection type and collection source (https://github.com/ansible/ansible/issues/79463).
+- gather_facts parallel option was doing the reverse of what was stated, now it does run modules in parallel when True and serially when False.
+- handlers - fix ``v2_playbook_on_notify`` callback not being called when notifying handlers
+- handlers - the ``listen`` keyword can affect only one handler with the same name, the last one defined as it is a case with the ``notify`` keyword (https://github.com/ansible/ansible/issues/81013)
+- include_role - expose variables from parent roles to role's handlers (https://github.com/ansible/ansible/issues/80459)
+- inventory_ini - handle SyntaxWarning while parsing ini file in inventory (https://github.com/ansible/ansible/issues/81457).
+- iptables - remove default rule creation when creating iptables chain to be more similar to the command line utility (https://github.com/ansible/ansible/issues/80256).
+- lib/ansible/utils/encrypt.py - remove unused private ``_LOCK`` (https://github.com/ansible/ansible/issues/81613)
+- lookup/url.py - Fix incorrect var/env/ini entry for `force_basic_auth`
+- man page build - Remove the dependency on the ``docs`` directory for building man pages.
+- man page build - Sub commands of ``ansible-galaxy role`` and ``ansible-galaxy collection`` are now documented.
+- module responses - Ensure that module responses are utf-8 adhereing to JSON RFC and expectations of the core code.
+- module/role argument spec - validate the type for options that are None when the option is required or has a non-None default (https://github.com/ansible/ansible/issues/79656).
+- modules/user.py - Add check for valid directory when creating new user homedir (allows /dev/null as skeleton) (https://github.com/ansible/ansible/issues/75063)
+- paramiko_ssh, psrp, and ssh connection plugins - ensure that all values for options that should be strings are actually converted to strings (https://github.com/ansible/ansible/pull/81029).
+- password_hash - fix salt format for ``crypt``  (only used if ``passlib`` is not installed) for the ``bcrypt`` algorithm.
+- pep517 build backend - Copy symlinks when copying the source tree. This avoids tracebacks in various scenarios, such as when a venv is present in the source tree.
+- pep517 build backend - Use the documented ``import_module`` import from ``importlib``.
+- pip module - Update module to prefer use of the python ``packaging`` and ``importlib.metadata`` modules due to ``pkg_resources`` being deprecated (https://github.com/ansible/ansible/issues/80488)
+- pkg_mgr.py - Fix `ansible_pkg_mgr` incorrect in TencentOS Server Linux
+- pkg_mgr.py - Fix `ansible_pkg_mgr` is unknown in Kylin Linux (https://github.com/ansible/ansible/issues/81332)
+- powershell modules - Only set an rc of 1 if the PowerShell pipeline signaled an error occurred AND there are error records present. Previously it would do so only if the error signal was present without checking the error count.
+- replace - handle exception when bad escape character is provided in replace (https://github.com/ansible/ansible/issues/79364).
+- role deduplication - don't deduplicate before a role has had a task run for that particular host (https://github.com/ansible/ansible/issues/81486).
+- service module, does not permanently configure flags flags on Openbsd when enabling/disabling a service.
+- service module, enable/disable is not a exclusive action in checkmode anymore.
+- setup gather_timeout - Fix timeout in get_mounts_facts for linux.
+- setup module (fact gathering) will now try to be smarter about different versions of facter emitting error when --puppet flag is used w/o puppet.
+- syntax check - Limit ``--syntax-check`` to ``ansible-playbook`` only, as that is the only CLI affected by this argument (https://github.com/ansible/ansible/issues/80506)
+- tarfile - handle data filter deprecation warning message for extract and extractall (https://github.com/ansible/ansible/issues/80832).
+- template - Fix for formatting issues when a template path contains valid jinja/strftime pattern (especially line break one) and using the template path in ansible_managed (https://github.com/ansible/ansible/pull/79129)
+- templating - In the template action and lookup, use local jinja2 environment overlay overrides instead of mutating the templars environment
+- templating - prevent setting arbitrary attributes on Jinja2 environments via Jinja2 overrides in templates
+- templating escape and single var optimization now use correct delimiters when custom ones are provided either via task or template header.
+- unarchive - fix unarchiving sources that are copied to the remote node using a relative temporory directory path (https://github.com/ansible/ansible/issues/80710).
+- uri - fix search for JSON type to include complex strings containing '+'
+- urls.py - fixed cert_file and key_file parameters when running on Python 3.12 - https://github.com/ansible/ansible/issues/80490
+- user - set expiration value correctly when unable to retrieve the current value from the system (https://github.com/ansible/ansible/issues/71916)
+- validate-modules sanity test - replace semantic markup parsing and validating code with the code from `antsibull-docs-parser 0.2.0 <https://github.com/ansible-community/antsibull-docs-parser/releases/tag/0.2.0>`__ (https://github.com/ansible/ansible/pull/80406).
+- vars_prompt - internally convert the ``unsafe`` value to ``bool``
+- vault and unvault filters now properly take ``vault_id`` parameter.
+- win_fetch - Add support for using file with wildcards in file name. (https://github.com/ansible/ansible/issues/73128)
+
+Known Issues
+------------
+
+- ansible-galaxy - dies in the middle of installing a role when that role contains Java inner classes (files with $ in the file name).  This is by design, to exclude temporary or backup files. (https://github.com/ansible/ansible/pull/81553).
+- ansible-test - The ``pep8`` sanity test is unable to detect f-string spacing issues (E201, E202) on Python 3.10 and 3.11. They are correctly detected under Python 3.12. See (https://github.com/PyCQA/pycodestyle/issues/1190).
+- ansible-test - The ``pylint`` sanity test is not supported on Python 3.12. Use Python 3.10 or 3.11 instead.

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,2 +1,680 @@
-ancestor: 2.17.0
-releases: {}
+ancestor: 2.15.0
+releases:
+  2.16.0b1:
+    changes:
+      breaking_changes:
+      - Any plugin using the config system and the `cli` entry to use the `timeout`
+        from the command line, will see the value change if the use had configured
+        it in any of the lower precedence methods. If relying on this behaviour to
+        consume the global/generic timeout from the DEFAULT_TIMEOUT constant, please
+        consult the documentation on plugin configuration to add the overlaping entries.
+      - ansible-test - Test plugins that rely on containers no longer support reusing
+        running containers. The previous behavior was an undocumented, untested feature.
+      - service module will not permanently configure variables/flags for openbsd
+        when doing enable/disable operation anymore, this module was never meant to
+        do this type of work, just to manage the service state itself. A rcctl_config
+        or similar module should be created and used instead.
+      bugfixes:
+      - Allow for searching handler subdir for included task via include_role (https://github.com/ansible/ansible/issues/81722)
+      - AnsibleModule.run_command - Only use selectors when needed, and rely on Python
+        stdlib subprocess for the simple task of collecting stdout/stderr when prompt
+        matching is not required.
+      - Display - Defensively configure writing to stdout and stderr with a custom
+        encoding error handler that will replace invalid characters while providing
+        a deprecation warning that non-utf8 text will result in an error in a future
+        version.
+      - Exclude internal options from man pages and docs.
+      - Fix ``ansible-config init`` man page option indentation.
+      - Fix ``ast`` deprecation warnings for ``Str`` and ``value.s`` when using Python
+        3.12.
+      - Fix exceptions caused by various inputs when performing arg splitting or parsing
+        key/value pairs. Resolves issue https://github.com/ansible/ansible/issues/46379
+        and issue https://github.com/ansible/ansible/issues/61497
+      - Fix incorrect parsing of multi-line Jinja2 blocks when performing arg splitting
+        or parsing key/value pairs.
+      - Fix post-validating looped task fields so the strategy uses the correct values
+        after task execution.
+      - Fixed `pip` module failure in case of usage quotes for `virtualenv_command`
+        option for the venv command. (https://github.com/ansible/ansible/issues/76372)
+      - From issue https://github.com/ansible/ansible/issues/80880, when notifying
+        a handler from another handler, handler notifications must be registered immediately
+        as the flush_handler call is not recursive.
+      - Import ``FILE_ATTRIBUTES`` from ``ansible.module_utils.common.file`` in ``ansible.module_utils.basic``
+        instead of defining it twice.
+      - Inventory scripts parser not treat exception when getting hostsvar (https://github.com/ansible/ansible/issues/81103)
+      - On Python 3 use datetime methods ``fromtimestamp`` and ``now`` with UTC timezone
+        instead of ``utcfromtimestamp`` and ``utcnow``, which are deprecated in Python
+        3.12.
+      - PluginLoader - fix Jinja plugin performance issues (https://github.com/ansible/ansible/issues/79652)
+      - PowerShell - Remove some code which is no longer valid for dotnet 5+
+      - Prevent running same handler multiple times when included via ``include_role``
+        (https://github.com/ansible/ansible/issues/73643)
+      - Prompting - add a short sleep between polling for user input to reduce CPU
+        consumption (https://github.com/ansible/ansible/issues/81516).
+      - Properly disable ``jinja2_native`` in the template module when jinja2 override
+        is used in the template (https://github.com/ansible/ansible/issues/80605)
+      - Remove unreachable parser error for removed ``static`` parameter of ``include_role``
+      - Replace uses of ``configparser.ConfigParser.readfp()`` which was removed in
+        Python 3.12 with ``configparser.ConfigParser.read_file()`` (https://github.com/ansible/ansible/issues/81656)
+      - Set filters ``intersect``, ``difference``, ``symmetric_difference`` and ``union``
+        now always return a ``list``, never a ``set``. Previously, a ``set`` would
+        be returned if the inputs were a hashable type such as ``str``, instead of
+        a collection, such as a ``list`` or ``tuple``.
+      - Set filters ``intersect``, ``difference``, ``symmetric_difference`` and ``union``
+        now use set operations when the given items are hashable. Previously, list
+        operations were performed unless the inputs were a hashable type such as ``str``,
+        instead of a collection, such as a ``list`` or ``tuple``.
+      - Switch result queue from a ``multiprocessing.queues.Queue` to ``multiprocessing.queues.SimpleQueue``,
+        primarily to allow properly handling pickling errors, to prevent an infinite
+        hang waiting for task results
+      - The ``ansible-config init`` command now has a documentation description.
+      - The ``ansible-galaxy collection download`` command now has a documentation
+        description.
+      - The ``ansible-galaxy collection install`` command documentation is now visible
+        (previously hidden by a decorator).
+      - The ``ansible-galaxy collection verify`` command now has a documentation description.
+      - The ``ansible-galaxy role install`` command documentation is now visible (previously
+        hidden by a decorator).
+      - The ``ansible-inventory`` command command now has a documentation description
+        (previously used as the epilog).
+      - The ``hostname`` module now also updates both current and permanent hostname
+        on OpenBSD. Before it only updated the permanent hostname (https://github.com/ansible/ansible/issues/80520).
+      - Update module_utils.urls unit test to work with cryptography >= 41.0.0.
+      - When generating man pages, use ``func`` to find the command function instead
+        of looking it up by the command name.
+      - '``StrategyBase._process_pending_results`` - create a ``Templar`` on demand
+        for templating ``changed_when``/``failed_when``.'
+      - '``ansible-galaxy`` now considers all collection paths when identifying which
+        collection requirements are already installed. Use the ``COLLECTIONS_PATHS``
+        and ``COLLECTIONS_SCAN_SYS_PATHS`` config options to modify these. Previously
+        only the install path was considered when resolving the candidates. The install
+        path will remain the only one potentially modified. (https://github.com/ansible/ansible/issues/79767,
+        https://github.com/ansible/ansible/issues/81163)'
+      - '``ansible.module_utils.service`` - ensure binary data transmission in ``daemonize()``'
+      - '``ansible.module_utils.service`` - fix inter-process communication in ``daemonize()``'
+      - '``pkg_mgr`` - fix the default dnf version detection'
+      - ansiballz - Prevent issue where the time on the control host could change
+        part way through building the ansiballz file, potentially causing a pre-1980
+        date to be used during ansiballz unpacking leading to a zip file error (https://github.com/ansible/ansible/issues/80089)
+      - ansible terminal color settings were incorrectly limited to 16 options via
+        'choices', removing so all 256 can be accessed.
+      - ansible-console - fix filtering by collection names when a collection search
+        path was set (https://github.com/ansible/ansible/pull/81450).
+      - ansible-galaxy - Enabled the ``data`` tarfile filter during role installation
+        for Python versions that support it. A probing mechanism is used to avoid
+        Python versions with a broken implementation.
+      - ansible-galaxy - Fix issue installing collections containing directories with
+        more than 100 characters on python versions before 3.10.6
+      - ansible-galaxy - Fix variable type error when installing subdir collections
+        (https://github.com/ansible/ansible/issues/80943)
+      - ansible-galaxy - fix installing collections from directories that have a trailing
+        path separator (https://github.com/ansible/ansible/issues/77803).
+      - ansible-galaxy - fix installing signed collections (https://github.com/ansible/ansible/issues/80648).
+      - ansible-galaxy - reduce API calls to servers by fetching signatures only for
+        final candidates.
+      - ansible-galaxy - started allowing the use of pre-releases for collections
+        that do not have any stable versions published. (https://github.com/ansible/ansible/pull/81606)
+      - ansible-galaxy - started allowing the use of pre-releases for dependencies
+        on any level of the dependency tree that specifically demand exact pre-release
+        versions of collections and not version ranges. (https://github.com/ansible/ansible/pull/81606)
+      - ansible-galaxy collection verify - fix verifying signed collections when the
+        keyring is not configured.
+      - ansible-test - Add support for ``argcomplete`` version 3.
+      - ansible-test - All containers created by ansible-test now include the current
+        test session ID in their name. This avoids conflicts between concurrent ansible-test
+        invocations using the same container host.
+      - ansible-test - Always use ansible-test managed entry points for ansible-core
+        CLI tools when not running from source. This fixes issues where CLI entry
+        points created during install are not compatible with ansible-test.
+      - ansible-test - Fix a traceback that occurs when attempting to test Ansible
+        source using a different ansible-test. A clear error message is now given
+        when this scenario occurs.
+      - ansible-test - Fix handling of timeouts exceeding one day.
+      - ansible-test - Fix several possible tracebacks when using the ``-e`` option
+        with sanity tests.
+      - ansible-test - Fix various cases where the test timeout could expire without
+        terminating the tests.
+      - ansible-test - Pre-build a PyYAML wheel before installing requirements to
+        avoid a potential Cython build failure.
+      - ansible-test - Remove redundant warning about missing programs before attempting
+        to execute them.
+      - ansible-test - The ``import`` sanity test now checks the collection loader
+        for remote-only Python support when testing ansible-core.
+      - ansible-test - Unit tests now report warnings generated during test runs.
+        Previously only warnings generated during test collection were reported.
+      - ansible-test - Update ``pylint`` to 2.17.2 to resolve several possible false
+        positives.
+      - ansible-test - Update ``pylint`` to 2.17.3 to resolve several possible false
+        positives.
+      - ansible-test - Use ``raise ... from ...`` when raising exceptions from within
+        an exception handler.
+      - ansible-test - When bootstrapping remote FreeBSD instances, use the OS packaged
+        ``setuptools`` instead of installing the latest version from PyPI.
+      - ansible-test local change detection - use ``git merge-base <branch> HEAD``
+        instead of ``git merge-base --fork-point <branch>`` (https://github.com/ansible/ansible/pull/79734).
+      - ansible-vault - fail when the destination file location is not writable before
+        performing encryption (https://github.com/ansible/ansible/issues/81455).
+      - apt - ignore fail_on_autoremove and allow_downgrade parameters when using
+        aptitude (https://github.com/ansible/ansible/issues/77868).
+      - blockinfile - avoid crash with Python 3 if creating the directory fails when
+        ``create=true`` (https://github.com/ansible/ansible/pull/81662).
+      - connection timeouts defined in ansible.cfg will now be properly used, the
+        --timeout cli option was obscuring them by always being set.
+      - copy - print correct destination filename when using `content` and `--diff`
+        (https://github.com/ansible/ansible/issues/79749).
+      - copy unit tests - Fixing "dir all perms" documentation and formatting for
+        easier reading.
+      - core will now also look at the connection plugin to force 'local' interpreter
+        for networking path compatibility as just ansible_network_os could be misleading.
+      - deb822_repository - use http-agent for receiving content (https://github.com/ansible/ansible/issues/80809).
+      - debconf - idempotency in questions with type 'password' (https://github.com/ansible/ansible/issues/47676).
+      - distribution facts - fix Source Mage family mapping
+      - dnf - fix a failure when a package from URI was specified and ``update_only``
+        was set (https://github.com/ansible/ansible/issues/81376).
+      - dnf5 - Update dnf5 module to handle API change for setting the download directory
+        (https://github.com/ansible/ansible/issues/80887)
+      - dnf5 - Use ``transaction.check_gpg_signatures`` API call to check package
+        signatures AND possibly to recover from when keys are missing.
+      - dnf5 - fix module and package names in the message following failed module
+        respawn attempt
+      - dnf5 - use the logs API to determine transaction problems
+      - dpkg_selections - check if the package exists before performing the selection
+        operation (https://github.com/ansible/ansible/issues/81404).
+      - encrypt - deprecate passlib_or_crypt API (https://github.com/ansible/ansible/issues/55839).
+      - fetch - Handle unreachable errors properly (https://github.com/ansible/ansible/issues/27816)
+      - file modules - Make symbolic modes with X use the computed permission, not
+        original file (https://github.com/ansible/ansible/issues/80128)
+      - file modules - fix validating invalid symbolic modes.
+      - first found lookup has been updated to use the normalized argument parsing
+        (pythonic) matching the documented examples.
+      - first found lookup, fixed an issue with subsequent items clobbering information
+        from previous ones.
+      - first_found lookup now gets 'untemplated' loop entries and handles templating
+        itself as task_executor was removing even 'templatable' entries and breaking
+        functionality. https://github.com/ansible/ansible/issues/70772
+      - galaxy - check if the target for symlink exists (https://github.com/ansible/ansible/pull/81586).
+      - galaxy - cross check the collection type and collection source (https://github.com/ansible/ansible/issues/79463).
+      - gather_facts parallel option was doing the reverse of what was stated, now
+        it does run modules in parallel when True and serially when False.
+      - handlers - fix ``v2_playbook_on_notify`` callback not being called when notifying
+        handlers
+      - handlers - the ``listen`` keyword can affect only one handler with the same
+        name, the last one defined as it is a case with the ``notify`` keyword (https://github.com/ansible/ansible/issues/81013)
+      - include_role - expose variables from parent roles to role's handlers (https://github.com/ansible/ansible/issues/80459)
+      - inventory_ini - handle SyntaxWarning while parsing ini file in inventory (https://github.com/ansible/ansible/issues/81457).
+      - iptables - remove default rule creation when creating iptables chain to be
+        more similar to the command line utility (https://github.com/ansible/ansible/issues/80256).
+      - lib/ansible/utils/encrypt.py - remove unused private ``_LOCK`` (https://github.com/ansible/ansible/issues/81613)
+      - lookup/url.py - Fix incorrect var/env/ini entry for `force_basic_auth`
+      - man page build - Remove the dependency on the ``docs`` directory for building
+        man pages.
+      - man page build - Sub commands of ``ansible-galaxy role`` and ``ansible-galaxy
+        collection`` are now documented.
+      - module responses - Ensure that module responses are utf-8 adhereing to JSON
+        RFC and expectations of the core code.
+      - module/role argument spec - validate the type for options that are None when
+        the option is required or has a non-None default (https://github.com/ansible/ansible/issues/79656).
+      - modules/user.py - Add check for valid directory when creating new user homedir
+        (allows /dev/null as skeleton) (https://github.com/ansible/ansible/issues/75063)
+      - paramiko_ssh, psrp, and ssh connection plugins - ensure that all values for
+        options that should be strings are actually converted to strings (https://github.com/ansible/ansible/pull/81029).
+      - password_hash - fix salt format for ``crypt``  (only used if ``passlib`` is
+        not installed) for the ``bcrypt`` algorithm.
+      - pep517 build backend - Copy symlinks when copying the source tree. This avoids
+        tracebacks in various scenarios, such as when a venv is present in the source
+        tree.
+      - pep517 build backend - Use the documented ``import_module`` import from ``importlib``.
+      - pip module - Update module to prefer use of the python ``packaging`` and ``importlib.metadata``
+        modules due to ``pkg_resources`` being deprecated (https://github.com/ansible/ansible/issues/80488)
+      - pkg_mgr.py - Fix `ansible_pkg_mgr` incorrect in TencentOS Server Linux
+      - pkg_mgr.py - Fix `ansible_pkg_mgr` is unknown in Kylin Linux (https://github.com/ansible/ansible/issues/81332)
+      - powershell modules - Only set an rc of 1 if the PowerShell pipeline signaled
+        an error occurred AND there are error records present. Previously it would
+        do so only if the error signal was present without checking the error count.
+      - replace - handle exception when bad escape character is provided in replace
+        (https://github.com/ansible/ansible/issues/79364).
+      - role deduplication - don't deduplicate before a role has had a task run for
+        that particular host (https://github.com/ansible/ansible/issues/81486).
+      - service module, does not permanently configure flags flags on Openbsd when
+        enabling/disabling a service.
+      - service module, enable/disable is not a exclusive action in checkmode anymore.
+      - setup gather_timeout - Fix timeout in get_mounts_facts for linux.
+      - setup module (fact gathering) will now try to be smarter about different versions
+        of facter emitting error when --puppet flag is used w/o puppet.
+      - syntax check - Limit ``--syntax-check`` to ``ansible-playbook`` only, as that
+        is the only CLI affected by this argument (https://github.com/ansible/ansible/issues/80506)
+      - tarfile - handle data filter deprecation warning message for extract and extractall
+        (https://github.com/ansible/ansible/issues/80832).
+      - template - Fix for formatting issues when a template path contains valid jinja/strftime
+        pattern (especially line break one) and using the template path in ansible_managed
+        (https://github.com/ansible/ansible/pull/79129)
+      - templating - In the template action and lookup, use local jinja2 environment
+        overlay overrides instead of mutating the templars environment
+      - templating - prevent setting arbitrary attributes on Jinja2 environments via
+        Jinja2 overrides in templates
+      - templating escape and single var optimization now use correct delimiters when
+        custom ones are provided either via task or template header.
+      - unarchive - fix unarchiving sources that are copied to the remote node using
+        a relative temporory directory path (https://github.com/ansible/ansible/issues/80710).
+      - uri - fix search for JSON type to include complex strings containing '+'
+      - urls.py - fixed cert_file and key_file parameters when running on Python 3.12
+        - https://github.com/ansible/ansible/issues/80490
+      - user - set expiration value correctly when unable to retrieve the current
+        value from the system (https://github.com/ansible/ansible/issues/71916)
+      - validate-modules sanity test - replace semantic markup parsing and validating
+        code with the code from `antsibull-docs-parser 0.2.0 <https://github.com/ansible-community/antsibull-docs-parser/releases/tag/0.2.0>`__
+        (https://github.com/ansible/ansible/pull/80406).
+      - vars_prompt - internally convert the ``unsafe`` value to ``bool``
+      - vault and unvault filters now properly take ``vault_id`` parameter.
+      - win_fetch - Add support for using file with wildcards in file name. (https://github.com/ansible/ansible/issues/73128)
+      deprecated_features:
+      - Deprecated ini config option ``collections_paths``, use the singular form
+        ``collections_path`` instead
+      - Deprecated the env var ``ANSIBLE_COLLECTIONS_PATHS``, use the singular form
+        ``ANSIBLE_COLLECTIONS_PATH`` instead
+      - Support for Windows Server 2012 and 2012 R2 has been removed as the support
+        end of life from Microsoft is October 10th 2023. These versions of Windows
+        will no longer be tested in this Ansible release and it cannot be guaranteed
+        that they will continue to work going forward.
+      - '``STRING_CONVERSION_ACTION`` config option is deprecated as it is no longer
+        used in the Ansible Core code base.'
+      - the 'smart' option for setting a connection plugin is being removed as it's
+        main purpose (choosing between ssh and paramiko) is now irrelevant.
+      - vault and unfault filters - the undocumented ``vaultid`` parameter is deprecated
+        and will be removed in ansible-core 2.20. Use ``vault_id`` instead.
+      - yum_repository - deprecated parameter 'keepcache' (https://github.com/ansible/ansible/issues/78693).
+      known_issues:
+      - ansible-galaxy - dies in the middle of installing a role when that role contains
+        Java inner classes (files with $ in the file name).  This is by design, to
+        exclude temporary or backup files. (https://github.com/ansible/ansible/pull/81553).
+      - ansible-test - The ``pep8`` sanity test is unable to detect f-string spacing
+        issues (E201, E202) on Python 3.10 and 3.11. They are correctly detected under
+        Python 3.12. See (https://github.com/PyCQA/pycodestyle/issues/1190).
+      - ansible-test - The ``pylint`` sanity test is not supported on Python 3.12.
+        Use Python 3.10 or 3.11 instead.
+      minor_changes:
+      - Add Python type hints to the Display class (https://github.com/ansible/ansible/issues/80841)
+      - Add ``GALAXY_COLLECTIONS_PATH_WARNING`` option to disable the warning given
+        by ``ansible-galaxy collection install`` when installing a collection to a
+        path that isn't in the configured collection paths.
+      - Add ``python3.12`` to the default ``INTERPRETER_PYTHON_FALLBACK`` list.
+      - Add ``utcfromtimestamp`` and ``utcnow`` to ``ansible.module_utils.compat.datetime``
+        to return fixed offset datetime objects.
+      - Add a general ``GALAXY_SERVER_TIMEOUT`` config option for distribution servers
+        (https://github.com/ansible/ansible/issues/79833).
+      - Added Python type annotation to connection plugins
+      - CLI argument parsing - Automatically prepend to the help of CLI arguments
+        that support being specified multiple times. (https://github.com/ansible/ansible/issues/22396)
+      - DEFAULT_TRANSPORT now defaults to 'ssh', the old 'smart' option is being deprecated
+        as versions of OpenSSH without control persist are basically not present anymore.
+      - Documentation for set filters ``intersect``, ``difference``, ``symmetric_difference``
+        and ``union`` now states that the returned list items are in arbitrary order.
+      - Record ``removal_date`` in runtime metadata as a string instead of a date.
+      - Remove the ``CleansingNodeVisitor`` class and its usage due to the templating
+        changes that made it superfluous. Also simplify the ``Conditional`` class.
+      - Removed ``exclude`` and ``recursive-exclude`` commands for generated files
+        from the ``MANIFEST.in`` file. These excludes were unnecessary since releases
+        are expected to be built with a clean worktree.
+      - Removed ``exclude`` commands for sanity test files from the ``MANIFEST.in``
+        file. These tests were previously excluded because they did not pass when
+        run from an sdist. However, sanity tests are not expected to pass from an
+        sdist, so excluding some (but not all) of the failing tests makes little sense.
+      - Removed redundant ``include`` commands from the ``MANIFEST.in`` file. These
+        includes either duplicated default behavior or another command.
+      - The ``ansible-core`` sdist no longer contains pre-generated man pages. Instead,
+        a ``packaging/cli-doc/build.py`` script is included in the sdist. This script
+        can generate man pages and standalone RST documentation for ``ansible-core``
+        CLI programs.
+      - The ``docs`` and ``examples`` directories are no longer included in the ``ansible-core``
+        sdist. These directories have been moved to the https://github.com/ansible/ansible-documentation
+        repository.
+      - The minimum required ``setuptools`` version is now 66.1.0, as it is the oldest
+        version to support Python 3.12.
+      - Update ``ansible_service_mgr`` fact to include init system for SMGL OS family
+      - Use ``ansible.module_utils.common.text.converters`` instead of ``ansible.module_utils._text``.
+      - Use ``importlib.resources.abc.TraversableResources`` instead of deprecated
+        ``importlib.abc.TraversableResources`` where available (https:/github.com/ansible/ansible/pull/81082).
+      - Use ``include`` where ``recursive-include`` is unnecessary in the ``MANIFEST.in``
+        file.
+      - Use ``package_data`` instead of ``include_package_data`` for ``setup.cfg``
+        to avoid ``setuptools`` warnings.
+      - Utilize gpg check provided internally by the ``transaction.run`` method as
+        oppose to calling it manually.
+      - '``Templar`` - do not add the ``dict`` constructor to ``globals`` as all required
+        Jinja2 versions already do so'
+      - ansible-doc - allow to filter listing of collections and metadata dump by
+        more than one collection (https://github.com/ansible/ansible/pull/81450).
+      - ansible-galaxy - Add a plural option to improve ignoring multiple signature
+        error status codes when installing or verifying collections. A space-separated
+        list of error codes can follow --ignore-signature-status-codes in addition
+        to specifying --ignore-signature-status-code multiple times (for example,
+        ``--ignore-signature-status-codes NO_PUBKEY UNEXPECTED``).
+      - ansible-galaxy - Remove internal configuration argument ``v3`` (https://github.com/ansible/ansible/pull/80721)
+      - ansible-galaxy - add note to the collection dependency resolver error message
+        about pre-releases if ``--pre`` was not provided (https://github.com/ansible/ansible/issues/80048).
+      - ansible-galaxy - used to crash out with a "Errno 20 Not a directory" error
+        when extracting files from a role when hitting a file with an illegal name
+        (https://github.com/ansible/ansible/pull/81553). Now it gives a warning identifying
+        the culprit file and the rule violation (e.g., ``my$class.jar`` has a ``$``
+        in the name) before crashing out, giving the user a chance to remove the invalid
+        file and try again. (https://github.com/ansible/ansible/pull/81555).
+      - ansible-test - Add Alpine 3.18 to remotes
+      - ansible-test - Add Fedora 38 container.
+      - ansible-test - Add Fedora 38 remote.
+      - ansible-test - Add FreeBSD 13.2 remote.
+      - ansible-test - Add new pylint checker for new ``# deprecated:`` comments within
+        code to trigger errors when time to remove code that has no user facing deprecation
+        message. Only supported in ansible-core, not collections.
+      - ansible-test - Add support for RHEL 8.8 remotes.
+      - ansible-test - Add support for RHEL 9.2 remotes.
+      - ansible-test - Add support for testing with Python 3.12.
+      - ansible-test - Allow float values for the ``--timeout`` option to the ``env``
+        command. This simplifies testing.
+      - ansible-test - Enable ``thread`` code coverage in addition to the existing
+        ``multiprocessing`` coverage.
+      - ansible-test - RHEL 8.8 provisioning can now be used with the ``--python 3.11``
+        option.
+      - ansible-test - RHEL 9.2 provisioning can now be used with the ``--python 3.11``
+        option.
+      - ansible-test - Refactored ``env`` command logic and timeout handling.
+      - ansible-test - Remove Fedora 37 remote support.
+      - ansible-test - Remove Fedora 37 test container.
+      - ansible-test - Remove Python 3.8 and 3.9 from RHEL 8.8.
+      - ansible-test - Remove obsolete embedded script for configuring WinRM on Windows
+        remotes.
+      - ansible-test - Removed Ubuntu 20.04 LTS image from the `--remote` option.
+      - ansible-test - Removed `freebsd/12.4` remote.
+      - ansible-test - Removed `freebsd/13.1` remote.
+      - 'ansible-test - Removed test remotes: rhel/8.7, rhel/9.1'
+      - ansible-test - Removed the deprecated ``--docker-no-pull`` option.
+      - ansible-test - Removed the deprecated ``--no-pip-check`` option.
+      - ansible-test - Removed the deprecated ``foreman`` test plugin.
+      - ansible-test - Removed the deprecated ``govcsim`` support from the ``vcenter``
+        test plugin.
+      - ansible-test - Replace the ``pytest-forked`` pytest plugin with a custom plugin.
+      - ansible-test - The ``no-get-exception`` sanity test is now limited to plugins
+        in collections. Previously any Python file in a collection was checked for
+        ``get_exception`` usage.
+      - ansible-test - The ``replace-urlopen`` sanity test is now limited to plugins
+        in collections. Previously any Python file in a collection was checked for
+        ``urlopen`` usage.
+      - ansible-test - The ``use-compat-six`` sanity test is now limited to plugins
+        in collections. Previously any Python file in a collection was checked for
+        ``six`` usage.
+      - ansible-test - The openSUSE test container has been updated to openSUSE Leap
+        15.5.
+      - ansible-test - Update pip to ``23.1.2`` and setuptools to ``67.7.2``.
+      - ansible-test - Update the ``default`` containers.
+      - ansible-test - Update the ``nios-test-container`` to version 2.0.0, which
+        supports API version 2.9.
+      - ansible-test - Update the logic used to detect when ``ansible-test`` is running
+        from source.
+      - ansible-test - Updated the CloudStack test container to version 1.6.1.
+      - ansible-test - Use ``datetime.datetime.now`` with ``tz`` specified instead
+        of ``datetime.datetime.utcnow``.
+      - ansible-test - Use a context manager to perform cleanup at exit instead of
+        using the built-in ``atexit`` module.
+      - ansible-test - remove Alpine 3.17 from remotes
+      - "ansible-test \u2014 Python 3.8\u20133.12 will use ``coverage`` v7.3.0."
+      - "ansible-test \u2014 ``coverage`` v6.5.0 is to be used only under Python 3.7."
+      - 'ansible-vault create: Now raises an error when opening the editor without
+        tty. The flag --skip-tty-check restores previous behaviour.'
+      - ansible_user_module - tweaked macos user defaults to reflect expected defaults
+        (https://github.com/ansible/ansible/issues/44316)
+      - apt - return calculated diff while running apt clean operation.
+      - blockinfile - add append_newline and prepend_newline options (https://github.com/ansible/ansible/issues/80835).
+      - cli - Added short option '-J' for asking for vault password (https://github.com/ansible/ansible/issues/80523).
+      - command - Add option ``expand_argument_vars`` to disable argument expansion
+        and use literal values - https://github.com/ansible/ansible/issues/54162
+      - config lookup new option show_origin to also return the origin of a configuration
+        value.
+      - display methods for warning and deprecation are now proxied to main process
+        when issued from a fork. This allows for the deduplication of warnings and
+        deprecations to work globally.
+      - dnf5 - enable environment groups installation testing in CI as its support
+        was added.
+      - dnf5 - enable now implemented ``cacheonly`` functionality
+      - executor now skips persistent connection when it detects an action that does
+        not require a connection.
+      - find module - Add ability to filter based on modes
+      - gather_facts now will use gather_timeout setting to limit parallel execution
+        of modules that do not themselves use gather_timeout.
+      - group - remove extraneous warning shown when user does not exist (https://github.com/ansible/ansible/issues/77049).
+      - include_vars - os.walk now follows symbolic links when traversing directories
+        (https://github.com/ansible/ansible/pull/80460)
+      - module compression is now sourced directly via config, bypassing play_context
+        possibly stale values.
+      - reboot - show last error message in verbose logs (https://github.com/ansible/ansible/issues/81574).
+      - service_facts now returns more info for rcctl managed systesm (OpenBSD).
+      - tasks - the ``retries`` keyword can be specified without ``until`` in which
+        case the task is retried until it succeeds but at most ``retries`` times (https://github.com/ansible/ansible/issues/20802)
+      - user - add new option ``password_expire_warn`` (supported on Linux only) to
+        set the number of days of warning before a password change is required (https://github.com/ansible/ansible/issues/79882).
+      - yum_repository - Align module documentation with parameters
+      release_summary: '| Release Date: 2023-09-26
+
+        | `Porting Guide <https://docs.ansible.com/ansible-core/2.16/porting_guides/porting_guide_core_2.16.html>`__
+
+        '
+      removed_features:
+      - ActionBase - remove deprecated ``_remote_checksum`` method
+      - PlayIterator - remove deprecated ``cache_block_tasks`` and ``get_original_task``
+        methods
+      - Remove deprecated ``FileLock`` class
+      - Removed Python 3.9 as a supported version on the controller. Python 3.10 or
+        newer is required.
+      - Removed ``include`` which has been deprecated in Ansible 2.12. Use ``include_tasks``
+        or ``import_tasks`` instead.
+      - '``Templar`` - remove deprecated ``shared_loader_obj`` parameter of ``__init__``'
+      - '``fetch_url`` - remove auto disabling ``decompress`` when gzip is not available'
+      - '``get_action_args_with_defaults`` - remove deprecated ``redirected_names``
+        method parameter'
+      - ansible-test - Removed support for the remote Windows targets 2012 and 2012-R2
+      - inventory_cache - remove deprecated ``default.fact_caching_prefix`` ini configuration
+        option, use ``defaults.fact_caching_prefix`` instead.
+      - module_utils/basic.py - Removed Python 3.5 as a supported remote version.
+        Python 2.7 or Python 3.6+ is now required.
+      - stat - removed unused `get_md5` parameter.
+    codename: All My Love
+    fragments:
+    - 2.16.0b1_summary.yaml
+    - 20802-until-default.yml
+    - 22396-indicate-which-args-are-multi.yml
+    - 27816-fetch-unreachable.yml
+    - 50603-tty-check.yaml
+    - 71916-user-expires-int.yml
+    - 73643-handlers-prevent-multiple-runs.yml
+    - 74723-support-wildcard-win_fetch.yml
+    - 75063-allow-dev-nul-as-skeleton-for-new-homedir.yml
+    - 76372-fix-pip-virtualenv-command-parsing.yml
+    - 78487-galaxy-collections-path-warnings.yml
+    - 79129-ansible-managed-filename-format.yaml
+    - 79364_replace.yml
+    - 79677-fix-argspec-type-check.yml
+    - 79734-ansible-test-change-detection.yml
+    - 79844-fix-timeout-mounts-linux.yml
+    - 79999-ansible-user-tweak-macos-defaults.yaml
+    - 80089-prevent-module-build-date-issue.yml
+    - 80128-symbolic-modes-X-use-computed.yml
+    - 80257-iptables-chain-creation-does-not-populate-a-rule.yml
+    - 80258-defensive-display-non-utf8.yml
+    - 80334-reduce-ansible-galaxy-api-calls.yml
+    - 80406-validate-modules-semantic-markup.yml
+    - 80449-fix-symbolic-mode-error-msg.yml
+    - 80459-handlers-nested-includes-vars.yml
+    - 80460-add-symbolic-links-with-dir.yml
+    - 80476-fix-loop-task-post-validation.yml
+    - 80488-pip-pkg-resources.yml
+    - 80506-syntax-check-playbook-only.yml
+    - 80520-fix-current-hostname-openbsd.yml
+    - 80523_-_adding_short_option_for_--ask-vault-pass.yml
+    - 80605-template-overlay-native-jinja.yml
+    - 80648-fix-ansible-galaxy-cache-signatures-bug.yml
+    - 80721-ansible-galaxy.yml
+    - 80738-abs-unarachive-src.yml
+    - 80841-display-type-annotation.yml
+    - 80880-register-handlers-immediately-if-iterating-handlers.yml
+    - 80887-dnf5-api-change.yml
+    - 80943-ansible-galaxy-collection-subdir-install.yml
+    - 80968-replace-deprecated-ast-attr.yml
+    - 80985-fix-smgl-family-mapping.yml
+    - 81005-use-overlay-overrides.yml
+    - 81013-handlers-listen-last-defined-only.yml
+    - 81029-connection-types.yml
+    - 81064-daemonize-fixes.yml
+    - 81082-deprecated-importlib-abc.yml
+    - 81083-add-blockinfile-append-and-prepend-new-line-options.yml
+    - 81104-inventory-script-plugin-raise-execution-error.yml
+    - 81319-cloudstack-test-container-bump-version.yml
+    - 81332-fix-pkg-mgr-in-kylin.yml
+    - 81450-list-filters.yml
+    - 81494-remove-duplicated-file-attribute-constant.yml
+    - 81555-add-warning-for-illegal-filenames-in-roles.yaml
+    - 81584-daemonize-follow-up-fixes.yml
+    - 81606-ansible-galaxy-collection-pre-releases.yml
+    - 81613-remove-unusued-private-lock.yml
+    - 81656-cf_readfp-deprecated.yml
+    - 81662-blockinfile-exc.yml
+    - 81722-handler-subdir-include_tasks.yml
+    - CleansingNodeVisitor-removal.yml
+    - a-g-col-install-directory-with-trailing-sep.yml
+    - a-g-col-prevent-reinstalling-satisfied-req.yml
+    - a_test_rmv_alpine_317.yml
+    - add-missing-cli-docs.yml
+    - ag-ignore-multiple-signature-statuses.yml
+    - ansible-galaxy-server-timeout.yml
+    - ansible-runtime-metadata-removal-date.yml
+    - ansible-test-added-fedora-38.yml
+    - ansible-test-argcomplete-3.yml
+    - ansible-test-atexit.yml
+    - ansible-test-coverage-update.yml
+    - ansible-test-default-containers.yml
+    - ansible-test-deprecated-cleanup.yml
+    - ansible-test-distro-containers.yml
+    - ansible-test-entry-points.yml
+    - ansible-test-explain-traceback.yml
+    - ansible-test-fedora-37.yml
+    - ansible-test-freebsd-bootstrap-setuptools.yml
+    - ansible-test-import-sanity-fix.yml
+    - ansible-test-layout-detection.yml
+    - ansible-test-long-timeout-fix.yml
+    - ansible-test-minimum-setuptools.yml
+    - ansible-test-nios-container.yml
+    - ansible-test-pylint-python-3.12.yml
+    - ansible-test-pylint-update.yml
+    - ansible-test-pytest-forked.yml
+    - ansible-test-python-3.12.yml
+    - ansible-test-pyyaml-build.yml
+    - ansible-test-remove-old-rhel-remotes.yml
+    - ansible-test-remove-ubuntu-2004.yml
+    - ansible-test-rhel-9.2-python-3.11.yml
+    - ansible-test-rhel-9.2.yml
+    - ansible-test-sanity-scope.yml
+    - ansible-test-source-detection.yml
+    - ansible-test-thread-coverage.yml
+    - ansible-test-timeout-fix.yml
+    - ansible-test-unique-container-names.yml
+    - ansible-test-use-raise-from.yml
+    - ansible-test-utcnow.yml
+    - ansible-test-winrm-config.yml
+    - ansible-vault.yml
+    - ansible_test_alpine_3.18.yml
+    - apt_fail_on_autoremove.yml
+    - aptclean_diff.yml
+    - basestrategy-lazy-templar.yml
+    - ci_freebsd_new.yml
+    - collections_paths-deprecation.yml
+    - colors.yml
+    - command-expand-args.yml
+    - config_origins_option.yml
+    - connection-type-annotation.yml
+    - copy_diff.yml
+    - deb822_open_url.yml
+    - debconf.yml
+    - deprecated_string_conversion_action.yml
+    - display_proxy.yml
+    - dnf-update-only-latest.yml
+    - dnf5-cacheonly.yml
+    - dnf5-fix-interpreter-fail-msg.yml
+    - dnf5-gpg-check-api.yml
+    - dnf5-gpg-check-builtin.yml
+    - dnf5-logs-api.yml
+    - dnf5-test-env-groups.yml
+    - dotnet-preparation.yml
+    - dpkg_selections.yml
+    - fbsd13_1_remove.yml
+    - fetch_url-remove-auto-disable-decompress.yml
+    - find-mode.yml
+    - first_found_fixes.yml
+    - first_found_template_fix.yml
+    - fix-display-prompt-cpu-consumption.yml
+    - fix-handlers-callback.yml
+    - fix-pkg-mgr-in-TencentOS.yml
+    - fix-setuptools-warnings.yml
+    - fix-url-lookup-plugin-docs.yml
+    - forced_local+fix+.yml
+    - freebsd_12_4_removal.yml
+    - galaxy_check_type.yml
+    - galaxy_symlink.yml
+    - gather_facts_fix_parallel.yml
+    - get_action_args_with_defaults-remove-deprecated-arg.yml
+    - group_warning.yml
+    - inventory_cache-remove-deprecated-default-section.yml
+    - inventory_ini.yml
+    - jinja_plugin_cache_cleanup.yml
+    - long-collection-paths-fix.yml
+    - man-page-build-docs-dependency.yml
+    - man-page-subcommands.yml
+    - manifest-in-cleanup.yml
+    - mc_from_config.yml
+    - missing-doc-func.yml
+    - no-arbitrary-j2-override.yml
+    - omit-man-pages-from-sdist.yml
+    - parsing-splitter-fixes.yml
+    - passlib_or_crypt.yml
+    - password_hash-fix-crypt-salt-bcrypt.yml
+    - pep517-backend-import-fix.yml
+    - pep517-backend-traceback-fix.yml
+    - pep8-known-issue.yml
+    - persist_skip.yml
+    - pkg_mgr-default-dnf.yml
+    - powershell-module-error-handling.yml
+    - pre-release-hint-for-dep-resolution-error.yml
+    - pylint-deprecated-comment-checker.yml
+    - reboot.yml
+    - remove-deprecated-actionbase-_remote_checksum.yml
+    - remove-deprecated-datetime-methods.yml
+    - remove-deprecated-filelock-class.yml
+    - remove-docs-examples.yml
+    - remove-include.yml
+    - remove-play_iterator-deprecated-methods.yml
+    - remove-python3.5.yml
+    - remove-python3.9-controller-support.yml
+    - remove-templar-shared_loader_obj-arg.yml
+    - remove-unreachable-include_role-static-err.yml
+    - remove_md5.yml
+    - role-deduplication-condition.yml
+    - run-command-selectors-prompt-only.yml
+    - server2012-deprecation.yml
+    - service_facts_rcctl.yml
+    - service_facts_simpleinit_msb.yml
+    - service_fix_obsd.yml
+    - set-filters.yml
+    - setup_facter_fix.yml
+    - simple-result-queue.yml
+    - smart_connection_bye.yml
+    - suppressed-options.yml
+    - tarfile_extract_warn.yml
+    - templar-globals-dict.yml
+    - templating_fixes.yml
+    - text-converters.yml
+    - timeout_config_fix.yml
+    - update-maybe-json-uri.yml
+    - urls-client-cert-py12.yml
+    - urls-unit-test-latest-cryptography.yml
+    - user-add-password-exp-warning.yml
+    - v2.16.0-initial-commit.yaml
+    - vault_unvault_id_fix.yml
+    - yum-repository-docs-fixes.yml
+    - yum_repository_keepcache.yml
+    release_date: '2023-09-26'

--- a/changelogs/fragments/2.16.0b1_summary.yaml
+++ b/changelogs/fragments/2.16.0b1_summary.yaml
@@ -1,0 +1,3 @@
+release_summary: |
+   | Release Date: 2023-09-26
+   | `Porting Guide <https://docs.ansible.com/ansible-core/2.16/porting_guides/porting_guide_core_2.16.html>`__

--- a/changelogs/fragments/81806-py2-content-disposition.yml
+++ b/changelogs/fragments/81806-py2-content-disposition.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- uri/urls - Add compat function to handle the ability to parse the filename from a Content-Disposition header
+  (https://github.com/ansible/ansible/issues/81806)

--- a/changelogs/fragments/ansible-test-coverage-update.yml
+++ b/changelogs/fragments/ansible-test-coverage-update.yml
@@ -1,2 +1,5 @@
 minor_changes:
-  - ansible-test - Update ``coverage`` to version 7.6.1.
+- ansible-test — Python 3.8–3.12 will use ``coverage`` v7.3.2.
+- ansible-test — ``coverage`` v6.5.0 is to be used only under Python 3.7.
+
+...

--- a/changelogs/fragments/import_role_goes_public.yml
+++ b/changelogs/fragments/import_role_goes_public.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "``import_role`` reverts to previous behavior of exporting vars at compile time."

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -339,6 +339,18 @@ def extract_pem_certs(data):
         yield match.group(0)
 
 
+def _py2_get_param(headers, param, header='content-type'):
+    m = httplib.HTTPMessage(io.StringIO())
+    cd = headers.getheader(header) or ''
+    try:
+        m.plisttext = cd[cd.index(';'):]
+        m.parseplist()
+    except ValueError:
+        return None
+
+    return m.getparam(param)
+
+
 def get_response_filename(response):
     url = response.geturl()
     path = urlparse(url)[2]
@@ -346,7 +358,12 @@ def get_response_filename(response):
     if filename:
         filename = unquote(filename)
 
-    return response.headers.get_param('filename', header='content-disposition') or filename
+    if PY2:
+        get_param = functools.partial(_py2_get_param, response.headers)
+    else:
+        get_param = response.headers.get_param
+
+    return get_param('filename', header='content-disposition') or filename
 
 
 def parse_content_type(response):

--- a/lib/ansible/release.py
+++ b/lib/ansible/release.py
@@ -17,6 +17,6 @@
 
 from __future__ import annotations
 
-__version__ = '2.18.0.dev0'
+__version__ = '2.16.0b1'
 __author__ = 'Ansible, Inc.'
 __codename__ = "Fool in the Rain"

--- a/lib/ansible/release.py
+++ b/lib/ansible/release.py
@@ -17,6 +17,6 @@
 
 from __future__ import annotations
 
-__version__ = '2.16.0b1'
+__version__ = '2.16.0b1.post0'
 __author__ = 'Ansible, Inc.'
 __codename__ = "Fool in the Rain"

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,6 +1,6 @@
-base image=quay.io/ansible/base-test-container:5.8.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12
-default image=quay.io/ansible/default-test-container:8.9.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12 context=collection
-default image=quay.io/ansible/ansible-core-test-container:8.9.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12 context=ansible-core
+base image=quay.io/ansible/base-test-container:5.9.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12
+default image=quay.io/ansible/default-test-container:8.11.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12 context=collection
+default image=quay.io/ansible/ansible-core-test-container:8.11.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12 context=ansible-core
 alpine3 image=quay.io/ansible/alpine3-test-container:5.0.0 python=3.10 cgroup=none audit=none
 centos7 image=quay.io/ansible/centos7-test-container:5.0.0 python=2.7 cgroup=v1-only
 fedora38 image=quay.io/ansible/fedora38-test-container:6.1.0 python=3.11

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,7 +1,9 @@
-base image=quay.io/ansible/base-test-container:7.5.0 python=3.12,3.8,3.9,3.10,3.11,3.13
-default image=quay.io/ansible/default-test-container:10.5.0 python=3.12,3.8,3.9,3.10,3.11,3.13 context=collection
-default image=quay.io/ansible/ansible-core-test-container:10.5.0 python=3.12,3.8,3.9,3.10,3.11,3.13 context=ansible-core
-alpine320 image=quay.io/ansible/alpine320-test-container:8.1.0 python=3.12 cgroup=none audit=none
-fedora40 image=quay.io/ansible/fedora40-test-container:8.1.0 python=3.12
-ubuntu2204 image=quay.io/ansible/ubuntu2204-test-container:8.1.0 python=3.10
-ubuntu2404 image=quay.io/ansible/ubuntu2404-test-container:8.1.0 python=3.12
+base image=quay.io/ansible/base-test-container:5.8.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12
+default image=quay.io/ansible/default-test-container:8.9.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12 context=collection
+default image=quay.io/ansible/ansible-core-test-container:8.9.0 python=3.11,2.7,3.6,3.7,3.8,3.9,3.10,3.12 context=ansible-core
+alpine3 image=quay.io/ansible/alpine3-test-container:5.0.0 python=3.10 cgroup=none audit=none
+centos7 image=quay.io/ansible/centos7-test-container:5.0.0 python=2.7 cgroup=v1-only
+fedora38 image=quay.io/ansible/fedora38-test-container:6.1.0 python=3.11
+opensuse15 image=quay.io/ansible/opensuse15-test-container:6.0.0 python=3.6
+ubuntu2004 image=quay.io/ansible/ubuntu2004-test-container:5.0.0 python=3.8
+ubuntu2204 image=quay.io/ansible/ubuntu2204-test-container:5.0.0 python=3.10

--- a/test/lib/ansible_test/_data/requirements/ansible-test.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible-test.txt
@@ -1,2 +1,5 @@
 # The test-constraints sanity test verifies this file, but changes must be made manually to keep it in up-to-date.
-coverage == 7.6.1 ; python_version >= '3.8' and python_version <= '3.13'
+virtualenv == 16.7.12 ; python_version < '3'
+coverage == 7.3.2 ; python_version >= '3.8' and python_version <= '3.12'
+coverage == 6.5.0 ; python_version >= '3.7' and python_version <= '3.7'
+coverage == 4.5.4 ; python_version >= '2.6' and python_version <= '3.6'

--- a/test/lib/ansible_test/_internal/coverage_util.py
+++ b/test/lib/ansible_test/_internal/coverage_util.py
@@ -69,7 +69,9 @@ class CoverageVersion:
 
 COVERAGE_VERSIONS = (
     # IMPORTANT: Keep this in sync with the ansible-test.txt requirements file.
-    CoverageVersion('7.6.1', 7, (3, 8), (3, 13)),
+    CoverageVersion('7.3.2', 7, (3, 8), (3, 12)),
+    CoverageVersion('6.5.0', 7, (3, 7), (3, 7)),
+    CoverageVersion('4.5.4', 0, (2, 6), (3, 6)),
 )
 """
 This tuple specifies the coverage version to use for Python version ranges.


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Add a new option `GALAXY_COLLECTIONS_INSTALL_PATH` that allows to specify an install path
for collection, instead of using `COLLECTIONS_INSTALL_PATH`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


For exemple, on a local workstation, while developping collections in `~/prj/ansible_collections`, you can safely run the `ansible-galaxy collection install --force` wihtout fearing of overwriting your ongoing work in `~/prj/ansible_collections`. Exemple of config with environment vars:

```
export ANSIBLE_COLLECTIONS_PATH=~/prj/ansible_collections:~/.ansible/collections:/usr/share/ansible/collections
export ANSIBLE_GALAXY_COLLECTIONS_INSTALL_PATH=~/.ansible/collections
```

Without this setup, a `ansible-galaxy collection install --force` would have overwrite your
`~/prj/ansible_collections`, which is ... sad if you did not pushed your work.

<!--- Paste verbatim command output below, e.g. before and after your change -->
No output change, but this can be tested this way:
```paste below
ansible-galaxy collection install --force -r requirements.yml
```
