### PR TITLE
[2.16] Trim `selinux_policytype` @ integration tests

### DIFF
--- a/test/integration/targets/module_utils_facts.system.selinux/tasks/main.yml
+++ b/test/integration/targets/module_utils_facts.system.selinux/tasks/main.yml
@@ -22,7 +22,7 @@
   register: r
 
 - set_fact:
-    selinux_policytype: "{{ r.stdout_lines[0] }}"
+    selinux_policytype: "{{ r.stdout_lines[0] | trim }}"
   when: r is success and r.stdout_lines
 
 - assert:


### PR DESCRIPTION
The shell command sometimes prints a trailing whitespace which breaks the tests on old RHELs. This patch is supposed to fix that.

(cherry picked from commit cd74c4bcd512ada50e9fc04e3e04f7b117f2eb19)

##### SUMMARY

$sbj.

##### ISSUE TYPE

- Test Pull Request

##### ADDITIONAL INFORMATION

This is a backport of #84136.

https://dev.azure.com/ansible/ansible/_build/results?buildId=126058&view=logs&j=b28a635e-7e2d-5820-3489-5c448731e84f&t=1eeee25e-e288-5056-5580-4c71a57e2e34&l=8395