### PR TITLE
[stable-2.18] ansible-test - Disable pylint deprecated-* rules (#84050)

### DIFF
--- a/changelogs/fragments/ansible-test-update.yml
+++ b/changelogs/fragments/ansible-test-update.yml
@@ -1,3 +1,4 @@
 minor_changes:
   - ansible-test - Update ``pylint`` sanity test to use version 3.3.1.
   - ansible-test - Default to Python 3.13 in the ``base`` and ``default`` containers.
+  - ansible-test - Disable the ``deprecated-`` prefixed ``pylint`` rules as their results vary by Python version.

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test-target.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test-target.cfg
@@ -3,6 +3,10 @@
 disable=
     consider-using-f-string,  # Python 2.x support still required
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
+    deprecated-argument,  # results vary by Python version
+    deprecated-attribute,  # results vary by Python version
+    deprecated-class,  # results vary by Python version
+    deprecated-decorator,  # results vary by Python version
     deprecated-method,  # results vary by Python version
     deprecated-module,  # results vary by Python version
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test.cfg
@@ -3,6 +3,10 @@
 disable=
     consider-using-f-string,  # many occurrences
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
+    deprecated-argument,  # results vary by Python version
+    deprecated-attribute,  # results vary by Python version
+    deprecated-class,  # results vary by Python version
+    deprecated-decorator,  # results vary by Python version
     deprecated-method,  # results vary by Python version
     deprecated-module,  # results vary by Python version
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/code-smell.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/code-smell.cfg
@@ -3,6 +3,10 @@
 disable=
     consider-using-f-string,  # many occurrences
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
+    deprecated-argument,  # results vary by Python version
+    deprecated-attribute,  # results vary by Python version
+    deprecated-class,  # results vary by Python version
+    deprecated-decorator,  # results vary by Python version
     deprecated-method,  # results vary by Python version
     deprecated-module,  # results vary by Python version
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
@@ -30,7 +30,11 @@ disable=
     consider-using-max-builtin,
     consider-using-min-builtin,
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
+    deprecated-argument,  # results vary by Python version
+    deprecated-attribute,  # results vary by Python version
+    deprecated-class,  # results vary by Python version
     deprecated-comment,  # custom plugin only used by ansible-core, not collections
+    deprecated-decorator,  # results vary by Python version
     deprecated-method,  # results vary by Python version
     deprecated-module,  # results vary by Python version
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
@@ -28,6 +28,10 @@ disable=
     consider-using-max-builtin,
     consider-using-min-builtin,
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
+    deprecated-argument,  # results vary by Python version
+    deprecated-attribute,  # results vary by Python version
+    deprecated-class,  # results vary by Python version
+    deprecated-decorator,  # results vary by Python version
     deprecated-method,  # results vary by Python version
     deprecated-module,  # results vary by Python version
     duplicate-code,  # consistent results require running with --jobs 1 and testing all files

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -61,8 +61,6 @@ lib/ansible/plugins/cache/base.py ansible-doc!skip  # not a plugin, but a stub f
 lib/ansible/plugins/callback/__init__.py pylint:arguments-renamed
 lib/ansible/plugins/inventory/advanced_host_list.py pylint:arguments-renamed
 lib/ansible/plugins/inventory/host_list.py pylint:arguments-renamed
-lib/ansible/utils/collection_loader/_collection_finder.py pylint:deprecated-class
-lib/ansible/utils/collection_loader/_collection_meta.py pylint:deprecated-class
 test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/integration/targets/hello/files/bad.py pylint:ansible-bad-function # ignore, required for testing
 test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/integration/targets/hello/files/bad.py pylint:ansible-bad-import-from # ignore, required for testing
 test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/integration/targets/hello/files/bad.py pylint:ansible-bad-import # ignore, required for testing


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/84050

(cherry picked from commit 3cf308f6726ac8d0b8fd850b8f88a46ae0da546e)

##### ISSUE TYPE

Bugfix Pull Request
