### PR TITLE
ansible.builtin.dnf revert import for dnf.cli

### DIFF
--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -475,6 +475,7 @@ class DnfModule(YumDnf):
         global dnf
         try:
             import dnf
+            import dnf.cli
             import dnf.const
             import dnf.exceptions
             import dnf.package


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

Starting from ansible-core 2.16.7, after this [commit](https://github.com/ansible/ansible/pull/82725/files#diff-b1696caabd083d8176e1b14ad10716e8c88d882bf9e49e1a167f3a6cb702a21eL578), with mitogen strategy I see errors like:
```
Failed loading plugin "copr": module 'dnf' has no attribute 'cli'
Failed loading plugin "debuginfo-install": module 'dnf' has no attribute 'cli'
```
For fix this, I would like to return import of dnf.cli inside module, issue in https://github.com/mitogen-hq/mitogen/issues/1143.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

