### PR TITLE
[2.17] [fix] `warn_if_reserved` expects a list (#84624)

### DIFF
--- a/changelogs/fragments/fix-include_vars-reserved-warning.yml
+++ b/changelogs/fragments/fix-include_vars-reserved-warning.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- >-
+  include_vars - fixed erroneous warning if an unreserved variable name
+  contains a single character that matches a reserved variable.
+  (https://github.com/ansible/ansible/issues/84623)

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -742,7 +742,7 @@ class VariableManager:
         Sets a value in the vars_cache for a host.
         """
 
-        warn_if_reserved(varname)
+        warn_if_reserved([varname])
         if host not in self._vars_cache:
             self._vars_cache[host] = dict()
         if varname in self._vars_cache[host] and isinstance(self._vars_cache[host][varname], MutableMapping) and isinstance(value, MutableMapping):

--- a/test/integration/targets/var_reserved/tasks/include_vars.yml
+++ b/test/integration/targets/var_reserved/tasks/include_vars.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - include_vars:
+      file: ../vars/set_host_variable.yml

--- a/test/integration/targets/var_reserved/tasks/main.yml
+++ b/test/integration/targets/var_reserved/tasks/main.yml
@@ -2,22 +2,32 @@
   vars:
     canary: Found variable using reserved name
   block:
-  - shell: ansible-playbook '{{[ role_path, "tasks", item ~ ".yml"] | path_join }}'
+  - shell: ansible-playbook '{{[ role_path, "tasks", item.file ~ ".yml"] | path_join }}'
     environment:
       ANSIBLE_LOCALHOST_WARNING: 0
+      ANSIBLE_FORCE_COLOR: 0
     failed_when: false
     loop:
-    - play_vars
-    - block_vars
-    - task_vars
-    - task_vars_used
-    - set_fact
+    - file: play_vars
+      name: lipsum
+    - file: block_vars
+      name: query
+    - file: task_vars
+      name: query
+    - file: task_vars_used
+      name: q
+    - file: set_fact
+      name: lookup
+    - file: include_vars
+      name: query
     register: play_out
 
   - name: check they all complain about bad defined var
     assert:
       that:
-        - canary in item['stderr']
+        - item.stderr == warning_message
     loop: '{{play_out.results}}'
     loop_control:
-      label: '{{item.item}}'
+      label: '{{item.item.file}}'
+    vars:
+      warning_message: "[WARNING]: {{ canary }}: {{ item.item.name }}"

--- a/test/integration/targets/var_reserved/vars/set_host_variable.yml
+++ b/test/integration/targets/var_reserved/vars/set_host_variable.yml
@@ -1,0 +1,1 @@
+query: overwrite global Jinja2 function


### PR DESCRIPTION
##### SUMMARY

Backport https://github.com/ansible/ansible/pull/84624, follow up to https://github.com/ansible/ansible/pull/84543

Fixes #84623

(cherry picked from commit 48d71ba3aaf5f815d8193f7cd5bafccc76520c60)

##### ISSUE TYPE

- Bugfix Pull Request
