### PR TITLE
add: new option GALAXY_COLLECTIONS_INSTALL_PATH

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -708,6 +708,15 @@ class GalaxyCLI(CLI):
         return self.lazy_role_api.api
 
     def _get_default_collection_path(self):
+
+        if isinstance(C.GALAXY_COLLECTIONS_INSTALL_PATH, list) and \
+            len(C.GALAXY_COLLECTIONS_INSTALL_PATH) > 0 :
+            path_candidates = C.GALAXY_COLLECTIONS_INSTALL_PATH
+            for _path in path_candidates:
+                if os.path.isdir(_path):
+                    return _path
+            return path_candidates[0]
+
         return C.COLLECTIONS_PATHS[0]
 
     def _parse_requirements_file(self, requirements_file, allow_old_format=True, artifacts_manager=None, validate_signature_options=True):

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -227,6 +227,22 @@ COLLECTIONS_PATHS:
   - key: collections_path
     section: defaults
     version_added: '2.10'
+GALAXY_COLLECTIONS_INSTALL_PATH:
+  name: preferred collection install path
+  description: >
+    Preferred install path for collection. If empty or not set, fallback on first ``COLLECTIONS_PATHS`` path.
+    If one or more paths are provided, the first existing directory is selected. If no directory exists, it
+    will use the last one of the list. If the selected path is not in the ``COLLECTIONS_PATHS`` list, then
+    a warning is raised, unless ``GALAXY_COLLECTIONS_PATH_WARNING`` is set to ``false``.
+  default: null
+  type: pathspec
+  env:
+  - name: ANSIBLE_GALAXY_COLLECTIONS_INSTALL_PATH
+    version_added: '2.16'
+  ini:
+  - key: collections_install_path
+    section: defaults
+    version_added: '2.10'
 COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH:
   name: Defines behavior when loading a collection that does not support the current Ansible version
   description:


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Add a new option `GALAXY_COLLECTIONS_INSTALL_PATH` that allows to specify an install path
for collection, instead of using `COLLECTIONS_INSTALL_PATH`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


For exemple, on a local workstation, while developping collections in `~/prj/ansible_collections`, you can safely run the `ansible-galaxy collection install --force` wihtout fearing of overwriting your ongoing work in `~/prj/ansible_collections`. Exemple of config with environment vars:

```
export ANSIBLE_COLLECTIONS_PATH=~/prj/ansible_collections:~/.ansible/collections:/usr/share/ansible/collections
export ANSIBLE_GALAXY_COLLECTIONS_INSTALL_PATH=~/.ansible/collections
```

Without this setup, a `ansible-galaxy collection install --force` would have overwrite your
`~/prj/ansible_collections`, which is ... sad if you did not pushed your work.

<!--- Paste verbatim command output below, e.g. before and after your change -->
No output change, but this can be tested this way:
```paste below
ansible-galaxy collection install --force -r requirements.yml
```