### PR TITLE
[2.18] linear - don't treat end_role as a run_once task (#84673)

### DIFF
--- a/changelogs/fragments/84660-fix-meta-end_role-linear-strategy.yml
+++ b/changelogs/fragments/84660-fix-meta-end_role-linear-strategy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - linear strategy - fix executing ``end_role`` meta tasks for each host, instead of handling these as implicit run_once tasks (https://github.com/ansible/ansible/issues/84660).

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -162,7 +162,7 @@ class StrategyModule(StrategyBase):
                         # for the linear strategy, we run meta tasks just once and for
                         # all hosts currently being iterated over rather than one host
                         results.extend(self._execute_meta(task, play_context, iterator, host))
-                        if task.args.get('_raw_params', None) not in ('noop', 'reset_connection', 'end_host', 'role_complete', 'flush_handlers'):
+                        if task.args.get('_raw_params', None) not in ('noop', 'reset_connection', 'end_host', 'role_complete', 'flush_handlers', 'end_role'):
                             run_once = True
                         if (task.any_errors_fatal or run_once) and not task.ignore_errors:
                             any_errors_fatal = True

--- a/test/integration/targets/roles/end_role.yml
+++ b/test/integration/targets/roles/end_role.yml
@@ -1,4 +1,4 @@
-- hosts: localhost
+- hosts: localhost,testhost
   gather_facts: false
   pre_tasks:
     - set_fact:

--- a/test/integration/targets/roles/roles/end_role_inside/tasks/main.yml
+++ b/test/integration/targets/roles/roles/end_role_inside/tasks/main.yml
@@ -1,7 +1,8 @@
 - set_fact:
     role_executed: "{{ role_executed|default(0)|int + 1 }}"
 
-- command: echo
+- debug:
+  changed_when: true
   notify: role_handler
 
 - meta: end_role

--- a/test/integration/targets/roles/runme.sh
+++ b/test/integration/targets/roles/runme.sh
@@ -55,7 +55,7 @@ ANSIBLE_PRIVATE_ROLE_VARS=0 ansible-playbook privacy.yml -e @vars/privacy_vars.y
 ansible-playbook privacy.yml -e @vars/privacy_vars.yml "$@"
 
 for strategy in linear free; do
-  [ "$(ANSIBLE_STRATEGY=$strategy ansible-playbook end_role.yml | grep -c CHECKPOINT)" = "1" ]
+  [ "$(ANSIBLE_STRATEGY=$strategy ansible-playbook -i testhost, end_role.yml | grep -c CHECKPOINT)" = "2" ]
   [ "$(ANSIBLE_STRATEGY=$strategy ansible-playbook -i host1,host2 end_role_nested.yml | grep -c CHECKPOINT)" = "4" ]
 done
 


### PR DESCRIPTION
##### SUMMARY

Backport for #84673. This feature is new in 2.18 so it doesn't need to be backported further.

(cherry picked from commit a086c34a913b9789933025b883cc0d3509eab17e)

##### ISSUE TYPE

- Bugfix Pull Request
