### PR TITLE
[stable-2.18] dnf5: fix is_installed check (#84275)

### DIFF
--- a/changelogs/fragments/84259-dnf5-latest-fix.yml
+++ b/changelogs/fragments/84259-dnf5-latest-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "dnf5 - fix installing a package using ``state=latest`` when a binary of the same name as the package is already installed (https://github.com/ansible/ansible/issues/84259)"

--- a/changelogs/fragments/84334-dnf5-consolidate-settings.yml
+++ b/changelogs/fragments/84334-dnf5-consolidate-settings.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf5 - matching on a binary can be achieved only by specifying a full path (https://github.com/ansible/ansible/issues/84334)

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -358,6 +358,15 @@ libdnf5 = None
 
 def is_installed(base, spec):
     settings = libdnf5.base.ResolveSpecSettings()
+    # Disable checking whether SPEC is a binary -> `/usr/(s)bin/<SPEC>`,
+    # this prevents scenarios like the following:
+    #   * the `sssd-common` package is installed and provides `/usr/sbin/sssd` binary
+    #   * the `sssd` package is NOT installed
+    #   * due to `set_with_binaries(True)` being default `is_installed(base, "sssd")` would "unexpectedly" return True
+    # If users wish to target the `sssd` binary they can by specifying the full path `name=/usr/sbin/sssd` explicitly
+    # due to settings.set_with_filenames(True) being default.
+    settings.set_with_binaries(False)
+
     installed_query = libdnf5.rpm.PackageQuery(base)
     installed_query.filter_installed()
     match, nevra = installed_query.resolve_pkg_spec(spec, settings, True)

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -517,3 +517,50 @@
       dnf:
         name: provides_foo*
         state: absent
+
+# https://github.com/ansible/ansible/issues/84259
+- name: test installing a package named `package-name` while a package providing `/usr/sbin/package-name` is installed
+  block:
+    - dnf:
+        name: package-name
+        state: absent
+
+    - dnf:
+        name: provides-binary
+        state: present
+
+    - dnf:
+        name: package-name
+        state: latest
+      register: dnf_result
+
+    - assert:
+        that:
+          - dnf_result is changed
+  always:
+    - name: Clean up
+      dnf:
+        name:
+          - provides-binary
+          - package-name
+        state: absent
+
+- name: test installing a package that provides a binary by specifying the binary name
+  block:
+    - dnf:
+        name: provides-binary
+        state: absent
+
+    - dnf:
+        name: /usr/sbin/package-name
+        state: present
+      register: dnf_result
+
+    - assert:
+        that:
+          - dnf_result is changed
+  always:
+    - name: Clean up
+      dnf:
+        name: provides-binary
+        state: absent

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -564,3 +564,26 @@
       dnf:
         name: provides-binary
         state: absent
+
+# https://github.com/ansible/ansible/issues/84334
+- name: test that a binary is not matched by its base name
+  block:
+    - dnf:
+        name: provides-binary
+        state: present
+
+    - dnf:
+        name: package-name
+        state: absent
+      register: dnf_result
+
+    - assert:
+        that:
+          - dnf_result is not changed
+  always:
+    - name: Clean up
+      dnf:
+        name:
+          - provides-binary
+          - package-name
+        state: absent


### PR DESCRIPTION
##### SUMMARY
Backport of #84275 
Backport of #84335

(cherry picked from commit a27a7a27d144ff00db1d0a0b2dae494c21f83f10)
(cherry picked from commit c99493eb3f1121b73f76927e37834afa0d6e0269)
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request