### PR TITLE
Set priority=6 for log_invocation() in basic.py

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1299,6 +1299,7 @@ class AnsibleModule(object):
         # TODO: generalize a separate log function and make log_invocation use it
         # Sanitize possible password argument when logging.
         log_args = dict()
+        log_args["PRIORITY"] = 6
 
         for param in self.params:
             canon = self.aliases.get(param, param)

--- a/test/units/module_utils/basic/test__log_invocation.py
+++ b/test/units/module_utils/basic/test__log_invocation.py
@@ -32,7 +32,7 @@ def test_module_utils_basic__log_invocation(am, mocker):
     message = args[0]
 
     assert len(message) == \
-        len('Invoked with bam=bam bar=[1, 2, 3] foo=False baz=baz no_log=NOT_LOGGING_PARAMETER password=NOT_LOGGING_PASSWORD')
+        len('Invoked with bam=bam bar=[1, 2, 3] foo=False baz=baz no_log=NOT_LOGGING_PARAMETER password=NOT_LOGGING_PASSWORD PRIORITY=6')
 
     assert message.startswith('Invoked with ')
     assert ' bam=bam' in message
@@ -51,4 +51,5 @@ def test_module_utils_basic__log_invocation(am, mocker):
             'baz': 'baz',
             'password': 'NOT_LOGGING_PASSWORD',
             'no_log': 'NOT_LOGGING_PARAMETER',
+            'PRIORITY': 6,
         })


### PR DESCRIPTION
log_invocation() is called frequently, and doesn't indicate anything out of the ordinary.

Set an explicit priority, so systemd users can filter it out when looking for issues.

##### SUMMARY

Ansible log messages are sent through systemd on systems that have the python3 `sdnotify` package installed.  This could be deliberate, but in my case, I just happen to have some services that depend on Debian's `python3-sdnotify` package.

Ansible currently gives me a barrage of messages (details below) that obscure more important messages.  Setting `PRIORITY=6` ("informational message") for invocation messages makes it easy to filter by priority.

##### ISSUE TYPE

- Feature Pull Request

##### ADDITIONAL INFORMATION

In my case, messages usually look like the following:

```
ansible-ansible.posix.authorized_key Invoked with user=<me> state=present key=<my-entire-public-key> 
 key_options=<all-key-options> manage_dir=True exclusive=False validate_certs=True follow=False path=None comment=None
```

Each line expands to nearly a kilobyte of text, and a typical run will generate about 5-20 such lines.  Important messages can be easy to miss or scroll off the screen with so much visual clutter.