### PR TITLE
Update apt.py

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -192,7 +192,6 @@ options:
     version_added: "2.12"
 requirements:
    - python-apt (python 2)
-   - python3-apt (python 3)
    - aptitude (before 2.4)
 author: "Matthew Williams (@mgwilliams)"
 extends_documentation_fragment: action_common_attributes


### PR DESCRIPTION
removed python3-apt requirement. Python3-apt no longer exists and is no longer needed for ansible.builtin.apt to work correctly.

##### SUMMARY

Python3-apt no longer exists and is no longer needed for ansible.builtin.apt to work correctly.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
