### PR TITLE
Remove remaining 2.18 deprecations

### DIFF
--- a/lib/ansible/module_utils/common/text/converters.py
+++ b/lib/ansible/module_utils/common/text/converters.py
@@ -267,14 +267,11 @@ def _json_encode_fallback(obj):
 
 
 def jsonify(data, **kwargs):
-    # After 2.18, we should remove this loop, and hardcode to utf-8 in alignment with requiring utf-8 module responses
-    for encoding in ("utf-8", "latin-1"):
-        try:
-            new_data = container_to_text(data, encoding=encoding)
-        except UnicodeDecodeError:
-            continue
-        return json.dumps(new_data, default=_json_encode_fallback, **kwargs)
-    raise UnicodeError('Invalid unicode encoding encountered')
+    try:
+        new_data = container_to_text(data, encoding='utf-8')
+    except UnicodeDecodeError:
+        raise UnicodeError('Invalid unicode encoding encountered')
+    return json.dumps(new_data, default=_json_encode_fallback, **kwargs)
 
 
 def container_to_bytes(d, encoding='utf-8', errors='surrogate_or_strict'):

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1226,11 +1226,9 @@ class ActionBase(ABC):
                 try:
                     _validate_utf8_json(data)
                 except UnicodeEncodeError:
-                    # When removing this, also remove the loop and latin-1 from ansible.module_utils.common.text.converters.jsonify
-                    display.deprecated(
+                    raise ValueError(
                         f'Module "{self._task.resolved_action or self._task.action}" returned non UTF-8 data in '
-                        'the JSON response. This will become an error in the future',
-                        version='2.18',
+                        'the JSON response.',
                     )
 
             data['_ansible_parsed'] = True

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1232,7 +1232,7 @@ class ActionBase(ABC):
                     )
 
             data['_ansible_parsed'] = True
-        except ValueError:
+        except ValueError as e:
             # not valid json, lets try to capture error
             data = dict(failed=True, _ansible_parsed=False)
             data['module_stdout'] = res.get('stdout', u'')
@@ -1246,7 +1246,7 @@ class ActionBase(ABC):
                 data['exception'] = data['module_stdout']
 
             # The default
-            data['msg'] = "MODULE FAILURE"
+            data['msg'] = f"MODULE FAILURE: {e}"
 
             # try to figure out if we are missing interpreter
             if self._used_interpreter is not None:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -706,16 +706,13 @@ class Templar:
             setattr(obj, key, original[key])
 
     def template(self, variable, convert_bare=False, preserve_trailing_newlines=True, escape_backslashes=True, fail_on_undefined=None, overrides=None,
-                 convert_data=True, static_vars=None, cache=None, disable_lookups=False):
+                 convert_data=True, static_vars=None, disable_lookups=False):
         '''
         Templates (possibly recursively) any given data as input. If convert_bare is
         set to True, the given data will be wrapped as a jinja2 variable ('{{foo}}')
         before being sent through the template engine.
         '''
         static_vars = [] if static_vars is None else static_vars
-
-        if cache is not None:
-            display.deprecated("The `cache` option to `Templar.template` is no longer functional, and will be removed in a future release.", version='2.18')
 
         # Don't template unsafe variables, just return them.
         if hasattr(variable, '__UNSAFE__'):
@@ -883,11 +880,9 @@ class Templar:
             return [] if wantlist else None
 
         if not is_sequence(ran):
