### PR TITLE
Remove deprecated plural form of collection path

### DIFF
--- a/changelogs/fragments/config.yml
+++ b/changelogs/fragments/config.yml
@@ -1,0 +1,3 @@
+---
+removed_features:
+  - Remove deprecated plural form of collection path (https://github.com/ansible/ansible/pull/84156).

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -212,18 +212,9 @@ COLLECTIONS_PATHS:
   default: '{{ ANSIBLE_HOME ~ "/collections:/usr/share/ansible/collections" }}'
   type: pathspec
   env:
-  - name: ANSIBLE_COLLECTIONS_PATHS
-    deprecated:
-      why: does not fit var naming standard, use the singular form ANSIBLE_COLLECTIONS_PATH instead
-      version: "2.19"
   - name: ANSIBLE_COLLECTIONS_PATH
     version_added: '2.10'
   ini:
-  - key: collections_paths
-    section: defaults
-    deprecated:
-      why: does not fit var naming standard, use the singular form collections_path instead
-      version: "2.19"
   - key: collections_path
     section: defaults
     version_added: '2.10'

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -1155,7 +1155,7 @@
   - name: install collection with directory source and trailing slash - {{ test_id }}
     command: ansible-galaxy collection install '{{ galaxy_dir }}/scratch/trailing_dir/name/' {{ galaxy_verbosity }}
     environment:
-      ANSIBLE_COLLECTIONS_PATHS: '{{ galaxy_dir }}/ansible_collections'
+      ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
     register: install_dir_slash
 
   - name: get result of install collections with with trailing slash - {{ test_id }}


### PR DESCRIPTION
##### SUMMARY

* Removed ANSIBLE_COLLECTIONS_PATHS
* Removed collections_paths

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


