### PR TITLE
ansible-test no longer needs special casing in `__main__.py`

### DIFF
--- a/lib/ansible/__main__.py
+++ b/lib/ansible/__main__.py
@@ -19,22 +19,10 @@ def main():
     ep_map = {_short_name(ep.name): ep for ep in dist.entry_points if ep.group == 'console_scripts'}
 
     parser = argparse.ArgumentParser(prog='python -m ansible', add_help=False)
-    parser.add_argument('entry_point', choices=list(ep_map) + ['test'])
+    parser.add_argument('entry_point', choices=list(ep_map))
     args, extra = parser.parse_known_args()
 
-    if args.entry_point == 'test':
-        ansible_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        source_root = os.path.join(ansible_root, 'test', 'lib')
-
-        if os.path.exists(os.path.join(source_root, 'ansible_test', '_internal', '__init__.py')):
-            # running from source, use that version of ansible-test instead of any version that may already be installed
-            sys.path.insert(0, source_root)
-
-        module = importlib.import_module('ansible_test._util.target.cli.ansible_test_cli_stub')
-        main = module.main
-    else:
-        main = ep_map[args.entry_point].load()
-
+    main = ep_map[args.entry_point].load()
     main([args.entry_point] + extra)
 
 

--- a/lib/ansible/__main__.py
+++ b/lib/ansible/__main__.py
@@ -3,9 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import importlib
-import os
-import sys
 
 from importlib.metadata import distribution
 


### PR DESCRIPTION
##### SUMMARY

Due to changes in https://github.com/ansible/ansible/commit/68515abf97dfc769c9aed2ba457ed7b8b2580a5c to create an entrypoint for `ansible-test`, we no longer require the special casing.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
