### PR TITLE
Ansible.Basic - Fix required_if check

### DIFF
--- a/changelogs/fragments/Ansible.Basic-required_if-null.yml
+++ b/changelogs/fragments/Ansible.Basic-required_if-null.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - >-
+    Ansible.Basic - Fix ``required_if`` check when the option value to check is unset or set to null.

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -1209,7 +1209,7 @@ namespace Ansible.Basic
                 object val = requiredCheck[1];
                 IList requirements = (IList)requiredCheck[2];
 
-                if (ParseStr(param[key]) != ParseStr(val))
+                if (param[key] == null || ParseStr(param[key]) != ParseStr(val))
                     continue;
 
                 string term = "all";


### PR DESCRIPTION
##### SUMMARY
Fixes the Ansible.Basic `required_if` check when the option to check is either unset or explicitly set to null.

##### ISSUE TYPE
- Bugfix Pull Request