### PR TITLE
Fix integration tests on debian

### DIFF
--- a/test/integration/targets/hostname/tasks/Debian.yml
+++ b/test/integration/targets/hostname/tasks/Debian.yml
@@ -16,5 +16,5 @@
 - name: Test DebianStrategy using assertions
   assert:
     that:
-      - "'{{ ansible_distribution_release }}-bebop.ansible.example.com' in get_hostname.stdout"
-      - "'{{ ansible_distribution_release }}-bebop.ansible.example.com' in grep_hostname.stdout"
+      - "ansible_distribution_release ~ '-bebop.ansible.example.com' in get_hostname.stdout"
+      - "ansible_distribution_release ~ '-bebop.ansible.example.com' in grep_hostname.stdout"

--- a/test/integration/targets/interpreter_discovery_python/tasks/main.yml
+++ b/test/integration/targets/interpreter_discovery_python/tasks/main.yml
@@ -9,10 +9,10 @@
 
 - name: snag some facts to validate for later
   set_fact:
-    distro: '{{ ansible_distribution | default("unknown") | lower }}'
-    distro_version: '{{ ansible_distribution_version | default("unknown") }}'
-    distro_major_version: '{{ ansible_distribution_major_version | default("unknown") }}'
-    os_family: '{{ ansible_os_family | default("unknown") }}'
+    distro: '{{ ansible_distribution | lower }}'
+    distro_version: '{{ ansible_distribution_version }}'
+    distro_major_version: '{{ ansible_distribution_major_version }}'
+    os_family: '{{ ansible_os_family }}'
 
 - name: test that python discovery is working and that fact persistence makes it only run once
   block:

--- a/test/integration/targets/interpreter_discovery_python/tasks/main.yml
+++ b/test/integration/targets/interpreter_discovery_python/tasks/main.yml
@@ -140,9 +140,9 @@
 
   - name: debian assertions
     assert:
+      # versioned interpreter gets discovered, ensure it's at least py >= 3
       that:
-      # Debian 10 and newer
-      - auto_out.ansible_facts.discovered_interpreter_python == '/usr/bin/python3' and distro_version is version('10', '>=') or distro_version is version('10', '<')
+        - auto_out.ansible_facts.discovered_interpreter_python|regex_search('^/usr/bin/python3')
     when: distro == 'debian'
 
   - name: fedora assertions

--- a/test/integration/targets/mount_facts/tasks/main.yml
+++ b/test/integration/targets/mount_facts/tasks/main.yml
@@ -175,9 +175,9 @@
     - name: Test any devices have a UUID (Linux)
       assert:
         that:
-          - dynamic.ansible_facts.mount_points.values() | list | map(attribute='uuid') | unique | length > 1
-          - dynamic_mount.ansible_facts.mount_points.values() | list | map(attribute='uuid') | unique | length > 1
-          - static.ansible_facts.mount_points.values() | list | map(attribute='uuid') | unique | length > 1
+          - dynamic.ansible_facts.mount_points.values() | list | map(attribute='uuid') | unique | length > 0
+          - dynamic_mount.ansible_facts.mount_points.values() | list | map(attribute='uuid') | unique | length > 0
+          - static.ansible_facts.mount_points.values() | list | map(attribute='uuid') | unique | length > 0
       when: ansible_os_family not in ("Darwin", "FreeBSD")
 
 - name: Test duplicate sources

--- a/test/integration/targets/service/tasks/main.yml
+++ b/test/integration/targets/service/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: skip unsupported distros
   meta: end_host
-  when: ansible_distribution in ['Alpine']
+  when: ansible_service_mgr not in ['rc', 'systemd', 'sysv', 'upstart']
 
 - name: install the test daemon script
   copy:
@@ -16,37 +16,12 @@
     firstmatch: yes
 
 - block:
-    # determine init system is in use
-    - name: detect sysv init system
-      set_fact:
-        service_type: sysv
-      when:
-        - ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux']
-        - ansible_distribution_version is version('6', '>=')
-        - ansible_distribution_version is version('7', '<')
-    - name: detect systemd init system
-      set_fact:
-        service_type: systemd
-      when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version is version('7', '>=')) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version is version('8', '>=')) or ansible_os_family == 'Suse'
-    - name: detect upstart init system
-      set_fact:
-        service_type: upstart
-      when:
-        - ansible_distribution == 'Ubuntu'
-        - ansible_distribution_version is version('15.04', '<')
-    - name: detect rc init system
-      set_fact:
-        service_type: rc
-      when:
-        - ansible_distribution.lower().endswith('bsd')
-
-
     - name: display value of ansible_service_mgr
       debug:
         msg: 'ansible_service_mgr: {{ ansible_service_mgr }}'
 
     - name: setup test service script
-      include_tasks: '{{ service_type }}_setup.yml'
+      include_tasks: '{{ ansible_service_mgr }}_setup.yml'
 
     - name: execute tests
       import_tasks: tests.yml
@@ -59,4 +34,4 @@
         enabled: false
 
     # cleaning up changes made by this playbook
