### PR TITLE
deps: new module utils

### DIFF
--- a/lib/ansible/module_utils/deps.py
+++ b/lib/ansible/module_utils/deps.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# (c) 2022, Alexei Znamensky <russoz@gmail.com>
-# Copyright (c) 2022, Ansible Project
+# (c) 2024, Alexei Znamensky <russoz@gmail.com>
+# Copyright (c) 2024, Ansible Project
 # Simplified BSD License (see LICENSES/BSD-2-Clause.txt or https://opensource.org/licenses/BSD-2-Clause)
 # SPDX-License-Identifier: BSD-2-Clause
 

--- a/lib/ansible/module_utils/deps.py
+++ b/lib/ansible/module_utils/deps.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# (c) 2024, Alexei Znamensky <russoz@gmail.com>
+# (c) 2024, Ansible Project
+# Simplified BSD License (see LICENSES/BSD-2-Clause.txt or https://opensource.org/licenses/BSD-2-Clause)
+# SPDX-License-Identifier: BSD-2-Clause
+
+from __future__ import annotations
+
+import traceback
+from contextlib import contextmanager
+
+from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.basic import missing_required_lib
+
+
+_deps = dict()
+
+
+class _Dependency(object):
+    _states = ["pending", "failure", "success"]
+
+    def __init__(self, name, reason=None, url=None, msg=None):
+        self.name = name
+        self.reason = reason
+        self.url = url
+        self.msg = msg
+
+        self.state = 0
+        self.trace = None
+        self.exc = None
+
+    def succeed(self):
+        self.state = 2
+
+    def fail(self, exc, trace):
+        self.state = 1
+        self.exc = exc
+        self.trace = trace
+
+    @property
+    def message(self):
+        if self.msg:
+            return to_native(self.msg)
+        else:
+            return missing_required_lib(self.name, reason=self.reason, url=self.url)
+
+    @property
+    def failed(self):
+        return self.state == 1
+
+    def validate(self, module):
+        if self.failed:
+            module.fail_json(msg=self.message, exception=self.trace)
+
+    def __str__(self):
+        return "<dependency: {0} [{1}]>".format(self.name, self._states[self.state])
+
+
+@contextmanager
+def declare(name, *args, **kwargs):
+    dep = _Dependency(name, *args, **kwargs)
+    try:
+        yield dep
+    except Exception as e:
+        dep.fail(e, traceback.format_exc())
+    else:
+        dep.succeed()
+    finally:
+        _deps[name] = dep
+
+
+def _select_names(spec):
+    dep_names = sorted(_deps)
+
+    if spec:
+        if spec.startswith("-"):
+            spec_split = spec[1:].split(":")
+            for d in spec_split:
+                dep_names.remove(d)
+        else:
+            spec_split = spec.split(":")
+            dep_names = []
+            for d in spec_split:
+                _deps[d]  # ensure it exists
+                dep_names.append(d)
+
+    return dep_names
+
+
+def validate(module, spec=None):
+    for dep in _select_names(spec):
+        _deps[dep].validate(module)
+
+
+def failed(spec=None):
+    return any(_deps[d].failed for d in _select_names(spec))

--- a/lib/ansible/module_utils/deps.py
+++ b/lib/ansible/module_utils/deps.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# (c) 2024, Alexei Znamensky <russoz@gmail.com>
-# (c) 2024, Ansible Project
+# (c) 2022, Alexei Znamensky <russoz@gmail.com>
+# Copyright (c) 2022, Ansible Project
 # Simplified BSD License (see LICENSES/BSD-2-Clause.txt or https://opensource.org/licenses/BSD-2-Clause)
 # SPDX-License-Identifier: BSD-2-Clause
 
@@ -81,7 +81,7 @@ def _select_names(spec):
             spec_split = spec.split(":")
             dep_names = []
             for d in spec_split:
-                _deps[d]  # ensure it exists
+                _deps[d]  # pylint:disable=pointless-statement
                 dep_names.append(d)
 
     return dep_names
