### PR TITLE
Fix wrong homedir permissions when UMASK is unset in /etc/login.defs …

### DIFF
--- a/test/integration/targets/user/tasks/test_no_home_fallback.yml
+++ b/test/integration/targets/user/tasks/test_no_home_fallback.yml
@@ -35,12 +35,17 @@
         import os
         try:
             for line in open('/etc/login.defs').readlines():
+                m = re.match(r'^HOME_MODE\s+(\d+)$', line)
+                if m:
+                    mode = int(m.group(1), 8)
+                    break
                 m = re.match(r'^UMASK\s+(\d+)$', line)
                 if m:
                     umask = int(m.group(1), 8)
+                    mode = oct(0o777 & ~umask)
         except:
             umask = os.umask(0)
-        mode = oct(0o777 & ~umask)
+            mode = oct(0o777 & ~umask)
         print(str(mode).replace('o', ''))
       args:
         executable: "{{ ansible_python_interpreter }}"


### PR DESCRIPTION
##### SUMMARY


When a user doesn't exist and user module is used to create the user and the homedir, adduser is called which parses HOME_MODE from /etc/login.defs, and when not set calculates the mode from UMASK from the same file.

When a user already exists without homedir, and the user module is used to add a home dir, it incorrectly ignores HOME_MODE, resulting in a world-readable home dir when UMASK is not set. This is for example the case in Debian trixie and later, and likely Ubuntu 25.04 and later.

Steps to reproduce are here: https://github.com/ansible/ansible/issues/24862#issuecomment-2555768750

Fixes #24862, at least for the regular user permissions. I have not tested it with selinux labels.

Also fixes CI test failure on Debian trixie and later.

##### ISSUE TYPE
- Bugfix Pull Request
