### PR TITLE
ansible-test - Add experimental pass env support

### DIFF
--- a/changelogs/fragments/ansible-test-pass-env.yml
+++ b/changelogs/fragments/ansible-test-pass-env.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - ansible-test - Experimental support has been added for passing additional environment variables to subprocesses.
+                   Set ``ANSIBLE_TEST_PASS_ENV`` to a space-separated list of environment variable names to propagate.
+                   Use with caution, as additional environment variables may have unintended consequences.
+                   Variables are only exposed on the origin host and will not be relayed to delegated hosts.

--- a/test/integration/targets/ansible-test-integration-pass-env/aliases
+++ b/test/integration/targets/ansible-test-integration-pass-env/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group3  # runs in the distro test containers
+shippable/generic/group1  # runs in the default test container
+context/controller
+needs/target/collection

--- a/test/integration/targets/ansible-test-integration-pass-env/ansible_collections/ns/col/tests/integration/targets/with/aliases
+++ b/test/integration/targets/ansible-test-integration-pass-env/ansible_collections/ns/col/tests/integration/targets/with/aliases
@@ -1,0 +1,2 @@
+context/controller
+gather_facts/no

--- a/test/integration/targets/ansible-test-integration-pass-env/ansible_collections/ns/col/tests/integration/targets/with/tasks/main.yml
+++ b/test/integration/targets/ansible-test-integration-pass-env/ansible_collections/ns/col/tests/integration/targets/with/tasks/main.yml
@@ -1,0 +1,5 @@
+- assert:
+    that:
+      - lookup("env", "MYVAR1") == "one"
+      - lookup("env", "MYVAR2") == "two"
+      - lookup("env", "MYVAR3") == ""

--- a/test/integration/targets/ansible-test-integration-pass-env/ansible_collections/ns/col/tests/integration/targets/without/aliases
+++ b/test/integration/targets/ansible-test-integration-pass-env/ansible_collections/ns/col/tests/integration/targets/without/aliases
@@ -1,0 +1,2 @@
+context/controller
+gather_facts/no

--- a/test/integration/targets/ansible-test-integration-pass-env/ansible_collections/ns/col/tests/integration/targets/without/tasks/main.yml
+++ b/test/integration/targets/ansible-test-integration-pass-env/ansible_collections/ns/col/tests/integration/targets/without/tasks/main.yml
@@ -1,0 +1,5 @@
+- assert:
+    that:
+      - lookup("env", "MYVAR1") == ""
+      - lookup("env", "MYVAR2") == ""
+      - lookup("env", "MYVAR3") == ""

--- a/test/integration/targets/ansible-test-integration-pass-env/runme.sh
+++ b/test/integration/targets/ansible-test-integration-pass-env/runme.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+source ../collection/setup.sh
+
+set -x
+
+ansible-test integration without --venv --color --truncate 0 "${@}"
+
+export MYVAR1='one'
+export MYVAR2='two'
+export ANSIBLE_TEST_PASS_ENV='ANSIBLE_TEST_PASS_ENV MYVAR1 MYVAR2 MYVAR3'
+
+ansible-test integration with --venv --color --truncate 0 "${@}"

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -694,6 +694,12 @@ def common_environment() -> dict[str, str]:
         'CFLAGS',
     )
 
+    # Allow additional environment variables to be passed to subprocesses.
+    # Use with caution, as additional environment variables may have unintended consequences.
+    # Variables are only exposed on the origin host and will not be relayed to delegated hosts.
+    pass_env = tuple(os.environ.get('ANSIBLE_TEST_PASS_ENV', '').split())
+    optional = optional + pass_env
+
     # FreeBSD Compatibility
     # This is required to include libyaml support in PyYAML.
     # The header /usr/local/include/yaml.h isn't in the default include path for the compiler.


### PR DESCRIPTION
##### SUMMARY

Experimental support has been added for passing additional environment variables to subprocesses.
Set ``ANSIBLE_TEST_PASS_ENV`` to a space-separated list of environment variable names to propagate.
Use with caution, as additional environment variables may have unintended consequences.
Variables are only exposed on the origin host and will not be relayed to delegated hosts.

##### ISSUE TYPE

Feature Pull Request
