### PR TITLE
[2.18] fix reset_connection with templated connection variables (#84240)

### DIFF
--- a/changelogs/fragments/84238-fix-reset_connection-ssh_executable-templated.yml
+++ b/changelogs/fragments/84238-fix-reset_connection-ssh_executable-templated.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ssh - connection options were incorrectly templated during ``reset_connection`` tasks (https://github.com/ansible/ansible/pull/84238).

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -285,6 +285,27 @@ class ConnectionBase(AnsiblePlugin):
                 display.debug('Set connection var {0} to {1}'.format(varname, value))
                 variables[varname] = value
 
+    def _resolve_option_variables(self, variables, templar):
+        """
+        Return a dict of variable -> templated value, for any variables that
+        that match options registered by this plugin.
+        """
+        # create dict of 'templated vars'
+        var_options = {
+            '_extras': {},
+        }
+        for var_name in C.config.get_plugin_vars('connection', self._load_name):
+            if var_name in variables:
+                var_options[var_name] = templar.template(variables[var_name])
+
+        # add extras if plugin supports them
+        if getattr(self, 'allow_extras', False):
+            for var_name in variables:
+                if var_name.startswith(f'ansible_{self.extras_prefix}_') and var_name not in var_options:
+                    var_options['_extras'][var_name] = templar.template(variables[var_name])
+
+        return var_options
+
 
 class NetworkConnectionBase(ConnectionBase):
     """

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1068,7 +1068,8 @@ class StrategyBase:
                 del self._active_connections[target_host]
             else:
                 connection = plugin_loader.connection_loader.get(play_context.connection, play_context, os.devnull)
-                connection.set_options(task_keys=task.dump_attrs(), var_options=all_vars)
+                var_options = connection._resolve_option_variables(all_vars, templar)
+                connection.set_options(task_keys=task.dump_attrs(), var_options=var_options)
                 play_context.set_attributes_from_plugin(connection)
 
             if connection:

--- a/test/integration/targets/connection/test.sh
+++ b/test/integration/targets/connection/test.sh
@@ -20,3 +20,4 @@ else
 fi
 
 ansible-playbook test_reset_connection.yml -i "${INVENTORY}" "$@"
+ansible-playbook test_reset_connection_templated.yml -i "${INVENTORY}" "$@"

--- a/test/integration/targets/connection/test_reset_connection_templated.yml
+++ b/test/integration/targets/connection/test_reset_connection_templated.yml
@@ -1,0 +1,7 @@
+- hosts: "{{ target_hosts }}"
+  gather_facts: false
+  vars:
+    ansible_ssh_executable: "{{ 'ssh' | trim }}"
+  tasks:
+    # https://github.com/ansible/ansible/issues/84238
+    - meta: reset_connection


### PR DESCRIPTION
##### SUMMARY
Backport for #84240

* ssh: Test reset_connection with templated ansible_ssh_executable

Add failing test to confirm subsequent fixes are necessary & sufficient.

* ssh: Fix reset_connection with templated ansible_ssh_executable

Signed-off-by: Alex Willmer <alex@moreati.org.uk>
(cherry picked from commit 59d9737788d63ea4e17b74d3c3ca1a0cf03f89ba)

##### ISSUE TYPE

- Bugfix Pull Request