### PR TITLE
Faster host removal from a handler

### DIFF
--- a/lib/ansible/playbook/handler.py
+++ b/lib/ansible/playbook/handler.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+from ansible.errors import AnsibleAssertionError
 from ansible.playbook.attribute import NonInheritableFieldAttribute
 from ansible.playbook.task import Task
 from ansible.module_utils.six import string_types
@@ -59,7 +60,12 @@ class Handler(Task):
         return False
 
     def remove_host(self, host):
-        self.notified_hosts = [h for h in self.notified_hosts if h != host]
+        try:
+            self.notified_hosts.remove(host)
+        except ValueError:
+            raise AnsibleAssertionError(
+                f"Attempting to remove a notification on handler '{self}' for host '{host}' but it has not been notified."
+            )
 
     def clear_hosts(self):
         self.notified_hosts = []


### PR DESCRIPTION
##### SUMMARY
In ``Handler.notify_host`` we ensure that ``Handler.notified_hosts`` can contain particular host at most once. Therefore for removing a host it should be faster to use ``list.remove`` which removes the first item in the list, as opposed to using list comprehension removing all such items.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
