### PR TITLE
[2.18] Make sure we are always using Lock from our multiprocessing context

### DIFF
--- a/changelogs/fragments/macos-correct-lock.yml
+++ b/changelogs/fragments/macos-correct-lock.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Use consistent multiprocessing context for action write locks

--- a/lib/ansible/executor/action_write_locks.py
+++ b/lib/ansible/executor/action_write_locks.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import multiprocessing.synchronize
 
-from multiprocessing import Lock
+from ansible.utils.multiprocessing import context as multiprocessing_context
 
 from ansible.module_utils.facts.system.pkg_mgr import PKG_MGRS
 
@@ -32,7 +32,7 @@ if 'action_write_locks' not in globals():
     # Below is a Lock for use when we weren't expecting a named module.  It gets used when an action
     # plugin invokes a module whose name does not match with the action's name.  Slightly less
     # efficient as all processes with unexpected module names will wait on this lock
-    action_write_locks[None] = Lock()
+    action_write_locks[None] = multiprocessing_context.Lock()
 
     # These plugins are known to be called directly by action plugins with names differing from the
     # action plugin name.  We precreate them here as an optimization.
@@ -41,4 +41,4 @@ if 'action_write_locks' not in globals():
 
     mods.update(('copy', 'file', 'setup', 'slurp', 'stat'))
     for mod_name in mods:
-        action_write_locks[mod_name] = Lock()
+        action_write_locks[mod_name] = multiprocessing_context.Lock()

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -28,7 +28,7 @@ import time
 import typing as t
 
 from collections import deque
-from multiprocessing import Lock
+
 
 from jinja2.exceptions import UndefinedError
 
@@ -55,6 +55,7 @@ from ansible.utils.fqcn import add_internal_fqcns
 from ansible.utils.unsafe_proxy import wrap_var
 from ansible.utils.sentinel import Sentinel
 from ansible.utils.vars import combine_vars
+from ansible.utils.multiprocessing import context as multiprocessing_context
 from ansible.vars.clean import strip_internal_keys, module_response_deepcopy
 
 display = Display()
@@ -365,7 +366,7 @@ class StrategyBase:
 
         if task.action not in action_write_locks.action_write_locks:
             display.debug('Creating lock for %s' % task.action)
-            action_write_locks.action_write_locks[task.action] = Lock()
+            action_write_locks.action_write_locks[task.action] = multiprocessing_context.Lock()
 
         # create a templar and template things we need later for the queuing process
         templar = Templar(loader=self._loader, variables=task_vars)


### PR DESCRIPTION
##### SUMMARY

Backport #84453

* Make sure we are always using Lock from our multiprocessing context

* add clog frag

(cherry picked from commit 73d8f4ad46c22e180fa3e3e1c6db1665378f674b)

##### ISSUE TYPE

- Bugfix Pull Request