### PR TITLE
INVENTORY_IGNORE_EXTS stop ignoring ini

### DIFF
--- a/changelogs/fragments/remove_ini_ignored_dir.yml
+++ b/changelogs/fragments/remove_ini_ignored_dir.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - INVENTORY_IGNORE_EXTS config, removed ``ini`` from the default list, inventory scripts using a corresponding .ini configuration are rare now and inventory.ini files are more common. Those that need to ignore the ini files for inventory scripts can still add it to configuration.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1719,7 +1719,7 @@ INVENTORY_EXPORT:
   type: bool
 INVENTORY_IGNORE_EXTS:
   name: Inventory ignore extensions
-  default: "{{(REJECT_EXTS + ('.orig', '.ini', '.cfg', '.retry'))}}"
+  default: "{{(REJECT_EXTS + ('.orig', '.cfg', '.retry'))}}"
   description: List of extensions to ignore when using a directory as an inventory source.
   env: [{name: ANSIBLE_INVENTORY_IGNORE}]
   ini:

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -29,6 +29,8 @@ DOCUMENTATION = '''
         - The plugin does not cache results because external inventory scripts are responsible for their own caching.
         - To write your own inventory script see (R(Developing dynamic inventory,developing_inventory) from the documentation site.
         - To find the scripts that used to be part of the code release, go to U(https://github.com/ansible-community/contrib-scripts/).
+        - Since 2.19 using a directory as inventory source will no longer ignore .ini files by default,
+          but you can still update the configuration to do so.
 '''
 
 EXAMPLES = r'''# fmt: code

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -29,7 +29,7 @@ DOCUMENTATION = '''
         - The plugin does not cache results because external inventory scripts are responsible for their own caching.
         - To write your own inventory script see (R(Developing dynamic inventory,developing_inventory) from the documentation site.
         - To find the scripts that used to be part of the code release, go to U(https://github.com/ansible-community/contrib-scripts/).
-        - Since 2.19 using a directory as inventory source will no longer ignore .ini files by default,
+        - Since 2.19 using a directory as an inventory source will no longer ignore .ini files by default,
           but you can still update the configuration to do so.
 '''
 


### PR DESCRIPTION
Originally added to avoid configuration files for inventory scripts now clashes with the much more common ini inventory files.

Now that behavior has changed, we should remove from defaults.

Related #83983

##### ISSUE TYPE

- Feature Pull Request

