### PR TITLE
[stable-2.18] ssh - Improve CLIXML stderr parsing (#84569)

### DIFF
--- a/changelogs/fragments/ssh-clixml.yml
+++ b/changelogs/fragments/ssh-clixml.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    ssh - Improve the logic for parsing CLIXML data in stderr when working with Windows host. This fixes issues when
+    the raw stderr contains invalid UTF-8 byte sequences and improves embedded CLIXML sequences.

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -389,7 +389,7 @@ from ansible.errors import (
 from ansible.module_utils.six import PY3, text_type, binary_type
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-from ansible.plugins.shell.powershell import _parse_clixml
+from ansible.plugins.shell.powershell import _replace_stderr_clixml
 from ansible.utils.display import Display
 from ansible.utils.path import unfrackpath, makedirs_safe
 
@@ -1327,8 +1327,8 @@ class Connection(ConnectionBase):
         (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable)
 
         # When running on Windows, stderr may contain CLIXML encoded output
-        if getattr(self._shell, "_IS_WINDOWS", False) and stderr.startswith(b"#< CLIXML"):
-            stderr = _parse_clixml(stderr)
+        if getattr(self._shell, "_IS_WINDOWS", False):
+            stderr = _replace_stderr_clixml(stderr)
 
         return (returncode, stdout, stderr)
 


### PR DESCRIPTION
##### SUMMARY
Improves the logic for parsing CLIXML values in the stderr returned by SSH. This fixes encoding problems by having a fallback in case the output is not valid UTF-8. It also can now extract embedded CLIXML sequences in all of stderr rather than just at the start.

(cherry picked from commit f86c58e2d235d8b96029d102c71ee2dfafd57997)

Backport of https://github.com/ansible/ansible/pull/84569

##### ISSUE TYPE
- Bugfix Pull Request