### PR TITLE
simplify copy module

### DIFF
--- a/changelogs/fragments/simplify-copy-module.yml
+++ b/changelogs/fragments/simplify-copy-module.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - copy - refactor copy module for simplicity.

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -286,10 +286,8 @@ state:
 
 import errno
 import filecmp
-import grp
 import os
 import os.path
-import pwd
 import shutil
 import stat
 import tempfile

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -378,8 +378,7 @@ def copy_diff_files(src, dest, module):
                 shutil.copyfile(b_src_item_path, b_dest_item_path)
                 shutil.copymode(b_src_item_path, b_dest_item_path)
 
-            module.set_owner_if_different(b_dest_item_path, owner, False)
-            module.set_group_if_different(b_dest_item_path, group, False)
+            chown_path(module, b_dest_item_path, owner, group)
             changed = True
     return changed
 
@@ -411,8 +410,7 @@ def copy_left_only(src, dest, module):
 
             if os.path.islink(b_src_item_path) and os.path.isfile(b_src_item_path) and local_follow is True:
                 shutil.copyfile(b_src_item_path, b_dest_item_path)
-                module.set_owner_if_different(b_dest_item_path, owner, False)
-                module.set_group_if_different(b_dest_item_path, group, False)
+                chown_path(module, b_dest_item_path, owner, group)
 
             if os.path.islink(b_src_item_path) and os.path.isfile(b_src_item_path) and local_follow is False:
                 linkto = os.readlink(b_src_item_path)
@@ -421,9 +419,7 @@ def copy_left_only(src, dest, module):
             if not os.path.islink(b_src_item_path) and os.path.isfile(b_src_item_path):
                 shutil.copyfile(b_src_item_path, b_dest_item_path)
                 shutil.copymode(b_src_item_path, b_dest_item_path)
-
-                module.set_owner_if_different(b_dest_item_path, owner, False)
-                module.set_group_if_different(b_dest_item_path, group, False)
+                chown_path(module, b_dest_item_path, owner, group)
 
             if not os.path.islink(b_src_item_path) and os.path.isdir(b_src_item_path):
                 shutil.copytree(b_src_item_path, b_dest_item_path, symlinks=not local_follow)
@@ -617,8 +613,7 @@ def main():
                     # if we have a mode, make sure we set it on the temporary
                     # file source as some validations may require it
                     module.set_mode_if_different(src, mode, False)
-                    module.set_owner_if_different(src, owner, False)
-                    module.set_group_if_different(src, group, False)
+                    chown_path(module, src, owner, group)
                     if "%s" not in validate:
                         module.fail_json(msg="validate must contain %%s: %s" % (validate))
                     (rc, out, err) = module.run_command(validate % src)

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -642,7 +642,9 @@ def main():
         changed = True
 
     # If neither have checksums, both src and dest are directories.
-    if checksum_src is None and checksum_dest is None and remote_src and os.path.isdir(module.params['src']):
+    checksums_none = checksum_src is None and checksum_dest is None
+    both_directories = os.path.isdir(module.params['src']) and (os.path.isdir(module.params['dest']) or not os.path.exists(module.params['dest']))
+    if checksums_none and remote_src and both_directories:
         b_src = to_bytes(module.params['src'], errors='surrogate_or_strict')
         b_dest = to_bytes(module.params['dest'], errors='surrogate_or_strict')
 

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -461,7 +461,8 @@ def copy_directory(src, dest, module):
         diff_files_changed = copy_diff_files(src, dest, module)
         left_only_changed = copy_left_only(src, dest, module)
         common_dirs_changed = copy_common_dirs(src, dest, module)
-        changed = diff_files_changed or left_only_changed or common_dirs_changed
+        owner_group_changed = chown_recursive(dest, module)
+        changed = any([diff_files_changed, left_only_changed, common_dirs_changed, owner_group_changed])
     return changed
 
 


### PR DESCRIPTION
##### SUMMARY

The `set_*_if_different` methods handle check mode, null parameters, and looking up uid/gid, but the copy module reimplements a lot of that unnecessarily. This shouldn't change anything behavior-wise, only simplify the code.

##### ISSUE TYPE

- Bugfix Pull Request