### PR TITLE
🧪 Depend on `setuptools` @ `egg-info` test

### DIFF
--- a/test/integration/targets/egg-info/meta/main.yml
+++ b/test/integration/targets/egg-info/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_setuptools

--- a/test/integration/targets/setup_setuptools/tasks/main.yml
+++ b/test/integration/targets/setup_setuptools/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: Install setuptools
+  pip:
+    name: setuptools
+    state: present


### PR DESCRIPTION
Previously, the integration test depended on luck. `setuptools` used to be bundled in Python stdlib's `ensurepip`. Python 3.12 and newer no longer include it. This test imports `pkg_resources` that is a part of `setuptools`, meaning that it'll run out of luck at some point, under newer Python runtimes.

This change makes `setuptools` an explicit dependency of the test to address said problem.

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
SSIA
<!--- Add "Fixes #1234" if there is a corresponding issue -->

##### ISSUE TYPE

- Test Pull Request
