### PR TITLE
Move ansible-deprecated ignores for tests inline

### DIFF
--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -135,10 +135,6 @@ test/support/windows-integration/plugins/modules/win_user_right.ps1 pslint!skip
 test/support/windows-integration/plugins/modules/win_user.ps1 pslint!skip
 test/support/windows-integration/plugins/modules/win_wait_for.ps1 pslint!skip
 test/support/windows-integration/plugins/modules/win_whoami.ps1 pslint!skip
-test/units/module_utils/basic/test_deprecate_warn.py pylint:ansible-deprecated-no-version
-test/units/module_utils/basic/test_deprecate_warn.py pylint:ansible-deprecated-version
-test/units/module_utils/common/warnings/test_deprecate.py pylint:ansible-deprecated-no-version  # testing Display.deprecated call without a version or date
-test/units/module_utils/common/warnings/test_deprecate.py pylint:ansible-deprecated-version  # testing Deprecated version found in call to Display.deprecated or AnsibleModule.deprecate
 test/units/module_utils/urls/fixtures/multipart.txt line-endings  # Fixture for HTTP tests that use CRLF
 test/units/utils/collection_loader/fixtures/collections/ansible_collections/testns/testcoll/plugins/action/my_action.py pylint:relative-beyond-top-level
 test/units/utils/collection_loader/fixtures/collections/ansible_collections/testns/testcoll/plugins/modules/__init__.py empty-init  # testing that collections don't need inits

--- a/test/units/module_utils/basic/test_deprecate_warn.py
+++ b/test/units/module_utils/basic/test_deprecate_warn.py
@@ -27,13 +27,13 @@ def test_warn(am, capfd):
 def test_deprecate(am, capfd, monkeypatch):
     monkeypatch.setattr(warnings, '_global_deprecations', [])
 
-    am.deprecate('deprecation1')
-    am.deprecate('deprecation2', '2.3')  # pylint: disable=ansible-deprecated-no-collection-name
-    am.deprecate('deprecation3', version='2.4')  # pylint: disable=ansible-deprecated-no-collection-name
-    am.deprecate('deprecation4', date='2020-03-10')  # pylint: disable=ansible-deprecated-no-collection-name
-    am.deprecate('deprecation5', collection_name='ansible.builtin')
-    am.deprecate('deprecation6', '2.3', collection_name='ansible.builtin')
-    am.deprecate('deprecation7', version='2.4', collection_name='ansible.builtin')
+    am.deprecate('deprecation1')  # pylint: disable=ansible-deprecated-no-version
+    am.deprecate('deprecation2', '2.3')  # pylint: disable=ansible-deprecated-version
+    am.deprecate('deprecation3', version='2.4')  # pylint: disable=ansible-deprecated-version
+    am.deprecate('deprecation4', date='2020-03-10')
+    am.deprecate('deprecation5', collection_name='ansible.builtin')  # pylint: disable=ansible-deprecated-no-version
+    am.deprecate('deprecation6', '2.3', collection_name='ansible.builtin')  # pylint: disable=ansible-deprecated-version
+    am.deprecate('deprecation7', version='2.4', collection_name='ansible.builtin')  # pylint: disable=ansible-deprecated-version
     am.deprecate('deprecation8', date='2020-03-10', collection_name='ansible.builtin')
 
     with pytest.raises(SystemExit):
@@ -72,5 +72,5 @@ def test_deprecate_without_list(am, capfd):
 @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
 def test_deprecate_without_list_version_date_not_set(am, capfd):
     with pytest.raises(AssertionError) as ctx:
-        am.deprecate('Simple deprecation warning', date='', version='')
+        am.deprecate('Simple deprecation warning', date='', version='')  # pylint: disable=ansible-deprecated-no-version
     assert ctx.value.args[0] == "implementation error -- version and date must not both be set"

--- a/test/units/module_utils/common/warnings/test_deprecate.py
+++ b/test/units/module_utils/common/warnings/test_deprecate.py
@@ -30,25 +30,25 @@ def reset(monkeypatch):
 
 
 def test_deprecate_message_only(reset):
-    deprecate('Deprecation message')
+    deprecate('Deprecation message')  # pylint: disable=ansible-deprecated-no-version
     assert warnings._global_deprecations == [
         {'msg': 'Deprecation message', 'version': None, 'collection_name': None}]
 
 
 def test_deprecate_with_collection(reset):
-    deprecate(msg='Deprecation message', collection_name='ansible.builtin')
+    deprecate(msg='Deprecation message', collection_name='ansible.builtin')  # pylint: disable=ansible-deprecated-no-version
     assert warnings._global_deprecations == [
         {'msg': 'Deprecation message', 'version': None, 'collection_name': 'ansible.builtin'}]
 
 
 def test_deprecate_with_version(reset):
-    deprecate(msg='Deprecation message', version='2.14')
+    deprecate(msg='Deprecation message', version='2.14')  # pylint: disable=ansible-deprecated-version
     assert warnings._global_deprecations == [
         {'msg': 'Deprecation message', 'version': '2.14', 'collection_name': None}]
 
 
 def test_deprecate_with_version_and_collection(reset):
-    deprecate(msg='Deprecation message', version='2.14', collection_name='ansible.builtin')
+    deprecate(msg='Deprecation message', version='2.14', collection_name='ansible.builtin')  # pylint: disable=ansible-deprecated-version
     assert warnings._global_deprecations == [
         {'msg': 'Deprecation message', 'version': '2.14', 'collection_name': 'ansible.builtin'}]
 
@@ -96,4 +96,4 @@ def test_get_deprecation_messages(deprecation_messages, reset):
 )
 def test_deprecate_failure(test_case):
     with pytest.raises(TypeError, match='deprecate requires a string not a %s' % type(test_case)):
-        deprecate(test_case)
+        deprecate(test_case)  # pylint: disable=ansible-deprecated-no-version


### PR DESCRIPTION
##### SUMMARY

Move ansible-deprecated ignores for tests inline.

##### ISSUE TYPE

Test Pull Request
