### PR TITLE
Removed deprecated include_delegate_to param

### DIFF
--- a/changelogs/fragments/include_delegate_to.yml
+++ b/changelogs/fragments/include_delegate_to.yml
@@ -1,0 +1,3 @@
+---
+removed_features:
+  - manager - remove deprecated include_delegate_to parameter from get_vars API.

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -135,7 +135,7 @@ class VariableManager:
     def set_inventory(self, inventory):
         self._inventory = inventory
 
-    def get_vars(self, play=None, host=None, task=None, include_hostvars=True, include_delegate_to=False, use_cache=True,
+    def get_vars(self, play=None, host=None, task=None, include_hostvars=True, use_cache=True,
                  _hosts=None, _hosts_all=None, stage='task'):
         """
         Returns the variables, with optional "context" given via the parameters
@@ -159,11 +159,6 @@ class VariableManager:
         on the functionality they provide. These arguments may be removed at a later date without a deprecation
         period and without warning.
         """
-        if include_delegate_to:
-            display.deprecated(
-                "`VariableManager.get_vars`'s argument `include_delegate_to` has no longer any effect.",
-                version="2.19",
-            )
 
         display.debug("in VariableManager get_vars()")
 

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -155,7 +155,6 @@ lib/ansible/plugins/action/copy.py pylint:undefined-variable
 test/integration/targets/module_utils/library/test_optional.py pylint:used-before-assignment
 test/support/windows-integration/plugins/action/win_copy.py pylint:undefined-variable
 lib/ansible/plugins/connection/__init__.py pylint:ansible-deprecated-version
-lib/ansible/vars/manager.py pylint:ansible-deprecated-version
 test/units/module_utils/basic/test_exit_json.py mypy-3.13:assignment
 test/units/module_utils/basic/test_exit_json.py mypy-3.13:misc
 test/units/module_utils/common/text/converters/test_json_encode_fallback.py mypy-3.13:abstract


### PR DESCRIPTION
##### SUMMARY

* Remove deprecated include_delegate_to param from
  get_vars API in manager.py

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


