### PR TITLE
Fix runas become SYSTEM logic

### DIFF
--- a/changelogs/fragments/become-runas-system-deux.yml
+++ b/changelogs/fragments/become-runas-system-deux.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - >-
+    runas become - Fix up become logic to still get the SYSTEM token with the most privileges when running as SYSTEM.


### PR DESCRIPTION
##### SUMMARY
Fixes the logic when attempting to become the SYSTEM user using the runas plugin. It was incorrectly assumed that calling LogonUser with the SYSTEM username would produce a new token with all the privileges but instead it creates a copy of the existing token. This reverts the logic back to the original process and adds in new logic to avoid any tokens that are restricted from creating new processes.

Was introduced by https://github.com/ansible/ansible/pull/83827 to solve the process mitigation policy but it turns out the logic around token creation was wrong. This does the revert and adds in the extra logic to handle the process mitigation policy issue.

##### ISSUE TYPE
- Bugfix Pull Request