### PR TITLE
.github: simplify PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/Bug fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Bug fix.md
@@ -2,19 +2,8 @@
 
 <!--- Describe the change below, including rationale and design decisions -->
 
-<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
+<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->
 
 ##### ISSUE TYPE
 
 - Bugfix Pull Request
-
-##### ADDITIONAL INFORMATION
-
-<!--- Include additional information to help people understand the change here -->
-<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
-
-<!--- Paste verbatim command output below, e.g. before and after your change -->
-
-```paste below
-
-```

--- a/.github/PULL_REQUEST_TEMPLATE/Documentation change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Documentation change.md
@@ -2,18 +2,8 @@
 
 <!--- Describe the change below, including rationale -->
 
-<!--- HINT: Include "Closes #nnn" if you are fixing an existing issue -->
+<!--- Add "Fixes #1234" if there is a corresponding issue -->
 
 ##### ISSUE TYPE
 
 - Docs Pull Request
-
-##### ADDITIONAL INFORMATION
-
-<!--- Include additional information to help people understand the change here -->
-
-<!--- Paste verbatim command output below, e.g. before and after your change -->
-
-```paste below
-
-```

--- a/.github/PULL_REQUEST_TEMPLATE/New feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/New feature.md
@@ -2,18 +2,8 @@
 
 <!--- Describe the change below, including rationale and design decisions -->
 
-<!--- HINT: Include "Resolves #nnn" if you are fixing an existing issue -->
+<!--- Add "Fixes #1234" if there is a corresponding issue -->
 
 ##### ISSUE TYPE
 
 - Feature Pull Request
-
-##### ADDITIONAL INFORMATION
-
-<!--- Include additional information to help people understand the change here -->
-
-<!--- Paste verbatim command output below, e.g. before and after your change -->
-
-```paste below
-
-```

--- a/.github/PULL_REQUEST_TEMPLATE/Tests.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Tests.md
@@ -2,19 +2,8 @@
 
 <!--- Describe the change below, including rationale and design decisions -->
 
-<!--- HINT: Include "Closes #nnn" if you are fixing an existing issue -->
+<!--- Add "Fixes #1234" if there is a corresponding issue -->
 
 ##### ISSUE TYPE
 
 - Test Pull Request
-
-##### ADDITIONAL INFORMATION
-
-<!--- Include additional information to help people understand the change here -->
-<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
-
-<!--- Paste verbatim command output below, e.g. before and after your change -->
-
-```paste below
-
-```

--- a/.github/PULL_REQUEST_TEMPLATE/Unclear purpose or motivation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/Unclear purpose or motivation.md
@@ -2,7 +2,7 @@
 
 <!--- Describe the change below, including rationale and design decisions -->
 
-<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
+<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->
 
 ##### ISSUE TYPE
 
@@ -12,14 +12,3 @@
 - Docs Pull Request
 - Feature Pull Request
 - Test Pull Request
-
-##### ADDITIONAL INFORMATION
-
-<!--- Include additional information to help people understand the change here -->
-<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
-
-<!--- Paste verbatim command output below, e.g. before and after your change -->
-
-```paste below
-
-```


### PR DESCRIPTION
##### SUMMARY
It is rare that we need to provide information like "before and after the change". In majority of cases we just ignore "Additional information" when submitting PRs. We can just put the needed information into the summary if needed and remove the section from the template, simplifying it.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request
