### PR TITLE
[stable-2.17] dnf5: fix is_installed check (#84275)

### DIFF
--- a/changelogs/fragments/84259-dnf5-latest-fix.yml
+++ b/changelogs/fragments/84259-dnf5-latest-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "dnf5 - fix installing a package using ``state=latest`` when a binary of the same name as the package is already installed (https://github.com/ansible/ansible/issues/84259)"

--- a/changelogs/fragments/84334-dnf5-consolidate-settings.yml
+++ b/changelogs/fragments/84334-dnf5-consolidate-settings.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf5 - matching on a binary can be achieved only by specifying a full path (https://github.com/ansible/ansible/issues/84334)

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -357,6 +357,15 @@ libdnf5 = None
 
 def is_installed(base, spec):
     settings = libdnf5.base.ResolveSpecSettings()
+    # Disable checking whether SPEC is a binary -> `/usr/(s)bin/<SPEC>`,
+    # this prevents scenarios like the following:
+    #   * the `sssd-common` package is installed and provides `/usr/sbin/sssd` binary
+    #   * the `sssd` package is NOT installed
+    #   * due to `set_with_binaries(True)` being default `is_installed(base, "sssd")` would "unexpectedly" return True
+    # If users wish to target the `sssd` binary they can by specifying the full path `name=/usr/sbin/sssd` explicitly
+    # due to settings.set_with_filenames(True) being default.
+    settings.set_with_binaries(False)
+
     installed_query = libdnf5.rpm.PackageQuery(base)
     installed_query.filter_installed()
     match, nevra = installed_query.resolve_pkg_spec(spec, settings, True)

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -357,14 +357,20 @@ libdnf5 = None
 
 def is_installed(base, spec):
     settings = libdnf5.base.ResolveSpecSettings()
-    # Disable checking whether SPEC is a binary -> `/usr/(s)bin/<SPEC>`,
-    # this prevents scenarios like the following:
-    #   * the `sssd-common` package is installed and provides `/usr/sbin/sssd` binary
-    #   * the `sssd` package is NOT installed
-    #   * due to `set_with_binaries(True)` being default `is_installed(base, "sssd")` would "unexpectedly" return True
-    # If users wish to target the `sssd` binary they can by specifying the full path `name=/usr/sbin/sssd` explicitly
-    # due to settings.set_with_filenames(True) being default.
-    settings.set_with_binaries(False)
+    try:
+        settings.set_group_with_name(True)
+        # Disable checking whether SPEC is a binary -> `/usr/(s)bin/<SPEC>`,
+        # this prevents scenarios like the following:
+        #   * the `sssd-common` package is installed and provides `/usr/sbin/sssd` binary
+        #   * the `sssd` package is NOT installed
+        #   * due to `set_with_binaries(True)` being default `is_installed(base, "sssd")` would "unexpectedly" return True
+        # If users wish to target the `sssd` binary they can by specifying the full path `name=/usr/sbin/sssd` explicitly
+        # due to settings.set_with_filenames(True) being default.
+        settings.set_with_binaries(False)
+    except AttributeError:
+        # dnf5 < 5.2.0.0
+        settings.group_with_name = True
+        settings.with_binaries = False
 
     installed_query = libdnf5.rpm.PackageQuery(base)
     installed_query.filter_installed()
@@ -630,9 +636,12 @@ class Dnf5Module(YumDnf):
         settings = libdnf5.base.GoalJobSettings()
         try:
             settings.set_group_with_name(True)
+            settings.set_with_binaries(False)
         except AttributeError:
             # dnf5 < 5.2.0.0
             settings.group_with_name = True
+            settings.with_binaries = False
+
         if self.bugfix or self.security:
             advisory_query = libdnf5.advisory.AdvisoryQuery(base)
             types = []

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -589,3 +589,26 @@
       dnf:
         name: provides-binary
         state: absent
+
+# https://github.com/ansible/ansible/issues/84334
+- name: test that a binary is not matched by its base name
+  block:
+    - dnf:
+        name: provides-binary
+        state: present
+
+    - dnf:
+        name: package-name
+        state: absent
+      register: dnf_result
+
+    - assert:
+        that:
+          - dnf_result is not changed
+  always:
+    - name: Clean up
+      dnf:
+        name:
+          - provides-binary
+          - package-name
+        state: absent

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -542,3 +542,50 @@
       dnf:
         name: provides_foo*
         state: absent
+
+# https://github.com/ansible/ansible/issues/84259
+- name: test installing a package named `package-name` while a package providing `/usr/sbin/package-name` is installed
+  block:
+    - dnf:
+        name: package-name
+        state: absent
+
+    - dnf:
+        name: provides-binary
+        state: present
+
+    - dnf:
+        name: package-name
+        state: latest
+      register: dnf_result
+
+    - assert:
+        that:
+          - dnf_result is changed
+  always:
+    - name: Clean up
+      dnf:
+        name:
+          - provides-binary
+          - package-name
+        state: absent
+
+- name: test installing a package that provides a binary by specifying the binary name
+  block:
+    - dnf:
+        name: provides-binary
+        state: absent
+
+    - dnf:
+        name: /usr/sbin/package-name
+        state: present
+      register: dnf_result
+
+    - assert:
+        that:
+          - dnf_result is changed
+  always:
+    - name: Clean up
+      dnf:
+        name: provides-binary
+        state: absent

--- a/test/integration/targets/setup_rpm_repo/library/create_repo.py
+++ b/test/integration/targets/setup_rpm_repo/library/create_repo.py
@@ -78,6 +78,9 @@ def create_repo(arch='x86_64'):
                 )
             )
 
