### PR TITLE
🧪 Let `ansible-test` diff ancient branches (granular approach)

### DIFF
--- a/test/lib/ansible_test/_internal/git.py
+++ b/test/lib/ansible_test/_internal/git.py
@@ -27,7 +27,14 @@ class Git:
     def get_diff_names(self, args: list[str]) -> list[str]:
         """Return a list of file names from the `git diff` command."""
         cmd = ['diff', '--name-only', '--no-renames', '-z'] + args
-        return self.run_git_split(cmd, '\0')
+
+        try:
+            return self.run_git_split(cmd, '\0')
+        except SubprocessError as git_diff_proc_err:
+            raise LookupError(
+                'Failed to retrieve files differing between Git refs: '
+                f'{git_diff_proc_err !s}',
+            ) from git_diff_proc_err
 
     def get_submodule_paths(self) -> list[str]:
         """Return a list of submodule paths recursively."""


### PR DESCRIPTION
This patch addresses the long-standing issue with being unable to run CI on PRs that have their branches created over 500 commits prior.

When the first `git diff` attempt fails, this patch attempts to augment the Git tree with missing commits.

This is achieved by doing the following:
1. Fetch one additional commit at the root of each orphaned branch.
2. Identify said commits as tree roots or “grafted”.
3. Retrieve the timestamps of both and safe the oldest one.
4. Fetch again, now instructing Git to include everything past this date.

The idea is that the very first commit in the PR branch might be created on the same day as the PR is opened. However, its parent would belong to the base branch, which is immutable. So if we take that commit's time stamp, we can tell Git to fill in the commits between the PR branch chunk and the commit it branched out of (the fork point). We'll also fill in the commits on the other side of the “fork”, in the base branch. With those commits retrieved and available in the local cache of the remote, it will be possible for git diff to locate the merge base and compute the file list, while the tree remains shallow. This is still a heuristic, of course, since the commit dates can be out of order in the tree. But it's not expected that we'll hit this corner case often or ever.

##### SUMMARY

SSIA

##### ISSUE TYPE

- Maintenance Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

This is a cheap / granular alternative to #84402. It is 33 seconds faster than the expensive variant, in each job.

Demo log output: https://dev.azure.com/ansible/ansible/_build/results?buildId=129259&view=logs&j=892f34bc-a8a9-5237-5b46-fa1aa2a1ecb5&t=f8ffb6b0-2cdd-5adc-18ee-2801169a4ffd&l=123 (from https://github.com/ansible/ansible/pull/84376)