### PR TITLE
Allow async_status jid to be the full results_file path

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -866,6 +866,7 @@ class TaskExecutor:
             task_vars = self._job_vars
 
         async_jid = result.get('ansible_job_id')
+        results_file = result.get('results_file')
         if async_jid is None:
             return dict(failed=True, msg="No job id was returned by the async task")
 
@@ -875,7 +876,7 @@ class TaskExecutor:
 
         async_task = Task.load(dict(
             action='async_status',
-            args={'jid': async_jid},
+            args={'jid': results_file or async_jid},
             check_mode=self._task.check_mode,
             environment=self._task.environment,
         ))
@@ -947,7 +948,7 @@ class TaskExecutor:
             cleanup_task = Task.load(
                 {
                     'async_status': {
-                        'jid': async_jid,
+                        'jid': results_file or async_jid,
                         'mode': 'cleanup',
                     },
                     'check_mode': self._task.check_mode,

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -135,7 +135,12 @@ class ActionModule(ActionBase):
 
             while jobs:
                 for module in jobs:
-                    poll_args = {'jid': jobs[module]['ansible_job_id'], '_async_dir': os.path.dirname(jobs[module]['results_file'])}
+                    jid = jobs[module]['ansible_job_id']
+                    if os.path.isabs(jid):
+                        async_dir = ''
+                    else:
+                        async_dir = os.path.dirname(jobs[module]['results_file'])
+                    poll_args = {'jid': jid, '_async_dir': async_dir}
                     res = self._execute_module(module_name='ansible.legacy.async_status', module_args=poll_args, task_vars=task_vars, wrap_async=False)
                     if res.get('finished', 0) == 1:
                         if res.get('failed', False):

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -122,7 +122,7 @@
 - name: assert task failed correctly
   assert:
     that:
-    - async_result.ansible_job_id is match('j\d+\.\d+')
+    - async_result.ansible_job_id|basename is match('j\d+\.\d+')
     - async_result.finished == 1
     - async_result is finished
     - async_result is not changed
@@ -140,7 +140,7 @@
 - name: validate response
   assert:
     that:
-    - async_result.ansible_job_id is match('j\d+\.\d+')
+    - async_result.ansible_job_id|basename is match('j\d+\.\d+')
     - async_result.finished == 1
     - async_result is finished
     - async_result.changed == false
@@ -159,7 +159,7 @@
 - name: validate response
   assert:
     that:
-    - async_result.ansible_job_id is match('j\d+\.\d+')
+    - async_result.ansible_job_id|basename is match('j\d+\.\d+')
     - async_result.finished == 1
     - async_result is finished
     - async_result.changed == true
@@ -176,7 +176,7 @@
 - name: validate response
   assert:
     that:
-    - async_result.ansible_job_id is match('j\d+\.\d+')
+    - async_result.ansible_job_id|basename is match('j\d+\.\d+')
     - async_result.finished == 1
     - async_result is finished
     - async_result.changed == true

--- a/test/integration/targets/async_fail/tasks/main.yml
+++ b/test/integration/targets/async_fail/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: validate that by the end of the retry interval, we succeeded
   assert:
     that:
-    - async_result.ansible_job_id is match('j\d+\.\d+')
+    - async_result.ansible_job_id|basename is match('j\d+\.\d+')
     - async_result.finished == 1
     - async_result is finished
     - async_result is changed

--- a/test/integration/targets/callback_default/runme.sh
+++ b/test/integration/targets/callback_default/runme.sh
@@ -136,8 +136,8 @@ set -e
 # Check for async output
 # NOTE: regex to match 1 or more digits works for both BSD and GNU grep
 ansible-playbook -i inventory test_async.yml 2>&1 | tee async_test.out
-grep "ASYNC OK .* jid=j[0-9]\{1,\}" async_test.out
-grep "ASYNC FAILED .* jid=j[0-9]\{1,\}" async_test.out
+grep "ASYNC OK .* jid=.*j[0-9]\{1,\}" async_test.out
+grep "ASYNC FAILED .* jid=.*j[0-9]\{1,\}" async_test.out
 rm -f async_test.out
 
 # Hide skipped


### PR DESCRIPTION
##### SUMMARY

Allow `async_status` `jid` to be the full `results_file` path

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

I believe my original discussion around this was to return the full path in `jid`.  This PR currently is an intermediate step, in that it still returns `jid` and `results_file` as separate values, but the `jid` argument for `async_status` accepts both an ID or the path.  Implicit async tasks will use the path.

If we think it is safe, we could modify this now or later to have the jid returned by the async wrapper be the full path.