-            display.deprecated(
+            raise AnsibleLookupError(
                 f'The lookup plugin \'{name}\' was expected to return a list, got \'{type(ran)}\' instead. '
                 f'The lookup plugin \'{name}\' needs to be changed to return a list. '
-                'This will be an error in Ansible 2.18',
-                version='2.18'
             )
 
         if ran and allow_unsafe is False:

--- a/test/integration/targets/expect/aliases
+++ b/test/integration/targets/expect/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group2
 destructive
 needs/target/setup_pexpect
+gather_facts/no

--- a/test/integration/targets/expect/files/test_command.py
+++ b/test/integration/targets/expect/files/test_command.py
@@ -1,24 +1,38 @@
 from __future__ import annotations
 
+import argparse
+import os
 import sys
 
-try:
-    input_function = raw_input
-except NameError:
-    input_function = input
+parser = argparse.ArgumentParser()
+parser.add_argument('--latin1', action='store_true')
+parser.add_argument('prompts', nargs='*')
+args = parser.parse_args()
 
-prompts = sys.argv[1:] or ['foo']
+prompts = args.prompts or ['foo']
+
+
+def tty_prompt(prompt):
+    fd = os.open('/dev/tty', os.O_RDWR | os.O_NOCTTY)
+    with os.fdopen(fd, 'w') as stream:
+        stream.write(prompt)
+        stream.close()
+
+    response = input()
+    return response
+
 
 # latin1 encoded bytes
 # to ensure pexpect doesn't have any encoding errors
 data = b'premi\xe8re is first\npremie?re is slightly different\n????????? is Cyrillic\n? am Deseret\n'
 
-try:
-    sys.stdout.buffer.write(data)
-except AttributeError:
-    sys.stdout.write(data)
-print()
+if args.latin1:
+    try:
+        sys.stdout.buffer.write(data)
+    except AttributeError:
+        sys.stdout.write(data)
+    print()
 
 for prompt in prompts:
-    user_input = input_function(prompt)
+    user_input = tty_prompt(prompt)
     print(user_input)

--- a/test/integration/targets/expect/files/test_non_utf8_command.py
+++ b/test/integration/targets/expect/files/test_non_utf8_command.py
@@ -4,9 +4,9 @@ import sys
 
 prompts = sys.argv[1:] or ['foo']
 
-# UTF8 encoded bytes
+# latin1 encoded bytes
 # to ensure pexpect doesn't have any encoding errors
-data = 'line one 汉语\nline two\nline three\nline four\n'.encode()
+data = b'premi\xe8re is first\npremie?re is slightly different\n????????? is Cyrillic\n? am Deseret\n'
 
 sys.stdout.buffer.write(data)
 print()

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -19,14 +19,39 @@
   import_role:
     name: setup_pexpect
 
-- name: record the test_command file
-  set_fact: test_command_file={{remote_tmp_dir | expanduser}}/test_command.py
+- name: record the test command files
+  set_fact:
+    test_command_file: "{{ remote_tmp_dir | expanduser }}/test_command.py"
+    test_non_utf8_command_file: "{{ remote_tmp_dir | expanduser }}/test_non_utf8_command.py"
 
 - name: copy script into output directory
-  copy: src=test_command.py dest={{test_command_file}} mode=0444
+  copy:
+    src: test_command.py
+    dest: "{{ test_command_file }}"
+    mode: "0444"
+
+- name: copy non-UTF8 script into output directory
+  copy:
+    src: test_non_utf8_command.py
+    dest: "{{ test_non_utf8_command_file }}"
+    mode: "0444"
 
 - name: record the output file
   set_fact: output_file={{remote_tmp_dir}}/foo.txt
+
+- name: use expect with non-UTF8 output which should fail
+  expect:
+    command: "{{ ansible_python_interpreter }} {{ test_non_utf8_command_file }}"
+    responses:
+      foo: bar
+  register: expect_result
+  ignore_errors: yes
+
+- name: verify expect with non-UTF8 output failed as expected
+  assert:
+    that:
+      - expect_result is failed
+      - expect_result.msg is contains 'returned non UTF-8 data'  # controller-side failure, not module-side
 
 - copy:
    content: "foo"
@@ -34,7 +59,7 @@
 
 - name: test expect
   expect:
-    command: /bin/sh -c "{{ansible_python_interpreter}} {{test_command_file}} --latin1 | {{ ansible_python_interpreter }} -m base64 -e - }}"
+    command: "{{ansible_python_interpreter}} {{test_command_file}}"
     responses:
       foo: bar
   register: expect_result
@@ -43,7 +68,7 @@
   assert:
     that:
     - "expect_result.changed == true"
-    - "expect_result.stdout|regex_replace('^foo', '')|b64decode|trim|split('\n')|last == 'bar'"
+    - "expect_result.stdout_lines|last == 'foobar'"
 
 - name: test creates option
   expect:
@@ -117,7 +142,7 @@
 - name: assert chdir works
   assert:
     that:
-    - "chdir_result.stdout | trim == remote_tmp_dir_real_path.stdout | trim"
+    - chdir_result.stdout | trim == remote_tmp_dir_real_path.stdout | trim
 
 - name: test timeout option
   expect:
@@ -144,7 +169,7 @@
 - name: assert echo works
   assert:
     that:
-    - "echo_result.stdout_lines|length == 2"
+    - "echo_result.stdout_lines|length == 7"
     - "echo_result.stdout_lines[-2] == 'foobar'"
     - "echo_result.stdout_lines[-1] == 'bar'"
 
@@ -169,7 +194,7 @@
 - name: assert list response works
   assert:
     that:
-    - "list_result.stdout_lines|length == 2"
+    - "list_result.stdout_lines|length == 7"
     - "list_result.stdout_lines[-2] == 'foobar'"
     - "list_result.stdout_lines[-1] == 'foobaz'"
 

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: test expect
   expect:
-    command: "{{ansible_python_interpreter}} {{test_command_file}}"
+    command: /bin/sh -c "{{ansible_python_interpreter}} {{test_command_file}} --latin1 | {{ ansible_python_interpreter }} -m base64 -e - }}"
     responses:
       foo: bar
   register: expect_result
@@ -43,7 +43,7 @@
   assert:
     that:
     - "expect_result.changed == true"
-    - "expect_result.stdout_lines|last == 'foobar'"
+    - "expect_result.stdout|regex_replace('^foo', '')|b64decode|trim|split('\n')|last == 'bar'"
 
 - name: test creates option
   expect:
@@ -144,7 +144,7 @@
 - name: assert echo works
   assert:
     that:
-    - "echo_result.stdout_lines|length == 7"
+    - "echo_result.stdout_lines|length == 2"
     - "echo_result.stdout_lines[-2] == 'foobar'"
     - "echo_result.stdout_lines[-1] == 'bar'"
 
@@ -169,7 +169,7 @@
 - name: assert list response works
   assert:
     that:
-    - "list_result.stdout_lines|length == 7"
+    - "list_result.stdout_lines|length == 2"
     - "list_result.stdout_lines[-2] == 'foobar'"
     - "list_result.stdout_lines[-1] == 'foobaz'"
 

--- a/test/integration/targets/templating_lookups/template_lookups/mock_lookup_plugins/77788.py
+++ b/test/integration/targets/templating_lookups/template_lookups/mock_lookup_plugins/77788.py
@@ -1,8 +1,0 @@
-from __future__ import annotations
-
-from ansible.plugins.lookup import LookupBase
-
-
-class LookupModule(LookupBase):
-    def run(self, terms, variables, **kwargs):
-        return {'one': 1, 'two': 2}

--- a/test/integration/targets/templating_lookups/template_lookups/tasks/main.yml
+++ b/test/integration/targets/templating_lookups/template_lookups/tasks/main.yml
@@ -87,15 +87,4 @@
     that:
       - password1 != password2
 
-# 77788 - KeyError when wantlist=False with dict returned
-- name: Test that dicts can be parsed with wantlist false
-  set_fact:
-    dict_wantlist_true: "{{ lookup('77788', wantlist=True) }}"
-    dict_wantlist_false: "{{ lookup('77788', wantlist=False) }}"
-
-- assert:
-    that:
-      - dict_wantlist_true is mapping
-      - dict_wantlist_false is string
-
 - include_tasks: ./errors.yml

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -155,8 +155,6 @@ README.md pymarkdown:line-length
 test/units/cli/test_data/role_skeleton/README.md pymarkdown:line-length
 test/integration/targets/find/files/hello_world.gbk no-smart-quotes
 test/integration/targets/find/files/hello_world.gbk no-unwanted-characters
-lib/ansible/plugins/action/__init__.py pylint:ansible-deprecated-version  # 2.18 deprecation
-lib/ansible/template/__init__.py pylint:ansible-deprecated-version  # 2.18 deprecation
 lib/ansible/module_utils/facts/hardware/aix.py pylint:used-before-assignment
 lib/ansible/modules/rpm_key.py pylint:used-before-assignment
 lib/ansible/modules/service.py pylint:used-before-assignment


### PR DESCRIPTION
##### SUMMARY

Remove remaining 2.18 deprecations. Fixes #82948. Fixes #82946.

These were initially left because data tagging was to resolve them. Data tagging is now deferred for more testing, so this PR removes the deprecated functionality for 2.18.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
