### PR TITLE
Add /usr/local/bin in search path

### DIFF
--- a/changelogs/fragments/51719-gtar-was-not-found-on-mac.yml
+++ b/changelogs/fragments/51719-gtar-was-not-found-on-mac.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unarchive - fix gtar not found on MacOS caused by a missing path, ``/usr/local/bin`` (https://github.com/ansible/ansible/pull/84102)

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -930,7 +930,10 @@ class TgzArchive(object):
     def can_handle_archive(self):
         # Prefer gtar (GNU tar) as it supports the compression options -z, -j and -J
         try:
-            self.cmd_path = get_bin_path('gtar')
+            if platform.system() == 'Darwin':
+                self.cmd_path = get_bin_path('gtar', ['/usr/local/bin'])
+            else:
+                self.cmd_path = get_bin_path('gtar')
         except ValueError:
             # Fallback to tar
             try:

--- a/test/units/module_utils/common/process/test_get_bin_path.py
+++ b/test/units/module_utils/common/process/test_get_bin_path.py
@@ -27,6 +27,22 @@ def test_get_bin_path(mocker):
     assert '/usr/local/bin/notacommand' == get_bin_path('notacommand')
 
 
+def test_get_bin_path_usr_local_bin_not_in_env(mocker):
+    path = '/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin'
+    mocker.patch.dict('os.environ', {'PATH': path})
+    mocker.patch('os.pathsep', ':')
+
+    mocker.patch('os.path.isdir', return_value=False)
+    mocker.patch('ansible.module_utils.common.process.is_executable', return_value=True)
+
+    def mock_path_exists(path):
+        return path in ('/usr/local/bin', '/usr/local/bin/notacommand')
+
+    mocker.patch('os.path.exists', return_value=mock_path_exists)
+
+    assert '/usr/local/bin/notacommand' == get_bin_path('notacommand', ['/usr/local/bin'])
+
+
 def test_get_path_path_raise_valueerror(mocker):
     mocker.patch.dict('os.environ', {'PATH': ''})
 


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Add /usr/local/bin in search path in get_bin_path
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #51719
##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
On remote target
```shell
% brew install gnu-tar
% which gtar
/usr/local/bin/gtar
```

On ansible node

See environment variable PATH, it does not include `/usr/local/bin`, then `gtar` would not be found.

```shell
$ ansible -m ansible.builtin.setup -a 'filter=ansible_env'
    "ansible_facts": {
        "ansible_env": {
            "CPATH": "/usr/local/include",
            "HOME": "/Users/foo",
            "LANG": "en_US.UTF-8",
            "LC_ALL": "en_US.UTF-8",
            "LC_CTYPE": "UTF-8",
            "LC_TERMINAL": "iTerm2",
            "LC_TERMINAL_VERSION": "3.4.8",
            "LIBRARY_PATH": "/usr/local/lib",
            "LOGNAME": "foo",
            "MANPATH": "/Applications/Xcode-15.3.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/share/man:/Applications/Xcode-15.3.0.app/Contents/Developer/Platforms/MacOSX.platform/usr/share/man:/Applications/Xcode-15.3.0.app/Contents/Developer/usr/share/man:/Applications/Xcode-15.3.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man:",
            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
...
```

<!--- Paste verbatim command output below, e.g. before and after your change -->

