### PR TITLE
ssh - Improve CLIXML stderr parsing

### DIFF
--- a/changelogs/fragments/ssh-clixml.yml
+++ b/changelogs/fragments/ssh-clixml.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    ssh - Improve the logic for parsing CLIXML data in stderr when working with Windows host. This fixes issues when
+    the raw stderr contains invalid UTF-8 byte sequences and improves embedded CLIXML sequences
+

--- a/changelogs/fragments/ssh-clixml.yml
+++ b/changelogs/fragments/ssh-clixml.yml
@@ -1,5 +1,4 @@
 bugfixes:
   - >-
     ssh - Improve the logic for parsing CLIXML data in stderr when working with Windows host. This fixes issues when
-    the raw stderr contains invalid UTF-8 byte sequences and improves embedded CLIXML sequences
-
+    the raw stderr contains invalid UTF-8 byte sequences and improves embedded CLIXML sequences.

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -389,7 +389,7 @@ from ansible.errors import (
 from ansible.module_utils.six import PY3, text_type, binary_type
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-from ansible.plugins.shell.powershell import _parse_clixml
+from ansible.plugins.shell.powershell import _replace_stderr_clixml
 from ansible.utils.display import Display
 from ansible.utils.path import unfrackpath, makedirs_safe
 
@@ -1329,8 +1329,8 @@ class Connection(ConnectionBase):
         (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable)
 
         # When running on Windows, stderr may contain CLIXML encoded output
-        if getattr(self._shell, "_IS_WINDOWS", False) and stderr.startswith(b"#< CLIXML"):
-            stderr = _parse_clixml(stderr)
+        if getattr(self._shell, "_IS_WINDOWS", False):
+            stderr = _replace_stderr_clixml(stderr)
 
         return (returncode, stdout, stderr)
 


### PR DESCRIPTION
##### SUMMARY
Improves the logic for parsing CLIXML values in the stderr returned by SSH. This fixes encoding problems by having a fallback in case the output is not valid UTF-8. It also can now extract embedded CLIXML sequences in all of stderr rather than just at the start.

The original issue was using ssh against a German language Windows install where the CLIXML contained the byte string below

```
b"...<AV>Module werden f\x81r erstmalige Verwendung vorbereitet.</AV>..."
```

The `\x81` is not a valid UTF-8 sequence but rather cp437 which is the default codepage for the host in question. As we cannot guarantee the codepage used for the initial entrypoint we need to have a fallback if UTF-8 fails. The original report was complicated because CLIXML was only parsed if all of stderr was just the CLIXML string but when increasing the verbosity to get the stacktrace meant stderr contained the SSH debug entries which skipped the CLIXML check. Now this attempts to decode any CLIXML line rather than just at the start.

##### ISSUE TYPE
- Bugfix Pull Request