### PR TITLE
remove stale changelog entry

### DIFF
--- a/changelogs/fragments/cve-2023-5764.yml
+++ b/changelogs/fragments/cve-2023-5764.yml
@@ -1,6 +1,0 @@
-security_fixes:
-- templating - Address issues where internal templating can cause unsafe
-  variables to lose their unsafe designation (CVE-2023-5764)
-breaking_changes:
-- assert - Nested templating may result in an inability for the conditional
-  to be evaluated. See the porting guide for more information.


### PR DESCRIPTION
##### SUMMARY

* the related change was a forward-port of a fix that was already included in 2.17.0 and backported to all supported stable branches, so no need for changelog/porting-guide ref

##### ISSUE TYPE
- Docs Pull Request
