### PR TITLE
Make log severity configurable and consistent between syslog and systemd

### DIFF
--- a/changelogs/fragments/84574-target_log_severity.yml
+++ b/changelogs/fragments/84574-target_log_severity.yml
@@ -1,0 +1,6 @@
+breaking_changes:
+  - >-
+    Ansible's systemd logs now contain a PRIORITY field (default value: 5).
+    Downstream programs that inspect Ansible's systemd logs should be updated
+    if they expect the PRIORITY field to be missing
+    (https://github.com/ansible/ansible/pull/84574).

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -2048,6 +2048,14 @@ TARGET_LOG_INFO:
   vars:
   - name: ansible_target_log_info
   version_added: "2.17"
+TARGET_LOG_SEVERITY:
+  name: logging severity
+  default: LOG_INFO
+  description: Default syslog-style log level to use when Ansible logs to the remote target.
+  env: [{name: ANSIBLE_TARGET_LOG_SEVERITY}]
+  ini:
+  - {key: target_log_severity, section: defaults}
+
 TASK_TIMEOUT:
   name: Task Timeout
   default: 0

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1313,6 +1313,8 @@ class AnsibleModule(object):
                         name = "_%s" % name
                     journal_args.append((name, value))
 
+                priority = getattr(syslog, self._target_log_severity, syslog.LOG_INFO)
+
                 try:
                     if HAS_SYSLOG:
                         # If syslog_facility specified, it needs to convert
@@ -1323,9 +1325,11 @@ class AnsibleModule(object):
                                            syslog.LOG_USER) >> 3
                         journal.send(MESSAGE=u"%s %s" % (module, journal_msg),
                                      SYSLOG_FACILITY=facility,
+                                     PRIORITY=priority,
                                      **dict(journal_args))
                     else:
                         journal.send(MESSAGE=u"%s %s" % (module, journal_msg),
+                                     PRIORITY=priority,
                                      **dict(journal_args))
                 except OSError:
                     # fall back to syslog since logging to journal failed

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -395,6 +395,7 @@ class AnsibleModule(object):
         self._socket_path = None
         self._shell = None
         self._syslog_facility = 'LOG_USER'
+        self._target_log_severity = 'LOG_INFO'
         self._verbosity = 0
         # May be used to set modifications to the environment for any
         # run_command invocation
@@ -1255,8 +1256,9 @@ class AnsibleModule(object):
             try:
                 module = 'ansible-%s' % self._name
                 facility = getattr(syslog, self._syslog_facility, syslog.LOG_USER)
+                level = getattr(syslog, self._target_log_severity, syslog.LOG_INFO)
                 syslog.openlog(str(module), 0, facility)
-                syslog.syslog(syslog.LOG_INFO, msg)
+                syslog.syslog(level, msg)
             except (TypeError, ValueError) as e:
                 self.fail_json(
                     msg='Failed to log to syslog (%s). To proceed anyway, '

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -90,7 +90,7 @@ PASS_VARS: dict[str, t.Any] = {
     'selinux_special_fs': ('_selinux_special_fs', ['fuse', 'nfs', 'vboxsf', 'ramfs', '9p', 'vfat']),
     'shell_executable': ('_shell', '/bin/sh'),
     'socket': ('_socket_path', None),
-    'syslog_facility': ('_syslog_facility', 'INFO'),
+    'syslog_facility': ('_syslog_facility', 'LOG_USER'),
     'tmpdir': ('_tmpdir', None),
     'tracebacks_for': ('_tracebacks_for', frozenset()),
     'verbosity': ('_verbosity', 0),

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -86,6 +86,7 @@ PASS_VARS: dict[str, t.Any] = {
     'no_log': ('no_log', False),
     'remote_tmp': ('_remote_tmp', None),
     'target_log_info': ('_target_log_info', None),
+    'target_log_severity': ('_target_log_severity', 'LOG_INFO'),
     'selinux_special_fs': ('_selinux_special_fs', ['fuse', 'nfs', 'vboxsf', 'ramfs', '9p', 'vfat']),
     'shell_executable': ('_shell', '/bin/sh'),
     'socket': ('_socket_path', None),

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -75,6 +75,7 @@ namespace Ansible.Basic
             { "socket", null },
             { "syslog_facility", null },
             { "target_log_info", "TargetLogInfo" },
+            { "target_log_severity", null },
             { "tracebacks_for", "_tracebacksFor" },
             { "tmpdir", "tmpdir" },
             { "verbosity", "Verbosity" },

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1027,6 +1027,9 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         # allow user to insert string to add context to remote logging
         module_args['_ansible_target_log_info'] = C.config.get_config_value('TARGET_LOG_INFO', variables=task_vars)
 
+        # set the syslog-style severity to be used in the module
+        module_args['_ansible_target_log_severity'] = C.config.get_config_value('TARGET_LOG_SEVERITY', variables=task_vars)
+
         module_args['_ansible_tracebacks_for'] = _traceback.traceback_for()
 
     def _execute_module(self, module_name=None, module_args=None, tmp=None, task_vars=None, persist_files=False, delete_remote_tmp=None, wrap_async=False,


### PR DESCRIPTION
##### SUMMARY

This builds on a discussion in ansible/proposals#214, and replaces #84504.

syslog messages are currently hardcoded to LOG_INFO, systemd messages have no defined priority.
Add a `TARGET_LOG_SEVERITY` option and use it in both logging frameworks.

Ansible log messages are sent through systemd on systems that have the python3 `sdnotify` package installed.  This could be deliberate, but in my case, I just happen to have some services that depend on Debian's `python3-sdnotify` package.  Setting a priority for these messages makes it easier to filter them.

There is already a `syslog_facility` option, so it seems natural to add a severity option as part of this job.

Note: the final commit in this PR changes the value of `syslog_facility` in `parameters.py`.  Ansible tried to evaluate this as `syslog.INFO`, failed because there's no such symbol, and fell back to `LOG_USER`.  I've changed the value to `LOG_USER` in this PR because it's a tangentially related and easy to review at the same time, but the first two commits can be accepted separately if that's better.

##### ISSUE TYPE

- Feature Pull Request
