### PR TITLE
[stable-2.17] release.py - Use changelog requirements (#83920)

### DIFF
--- a/packaging/release.py
+++ b/packaging/release.py
@@ -672,7 +672,7 @@ build
 twine
 """
 
-    requirements_file = CHECKOUT_DIR / "test/sanity/code-smell/package-data.requirements.txt"
+    requirements_file = CHECKOUT_DIR / "test/lib/ansible_test/_data/requirements/sanity.changelog.txt"
     requirements_content = requirements_file.read_text()
     requirements_content += ansible_requirements
     requirements_content += release_requirements


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/83920

Use the changelog sanity test requirements instead of the package-data sanity test requirements.

(cherry picked from commit cd342f76b4c6efdbdcbc61368fdd0d1ce8ad9097)

##### ISSUE TYPE

Feature Pull Request
