### PR TITLE
Mark integration tests as needs/root

### DIFF
--- a/test/integration/targets/apt/aliases
+++ b/test/integration/targets/apt/aliases
@@ -1,5 +1,6 @@
 shippable/posix/group2
 destructive
+needs/root
 skip/freebsd
 skip/macos
 skip/rhel

--- a/test/integration/targets/become/aliases
+++ b/test/integration/targets/become/aliases
@@ -2,4 +2,5 @@ destructive
 shippable/posix/group1
 context/target
 gather_facts/no
+needs/root
 setup/always/setup_passlib_controller  # required for setup_test_user

--- a/test/integration/targets/become_su/aliases
+++ b/test/integration/targets/become_su/aliases
@@ -2,6 +2,7 @@ destructive
 shippable/posix/group1
 context/target
 gather_facts/no
+needs/root
 needs/target/setup_become_user_pair
 needs/target/setup_test_user
 setup/always/setup_passlib_controller  # required for setup_test_user

--- a/test/integration/targets/become_sudo/aliases
+++ b/test/integration/targets/become_sudo/aliases
@@ -2,6 +2,7 @@ destructive
 shippable/posix/group1
 context/target
 gather_facts/no
+needs/root
 needs/target/setup_become_user_pair
 needs/target/setup_test_user
 setup/always/setup_passlib_controller  # required for setup_test_user

--- a/test/integration/targets/deb822_repository/aliases
+++ b/test/integration/targets/deb822_repository/aliases
@@ -1,4 +1,5 @@
 destructive
+needs/root
 shippable/posix/group1
 skip/freebsd
 skip/osx

--- a/test/integration/targets/hardware_facts/aliases
+++ b/test/integration/targets/hardware_facts/aliases
@@ -1,4 +1,5 @@
 destructive
 needs/privileged
+needs/root
 shippable/posix/group4
 context/controller

--- a/test/integration/targets/package_facts/aliases
+++ b/test/integration/targets/package_facts/aliases
@@ -1,3 +1,4 @@
 destructive
+needs/root
 shippable/posix/group2
 skip/macos

--- a/test/integration/targets/slurp/aliases
+++ b/test/integration/targets/slurp/aliases
@@ -1,3 +1,4 @@
 shippable/posix/group1
 destructive
+needs/root
 setup/always/setup_passlib_controller  # required for setup_test_user


### PR DESCRIPTION
For calling setup_test_user, which adds a user to the system (and thus requiring
root):
- become
- become_su
- become_sudo
- slurp

And also:
- apt, which installs/removes system packages
- deb822_repository, which adds/removes apt repos
- hardware_facts calls losetup, which requires root
- package_facts, which installs/removes system packages

##### ISSUE TYPE

- Test Pull Request