### PR TITLE
Fix wrong homedir permissions when UMASK is unset in /etc/login.defs …

### DIFF
--- a/changelogs/fragments/user_module.yml
+++ b/changelogs/fragments/user_module.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - user - Use higher precedence HOME_MODE as UMASK for path provided (https://github.com/ansible/ansible/pull/84482).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1370,23 +1370,20 @@ class User(object):
                     self.module.exit_json(failed=True, msg="%s" % to_native(e))
             # get umask from /etc/login.defs and set correct home mode
             if os.path.exists(self.LOGIN_DEFS):
-                with open(self.LOGIN_DEFS, 'r') as f:
-                    for line in f:
-                        # HOME_MODE has higher precedence as UMASK
-                        m = re.match(r'^HOME_MODE\s+(\d+)$', line)
-                        if m:
-                            mode = int(m.group(1), 8)
-                            break  # higher precedence
-                        m = re.match(r'^UMASK\s+(\d+)$', line)
-                        if m:
-                            umask = int(m.group(1), 8)
-                            mode = 0o777 & ~umask
                 # fallback if neither HOME_MODE nor UMASK are set;
                 # follow behaviour of useradd initializing UMASK = 022
-                try:
-                    mode
-                except NameError:
-                    mode = 0o755
+                mode = 0o755
+                with open(self.LOGIN_DEFS, 'r') as fh:
+                    for line in fh:
+                        # HOME_MODE has higher precedence as UMASK
+                        match = re.match(r'^HOME_MODE\s+(\d+)$', line)
+                        if match:
+                            mode = int(m.group(1), 8)
+                            break  # higher precedence
+                        match = re.match(r'^UMASK\s+(\d+)$', line)
+                        if match:
+                            umask = int(m.group(1), 8)
+                            mode = 0o777 & ~umask
                 try:
                     os.chmod(path, mode)
                 except OSError as e:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1378,11 +1378,11 @@ class User(object):
                         # HOME_MODE has higher precedence as UMASK
                         match = re.match(r'^HOME_MODE\s+(\d+)$', line)
                         if match:
-                            mode = int(m.group(1), 8)
+                            mode = int(match.group(1), 8)
                             break  # higher precedence
                         match = re.match(r'^UMASK\s+(\d+)$', line)
                         if match:
-                            umask = int(m.group(1), 8)
+                            umask = int(match.group(1), 8)
                             mode = 0o777 & ~umask
                 try:
                     os.chmod(path, mode)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1390,7 +1390,7 @@ class User(object):
                 try:
                     os.chmod(path, mode)
                 except OSError as e:
-                    self.module.exit_json(failed=True, msg="%s" % to_native(e))
+                    self.module.exit_json(failed=True, msg=to_native(e))
 
     def chown_homedir(self, uid, gid, path):
         try:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1372,14 +1372,25 @@ class User(object):
             if os.path.exists(self.LOGIN_DEFS):
                 with open(self.LOGIN_DEFS, 'r') as f:
                     for line in f:
+                        # HOME_MODE has higher precedence as UMASK
+                        m = re.match(r'^HOME_MODE\s+(\d+)$', line)
+                        if m:
+                            mode = int(m.group(1), 8)
+                            break  # higher precedence
                         m = re.match(r'^UMASK\s+(\d+)$', line)
                         if m:
                             umask = int(m.group(1), 8)
                             mode = 0o777 & ~umask
-                            try:
-                                os.chmod(path, mode)
-                            except OSError as e:
-                                self.module.exit_json(failed=True, msg="%s" % to_native(e))
+                # fallback if neither HOME_MODE nor UMASK are set;
+                # follow behaviour of useradd initializing UMASK = 022
+                try:
+                    mode
+                except NameError:
+                    mode = 0o755
+                try:
+                    os.chmod(path, mode)
+                except OSError as e:
+                    self.module.exit_json(failed=True, msg="%s" % to_native(e))
 
     def chown_homedir(self, uid, gid, path):
         try:

--- a/test/integration/targets/user/tasks/test_no_home_fallback.yml
+++ b/test/integration/targets/user/tasks/test_no_home_fallback.yml
@@ -35,12 +35,17 @@
         import os
         try:
             for line in open('/etc/login.defs').readlines():
+                m = re.match(r'^HOME_MODE\s+(\d+)$', line)
+                if m:
+                    mode = oct(int(m.group(1), 8))
+                    break
                 m = re.match(r'^UMASK\s+(\d+)$', line)
                 if m:
                     umask = int(m.group(1), 8)
+                    mode = oct(0o777 & ~umask)
         except:
             umask = os.umask(0)
-        mode = oct(0o777 & ~umask)
+            mode = oct(0o777 & ~umask)
         print(str(mode).replace('o', ''))
       args:
         executable: "{{ ansible_python_interpreter }}"


### PR DESCRIPTION
##### SUMMARY

(new PR since I could not reopen the previous one)

When a user doesn't exist and user module is used to create the user and the homedir, `adduser` is called which parses `HOME_MODE` from `/etc/login.defs`, and when not set calculates the mode from `UMASK` from the same file.

When a user already exists without homedir, and the user module is used to add a home dir, it incorrectly ignores `HOME_MODE`, resulting in a world-readable home dir when UMASK is not set. This is for example the case in Debian trixie and later, and likely Ubuntu 25.04 and later.

Finally, when neither `HOME_MODE` nor `UMASK` was set, this module threw an exception. So instead, follow `adduser` behaviour and initialize `UMASK = 022`.

Steps to reproduce are here: https://github.com/ansible/ansible/issues/24862#issuecomment-2555768750

Fixes #24862, at least for the regular user permissions. I have not tested it with selinux labels.

Also fixes CI test failure on Debian trixie and later.

##### ISSUE TYPE
- Bugfix Pull Request
