### PR TITLE
template: update links to docs

### DIFF
--- a/lib/ansible/plugins/doc_fragments/template_common.py
+++ b/lib/ansible/plugins/doc_fragments/template_common.py
@@ -11,9 +11,9 @@ class ModuleDocFragment(object):
     # Standard template documentation fragment, use by template and win_template.
     DOCUMENTATION = r"""
 description:
-- Templates are processed by the L(Jinja2 templating language,http://jinja.pocoo.org/docs/).
+- Templates are processed by the L(Jinja2 templating language,https://jinja.palletsprojects.com/en/stable/).
 - Documentation on the template formatting can be found in the
-  L(Template Designer Documentation,http://jinja.pocoo.org/docs/templates/).
+  L(Template Designer Documentation,https://jinja.palletsprojects.com/en/stable/templates/).
 - Additional variables listed below can be used in templates.
 - C(ansible_managed) (configurable via the C(defaults) section of C(ansible.cfg)) contains a string which can be used to
   describe the template name, host, modification time of the template file and the owner uid.


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
The links to template docs are using http and jinja.pocoo.org is redirecting to jinja.palletsprojects.com.

This PR updates these links to point to their final redirect with https, saving the user from a "site is not secure" warning and redirect.
 
<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request
