### PR TITLE
remove useless error message (ansible#84342)

### DIFF
--- a/changelogs/fragments/remove-useless-error-message.yml
+++ b/changelogs/fragments/remove-useless-error-message.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Remove useless error message when an exception occurs without specific information
+  - Fix a display.debug statement with the wrong param in _get_diff_data() method

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1372,7 +1372,7 @@ class ActionBase(ABC):
             elif peek_result.get('size') and C.MAX_FILE_SIZE_FOR_DIFF > 0 and peek_result['size'] > C.MAX_FILE_SIZE_FOR_DIFF:
                 diff['dst_larger'] = C.MAX_FILE_SIZE_FOR_DIFF
             else:
-                display.debug(u"Slurping the file %s" % source)
+                display.debug(u"Slurping the file %s" % destination)
                 dest_result = self._execute_module(
                     module_name='ansible.legacy.slurp', module_args=dict(path=destination),
                     task_vars=task_vars, persist_files=True)

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -164,6 +164,7 @@ class CallbackBase(AnsiblePlugin):
             self.set_options(options)
 
         self._hide_in_debug = ('changed', 'failed', 'skipped', 'invocation', 'skip_reason')
+        self._no_display_errors = ('NoneType: None',)
 
     # helper for callbacks, so they don't all have to include deepcopy
     _copy_result = deepcopy
@@ -305,7 +306,9 @@ class CallbackBase(AnsiblePlugin):
             if self._display.verbosity < 3:
                 # extract just the actual error message from the exception text
                 error = exception_str.strip().split('\n')[-1]
-                msg += "To see the full traceback, use -vvv. The error was: %s" % error
+                msg += "To see the full traceback, use -vvv."
+                if error and not error.strip() in self._no_display_errors:
+                    msg += " The error was: %s" % error
             else:
                 msg = "The full traceback is:\n" + exception_str
                 del result['exception']

--- a/lib/ansible/plugins/callback/oneline.py
+++ b/lib/ansible/plugins/callback/oneline.py
@@ -41,7 +41,9 @@ class CallbackModule(CallbackBase):
             if self._display.verbosity < 3:
                 # extract just the actual error message from the exception text
                 error = result._result['exception'].strip().split('\n')[-1]
-                msg = "An exception occurred during task execution. To see the full traceback, use -vvv. The error was: %s" % error
+                msg = "An exception occurred during task execution. To see the full traceback, use -vvv."
+                if error and not error.strip() in self._no_display_errors:
+                    msg += " The error was: %s" % error
             else:
                 msg = "An exception occurred during task execution. The full traceback is:\n" + result._result['exception'].replace('\n', '')
 

--- a/test/units/errors/test_errors.py
+++ b/test/units/errors/test_errors.py
@@ -152,7 +152,7 @@ class TestErrors(unittest.TestCase):
         no_display_errors = ('NoneType: None', )
         result = {}
         try:
-            raise AnsibleActionFail("test exception") 
+            raise AnsibleActionFail("test exception")
         except Exception as e:
             result = e.result
 


### PR DESCRIPTION
##### SUMMARY
remove useless error message when an exception occurs without specific information.
see #84342 

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

