### PR TITLE
Add additional logging for SSH runtime output timeouts and escalation messages

### DIFF
--- a/changelogs/fragments/84008-additional-logging.yml
+++ b/changelogs/fragments/84008-additional-logging.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Added a -vvvvv log message indicating when a host fails to produce output within the timeout period.
+  - SSH Escalation-related -vvv log messages now include the associated host information.

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1049,6 +1049,8 @@ class Connection(ConnectionBase):
                         self._terminate_process(p)
                         raise AnsibleError('Timeout (%ds) waiting for privilege escalation prompt: %s' % (timeout, to_native(b_stdout)))
 
+                    display.vvv(u'SSH: Timeout ({}s) waiting for output'.format(timeout), host=self.host)
+
                 # Read whatever output is available on stdout and stderr, and stop
                 # listening to the pipe if it's been closed.
 
@@ -1117,23 +1119,23 @@ class Connection(ConnectionBase):
 
                 if states[state] == 'awaiting_escalation':
                     if self._flags['become_success']:
-                        display.vvv(u'Escalation succeeded')
+                        display.vvv(u'Escalation succeeded', host=self.host)
                         self._flags['become_success'] = False
                         state += 1
                     elif self._flags['become_error']:
-                        display.vvv(u'Escalation failed')
+                        display.vvv(u'Escalation failed', host=self.host)
                         self._terminate_process(p)
                         self._flags['become_error'] = False
                         raise AnsibleError('Incorrect %s password' % self.become.name)
                     elif self._flags['become_nopasswd_error']:
-                        display.vvv(u'Escalation requires password')
+                        display.vvv(u'Escalation requires password', host=self.host)
                         self._terminate_process(p)
                         self._flags['become_nopasswd_error'] = False
                         raise AnsibleError('Missing %s password' % self.become.name)
                     elif self._flags['become_prompt']:
                         # This shouldn't happen, because we should see the "Sorry,
                         # try again" message first.
-                        display.vvv(u'Escalation prompt repeated')
+                        display.vvv(u'Escalation prompt repeated', host=self.host)
                         self._terminate_process(p)
                         self._flags['become_prompt'] = False
                         raise AnsibleError('Incorrect %s password' % self.become.name)
@@ -1372,18 +1374,18 @@ class Connection(ConnectionBase):
         # only run the reset if the ControlPath already exists or if it isn't configured and ControlPersist is set
         # 'check' will determine this.
         cmd = self._build_command(self.get_option('ssh_executable'), 'ssh', '-O', 'check', self.host)
-        display.vvv(u'sending connection check: %s' % to_text(cmd))
+        display.vvv(u'sending connection check: %s' % to_text(cmd), host=self.host)
         p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = p.communicate()
         status_code = p.wait()
         if status_code != 0:
-            display.vvv(u"No connection to reset: %s" % to_text(stderr))
+            display.vvv(u"No connection to reset: %s" % to_text(stderr), host=self.host)
         else:
             run_reset = True
 
         if run_reset:
             cmd = self._build_command(self.get_option('ssh_executable'), 'ssh', '-O', 'stop', self.host)
-            display.vvv(u'sending connection stop: %s' % to_text(cmd))
+            display.vvv(u'sending connection stop: %s' % to_text(cmd), host=self.host)
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
             status_code = p.wait()

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1049,7 +1049,7 @@ class Connection(ConnectionBase):
                         self._terminate_process(p)
                         raise AnsibleError('Timeout (%ds) waiting for privilege escalation prompt: %s' % (timeout, to_native(b_stdout)))
 
-                    display.vvv(u'SSH: Timeout ({}s) waiting for output'.format(timeout), host=self.host)
+                    display.vvvvv(f'SSH: Timeout ({timeout}s) waiting for the output', host=self.host)
 
                 # Read whatever output is available on stdout and stderr, and stop
                 # listening to the pipe if it's been closed.


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
I’ve been working with Ansible recently, and spent a few days troubleshooting an issue where everything seemed fine with the Ansible, but the problem turned out to be semi-dead machines. These machines were accepting SSH connections, but fact gathering (and/or running some tasks) was either not working or running extremely slowly. Since we were running tasks in parallel, it was really hard to pinpoint which machines were causing the issue because of no indication of which hosts is stuck.

This feature aims to provide more useful information during debugging, especially for long jobs like stuck fact gathering on broken hosts. When a piece of code executed on a remote machine doesn't return any data to stdout and stderr during the timeout period, it will be helpful for users to get this information. Additionally, associating host information with events like "Escalation succeeded" will provide better context during debugging.

<!--- HINT: Include "Resolves #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->

Acceptance Criteria:

When running ansible-playbook -vvvvv :

- a log message like "SSH: Timeout ("seconds") waiting for output" should appear periodically if no new output is received from the remote task during the timeout period.

- Escalation-related messages (like "Escalation succeeded") should now include information about the specific host

so it will look like 

```
<123.123.123.123> Escalation succeeded
<123.123.123.123> SSH: Timeout (12s) waiting for output
```

instead of
`Escalation succeeded`
and no timeout warning

Simple script that will allow to simulate this stuck condition on remote machine

```
mkdir -p /etc/ansible/facts.d
echo -e '#!/bin/bash\nsleep 9000' > /etc/ansible/facts.d/very_long_task.fact
chmod +x /etc/ansible/facts.d/very_long_task.fact
```
