### PR TITLE
service_facts: skip unwanted lines in openrc output

### DIFF
--- a/changelogs/fragments/openrc-status.yml
+++ b/changelogs/fragments/openrc-status.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - service_facts - skip lines which does not contain service names in openrc output (https://github.com/ansible/ansible/issues/84512).

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -211,8 +211,8 @@ class ServiceScanService(BaseService):
 
     def _list_openrc(self, services):
         all_services_runlevels = {}
-        rc, stdout, stderr = self.module.run_command("%s -a -s -m 2>&1 | grep '^ ' | tr -d '[]'" % self.rc_status_path, use_unsafe_shell=True)
-        rc_u, stdout_u, stderr_u = self.module.run_command("%s show -v 2>&1 | grep '|'" % self.rc_update_path, use_unsafe_shell=True)
+        dummy, stdout, dummy = self.module.run_command("%s -a -s -m 2>&1 | grep '^ ' | tr -d '[]'" % self.rc_status_path, use_unsafe_shell=True)
+        dummy, stdout_u, dummy = self.module.run_command("%s show -v 2>&1 | grep '|'" % self.rc_update_path, use_unsafe_shell=True)
         for line in stdout_u.split('\n'):
             line_data = line.split('|')
             if len(line_data) < 2:
@@ -228,6 +228,9 @@ class ServiceScanService(BaseService):
             if len(line_data) < 2:
                 continue
             service_name = line_data[0]
+            # Skip lines which are not service names
+            if service_name == "*":
+                continue
             service_state = line_data[1]
             service_runlevels = all_services_runlevels[service_name]
             service_data = {"name": service_name, "runlevels": service_runlevels, "state": service_state, "source": "openrc"}


### PR DESCRIPTION
##### SUMMARY

* rc-status commands returns unwanted lines with service names
  and their status. Skip such lines while parsing service names

Fixes: #84512

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


