### PR TITLE
Remove scheduled CI runs

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -12,15 +12,6 @@ pr:
       - devel
       - stable-*
 
-schedules:
-  - cron: 0 7 * * *
-    displayName: Nightly
-    always: true
-    branches:
-      include:
-        - devel
-        - stable-*
-
 variables:
   - name: checkoutPath
     value: ansible


### PR DESCRIPTION
##### SUMMARY

The ansible-core 2.15 branch is EOL now that ansible-core 2.18 has been released.

##### ISSUE TYPE

Test Pull Request
