### PR TITLE
split: Fix incorrect example result of the split builtin filter

### DIFF
--- a/lib/ansible/plugins/filter/split.yml
+++ b/lib/ansible/plugins/filter/split.yml
@@ -22,7 +22,7 @@ EXAMPLES: |
     # listjojo => [ "jojo", "is", "a" ]
     listjojo: "{{ 'jojo is a' | split }}"
 
-    # listjojocomma => [ "jojo is", "a" ]
+    # listjojocomma => [ "jojo is", " a" ]
     listjojocomma: "{{ 'jojo is, a' | split(',') }}"
 
 RETURN:


### PR DESCRIPTION

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
The following Python output proves that the second member of the resulting list should be " a", not "a":

```txt
$ python3 
Python 3.12.3 (main, Sep 11 2024, 14:17:37) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> string = "jojo is, a"
>>> string.split(',')
['jojo is', ' a']
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request
