### PR TITLE
Enable bad-docstring-quotes pylint rule for core

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -2,3 +2,5 @@
 # Bulk PowerShell sanity fixes
 6def4a3180fe03981ba64c6d8db28fed3bb39c0c
 716631189cb5a3f66b3add98f39e64e98bc17bf7
+# Bulk update of strings from triple single quotes to triple double quotes
+a0495fc31497798a7a833ba7406a9729e1528dd8

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/default.cfg
@@ -2,7 +2,11 @@
 
 max-line-length=160
 
+load-plugins=
+    pylint.extensions.docstyle,
+
 disable=
+    docstring-first-line-empty,
     import-outside-toplevel,  # common pattern in ansible related code
     abstract-method,
     access-member-before-definition,


### PR DESCRIPTION
##### SUMMARY

Enable the `bad-docstring-quotes` pylint rule for core and ignore the previous bulk update in `git blame`.

##### ISSUE TYPE

Feature Pull Request
