### PR TITLE
[2.17] Fix ansible.module_utils.facts.timeout.timeout error message

### DIFF
--- a/changelogs/fragments/fix-module-utils-facts-timeout.yml
+++ b/changelogs/fragments/fix-module-utils-facts-timeout.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Use the requested error message in the ansible.module_utils.facts.timeout timeout function instead of hardcoding one.

--- a/lib/ansible/module_utils/facts/timeout.py
+++ b/lib/ansible/module_utils/facts/timeout.py
@@ -48,7 +48,7 @@ def timeout(seconds=None, error_message="Timer expired"):
                 return res.get(timeout_value)
             except multiprocessing.TimeoutError:
                 # This is an ansible.module_utils.common.facts.timeout.TimeoutError
-                raise TimeoutError('Timer expired after %s seconds' % timeout_value)
+                raise TimeoutError(f'{error_message} after {timeout_value} seconds')
             finally:
                 pool.terminate()
 


### PR DESCRIPTION
##### SUMMARY

Backport for #83945, excluding the unit test for the 2.18 feature 

Fix error message given by ansible.module_utils.facts.timeout.timeout (#83945)

(cherry picked from commit ee9e6130a7d4a3765a6e18abdd979d244c3fce7c)

##### ISSUE TYPE

- Bugfix Pull Request