### PR TITLE
ansible-galaxy - support service accounts authentication

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -639,6 +639,7 @@ class GalaxyCLI(CLI):
             # it doesn't need to be passed as kwarg to GalaxyApi, same for others we pop here
             auth_url = server_options.pop('auth_url')
             client_id = server_options.pop('client_id')
+            client_secret = server_options.pop('client_secret')
             token_val = server_options['token'] or NoTokenSentinel
             username = server_options['username']
             api_version = server_options.pop('api_version')
@@ -669,7 +670,8 @@ class GalaxyCLI(CLI):
                         server_options['token'] = KeycloakToken(access_token=token_val,
                                                                 auth_url=auth_url,
                                                                 validate_certs=validate_certs,
-                                                                client_id=client_id)
+                                                                client_id=client_id,
+                                                                client_secret=client_secret)
                     else:
                         # The galaxy v1 / github / django / 'Token'
                         server_options['token'] = GalaxyToken(token=token_val)

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -40,6 +40,7 @@ GALAXY_SERVER_DEF = [
     ('api_version', False, 'int'),
     ('validate_certs', False, 'bool'),
     ('client_id', False, 'str'),
+    ('client_secret', False, 'str'),
     ('timeout', False, 'int'),
 ]
 

--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -47,7 +47,7 @@ class KeycloakToken(object):
 
     token_type = 'Bearer'
 
-    def __init__(self, access_token=None, auth_url=None, validate_certs=True, client_id=None):
+    def __init__(self, access_token=None, auth_url=None, validate_certs=True, client_id=None, client_secret=None):
         self.access_token = access_token
         self.auth_url = auth_url
         self._token = None
@@ -56,8 +56,11 @@ class KeycloakToken(object):
         if self.client_id is None:
             self.client_id = 'cloud-services'
         self._expiration = None
+        self.client_secret = client_secret
 
     def _form_payload(self):
+        if self.client_secret:
+            return 'grant_type=client_credentials&client_id=%s&client_secret=%s&scope=openid api.iam.service_accounts' % (self.client_id, self.client_secret)
         return 'grant_type=refresh_token&client_id=%s&refresh_token=%s' % (self.client_id,
                                                                            self.access_token)
 


### PR DESCRIPTION
##### SUMMARY
Red Hat Hybrid Cloud Console APIs will transition from basic authentication to token-based authentication via service accounts. Currently, token-based authentication does not support passing ``client_secret``. This pull request adds this new feature.
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### ADDITIONAL INFORMATION

User can now define an ``ansible.cfg`` including ``client_secret`` for the ``ansible-galaxy`` executable. Here is an example

```cfg
[galaxy]
server_list = automation_hub

[galaxy_server.automation_hub]
url = https://cloud.redhat.com/api/automation-hub/
auth_url = https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
client_id = xxxxxxxxxxx
client_secret = xxxxxxxxxxxxxxx
```
