### PR TITLE
Deprecated host_key_checking option

### DIFF
--- a/changelogs/fragments/deprecate_host_key_checking.yml
+++ b/changelogs/fragments/deprecate_host_key_checking.yml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+  - config - deprecate host_key_checking from the global configuration.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1551,6 +1551,10 @@ HOST_KEY_CHECKING:
   ini:
   - {key: host_key_checking, section: defaults}
   type: boolean
+  deprecated:
+    why: This option was moved to the individual plugin itself
+    version: "2.22"
+    alternatives: Use the option from the plugin itself.
 HOST_PATTERN_MISMATCH:
   name: Control host pattern mismatch behaviour
   default: 'warning'


### PR DESCRIPTION
##### SUMMARY

* User can set host_key_checking configuration from
  connection plugins such as ssh and paramiko_ssh itself.
  Deprecate host_key_checking from global configuration.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


