### PR TITLE
ansible-pull, ansible-console - remove unused --list-hosts option

### DIFF
--- a/changelogs/fragments/84149-add-flush-cache-for-adhoc-commands.yml
+++ b/changelogs/fragments/84149-add-flush-cache-for-adhoc-commands.yml
@@ -1,3 +1,2 @@
 minor_changes:
-- >
-  ansible, ansible-console, ansible-pull - add --flush-cache option (https://github.com/ansible/ansible/issues/83749).
+  - ansible cli - add --flush-cache option for ad-hoc commands (https://github.com/ansible/ansible/issues/83749).

--- a/changelogs/fragments/rm-unused-inventory-options.yml
+++ b/changelogs/fragments/rm-unused-inventory-options.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- >
+  ansible-pull, ansible-console - remove ignored --list-hosts option.

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 # ansible.cli needs to be imported first, to ensure the source bin/* scripts run that code first
 from ansible.cli import CLI
 
+import argparse
 import atexit
 import cmd
 import getpass
@@ -115,6 +116,9 @@ class ConsoleCLI(CLI, cmd.Cmd):
         opt_help.add_basedir_options(self.parser)
         opt_help.add_runtask_options(self.parser)
         opt_help.add_tasknoplay_options(self.parser)
+
+        # remove unused default options
+        self.parser.add_argument('--list-hosts', help=argparse.SUPPRESS, action=opt_help.UnrecognizedArgument)
 
         # options unique to shell
         self.parser.add_argument('pattern', help='host pattern', metavar='pattern', default='all', nargs='?')

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 # ansible.cli needs to be imported first, to ensure the source bin/* scripts run that code first
 from ansible.cli import CLI
 
+import argparse
 import datetime
 import os
 import platform
@@ -92,6 +93,9 @@ class PullCLI(CLI):
         opt_help.add_runas_prompt_options(self.parser)
 
         self.parser.add_argument('args', help='Playbook(s)', metavar='playbook.yml', nargs='*')
+
+        # remove unused default options
+        self.parser.add_argument('--list-hosts', help=argparse.SUPPRESS, action=opt_help.UnrecognizedArgument)
 
         # options unique to pull
         self.parser.add_argument('--purge', default=False, action='store_true', help='purge checkout after playbook run')
@@ -297,9 +301,6 @@ class PullCLI(CLI):
             cmd += ' -C'
         if context.CLIARGS['diff']:
             cmd += ' -D'
-
-        if context.CLIARGS['flush_cache']:
-            cmd += ' --flush-cache'
 
         os.chdir(context.CLIARGS['dest'])
 

--- a/test/integration/targets/ansible-pull/pull-integration-test/gather_facts.yml
+++ b/test/integration/targets/ansible-pull/pull-integration-test/gather_facts.yml
@@ -1,2 +1,0 @@
-- hosts: localhost
-  gather_facts: true

--- a/test/integration/targets/ansible-pull/pull-integration-test/test_empty_facts.yml
+++ b/test/integration/targets/ansible-pull/pull-integration-test/test_empty_facts.yml
@@ -1,5 +1,0 @@
-- hosts: localhost
-  gather_facts: false
-  tasks:
-  - assert:
-      that: ansible_facts == {}


### PR DESCRIPTION
##### SUMMARY

Fix suppressing some unused option from ansible-pull and ansible-console, noticed while reviewing #84149

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
