### PR TITLE
test: Use password lookup instead of range

### DIFF
--- a/test/integration/targets/git/tasks/archive.yml
+++ b/test/integration/targets/git/tasks/archive.yml
@@ -84,7 +84,7 @@
 
 - name: ARCHIVE | Generate an archive prefix
   set_fact:
-    git_archive_prefix: '{{ range(2 ** 30, 2 ** 31) | random }}' # Generate some random archive prefix
+    git_archive_prefix: "{{ lookup('ansible.builtin.password', '/dev/null', length=10, chars=['digits']) }}" # Generate some random archive prefix
 
 - name: ARCHIVE | Archive repo using various archival format and with an archive prefix
   git:

--- a/test/integration/targets/git/tasks/archive.yml
+++ b/test/integration/targets/git/tasks/archive.yml
@@ -84,7 +84,7 @@
 
 - name: ARCHIVE | Generate an archive prefix
   set_fact:
-    git_archive_prefix: '{{ range(2 ** 31, 2 ** 32) | random }}' # Generate some random archive prefix
+    git_archive_prefix: '{{ range(2 ** 30, 2 ** 31) | random }}' # Generate some random archive prefix
 
 - name: ARCHIVE | Archive repo using various archival format and with an archive prefix
   git:


### PR DESCRIPTION
##### SUMMARY

On 32-bit architectures, the `git` integration tests fail with:

```
TASK [git : ARCHIVE | Generate an archive prefix] ******************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: OverflowError: Python int too large to convert to C ssize_t
```

It doesn't seem vital that this prefix should be larger than a signed 32-bit integer can hold, so drop one bit.

##### ISSUE TYPE

- Test Pull Request