### PR TITLE
wait_for_connection: fix errant warning for local connection(s)

### DIFF
--- a/changelogs/fragments/84419-fix-wait_for_connection-warning.yml
+++ b/changelogs/fragments/84419-fix-wait_for_connection-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - wait_for_connection - a warning was displayed if any hosts used a local connection (https://github.com/ansible/ansible/issues/84419)

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -189,6 +189,9 @@ class Connection(ConnectionBase):
         display.vvv(u"FETCH {0} TO {1}".format(in_path, out_path), host=self._play_context.remote_addr)
         self.put_file(in_path, out_path)
 
+    def reset(self) -> None:
+        pass
+
     def close(self) -> None:
         """ terminate the connection; nothing to do here """
         self._connected = False


### PR DESCRIPTION
##### SUMMARY

This prevents "[WARNING]: Reset is not implemented for this connection" when using wait_for_connection with localhost or other local hosts.

It's arguable (from a consistency/correctness perspective) that `ansible.plugins.connection.local.Connection.reset()` should call `Connection.close()`. I went for a no-op on the basis of "if it aint broke don't fix it", and erred on the side of keeping existing semantics. However either option would be fine with me.

Fixes #84419 

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

A distant cousin of #84240