### PR TITLE
user - unlock user by default with no password, busybox

### DIFF
--- a/changelogs/fragments/busybox_unlock_user.yml
+++ b/changelogs/fragments/busybox_unlock_user.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - user - When creating a user account with no password on busybox systems such as Alpine, the account is now unlocked after it is created, for consistency with other platforms (https://github.com/ansible/ansible/issues/68676).
+  - user - add helper method to write safely to the shadow file.

--- a/changelogs/fragments/busybox_unlock_user.yml
+++ b/changelogs/fragments/busybox_unlock_user.yml
@@ -1,4 +1,3 @@
 ---
 bugfixes:
   - user - When creating a user account with no password on busybox systems such as Alpine, the account is now unlocked after it is created, for consistency with other platforms (https://github.com/ansible/ansible/issues/68676).
-  - user - add helper method to write safely to the shadow file.

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -302,7 +302,7 @@ options:
             - IMPORTANT! Unsafe writes are subject to race conditions and can lead to data corruption.
         type: bool
         default: no
-        version_added: '2.19'
+        version_added: "2.20"
 extends_documentation_fragment: action_common_attributes
 attributes:
     check_mode:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1422,10 +1422,10 @@ class User(object):
             self.module.exit_json(failed=True, msg="%s" % to_native(e))
 
     def write_changes(self, contents, path):
-        tmpfd, tmpfile = tempfile.mkstemp(dir=self.module.tmpdir)
-        with os.fdopen(tmpfd, 'w') as tf:
+        with tempfile.NamedTemporaryFile(dir=self.module.tmpdir, delete=False) as tf:
             for line in contents:
                 tf.write(line)
+            tmpfile = tf.name
 
         self.module.atomic_move(tmpfile, path, unsafe_writes=self.module.params['unsafe_writes'])
 
@@ -3136,19 +3136,14 @@ class BusyBox(User):
     def _disable_password_in_shadow_or_fail(self, username):
         self.backup_shadow()
         out_lines = []
-        try:
-            with open(self.SHADOWFILE, 'r') as f:
-                for line in f.readlines():
-                    components = line.split(':')
-                    if components[0] == username:
-                        components[1] = '*'
-                        out_lines.append(':'.join(components))
-                    else:
-                        out_lines.append(line)
-        except Exception as e:
-            self.module.fail_json(
-                msg="Something went wrong when trying to modify %s: %s" %
-                (self.SHADOWFILE, to_native(e)))
+        with open(self.SHADOWFILE, 'r') as f:
+            for line in f.readlines():
+                components = line.split(':')
+                if components[0] == username:
+                    components[1] = '*'
+                    out_lines.append(':'.join(components))
+                else:
+                    out_lines.append(line)
         self.write_changes(out_lines, self.SHADOWFILE)
 
     def create_user(self):

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1422,9 +1422,8 @@ class User(object):
             self.module.exit_json(failed=True, msg="%s" % to_native(e))
 
     def write_changes(self, contents, path):
-        with tempfile.NamedTemporaryFile(dir=self.module.tmpdir, delete=False) as tf:
-            for line in contents:
-                tf.write(line)
+        with tempfile.NamedTemporaryFile(dir=self.module.tmpdir, mode='w+t', delete=False) as tf:
+            tf.writelines(contents)
             tmpfile = tf.name
 
         self.module.atomic_move(tmpfile, path, unsafe_writes=self.module.params['unsafe_writes'])

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3353,6 +3353,7 @@ def main():
             password_expire_account_disable=dict(type='int', no_log=False),
             uid_min=dict(type='int'),
             uid_max=dict(type='int'),
+            unsafe_writes=dict(type='bool', default=False, fallback=(env_fallback, ['ANSIBLE_UNSAFE_WRITES'])),
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -521,6 +521,7 @@ from ansible.module_utils import distro
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.locale import get_best_parsable_locale
+from ansible.module_utils.common.parameters import env_fallback
 from ansible.module_utils.common.sys_info import get_platform_subclass
 
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -302,7 +302,7 @@ options:
             - IMPORTANT! Unsafe writes are subject to race conditions and can lead to data corruption.
         type: bool
         default: no
-        version_added: "2.20"
+        version_added: "2.21"
 extends_documentation_fragment: action_common_attributes
 attributes:
     check_mode:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -291,7 +291,18 @@ options:
             - Requires O(local) is omitted or V(False).
         type: int
         version_added: "2.18"
-
+    unsafe_writes:
+        description:
+            - Influence when to use atomic operation to prevent data corruption or inconsistent reads from the target filesystem object.
+            - By default this module uses atomic operations to prevent data corruption or inconsistent reads from the target filesystem objects,
+              but sometimes systems are configured or just broken in ways that prevent this. One example is docker mounted filesystem objects,
+              which cannot be updated atomically from inside the container and can only be written in an unsafe manner.
+            - This option allows Ansible to fall back to unsafe methods of updating filesystem objects when atomic operations fail
+              (however, it doesn't force Ansible to perform unsafe writes).
+            - IMPORTANT! Unsafe writes are subject to race conditions and can lead to data corruption.
+        type: bool
+        default: no
+        version_added: '2.19'
 extends_documentation_fragment: action_common_attributes
 attributes:
     check_mode:
@@ -501,6 +512,7 @@ import select
 import shutil
 import socket
 import subprocess
+import tempfile
 import time
 import math
 import typing as t
@@ -1408,6 +1420,14 @@ class User(object):
         except OSError as e:
             self.module.exit_json(failed=True, msg="%s" % to_native(e))
 
+    def write_changes(self, contents, path):
+        tmpfd, tmpfile = tempfile.mkstemp(dir=self.module.tmpdir)
+        with os.fdopen(tmpfd, 'w') as tf:
+            for line in contents:
+                tf.write(line)
+
+        self.module.atomic_move(tmpfile, path, unsafe_writes=self.module.params['unsafe_writes'])
+
 
 # ===========================================
 
@@ -2246,8 +2266,7 @@ class SunOS(User):
                                     pass
                             line = ':'.join(fields)
                             lines.append('%s\n' % line)
-                    with open(self.SHADOWFILE, 'w+') as f:
-                        f.writelines(lines)
+                    self.write_changes(lines, self.SHADOWFILE)
                 except Exception as err:
                     self.module.fail_json(msg="failed to update users password: %s" % to_native(err))
 
@@ -2359,8 +2378,7 @@ class SunOS(User):
                                 fields[5] = str(int(warnweeks) * 7)
                             line = ':'.join(fields)
                             lines.append('%s\n' % line)
-                    with open(self.SHADOWFILE, 'w+') as f:
-                        f.writelines(lines)
+                    self.write_changes(lines, self.SHADOWFILE)
                     rc = 0
                 except Exception as err:
                     self.module.fail_json(msg="failed to update users password: %s" % to_native(err))
@@ -3114,6 +3132,23 @@ class BusyBox(User):
         - remove_user()
         - modify_user()
     """
+    def _disable_password_in_shadow_or_fail(self, username):
+        self.backup_shadow()
+        out_lines = []
+        try:
+            with open(self.SHADOWFILE, 'r') as f:
+                for line in f.readlines():
+                    components = line.split(':')
+                    if components[0] == username:
+                        components[1] = '*'
+                        out_lines.append(':'.join(components))
+                    else:
+                        out_lines.append(line)
+        except Exception as e:
+            self.module.fail_json(
+                msg="Something went wrong when trying to modify %s: %s" %
+                (self.SHADOWFILE, to_native(e)))
+        self.write_changes(out_lines, self.SHADOWFILE)
 
     def create_user(self):
         cmd = [self.module.get_bin_path('adduser', True)]
@@ -3179,6 +3214,8 @@ class BusyBox(User):
 
             if rc is not None and rc != 0:
                 self.module.fail_json(name=self.name, msg=err, rc=rc)
+        else:
+            self._disable_password_in_shadow_or_fail(self.name)
 
         # Add to additional groups
         if self.groups is not None and len(self.groups):

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -34,3 +34,5 @@
     - ansible_facts.system == 'Linux'
     - ansible_distribution != 'Alpine'
 - import_tasks: ssh_keygen.yml
+- include_tasks: test_locked_user_alpine.yml
+  when: ansible_distribution == 'Alpine'

--- a/test/integration/targets/user/tasks/test_locked_user_alpine.yml
+++ b/test/integration/targets/user/tasks/test_locked_user_alpine.yml
@@ -1,0 +1,37 @@
+---
+- name: Test locked user on Alpine
+  block:
+    - name: Remove ansibulluser
+      user:
+        name: ansibulluser
+        state: absent
+        remove: yes
+
+    - name: Create ansibulluser without password
+      user:
+        name: ansibulluser
+      register: password_lock_1
+
+    - name: Ensure task reported changes appropriately
+      assert:
+        that:
+          - password_lock_1 is changed
+
+    - name: Verify account lock for Linux
+      block:
+        - name: LINUX | Get account status
+          getent:
+            database: shadow
+            key: ansibulluser
+
+        - name: LINUX | Ensure account is locked
+          assert:
+            that:
+              - getent_shadow['ansibulluser'][0].startswith('!')
+
+  always:
+    - name: Remove ansibulluser
+      user:
+        name: ansibulluser
+        state: absent
+        remove: yes

--- a/test/integration/targets/user/tasks/test_locked_user_alpine.yml
+++ b/test/integration/targets/user/tasks/test_locked_user_alpine.yml
@@ -1,5 +1,5 @@
 ---
-- name: Test locked user on Alpine
+- name: Test if new user with no password is unlocked by default
   block:
     - name: Remove ansibulluser
       user:
@@ -17,17 +17,15 @@
         that:
           - password_lock_1 is changed
 
-    - name: Verify account lock for Linux
-      block:
-        - name: LINUX | Get account status
-          getent:
-            database: shadow
-            key: ansibulluser
+    - name: Get account status
+      getent:
+        database: shadow
+        key: ansibulluser
 
-        - name: LINUX | Ensure account is locked
-          assert:
-            that:
-              - getent_shadow['ansibulluser'][0].startswith('!')
+    - name: Ensure account is unlocked
+      assert:
+        that:
+          - getent_shadow['ansibulluser'][0].startswith('*')
 
   always:
     - name: Remove ansibulluser


### PR DESCRIPTION
##### SUMMARY

* When creating a user account with no password on busybox systems such as Alpine, the account is now unlocked after it is created, for consistency with other platforms
* Added helper method to write safely the contents to shadow file

Fixes: #68676

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


