### PR TITLE
atomic_move - fix preserving the dest attributes when using a tmp file

### DIFF
--- a/changelogs/fragments/83972-atomic_move-fix-preserving-dest-attrs.yml
+++ b/changelogs/fragments/83972-atomic_move-fix-preserving-dest-attrs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - atomic_move - Fix preserving destination attrs when copying across different partitions (https://github.com/ansible/ansible/issues/83972).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1785,6 +1785,8 @@ class AnsibleModule(object):
                                 if keep_dest_attrs:
                                     if dest_stat and (tmp_stat.st_uid != dest_stat.st_uid or tmp_stat.st_gid != dest_stat.st_gid):
                                         os.chown(b_tmp_dest_name, dest_stat.st_uid, dest_stat.st_gid)
+                                    if dest_stat:
+                                        shutil.copystat(b_dest, b_tmp_dest_name)
                                     os.utime(b_tmp_dest_name, times=(time.time(), time.time()))
                             except OSError as ex:
                                 if ex.errno != errno.EPERM:

--- a/test/integration/targets/copy/tasks/acls.yml
+++ b/test/integration/targets/copy/tasks/acls.yml
@@ -36,6 +36,21 @@
         - "'group::r--' in acls.stdout_lines"
         - "'other::r--' in acls.stdout_lines"
 
+  - name: Update the mode
+    command: chmod 664 /home/{{ remote_unprivileged_user }}/test.txt
+    become: yes
+
+  - name: Test updating the content preserves the mode
+    copy:
+      content: "UPDATE"
+      dest: "~/test.txt"
+    register: copy_update
+    become: yes
+    become_user: "{{ remote_unprivileged_user }}"
+
+  - assert:
+      that: copy_update.mode == "0664"
+
   always:
     - name: Remove the acl package on Ubuntu
       apt:


### PR DESCRIPTION
##### SUMMARY

Fixes #83972

This looks like a long term bug, though #82818 (2.17+) impacted it. The fix is just adding `shutil.copystat` before attempting the final rename.

In the test case I added, the mode is expected to remain "0664". In 2.17 and later, the mode is "0654". In 2.16 and earlier, the mode is "0644".

##### ISSUE TYPE

- Bugfix Pull Request