### PR TITLE
docs: `unique` add missing settings

### DIFF
--- a/lib/ansible/plugins/filter/unique.yml
+++ b/lib/ansible/plugins/filter/unique.yml
@@ -10,6 +10,10 @@ DOCUMENTATION:
       description: A list.
       type: list
       required: true
+    case_sensitive:
+      description: Whether to consider case when comparing elements.
+      default: false
+      type: bool
   seealso:
     - plugin_type: filter
       plugin: ansible.builtin.difference
@@ -24,6 +28,14 @@ EXAMPLES: |
   # list1: [1, 2, 5, 1, 3, 4, 10]
   {{ list1 | unique }}
   # => [1, 2, 5, 3, 4, 10]
+  
+  # return case sensitive unique elements
+  {{ ['a', 'A', 'a'] | unique('case_sensitive=true') }}
+  # => ['a', 'A']
+  
+  # return case insensitive unique elements
+  {{ ['b', 'B', 'b'] | unique() }}
+  # => ['b']
 RETURN:
   _value:
     description: A list with unique elements, also known as a set.


### PR DESCRIPTION
Documented the `case_sensitive` setting of `unique()`

##### SUMMARY

The docs of `unique()` don't specify it can work in a case sensitive mode and that it's case insensitive by default.
Nor that it has a parameter named: `case_sensitive`.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

The undocumented setting:
https://github.com/ansible/ansible/blob/fa0bccf6a1f09c0118b1609aadd10f85927f5edb/lib/ansible/plugins/filter/mathstuff.py#L55
