### PR TITLE
[stable-2.18] ansible-test - Update astroid for pylint sanity test

### DIFF
--- a/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.pylint.txt
@@ -1,5 +1,5 @@
 # edit "sanity.pylint.in" and generate with: hacking/update-sanity-requirements.py --test pylint
-astroid==3.3.4
+astroid==3.3.5
 dill==0.3.9
 isort==5.13.2
 mccabe==0.7.0

--- a/test/sanity/code-smell/pymarkdown.requirements.txt
+++ b/test/sanity/code-smell/pymarkdown.requirements.txt
@@ -4,6 +4,6 @@ Columnar==1.4.1
 pymarkdownlnt==0.9.23
 PyYAML==6.0.2
 tomli==2.0.2
-toolz==0.12.1
+toolz==1.0.0
 typing_extensions==4.12.2
 wcwidth==0.2.13


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/84054

(cherry picked from commit 50604e84615e239c2b83e0c55969dbf68e5de0cf)
