### PR TITLE
add rootdir support to user module (FreeBSD only)

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -625,6 +625,7 @@ class User(object):
         self.inactive = module.params['password_expire_account_disable']
         self.uid_min = module.params['uid_min']
         self.uid_max = module.params['uid_max']
+        self.rootdir = None
 
         if self.local:
             if self.umask is not None:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -295,7 +295,7 @@ options:
         description:
             - chroot directory where to execute the pw command
             - Currently only supported on FreeBSD
-        type: int
+        type: str
         version_added: "2.18"
 
 extends_documentation_fragment: action_common_attributes

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -291,6 +291,12 @@ options:
             - Requires O(local) is omitted or V(False).
         type: int
         version_added: "2.18"
+    rootdir:
+        description:
+            - chroot directory where to execute the pw command
+            - Currently only supported on FreeBSD
+        type: int
+        version_added: "2.18"
 
 extends_documentation_fragment: action_common_attributes
 attributes:
@@ -486,6 +492,11 @@ uid:
   returned: When O(uid) is passed to the module
   type: int
   sample: 1044
+rootdir:
+  description: chroot directory where to execute the pw command
+  returned: always
+  type: str
+  sample: '/usr/local/bastille/jails/jumper/root'
 """
 
 
@@ -1438,6 +1449,10 @@ class FreeBsdUser(User):
                 cmd.append(self.uid)
             return self.execute_command(cmd)
 
+        if self.rootdir is not None:
+            cmd.append(-R)
+            cmd.append(selr.rootdir)
+
         return (None, '', '')
 
     def remove_user(self):
@@ -1449,6 +1464,10 @@ class FreeBsdUser(User):
         ]
         if self.remove:
             cmd.append('-r')
+
+        if self.rootdir is not None:
+            cmd.append(-R)
+            cmd.append(selr.rootdir)
 
         return self.execute_command(cmd)
 
@@ -1519,6 +1538,10 @@ class FreeBsdUser(User):
         if self.uid_max is not None:
             cmd.append('-K')
             cmd.append('UID_MAX=' + str(self.uid_max))
+
+        if self.rootdir is not None:
+            cmd.append(-R)
+            cmd.append(selr.rootdir)
 
         # system cannot be handled currently - should we error if its requested?
         # create the user
@@ -1654,6 +1677,10 @@ class FreeBsdUser(User):
                 if current_expires <= 0 or current_expire_date[:3] != self.expires[:3]:
                     cmd.append('-e')
                     cmd.append(str(calendar.timegm(self.expires)))
+
+        if self.rootdir is not None:
+            cmd.append(-R)
+            cmd.append(selr.rootdir)
 
         (rc, out, err) = (None, '', '')
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1451,8 +1451,8 @@ class FreeBsdUser(User):
             return self.execute_command(cmd)
 
         if self.rootdir is not None:
-            cmd.append(-R)
-            cmd.append(selr.rootdir)
+            cmd.append('-R')
+            cmd.append(self.rootdir)
 
         return (None, '', '')
 
@@ -1467,8 +1467,8 @@ class FreeBsdUser(User):
             cmd.append('-r')
 
         if self.rootdir is not None:
-            cmd.append(-R)
-            cmd.append(selr.rootdir)
+            cmd.append('-R')
+            cmd.append(self.rootdir)
 
         return self.execute_command(cmd)
 
@@ -1541,8 +1541,8 @@ class FreeBsdUser(User):
             cmd.append('UID_MAX=' + str(self.uid_max))
 
         if self.rootdir is not None:
-            cmd.append(-R)
-            cmd.append(selr.rootdir)
+            cmd.append('-R')
+            cmd.append(self.rootdir)
 
         # system cannot be handled currently - should we error if its requested?
         # create the user
@@ -1680,8 +1680,8 @@ class FreeBsdUser(User):
                     cmd.append(str(calendar.timegm(self.expires)))
 
         if self.rootdir is not None:
-            cmd.append(-R)
-            cmd.append(selr.rootdir)
+            cmd.append('-R')
+            cmd.append(self.rootdir)
 
         (rc, out, err) = (None, '', '')
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 
 DOCUMENTATION = r"""
-module: user
+module: freebsduser
 version_added: "0.2"
 short_description: Manage user accounts
 description:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3331,6 +3331,7 @@ def main():
             password_expire_account_disable=dict(type='int', no_log=False),
             uid_min=dict(type='int'),
             uid_max=dict(type='int'),
+            rootdir=dict(type='str'),
         ),
         supports_check_mode=True,
     )


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

Add rootdir support for user module on FreeBSD, fixes #84370. 

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

On FreeBSD you can maintain containers (called "jails") to isolate processes and users. The current builtin user module cannot be used for this, because it doesn't have any clue about jails. However, the FreeBSD user management tool `pw` has, it supports it with the flag `-R`.

This PR implements a new variable for the user module `rootdir` which uses this feature.


