### PR TITLE
[stable-2.17] dnf5: re-introduce ``state: installed`` alias (#83961)

### DIFF
--- a/changelogs/fragments/83960-dnf5-state-installed-fix.yml
+++ b/changelogs/fragments/83960-dnf5-state-installed-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "dnf5 - re-introduce the ``state: installed`` alias to ``state: present`` (https://github.com/ansible/ansible/issues/83960)"

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -638,7 +638,7 @@ class Dnf5Module(YumDnf):
         results = []
         if self.names == ["*"] and self.state == "latest":
             goal.add_rpm_upgrade(settings)
-        elif self.state in {"install", "present", "latest"}:
+        elif self.state in {"installed", "present", "latest"}:
             upgrade = self.state == "latest"
             for spec in self.names:
                 if is_newer_version_installed(base, spec):
@@ -671,7 +671,7 @@ class Dnf5Module(YumDnf):
         if transaction.get_problems():
             failures = []
             for log_event in transaction.get_resolve_logs():
-                if log_event.get_problem() == libdnf5.base.GoalProblem_NOT_FOUND and self.state in {"install", "present", "latest"}:
+                if log_event.get_problem() == libdnf5.base.GoalProblem_NOT_FOUND and self.state in {"installed", "present", "latest"}:
                     # NOTE dnf module compat
                     failures.append("No package {} available.".format(log_event.get_spec()))
                 else:

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -2,7 +2,7 @@
     - name: Install dinginessentail-1.0-1
       dnf:
         name: dinginessentail-1.0-1
-        state: present
+        state: installed
       register: dnf_result
 
     - name: Check dinginessentail with rpm


### PR DESCRIPTION
##### SUMMARY
Backport of #83961

(cherry picked from commit aa24e97435433d08eb0b4cb69a2eaab8bae3a2ff)
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request