### PR TITLE
ansible-test - Fix FreeBSD instance CA certs

### DIFF
--- a/changelogs/fragments/ansible-test-freebsd-nss.yml
+++ b/changelogs/fragments/ansible-test-freebsd-nss.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Ensure CA certificates are installed on managed FreeBSD instances.

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -154,6 +154,7 @@ bootstrap_remote_freebsd()
         py${python_package_version}-sqlite3
         py${python_package_version}-setuptools
         bash
+        ca_root_nss
         curl
         gtar
         sudo


### PR DESCRIPTION
##### SUMMARY

Some versions and architectures come with `ca_root_nss` pre-installed. However, at least FreeBSD 13.4 on aarch64 does not. This change ensures the certificates will always be installed.

##### ISSUE TYPE

Bugfix Pull Request
