### PR TITLE
package/dnf action plugins: better facts failure msg

### DIFF
--- a/changelogs/fragments/package-dnf-action-plugins-facts-fail-msg.yml
+++ b/changelogs/fragments/package-dnf-action-plugins-facts-fail-msg.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "``package``/``dnf`` action plugins - provide the reason behind the failure to gather the ``ansible_pkg_mgr`` fact to identify the package backend"

--- a/lib/ansible/plugins/action/dnf.py
+++ b/lib/ansible/plugins/action/dnf.py
@@ -43,15 +43,10 @@ class ActionModule(ActionBase):
                 task_vars=task_vars)
 
             if facts.get("failed", False):
-                result.update(
-                    {
-                        "failed": True,
-                        "stderr": facts.get("module_stderr", "").strip(),
-                        "stdout": facts.get("module_stdout", "").strip(),
-                        "msg": "Failed to fetch ansible_pkg_mgr to determine the dnf module backend."
-                    }
+                raise AnsibleActionFail(
+                    f"Failed to fetch ansible_pkg_mgr to determine the dnf action backend: {facts.get('msg')}",
+                    result=facts,
                 )
-                return result
 
             display.debug("Facts %s" % facts)
             module = facts.get("ansible_facts", {}).get("ansible_pkg_mgr", "auto")

--- a/lib/ansible/plugins/action/dnf.py
+++ b/lib/ansible/plugins/action/dnf.py
@@ -41,6 +41,18 @@ class ActionModule(ActionBase):
             facts = self._execute_module(
                 module_name="ansible.legacy.setup", module_args=dict(filter="ansible_pkg_mgr", gather_subset="!all"),
                 task_vars=task_vars)
+
+            if facts.get("failed", False):
+                result.update(
+                    {
+                        "failed": True,
+                        "stderr": facts.get("module_stderr", "").strip(),
+                        "stdout": facts.get("module_stdout", "").strip(),
+                        "msg": "Failed to fetch ansible_pkg_mgr to determine the dnf module backend."
+                    }
+                )
+                return result
+
             display.debug("Facts %s" % facts)
             module = facts.get("ansible_facts", {}).get("ansible_pkg_mgr", "auto")
             if (not self._task.delegate_to or self._task.delegate_facts) and module != 'auto':
@@ -74,10 +86,5 @@ class ActionModule(ActionBase):
                 display.vvvv("Running %s as the backend for the dnf action plugin" % module)
                 result.update(self._execute_module(
                     module_name=module, module_args=new_module_args, task_vars=task_vars, wrap_async=self._task.async_val))
-
-        # Cleanup
-        if not self._task.async_val:
-            # remove a temporary path we created
-            self._remove_tmp_path(self._connection._shell.tmpdir)
 
         return result

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -69,15 +69,10 @@ class ActionModule(ActionBase):
                             task_vars=task_vars,
                         )
                         if facts.get("failed", False):
-                            result.update(
-                                {
-                                    "failed": True,
-                                    "stderr": facts.get("module_stderr", "").strip(),
-                                    "stdout": facts.get("module_stdout", "").strip(),
-                                    "msg": "Failed to fetch ansible_pkg_mgr to determine the package action backend."
-                                }
+                            raise AnsibleActionFail(
+                                f"Failed to fetch ansible_pkg_mgr to determine the package action backend: {facts.get('msg')}",
+                                result=facts,
                             )
-                            return result
                         pmgr = 'ansible_pkg_mgr'
 
                     try:

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -68,6 +68,16 @@ class ActionModule(ActionBase):
                             module_args=dict(filter='ansible_pkg_mgr', gather_subset='!all'),
                             task_vars=task_vars,
                         )
+                        if facts.get("failed", False):
+                            result.update(
+                                {
+                                    "failed": True,
+                                    "stderr": facts.get("module_stderr", "").strip(),
+                                    "stdout": facts.get("module_stdout", "").strip(),
+                                    "msg": "Failed to fetch ansible_pkg_mgr to determine the package action backend."
+                                }
+                            )
+                            return result
                         pmgr = 'ansible_pkg_mgr'
 
                     try:
@@ -103,9 +113,5 @@ class ActionModule(ActionBase):
 
         except AnsibleAction as e:
             result.update(e.result)
-        finally:
-            if not self._task.async_val:
-                # remove a temporary path we created
-                self._remove_tmp_path(self._connection._shell.tmpdir)
 
         return result


### PR DESCRIPTION
##### SUMMARY
Before:
`ansible host -m dnf -a "name=mc"`
```
host | FAILED! => {
    "changed": false,
    "msg": [
        "Could not detect which major revision of dnf is in use, which is required to determine module backend.",
        "You should manually specify use_backend to tell the module whether to use the dnf4 or dnf5 backend})"
    ]
}
```
`ansible host -m package -a "name=mc"`
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'ansible_facts'
host | FAILED! => {
    "changed": false,
    "msg": "Could not detect a package manager. Try using the \"use\" option."
}
```

After:
`ansible host -m dnf -a "name=mc"`
```
host | FAILED! => {
    "changed": false,
    "msg": "Failed to fetch ansible_pkg_mgr to determine the dnf module backend.",
    "stderr": "/bin/sh: line 1: python3: command not found",
    "stdout": ""
}
```
`ansible host -m package -a "name=mc"`
```
host | FAILED! => {
    "changed": false,
    "msg": "Failed to fetch ansible_pkg_mgr to determine the package action backend.",
    "stderr": "/bin/sh: line 1: python3: command not found",
    "stdout": ""
}
```
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request