### PR TITLE
remove unused server-related options from ansible-galaxy

### DIFF
--- a/changelogs/fragments/fix-ansible-galaxy-options.yml
+++ b/changelogs/fragments/fix-ansible-galaxy-options.yml
@@ -1,0 +1,7 @@
+bugfixes:
+- >
+  ansible-galaxy collection init|build|list - remove unused options '--server', '--token', '--ignore-certs', and '--timeout'.
+- >
+  ansible-galaxy role init|list|remove - remove unused options '--server', '--token', '--ignore-certs', and '--timeout'.
+- >
+  ansible-galaxy role init - remove unused option '--offline'.

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -86,7 +86,11 @@ class GalaxyRole(object):
         self._metadata_dependencies = None
         self._requirements = None
         self._install_info = None
-        self._validate_certs = not context.CLIARGS['ignore_certs']
+        try:
+            self._validate_certs = not context.CLIARGS['ignore_certs']
+        except KeyError:
+            # set default for inherently offline action
+            self._validate_certs = True
 
         display.debug('Validate TLS certificates: %s' % self._validate_certs)
 

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -64,7 +64,7 @@ class TestGalaxy(unittest.TestCase):
         shutil.rmtree("./delete_me", ignore_errors=True)
 
         # creating framework for a role
-        gc = GalaxyCLI(args=["ansible-galaxy", "init", "--offline", "delete_me"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "init", "delete_me"])
         gc.run()
         cls.role_dir = "./delete_me"
         cls.role_name = "delete_me"
@@ -215,7 +215,6 @@ class TestGalaxy(unittest.TestCase):
         """ testing the options parser when the action 'init' is given """
         gc = GalaxyCLI(args=["ansible-galaxy", "init", "foo"])
         gc.parse()
-        assert not context.CLIARGS['offline']
         assert not context.CLIARGS['force']
 
     def test_parse_install(self):
@@ -279,7 +278,7 @@ class ValidRoleTests(object):
         args = ['ansible-galaxy']
         if use_explicit_type:
             args += ['role']
-        args += ['init', '-c', '--offline'] + galaxy_args + ['--init-path', cls.test_dir, cls.role_name]
+        args += ['init'] + galaxy_args + ['--init-path', cls.test_dir, cls.role_name]
 
         gc = GalaxyCLI(args=args)
         gc.run()
@@ -480,7 +479,7 @@ def test_verbosity_arguments(cli_args, expected, monkeypatch):
 def collection_skeleton(request, tmp_path_factory):
     name, skeleton_path = request.param
 
-    galaxy_args = ['ansible-galaxy', 'collection', 'init', '-c']
+    galaxy_args = ['ansible-galaxy', 'collection', 'init']
 
     if skeleton_path is not None:
         galaxy_args += ['--collection-skeleton', skeleton_path]

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -54,7 +54,7 @@ def collection_input(tmp_path_factory, collection_path_suffix):
     skeleton = os.path.join(os.path.dirname(os.path.split(__file__)[0]), 'cli', 'test_data', 'collection_skeleton')
 
     galaxy_args = ['ansible-galaxy', 'collection', 'init', '%s.%s' % (namespace, collection),
-                   '-c', '--init-path', test_dir, '--collection-skeleton', skeleton]
+                   '--init-path', test_dir, '--collection-skeleton', skeleton]
     GalaxyCLI(args=galaxy_args).run()
     collection_dir = os.path.join(test_dir, namespace, collection)
     output_dir = to_text(tmp_path_factory.mktemp('test-ÅÑŚÌβŁÈ Collections Output'))

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -69,7 +69,7 @@ def collection_artifact(request, tmp_path_factory):
     skeleton_path = os.path.join(os.path.dirname(os.path.split(__file__)[0]), 'cli', 'test_data', 'collection_skeleton')
     collection_path = os.path.join(test_dir, namespace, collection)
 
-    call_galaxy_cli(['init', '%s.%s' % (namespace, collection), '-c', '--init-path', test_dir,
+    call_galaxy_cli(['init', '%s.%s' % (namespace, collection), '--init-path', test_dir,
                      '--collection-skeleton', skeleton_path])
     dependencies = getattr(request, 'param', {})
 

--- a/test/units/galaxy/test_role_install.py
+++ b/test/units/galaxy/test_role_install.py
@@ -48,7 +48,7 @@ def init_role_dir(tmp_path_factory):
     namespace = 'ansible_namespace'
     role = 'role'
     skeleton_path = os.path.join(os.path.dirname(os.path.split(__file__)[0]), 'cli', 'test_data', 'role_skeleton')
-    call_galaxy_cli(['init', '%s.%s' % (namespace, role), '-c', '--init-path', test_dir, '--role-skeleton', skeleton_path])
+    call_galaxy_cli(['init', '%s.%s' % (namespace, role), '--init-path', test_dir, '--role-skeleton', skeleton_path])
 
 
 def mock_NamedTemporaryFile(mocker, **args):


### PR DESCRIPTION
##### SUMMARY

Remove unused ansible-galaxy options from `ansible-galaxy collection init|build|list` and `ansible-galaxy role init|list|remove`.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
