### PR TITLE
package_facts: extend note about python3-rpm to cover Fedora 41+

### DIFF
--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -23,7 +23,7 @@ options:
     default: ['auto']
     choices:
         auto: Depending on O(strategy), will match the first or all package managers provided, in order
-        rpm: For RPM based distros, requires RPM Python bindings, not installed by default on Suse (python3-rpm)
+        rpm: For RPM based distros, requires RPM Python bindings, not installed by default on Suse or Fedora 41+ (python3-rpm)
         yum: Alias to rpm
         dnf: Alias to rpm
         dnf5: Alias to rpm


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Fedora 41 no longer has python3-rpm installed by default either, so package_facts blows up on Fedora 41 hosts unless you make sure python3-rpm is installed first. Not sure we can do a lot about this besides extending this note.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Try and run any playbook that touches `package_facts` on a clean Fedora 41 install

<!--- Paste verbatim command output below, e.g. before and after your change -->

N/A (command output is the same, but at least you can maybe find this note now?)