### PR TITLE
allow displaying skipped hosts to be configured by vars

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -25,6 +25,8 @@ from ansible.playbook.task_include import TaskInclude
 from ansible.plugins.callback import CallbackBase
 from ansible.utils.color import colorize, hostcolor
 from ansible.utils.fqcn import add_internal_fqcns
+from ansible.cli import CLI
+from ansible.template import Templar
 
 
 class CallbackModule(CallbackBase):
@@ -44,7 +46,29 @@ class CallbackModule(CallbackBase):
         self._last_task_banner = None
         self._last_task_name = None
         self._task_type_cache = {}
+        self._display_skipped_hosts = None
         super(CallbackModule, self).__init__()
+
+    def display_skipped_hosts(self):
+        """
+        Evaluates and returns dynamic configuration of display_skipped_hosts in a playbook
+        """
+        self._loader, _, self._variable_manager = CLI._play_prereqs()
+        vars = self._variable_manager.get_vars(play=self._play)
+        if "display_skipped_hosts" not in vars:
+            return self.get_option("display_skipped_hosts")
+        #print(variableManager.get_vars(play=self._play)["display_skipped_hosts"])
+        templar = Templar(loader=self._loader, variables=vars)
+
+        display_skipped_hosts_val = templar.template(vars["display_skipped_hosts"], convert_data=True)
+        if display_skipped_hosts_val == True or display_skipped_hosts_val == "true":
+            return True
+        elif display_skipped_hosts_val == False or display_skipped_hosts_val == "false":
+            return False
+        else:
+            msg = "[WARNING]: display_skipped_hosts requires boolean value, has value \"%s\"" % display_skipped_hosts_val
+            self._display.display(msg, color=C.COLOR_WARN)
+            return self.get_option("display_skipped_hosts")
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
 
@@ -105,8 +129,9 @@ class CallbackModule(CallbackBase):
             self._display.display(msg, color=color)
 
     def v2_runner_on_skipped(self, result):
-
-        if self.get_option('display_skipped_hosts'):
+        if self._display_skipped_hosts == None:
+            self._display_skipped_hosts = self.display_skipped_hosts()
+        if self._display_skipped_hosts:
 
             self._clean_results(result._result, result._task.action)
 
@@ -158,7 +183,9 @@ class CallbackModule(CallbackBase):
             self._last_task_name = task.get_name().strip()
 
             # Display the task banner immediately if we're not doing any filtering based on task result
-            if self.get_option('display_skipped_hosts') and self.get_option('display_ok_hosts'):
+            if self._display_skipped_hosts == None:
+                self._display_skipped_hosts = self.display_skipped_hosts()
+            if self._display_skipped_hosts and self.get_option('display_ok_hosts'):
                 self._print_task_banner(task)
 
     def _print_task_banner(self, task):
@@ -278,7 +305,9 @@ class CallbackModule(CallbackBase):
         )
 
     def v2_runner_item_on_skipped(self, result):
-        if self.get_option('display_skipped_hosts'):
+        if self._display_skipped_hosts == None:
+            self._display_skipped_hosts = self.display_skipped_hosts()
+        if self._display_skipped_hosts:
             if self._last_task_banner != result._task._uuid:
                 self._print_task_banner(result._task)
 

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -53,17 +53,18 @@ class CallbackModule(CallbackBase):
         """
         Evaluates and returns dynamic configuration of display_skipped_hosts in a playbook
         """
-        self._loader, _, self._variable_manager = CLI._play_prereqs()
+        prereqs = CLI._play_prereqs()
+        self._loader = prereqs[0]
+        self._variable_manager = prereqs[2]
         vars = self._variable_manager.get_vars(play=self._play)
         if "display_skipped_hosts" not in vars:
             return self.get_option("display_skipped_hosts")
-        #print(variableManager.get_vars(play=self._play)["display_skipped_hosts"])
         templar = Templar(loader=self._loader, variables=vars)
 
         display_skipped_hosts_val = templar.template(vars["display_skipped_hosts"], convert_data=True)
