### PR TITLE
Adding an explanation about ansible_ssh_pass parameter. 

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -56,7 +56,9 @@ DOCUMENTATION = """
               - name: ansible_ssh_host_key_checking
                 version_added: '2.5'
       password:
-          description: Authentication password for the O(remote_user). Can be supplied as CLI option.
+          description:
+              - Authentication password for the O(remote_user). Can be supplied as CLI option.
+              - Note that ansible_ssh_pass is used as an SSH key passphrase when ansible_sshpass_prompt is configured.
           type: string
           vars:
               - name: ansible_password


### PR DESCRIPTION
##### SUMMARY

This change clarifies the behavior of ansible_ssh_pass. Currently, the documentation only explains that ansible_ssh_pass is used as an SSH password. However, this parameter also acts as an SSH key passphrase when ansible_sshpass_prompt is configured. We need to explain this behavior on the documentation.


