### PR TITLE
uri: form location correctly from relative redirect

### DIFF
--- a/changelogs/fragments/84540-uri-relative-redirect.yml
+++ b/changelogs/fragments/84540-uri-relative-redirect.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - uri - Form location correctly when the server returns a relative redirect (https://github.com/ansible/ansible/issues/84540)

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -439,11 +439,10 @@ import re
 import shutil
 import tempfile
 from datetime import datetime, timezone
-import urllib
 
 from ansible.module_utils.basic import AnsibleModule, sanitize_keys
 from ansible.module_utils.six import binary_type, iteritems, string_types
-from ansible.module_utils.six.moves.urllib.parse import urlencode, urlsplit
+from ansible.module_utils.six.moves.urllib.parse import urlencode, urljoin
 from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.six.moves.collections_abc import Mapping, Sequence
 from ansible.module_utils.urls import (
@@ -511,7 +510,7 @@ def absolute_location(url, location):
     next URL, specifically in the case of a ``Location`` header.
     """
 
-    return urllib.parse.urljoin(url, location)
+    return urljoin(url, location)
 
 
 def kv_list(data):

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -439,6 +439,7 @@ import re
 import shutil
 import tempfile
 from datetime import datetime, timezone
+import urllib
 
 from ansible.module_utils.basic import AnsibleModule, sanitize_keys
 from ansible.module_utils.six import binary_type, iteritems, string_types
@@ -510,20 +511,7 @@ def absolute_location(url, location):
     next URL, specifically in the case of a ``Location`` header.
     """
 
-    if '://' in location:
-        return location
-
-    elif location.startswith('/'):
-        parts = urlsplit(url)
-        base = url.replace(parts[2], '')
-        return '%s%s' % (base, location)
-
-    elif not location.startswith('/'):
-        base = os.path.dirname(url)
-        return '%s/%s' % (base, location)
-
-    else:
-        return location
+    return urllib.parse.urljoin(url, location)
 
 
 def kv_list(data):

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -505,14 +505,6 @@ def write_file(module, dest, content, resp):
         os.remove(tmpsrc)
 
 
-def absolute_location(url, location):
-    """Attempts to create an absolute URL based on initial URL, and
-    next URL, specifically in the case of a ``Location`` header.
-    """
-
-    return urljoin(url, location)
-
-
 def kv_list(data):
     """ Convert data into a list of key-value tuples """
     if data is None:
@@ -760,7 +752,7 @@ def main():
         uresp[ukey] = value
 
     if 'location' in uresp:
-        uresp['location'] = absolute_location(url, uresp['location'])
+        uresp['location'] = urljoin(url, uresp['location'])
 
     # Default content_encoding to try
     if isinstance(content, binary_type):

--- a/test/integration/targets/uri/tasks/redirect-none.yml
+++ b/test/integration/targets/uri/tasks/redirect-none.yml
@@ -294,3 +294,24 @@
     - http_308_post.redirected == false
     - http_308_post.status == 308
     - http_308_post.url == 'https://' + httpbin_host + '/redirect-to?status_code=308&url=https://' + httpbin_host + '/anything'
+
+- name: Test HTTP return value for location using relative redirects
+  uri:
+    url: https://{{ httpbin_host }}/redirect-to?url={{ item }}
+    status_code: 302
+    follow_redirects: none
+  register: http_302
+  loop:
+    - "/anything?foo=bar"
+    - "status/302"
+    - "./status/302"
+    - "/status/302"
+    - "//{{ httpbin_host }}/status/302"
+    - "https:status/302"
+
+- assert:
+    that:
+      - item.location == ('https://' + httpbin_host + ((idx == 0) | ternary('/anything?foo=bar', '/status/302')))
+  loop: "{{ http_302.results }}"
+  loop_control:
+    index_var: idx

--- a/test/integration/targets/uri/tasks/redirect-safe.yml
+++ b/test/integration/targets/uri/tasks/redirect-safe.yml
@@ -272,3 +272,27 @@
     - http_308_post.redirected == false
     - http_308_post.status == 308
     - http_308_post.url == 'https://' + httpbin_host + '/redirect-to?status_code=308&url=https://' + httpbin_host + '/anything'
+
+
+- name: Test HTTP using HEAD with relative path in redirection
+  uri:
+    url: https://{{ httpbin_host }}/redirect-to?status_code={{ item }}&url=/anything?foo=bar
+    follow_redirects: safe
+    return_content: yes
+    method: HEAD
+  register: http_head
+  loop:
+    - '301'
+    - '302'
+    - '303'
+    - '307'
+    - '308'
+
+- assert:
+    that:
+    - item.changed is false
+    - item.json is not defined
+    - item.redirected
+    - item.status == 200
+    - item.url == 'https://' + httpbin_host + '/anything?foo=bar'
+  loop: "{{ http_head.results }}"

--- a/test/units/modules/test_uri.py
+++ b/test/units/modules/test_uri.py
@@ -41,3 +41,16 @@ class TestUri(ModuleTestCase):
                 uri.main()
             fetch_url.assert_called_once()
             assert fetch_url.call_args[1].get("force")
+
+    def test_absolute_location(self):
+        assert (
+            uri.absolute_location("http://example.com/a", "/a")
+            == "http://example.com/a"
+        )
+        assert (
+            uri.absolute_location("http://example.com/a?x=1", "/b?y=2")
+            == "http://example.com/b?y=2"
+        )
+        assert (
+            uri.absolute_location("http://example.com/", "/a") == "http://example.com/a"
+        )

--- a/test/units/modules/test_uri.py
+++ b/test/units/modules/test_uri.py
@@ -41,16 +41,3 @@ class TestUri(ModuleTestCase):
                 uri.main()
             fetch_url.assert_called_once()
             assert fetch_url.call_args[1].get("force")
-
-    def test_absolute_location(self):
-        assert (
-            uri.absolute_location("http://example.com/a", "/a")
-            == "http://example.com/a"
-        )
-        assert (
-            uri.absolute_location("http://example.com/a?x=1", "/b?y=2")
-            == "http://example.com/b?y=2"
-        )
-        assert (
-            uri.absolute_location("http://example.com/", "/a") == "http://example.com/a"
-        )


### PR DESCRIPTION
##### SUMMARY

Previously, the original URL would be combined with the relative location incorrectly, especially for URL of any complexity.

Add simple tests demonstrating the problem that fail without the fix

Fixes #84540 

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

See the added unit tests which demonstrate the problem, or the ansible reproducer from the linked issue:
```yaml
- name: simple repro of uri issues
  hosts: localhost
  gather_facts: false
  tasks:
    - name: issue request that will redirect to /get
      uri:
        url: http://httpbin.org/relative-redirect/1?foo=bar
        status_code: 302
        follow_redirects: none
      register: response
    - name: verify correct absoluteized location header
      assert:
        that:
          # instead it is http://httpbin.org?foo=bar/get
          - response.location == 'http://httpbin.org/get'
```
