### PR TITLE
Add warning message for files doc_fragment

### DIFF
--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/file_common_args.py
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/file_common_args.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+
+DOCUMENTATION = """
+module: file_common_args
+short_description: using file common args
+description: Using file common args.
+author:
+  - Ansible Core Team
+options:
+  name:
+    description: The name
+    type: str
+"""
+
+EXAMPLES = """#"""
+RETURN = """"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+if __name__ == '__main__':
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type='str'),
+        ),
+        add_file_common_args=True,
+    )
+    module.exit_json()

--- a/test/integration/targets/ansible-test-sanity-validate-modules/expected.txt
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/expected.txt
@@ -3,6 +3,27 @@ plugins/modules/check_mode_attribute_1.py:0:0: attributes-check-mode: The module
 plugins/modules/check_mode_attribute_2.py:0:0: attributes-check-mode: The module does not declare support for check mode, but the check_mode attribute's support value is 'partial' and not 'none'
 plugins/modules/check_mode_attribute_3.py:0:0: attributes-check-mode: The module does declare support for check mode, but the check_mode attribute's support value is 'none'
 plugins/modules/check_mode_attribute_4.py:0:0: attributes-check-mode-details: The module declares it does not fully support check mode, but has no details on what exactly that means
+plugins/modules/file_common_args.py:0:0: doc-default-does-not-match-spec: Argument 'unsafe_writes' in argument_spec defines default as (False) but documentation defines default as (None)
+plugins/modules/file_common_args.py:0:0: no-file-common-args-doc-fragment: add_file_common_args specified but no doc_fragment 'files' included in 'extends_documentation_fragment'
+plugins/modules/file_common_args.py:0:0: parameter-type-not-in-doc: Argument 'attributes' in argument_spec defines type as 'str' but documentation doesn't define type
+plugins/modules/file_common_args.py:0:0: parameter-type-not-in-doc: Argument 'group' in argument_spec defines type as 'str' but documentation doesn't define type
+plugins/modules/file_common_args.py:0:0: parameter-type-not-in-doc: Argument 'mode' in argument_spec defines type as 'raw' but documentation doesn't define type
+plugins/modules/file_common_args.py:0:0: parameter-type-not-in-doc: Argument 'owner' in argument_spec defines type as 'str' but documentation doesn't define type
+plugins/modules/file_common_args.py:0:0: parameter-type-not-in-doc: Argument 'selevel' in argument_spec defines type as 'str' but documentation doesn't define type
+plugins/modules/file_common_args.py:0:0: parameter-type-not-in-doc: Argument 'serole' in argument_spec defines type as 'str' but documentation doesn't define type
+plugins/modules/file_common_args.py:0:0: parameter-type-not-in-doc: Argument 'setype' in argument_spec defines type as 'str' but documentation doesn't define type
+plugins/modules/file_common_args.py:0:0: parameter-type-not-in-doc: Argument 'seuser' in argument_spec defines type as 'str' but documentation doesn't define type
+plugins/modules/file_common_args.py:0:0: parameter-type-not-in-doc: Argument 'unsafe_writes' in argument_spec defines type as 'bool' but documentation doesn't define type
+plugins/modules/file_common_args.py:0:0: undocumented-parameter: Argument 'attr' is listed in the argument_spec, but not documented in the module documentation
+plugins/modules/file_common_args.py:0:0: undocumented-parameter: Argument 'attributes' is listed in the argument_spec, but not documented in the module documentation
+plugins/modules/file_common_args.py:0:0: undocumented-parameter: Argument 'group' is listed in the argument_spec, but not documented in the module documentation
+plugins/modules/file_common_args.py:0:0: undocumented-parameter: Argument 'mode' is listed in the argument_spec, but not documented in the module documentation
+plugins/modules/file_common_args.py:0:0: undocumented-parameter: Argument 'owner' is listed in the argument_spec, but not documented in the module documentation
+plugins/modules/file_common_args.py:0:0: undocumented-parameter: Argument 'selevel' is listed in the argument_spec, but not documented in the module documentation
+plugins/modules/file_common_args.py:0:0: undocumented-parameter: Argument 'serole' is listed in the argument_spec, but not documented in the module documentation
+plugins/modules/file_common_args.py:0:0: undocumented-parameter: Argument 'setype' is listed in the argument_spec, but not documented in the module documentation
+plugins/modules/file_common_args.py:0:0: undocumented-parameter: Argument 'seuser' is listed in the argument_spec, but not documented in the module documentation
+plugins/modules/file_common_args.py:0:0: undocumented-parameter: Argument 'unsafe_writes' is listed in the argument_spec, but not documented in the module documentation
 plugins/modules/import_order.py:7:0: import-before-documentation: Import found before documentation variables. All imports must appear below DOCUMENTATION/EXAMPLES/RETURN.
 plugins/modules/invalid_argument_spec_extra_key.py:0:0: invalid-ansiblemodule-schema: AnsibleModule.argument_spec.foo.extra_key: extra keys not allowed @ data['argument_spec']['foo']['extra_key']. Got 'bar'
 plugins/modules/invalid_argument_spec_incorrect_context.py:0:0: invalid-ansiblemodule-schema: AnsibleModule.argument_spec.foo.context: expected dict for dictionary value @ data['argument_spec']['foo']['context']. Got 'bar'

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -1615,7 +1615,7 @@ class ModuleValidator(Validator):
             # Check if files doc_fragment is included
             file_common_keys = ['mode', 'owner', 'group', 'seuser', 'serole', 'setype', 'selevel', 'unsafe_writes', 'attributes']
             if any(missing_key not in list(doc_options.keys()) for missing_key in file_common_keys):
-                msg="add_file_common_args specified but no doc_fragment 'files' included in 'extends_documentation_fragment'"
+                msg = "add_file_common_args specified but no doc_fragment 'files' included in 'extends_documentation_fragment'"
                 self.reporter.error(
                     path=self.object_path,
                     code='no-file-common-args-doc-fragment',

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -1610,6 +1610,18 @@ class ModuleValidator(Validator):
         doc_options = docs.get('options', {})
         if doc_options is None:
             doc_options = {}
+
+        if last_context_spec.get('add_file_common_args', False):
+            # Check if files doc_fragment is included
+            file_common_keys = ['mode', 'owner', 'group', 'seuser', 'serole', 'setype', 'selevel', 'unsafe_writes', 'attributes']
+            if any(missing_key not in list(doc_options.keys()) for missing_key in file_common_keys):
+                msg="add_file_common_args specified but no doc_fragment 'files' included in 'extends_documentation_fragment'"
+                self.reporter.error(
+                    path=self.object_path,
+                    code='no-file-common-args-doc-fragment',
+                    msg=msg,
+                )
+
         for arg, data in spec.items():
             restricted_argument_names = ('message', 'syslog_facility')
             if arg.lower() in restricted_argument_names:


### PR DESCRIPTION
##### SUMMARY

* Warn user if 'files' doc_fragment is not included when
  add_file_common_args is used.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE



- Test Pull Request