### PR TITLE
Remove selinux import

### DIFF
--- a/changelogs/fragments/selinux_import.yml
+++ b/changelogs/fragments/selinux_import.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - remove extraneous selinux import (https://github.com/ansible/ansible/issues/83657).

--- a/lib/ansible/module_utils/common/file.py
+++ b/lib/ansible/module_utils/common/file.py
@@ -7,12 +7,6 @@ import os
 import stat
 import re
 
-try:
-    import selinux  # pylint: disable=unused-import
-    HAVE_SELINUX = True
-except ImportError:
-    HAVE_SELINUX = False
-
 
 FILE_ATTRIBUTES = {
     'A': 'noatime',


### PR DESCRIPTION
##### SUMMARY

Remove selinux import which was kept for backward compatibility

Fixes: #83657

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit d23a2de5f249727e70c1b45c3b22dc1dee7c5865)

##### ISSUE TYPE
- Bugfix Pull Request


