### PR TITLE
ansible-test - Enable pylint docstyle for tests

### DIFF
--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test-target.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test-target.cfg
@@ -1,6 +1,12 @@
-[MESSAGES CONTROL]
+[pylint]
+
+max-line-length=160
+
+load-plugins=
+    pylint.extensions.docstyle,
 
 disable=
+    docstring-first-line-empty,
     consider-using-f-string,  # Python 2.x support still required
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
     deprecated-argument,  # results vary by Python version
@@ -28,8 +34,6 @@ disable=
     use-dict-literal,  # ignoring as a common style issue
     useless-return,  # complains about returning None when the return type is optional
 
-[BASIC]
-
 bad-names=
     _,
     bar,
@@ -51,8 +55,6 @@ class-attribute-rgx=[A-Za-z_][A-Za-z0-9_]{1,40}$
 attr-rgx=[a-z_][a-z0-9_]{1,40}$
 method-rgx=[a-z_][a-z0-9_]{1,40}$
 function-rgx=[a-z_][a-z0-9_]{1,40}$
-
-[IMPORTS]
 
 preferred-modules =
     distutils.version:ansible.module_utils.compat.version,

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test.cfg
@@ -1,6 +1,12 @@
-[MESSAGES CONTROL]
+[pylint]
+
+max-line-length=160
+
+load-plugins=
+    pylint.extensions.docstyle,
 
 disable=
+    docstring-first-line-empty,
     consider-using-f-string,  # many occurrences
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
     deprecated-argument,  # results vary by Python version
@@ -27,8 +33,6 @@ disable=
     unspecified-encoding,  # always run with UTF-8 encoding enforced
     useless-return,  # complains about returning None when the return type is optional
 
-[BASIC]
-
 bad-names=
     _,
     bar,
@@ -54,8 +58,6 @@ function-rgx=[a-z_][a-z0-9_]{1,40}$
 # Use the regex from earlier versions of pylint.
 # See: https://github.com/PyCQA/pylint/pull/7322
 typevar-rgx=^_{0,2}(?:[^\W\da-z_]+|(?:[^\W\da-z_]+[^\WA-Z_]+)+T?(?<!Type))(?:_co(?:ntra)?)?$
-
-[IMPORTS]
 
 preferred-modules =
     distutils.version:ansible.module_utils.compat.version,

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/code-smell.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/code-smell.cfg
@@ -1,6 +1,12 @@
-[MESSAGES CONTROL]
+[pylint]
+
+max-line-length=160
+
+load-plugins=
+    pylint.extensions.docstyle,
 
 disable=
+    docstring-first-line-empty,
     consider-using-f-string,  # many occurrences
     cyclic-import,  # consistent results require running with --jobs 1 and testing all files
     deprecated-argument,  # results vary by Python version
@@ -26,8 +32,6 @@ disable=
     unspecified-encoding,  # always run with UTF-8 encoding enforced
     useless-return,  # complains about returning None when the return type is optional
 
-[BASIC]
-
 bad-names=
     _,
     bar,
@@ -50,8 +54,6 @@ attr-rgx=[a-z_][a-z0-9_]{1,40}$
 method-rgx=[a-z_][a-z0-9_]{1,40}$
 function-rgx=[a-z_][a-z0-9_]{1,40}$
 module-rgx=[a-z_][a-z0-9_-]{2,40}$
-
-[IMPORTS]
 
 preferred-modules =
     distutils.version:ansible.module_utils.compat.version,

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/collection.cfg
@@ -1,4 +1,6 @@
-[MESSAGES CONTROL]
+[pylint]
+
+max-line-length=160
 
 disable=
     abstract-method,
@@ -127,8 +129,6 @@ disable=
     wrong-import-order,
     wrong-import-position,
 
-[BASIC]
-
 bad-names=
     _,
     bar,
@@ -144,8 +144,6 @@ good-names=
     j,
     k,
     Run,
-
-[TYPECHECK]
 
 ignored-modules=
     _MovedItems,

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
@@ -1,4 +1,6 @@
-[MESSAGES CONTROL]
+[pylint]
+
+max-line-length=160
 
 disable=
     import-outside-toplevel,  # common pattern in ansible related code
@@ -118,8 +120,6 @@ disable=
     wrong-import-order,
     wrong-import-position,
 
-[BASIC]
-
 bad-names=
     _,
     bar,
@@ -136,12 +136,8 @@ good-names=
     k,
     Run,
 
-[TYPECHECK]
-
 ignored-modules=
     _MovedItems,
-
-[IMPORTS]
 
 preferred-modules =
     distutils.version:ansible.module_utils.compat.version,


### PR DESCRIPTION
##### SUMMARY

This cleans up the implementation of the pylint sanity test and enables the docstyle extension rule `bad-docstring-quotes` for tests.

The rule will be enabled for the rest of ansible-core once automated cleanup has been performed on existing docstrings.

##### ISSUE TYPE

Test Pull Request
