### PR TITLE
Remove encrypt unit tests for undocumented algorithms

### DIFF
--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -81,13 +81,6 @@ def test_password_hash_filter_passlib():
     assert (get_encrypted_password("123", "sha512", salt="12345678", rounds=5000) ==
             "$6$12345678$LcV9LQiaPekQxZ.OfkMADjFdSO2k9zfbDQrHPVcYjSLqSdjLYpsgqviYvTEP/R41yPmhH3CCeEDqVhW1VHr3L.")
 
-    assert get_encrypted_password("123", "crypt16", salt="12") == "12pELHK2ME3McUFlHxel6uMM"
-
-    # Try algorithm that uses a raw salt
-    assert get_encrypted_password("123", "pbkdf2_sha256")
-    # Try algorithm with ident
-    assert get_encrypted_password("123", "pbkdf2_sha256", ident='invalid_ident')
-
 
 @pytest.mark.skipif(not encrypt.PASSLIB_AVAILABLE, reason='passlib must be installed to run this test')
 def test_do_encrypt_passlib():


### PR DESCRIPTION
##### SUMMARY
Follow up to https://github.com/ansible/ansible/pull/84186

Fixes https://dev.azure.com/ansible/ansible/_build/results?buildId=127357&view=logs&j=581857c8-e963-525c-7ffc-77d04359cd65&t=90d9435e-b00a-5b9c-4027-389507057959&l=8338

I didn't add a replacement test, because this codepath is covered by the first test case in `test_password_hash_filter_passlib`.

##### ISSUE TYPE

- Test Pull Request
