### PR TITLE
remove hard coded "/tmp" in ansible-test injector paths

### DIFF
--- a/test/lib/ansible_test/_internal/util_common.py
+++ b/test/lib/ansible_test/_internal/util_common.py
@@ -296,7 +296,7 @@ def write_text_test_results(category: ResultType, name: str, content: str) -> No
 @cache
 def get_injector_path() -> str:
     """Return the path to a directory which contains a `python.py` executable and associated injector scripts."""
-    injector_path = tempfile.mkdtemp(prefix='ansible-test-', suffix='-injector', dir='/tmp')
+    injector_path = tempfile.mkdtemp(prefix='ansible-test-', suffix='-injector')
 
     display.info(f'Initializing "{injector_path}" as the temporary injector directory.', verbosity=1)
 
@@ -370,9 +370,7 @@ def get_python_path(interpreter: str) -> str:
     prefix = 'python-'
     suffix = '-ansible'
 
-    root_temp_dir = '/tmp'
-
-    python_path = tempfile.mkdtemp(prefix=prefix, suffix=suffix, dir=root_temp_dir)
+    python_path = tempfile.mkdtemp(prefix=prefix, suffix=suffix)
     injected_interpreter = os.path.join(python_path, 'python')
 
     # A symlink is faster than the execv wrapper, but isn't guaranteed to provide the correct result.


### PR DESCRIPTION
fixes https://github.com/ansible/ansible/issues/82214

Not entirely clear on why this was hardcoded in the first place, so there might be some good reason not to do this.