### PR TITLE
[stable-2.18] Prevent condor from being installed and fulfilling libfmt dependency (#84023)

### DIFF
--- a/test/integration/targets/dnf5/playbook.yml
+++ b/test/integration/targets/dnf5/playbook.yml
@@ -3,7 +3,7 @@
     - block:
         - command: "dnf install -y 'dnf-command(copr)'"
         - command: dnf copr enable -y rpmsoftwaremanagement/dnf-nightly
-        - command: dnf install -y python3-libdnf5
+        - command: dnf install -y -x condor python3-libdnf5
 
         - include_role:
             name: dnf


### PR DESCRIPTION
(cherry picked from commit fb7fd51)


Co-authored-by: Matt Martz <matt@sivel.net>