### PR TITLE
Remove support for resolvelib < 0.8.0, since 0.8.0 is over 3 years old

### DIFF
--- a/changelogs/fragments/update-resolvelib-lt-2_0_0.yml
+++ b/changelogs/fragments/update-resolvelib-lt-2_0_0.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ansible-galaxy - support ``resolvelib >= 0.5.3, < 2.0.0`` (https://github.com/ansible/ansible/issues/84217).
+  - ansible-galaxy - support ``resolvelib >= 0.8.0, < 2.0.0`` (https://github.com/ansible/ansible/issues/84217).

--- a/lib/ansible/galaxy/collection/galaxy_api_proxy.py
+++ b/lib/ansible/galaxy/collection/galaxy_api_proxy.py
@@ -12,9 +12,7 @@ if t.TYPE_CHECKING:
     from ansible.galaxy.collection.concrete_artifact_manager import (
         ConcreteArtifactsManager,
     )
-    from ansible.galaxy.dependency_resolution.dataclasses import (
-        Candidate, Requirement,
-    )
+    from ansible.galaxy.dependency_resolution.dataclasses import Candidate
 
 from ansible.galaxy.api import GalaxyAPI, GalaxyError
 from ansible.module_utils.common.text.converters import to_text
@@ -41,7 +39,7 @@ class MultiGalaxyAPIProxy:
         if self.is_offline_mode_requested:
             raise NotImplementedError("The calling code is not supposed to be invoked in 'offline' mode.")
 
-    def _get_collection_versions(self, requirement: Requirement) -> t.Iterator[tuple[GalaxyAPI, str]]:
+    def _get_collection_versions(self, requirement: Candidate) -> t.Iterator[tuple[GalaxyAPI, str]]:
         """Helper for get_collection_versions.
 
         Yield api, version pairs for all APIs,
@@ -84,7 +82,7 @@ class MultiGalaxyAPIProxy:
         if not found_api and last_error is not None:
             raise last_error
 
-    def get_collection_versions(self, requirement: Requirement) -> t.Iterable[tuple[str, GalaxyAPI]]:
+    def get_collection_versions(self, requirement: Candidate) -> t.Iterable[tuple[str, GalaxyAPI]]:
         """Get a set of unique versions for FQCN on Galaxy servers."""
         if requirement.is_concrete_artifact:
             return {

--- a/lib/ansible/galaxy/collection/galaxy_api_proxy.py
+++ b/lib/ansible/galaxy/collection/galaxy_api_proxy.py
@@ -42,7 +42,7 @@ class MultiGalaxyAPIProxy:
         if self.is_offline_mode_requested:
             raise NotImplementedError("The calling code is not supposed to be invoked in 'offline' mode.")
 
-    def _get_collection_versions(self, requirement: Requirement | Candidate) -> t.Iterator[tuple[GalaxyAPI, str]]:
+    def _get_collection_versions(self, requirement: Requirement) -> t.Iterator[tuple[GalaxyAPI, str]]:
         """Helper for get_collection_versions.
 
         Yield api, version pairs for all APIs,
@@ -85,7 +85,7 @@ class MultiGalaxyAPIProxy:
         if not found_api and last_error is not None:
             raise last_error
 
-    def get_collection_versions(self, requirement: Requirement | Candidate) -> t.Iterable[tuple[str, GalaxyAPI]]:
+    def get_collection_versions(self, requirement: Requirement) -> t.Iterable[tuple[str, GalaxyAPI]]:
         """Get a set of unique versions for FQCN on Galaxy servers."""
         if requirement.is_concrete_artifact:
             return {

--- a/lib/ansible/galaxy/collection/galaxy_api_proxy.py
+++ b/lib/ansible/galaxy/collection/galaxy_api_proxy.py
@@ -12,7 +12,10 @@ if t.TYPE_CHECKING:
     from ansible.galaxy.collection.concrete_artifact_manager import (
         ConcreteArtifactsManager,
     )
-    from ansible.galaxy.dependency_resolution.dataclasses import Candidate
+    from ansible.galaxy.dependency_resolution.dataclasses import (
+        Candidate,
+        Requirement,
+    )
 
 from ansible.galaxy.api import GalaxyAPI, GalaxyError
 from ansible.module_utils.common.text.converters import to_text
@@ -39,7 +42,7 @@ class MultiGalaxyAPIProxy:
         if self.is_offline_mode_requested:
             raise NotImplementedError("The calling code is not supposed to be invoked in 'offline' mode.")
 
-    def _get_collection_versions(self, requirement: Candidate) -> t.Iterator[tuple[GalaxyAPI, str]]:
+    def _get_collection_versions(self, requirement: Requirement | Candidate) -> t.Iterator[tuple[GalaxyAPI, str]]:
         """Helper for get_collection_versions.
 
         Yield api, version pairs for all APIs,
@@ -82,7 +85,7 @@ class MultiGalaxyAPIProxy:
         if not found_api and last_error is not None:
             raise last_error
 
-    def get_collection_versions(self, requirement: Candidate) -> t.Iterable[tuple[str, GalaxyAPI]]:
+    def get_collection_versions(self, requirement: Requirement | Candidate) -> t.Iterable[tuple[str, GalaxyAPI]]:
         """Get a set of unique versions for FQCN on Galaxy servers."""
         if requirement.is_concrete_artifact:
             return {

--- a/lib/ansible/galaxy/collection/galaxy_api_proxy.py
+++ b/lib/ansible/galaxy/collection/galaxy_api_proxy.py
@@ -13,8 +13,7 @@ if t.TYPE_CHECKING:
         ConcreteArtifactsManager,
     )
     from ansible.galaxy.dependency_resolution.dataclasses import (
-        Candidate,
-        Requirement,
+        Candidate, Requirement,
     )
 
 from ansible.galaxy.api import GalaxyAPI, GalaxyError

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -390,8 +390,7 @@ class CollectionDependencyProvider(AbstractProvider):
             requirements=requirement.ver,
         )
 
-    def get_dependencies(self, candidate):
-        # type: (Candidate) -> list[Candidate]
+    def get_dependencies(self, candidate: Candidate) -> list[Requirement]:
         r"""Get direct dependencies of a candidate.
 
         :returns: A collection of requirements that `candidate` \

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -364,7 +364,7 @@ class CollectionDependencyProvider(AbstractProvider):
 
         return list(preinstalled_candidates) + latest_matches
 
-    def is_satisfied_by(self, requirement: Candidate, candidate: Candidate) -> bool:
+    def is_satisfied_by(self, requirement: Requirement, candidate: Candidate) -> bool:
         r"""Whether the given requirement is satisfiable by a candidate.
 
         :param requirement: A requirement that produced the `candidate`.

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -165,7 +165,7 @@ class CollectionDependencyProvider(AbstractProvider):
     def find_matches(
         self,
         identifier: str,
-        requirements: t.Mapping[str, t.Iterator[Candidate]],
+        requirements: t.Mapping[str, t.Iterator[Requirement]],
         incompatibilities: t.Mapping[str, t.Iterator[Candidate]]
     ) -> list[Candidate]:
         r"""Find all possible candidates satisfying given requirements.
@@ -195,7 +195,7 @@ class CollectionDependencyProvider(AbstractProvider):
             if not any(match.ver == incompat.ver for incompat in incompatibilities[identifier])
         ]
 
-    def _find_matches(self, requirements: list[Candidate]) -> list[Candidate]:
+    def _find_matches(self, requirements: list[Requirement]) -> list[Candidate]:
         # FIXME: The first requirement may be a Git repo followed by
         # FIXME: its cloned tmp dir. Using only the first one creates
         # FIXME: loops that prevent any further dependency exploration.

--- a/test/integration/targets/ansible-galaxy-collection-scm/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/vars/main.yml
@@ -6,4 +6,4 @@ test_error_repo_path: "{{ galaxy_dir }}/development/error_test"
 
 supported_resolvelib_versions:
   - "0.8.0"  # Oldest supported
-  - "<2.0.0"
+  - "< 2.0.0"

--- a/test/integration/targets/ansible-galaxy-collection-scm/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/vars/main.yml
@@ -5,7 +5,5 @@ test_repo_path: "{{ galaxy_dir }}/development/ansible_test"
 test_error_repo_path: "{{ galaxy_dir }}/development/error_test"
 
 supported_resolvelib_versions:
-  - "0.5.3"  # Oldest supported
-  - "0.6.0"
-  - "0.7.0"
-  - "0.8.0"
+  - "0.8.0"  # Oldest supported
+  - "<2.0.0"

--- a/test/integration/targets/ansible-galaxy-collection/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/vars/main.yml
@@ -8,7 +8,7 @@ offline_server: https://test-hub.demolab.local/api/galaxy/content/api/
 # NOTE: If ansible-galaxy incorporates new resolvelib features, this matrix should be updated to verify the features work on all supported versions.
 supported_resolvelib_versions:
   - "0.8.0"
-  - "<2.0.0"
+  - "< 2.0.0"
 
 unsupported_resolvelib_versions:
   - "0.2.0"  # Fails on import

--- a/test/integration/targets/ansible-galaxy-collection/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/vars/main.yml
@@ -5,14 +5,10 @@ gpg_homedir: "{{ galaxy_dir }}/gpg"
 offline_server: https://test-hub.demolab.local/api/galaxy/content/api/
 
 # Test oldest and most recently supported, and versions with notable changes.
-# The last breaking change for a feature ansible-galaxy uses was in 0.8.0.
-# It would be redundant to test every minor version since 0.8.0, so we just test against the latest minor release.
 # NOTE: If ansible-galaxy incorporates new resolvelib features, this matrix should be updated to verify the features work on all supported versions.
 supported_resolvelib_versions:
-  - "0.5.3"  # test CollectionDependencyProvider050
-  - "0.6.0"  # test CollectionDependencyProvider060
-  - "0.7.0"  # test CollectionDependencyProvider070
-  - "<2.0.0"  # test CollectionDependencyProvider080
+  - "0.8.0"
+  - "<2.0.0"
 
 unsupported_resolvelib_versions:
   - "0.2.0"  # Fails on import


### PR DESCRIPTION
##### SUMMARY

Follow up to #84218.

@mattclay suggested some of the old 0.x versions should be dropped since 0.8.0 is several years old already, and this lets us simplify the code and reduce test time.

##### ISSUE TYPE

- Feature Pull Request
