### PR TITLE
improve ansible-galaxy-collection test failure logs for CI

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection/aliases
+++ b/test/integration/targets/ansible-galaxy-collection/aliases
@@ -2,3 +2,5 @@ shippable/galaxy/group1
 shippable/galaxy/smoketest
 cloud/galaxy
 context/controller
+# TODO: remove once the test cleans up between failures reliably and delete the runme.sh
+never/retry/

--- a/test/integration/targets/ansible-galaxy-collection/runme.sh
+++ b/test/integration/targets/ansible-galaxy-collection/runme.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# running the test with -vvvv by default since it is not retried
+ansible -i ../../inventory -m include_role -a "name=../../ansible-galaxy-collection/" -vvvv "$@" all


### PR DESCRIPTION
##### SUMMARY

add the never/retry/ test alias since it doesn't fully clean up after itself, and the previous attempt is usually the cause of failure for the retry rather than adding anything informative

convert the integration test role to a runme.sh test and run the test with minimum verbosity -vvvv

##### ISSUE TYPE

- Test Pull Request
