### PR TITLE
add get_options function for CallbackBase

### DIFF
--- a/changelogs/fragments/84496-CallbackBase-get_options.yml
+++ b/changelogs/fragments/84496-CallbackBase-get_options.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - callback plugins - add get_options() to CallbackBase to match other functions overloaded from AnsiblePlugin

--- a/changelogs/fragments/84496-CallbackBase-get_options.yml
+++ b/changelogs/fragments/84496-CallbackBase-get_options.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - callback plugins - add get_options() to CallbackBase to match other functions overloaded from AnsiblePlugin
+  - callback plugins - add has_option() to CallbackBase to match other functions overloaded from AnsiblePlugin
+  - callback plugins - fix get_options() for CallbackBase

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -129,7 +129,7 @@ class AnsiblePlugin(ABC):
 
     @property
     def option_definitions(self):
-        if self._defs is None:
+        if (not hasattr(self, "_defs")) or self._defs is None:
             self._defs = C.config.get_configuration_definitions(plugin_type=self.plugin_type, name=self._load_name)
         return self._defs
 

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -171,11 +171,11 @@ class CallbackBase(AnsiblePlugin):
     def set_option(self, k, v):
         self._plugin_options[k] = C.config.get_config_value(k, plugin_type=self.plugin_type, plugin_name=self._load_name, direct={k: v})
 
-    def get_option(self, k):
+    def get_option(self, k, hostvars=None):
         return self._plugin_options[k]
 
-    def get_options(self):
-        return self._plugin_options
+    def has_option(self, option):
+        return (option in self._plugin_options)
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
         """ This is different than the normal plugin method as callbacks get called early and really don't accept keywords.

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -174,6 +174,9 @@ class CallbackBase(AnsiblePlugin):
     def get_option(self, k):
         return self._plugin_options[k]
 
+    def get_options(self):
+        return self._plugin_options
+
     def set_options(self, task_keys=None, var_options=None, direct=None):
         """ This is different than the normal plugin method as callbacks get called early and really don't accept keywords.
             Also _options was already taken for CLI args and callbacks use _plugin_options instead.


### PR DESCRIPTION
##### SUMMARY

`AnsiblePlugin` has the following functions:

* get_option
* set_option
* get_options
* set_options

`CallbackBase` overrides the following functions to use it's own internal `self._plugin_options`:

* get_option
* set_option
* set_options

but it leaves behind the default `get_options` in a broken state:

```console
[WARNING]: Failure using method (...) in callback plugin (...): 'CallbackModule' object has no attribute '_defs'
Callback Exception:
...
   File ".../.local/lib/python3.12/site-packages/ansible/plugins/__init__.py", line 96, in get_options
    for option in self.option_definitions.keys():
                  ^^^^^^^^^^^^^^^^^^^^^^^
   File ".../.local/lib/python3.12/site-packages/ansible/plugins/__init__.py", line 132, in option_definitions
    if self._defs is None:
       ^^^^^^^^^^
```

https://github.com/ansible/ansible/blob/cae4f90b21bc40c88a00e712d28531ab0261f759/lib/ansible/plugins/__init__.py#L130-L134

I tried tweaking this function to handle an undefined `self._defs` using `hasattr`, but ran into another problem:

```console
[WARNING]: Failure using method (...) in callback plugin (...): CallbackBase.get_option() got an unexpected keyword argument 'hostvars'
Callback Exception:
...
   File ".../.local/lib/python3.12/site-packages/ansible/plugins/__init__.py", line 97, in get_options
    options[option] = self.get_option(option, hostvars=hostvars)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

since `CallbackBase`'s option logic is so simple, this small change seems reasonable to me. But I'm sure there could be reasons why this is not desirable. Since I now know that I can use `self._plugin_options` directly, this issue isn't blocking my workflow.

I haven't checked, but if the other option-related functions are also broken, perhaps they should be re-implemented for `CallbackBase` or at least replaced with another function that makes a `NotImplementedError`?

##### ISSUE TYPE

- Feature Pull Request
