### PR TITLE
Bump acme test container to 2.3.0

### DIFF
--- a/changelogs/fragments/84547-acme-test-container.yml
+++ b/changelogs/fragments/84547-acme-test-container.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "ansible-test acme test container - bump `version to 2.2.0 <https://github.com/ansible/acme-test-container/releases/tag/2.2.0>`__
+     to include newer versions of Pebble, dependencies, and runtimes. This adds support for ACME profiles, ``dns-account-01`` support,
+     and some smaller improvements (https://github.com/ansible/ansible/pull/84547)."

--- a/changelogs/fragments/84547-acme-test-container.yml
+++ b/changelogs/fragments/84547-acme-test-container.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - "ansible-test acme test container - bump `version to 2.2.0 <https://github.com/ansible/acme-test-container/releases/tag/2.2.0>`__
+  - "ansible-test acme test container - bump `version to 2.3.0 <https://github.com/ansible/acme-test-container/releases/tag/2.3.0>`__
      to include newer versions of Pebble, dependencies, and runtimes. This adds support for ACME profiles, ``dns-account-01`` support,
      and some smaller improvements (https://github.com/ansible/ansible/pull/84547)."

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
@@ -28,7 +28,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:2.2.0'
+            self.image = 'quay.io/ansible/acme-test-container:2.3.0'
 
         self.uses_docker = True
 

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
@@ -28,7 +28,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:2.1.0'
+            self.image = 'quay.io/ansible/acme-test-container:2.2.0'
 
         self.uses_docker = True
 


### PR DESCRIPTION
##### SUMMARY
New container version: https://github.com/ansible/acme-test-container/releases/tag/2.2.0
Corresponding PR for community.crypto: https://github.com/felixfontein/ansible-acme/pull/86

Needed to test ARI and ACME profiles in CI.

##### ISSUE TYPE
- Feature Pull Request
