### PR TITLE
[stable-2.18] facts: Skip path if the distribution path is directory

### DIFF
--- a/changelogs/fragments/os_family.yml
+++ b/changelogs/fragments/os_family.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - facts - skip if distribution file path is directory, instead of raising error (https://github.com/ansible/ansible/issues/84006).

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -30,7 +30,7 @@ def get_uname(module, flags=('-v')):
 
 def _file_exists(path, allow_empty=False):
     # not finding the file, exit early
-    if not os.path.exists(path):
+    if not os.path.isfile(path):
         return False
 
     # if just the path needs to exists (ie, it can be empty) we are done

--- a/test/units/module_utils/facts/system/distribution/test_distribution_files.py
+++ b/test/units/module_utils/facts/system/distribution/test_distribution_files.py
@@ -1,0 +1,17 @@
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import tempfile
+
+
+from ansible.module_utils.facts.system.distribution import DistributionFiles
+
+
+def test_distribution_files(mock_module):
+    d = DistributionFiles(mock_module)
+    temp_dir = tempfile.TemporaryDirectory()
+    dist_file, dist_file_content = d._get_dist_file_content(temp_dir.name)
+    assert not dist_file
+    assert dist_file_content is None


### PR DESCRIPTION
##### SUMMARY

Skip path if the distribution path is directory instead of file.
Handle exception raised while handling distribution path.

Fixes: #84006

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit 34f8f55d9e5a85d21207cc174f88eb2d62edd119)

##### ISSUE TYPE
- Bugfix Pull Request


