### PR TITLE
re: maxsplit is now keyword argument

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -488,7 +488,7 @@ class PolicyRcD(object):
 
 
 def package_split(pkgspec):
-    parts = re.split(r'(>?=)', pkgspec, 1)
+    parts = re.split(r'(>?=)', pkgspec, maxsplit=1)
     if len(parts) > 1:
         return parts
     return parts[0], None, None

--- a/lib/ansible/modules/mount_facts.py
+++ b/lib/ansible/modules/mount_facts.py
@@ -359,7 +359,7 @@ def gen_mounts_from_stdout(stdout: str) -> t.Iterable[MountInfo]:
         elif pattern is BSD_MOUNT_RE:
             # the group containing fstype is comma separated, and may include whitespace
             mount_info = match.groupdict()
-            parts = re.split(r"\s*,\s*", match.group("fstype"), 1)
+            parts = re.split(r"\s*,\s*", match.group("fstype"), maxsplit=1)
             if len(parts) == 1:
                 mount_info["fstype"] = parts[0]
             else:


### PR DESCRIPTION
##### SUMMARY

* Passing maxsplit and flags as positional arguments is deprecated in
  3.13.

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


