### PR TITLE
unarchive: Clamp zip timestamps on 32-bit time_t

### DIFF
--- a/changelogs/fragments/unarchive_timestamp_t32.yaml
+++ b/changelogs/fragments/unarchive_timestamp_t32.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - unarchive - Clamp timestamps from beyond y2038 to representible values when unpacking zip files on platforms that use 32-bit time_t (e.g. Debian i386).

--- a/test/units/modules/test_unarchive.py
+++ b/test/units/modules/test_unarchive.py
@@ -14,6 +14,14 @@ def fake_ansible_module():
     return FakeAnsibleModule()
 
 
+def max_zip_timestamp():
+    """Return the max clamp value that will be selected."""
+    try:
+        return time.mktime(time.struct_time((2107, 12, 31, 23, 59, 59, 0, 0, 0)))
+    except OverflowError:
+        return time.mktime(time.struct_time((2038, 1, 1, 0, 0, 0, 0, 0, 0)))
+
+
 class FakeAnsibleModule:
     def __init__(self):
         self.params = {}
@@ -68,7 +76,7 @@ class TestCaseZipArchive:
             ),
             pytest.param(
                 "21081231.000000",
-                time.mktime(time.struct_time((2107, 12, 31, 23, 59, 59, 0, 0, 0))),
+                max_zip_timestamp(),
                 id="invalid-year-2108",
             ),
             pytest.param(


### PR DESCRIPTION
##### SUMMARY

Clamp zip timestamps to representible values when unpacking zip files on platforms that use 32-bit `time_t` (e.g.  Debian i386). This is a non-issue in practice (in 2024), but should allow the test suite to pass on Debian i386.

We use a round value of 2038-01-01 00:00:00 for simplicity, and to avoid running into timezone offsets closer to the actual limit.

#81520 introduced sanity-checking tests that used dates not representable with a 32-bit `time_t`.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Example failure: https://ci.debian.net/packages/a/ansible-core/testing/i386/54952585/

Debian considers i386 to be a legacy architecture primarily for compatibility with old binaries built for 32-bit systems. Thus it didn't go through the 64-bit `time_t` migration that other 32-bit architectures did, as that would have broken ABIs used by old binaries.