### PR TITLE
[stable-2.16] ansible-test - Fix interactive cmd traceback (#84264)

### DIFF
--- a/changelogs/fragments/ansible-test-fix-command-traceback.yml
+++ b/changelogs/fragments/ansible-test-fix-command-traceback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix traceback that occurs after an interactive command fails.

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -974,15 +974,15 @@ class HostConnectionError(ApplicationError):
             self._callback()
 
 
-def format_command_output(stdout: str, stderr: str) -> str:
+def format_command_output(stdout: str | None, stderr: str | None) -> str:
     """Return a formatted string containing the given stdout and stderr (if any)."""
     message = ''
 
-    if stderr := stderr.strip():
+    if stderr and (stderr := stderr.strip()):
         message += '>>> Standard Error\n'
         message += f'{stderr}{Display.clear}\n'
 
-    if stdout := stdout.strip():
+    if stdout and (stdout := stdout.strip()):
         message += '>>> Standard Output\n'
         message += f'{stdout}{Display.clear}\n'
 

--- a/test/units/ansible_test/_internal/test_util.py
+++ b/test/units/ansible_test/_internal/test_util.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_failed_non_interactive_captured_command() -> None:
+    """Verify failed non-interactive captured commands raise a `SubprocessError` with `stdout` and `stderr` set."""
+    from ansible_test._internal.util import raw_command, SubprocessError
+
+    with pytest.raises(SubprocessError, match='Command "ls /dev/null /does/not/exist" returned exit status [0-9]+.\n>>> Standard Error\n') as error:
+        raw_command(['ls', '/dev/null', '/does/not/exist'], True)
+
+    assert '/dev/null' in error.value.stdout
+    assert '/does/not/exist' in error.value.stderr
+
+
+def test_failed_non_interactive_command() -> None:
+    """Verify failed non-interactive non-captured commands raise a `SubprocessError` with `stdout` and `stderr` set to an empty string."""
+    from ansible_test._internal.util import raw_command, SubprocessError
+
+    with pytest.raises(SubprocessError, match='Command "ls /dev/null /does/not/exist" returned exit status [0-9]+.') as error:
+        raw_command(['ls', '/dev/null', '/does/not/exist'], False)
+
+    assert error.value.stdout == ''
+    assert error.value.stderr == ''
+
+
+def test_failed_interactive_command() -> None:
+    """Verify failed interactive commands raise a `SubprocessError` with `stdout` and `stderr` set to `None`."""
+    from ansible_test._internal.util import raw_command, SubprocessError
+
+    with pytest.raises(SubprocessError, match='Command "ls /dev/null /does/not/exist" returned exit status [0-9]+.') as error:
+        raw_command(['ls', '/dev/null', '/does/not/exist'], False, interactive=True)
+
+    assert error.value.stdout is None
+    assert error.value.stderr is None

--- a/test/units/ansible_test/conftest.py
+++ b/test/units/ansible_test/conftest.py
@@ -8,7 +8,7 @@ import sys
 
 
 @pytest.fixture(autouse=True, scope='session')
-def ansible_test():
-    """Make ansible_test available on sys.path for unit testing ansible-test."""
+def inject_ansible_test():
+    """Make ansible_test available on `sys.path` for unit testing ansible-test."""
     test_lib = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'lib')
     sys.path.insert(0, test_lib)


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/84264

(cherry picked from commit 68bfa378386f1f1b5ea9156324f2f5d7942d8a5c)

##### ISSUE TYPE

Bugfix Pull Request
