### PR TITLE
fix documentation about avoiding apt_key

### DIFF
--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -143,7 +143,7 @@ EXAMPLES = """
 
     - name: somerepo | apt source
       ansible.builtin.apt_repository:
-        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/myrepo.asc] https://download.example.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/somerepo.asc] https://download.example.com/linux/ubuntu {{ ansible_distribution_release }} stable"
         state: present
 """
 


### PR DESCRIPTION
If I understand correctly, the asc file you put in the apt_repository must be the same created with the previous get_url call

- Docs Pull Request