@@ -94,3 +94,7 @@ def validate(module, spec=None):
 
 def failed(spec=None):
     return any(_deps[d].failed for d in _select_names(spec))
+
+
+def clear():
+    _deps.clear()

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -230,10 +230,9 @@ import os
 import re
 import tempfile
 import textwrap
-import traceback
 
+from ansible.module_utils import deps
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.common.file import S_IRWXU_RXG_RXO, S_IRWU_RG_RO
 from ansible.module_utils.common.text.converters import to_bytes
@@ -244,13 +243,9 @@ from ansible.module_utils.urls import open_url
 from ansible.module_utils.urls import get_user_agent
 from ansible.module_utils.urls import urlparse
 
-HAS_DEBIAN = True
-DEBIAN_IMP_ERR = None
-try:
+
+with deps.declare("python3-debian"):
     from debian.deb822 import Deb822  # type: ignore[import]
-except ImportError:
-    HAS_DEBIAN = False
-    DEBIAN_IMP_ERR = traceback.format_exc()
 
 KEYRINGS_DIR = '/etc/apt/keyrings'
 
@@ -453,9 +448,7 @@ def main():
         supports_check_mode=True,
     )
 
-    if not HAS_DEBIAN:
-        module.fail_json(msg=missing_required_lib("python3-debian"),
-                         exception=DEBIAN_IMP_ERR)
+    deps.validate(module)
 
     check_mode = module.check_mode
 

--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -122,17 +122,14 @@ import datetime
 import os
 import traceback
 
-PEXPECT_IMP_ERR = None
-try:
-    import pexpect
-    HAS_PEXPECT = True
-except ImportError:
-    PEXPECT_IMP_ERR = traceback.format_exc()
-    HAS_PEXPECT = False
-
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.module_utils.common.validation import check_type_int
+from ansible.module_utils import deps
+
+
+with deps.declare("pexpect"):
+    import pexpect
 
 
 def response_closure(module, question, responses):
@@ -163,9 +160,7 @@ def main():
         )
     )
 
-    if not HAS_PEXPECT:
-        module.fail_json(msg=missing_required_lib("pexpect"),
-                         exception=PEXPECT_IMP_ERR)
+    deps.validate(module)
 
     chdir = module.params['chdir']
     args = module.params['command']

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -224,9 +224,3 @@ test/units/module_utils/facts/test_facts.py mypy-3.8:assignment
 test/units/modules/mount_facts_data.py mypy-3.8:arg-type
 test/units/modules/test_apt.py mypy-3.8:name-match
 test/units/modules/test_mount_facts.py mypy-3.8:index
-test/units/module_utils/test_deps.py mypy-3.8:import-not-found
-test/units/module_utils/test_deps.py mypy-3.9:import-not-found
-test/units/module_utils/test_deps.py mypy-3.10:import-not-found
-test/units/module_utils/test_deps.py mypy-3.11:import-not-found
-test/units/module_utils/test_deps.py mypy-3.12:import-not-found
-test/units/module_utils/test_deps.py mypy-3.13:import-not-found

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -224,3 +224,9 @@ test/units/module_utils/facts/test_facts.py mypy-3.8:assignment
 test/units/modules/mount_facts_data.py mypy-3.8:arg-type
 test/units/modules/test_apt.py mypy-3.8:name-match
 test/units/modules/test_mount_facts.py mypy-3.8:index
+test/units/module_utils/test_deps.py mypy-3.8:import-not-found
+test/units/module_utils/test_deps.py mypy-3.9:import-not-found
+test/units/module_utils/test_deps.py mypy-3.10:import-not-found
+test/units/module_utils/test_deps.py mypy-3.11:import-not-found
+test/units/module_utils/test_deps.py mypy-3.12:import-not-found
+test/units/module_utils/test_deps.py mypy-3.13:import-not-found

--- a/test/units/module_utils/test_deps.py
+++ b/test/units/module_utils/test_deps.py
@@ -1,36 +1,69 @@
 # -*- coding: utf-8 -*-
