### PR TITLE
validate-modules: enforce FQCNs in seealso plugin/module entries

### DIFF
--- a/changelogs/fragments/84325-validate-modules-seealso-fqcn.yml
+++ b/changelogs/fragments/84325-validate-modules-seealso-fqcn.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "validate-modules sanity test - make sure that ``module`` and ``plugin`` ``seealso`` entries use FQCNs (https://github.com/ansible/ansible/pull/84325)."

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -67,6 +67,17 @@ def collection_name(v, error_code=None):
     return v
 
 
+def fqcn(v, error_code=None):
+    if not isinstance(v, string_types):
+        raise _add_ansible_error_code(
+            Invalid('Module/plugin name must be a string'), error_code or 'invalid-documentation')
+    m = FULLY_QUALIFIED_COLLECTION_RESOURCE_RE.match(v)
+    if not m:
+        raise _add_ansible_error_code(
+            Invalid('Module/plugin name must be of format `<namespace>.<collection>.<name>(.<subname>)*`'), error_code or 'invalid-documentation')
+    return v
+
+
 def deprecation_versions():
     """Create a list of valid version for deprecation entries, current+4"""
     major, minor = [int(version) for version in __version__.split('.')[0:2]]
@@ -196,11 +207,11 @@ seealso_schema = Schema(
     [
         Any(
             {
-                Required('module'): Any(*string_types),
+                Required('module'): fqcn,
                 'description': doc_string,
             },
             {
-                Required('plugin'): Any(*string_types),
+                Required('plugin'): fqcn,
                 Required('plugin_type'): Any(*DOCUMENTABLE_PLUGINS),
                 'description': doc_string,
             },


### PR DESCRIPTION
##### SUMMARY
Not all modules/plugins use FQCNs there, for example https://github.com/CiscoDevNet/ansible-aci/blob/a3c9bd87290d6aa9412e852d25e4f3c94fc7ca54/plugins/modules/aci_l2out_logical_interface_profile.py#L53-L56. This causes some errors during the docs build.

##### ISSUE TYPE
- Feature Pull Request
