### PR TITLE
fix incongruent ansible-vault cli options (#84494)

### DIFF
--- a/changelogs/fragments/vault_cli_fix.yml
+++ b/changelogs/fragments/vault_cli_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-vault will now correctly handle `--prompt`, previously it would issue an error about stdin if no 2nd argument was passed

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -138,11 +138,12 @@ class VaultCLI(CLI):
             raise AnsibleOptionsError("At most one input file may be used with the --output option")
 
         if options.action == 'encrypt_string':
-            if '-' in options.args or not options.args or options.encrypt_string_stdin_name:
+            if '-' in options.args or options.encrypt_string_stdin_name or (not options.args and not options.encrypt_string_prompt):
+                # prompting from stdin and reading from stdin are mutually exclusive, if stdin is still provided, it is ignored
                 self.encrypt_string_read_stdin = True
 
-            # TODO: prompting from stdin and reading from stdin seem mutually exclusive, but verify that.
             if options.encrypt_string_prompt and self.encrypt_string_read_stdin:
+                # should only trigger if prompt + either - or encrypt string stdin name were provided
                 raise AnsibleOptionsError('The --prompt option is not supported if also reading input from stdin')
 
         return options

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -120,8 +120,21 @@ class TestVaultCli(unittest.TestCase):
         mock_setup_vault_secrets.return_value = [('default', TextVaultSecret('password'))]
         cli = VaultCLI(args=['ansible-vault',
                              'encrypt_string',
-                             '--prompt',
-                             'some string to encrypt'])
+                             '--prompt'])
+        cli.parse()
+        cli.run()
+        args, kwargs = mock_display.call_args
+        assert kwargs["private"]
+
+    @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
+    @patch('ansible.cli.vault.VaultEditor')
+    @patch('ansible.cli.vault.display.prompt', return_value='a_prompt')
+    def test_shadowed_encrypt_string_prompt_plus(self, mock_display, mock_vault_editor, mock_setup_vault_secrets):
+        mock_setup_vault_secrets.return_value = [('default', TextVaultSecret('password'))]
+        cli = VaultCLI(args=['ansible-vault',
+                             'encrypt_string',
+                             'some string to encrypt',
+                             '--prompt'])
         cli.parse()
         cli.run()
         args, kwargs = mock_display.call_args


### PR DESCRIPTION
prompt now only errors if stdin is specifically triggered and not due to lack of other args

fixes #84489

Co-authored-by: Sloane Hertel <19572925+s-hertel@users.noreply.github.com>
(cherry picked from commit a046ef5a95b3011bff097c0c709680324ab27c2c)

##### ISSUE TYPE

- Bugfix Pull Request
