### PR TITLE
Fix copyright format for gather_facts and mount_facts as documented

### DIFF
--- a/lib/ansible/modules/gather_facts.py
+++ b/lib/ansible/modules/gather_facts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017 Ansible Project
+# Copyright: Contributors to the Ansible project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import annotations

--- a/lib/ansible/modules/mount_facts.py
+++ b/lib/ansible/modules/mount_facts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2024 Ansible Project
+# Copyright: Contributors to the Ansible project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import annotations


### PR DESCRIPTION
##### SUMMARY

Fixed the default copyright statement https://docs.ansible.com/ansible-core/devel/dev_guide/developing_modules_documenting.html#copyright-and-license.

##### ISSUE TYPE

- Bugfix Pull Request