### PR TITLE
ansible-test - Add pytest-mock to mypy sanity test

### DIFF
--- a/test/sanity/code-smell/mypy.requirements.in
+++ b/test/sanity/code-smell/mypy.requirements.in
@@ -3,6 +3,7 @@ cryptography  # type stubs not published separately
 jinja2  # type stubs not published separately
 packaging  # type stubs not published separately
 pytest  # type stubs not published separately
+pytest-mock  # type stubs not published separately
 tomli  # type stubs not published separately, required for toml inventory plugin
 types-backports
 types-paramiko

--- a/test/sanity/code-smell/mypy.requirements.txt
+++ b/test/sanity/code-smell/mypy.requirements.txt
@@ -10,6 +10,7 @@ packaging==24.2
 pluggy==1.5.0
 pycparser==2.22
 pytest==8.3.4
+pytest-mock==3.14.0
 tomli==2.2.1
 types-backports==0.1.3
 types-paramiko==3.5.0.20240928


### PR DESCRIPTION
##### SUMMARY

ansible-test - Add pytest-mock to mypy sanity test.

##### ISSUE TYPE

Feature Pull Request
