### PR TITLE
[stable-2.18] Ansible.Basic - Fix required_if check (#84562)

### DIFF
--- a/changelogs/fragments/Ansible.Basic-required_if-null.yml
+++ b/changelogs/fragments/Ansible.Basic-required_if-null.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - >-
+    Ansible.Basic - Fix ``required_if`` check when the option value to check is unset or set to null.

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -1210,7 +1210,7 @@ namespace Ansible.Basic
                 object val = requiredCheck[1];
                 IList requirements = (IList)requiredCheck[2];
 
-                if (ParseStr(param[key]) != ParseStr(val))
+                if (param[key] == null || ParseStr(param[key]) != ParseStr(val))
                     continue;
 
                 string term = "all";


### PR DESCRIPTION
##### SUMMARY
Fixes the Ansible.Basic `required_if` check when the option to check is either unset or explicitly set to null.

(cherry picked from commit 8c5e33cd3aa604124234d407044d317a028e84ed)

Backport of https://github.com/ansible/ansible/pull/84562

##### ISSUE TYPE
- Bugfix Pull Request
