### PR TITLE
`with_dict` type error include value in error message

### DIFF
--- a/changelogs/fragments/84473-dict-lookup-type-error-message.yml
+++ b/changelogs/fragments/84473-dict-lookup-type-error-message.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - when the ``dict`` lookup is given a non-dict argument, show the value of the argument and its type in the error message.

--- a/lib/ansible/plugins/lookup/dict.py
+++ b/lib/ansible/plugins/lookup/dict.py
@@ -70,7 +70,7 @@ class LookupModule(LookupBase):
         for term in terms:
             # Expect any type of Mapping, notably hostvars
             if not isinstance(term, Mapping):
-                raise AnsibleError(f"lookup dict expects a dictionary, got '{term}' of type {type(term)})")
+                raise AnsibleError(f"the 'dict' lookup plugin expects a dictionary, got '{term}' of type {type(term)})")
 
             results.extend(self._flatten_hash_to_list(term))
         return results

--- a/lib/ansible/plugins/lookup/dict.py
+++ b/lib/ansible/plugins/lookup/dict.py
@@ -70,7 +70,7 @@ class LookupModule(LookupBase):
         for term in terms:
             # Expect any type of Mapping, notably hostvars
             if not isinstance(term, Mapping):
-                raise AnsibleError(f"with_dict expects a dict, got {term}")
+                raise AnsibleError(f"with_dict expects a dict, got '{term}' of type {type(term)})")
 
             results.extend(self._flatten_hash_to_list(term))
         return results

--- a/lib/ansible/plugins/lookup/dict.py
+++ b/lib/ansible/plugins/lookup/dict.py
@@ -70,7 +70,7 @@ class LookupModule(LookupBase):
         for term in terms:
             # Expect any type of Mapping, notably hostvars
             if not isinstance(term, Mapping):
-                raise AnsibleError(f"with_dict expects a dict, got '{term}' of type {type(term)})")
+                raise AnsibleError(f"lookup dict expects a dictionary, got '{term}' of type {type(term)})")
 
             results.extend(self._flatten_hash_to_list(term))
         return results

--- a/lib/ansible/plugins/lookup/dict.py
+++ b/lib/ansible/plugins/lookup/dict.py
@@ -70,7 +70,7 @@ class LookupModule(LookupBase):
         for term in terms:
             # Expect any type of Mapping, notably hostvars
             if not isinstance(term, Mapping):
-                raise AnsibleError("with_dict expects a dict")
+                raise AnsibleError(f"with_dict expects a dict, got {term}")
 
             results.extend(self._flatten_hash_to_list(term))
         return results


### PR DESCRIPTION
##### SUMMARY

I have been struggling with jinja2 and `with_dict`, and to solve it I had to find the error message in the ansible source code, open `plugins/lookup/dict.py` in vscode, make a breakpoint, run `ansible-playbook` with the vscode python debugger with `justmycode: false`, and then I got to see what was the value that my jinja2 expression returned. Ansible should just tell me the value. The `sublements` lookup already does this: https://github.com/ansible/ansible/blob/cae4f90b21bc40c88a00e712d28531ab0261f759/lib/ansible/plugins/lookup/subelements.py#L135

##### ISSUE TYPE

- Feature Pull Request
