### PR TITLE
Inventory plugin: Allow "parent_group" to have host variables in it

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -407,7 +407,7 @@ class Constructable(object):
                         raw_parent_name = keyed.get('parent_group', None)
                         if raw_parent_name:
                             try:
-                                raw_parent_name = self.templar.template(raw_parent_name)
+                                raw_parent_name = self.templar.template(raw_parent_name, variables)
                             except AnsibleError as e:
                                 if strict:
                                     raise AnsibleParserError("Could not generate parent group %s for group %s: %s" % (raw_parent_name, key, to_native(e)))


### PR DESCRIPTION
##### SUMMARY
Allow to build up multi-hierarchy  group-structure by arbitary inventory-plugins.

e.g. Provider -> Site1 -> Datacenter1
or Provider -> Zone -> DatacenterName

where Zone and Site are dynamically given.

##### ISSUE TYPE

- Feature Pull Request