### PR TITLE
Fix result_pickle_error integration test

### DIFF
--- a/test/integration/targets/result_pickle_error/action_plugins/result_pickle_error.py
+++ b/test/integration/targets/result_pickle_error/action_plugins/result_pickle_error.py
@@ -5,10 +5,14 @@
 from __future__ import annotations
 
 from ansible.plugins.action import ActionBase
-from jinja2 import Undefined
+
+
+class CannotBePickled:
+    def __getstate__(self):
+        raise Exception('pickle intentionally not supported')
 
 
 class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
-        return {'obj': Undefined('obj')}
+        return {'obj': CannotBePickled()}

--- a/test/integration/targets/result_pickle_error/tasks/main.yml
+++ b/test/integration/targets/result_pickle_error/tasks/main.yml
@@ -8,7 +8,7 @@
       - result.msg == expected_msg
       - result is failed
   vars:
-    expected_msg: "cannot pickle 'Undefined' object"
+    expected_msg: "pickle intentionally not supported"
 
 - debug:
     msg: Success, no hang


### PR DESCRIPTION
##### SUMMARY

The test has been updated to use a custom type which does not support pickling, instead of relying on Jinja's `Undefined` type. As of Jinja 3.1.5 that type now supports pickle, which breaks the original implementation of the test.

##### ISSUE TYPE

Test Pull Request
