### PR TITLE
[2.18] Fix ansible.module_utils.facts.timeout.timeout error message

### DIFF
--- a/changelogs/fragments/fix-module-utils-facts-timeout.yml
+++ b/changelogs/fragments/fix-module-utils-facts-timeout.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Use the requested error message in the ansible.module_utils.facts.timeout timeout function instead of hardcoding one.

--- a/lib/ansible/module_utils/facts/timeout.py
+++ b/lib/ansible/module_utils/facts/timeout.py
@@ -48,7 +48,7 @@ def timeout(seconds=None, error_message="Timer expired"):
                 return res.get(timeout_value)
             except multiprocessing.TimeoutError:
                 # This is an ansible.module_utils.common.facts.timeout.TimeoutError
-                raise TimeoutError('Timer expired after %s seconds' % timeout_value)
+                raise TimeoutError(f'{error_message} after {timeout_value} seconds')
             finally:
                 pool.terminate()
 

--- a/test/units/modules/test_mount_facts.py
+++ b/test/units/modules/test_mount_facts.py
@@ -272,9 +272,7 @@ def test_get_mount_size_timeout(monkeypatch, set_file_content, on_timeout, shoul
         raise Exception("Timeout failed")
 
     monkeypatch.setattr(mount_facts, "get_mount_size", mock_slow_function)
-    # FIXME
-    # match = "Timed out getting mount size .*"
-    match = "Timer expired after 0.1 seconds"
+    match = r"Timed out getting mount size for mount /proc \(type proc\) after 0.1 seconds"
 
     if should_raise:
         with pytest.raises(AnsibleFailJson, match=match):


### PR DESCRIPTION
##### SUMMARY

Fix error message given by ansible.module_utils.facts.timeout.timeout  (#83945)

* Update unit test

Co-authored-by: Sviatoslav Sydorenko (Святослав Сидоренко) <wk.cvs.github@sydorenko.org.ua>
(cherry picked from commit ee9e6130a7d4a3765a6e18abdd979d244c3fce7c)

##### ISSUE TYPE

- Bugfix Pull Request