### PR TITLE
[stable-2.16] Fix `is_pinned` property of `Requirement` (#81812)

### DIFF
--- a/changelogs/fragments/81812-ansible-galaxy-negative-spec-is-pinned.yml
+++ b/changelogs/fragments/81812-ansible-galaxy-negative-spec-is-pinned.yml
@@ -1,0 +1,8 @@
+---
+
+bugfixes:
+- >-
+  ``ansible-galaxy`` — the collection dependency resolver now treats
+  version specifiers starting with ``!=`` as unpinned.
+
+...

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -579,10 +579,9 @@ class _ComputedReqKindsMixin:
 
         See https://github.com/ansible/ansible/pull/81606 for extra context.
         """
-        version_string = self.ver[0]
-        return version_string.isdigit() or not (
-            version_string == '*' or
-            version_string.startswith(('<', '>', '!='))
+        version_spec_start_char = self.ver[0]
+        return version_spec_start_char.isdigit() or not (
+            version_spec_start_char.startswith(('<', '>', '!', '*'))
         )
 
     @property

--- a/test/units/galaxy/test_collection_dataclasses.py
+++ b/test/units/galaxy/test_collection_dataclasses.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2023, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Tests for depresolver dataclass objects."""
+
+
+from __future__ import annotations
+
+import pytest
+
+from ansible.galaxy.dependency_resolution.dataclasses import Requirement
+
+
+NO_LEADING_WHITESPACES = pytest.mark.xfail(
+    reason='Does not yet support leading whitespaces',
+    strict=True,
+)
+
+
+@pytest.mark.parametrize(
+    ('collection_version_spec', 'expected_is_pinned_outcome'),
+    (
+        ('1.2.3-dev4', True),
+        (' 1.2.3-dev4', True),
+        ('=1.2.3', True),
+        ('= 1.2.3', True),
+        (' = 1.2.3', True),
+        (' =1.2.3', True),
+        ('==1.2.3', True),
+        ('== 1.2.3', True),
+        (' == 1.2.3', True),
+        (' ==1.2.3', True),
+        ('!=1.0.0', False),
+        ('!= 1.0.0', False),
+        pytest.param(' != 1.0.0', False, marks=NO_LEADING_WHITESPACES),
+        pytest.param(' !=1.0.0', False, marks=NO_LEADING_WHITESPACES),
+        ('>1.0.0', False),
+        ('> 1.0.0', False),
+        pytest.param(' > 1.0.0', False, marks=NO_LEADING_WHITESPACES),
+        pytest.param(' >1.0.0', False, marks=NO_LEADING_WHITESPACES),
+        ('>=1.0.0', False),
+        ('>= 1.0.0', False),
+        pytest.param(' >= 1.0.0', False, marks=NO_LEADING_WHITESPACES),
+        pytest.param(' >=1.0.0', False, marks=NO_LEADING_WHITESPACES),
+        ('<1.0.0', False),
+        ('< 1.0.0', False),
+        pytest.param(' < 1.0.0', False, marks=NO_LEADING_WHITESPACES),
+        pytest.param(' <1.0.0', False, marks=NO_LEADING_WHITESPACES),
+        ('*', False),
+        ('* ', False),
+        pytest.param(' * ', False, marks=NO_LEADING_WHITESPACES),
+        pytest.param(' *', False, marks=NO_LEADING_WHITESPACES),
+        ('=1.2.3,!=1.2.3rc5', True),
+    ),
+)
+def test_requirement_is_pinned_logic(
+        collection_version_spec: str,
+        expected_is_pinned_outcome: bool,
+) -> None:
+    """Test how Requirement's is_pinned property detects pinned spec."""
+    assert Requirement(
+        'namespace.collection', collection_version_spec,
+        None, None, None,
+    ).is_pinned is expected_is_pinned_outcome


### PR DESCRIPTION
Previously, requirement version specs starting with `!=` were incorrectly considered as pinned release requests because the comparison was being made against a one-char string while the operator is two-char. This patch changes the check to test against `!` which is enough to detect this case.
(cherry picked from commit cdb1ce0)

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request
