### PR TITLE
cache: remove deprecated method

### DIFF
--- a/changelogs/fragments/deprecate_api.yml
+++ b/changelogs/fragments/deprecate_api.yml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+  - fact_cache - deprecate first_order_merge API (https://github.com/ansible/ansible/pull/84568).

--- a/lib/ansible/vars/fact_cache.py
+++ b/lib/ansible/vars/fact_cache.py
@@ -58,6 +58,10 @@ class FactCache(MutableMapping):
         self._plugin.flush()
 
     def first_order_merge(self, key, value):
+        display.deprecated(
+            "API 'first_order_merge' is deprecated, please update the usage",
+            version="2.22"
+        )
         host_facts = {key: value}
 
         try:


### PR DESCRIPTION
##### SUMMARY

* removed deprecated legacy method first_order_merge

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


