### PR TITLE
ssh: Fix reset_connection with templated ansible_ssh_executable

### DIFF
--- a/changelogs/fragments/84238-fix-reset_connection-ssh_executable-templated.yml
+++ b/changelogs/fragments/84238-fix-reset_connection-ssh_executable-templated.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ssh - connection options were incorrectly templated during ``reset_connection`` tasks (https://github.com/ansible/ansible/pull/84238).

--- a/changelogs/fragments/84238-fix-reset_connection-ssh_executable-templated.yml
+++ b/changelogs/fragments/84238-fix-reset_connection-ssh_executable-templated.yml
@@ -1,2 +1,2 @@
-minor_changes:
+bugfixes:
   - ssh - connection options were incorrectly templated during ``reset_connection`` tasks (https://github.com/ansible/ansible/pull/84238).

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -285,6 +285,27 @@ class ConnectionBase(AnsiblePlugin):
                 display.debug('Set connection var {0} to {1}'.format(varname, value))
                 variables[varname] = value
 
+    def _resolve_option_variables(self, variables, templar):
+        """
+        Return a dict of variable -> templated value, for any variables that
+        that match options registered by this plugin.
+        """
+        # create dict of 'templated vars'
+        var_options = {
+            '_extras': {},
+        }
+        for var_name in C.config.get_plugin_vars('connection', self._load_name):
+            if var_name in variables:
+                var_options[var_name] = templar.template(variables[var_name])
+
+        # add extras if plugin supports them
+        if getattr(self, 'allow_extras', False):
+            for var_name in variables:
+                if var_name.startswith(f'ansible_{self.extras_prefix}_') and var_name not in var_options:
+                    var_options['_extras'][var_name] = templar.template(variables[var_name])
+
+        return var_options
+
 
 class NetworkConnectionBase(ConnectionBase):
     """

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1068,7 +1068,8 @@ class StrategyBase:
                 del self._active_connections[target_host]
             else:
                 connection = plugin_loader.connection_loader.get(play_context.connection, play_context, os.devnull)
-                connection.set_options(task_keys=task.dump_attrs(), var_options=all_vars)
+                var_options = connection._resolve_option_variables(all_vars, templar)
+                connection.set_options(task_keys=task.dump_attrs(), var_options=var_options)
                 play_context.set_attributes_from_plugin(connection)
 
             if connection:

--- a/test/integration/targets/connection/test.sh
+++ b/test/integration/targets/connection/test.sh
@@ -20,3 +20,4 @@ else
 fi
 
 ansible-playbook test_reset_connection.yml -i "${INVENTORY}" "$@"
+ansible-playbook test_reset_connection_templated.yml -i "${INVENTORY}" "$@"

--- a/test/integration/targets/connection/test_reset_connection_templated.yml
+++ b/test/integration/targets/connection/test_reset_connection_templated.yml
@@ -1,0 +1,7 @@
+- hosts: "{{ target_hosts }}"
+  gather_facts: false
+  vars:
+    ansible_ssh_executable: "{{ 'ssh' | trim }}"
+  tasks:
+    # https://github.com/ansible/ansible/issues/84238
+    - meta: reset_connection


### PR DESCRIPTION
##### SUMMARY

Correctly template connection plugin options during `meta: reset_connection` tasks.

Fixes #84238
Fixes #79755

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before

```
➜  ansible git:(issue84238) ✗ .tox/py312/bin/ansible-playbook -i u2404.mynet, connection_set_options.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you
are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source
of code and can become unstable at any point.

PLAY [u2404.mynet] *********************************************************************************************

TASK [meta] ****************************************************************************************************

PLAY RECAP *****************************************************************************************************

➜  ansible git:(issue84238) ✗ echo $?                                                                   
2
```
After

```
➜  ansible git:(issue84238) ✗ .tox/py312/bin/ansible-playbook -i u2404.mynet, connection_set_options.yml
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you
are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source
of code and can become unstable at any point.

PLAY [u2404.mynet] *********************************************************************************************

TASK [meta] ****************************************************************************************************

TASK [ping] ****************************************************************************************************
[WARNING]: Platform linux on host u2404.mynet is using the discovered Python interpreter at
/usr/bin/python3.12, but future installation of another Python interpreter could change the meaning of that
path. See https://docs.ansible.com/ansible-core/devel/reference_appendices/interpreter_discovery.html for more
information.
ok: [u2404.mynet]

PLAY RECAP *****************************************************************************************************
u2404.mynet                : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

➜  ansible git:(issue84238) ✗ echo $?                                                                   
0
```