### PR TITLE
update ansible-galaxy's resolvelib requirement upperbound from 1.1.0 to 2.0.0

### DIFF
--- a/changelogs/fragments/update-resolvelib-lt-1_2_0.yml
+++ b/changelogs/fragments/update-resolvelib-lt-1_2_0.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - ansible-galaxy - support ``resolvelib >= 0.5.3, < 1.2.0`` (https://github.com/ansible/ansible/issues/84217).

--- a/changelogs/fragments/update-resolvelib-lt-1_2_0.yml
+++ b/changelogs/fragments/update-resolvelib-lt-1_2_0.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-galaxy - support ``resolvelib >= 0.5.3, < 1.2.0`` (https://github.com/ansible/ansible/issues/84217).

--- a/changelogs/fragments/update-resolvelib-lt-2_0_0.yml
+++ b/changelogs/fragments/update-resolvelib-lt-2_0_0.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-galaxy - support ``resolvelib >= 0.5.3, < 2.0.0`` (https://github.com/ansible/ansible/issues/84217).

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -39,7 +39,7 @@ except ImportError:
 
 # TODO: add python requirements to ansible-test's ansible-core distribution info and remove the hardcoded lowerbound/upperbound fallback
 RESOLVELIB_LOWERBOUND = SemanticVersion("0.5.3")
-RESOLVELIB_UPPERBOUND = SemanticVersion("1.2.0")
+RESOLVELIB_UPPERBOUND = SemanticVersion("2.0.0")
 RESOLVELIB_VERSION = SemanticVersion.from_loose_version(LooseVersion(resolvelib_version))
 
 

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -39,7 +39,7 @@ except ImportError:
 
 # TODO: add python requirements to ansible-test's ansible-core distribution info and remove the hardcoded lowerbound/upperbound fallback
 RESOLVELIB_LOWERBOUND = SemanticVersion("0.5.3")
-RESOLVELIB_UPPERBOUND = SemanticVersion("1.1.0")
+RESOLVELIB_UPPERBOUND = SemanticVersion("1.2.0")
 RESOLVELIB_VERSION = SemanticVersion.from_loose_version(LooseVersion(resolvelib_version))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ packaging
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, < 1.2.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, < 2.0.0  # dependency resolver used by ansible-galaxy

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ packaging
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, < 1.1.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, < 1.2.0  # dependency resolver used by ansible-galaxy

--- a/test/integration/targets/ansible-galaxy-collection/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/vars/main.yml
@@ -4,13 +4,12 @@ gpg_homedir: "{{ galaxy_dir }}/gpg"
 
 offline_server: https://test-hub.demolab.local/api/galaxy/content/api/
 
+# Test oldest and most recently supported, and versions with notable changes
 supported_resolvelib_versions:
-  - "0.5.3"  # Oldest supported
-  - "0.6.0"
-  - "0.7.0"
-  - "0.8.0"
-  - "0.9.0"
-  - "1.0.1"
+  - "0.5.3"  # test CollectionDependencyProvider050
+  - "0.6.0"  # test CollectionDependencyProvider060
+  - "0.7.0"  # test CollectionDependencyProvider070
+  - "1.1.0"  # test CollectionDependencyProvider080
 
 unsupported_resolvelib_versions:
   - "0.2.0"  # Fails on import

--- a/test/integration/targets/ansible-galaxy-collection/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/vars/main.yml
@@ -4,12 +4,15 @@ gpg_homedir: "{{ galaxy_dir }}/gpg"
 
 offline_server: https://test-hub.demolab.local/api/galaxy/content/api/
 
-# Test oldest and most recently supported, and versions with notable changes
+# Test oldest and most recently supported, and versions with notable changes.
+# The last breaking change for a feature ansible-galaxy uses was in 0.8.0.
+# It would be redundant to test every minor version since 0.8.0, so we just test against the latest minor release.
+# NOTE: If ansible-galaxy incorporates new resolvelib features, this matrix should be updated to verify the features work on all supported versions.
 supported_resolvelib_versions:
   - "0.5.3"  # test CollectionDependencyProvider050
   - "0.6.0"  # test CollectionDependencyProvider060
   - "0.7.0"  # test CollectionDependencyProvider070
-  - "1.1.0"  # test CollectionDependencyProvider080
+  - "<2.0.0"  # test CollectionDependencyProvider080
 
 unsupported_resolvelib_versions:
   - "0.2.0"  # Fails on import

--- a/test/lib/ansible_test/_data/requirements/ansible.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible.txt
@@ -12,4 +12,4 @@ packaging
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, < 1.2.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, < 2.0.0  # dependency resolver used by ansible-galaxy

--- a/test/lib/ansible_test/_data/requirements/ansible.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible.txt
@@ -12,4 +12,4 @@ packaging
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, < 1.1.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.5.3, < 1.2.0  # dependency resolver used by ansible-galaxy


### PR DESCRIPTION
##### SUMMARY
Fixes #84217

Update the resolvelib requirement upperbound to 1.2.0 and update the tests to use the new 1.1.0 release since it doesn't look like there are any incompatible changes https://github.com/sarugaku/resolvelib/blob/main/CHANGELOG.rst.

##### ISSUE TYPE

- Feature Pull Request
