### PR TITLE
gather_facts, fix 'smart' handling with network os and 'setup' (#84425)

### DIFF
--- a/changelogs/fragments/gather_facts_netos_fixes.yml
+++ b/changelogs/fragments/gather_facts_netos_fixes.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - gather_facts action will now issues errors and warnings as appropriate if a network OS is detected but no facts modules are defined for it.
+  - gather_facts action now defaults to `ansible.legacy.setup` if `smart` was set, no network OS was found and no other alias for `setup` was present.

--- a/test/integration/targets/gathering_facts/runme.sh
+++ b/test/integration/targets/gathering_facts/runme.sh
@@ -38,4 +38,11 @@ ANSIBLE_FACTS_MODULES='ansible.legacy.slow' ansible -m gather_facts localhost --
 
 # test parallelism
 ANSIBLE_FACTS_MODULES='dummy1,dummy2,dummy3' ansible -m gather_facts localhost --playbook-dir ./ -a 'gather_timeout=30 parallel=true' "$@" 2>&1
+
+# ensure we error out on bad network os
+ANSIBLE_FACTS_MODULES='smart' ansible -m gather_facts localhost -e 'ansible_network_os="N/A"' "$@" 2>&1 | grep "No fact modules available"
+
+# ensure we warn on setup + network OS
+ANSIBLE_FACTS_MODULES='smart, setup' ansible -m gather_facts localhost -e 'ansible_network_os="N/A"' "$@" 2>&1 | grep "Detected 'setup' module and a network OS is set"
+
 rm "${OUTPUT_DIR}/canary.txt"


### PR DESCRIPTION
gather_facts, fix network_os and smart logic and defaults

setup will be default for smart only if network_os is not set, now you get warnings and errors when missing a valid facts module for a network os

Co-authored-by: Abhijeet Kasurde <akasurde@redhat.com>
(cherry picked from commit c64c38900768ad668d118861d6f7c993b98daacb)

##### ISSUE TYPE

- Bugfix Pull Request
