### PR TITLE
Add support for empty file and directory to file module

### DIFF
--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -85,7 +85,8 @@ options:
     description:
     - This parameter indicates the time the file's modification time should be set to.
     - Should be V(preserve) when no modification is required, C(YYYYMMDDHHMM.SS) when using default time format, or V(now).
-    - Default is None meaning that V(preserve) is the default for O(state=[empty_file,empty_directory,file,directory,link,hard]) and V(now) is default for O(state=touch).
+    - Default is None meaning that V(preserve) is the default for O(state=[empty_file,empty_directory,file,directory,link,hard])
+      and V(now) is default for O(state=touch).
     type: str
     version_added: "2.7"
   modification_time_format:
@@ -99,7 +100,8 @@ options:
     description:
     - This parameter indicates the time the file's access time should be set to.
     - Should be V(preserve) when no modification is required, C(YYYYMMDDHHMM.SS) when using default time format, or V(now).
-    - Default is V(None) meaning that V(preserve) is the default for O(state=[empty_file,empty_directory,file,directory,link,hard]) and V(now) is default for O(state=touch).
+    - Default is V(None) meaning that V(preserve) is the default for O(state=[empty_file,empty_directory,file,directory,link,hard])
+      and V(now) is default for O(state=touch).
     type: str
     version_added: '2.7'
   access_time_format:

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -1086,10 +1086,11 @@ def main():
     # 2024-11-03 Keep old behaviour for now
     # Prevent state from being defined when nothing changed.
     # test/integration/targets/file/tasks/modification_time.yml:68 is checking for this.
-    if result["diff"]["after"]["state"] and result["diff"]["before"]["state"]:
-        if result["diff"]["after"]["state"] == result["diff"]["before"]["state"]:
-            del result["diff"]["after"]["state"]
-            del result["diff"]["before"]["state"]
+    if "diff" in result and "after" in result["diff"] and "before" in result["diff"]:
+        if result["diff"]["after"]["state"] and result["diff"]["before"]["state"]:
+            if result["diff"]["after"]["state"] == result["diff"]["before"]["state"]:
+                del result["diff"]["after"]["state"]
+                del result["diff"]["before"]["state"]
 
     if not module._diff:
         result.pop('diff', None)

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -1087,7 +1087,7 @@ def main():
     # Prevent state from being defined when nothing changed.
     # test/integration/targets/file/tasks/modification_time.yml:68 is checking for this.
     if "diff" in result and "after" in result["diff"] and "before" in result["diff"]:
-        if result["diff"]["after"]["state"] and result["diff"]["before"]["state"]:
+        if "state" in result["diff"]["after"] and "state" in result["diff"]["before"]:
             if result["diff"]["after"]["state"] == result["diff"]["before"]["state"]:
                 del result["diff"]["after"]["state"]
                 del result["diff"]["before"]["state"]

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -1083,6 +1083,14 @@ def main():
     if state in ('file', 'directory') and empty:
         result = ensure_absent(path, keep_empty=True, result=result)
 
+    # 2024-11-03 Keep old behaviour for now
+    # Prevent state from being defined when nothing changed.
+    # test/integration/targets/file/tasks/modification_time.yml:68 is checking for this.
+    if result["diff"]["after"]["state"] and result["diff"]["before"]["state"]:
+        if result["diff"]["after"]["state"] == result["diff"]["before"]["state"]:
+            del result["diff"]["after"]["state"]
+            del result["diff"]["before"]["state"]
+
     if not module._diff:
         result.pop('diff', None)
 

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -386,7 +386,7 @@ def recursive_set_attributes(b_path, follow, file_args, mtime, atime):
 
 
 def initial_diff(path, state, prev_state):
