### PR TITLE
use real path when listing collections to dedupe symlink

### DIFF
--- a/changelogs/fragments/84599-dedupe-symlink.yaml
+++ b/changelogs/fragments/84599-dedupe-symlink.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - listing collections would duplicate on symlinks. Fix prevents listing duplicate paths caused by symlinks 

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -235,7 +235,7 @@ class _AnsibleCollectionFinder:
                 # ensure we always have ansible_collections
                 if os.path.basename(p) == 'ansible_collections':
                     p = os.path.dirname(p)
-                r = os.path.realpath(p)
+                r = os.path.realpath(os.path.join(p, 'ansible_collections'))
                 if r not in real_paths and os.path.isdir(to_bytes(os.path.join(p, 'ansible_collections'), errors='surrogate_or_strict')):
                     real_paths.add(r)
                     good_paths.append(p)

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -228,20 +228,18 @@ class _AnsibleCollectionFinder:
             paths.extend(sys.path)
 
         good_paths = []
-        seen = set()
+        real_paths = set()
         # expand any placeholders in configured paths
         for p in paths:
-
-            # ensure we always have ansible_collections
-            if os.path.basename(p) == 'ansible_collections':
-                p = os.path.dirname(p)
-                real_path = os.path.realpath(p)
-                if real_path in seen:
-                    continue
-                seen.add(real_path)
-
-            if p not in good_paths and os.path.isdir(to_bytes(os.path.join(p, 'ansible_collections'), errors='surrogate_or_strict')):
-                good_paths.append(p)
+            if p not in good_paths:
+                # ensure we always have ansible_collections
+                if os.path.basename(p) == 'ansible_collections':
+                    p = os.path.dirname(p)
+                     
+                r = os.path.realpath(p)
+                if r not in real_paths and os.path.isdir(to_bytes(os.path.join(p, 'ansible_collections'), errors='surrogate_or_strict')):
+                    real_paths.add(r)
+                    good_paths.append(p)
 
         self._n_configured_paths = good_paths
         self._n_cached_collection_paths = None

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -235,7 +235,6 @@ class _AnsibleCollectionFinder:
                 # ensure we always have ansible_collections
                 if os.path.basename(p) == 'ansible_collections':
                     p = os.path.dirname(p)
-                     
                 r = os.path.realpath(p)
                 if r not in real_paths and os.path.isdir(to_bytes(os.path.join(p, 'ansible_collections'), errors='surrogate_or_strict')):
                     real_paths.add(r)

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -233,7 +233,7 @@ class _AnsibleCollectionFinder:
 
             # ensure we always have ansible_collections
             if os.path.basename(p) == 'ansible_collections':
-                p = os.path.dirname(p)
+                p = os.path.dirname(os.path.realpath(p))
 
             if p not in good_paths and os.path.isdir(to_bytes(os.path.join(p, 'ansible_collections'), errors='surrogate_or_strict')):
                 good_paths.append(p)

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -228,12 +228,17 @@ class _AnsibleCollectionFinder:
             paths.extend(sys.path)
 
         good_paths = []
+        seen = set()
         # expand any placeholders in configured paths
         for p in paths:
 
             # ensure we always have ansible_collections
             if os.path.basename(p) == 'ansible_collections':
-                p = os.path.dirname(os.path.realpath(p))
+                p = os.path.dirname(p)
+                real_path = os.path.realpath(p)
+                if real_path in seen:
+                    continue
+                seen.add(real_path)
 
             if p not in good_paths and os.path.isdir(to_bytes(os.path.join(p, 'ansible_collections'), errors='surrogate_or_strict')):
                 good_paths.append(p)


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
`ansible-galaxy collection list` may list the same collection multiple times if a symlink is present. This change uses the os.realpath to not duplicate the same collection when listing

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->
Fixes https://github.com/ansible/ansible/issues/84579

##### ISSUE TYPE

- Bugfix Pull Request