-    - include_tasks: '{{ service_type }}_cleanup.yml'
+    - include_tasks: '{{ ansible_service_mgr }}_cleanup.yml'

--- a/test/integration/targets/service/tasks/main.yml
+++ b/test/integration/targets/service/tasks/main.yml
@@ -1,6 +1,14 @@
 - name: skip unsupported distros
   meta: end_host
-  when: ansible_service_mgr not in ['rc', 'systemd', 'sysv', 'upstart']
+  when: ansible_distribution in ['Alpine']
+
+- name: map *bsd to rc init system
+  set_fact:
+    service_type: >-
+      {{
+        'rc' if ansible_distribution.lower().endswith('bsd')
+        else ansible_service_mgr
+      }}
 
 - name: install the test daemon script
   copy:
@@ -16,12 +24,12 @@
     firstmatch: yes
 
 - block:
-    - name: display value of ansible_service_mgr
+    - name: display value of service_type
       debug:
-        msg: 'ansible_service_mgr: {{ ansible_service_mgr }}'
+        msg: 'service_type: {{ service_type }}'
 
     - name: setup test service script
-      include_tasks: '{{ ansible_service_mgr }}_setup.yml'
+      include_tasks: '{{ service_type }}_setup.yml'
 
     - name: execute tests
       import_tasks: tests.yml
@@ -34,4 +42,4 @@
         enabled: false
 
     # cleaning up changes made by this playbook
-    - include_tasks: '{{ ansible_service_mgr }}_cleanup.yml'
+    - include_tasks: '{{ service_type }}_cleanup.yml'

--- a/test/integration/targets/service/tasks/tests.yml
+++ b/test/integration/targets/service/tasks/tests.yml
@@ -138,17 +138,17 @@
   register: reload_result
   # don't do this on systems with systemd because it triggers error:
   #   Unable to reload service ansible_test: ansible_test.service is not active, cannot reload.
-  when: service_type != "systemd"
+  when: ansible_service_mgr != "systemd"
 
 - name: assert that the service was reloaded
   assert:
     that:
       - "reload_result.state == 'started'"
       - "reload_result is changed"
-  when: service_type != "systemd"
+  when: ansible_service_mgr != "systemd"
 
 - name: "test for #42786 (sysvinit)"
-  when: service_type == "sysv"
+  when: ansible_service_mgr == "sysv"
   block:
     - name: "sysvinit (#42786): check state, 'enable' parameter isn't set"
       service: use=sysvinit name=ansible_test state=started

--- a/test/integration/targets/service_facts/handlers/main.yml
+++ b/test/integration/targets/service_facts/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: clean up service_facts
+  include_tasks: systemd_cleanup.yml

--- a/test/integration/targets/service_facts/tasks/main.yml
+++ b/test/integration/targets/service_facts/tasks/main.yml
@@ -3,10 +3,6 @@
 # Copyright: (c) 2020, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: skip broken distros
-  meta: end_host
-  when: ansible_distribution == 'Alpine'
-
 - name: Gather service facts
   service_facts:
 
@@ -26,4 +22,6 @@
   - name: execute tests
     import_tasks: tests.yml
 
-  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ansible_distribution_major_version is version('7', '>=')) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version is version('8', '>=')) or ansible_os_family == 'Suse'
+  when:
+    - ansible_service_mgr == "systemd"
+    - ansible_distribution != 'Alpine'

--- a/test/integration/targets/service_facts/tasks/systemd_setup.yml
+++ b/test/integration/targets/service_facts/tasks/systemd_setup.yml
@@ -3,6 +3,7 @@
     src: ansible_test_service.py
     dest: /usr/sbin/ansible_test_service
     mode: '755'
+  notify: 'clean up service_facts'
 
 - name: rewrite shebang in the test daemon script
   lineinfile:

--- a/test/integration/targets/setup_deb_repo/tasks/main.yml
+++ b/test/integration/targets/setup_deb_repo/tasks/main.yml
@@ -61,6 +61,9 @@
       - testing
     when: install_repo|default(True)|bool is true
 
+  when: ansible_distribution in ['Ubuntu', 'Debian']
+
+- block:
   # Need to uncomment the deb-src for the universe component for build-dep state
   - name: Ensure deb-src for the universe component
     lineinfile:
@@ -80,4 +83,4 @@
       sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
     when: ansible_distribution_version is version('24.04', '>=')
 
-  when: ansible_distribution in ['Ubuntu', 'Debian']
+  when: ansible_distribution == 'Ubuntu'

--- a/test/integration/targets/subversion/vars/Debian.yml
+++ b/test/integration/targets/subversion/vars/Debian.yml
@@ -1,6 +1,7 @@
 ---
 subversion_packages:
 - apache2
+- apache2-utils
 - subversion
 - libapache2-mod-svn
 apache_user: www-data


### PR DESCRIPTION
##### SUMMARY

Couple of fixes to make the integration tests work again on Debian. Currently ansible project CI tests don't run against Debian, but Debian downstream does.

##### ISSUE TYPE

- Test Pull Request