### PR TITLE
Prevent condor from being installed and fulfilling libfmt dependency

### DIFF
--- a/test/integration/targets/dnf5/playbook.yml
+++ b/test/integration/targets/dnf5/playbook.yml
@@ -3,7 +3,7 @@
     - block:
         - command: "dnf install -y 'dnf-command(copr)'"
         - command: dnf copr enable -y rpmsoftwaremanagement/dnf-nightly
-        - command: dnf install -y python3-libdnf5
+        - command: dnf install -y -x condor python3-libdnf5
 
         - include_role:
             name: dnf


### PR DESCRIPTION
##### SUMMARY

Prevent condor from being installed and fulfilling libfmt dependency

##### ISSUE TYPE

- Test Pull Request

##### ADDITIONAL INFORMATION

https://github.com/rpm-software-management/dnf5/issues/1740