### PR TITLE
ansible-test - align 2025 connection defaults to CI matrix

### DIFF
--- a/test/lib/ansible_test/_data/completion/windows.txt
+++ b/test/lib/ansible_test/_data/completion/windows.txt
@@ -1,5 +1,5 @@
 windows/2016 provider=aws arch=x86_64 connection=winrm+http
 windows/2019 provider=aws arch=x86_64 connection=winrm+https
 windows/2022 provider=aws arch=x86_64 connection=winrm+https
-windows/2025 provider=aws arch=x86_64 connection=winrm+https
+windows/2025 provider=aws arch=x86_64 connection=psrp+http
 windows provider=aws arch=x86_64 connection=winrm+https


### PR DESCRIPTION
##### SUMMARY
Aligns the default connection type to the one used in the test matrix.

##### ISSUE TYPE
- Test Pull Request