### PR TITLE
Fix ansible-galaxy-collection test and add assertion for the expected error

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection/tasks/fail_fast_resolvelib.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/fail_fast_resolvelib.yml
@@ -26,9 +26,12 @@
         chdir: "{{ galaxy_dir }}/resolvelib"
 
     - name: install a conflicting version of the dep with the tarfile (expected failure)
-      command: ansible-galaxy collection install namespace1.name1:1.0.9 ns-coll-1.0.0.tar.gz -vvvvv -s {{ test_name }} -p collections/
+      command: ansible-galaxy collection install namespace1.name1:1.0.9 ns-coll-1.0.0.tar.gz -vvvvv -s galaxy_ng -p collections/
       args:
         chdir: "{{ galaxy_dir }}/resolvelib"
+      environment:
+        ANSIBLE_NOCOLOR: true
+        ANSIBLE_FORCE_COLOR: false
       timeout: 30
       ignore_errors: yes
       register: incompatible
@@ -37,6 +40,12 @@
         that:
           - incompatible.failed
           - not incompatible.msg.startswith("The command action failed to execute in the expected time frame")
+          - expected in incompatible.msg
+      vars:
+        expected: |
+          Failed to resolve the requested dependencies map. Could not satisfy the following requirements:
+          * namespace1.name1:1.0.9 (direct request)
+          * namespace1.name1:0.0.5 (dependency of ns.coll:1.0.0)
 
   always:
     - name: cleanup resolvelib test

--- a/test/integration/targets/ansible-galaxy-collection/tasks/fail_fast_resolvelib.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/fail_fast_resolvelib.yml
@@ -40,7 +40,7 @@
         that:
           - incompatible.failed
           - not incompatible.msg.startswith("The command action failed to execute in the expected time frame")
-          - expected in incompatible.msg
+          - expected in incompatible.stderr
       vars:
         expected: |
           Failed to resolve the requested dependencies map. Could not satisfy the following requirements:


### PR DESCRIPTION
##### SUMMARY

This passes on devel because there's an undefined variable, and the assertion only tests the task timeout does not occur.

##### ISSUE TYPE

- Test Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```paste below

```
