### PR TITLE
Fix ansible/ansible#84295 (action/include_vars.py)

### DIFF
--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -13,6 +13,7 @@ from ansible.module_utils.six import string_types
 from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import combine_vars
+from ansible.parsing.yaml.objects import AnsibleMapping
 
 
 class ActionModule(ActionBase):
@@ -144,6 +145,8 @@ class ActionModule(ActionBase):
             merge_hashes = self.hash_behaviour == 'merge'
             for key, value in results.items():
                 old_value = task_vars.get(key, None)
+                if not isinstance(old_value, AnsibleMapping) or not isinstance(value, AnsibleMapping):
+                    continue
                 results[key] = combine_vars(old_value, value, merge=merge_hashes)
 
         result['ansible_included_var_files'] = self.included_files


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Added check if previous value is defined to define new value without merge during merge loop.
Added check if previous value is not a dict and override it with new value without merge during merge loop.
Added check if previous value is dict and new value is empty and then merge them assumming new value as empty dict during merge loop.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #84295

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