-# Copyright: (c) 2024, Alexei Znamensky <russoz@gmail.com>
-# Copyright: (c) 2024, Ansible Project
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# (c) 2024, Alexei Znamensky <russoz@gmail.com>
+# Copyright (c) 2024 Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
+
+from unittest.mock import MagicMock
 
 import pytest
 
 from ansible.module_utils import deps
+from units.modules.utils import AnsibleFailJson
 
-def test_deps():
-    with deps.declare("re"):
-        import re
 
-    deps.validate()
+@pytest.fixture
+def module():
+    m = MagicMock()
+    m.fail_json.side_effect = AnsibleFailJson
+    return m
 
-    ctx = DependencyCtxMgr("POTATOES", "Potatoes must be installed")
-    with ctx:
-        import potatoes_that_will_never_be_there  # noqa: F401, pylint: disable=unused-import
-    print("POTATOES: ctx.text={0}".format(ctx.text))
-    assert ctx.text == "Potatoes must be installed"
-    assert not ctx.has_it
 
-    ctx = DependencyCtxMgr("POTATOES2")
-    with ctx:
-        import potatoes_that_will_never_be_there_again  # noqa: F401, pylint: disable=unused-import
-    assert not ctx.has_it
-    print("POTATOES2: ctx.text={0}".format(ctx.text))
-    assert ctx.text.startswith("No module named")
-    assert "potatoes_that_will_never_be_there_again" in ctx.text
-
-    ctx = DependencyCtxMgr("TYPING")
-    with ctx:
+def test_wrong_name(module):
+    with deps.declare("sys") as sys_dep:
         import sys  # noqa: F401, pylint: disable=unused-import
-    assert ctx.has_it
+
+    with pytest.raises(KeyError):
+        deps.validate(module, "wrong_name")
+
+
+def test_fail_potatoes(module):
+    with deps.declare("potatoes", reason="Must have potatoes") as potatoes_dep:
+        import potatoes_that_will_never_be_there  # noqa: F401, pylint: disable=unused-import
+
+    with pytest.raises(AnsibleFailJson):
+        deps.validate(module)
+
+    assert potatoes_dep.failed is True
+    assert potatoes_dep.message.startswith("Failed to import the required Python library")
+
+
+def test_sys(module):
+    with deps.declare("sys") as sys_dep:
+        import sys  # noqa: F401, pylint: disable=unused-import
+
+    deps.validate(module)
+
+    assert sys_dep.failed is False
+
+
+def test_multiple(module):
+    with deps.declare("mpotatoes", reason="Must have mpotatoes"):
+        import potatoes_that_will_never_be_there  # noqa: F401, pylint: disable=unused-import
+
+    with deps.declare("msys", reason="Must have msys"):
+        import sys  # noqa: F401, pylint: disable=unused-import
+
+    deps.validate(module, "msys")
+    deps.validate(module, "-mpotatoes")
+
+    with pytest.raises(AnsibleFailJson):
+        deps.validate(module)
+
+    with pytest.raises(AnsibleFailJson):
+        deps.validate(module, "-msys")
+
+    with pytest.raises(AnsibleFailJson):
+        deps.validate(module, "mpotatoes")

--- a/test/units/module_utils/test_deps.py
+++ b/test/units/module_utils/test_deps.py
@@ -28,10 +28,12 @@ def test_wrong_name(module):
     with pytest.raises(KeyError):
         deps.validate(module, "wrong_name")
 
+    assert sys_dep.failed is True
+
 
 def test_fail_potatoes(module):
     with deps.declare("potatoes", reason="Must have potatoes") as potatoes_dep:
-        import potatoes_that_will_never_be_there  # noqa: F401, pylint: disable=unused-import
+        import potatoes_that_will_never_be_there  # type: ignore[import]  # pylint: disable=unused-import
 
     with pytest.raises(AnsibleFailJson):
         deps.validate(module)
@@ -51,7 +53,7 @@ def test_sys(module):
 
 def test_multiple(module):
     with deps.declare("mpotatoes", reason="Must have mpotatoes"):
