### PR TITLE
Add support for Windows Server 2025

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -78,6 +78,10 @@ stages:
               test: 2022/psrp/http
             - name: 2022 SSH Key
               test: 2022/ssh/key
+            - name: 2025 PSRP HTTP
+              test: 2025/psrp/http
+            - name: 2025 SSH Key
+              test: 2025/ssh/key
   - stage: Remote
     dependsOn: []
     jobs:
@@ -198,6 +202,10 @@ stages:
               test: 2022/psrp/http
             - name: 2022 SSH Key
               test: 2022/ssh/key
+            - name: 2025 PSRP HTTP
+              test: 2025/psrp/http
+            - name: 2025 SSH Key
+              test: 2025/ssh/key
   - stage: Incidental
     dependsOn: []
     jobs:

--- a/changelogs/fragments/84229-windows-server-2025.yml
+++ b/changelogs/fragments/84229-windows-server-2025.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >-
+    Windows - Add support for Windows Server 2025 to Ansible and as an ``ansible-test``
+    remote target - https://github.com/ansible/ansible/issues/84229

--- a/test/integration/targets/module_utils_Ansible.ModuleUtils.CommandUtil/library/command_util_test.ps1
+++ b/test/integration/targets/module_utils_Ansible.ModuleUtils.CommandUtil/library/command_util_test.ps1
@@ -65,7 +65,7 @@ Assert-Equal -actual $actual.executable -expected $exe
 $test_name = "no working directory set"
 $actual = Run-Command -command "cmd.exe /c cd"
 Assert-Equal -actual $actual.rc -expected 0
-Assert-Equal -actual $actual.stdout -expected "$($pwd.Path)`r`n"
+Assert-Equal -actual $actual.stdout.ToUpper() -expected "$($pwd.Path)`r`n".ToUpper()
 Assert-Equal -actual $actual.stderr -expected ""
 Assert-Equal -actual $actual.executable.ToUpper() -expected "$env:SystemRoot\System32\cmd.exe".ToUpper()
 

--- a/test/lib/ansible_test/_data/completion/windows.txt
+++ b/test/lib/ansible_test/_data/completion/windows.txt
@@ -1,4 +1,5 @@
 windows/2016 provider=aws arch=x86_64 connection=winrm+http
 windows/2019 provider=aws arch=x86_64 connection=winrm+https
 windows/2022 provider=aws arch=x86_64 connection=winrm+https
+windows/2025 provider=aws arch=x86_64 connection=winrm+https
 windows provider=aws arch=x86_64 connection=winrm+https


### PR DESCRIPTION
##### SUMMARY
Adds Windows Server 2025 to the testing matrix.

Fixes: https://github.com/ansible/ansible/issues/84229

##### ISSUE TYPE
- Feature Pull Request
- Test Pull Request