### PR TITLE
callback: filter _ansible_ in debug message

### DIFF
--- a/changelogs/fragments/debug_ansible.yml
+++ b/changelogs/fragments/debug_ansible.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - callback - filter key starting with _ansible_ from debug messages (https://github.com/ansible/ansible/issues/69731).

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -504,7 +504,7 @@ class CallbackBase(AnsiblePlugin):
             if 'msg' in result:
                 # msg should be alone
                 for key in list(result.keys()):
-                    if key not in _DEBUG_ALLOWED_KEYS and not key.startswith('_'):
+                    if key not in _DEBUG_ALLOWED_KEYS and not key.startswith('_ansible_'):
                         result.pop(key)
             else:
                 # 'var' value as field, so eliminate others and what is left should be varname

--- a/test/integration/targets/callback_default/callback_default.out.default.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.default.stdout
@@ -102,6 +102,11 @@ skipping: [testhost] => (item=1)
 skipping: [testhost] => (item=2) 
 skipping: [testhost]
 
+TASK [debug] *******************************************************************
+ok: [testhost] => (item=a) => {
+    "msg": "a"
+}
+
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
 
@@ -128,5 +133,5 @@ ok: [testhost] => {
 }
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=19   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
+testhost                   : ok=20   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.display_path_on_failure.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.display_path_on_failure.stdout
@@ -105,6 +105,11 @@ skipping: [testhost] => (item=1)
 skipping: [testhost] => (item=2) 
 skipping: [testhost]
 
+TASK [debug] *******************************************************************
+ok: [testhost] => (item=a) => {
+    "msg": "a"
+}
+
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
 
@@ -131,5 +136,5 @@ ok: [testhost] => {
 }
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=19   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
+testhost                   : ok=20   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.failed_to_stderr.stdout
@@ -72,6 +72,11 @@ skipping: [testhost] => (item=1)
 skipping: [testhost] => (item=2) 
 skipping: [testhost]
 
+TASK [debug] *******************************************************************
+ok: [testhost] => (item=a) => {
+    "msg": "a"
+}
+
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
 
@@ -98,5 +103,5 @@ ok: [testhost] => {
 }
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=19   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
+testhost                   : ok=20   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_ok.stdout
@@ -106,5 +106,5 @@ TASK [Include some tasks] ******************************************************
 included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=19   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
+testhost                   : ok=20   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped.stdout
@@ -87,6 +87,11 @@ changed: [testhost]
 TASK [replace] *****************************************************************
 ok: [testhost]
 
+TASK [debug] *******************************************************************
+ok: [testhost] => (item=a) => {
+    "msg": "a"
+}
+
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
 
@@ -113,5 +118,5 @@ ok: [testhost] => {
 }
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=19   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
+testhost                   : ok=20   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.hide_skipped_ok.stdout
@@ -91,5 +91,5 @@ TASK [Include some tasks] ******************************************************
 included: .../test/integration/targets/callback_default/include_me.yml for testhost => (item=1)
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=19   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
+testhost                   : ok=20   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml.stdout
@@ -103,6 +103,10 @@ skipping: [testhost] => (item=1)
 skipping: [testhost] => (item=2) 
 skipping: [testhost]
 
+TASK [debug] *******************************************************************
+ok: [testhost] => (item=a) => 
+    msg: a
+
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
 
@@ -128,5 +132,5 @@ ok: [testhost] =>
     item: 1
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=19   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
+testhost                   : ok=20   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml_indent_2.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml_indent_2.stdout
@@ -103,6 +103,11 @@ skipping: [testhost] => (item=1)
 skipping: [testhost] => (item=2) 
 skipping: [testhost]
 
+TASK [debug] *******************************************************************
+ok: [testhost] => (item=a) => {
+    "msg": "a"
+}
+
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]
 
@@ -128,5 +133,5 @@ ok: [testhost] =>
   item: 1
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=19   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
+testhost                   : ok=20   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2
 

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml_indent_2.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml_indent_2.stdout
@@ -104,7 +104,7 @@ skipping: [testhost] => (item=2)
 skipping: [testhost]
 
 TASK [debug] *******************************************************************
-ok: [testhost] => (item=a) =>
+ok: [testhost] => (item=a) => 
   msg: a
 
 RUNNING HANDLER [Test handler 1] ***********************************************

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml_indent_2.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml_indent_2.stdout
@@ -132,5 +132,5 @@ ok: [testhost] =>
   item: 1
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=20   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2
+testhost                   : ok=20   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml_indent_2.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml_indent_2.stdout
@@ -104,9 +104,8 @@ skipping: [testhost] => (item=2)
 skipping: [testhost]
 
 TASK [debug] *******************************************************************
-ok: [testhost] => (item=a) => {
-    "msg": "a"
-}
+ok: [testhost] => (item=a) =>
+  msg: a
 
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost]

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml_lossy_verbose.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml_lossy_verbose.stdout
@@ -231,6 +231,10 @@ skipping: [testhost] => (item=2)  =>
 skipping: [testhost] => 
     msg: All items skipped
 
+TASK [debug] *******************************************************************
+ok: [testhost] => (item=a) => 
+    msg: a
+
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost] => 
     changed: true
@@ -321,5 +325,5 @@ ok: [testhost] =>
     item: 1
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=19   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
+testhost                   : ok=20   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/callback_default.out.result_format_yaml_verbose.stdout
+++ b/test/integration/targets/callback_default/callback_default.out.result_format_yaml_verbose.stdout
@@ -238,6 +238,10 @@ skipping: [testhost] => (item=2)  =>
 skipping: [testhost] => 
     msg: All items skipped
 
+TASK [debug] *******************************************************************
+ok: [testhost] => (item=a) => 
+    msg: a
+
 RUNNING HANDLER [Test handler 1] ***********************************************
 changed: [testhost] => 
     changed: true
@@ -333,5 +337,5 @@ ok: [testhost] =>
     item: 1
 
 PLAY RECAP *********************************************************************
-testhost                   : ok=19   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
+testhost                   : ok=20   changed=11   unreachable=0    failed=0    skipped=4    rescued=1    ignored=2   
 

--- a/test/integration/targets/callback_default/test.yml
+++ b/test/integration/targets/callback_default/test.yml
@@ -95,6 +95,13 @@
         - 1
         - 2
 
+    - debug:
+        msg: "{{ _x }}"
+      loop:
+        - a
+      loop_control:
+        loop_var: _x
+
   handlers:
     - name: Test handler 1
       command: echo foo


### PR DESCRIPTION
##### SUMMARY

* Drop _ansible_ keys from debug message

Fixes: #69731

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