-    diff = {'before': {'path': path, 'state':prev_state},
+    diff = {'before': {'path': path, 'state': prev_state},
             'after': {'path': path, 'state': state},
             }
 
@@ -516,6 +516,7 @@ def execute_diff_peek(path):
 
     return appears_binary
 
+
 def __try_rmtree(fd):
     if module.check_mode:
         return
@@ -527,6 +528,7 @@ def __try_rmtree(fd):
             module.fail_json(
                 msg=f"rmtree failed: {to_native(e)}"
             )
+
 
 def __try_unlink(fd):
     if module.check_mode:
@@ -540,6 +542,7 @@ def __try_unlink(fd):
                 msg=f"unlink failed: {to_native(e)}"
             )
 
+
 def __try_truncate(fd):
     if module.check_mode:
         return
@@ -550,9 +553,12 @@ def __try_truncate(fd):
             msg=f"truncate failed: {to_native(e)}"
         )
 
-def ensure_absent(path, keep_empty=False, result={}):
+
+def ensure_absent(path, keep_empty=False, result=None):
     b_path = to_bytes(path, errors='surrogate_or_strict')
     prev_state = get_state(b_path)
+    if result is None:
+        result = {}
 
     if prev_state != 'absent':
         changed = True

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -430,13 +430,19 @@
 
 - name: create a test sub-directory
   file: dest={{remote_tmp_dir_test}}/sub1 state=directory
-  register: file15_result
+  register: file15a_result
+
+- name: check newly created directory is detected as empty
+  file: dest={{remote_tmp_dir_test}}/sub1 state=directory empty=yes
+  register: file15b_result
 
 - name: verify that the new directory was created
   assert:
     that:
-      - 'file15_result.changed == true'
-      - 'file15_result.state == "directory"'
+      - 'file15a_result.changed == true'
+      - 'file15a_result.state == "directory"'
+      - 'file15b_result.changed == false'
+      - 'file15b_result.state == "directory"'
 
 - name: create test files in the sub-directory
   file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=touch
@@ -444,14 +450,122 @@
   - file1
   - file2
   - file3
-  register: file16_result
+  register: file16a_result
+
+- name: 2nd create test files in the sub-directory
+  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=touch
+  with_items:
+  - file1
+  - file2
+  - file3
+  register: file16b_result
+
+- name: 3rd create test files in the sub-directory with empty=yes
+  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=file empty=yes
+  with_items:
+  - file1
+  - file2
+  - file3
+  register: file16c_result
+
+- name: 4th create test files in the sub-directory with empty=yes
+  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=file empty=yes
+  with_items:
+  - file4
+  - file5
+  - file6
+  register: file16d_result
+
+- name: 5th create test files in the sub-directory with empty=yes
+  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=file empty=yes
+  with_items:
+  - file4
+  - file5
+  - file6
+  register: file16e_result
+
+- name: Use stat module to check if files really exist.
+  stat:
+    path: '{{remote_tmp_dir_test}}/sub1/{{item}}'
+    follow: False
+  with_items:
+  - file1
+  - file2
+  - file3
+  - file4
+  - file5
+  - file6
+  register: file16f_result
 
 - name: verify the files were created
   assert:
     that:
       - 'item.changed == true'
       - 'item.state == "file"'
