### PR TITLE
🧪 Let `ansible-test` diff ancient branches (the expensive way)

### DIFF
--- a/test/lib/ansible_test/_internal/git.py
+++ b/test/lib/ansible_test/_internal/git.py
@@ -27,7 +27,14 @@ class Git:
     def get_diff_names(self, args: list[str]) -> list[str]:
         """Return a list of file names from the `git diff` command."""
         cmd = ['diff', '--name-only', '--no-renames', '-z'] + args
-        return self.run_git_split(cmd, '\0')
+
+        try:
+            return self.run_git_split(cmd, '\0')
+        except SubprocessError as git_diff_proc_err:
+            raise LookupError(
+                'Failed to retrieve files differing between Git refs: '
+                f'{git_diff_proc_err !s}',
+            ) from git_diff_proc_err
 
     def get_submodule_paths(self) -> list[str]:
         """Return a list of submodule paths recursively."""


### PR DESCRIPTION
This patch addresses the long-standing issue with being unable to run
CI on PRs that have their branches created over 500 commits prior.

When the first `git diff` attempt fails, this patch attempts to
augment the Git tree with missing commits.

This is achieved by unshallowing the entire Git tree.

##### SUMMARY

SSIA

##### ISSUE TYPE

- Maintenance Pull Request
- Test Pull Request

##### ADDITIONAL INFORMATION

This is a more expensive alternative to #84375. It adds 33 seconds to each job compared to the granular implementation.

Demo log output: https://dev.azure.com/ansible/ansible/_build/results?buildId=129703&view=logs&j=f39c292d-0a23-56d4-e7e5-386951c14ece&t=3af4f6c8-91cf-5ddb-8873-9e1cb9dedca9&l=73 (from https://github.com/ansible/ansible/pull/84403)