### PR TITLE
Ensure implicit flush_handlers have a parent block

### DIFF
--- a/changelogs/fragments/implicit_flush_handlers_parents.yml
+++ b/changelogs/fragments/implicit_flush_handlers_parents.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Implicit ``meta: flush_handlers`` tasks now have a parent block to prevent potential tracebacks when calling methods like ``get_play()`` on them internally."

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -330,24 +330,33 @@ class Play(Base, Taggable, CollectionSearch):
             noop_task.set_loader(self._loader)
 
             b = Block(play=self)
-            nt = noop_task.copy(exclude_parent=True)
-            nt._parent = b
-            b.block = self.pre_tasks or [nt]
+            if self.pre_tasks:
+                b.block = self.pre_tasks
+            else:
+                nt = noop_task.copy(exclude_parent=True)
+                nt._parent = b
+                b.block = [nt]
             b.always = [flush_block]
             block_list.append(b)
 
             tasks = self._compile_roles() + self.tasks
             b = Block(play=self)
-            nt = noop_task.copy(exclude_parent=True)
-            nt._parent = b
-            b.block = tasks or [nt]
+            if tasks:
+                b.block = tasks
+            else:
+                nt = noop_task.copy(exclude_parent=True)
+                nt._parent = b
+                b.block = [nt]
             b.always = [flush_block]
             block_list.append(b)
 
             b = Block(play=self)
-            nt = noop_task.copy(exclude_parent=True)
-            nt._parent = b
-            b.block = self.post_tasks or [nt]
+            if self.post_tasks:
+                b.block = self.post_tasks
+            else:
+                nt = noop_task.copy(exclude_parent=True)
+                nt._parent = b
+                b.block = [nt]
             b.always = [flush_block]
             block_list.append(b)
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -298,7 +298,7 @@ class Play(Base, Taggable, CollectionSearch):
         # of the playbook execution
         flush_block = Block(play=self)
 
-        t = Task()
+        t = Task(block=flush_block)
         t.action = 'meta'
         t.resolved_action = 'ansible.builtin.meta'
         t.args['_raw_params'] = 'flush_handlers'
@@ -327,17 +327,20 @@ class Play(Base, Taggable, CollectionSearch):
             noop_task.set_loader(self._loader)
 
             b = Block(play=self)
+            noop_task._parent = b
             b.block = self.pre_tasks or [noop_task]
             b.always = [flush_block]
             block_list.append(b)
 
             tasks = self._compile_roles() + self.tasks
             b = Block(play=self)
+            noop_task._parent = b
             b.block = tasks or [noop_task]
             b.always = [flush_block]
             block_list.append(b)
 
             b = Block(play=self)
+            noop_task._parent = b
             b.block = self.post_tasks or [noop_task]
             b.always = [flush_block]
             block_list.append(b)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -318,6 +318,9 @@ class Play(Base, Taggable, CollectionSearch):
         else:
             flush_block.block = [t]
 
+        # NOTE keep flush_handlers tasks even if a section has no regular tasks,
+        #      there may be notified handlers from the previous section
+        #      (typically when a handler notifies a handler defined before)
         block_list = []
         if self.force_handlers:
             noop_task = Task()
@@ -327,21 +330,24 @@ class Play(Base, Taggable, CollectionSearch):
             noop_task.set_loader(self._loader)
 
             b = Block(play=self)
-            noop_task._parent = b
-            b.block = self.pre_tasks or [noop_task]
+            nt = noop_task.copy(exclude_parent=True)
+            nt._parent = b
+            b.block = self.pre_tasks or [nt]
             b.always = [flush_block]
             block_list.append(b)
 
             tasks = self._compile_roles() + self.tasks
             b = Block(play=self)
-            noop_task._parent = b
-            b.block = tasks or [noop_task]
+            nt = noop_task.copy(exclude_parent=True)
+            nt._parent = b
+            b.block = tasks or [nt]
             b.always = [flush_block]
             block_list.append(b)
 
             b = Block(play=self)
-            noop_task._parent = b
-            b.block = self.post_tasks or [noop_task]
+            nt = noop_task.copy(exclude_parent=True)
+            nt._parent = b
+            b.block = self.post_tasks or [nt]
             b.always = [flush_block]
             block_list.append(b)
 


### PR DESCRIPTION
##### SUMMARY

To avoid getting tracebacks when calling methods like ``get_play()`` on them.

Noticed in https://github.com/ansible/ansible/pull/82314#issuecomment-2621764515
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