-        if display_skipped_hosts_val == True or display_skipped_hosts_val == "true":
+        if display_skipped_hosts_val is True or display_skipped_hosts_val == "true":
             return True
-        elif display_skipped_hosts_val == False or display_skipped_hosts_val == "false":
+        elif display_skipped_hosts_val is False or display_skipped_hosts_val == "false":
             return False
         else:
             msg = "[WARNING]: display_skipped_hosts requires boolean value, has value \"%s\"" % display_skipped_hosts_val
@@ -129,7 +130,7 @@ class CallbackModule(CallbackBase):
             self._display.display(msg, color=color)
 
     def v2_runner_on_skipped(self, result):
-        if self._display_skipped_hosts == None:
+        if self._display_skipped_hosts is None:
             self._display_skipped_hosts = self.display_skipped_hosts()
         if self._display_skipped_hosts:
 
@@ -183,7 +184,7 @@ class CallbackModule(CallbackBase):
             self._last_task_name = task.get_name().strip()
 
             # Display the task banner immediately if we're not doing any filtering based on task result
-            if self._display_skipped_hosts == None:
+            if self._display_skipped_hosts is None:
                 self._display_skipped_hosts = self.display_skipped_hosts()
             if self._display_skipped_hosts and self.get_option('display_ok_hosts'):
                 self._print_task_banner(task)
@@ -305,7 +306,7 @@ class CallbackModule(CallbackBase):
         )
 
     def v2_runner_item_on_skipped(self, result):
-        if self._display_skipped_hosts == None:
+        if self._display_skipped_hosts is None:
             self._display_skipped_hosts = self.display_skipped_hosts()
         if self._display_skipped_hosts:
             if self._last_task_banner != result._task._uuid:

--- a/test/integration/targets/old_style_vars_plugins/runme.sh
+++ b/test/integration/targets/old_style_vars_plugins/runme.sh
@@ -35,13 +35,13 @@ trap 'rm -rf -- "out.txt"' EXIT
 
 ANSIBLE_DEBUG=True ansible-playbook test_task_vars.yml > out.txt
 [ "$(grep -c "Loading VarsModule 'host_group_vars'" out.txt)" -eq 1 ]
-[ "$(grep -c "Loading VarsModule 'require_enabled'" out.txt)" -eq 22 ]
-[ "$(grep -c "Loading VarsModule 'auto_enabled'" out.txt)" -eq 22 ]
+[ "$(grep -c "Loading VarsModule 'require_enabled'" out.txt)" -eq 24 ]
+[ "$(grep -c "Loading VarsModule 'auto_enabled'" out.txt)" -eq 24 ]
 
 export ANSIBLE_VARS_ENABLED=ansible.builtin.host_group_vars
 ANSIBLE_DEBUG=True ansible-playbook test_task_vars.yml > out.txt
 [ "$(grep -c "Loading VarsModule 'host_group_vars'" out.txt)" -eq 1 ]
 [ "$(grep -c "Loading VarsModule 'require_enabled'" out.txt)" -lt 3 ]
-[ "$(grep -c "Loading VarsModule 'auto_enabled'" out.txt)" -eq 22 ]
+[ "$(grep -c "Loading VarsModule 'auto_enabled'" out.txt)" -eq 24 ]
 
 ansible localhost -m include_role -a 'name=a' "$@"


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Allow `display_skipped_hosts` to be configured via vars in a playbook.
If not present in playbook vars or invalid, default to global `display_skipped_hosts`

Allows use of jinja2 templating

For example:
```
- name: Example playbook
  hosts: kvm_hosts
  vars:
    display_skipped_hosts: "{{ enable_skipped_hosts_display | default(false) }}"
  tasks:
    - name: Task with a condition
      ansible.builtin.debug:
        msg: "This task runs only on RedHat systems"
      when: ansible_os_family == "RedHat"
```

One can then run 
`ansible-playbook example_pb.yaml -i inventory.ini -e "enable_skipped_hosts_display=true" `
<!--- Add "Fixes #1234" if there is a corresponding issue -->
https://github.com/ansible/ansible/issues/84469

##### ISSUE TYPE

- Feature Pull Request