-  with_items: "{{file16_result.results}}"
+  with_items: "{{file16a_result.results}}"
+
+- name: 2nd verify the files were created
+  assert:
+    that:
+      - 'item.changed == false'
+      - 'item.state == "file"'
+  with_items: "{{file16b_result.results}}"
+
+- name: 3rd verify the files were created
+  assert:
+    that:
+      - 'item.changed == false'
+      - 'item.state == "file"'
+  with_items: "{{file16c_result.results}}"
+
+- name: 4th verify the files were created
+  assert:
+    that:
+      - 'item.changed == true'
+      - 'item.state == "file"'
+  with_items: "{{file16d_result.results}}"
+
+- name: 5th verify the files were created
+  assert:
+    that:
+      - 'item.changed == false'
+      - 'item.state == "file"'
+  with_items: "{{file16e_result.results}}"
+
+- name: 6th verify the files were created using stat
+  assert:
+    that:
+      - 'item.changed == false'
+      - 'item.stat.exists == true'
+      - 'item.stat.isreg == true'
+  with_items: "{{file16f_result.results}}"
+
+- name: empty sub-directory again
+  file: dest={{remote_tmp_dir_test}}/sub1 state=directory empty=yes
+  register: file17_result
+
+- name: verify returned status of emptying sub-directory
+  assert:
+    that:
+      - 'item.changed == true'
+      - 'item.state == "directory"'
+  with_items: "{{file17_result.results}}"
+
+- name: 2nd create a test sub-directory
+  file: dest={{remote_tmp_dir_test}}/sub1 state=directory
+  register: file18a_result
+
+- name: 2nd check newly created directory is detected as empty
+  file: dest={{remote_tmp_dir_test}}/sub1 state=directory empty=yes
+  register: file18b_result
+
+- name: verify that the new directory was created
+  assert:
+    that:
+      - 'file18a_result.changed == false'
+      - 'file18a_result.state == "directory"'
+      - 'file18b_result.changed == false'
+      - 'file18b_result.state == "directory"'
 
 - name: test file creation with symbolic mode
   file: dest={{remote_tmp_dir_test}}/test_symbolic state=touch mode=u=rwx,g=rwx,o=rwx

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -433,7 +433,7 @@
   register: file15a_result
 
 - name: check newly created directory is detected as empty
-  file: dest={{remote_tmp_dir_test}}/sub1 state=directory empty=yes
+  file: dest={{remote_tmp_dir_test}}/sub1 state=empty_directory
   register: file15b_result
 
 - name: verify that the new directory was created
@@ -453,31 +453,31 @@
   register: file16a_result
 
 - name: 2nd create test files in the sub-directory
-  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=touch
+  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=touch modification_time=preserve access_time=preserve
   with_items:
   - file1
   - file2
   - file3
   register: file16b_result
 
-- name: 3rd create test files in the sub-directory with empty=yes
-  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=file empty=yes
+- name: 3rd create empty test files in the sub-directory
+  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=empty_file
   with_items:
   - file1
   - file2
   - file3
   register: file16c_result
 
-- name: 4th create test files in the sub-directory with empty=yes
-  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=file empty=yes
+- name: 4th create empty test files in the sub-directory
+  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=empty_file
   with_items:
   - file4
   - file5
   - file6
   register: file16d_result
 
-- name: 5th create test files in the sub-directory with empty=yes
-  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=file empty=yes
+- name: 5th create empty test files in the sub-directory
+  file: dest={{remote_tmp_dir_test}}/sub1/{{item}} state=empty_file
   with_items:
   - file4
   - file5
@@ -541,22 +541,21 @@
   with_items: "{{file16f_result.results}}"
 
 - name: empty sub-directory again
-  file: dest={{remote_tmp_dir_test}}/sub1 state=directory empty=yes
+  file: dest={{remote_tmp_dir_test}}/sub1 state=empty_directory
   register: file17_result
 
 - name: verify returned status of emptying sub-directory
   assert:
     that:
-      - 'item.changed == true'
-      - 'item.state == "directory"'
-  with_items: "{{file17_result.results}}"
+      - 'file17_result.changed == true'
+      - 'file17_result.state == "directory"'
 
 - name: 2nd create a test sub-directory
   file: dest={{remote_tmp_dir_test}}/sub1 state=directory
   register: file18a_result
 
 - name: 2nd check newly created directory is detected as empty
-  file: dest={{remote_tmp_dir_test}}/sub1 state=directory empty=yes
+  file: dest={{remote_tmp_dir_test}}/sub1 state=empty_directory
   register: file18b_result
 
 - name: verify that the new directory was created

--- a/test/integration/targets/file/tasks/unicode_path.yml
+++ b/test/integration/targets/file/tasks/unicode_path.yml
@@ -21,8 +21,7 @@
 - name: empty local file with unicode filename and content
   file:
     path: "{{ remote_tmp_dir_test }}/语/汉语.txt"
