### PR TITLE
Fix a debug message error

### DIFF
--- a/changelogs/fragments/fix-display-bug-in-action-plugin.yml
+++ b/changelogs/fragments/fix-display-bug-in-action-plugin.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix a display.debug statement with the wrong param in _get_diff_data() method

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1372,7 +1372,7 @@ class ActionBase(ABC):
             elif peek_result.get('size') and C.MAX_FILE_SIZE_FOR_DIFF > 0 and peek_result['size'] > C.MAX_FILE_SIZE_FOR_DIFF:
                 diff['dst_larger'] = C.MAX_FILE_SIZE_FOR_DIFF
             else:
-                display.debug(u"Slurping the file %s" % source)
+                display.debug(u"Slurping the file %s" % destination)
                 dest_result = self._execute_module(
                     module_name='ansible.legacy.slurp', module_args=dict(path=destination),
                     task_vars=task_vars, persist_files=True)


### PR DESCRIPTION
##### SUMMARY
i find the wrong debug message in `lib/ansible/plugins/action/__init__.py`, i fix this error in #84368 , but the community has other way to solve my issue (see #84422), so i open a separate PR for `display.debug` fix.

##### ISSUE TYPE

- Bugfix Pull Request