### PR TITLE
wait_for_connection - test connection=local does not emit reset warning

### DIFF
--- a/test/integration/targets/wait_for_connection/tasks/main.yml
+++ b/test/integration/targets/wait_for_connection/tasks/main.yml
@@ -28,3 +28,14 @@
     that:
     - invalid_parameter is failed
     - "invalid_parameter.msg == 'Invalid options for wait_for_connection: foo'"
+
+- name: Test local connection with wait_for_connection
+  command: ansible localhost -m wait_for_connection
+  delegate_to: localhost
+  register: local_wait_for_connection
+
+- name: Assert reset is a no-op rather than unimplemented
+  assert:
+    that: unexpected_warning not in local_wait_for_connection.stderr
+  vars:
+    unexpected_warning: "Reset is not implemented for this connection"


### PR DESCRIPTION
##### SUMMARY

Test case for bugfix in #84421

##### ISSUE TYPE

- Test Pull Request