### PR TITLE
📝 Drop drop-down default note from issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,7 +47,7 @@ body:
 - type: dropdown
   attributes:
     label: Issue Type
-    description: This is a marker for out automatic bot. Do not change it.
+    description: This is a marker for our automatic bot. Do not change it.
     options:
     - Bug Report
   validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,23 +47,7 @@ body:
 - type: dropdown
   attributes:
     label: Issue Type
-    description: >
-      Please select the single available option in the drop-down.
-
-      <details>
-        <summary>
-          <em>Why?</em>
-        </summary>
-
-        We would do it by ourselves but unfortunately, the current
-        edition of GitHub Issue Forms Alpha does not support this yet 🤷
-
-
-        _We will make it easier in the future, once GitHub
-        supports dropdown defaults. Promise!_
-
-      </details>
-    # FIXME: Once GitHub allows defining the default choice, update this
+    description: This is a marker for out automatic bot. Do not change it.
     options:
     - Bug Report
   validations:

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -84,7 +84,7 @@ body:
 - type: dropdown
   attributes:
     label: Issue Type
-    description: This is a marker for out automatic bot. Do not change it.
+    description: This is a marker for our automatic bot. Do not change it.
     options:
     - Documentation Report
   validations:

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -84,20 +84,7 @@ body:
 - type: dropdown
   attributes:
     label: Issue Type
-    description: >
-      Please select the single available option in the drop-down.
-
-      <details>
-        <summary>
-          <em>Why?</em>
-        </summary>
-
-
-        _We will make it easier in the future, once GitHub
-        supports dropdown defaults. Promise!_
-
-      </details>
-    # FIXME: Once GitHub allows defining the default choice, update this
+    description: This is a marker for out automatic bot. Do not change it.
     options:
     - Documentation Report
   validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -101,23 +101,7 @@ body:
 - type: dropdown
   attributes:
     label: Issue Type
-    description: >
-      Please select the single available option in the drop-down.
-
-      <details>
-        <summary>
-          <em>Why?</em>
-        </summary>
-
-        We would do it by ourselves but unfortunately, the current
-        edition of GitHub Issue Forms Alpha does not support this yet 🤷
-
-
-        _We will make it easier in the future, once GitHub
-        supports dropdown defaults. Promise!_
-
-      </details>
-    # FIXME: Once GitHub allows defining the default choice, update this
+    description: This is a marker for out automatic bot. Do not change it.
     options:
     - Feature Idea
   validations:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -101,7 +101,7 @@ body:
 - type: dropdown
   attributes:
     label: Issue Type
-    description: This is a marker for out automatic bot. Do not change it.
+    description: This is a marker for our automatic bot. Do not change it.
     options:
     - Feature Idea
   validations:


### PR DESCRIPTION
Earlier, this form would force the users to click on the single item of the drop-down list. But now, this is happening automatically and the enclosed explanaiton is outdated and misleading.

This patch removes it to reduce confusion.

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
$sbj.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Maintenance Pull Request

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
N/A