### PR TITLE
Docs: Replaces module reference with backticks

### DIFF
--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -295,7 +295,7 @@ notes:
     removal the module is unable to detect that the group is installed
     U(https://bugzilla.redhat.com/show_bug.cgi?id=1620324).
   - While O(use_backend=yum) and the ability to call the action plugin as
-    M(ansible.builtin.yum) are provided for syntax compatibility, the YUM
+    `ansible.builtin.yum` are provided for syntax compatibility, the YUM
     backend was removed in ansible-core 2.17 because the required libraries are
     not available for any supported version of Python. If you rely on this
     functionality, use an older version of Ansible.


### PR DESCRIPTION
##### SUMMARY

This change replaces the reference to a removed module with backticks. Follows up on PR #83429 and fixes docs build issues with broken intersphinx links.

##### ISSUE TYPE

- Docs Pull Request

##### ADDITIONAL INFORMATION

Unblocks https://github.com/ansible/ansible-documentation/pull/2212 to drop old intersphinx links.

Should be backported to stable-2.18.
