### PR TITLE
[2.17] fix reset_connection with templated connection variables (#84240)

### DIFF
--- a/changelogs/fragments/84238-fix-reset_connection-ssh_executable-templated.yml
+++ b/changelogs/fragments/84238-fix-reset_connection-ssh_executable-templated.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ssh - connection options were incorrectly templated during ``reset_connection`` tasks (https://github.com/ansible/ansible/pull/84238).

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1044,18 +1044,6 @@ class TaskExecutor:
         option_vars = C.config.get_plugin_vars('connection', self._connection._load_name)
         varnames.extend(option_vars)
 
-        # create dict of 'templated vars'
-        options = {'_extras': {}}
-        for k in option_vars:
-            if k in variables:
-                options[k] = templar.template(variables[k])
-
-        # add extras if plugin supports them
-        if getattr(self._connection, 'allow_extras', False):
-            for k in variables:
-                if k.startswith('ansible_%s_' % self._connection.extras_prefix) and k not in options:
-                    options['_extras'][k] = templar.template(variables[k])
-
         task_keys = self._task.dump_attrs()
 
         # The task_keys 'timeout' attr is the task's timeout, not the connection timeout.
@@ -1073,7 +1061,8 @@ class TaskExecutor:
         del task_keys['retries']
 
         # set options with 'templated vars' specific to this plugin and dependent ones
-        self._connection.set_options(task_keys=task_keys, var_options=options)
+        var_options = self._connection._resolve_option_variables(variables, templar)
+        self._connection.set_options(task_keys=task_keys, var_options=var_options)
         varnames.extend(self._set_plugin_options('shell', variables, templar, task_keys))
 
         if self._connection.become is not None:

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -285,6 +285,27 @@ class ConnectionBase(AnsiblePlugin):
                 display.debug('Set connection var {0} to {1}'.format(varname, value))
                 variables[varname] = value
 
+    def _resolve_option_variables(self, variables, templar):
+        """
+        Return a dict of variable -> templated value, for any variables that
+        that match options registered by this plugin.
+        """
+        # create dict of 'templated vars'
+        var_options = {
+            '_extras': {},
+        }
+        for var_name in C.config.get_plugin_vars('connection', self._load_name):
+            if var_name in variables:
+                var_options[var_name] = templar.template(variables[var_name])
+
+        # add extras if plugin supports them
+        if getattr(self, 'allow_extras', False):
+            for var_name in variables:
+                if var_name.startswith(f'ansible_{self.extras_prefix}_') and var_name not in var_options:
+                    var_options['_extras'][var_name] = templar.template(variables[var_name])
+
+        return var_options
+
 
 class NetworkConnectionBase(ConnectionBase):
     """

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1059,7 +1059,8 @@ class StrategyBase:
                 del self._active_connections[target_host]
             else:
                 connection = plugin_loader.connection_loader.get(play_context.connection, play_context, os.devnull)
-                connection.set_options(task_keys=task.dump_attrs(), var_options=all_vars)
+                var_options = connection._resolve_option_variables(all_vars, templar)
+                connection.set_options(task_keys=task.dump_attrs(), var_options=var_options)
                 play_context.set_attributes_from_plugin(connection)
 
             if connection:

--- a/test/integration/targets/connection/test.sh
+++ b/test/integration/targets/connection/test.sh
@@ -20,3 +20,4 @@ else
 fi
 
 ansible-playbook test_reset_connection.yml -i "${INVENTORY}" "$@"
+ansible-playbook test_reset_connection_templated.yml -i "${INVENTORY}" "$@"

--- a/test/integration/targets/connection/test_reset_connection_templated.yml
+++ b/test/integration/targets/connection/test_reset_connection_templated.yml
@@ -1,0 +1,7 @@
+- hosts: "{{ target_hosts }}"
+  gather_facts: false
+  vars:
+    ansible_ssh_executable: "{{ 'ssh' | trim }}"
+  tasks:
+    # https://github.com/ansible/ansible/issues/84238
+    - meta: reset_connection


### PR DESCRIPTION
##### SUMMARY
Backport for https://github.com/ansible/ansible/pull/84240

* ssh: Test reset_connection with templated ansible_ssh_executable

Add failing test to confirm subsequent fixes are necessary & sufficient.

* ssh: Fix reset_connection with templated ansible_ssh_executable

Signed-off-by: Alex Willmer <alex@moreati.org.uk>
(cherry picked from commit 59d9737788d63ea4e17b74d3c3ca1a0cf03f89ba)

##### ISSUE TYPE

- Bugfix Pull Request