-    state: file
-    empty: true
+    state: empty_file
   register: empty_test_file_1
 
 - name: Use stat module to check if file exists and is empty.
@@ -34,8 +33,7 @@
 - name: empty local directory with unicode names
   file:
     path: "{{ remote_tmp_dir_test }}/语"
-    state: directory
-    empty: true
+    state: empty_directory
   register: empty_test_dir_1
 
 - name: Use stat module to check if file still exists.

--- a/test/integration/targets/file/tasks/unicode_path.yml
+++ b/test/integration/targets/file/tasks/unicode_path.yml
@@ -3,8 +3,59 @@
     dest: "{{ remote_tmp_dir_test }}/语/汉语.txt"
     create: true
     line: 汉语
+  register: create_test_file_1
 
 - name: remove local file with unicode filename and content
   file:
     path: "{{ remote_tmp_dir_test }}/语/汉语.txt"
     state: absent
+  register: delete_test_file_1
+
+- name: create local file with unicode filename and content
+  lineinfile:
+    dest: "{{ remote_tmp_dir_test }}/语/汉语.txt"
+    create: true
+    line: 汉语
+  register: create_test_file_2
+
+- name: empty local file with unicode filename and content
+  file:
+    path: "{{ remote_tmp_dir_test }}/语/汉语.txt"
+    state: file
+    empty: true
+  register: empty_test_file_1
+
+- name: Use stat module to check if file exists and is empty.
+  stat:
+    path: "{{ remote_tmp_dir_test }}/语/汉语.txt"
+    follow: False
+  register: stat_test_file_1
+
+- name: empty local directory with unicode names
+  file:
+    path: "{{ remote_tmp_dir_test }}/语"
+    state: directory
+    empty: true
+  register: empty_test_dir_1
+
+- name: Use stat module to check if file still exists.
+  stat:
+    path: "{{ remote_tmp_dir_test }}/语/汉语.txt"
+    follow: False
+  register: stat_test_file_2
+
+- name: verify that the new directory was created
+  assert:
+    that:
+      - 'create_test_file_1.changed == true'
+      - 'delete_test_file_1.changed == true'
+      - 'create_test_file_2.changed == true'
+      - 'empty_test_file_1.changed == true'
+      - 'create_test_file_3.changed == false'
+      - 'stat_test_file_1.changed == false'
+      - 'stat_test_file_1.stat.isreg == true'
+      - 'stat_test_file_1.stat.exists == true'
+      - 'stat_test_file_1.stat.size == 0'
+      - 'empty_test_dir_1.changed == true'
+      - 'stat_test_file_2.changed == false'
+      - 'stat_test_file_2.stat.exists == false'

--- a/test/integration/targets/file/tasks/unicode_path.yml
+++ b/test/integration/targets/file/tasks/unicode_path.yml
@@ -51,7 +51,6 @@
       - 'delete_test_file_1.changed == true'
       - 'create_test_file_2.changed == true'
       - 'empty_test_file_1.changed == true'
-      - 'create_test_file_3.changed == false'
       - 'stat_test_file_1.changed == false'
       - 'stat_test_file_1.stat.isreg == true'
       - 'stat_test_file_1.stat.exists == true'


### PR DESCRIPTION
##### SUMMARY

This module adds a long overdue functionality to the file module. Over the past decade it was requested multiple times and always fell off because nobody wanted to work on a PR for it. So here is a PR to finally implement it.

Resolves #73585
Resolves #18910

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

I added the ability to ensure a file or folder is empty.

I also extended the unicode tests to cover this functionality as well.


Example usage:
systemd-networkd recreates this folder on startup so without this change this task would always report changed and always notify the restart task
```
- name: Remove systemd-networkd runtime configuration
  notify: Restart systemd-networkd
  ansible.builtin.file:
    path: "/run/systemd/network"
    state: empty_directory
    owner: root
    group: root
    mode: "0755"
```