### PR TITLE
Allow callback plugins to be dynamically configured

### DIFF
--- a/changelogs/fragments/dynamically-configure-callback-plugins.yaml
+++ b/changelogs/fragments/dynamically-configure-callback-plugins.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - plugins - allow callback plugins to be dynamically configured using extra_vars

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -56,7 +56,7 @@ class CallbackModule(CallbackBase):
             return self._extra_vars.get(option_name).lower() == 'true'
 
         # Fallback to default functionality
-        return super(CallbackModule, self).get_option(option_name)
+        return super().get_option(option_name)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -55,7 +55,7 @@ class CallbackModule(CallbackBase):
         if option_name in self._extra_vars:
             return self._extra_vars.get(option_name).lower() == 'true'
 
-        # Fallback to default functionality 
+        # Fallback to default functionality
         return super(CallbackModule, self).get_option(option_name)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -50,6 +50,7 @@ class CallbackModule(CallbackBase):
         super(CallbackModule, self).__init__()
 
     def get_option(self, option_name):
+
         # Check extra_vars first
         if option_name in self._extra_vars:
             return self._extra_vars.get(option_name).lower() == 'true'

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -25,6 +25,7 @@ from ansible.playbook.task_include import TaskInclude
 from ansible.plugins.callback import CallbackBase
 from ansible.utils.color import colorize, hostcolor
 from ansible.utils.fqcn import add_internal_fqcns
+from ansible.vars.manager import VariableManager
 
 
 class CallbackModule(CallbackBase):
@@ -44,7 +45,17 @@ class CallbackModule(CallbackBase):
         self._last_task_banner = None
         self._last_task_name = None
         self._task_type_cache = {}
+        self._variable_manager = VariableManager()
+        self._extra_vars = self._variable_manager.extra_vars
         super(CallbackModule, self).__init__()
+
+    def get_option(self, option_name):
+        # Check extra_vars first
+        if option_name in self._extra_vars:
+            return self._extra_vars.get(option_name).lower() == 'true'
+
+        # Fallback to environment variable and configuration file
+        return super(CallbackModule, self).get_option(option_name)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -54,7 +54,7 @@ class CallbackModule(CallbackBase):
         if option_name in self._extra_vars:
             return self._extra_vars.get(option_name).lower() == 'true'
 
-        # Fallback to environment variable and configuration file
+        # Fallback to default functionality 
         return super(CallbackModule, self).get_option(option_name)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):


### PR DESCRIPTION
##### SUMMARY

<!--- Added functionality to allow callback plugins to be dynamically configured using extra_vars -->

<!--- Fixes: #84469 -->

Added functionality to allow callback plugins to be dynamically configured using extra_vars

Fixes: #84469

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### ADDITIONAL INFORMATION

Imported `VariableManager` into default.py and loaded `extra_vars` for usage.

Added a method `get_option` in the `CallbackModule` class to first check for `extra_vars`. This ensures generic functionality across plugins.

Tested the functionality for `display_skipped_hosts` and `display_ok_hosts` using the command
` ANSIBLE_DISPLAY_SKIPPED_HOSTS=false ansible-playbook -i inventory.yaml playbook.yaml -e 'display_skipped_hosts=true'`

Option set using environment variables or using `ansible.cfg` file is overriden.

Output:
```
PLAY [Demonstrate display_skipped_hosts] ********************************************

TASK [Task that will run] ***********************************************************
ok: [192.168.209.127] => {
    "msg": "This task will run"
}

TASK [Task that will be skipped] ****************************************************
skipping: [192.168.209.127]

PLAY RECAP **************************************************************************
192.168.209.127            : ok=1    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   

```