-        import potatoes_that_will_never_be_there  # noqa: F401, pylint: disable=unused-import
+        import potatoes_that_will_never_be_there  # type: ignore[import]  # pylint: disable=unused-import
 
     with deps.declare("msys", reason="Must have msys"):
         import sys  # noqa: F401, pylint: disable=unused-import

--- a/test/units/module_utils/test_deps.py
+++ b/test/units/module_utils/test_deps.py
@@ -28,8 +28,6 @@ def test_wrong_name(module):
     with pytest.raises(KeyError):
         deps.validate(module, "wrong_name")
 
-    assert sys_dep.failed is True
-
 
 def test_fail_potatoes(module):
     with deps.declare("potatoes", reason="Must have potatoes") as potatoes_dep:

--- a/test/units/module_utils/test_deps.py
+++ b/test/units/module_utils/test_deps.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2024, Alexei Znamensky <russoz@gmail.com>
+# Copyright: (c) 2024, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import pytest
+
+from ansible.module_utils import deps
+
+def test_deps():
+    with deps.declare("re"):
+        import re
+
+    deps.validate()
+
+    ctx = DependencyCtxMgr("POTATOES", "Potatoes must be installed")
+    with ctx:
+        import potatoes_that_will_never_be_there  # noqa: F401, pylint: disable=unused-import
+    print("POTATOES: ctx.text={0}".format(ctx.text))
+    assert ctx.text == "Potatoes must be installed"
+    assert not ctx.has_it
+
+    ctx = DependencyCtxMgr("POTATOES2")
+    with ctx:
+        import potatoes_that_will_never_be_there_again  # noqa: F401, pylint: disable=unused-import
+    assert not ctx.has_it
+    print("POTATOES2: ctx.text={0}".format(ctx.text))
+    assert ctx.text.startswith("No module named")
+    assert "potatoes_that_will_never_be_there_again" in ctx.text
+
+    ctx = DependencyCtxMgr("TYPING")
+    with ctx:
+        import sys  # noqa: F401, pylint: disable=unused-import
+    assert ctx.has_it

--- a/test/units/module_utils/test_deps.py
+++ b/test/units/module_utils/test_deps.py
@@ -22,6 +22,7 @@ def module():
 
 
 def test_wrong_name(module):
+    deps.clear()
     with deps.declare("sys") as sys_dep:
         import sys  # noqa: F401, pylint: disable=unused-import
 
@@ -30,6 +31,7 @@ def test_wrong_name(module):
 
 
 def test_fail_potatoes(module):
+    deps.clear()
     with deps.declare("potatoes", reason="Must have potatoes") as potatoes_dep:
         import potatoes_that_will_never_be_there  # type: ignore[import]  # pylint: disable=unused-import
 
@@ -41,6 +43,7 @@ def test_fail_potatoes(module):
 
 
 def test_sys(module):
+    deps.clear()
     with deps.declare("sys") as sys_dep:
         import sys  # noqa: F401, pylint: disable=unused-import
 
@@ -50,6 +53,7 @@ def test_sys(module):
 
 
 def test_multiple(module):
+    deps.clear()
     with deps.declare("mpotatoes", reason="Must have mpotatoes"):
         import potatoes_that_will_never_be_there  # type: ignore[import]  # pylint: disable=unused-import
 


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
New for ansible-core, this PR intends to transpose `deps` module utils from community.general to a broader audience. 

This util provides a context manager that reduces the boilerplate code necessary to check for existing/missing dependencies in the code. This code has been in use in c.g. for a couple of years, it has been stable for a while, it is [documented](https://docs.ansible.com/ansible/latest/collections/community/general/docsite/guide_deps.html) (naturally that guide would need to be copied over to the ansible core documentation and adjusted).

Going beyond the unit tests, I have taken the liberty of adapting two modules to `deps`: `expect` and `deb822_repository` to demonstrate how it should be used and how those modules become leaner by using it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Feature Pull Request
