### PR TITLE
Add --flush-cache for ad-hoc commands

### DIFF
--- a/changelogs/fragments/84149-add-flush-cache-for-adhoc-commands.yml
+++ b/changelogs/fragments/84149-add-flush-cache-for-adhoc-commands.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible cli - add --flush-cache option for ad-hoc commands (https://github.com/ansible/ansible/issues/83749).

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -562,7 +562,7 @@ class CLI(ABC):
 
     @staticmethod
     def _flush_cache(inventory, variable_manager):
-
+        variable_manager.clear_facts('localhost')
         for host in inventory.list_hosts():
             hostname = host.get_name()
             variable_manager.clear_facts(hostname)

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -554,7 +554,18 @@ class CLI(ABC):
         # the code, ensuring a consistent view of global variables
         variable_manager = VariableManager(loader=loader, inventory=inventory, version_info=CLI.version_info(gitinfo=False))
 
+        # flush fact cache if requested
+        if options['flush_cache']:
+            CLI._flush_cache(inventory, variable_manager)
+
         return loader, inventory, variable_manager
+
+    @staticmethod
+    def _flush_cache(inventory, variable_manager):
+
+        for host in inventory.list_hosts():
+            hostname = host.get_name()
+            variable_manager.clear_facts(hostname)
 
     @staticmethod
     def get_host_list(inventory, subset, pattern='all'):

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -297,6 +297,8 @@ def add_inventory_options(parser):
                         help='outputs a list of matching hosts; does not execute anything else')
     parser.add_argument('-l', '--limit', default=C.DEFAULT_SUBSET, dest='subset',
                         help='further limit selected hosts to an additional pattern')
+    parser.add_argument('--flush-cache', dest='flush_cache', action='store_true',
+                        help="clear the fact cache for every host in inventory")
 
 
 def add_meta_options(parser):

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -305,8 +305,6 @@ def add_meta_options(parser):
     """Add options for commands which can launch meta tasks from the command line"""
     parser.add_argument('--force-handlers', default=C.DEFAULT_FORCE_HANDLERS, dest='force_handlers', action='store_true',
                         help="run handlers even if a task fails")
-    parser.add_argument('--flush-cache', dest='flush_cache', action='store_true',
-                        help="clear the fact cache for every host in inventory")
 
 
 def add_module_options(parser):

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -558,10 +558,6 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
         hosts = self.get_host_list(self.inventory, context.CLIARGS['subset'], self.pattern)
 
-        # flush fact cache if requested
-        if context.CLIARGS['flush_cache']:
-            self._flush_cache(self.inventory, self.variable_manager)
-
         self.groups = self.inventory.list_groups()
         self.hosts = [x.name for x in hosts]
 
@@ -601,12 +597,6 @@ class ConsoleCLI(CLI, cmd.Cmd):
             raise AttributeError(f"{self.__class__} does not have a {name} attribute")
 
         return attr
-
-    @staticmethod
-    def _flush_cache(inventory, variable_manager):
-        for host in inventory.list_hosts():
-            hostname = host.get_name()
-            variable_manager.clear_facts(hostname)
 
 
 def main(args=None):

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -558,7 +558,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
         hosts = self.get_host_list(self.inventory, context.CLIARGS['subset'], self.pattern)
 
-        #flush fact cache if requested
+        # flush fact cache if requested
         if context.CLIARGS['flush_cache']:
             self._flush_cache(self.inventory, self.variable_manager)
 

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -558,6 +558,10 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
         hosts = self.get_host_list(self.inventory, context.CLIARGS['subset'], self.pattern)
 
+        #flush fact cache if requested
+        if context.CLIARGS['flush_cache']:
+            self._flush_cache(self.inventory, self.variable_manager)
+
         self.groups = self.inventory.list_groups()
         self.hosts = [x.name for x in hosts]
 
@@ -597,6 +601,12 @@ class ConsoleCLI(CLI, cmd.Cmd):
             raise AttributeError(f"{self.__class__} does not have a {name} attribute")
 
         return attr
+
+    @staticmethod
+    def _flush_cache(inventory, variable_manager):
+        for host in inventory.list_hosts():
+            hostname = host.get_name()
+            variable_manager.clear_facts(hostname)
 
 
 def main(args=None):

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -143,10 +143,6 @@ class PlaybookCLI(CLI):
         # Fix this when we rewrite inventory by making localhost a real host (and thus show up in list_hosts())
         CLI.get_host_list(inventory, context.CLIARGS['subset'])
 
-        # flush fact cache if requested
-        if context.CLIARGS['flush_cache']:
-            self._flush_cache(inventory, variable_manager)
-
         # create the playbook executor, which manages running the plays via a task queue manager
         pbex = PlaybookExecutor(playbooks=context.CLIARGS['args'], inventory=inventory,
                                 variable_manager=variable_manager, loader=loader,
@@ -227,12 +223,6 @@ class PlaybookCLI(CLI):
             return 0
         else:
             return results
-
-    @staticmethod
-    def _flush_cache(inventory, variable_manager):
-        for host in inventory.list_hosts():
-            hostname = host.get_name()
-            variable_manager.clear_facts(hostname)
 
 
 def main(args=None):

--- a/test/integration/targets/adhoc/runme.sh
+++ b/test/integration/targets/adhoc/runme.sh
@@ -7,3 +7,11 @@ ansible -a 'sleep 20' --task-timeout 5 localhost |grep 'The command action faile
 
 # -a parsing with json
 ansible --task-timeout 5 localhost -m command -a '{"cmd": "whoami"}' | grep 'rc=0'
+
+# test ansible --flush-cache
+export ANSIBLE_CACHE_PLUGIN=jsonfile
+export ANSIBLE_CACHE_PLUGIN_CONNECTION=./
+# collect and cache facts
+ansible localhost -m setup > /dev/null && test -s localhost
+# test flushing the fact cache
+ansible --flush-cache localhost -m debug -a "msg={{ ansible_facts }}" | grep '"msg": {}'


### PR DESCRIPTION
##### SUMMARY
Added --flush-cache for ad-hoc commands

Fixes: #83749

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Modified options_helpers.py to include --flush-cache in add_inventory_options.
Modified console.py to include --flush-cache as CLI option.

Tested ansible ad-hoc command so that it shows --flush-cache as a CLI option and it's usage.

Created ansible.cfg to create facts_cache:
[defaults]
fact_caching = jsonfile
fact_caching_connection = <path-to-cache_file>

Run command to verify cache_file is created:
ansible localhost -m setup

Run command with flush_cache option:
ansible --flush-cache localhost -m setup

<!--- Paste verbatim command output below, e.g. before and after your change -->

Command with --flush-cache is successful.
```paste below

```