+        if spec.binary:
+            pkg.add_simple_compilation(installPath=spec.binary)
+
         pkgs.append(pkg)
 
     repo = YumRepoBuild(pkgs)

--- a/test/integration/targets/setup_rpm_repo/library/create_repo.py
+++ b/test/integration/targets/setup_rpm_repo/library/create_repo.py
@@ -12,15 +12,17 @@ from ansible.module_utils.common.respawn import has_respawned, probe_interpreter
 HAS_RPMFLUFF = True
 can_use_rpm_weak_deps = None
 try:
-    from rpmfluff import SimpleRpmBuild, GeneratedSourceFile, make_gif
+    from rpmfluff import SimpleRpmBuild, GeneratedSourceFile, make_gif, expectedArch
     from rpmfluff import YumRepoBuild
 except ImportError:
     try:
         from rpmfluff.make import make_gif
         from rpmfluff.sourcefile import GeneratedSourceFile
         from rpmfluff.rpmbuild import SimpleRpmBuild
+        from rpmfluff.utils import expectedArch
         from rpmfluff.yumrepobuild import YumRepoBuild
     except ImportError:
+        expectedArch = None  # define here to avoid NameError as it is used on top level in SPECS
         HAS_RPMFLUFF = False
 
 can_use_rpm_weak_deps = None
@@ -34,25 +36,27 @@ if HAS_RPMFLUFF:
             pass
 
 
-RPM = namedtuple('RPM', ['name', 'version', 'release', 'epoch', 'recommends', 'file', 'arch'])
+RPM = namedtuple('RPM', ['name', 'version', 'release', 'epoch', 'recommends', 'file', 'arch', 'binary'])
 
 SPECS = [
-    RPM('dinginessentail', '1.0', '1', None, None, None, None),
-    RPM('dinginessentail', '1.0', '2', '1', None, None, None),
-    RPM('dinginessentail', '1.1', '1', '1', None, None, None),
-    RPM('dinginessentail-olive', '1.0', '1', None, None, None, None),
-    RPM('dinginessentail-olive', '1.1', '1', None, None, None, None),
-    RPM('landsidescalping', '1.0', '1', None, None, None, None),
-    RPM('landsidescalping', '1.1', '1', None, None, None, None),
-    RPM('dinginessentail-with-weak-dep', '1.0', '1', None, ['dinginessentail-weak-dep'], None, None),
-    RPM('dinginessentail-weak-dep', '1.0', '1', None, None, None, None),
-    RPM('noarchfake', '1.0', '1', None, None, None, 'noarch'),
-    RPM('provides_foo_a', '1.0', '1', None, None, 'foo.gif', 'noarch'),
-    RPM('provides_foo_b', '1.0', '1', None, None, 'foo.gif', 'noarch'),
-    RPM('number-11-name', '11.0', '1', None, None, None, None),
-    RPM('number-11-name', '11.1', '1', None, None, None, None),
-    RPM('epochone', '1.0', '1', '1', None, None, "noarch"),
-    RPM('epochone', '1.1', '1', '1', None, None, "noarch"),
+    RPM('dinginessentail', '1.0', '1', None, None, None, None, None),
+    RPM('dinginessentail', '1.0', '2', '1', None, None, None, None),
+    RPM('dinginessentail', '1.1', '1', '1', None, None, None, None),
+    RPM('dinginessentail-olive', '1.0', '1', None, None, None, None, None),
+    RPM('dinginessentail-olive', '1.1', '1', None, None, None, None, None),
+    RPM('landsidescalping', '1.0', '1', None, None, None, None, None),
+    RPM('landsidescalping', '1.1', '1', None, None, None, None, None),
+    RPM('dinginessentail-with-weak-dep', '1.0', '1', None, ['dinginessentail-weak-dep'], None, None, None),
+    RPM('dinginessentail-weak-dep', '1.0', '1', None, None, None, None, None),
+    RPM('noarchfake', '1.0', '1', None, None, None, 'noarch', None),
+    RPM('provides_foo_a', '1.0', '1', None, None, 'foo.gif', 'noarch', None),
+    RPM('provides_foo_b', '1.0', '1', None, None, 'foo.gif', 'noarch', None),
+    RPM('number-11-name', '11.0', '1', None, None, None, None, None),
+    RPM('number-11-name', '11.1', '1', None, None, None, None, None),
+    RPM('epochone', '1.0', '1', '1', None, None, "noarch", None),
+    RPM('epochone', '1.1', '1', '1', None, None, "noarch", None),
+    RPM('provides-binary', '1.0', '1', '1', None, None, expectedArch, '/usr/sbin/package-name'),
+    RPM('package-name', '1.0', '1', '1', None, None, "noarch", None),
 ]
 
 
@@ -84,7 +88,7 @@ def create_repo(arch='x86_64'):
         pkgs.append(pkg)
 
     repo = YumRepoBuild(pkgs)
-    repo.make(arch, 'noarch')
+    repo.make(arch, 'noarch', expectedArch)
 
     for pkg in pkgs:
         pkg.clean()


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/84275
Backport of https://github.com/ansible/ansible/pull/84335

(cherry picked from commit https://github.com/ansible/ansible/commit/a27a7a27d144ff00db1d0a0b2dae494c21f83f10)
(cherry picked from commit https://github.com/ansible/ansible/commit/c99493eb3f1121b73f76927e37834afa0d6e0269)

The change in `test/integration/targets/setup_rpm_repo/library/create_repo.py` has been rewritten for 2.17 because that file has been refactored in 2.18 and devel.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request