### PR TITLE
Fix example in human_to_bytes.yml

### DIFF
--- a/lib/ansible/plugins/filter/human_to_bytes.yml
+++ b/lib/ansible/plugins/filter/human_to_bytes.yml
@@ -31,7 +31,7 @@ EXAMPLES: |
   # size => 2684354560
   size: '{{ "2.5 gigabyte" | human_to_bytes }}'
   
-  # size => 1234803098
+  # size => 1073741824
   size: '{{ "1 Gigabyte" | human_to_bytes }}'
 
   # this is an error, because gigggabyte is not a valid unit


### PR DESCRIPTION
Expected size given was incorrect

##### SUMMARY

<!--- Describe the change below, including rationale -->

Fixed an incorrect example, where the expected output given had evidently been copied from an earlier example accidentally.

I have tested the code and got the result I changed it to, which is expected as `1024^3 = 1073741824` .

<!--- Add "Fixes #1234" if there is a corresponding issue -->

##### ISSUE TYPE

- Docs Pull Request
