### PR TITLE
ansible-vault integration test fix (fixes: #83837)

### DIFF
--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -48,16 +48,19 @@ echo $?
 ansible-vault view "$@" --vault-id vault-password encrypted-vault-password
 
 # check if ansible-vault fails when destination is not writable
-NOT_WRITABLE_DIR="${MYTMPDIR}/not_writable"
-TEST_FILE_EDIT4="${NOT_WRITABLE_DIR}/testfile"
-mkdir "${NOT_WRITABLE_DIR}"
-touch "${TEST_FILE_EDIT4}"
-chmod ugo-w "${NOT_WRITABLE_DIR}"
-ansible-vault encrypt "$@" --vault-password-file vault-password "${TEST_FILE_EDIT4}" < /dev/null > log 2>&1 && :
-grep "not writable" log && :
-WRONG_RC=$?
-echo "rc was $WRONG_RC (1 is expected)"
-[ $WRONG_RC -eq 1 ]
+# skip check as root as root can always read/write
+if [ ${UID} -ne "0" ]; then
+    NOT_WRITABLE_DIR="${MYTMPDIR}/not_writable"
+    TEST_FILE_EDIT4="${NOT_WRITABLE_DIR}/testfile"
+    mkdir "${NOT_WRITABLE_DIR}"
+    touch "${TEST_FILE_EDIT4}"
+    chmod ugo-w "${NOT_WRITABLE_DIR}"
+    ansible-vault encrypt "$@" --vault-password-file vault-password "${TEST_FILE_EDIT4}" < /dev/null > log 2>&1 && :
+    grep "not writable" log && :
+    WRONG_RC=$?
+    echo "rc was $WRONG_RC (0 is expected)"
+    [ $WRONG_RC -eq 0 ]
+fi
 
 # encrypt with a password from a vault encrypted password file and multiple vault-ids
 # should fail because we dont know which vault id to use to encrypt with


### PR DESCRIPTION
Correct the test that expects an error when using ansible-vault to write against a non-writeable dir. Skip the test as root, as root can always write.

##### ISSUE TYPE

- Bugfix Pull Request
