### PR TITLE
[stable-2.16] Bump subversion to latest in its test on openSUSE

### DIFF
--- a/test/integration/targets/subversion/vars/Suse.yml
+++ b/test/integration/targets/subversion/vars/Suse.yml
@@ -1,6 +1,8 @@
 ---
 subversion_packages:
-- subversion
-- subversion-server
+- >-  # version sync needed post Dec 17, 2024
+  subversion >= 1.14.1-150400.5.3.1
+- >-  # version sync needed post Dec 17, 2024
+  subversion-server >= 1.14.1-150400.5.3.1
 apache_user: wwwrun
 apache_group: www


### PR DESCRIPTION
This is necessary because the openSUSE repo in use [[1]] got package updates on Dec 17, 2024. Our tests require “any” version of the `subversion` and `subversion-server` packages. So with `subversion` being pre-installed, it remained on some older version while the playbook installed the latest version of `subversion-server`. This caused Apache to fail loading the corresponding module `mod_dav_svn.so`. The task invoking `httpd` is asynchronous, and no logic checks that it started correctly before attempting to run the tests — it only checks for the `svn` binary presence.

This is how the problem manifests itself when the server is spawned interactively:

```console
root@2d3bae23bb22:/$ apachectl -k start -f /tmp/ansible-svn/subversion.conf
which: no w3m in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
which: no lynx in (/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin)
httpd-prefork: Syntax error on line 3 of /tmp/ansible-svn/subversion.conf: Cannot load /usr/lib64/apache2/mod_dav_svn.so into server: /usr/lib64/apache2/mod_dav_svn.so: undefined symbol: svn_repos__validate_new_path
```

This patch addresses the issue by setting the minimum required version to install to what's currently the latest.

[1]: http://download.opensuse.org/update/leap/15.5/sle/x86_64/

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
^
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

^