### PR TITLE
encrypt: raise error on passing unsupported passlib hashtype

### DIFF
--- a/changelogs/fragments/passlib.yml
+++ b/changelogs/fragments/passlib.yml
@@ -1,0 +1,3 @@
+---
+removed_features:
+  - encrypt - passing unsupported passlib hashtype now raises AnsibleFilterError.

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -286,26 +286,16 @@ def get_encrypted_password(password, hashtype='sha512', salt=None, salt_size=Non
 
     hashtype = passlib_mapping.get(hashtype, hashtype)
 
-    unknown_passlib_hashtype = False
     if PASSLIB_AVAILABLE and hashtype not in passlib_mapping and hashtype not in passlib_mapping.values():
-        unknown_passlib_hashtype = True
-        display.deprecated(
-            f"Checking for unsupported password_hash passlib hashtype '{hashtype}'. "
-            "This will be an error in the future as all supported hashtypes must be documented.",
-            version='2.19'
-        )
+        choices = ', '.join(passlib_mapping)
+        raise AnsibleFilterError(f"{hashtype} is not in the list of supported passlib algorithms: {choices}")
 
     try:
         return do_encrypt(password, hashtype, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
     except AnsibleError as e:
         reraise(AnsibleFilterError, AnsibleFilterError(to_native(e), orig_exc=e), sys.exc_info()[2])
     except Exception as e:
-        if unknown_passlib_hashtype:
-            # This can occur if passlib.hash has the hashtype attribute, but it has a different signature than the valid choices.
-            # In 2.19 this will replace the deprecation warning above and the extra exception handling can be deleted.
-            choices = ', '.join(passlib_mapping)
-            raise AnsibleFilterError(f"{hashtype} is not in the list of supported passlib algorithms: {choices}") from e
-        raise
+        raise AnsibleFilterError(f"Failed to encrypt the password due to: {e}")
 
 
 def to_uuid(string, namespace=UUID_NAMESPACE_ANSIBLE):

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -287,8 +287,7 @@ def get_encrypted_password(password, hashtype='sha512', salt=None, salt_size=Non
     hashtype = passlib_mapping.get(hashtype, hashtype)
 
     if PASSLIB_AVAILABLE and hashtype not in passlib_mapping and hashtype not in passlib_mapping.values():
-        choices = ', '.join(passlib_mapping)
-        raise AnsibleFilterError(f"{hashtype} is not in the list of supported passlib algorithms: {choices}")
+        raise AnsibleFilterError(f"{hashtype} is not in the list of supported passlib algorithms: {', '.join(passlib_mapping)}")
 
     try:
         return do_encrypt(password, hashtype, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -483,9 +483,7 @@
 
 - assert:
     that:
-      - unsupported_hash_type.msg == msg
-  vars:
-    msg: "'msdcc' is not in the list of supported passlib algorithms: md5, blowfish, sha256, sha512"
+      -  "'msdcc is not in the list of supported passlib algorithms' in unsupported_hash_type.msg"
 
 - name: Verify to_uuid throws on weird namespace
   set_fact:

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -468,12 +468,12 @@
 - name: Verify password_hash
   assert:
     that:
-      - "'what in the WORLD is up?'|password_hash|length == 120 or 'what in the WORLD is up?'|password_hash|length == 106"
+      - "'what in the WORLD is up?'|password_hash|length in (120, 106)"
       # This throws a vastly different error on py2 vs py3, so we just check
       # that it's a failure, not a substring of the exception.
       - password_hash_1 is failed
       - password_hash_2 is failed
-      - "'not support' in password_hash_2.msg"
+      - "'is not in the list of supported passlib algorithms' in password_hash_2.msg"
 
 - name: test using passlib with an unsupported hash type
   set_fact:
@@ -485,7 +485,7 @@
     that:
       - unsupported_hash_type.msg == msg
   vars:
-    msg: "msdcc is not in the list of supported passlib algorithms: md5, blowfish, sha256, sha512"
+    msg: "'msdcc' is not in the list of supported passlib algorithms: md5, blowfish, sha256, sha512"
 
 - name: Verify to_uuid throws on weird namespace
   set_fact:

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -483,7 +483,7 @@
 
 - assert:
     that:
-      -  "'msdcc is not in the list of supported passlib algorithms' in unsupported_hash_type.msg"
+      - "'msdcc is not in the list of supported passlib algorithms' in unsupported_hash_type.msg"
 
 - name: Verify to_uuid throws on weird namespace
   set_fact:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -156,7 +156,6 @@ lib/ansible/plugins/action/copy.py pylint:undefined-variable
 test/integration/targets/module_utils/library/test_optional.py pylint:used-before-assignment
 test/support/windows-integration/plugins/action/win_copy.py pylint:undefined-variable
 lib/ansible/plugins/connection/__init__.py pylint:ansible-deprecated-version
-lib/ansible/plugins/filter/core.py pylint:ansible-deprecated-version
 lib/ansible/vars/manager.py pylint:ansible-deprecated-version
 test/units/module_utils/basic/test_exit_json.py mypy-3.13:assignment
 test/units/module_utils/basic/test_exit_json.py mypy-3.13:misc


### PR DESCRIPTION
##### SUMMARY

* Raise an AnsibleFilterError when unsupported passlib hashtype is
  provided in do_encrypt.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


