### PR TITLE
Changed human_to_bytes input to a string

### DIFF
--- a/lib/ansible/plugins/filter/human_to_bytes.yml
+++ b/lib/ansible/plugins/filter/human_to_bytes.yml
@@ -8,7 +8,7 @@ DOCUMENTATION:
   options:
     _input:
       description: human-readable description of a number of bytes.
-      type: int
+      type: string
       required: true
     default_unit:
       description: Unit to assume when input does not specify it.


### PR DESCRIPTION

##### SUMMARY

<!--- Describe the change below, including rationale -->

The [documentation for `ansible.builtin.human_to_bytes`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/human_to_bytes_filter.html) stated that the input should be an `int`.
I corrected this to `string`. For the input to be a human readable description it can't be an int.
I pulled an example from the documentation to show this:
```
# size => 1234803098
size: '{{ "1.15 GB" | human_to_bytes }}'
```

<!--- HINT: Include "Closes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Docs Pull Request