### PR TITLE
ansible-test - Work around pylint issue on 3.11

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-fix.yml
+++ b/changelogs/fragments/ansible-test-pylint-fix.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - ansible-test - Enable the ``sys.unraisablehook`` work-around for the ``pylint`` sanity test on Python 3.11.
+    Previously the work-around was only enabled for Python 3.12 and later.
+    However, the same issue has been discovered on Python 3.11.

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/hide_unraisable.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/hide_unraisable.py
@@ -1,4 +1,4 @@
-"""Temporary plugin to prevent stdout noise pollution from finalization of abandoned generators under Python 3.12"""
+"""Temporary plugin to prevent stdout noise pollution from finalization of abandoned generators."""
 from __future__ import annotations
 
 import sys
@@ -10,7 +10,7 @@ if t.TYPE_CHECKING:
 
 def _mask_finalizer_valueerror(ur: t.Any) -> None:
     """Mask only ValueErrors from finalizing abandoned generators; delegate everything else"""
-    # work around Py3.12 finalizer changes that sometimes spews this error message to stdout
+    # work around Python finalizer issue that sometimes spews this error message to stdout
     # see https://github.com/pylint-dev/pylint/issues/9138
     if ur.exc_type is ValueError and 'generator already executing' in str(ur.exc_value):
         return
@@ -20,5 +20,4 @@ def _mask_finalizer_valueerror(ur: t.Any) -> None:
 
 def register(linter: PyLinter) -> None:  # pylint: disable=unused-argument
     """PyLint plugin registration entrypoint"""
-    if sys.version_info >= (3, 12):
-        sys.unraisablehook = _mask_finalizer_valueerror
+    sys.unraisablehook = _mask_finalizer_valueerror


### PR DESCRIPTION
##### SUMMARY

Enable the ``sys.unraisablehook`` work-around for the ``pylint`` sanity test on Python 3.11. Previously the work-around was only enabled for Python 3.12 and later. However, the same issue has been discovered on Python 3.11.

##### ISSUE TYPE

Bugfix Pull Request
