### PR TITLE
[2.16] Clarify galaxy CLI --help about install locations (#83919)

### DIFF
--- a/changelogs/fragments/ansible-galaxy-install-help.yml
+++ b/changelogs/fragments/ansible-galaxy-install-help.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- >-
+  Add descriptions for ``ansible-galaxy install --help` and ``ansible-galaxy role|collection install --help``.
+- >-
+  ``ansible-galaxy install --help`` - Fix the usage text and document that the requirements file passed to ``-r`` can include collections and roles.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -503,7 +503,7 @@ class GalaxyCLI(CLI):
             )
             prog = 'ansible-galaxy install'
         else:
-            prog = parser._prog_prefix
+            prog = f"ansible-galaxy {galaxy_type} install"
             description_text = (
                 'Install {0}(s) from file(s), URL(s) or Ansible '
                 'Galaxy to the first entry in the config {1}S_PATH '


### PR DESCRIPTION
##### SUMMARY

Backport for #83919 and #83979

* add descriptions for `ansible-galaxy install` and `ansible-galaxy role|collection install`

* fix the usage for installing roles and collections together and include collections in the description for -r

Closes #81159

Co-authored-by: Alan Rominger <arominge@redhat.com>
Co-authored-by: Sandra McCann <samccann@redhat.com>
(cherry picked from commit 85d9a40aacd4ec04dd6dd86cb681efb3475645c3)

##### ISSUE TYPE

- Bugfix Pull Request