### PR TITLE
Bump packaging to 24.2

### DIFF
--- a/test/lib/ansible_test/_data/requirements/sanity.ansible-doc.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.ansible-doc.txt
@@ -1,5 +1,5 @@
 # edit "sanity.ansible-doc.in" and generate with: hacking/update-sanity-requirements.py --test ansible-doc
 Jinja2==3.1.4
 MarkupSafe==2.1.5
-packaging==24.1
+packaging==24.2
 PyYAML==6.0.2

--- a/test/lib/ansible_test/_data/requirements/sanity.changelog.txt
+++ b/test/lib/ansible_test/_data/requirements/sanity.changelog.txt
@@ -1,7 +1,7 @@
 # edit "sanity.changelog.in" and generate with: hacking/update-sanity-requirements.py --test changelog
 antsibull-changelog==0.29.0
 docutils==0.18.1
-packaging==24.1
+packaging==24.2
 PyYAML==6.0.2
 rstcheck==5.0.0
 semantic-version==2.10.0

--- a/test/sanity/code-smell/mypy.requirements.txt
+++ b/test/sanity/code-smell/mypy.requirements.txt
@@ -6,7 +6,7 @@ Jinja2==3.1.4
 MarkupSafe==2.1.5
 mypy==1.11.2
 mypy-extensions==1.0.0
-packaging==24.1
+packaging==24.2
 pluggy==1.5.0
 pycparser==2.22
 pytest==8.3.3

--- a/test/sanity/code-smell/package-data.requirements.txt
+++ b/test/sanity/code-smell/package-data.requirements.txt
@@ -1,4 +1,4 @@
 # edit "package-data.requirements.in" and generate with: hacking/update-sanity-requirements.py --test package-data
 build==1.2.2
-packaging==24.1
+packaging==24.2
 pyproject_hooks==1.2.0

--- a/test/sanity/code-smell/update-bundled.requirements.txt
+++ b/test/sanity/code-smell/update-bundled.requirements.txt
@@ -1,2 +1,2 @@
 # edit "update-bundled.requirements.in" and generate with: hacking/update-sanity-requirements.py --test update-bundled
-packaging==24.1
+packaging==24.2


### PR DESCRIPTION
##### SUMMARY

`twine` 6.1.0 was recently released, that includes mitigation for invalid metadata created by setuptools. However, this mitigation only works if at least `packaging==24.2` is installed.  We don't pin `twine` in `packaging/release.py` so the last round of releases had issues.

The alternative, or potential related change is to pin `twine`.

Ref: https://github.com/pypa/twine/issues/1216

##### ISSUE TYPE

- Bugfix Pull Request