### PR TITLE
Ensure installed/downloaded collections support the running ansible-core version

### DIFF
--- a/changelogs/fragments/install-ansible-core-compatible-collections.yml
+++ b/changelogs/fragments/install-ansible-core-compatible-collections.yml
@@ -1,0 +1,6 @@
+bugfixes:
+- >-
+  ``ansible-galaxy install`` and ``ansible-galaxy collection install|download` - now consider
+  the ``COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH`` configuration.
+  Collections which will cause a warning/error at load time are no longer installed/downloaded.
+  (https://github.com/ansible/ansible/issues/78539)

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -288,6 +288,9 @@ class GalaxyAPI:
         if not no_cache:
             self._cache = _load_cache(self._b_cache_path)
 
+        # For efficiency, this metadata is populated when listing collection versions.
+        self.requires_ansible = {}
+
         display.debug('Validate TLS certificates for %s: %s' % (self.api_server, self.validate_certs))
 
     def __str__(self):
@@ -844,7 +847,9 @@ class GalaxyAPI:
 
         versions = []
         while True:
-            versions += [v['version'] for v in data[results_key]]
+            for v in data[results_key]:
+                versions.append(v["version"])
+                self.requires_ansible.setdefault(f"{namespace}.{name}", {})[v["version"]] = v.get("requires_ansible")
 
             next_link = data
             for path in pagination_path:

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -289,8 +289,7 @@ class GalaxyAPI:
         if not no_cache:
             self._cache = _load_cache(self._b_cache_path)
 
-        # For efficiency, this metadata is populated when listing collection versions.
-        self.requires_ansible = {}
+        self.requires_ansible = collections.defaultdict(dict)
 
         display.debug('Validate TLS certificates for %s: %s' % (self.api_server, self.validate_certs))
 
@@ -850,7 +849,7 @@ class GalaxyAPI:
         while True:
             for v in data[results_key]:
                 versions.append(v["version"])
-                self.requires_ansible.setdefault(f"{namespace}.{name}", {})[v["version"]] = v.get("requires_ansible")
+                self.requires_ansible[f"{namespace}.{name}"][v["version"]] = v.get("requires_ansible")
 
             next_link = data
             for path in pagination_path:

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -39,6 +39,7 @@ RETRY_HTTP_ERROR_CODES = {  # TODO: Allow user-configuration
     520,  # Galaxy rate limit error code (Cloudflare unknown error)
     HTTPStatus.BAD_GATEWAY,  # Common error from galaxy that may represent any number of transient backend issues
 }
+_DEFAULT_NORMALIZED_SERVER = 'https://galaxy.ansible.com/api/'
 
 
 def cache_lock(func):
@@ -86,7 +87,7 @@ def g_connect(versions):
                 error_context_msg = 'Error when finding available api versions from %s (%s)' % (self.name, n_url)
 
                 if self.api_server == 'https://galaxy.ansible.com' or self.api_server == 'https://galaxy.ansible.com/':
-                    n_url = 'https://galaxy.ansible.com/api/'
+                    n_url = _DEFAULT_NORMALIZED_SERVER
 
                 try:
                     data = self._call_galaxy(n_url, method='GET', error_context_msg=error_context_msg, cache=True)

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -110,7 +110,6 @@ try:
         CollectionDependencyInconsistentCandidate,
     )
     from ansible.galaxy.dependency_resolution.providers import (
-        _dependency_origin,
         RESOLVELIB_VERSION,
         RESOLVELIB_LOWERBOUND,
         RESOLVELIB_UPPERBOUND,
@@ -1855,10 +1854,7 @@ def _resolve_depenency_map(
                 if req_inf.requirement.supports_ansible:
                     continue
                 collection = str(req_inf.parent)
-                if (_dep := repr(req_inf.parent)) in _dependency_origin:
-                    dep_origin = f"dependency of {_dependency_origin[_dep]}"
-                else:
-                    dep_origin = "direct request"
+                dep_origin = 'direct request' if req_inf.parent._parent is None else f'dependency of {req_inf.parent._parent!s}'
             else:
                 collection = str(req_inf.requirement)
                 dep_origin = 'direct request' if req_inf.parent is None else f'dependency of {req_inf.parent!s}'

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1830,7 +1830,7 @@ def _resolve_depenency_map(
     )
     requires_ansible_hint = '' if C.COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH == 'ignore' else (
         'Hint: To disregard whether the collection supports the current version of '
-        'Ansible, configure COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH as "ignore".'
+        'ansible-core, configure COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH as "ignore".'
     )
 
     collection_dep_resolver = build_collection_dependency_resolver(

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1827,6 +1827,10 @@ def _resolve_depenency_map(
         'installed by default unless a specific version is requested. '
         'To enable pre-releases globally, use --pre.'
     )
+    requires_ansible_hint = '' if C.COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH == 'ignore' else (
+        'Hint: To disregard whether the collection supports the current version of '
+        'Ansible, configure COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH as "ignore".'
+    )
 
     collection_dep_resolver = build_collection_dependency_resolver(
         galaxy_apis=galaxy_apis,
@@ -1844,16 +1848,21 @@ def _resolve_depenency_map(
             max_rounds=2000000,  # NOTE: same constant pip uses
         ).mapping
     except CollectionDependencyResolutionImpossible as dep_exc:
-        conflict_causes = (
-            '* {req.fqcn!s}:{req.ver!s} ({dep_origin!s})'.format(
-                req=req_inf.requirement,
-                dep_origin='direct request'
-                if req_inf.parent is None
-                else 'dependency of {parent!s}'.
-                format(parent=req_inf.parent),
-            )
-            for req_inf in dep_exc.causes
-        )
+        conflict_causes = []
+        for req_inf in dep_exc.causes:
+            if req_inf.requirement.type == "requires_ansible":
+                collection = f"{req_inf.parent.fqcn!s}:{req_inf.parent.ver!s}"
+                dep_origin = 'direct request' if req_inf.parent._parent is None else f'dependency of {req_inf.parent._parent!s}'
+            else:
+                collection = f"{req_inf.requirement.fqcn!s}:{req_inf.requirement.ver!s}"
+                dep_origin = 'direct request' if req_inf.parent is None else f'dependency of {req_inf.parent!s}'
+
+            cause = f"* {collection} ({dep_origin})"
+            if req_inf.requirement.type == "requires_ansible":
+                cause += f" requires {req_inf.requirement.fqcn!s} {req_inf.requirement.ver!s}"
+
+            conflict_causes.append(cause)
+
         error_msg_lines = list(chain(
             (
                 'Failed to resolve the requested '
@@ -1862,6 +1871,8 @@ def _resolve_depenency_map(
             ),
             conflict_causes,
         ))
+        if any(req_inf.requirement.type == "requires_ansible" for req_inf in dep_exc.causes):
+            error_msg_lines.append(requires_ansible_hint)
         error_msg_lines.append(pre_release_hint)
         raise AnsibleError('\n'.join(error_msg_lines)) from dep_exc
     except CollectionDependencyInconsistentCandidate as dep_exc:

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -110,6 +110,7 @@ try:
         CollectionDependencyInconsistentCandidate,
     )
     from ansible.galaxy.dependency_resolution.providers import (
+        _dependency_origin,
         RESOLVELIB_VERSION,
         RESOLVELIB_LOWERBOUND,
         RESOLVELIB_UPPERBOUND,
@@ -1851,10 +1852,15 @@ def _resolve_depenency_map(
         conflict_causes = []
         for req_inf in dep_exc.causes:
             if req_inf.requirement.type == "requires_ansible":
-                collection = f"{req_inf.parent.fqcn!s}:{req_inf.parent.ver!s}"
-                dep_origin = 'direct request' if req_inf.parent._parent is None else f'dependency of {req_inf.parent._parent!s}'
+                if req_inf.requirement.supports_ansible:
+                    continue
+                collection = str(req_inf.parent)
+                if collection in _dependency_origin:
+                    dep_origin = f"dependency of {_dependency_origin[collection]}"
+                else:
+                    dep_origin = "direct request"
             else:
-                collection = f"{req_inf.requirement.fqcn!s}:{req_inf.requirement.ver!s}"
+                collection = str(req_inf.requirement)
                 dep_origin = 'direct request' if req_inf.parent is None else f'dependency of {req_inf.parent!s}'
 
             cause = f"* {collection} ({dep_origin})"

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1855,8 +1855,8 @@ def _resolve_depenency_map(
                 if req_inf.requirement.supports_ansible:
                     continue
                 collection = str(req_inf.parent)
-                if req_inf.parent in _dependency_origin:
-                    dep_origin = f"dependency of {_dependency_origin[req_inf.parent]}"
+                if (_dep := repr(req_inf.parent)) in _dependency_origin:
+                    dep_origin = f"dependency of {_dependency_origin[_dep]}"
                 else:
                     dep_origin = "direct request"
             else:

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1855,8 +1855,8 @@ def _resolve_depenency_map(
                 if req_inf.requirement.supports_ansible:
                     continue
                 collection = str(req_inf.parent)
-                if collection in _dependency_origin:
-                    dep_origin = f"dependency of {_dependency_origin[collection]}"
+                if req_inf.parent in _dependency_origin:
+                    dep_origin = f"dependency of {_dependency_origin[req_inf.parent]}"
                 else:
                     dep_origin = "direct request"
             else:

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -16,6 +16,7 @@ from collections.abc import Mapping
 from contextlib import contextmanager, suppress
 from functools import cache
 from hashlib import sha256
+from pathlib import Path
 from urllib.error import URLError
 from urllib.parse import urldefrag
 from shutil import rmtree
@@ -784,10 +785,9 @@ def _tarfile_extract(
 @cache
 def _get_runtime_from_dir(b_path: bytes) -> object:
     """Load the meta/runtime.yml from a collection directory."""
-    runtime_path = os.path.join(b_path, b"meta", b"runtime.yml")
+    runtime_path = Path(b_path.decode()) / "meta" / "runtime.yml"
     with suppress(OSError):
-        with open(runtime_path, 'r') as fd:
-            return yaml_load(fd)
+        return yaml_load(runtime_path.read_text())
 
 
 @cache

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -12,7 +12,9 @@ import subprocess
 import typing as t
 import yaml
 
-from contextlib import contextmanager
+from collections.abc import Mapping
+from contextlib import contextmanager, suppress
+from functools import cache
 from hashlib import sha256
 from urllib.error import URLError
 from urllib.parse import urldefrag
@@ -337,6 +339,27 @@ class ConcreteArtifactsManager:
 
         self._artifact_meta_cache[collection.src] = collection_meta
         return collection_meta
+
+    def get_direct_requires_ansible(self, collection: Candidate) -> str | None:
+        """Extract requires_ansible from the on-disk collection artifact."""
+        if collection.is_concrete_artifact:
+            b_artifact_path = self.get_artifact_path(collection)
+        else:
+            b_artifact_path = self.get_galaxy_artifact_path(collection)
+
+        if collection.is_url or collection.is_file or collection.is_online_index_pointer:
+            runtime = _get_runtime_from_tar(b_artifact_path) or {}
+        elif collection.is_dir:
+            runtime = _get_runtime_from_dir(b_artifact_path) or {}
+        elif collection.is_virtual:
+            runtime = {}
+
+        if not isinstance(runtime, Mapping):
+            raise AnsibleError(
+                f"The collection {collection} (type {collection.type}) (from {collection.src}) "
+                "has an invalid meta/runtime.yml metadata. This file must contain a YAML dictionary."
+            )
+        return runtime.get("requires_ansible")
 
     def save_collection_source(self, collection, url, sha256_hash, token, signatures_url, signatures):
         # type: (Candidate, str, str, GalaxyToken, str, list[dict[str, str]]) -> None
@@ -756,3 +779,22 @@ def _tarfile_extract(
     finally:
         if tar_obj is not None:
             tar_obj.close()
+
+
+@cache
+def _get_runtime_from_dir(b_path: bytes) -> object:
+    """Load the meta/runtime.yml from a collection directory."""
+    runtime_path = os.path.join(b_path, b"meta", b"runtime.yml")
+    with suppress(OSError):
+        with open(runtime_path, 'r') as fd:
+            return yaml_load(fd)
+
+
+@cache
+def _get_runtime_from_tar(b_path: bytes) -> object:
+    """Load the meta/runtime.yml from a collection artifact."""
+    with suppress(tarfile.TarError, KeyError):
+        with tarfile.open(b_path, mode='r') as collection_tar:
+            runtime = collection_tar.getmember("meta/runtime.yml")
+            with _tarfile_extract(collection_tar, runtime) as (_member, member_obj):
+                return yaml_load(member_obj)

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -28,7 +28,7 @@ if t.TYPE_CHECKING:
 
 from ansible import release
 from ansible.errors import AnsibleError, AnsibleAssertionError
-from ansible.galaxy.api import GalaxyAPI
+from ansible.galaxy.api import GalaxyAPI, _DEFAULT_NORMALIZED_SERVER
 from ansible.galaxy.collection import HAS_PACKAGING, PkgReq
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.common.arg_spec import ArgumentSpecValidator
@@ -184,7 +184,6 @@ class _ComputedReqKindsMixin:
                 self.name,
                 self.ver
             )
-        self._parent = None
 
     def __hash__(self):
         return hash(tuple(getattr(self, attr) for attr in _ComputedReqKindsMixin.UNIQUE_ATTRS))
@@ -657,7 +656,7 @@ class AnsibleRequirement(Requirement):
         #   the collection documents it.
         if self.ver in ('', None) and C.COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH != 'ignore':
             warning = (
-                "" if self._parent.type != 'galaxy' or self._parent.src.api_server == "https://galaxy.ansible.com/api/"
+                "" if self._parent.type != 'galaxy' or self._parent.src.api_server == _DEFAULT_NORMALIZED_SERVER
                 else f"Galaxy server {self._parent.src.api_server} didn't return 'requires_ansible' metadata for {self._parent!r} or "
             )
             display.warning(

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -26,7 +26,7 @@ if t.TYPE_CHECKING:
         '_ComputedReqKindsMixin',
     )
 
-from ansible import release
+from ansible import release, constants as C
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.galaxy.api import GalaxyAPI, _DEFAULT_NORMALIZED_SERVER
 from ansible.galaxy.collection import HAS_PACKAGING, PkgReq
@@ -38,7 +38,7 @@ from ansible.utils.display import Display
 from ansible.utils.version import SemanticVersion, LooseVersion
 
 
-_ANSIBLE_CANDIDATE_VERSION = SemanticVersion.from_loose_version(LooseVersion(release.__version__)).vstring
+_ANSIBLE_RUNTIME_VERSION = SemanticVersion.from_loose_version(LooseVersion(release.__version__)).vstring
 _ALLOW_CONCRETE_POINTER_IN_SOURCE = False  # NOTE: This is a feature flag
 _GALAXY_YAML = b'galaxy.yml'
 _MANIFEST_JSON = b'MANIFEST.json'
@@ -521,7 +521,7 @@ class _ComputedReqKindsMixin:
 
     @property
     def canonical_package_id(self):
-        if not self.is_virtual or self.is_ansible:
+        if not self.is_virtual or self.is_ansible_runtime:
             return to_native(self.fqcn)
 
         return (
@@ -531,10 +531,14 @@ class _ComputedReqKindsMixin:
 
     @property
     def is_virtual(self):
-        return self.is_scm or self.is_subdirs or self.is_ansible
+        # TODO: make it easier to plumb non-collection types through the dependency resolver.
+        # For example, if is_virtual is False, it shouldn't be assumed that the requirement
+        # is a collection, has metadata, has a SemVer version, and is installable.
+        # It would be safer to handle expected types explicitly, and error otherwise.
+        return self.is_scm or self.is_subdirs or self.is_ansible_runtime
 
     @property
-    def is_ansible(self):
+    def is_ansible_runtime(self):
         return self.type == "requires_ansible"
 
     @property
@@ -644,27 +648,28 @@ class Candidate(
 class AnsibleRequirement(Requirement):
     @property
     def supports_ansible(self):
+        """Whether the requires_ansible metadata is compatible with the ansible-core version.
+
+        If the version is unspecified/None/"", it is assumed to be compatible, to match runtime behavior.
         """
-        A boolean indicating whether the optional requires_ansible collection metadata is compatible with the running ansible version.
-        If the version is unspecified/None/"", it is assumed to be compatible to match runtime behavior.
-        """
-        # TODO: consider adding a toggle to make requires_ansible required.
-        # Besides being a documentation issue, missing metadata can cause a couple issues for galaxy type collections:
-        # - If no versions of the collection support the ansible version, an ancient version
-        #   missing the metadata would be selected instead of the latest.
-        # - Galaxy v2 servers and old GalaxyNG servers don't supply this metadata even when
-        #   the collection documents it.
+        # If no versions of a collection support ansible-core, the default behavior would select
+        # an ancient version missing metadata if there is one.
+        # TODO: add a toggle to require the metadata.
         if self.ver in ('', None) and C.COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH != 'ignore':
-            warning = (
-                "" if self._parent.type != 'galaxy' or self._parent.src.api_server == _DEFAULT_NORMALIZED_SERVER
-                else f"Galaxy server {self._parent.src.api_server} didn't return 'requires_ansible' metadata for {self._parent!r} or "
-            )
+
+            warning = ""
+
+            if self._parent.type == 'galaxy' and self._parent.src.api_server != _DEFAULT_NORMALIZED_SERVER:
+                # warning for custom galaxy servers
+                warning = f"Galaxy server {self._parent.src.api_server} didn't return " \
+                          f"'requires_ansible' metadata for {self._parent!r} or "
+
             display.warning(
                 f"{warning}{self._parent!r} has not documented 'requires_ansible' in the meta/runtime.yml. "
-                f"Assuming compatibility with Ansible {_ANSIBLE_CANDIDATE_VERSION}."
+                f"Assuming compatibility with ansible-core {_ANSIBLE_RUNTIME_VERSION}."
             )
         return (
-            _does_collection_support_ansible_version(self.ver or '', _ANSIBLE_CANDIDATE_VERSION)
+            _does_collection_support_ansible_version(self.ver or '', _ANSIBLE_RUNTIME_VERSION)
             or C.COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH == "ignore"
         )
 
@@ -673,9 +678,9 @@ class AnsibleRequirement(Requirement):
         """
         Create a Requirement from a collection's requires_ansible metadata.
         """
-        # Note: This should be called in/after calling find_matches.
+        # NOTE: This should be called in/after calling find_matches.
         # The candidate.src.requires_ansible cache is populated in find_matches.
-        # The concrete artifact data is avaiable after the temporary artifact is downloaded or built.
+        # The concrete artifact data is available after the temporary artifact is downloaded or built.
         if candidate.is_virtual:
             return None
 
@@ -684,6 +689,7 @@ class AnsibleRequirement(Requirement):
         else:
             requires_ansible = concrete_art_mgr.get_direct_requires_ansible(candidate)
 
-        res = cls("Ansible", requires_ansible, None, "requires_ansible", None)
+        # Passing the "fqcn" attribute so __unicode__ doesn't need to be overridden.
+        res = cls("ansible-core", requires_ansible, None, "requires_ansible", None)
         res._parent = candidate
         return res

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -172,7 +172,7 @@ def _is_concrete_artifact_pointer(tested_str):
 class _ComputedReqKindsMixin:
     UNIQUE_ATTRS = ('fqcn', 'ver', 'src', 'type')
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: object, **kwargs: object) -> None:
         if not self.may_have_offline_galaxy_info:
             self._source_info = None
         else:
@@ -184,6 +184,11 @@ class _ComputedReqKindsMixin:
                 self.name,
                 self.ver
             )
+        # This is used by requires_ansible requirement error handling.
+        # ResolutionImpossible causes have access to the parent,
+        # i.e. the incompatible collection containing the metadata,
+        # but not its origin.
+        self._parent: Candidate | None = None
 
     def __hash__(self):
         return hash(tuple(getattr(self, attr) for attr in _ComputedReqKindsMixin.UNIQUE_ATTRS))

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -26,15 +26,19 @@ if t.TYPE_CHECKING:
         '_ComputedReqKindsMixin',
     )
 
+from ansible import release
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.collection import HAS_PACKAGING, PkgReq
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.common.arg_spec import ArgumentSpecValidator
+from ansible.plugins.loader import _does_collection_support_ansible_version
 from ansible.utils.collection_loader import AnsibleCollectionRef
 from ansible.utils.display import Display
+from ansible.utils.version import SemanticVersion, LooseVersion
 
 
+_ANSIBLE_CANDIDATE_VERSION = SemanticVersion.from_loose_version(LooseVersion(release.__version__)).vstring
 _ALLOW_CONCRETE_POINTER_IN_SOURCE = False  # NOTE: This is a feature flag
 _GALAXY_YAML = b'galaxy.yml'
 _MANIFEST_JSON = b'MANIFEST.json'
@@ -180,6 +184,7 @@ class _ComputedReqKindsMixin:
                 self.name,
                 self.ver
             )
+        self._parent = None
 
     def __hash__(self):
         return hash(tuple(getattr(self, attr) for attr in _ComputedReqKindsMixin.UNIQUE_ATTRS))
@@ -517,7 +522,7 @@ class _ComputedReqKindsMixin:
 
     @property
     def canonical_package_id(self):
-        if not self.is_virtual:
+        if not self.is_virtual or self.is_ansible:
             return to_native(self.fqcn)
 
         return (
@@ -527,7 +532,11 @@ class _ComputedReqKindsMixin:
 
     @property
     def is_virtual(self):
-        return self.is_scm or self.is_subdirs
+        return self.is_scm or self.is_subdirs or self.is_ansible
+
+    @property
+    def is_ansible(self):
+        return self.type == "requires_ansible"
 
     @property
     def is_file(self):
@@ -631,3 +640,51 @@ class Candidate(
 
         signatures = self.src.get_collection_signatures(self.namespace, self.name, self.ver)
         return self.__class__(self.fqcn, self.ver, self.src, self.type, frozenset([*self.signatures, *signatures]))
+
+
+class AnsibleRequirement(Requirement):
+    @property
+    def supports_ansible(self):
+        """
+        A boolean indicating whether the optional requires_ansible collection metadata is compatible with the running ansible version.
+        If the version is unspecified/None/"", it is assumed to be compatible to match runtime behavior.
+        """
+        # TODO: consider adding a toggle to make requires_ansible required.
+        # Besides being a documentation issue, missing metadata can cause a couple issues for galaxy type collections:
+        # - If no versions of the collection support the ansible version, an ancient version
+        #   missing the metadata would be selected instead of the latest.
+        # - Galaxy v2 servers and old GalaxyNG servers don't supply this metadata even when
+        #   the collection documents it.
+        if self.ver in ('', None) and C.COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH != 'ignore':
+            warning = (
+                "" if self._parent.type != 'galaxy' or self._parent.src.api_server == "https://galaxy.ansible.com/api/"
+                else f"Galaxy server {self._parent.src.api_server} didn't return 'requires_ansible' metadata for {self._parent!r} or "
+            )
+            display.warning(
+                f"{warning}{self._parent!r} has not documented 'requires_ansible' in the meta/runtime.yml. "
+                f"Assuming compatibility with Ansible {_ANSIBLE_CANDIDATE_VERSION}."
+            )
+        return (
+            _does_collection_support_ansible_version(self.ver or '', _ANSIBLE_CANDIDATE_VERSION)
+            or C.COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH == "ignore"
+        )
+
+    @classmethod
+    def from_collection(cls, concrete_art_mgr: ConcreteArtifactsManager, candidate: Candidate):
+        """
+        Create a Requirement from a collection's requires_ansible metadata.
+        """
+        # Note: This should be called in/after calling find_matches.
+        # The candidate.src.requires_ansible cache is populated in find_matches.
+        # The concrete artifact data is avaiable after the temporary artifact is downloaded or built.
+        if candidate.is_virtual:
+            return None
+
+        if candidate.type == 'galaxy':
+            requires_ansible = (candidate.src.requires_ansible.get(candidate.fqcn) or {}).get(candidate.ver)
+        else:
+            requires_ansible = concrete_art_mgr.get_direct_requires_ansible(candidate)
+
+        res = cls("Ansible", requires_ansible, None, "requires_ansible", None)
+        res._parent = candidate
+        return res

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -436,15 +436,14 @@ class CollectionDependencyProviderBase(AbstractProvider):
             requirements=requirement.ver,
         )
 
-    def get_dependencies(self, candidate):
-        # type: (Candidate) -> list[Candidate]
+    def get_dependencies(self, candidate: Candidate) -> t.Generator[Requirement]:
         r"""Get direct dependencies of a candidate.
 
         :returns: A collection of requirements that `candidate` \
                   specifies as its dependencies.
         """
         if candidate.type == "requires_ansible":
-            return []
+            return
 
         # FIXME: If there's several galaxy servers set, there may be a
         # FIXME: situation when the metadata of the same collection
@@ -474,6 +473,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
         if (requires_ansible := self._get_ansible_requirement(candidate)):
             requires_ansible._parent = candidate
             yield requires_ansible
+
 
 # Classes to handle resolvelib API changes between minor versions for 0.X
 class CollectionDependencyProvider050(CollectionDependencyProviderBase):

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -17,8 +17,11 @@ if t.TYPE_CHECKING:
 
 from ansible.galaxy.collection.gpg import get_signature_from_source
 from ansible.galaxy.dependency_resolution.dataclasses import (
+    _ANSIBLE_CANDIDATE_VERSION,
     Candidate,
     Requirement,
+    AnsibleRequirement,
+
 )
 from ansible.galaxy.dependency_resolution.versioning import (
     is_pre_release,
@@ -83,6 +86,10 @@ class CollectionDependencyProviderBase(AbstractProvider):
         self._make_req_from_dict = functools.partial(
             Requirement.from_requirement_dict,
             art_mgr=concrete_artifacts_manager,
+        )
+        self._get_ansible_requirement = functools.partial(
+            AnsibleRequirement.from_collection,
+            concrete_artifacts_manager,
         )
         self._preferred_candidates = set(preferred_candidates or ())
         self._with_deps = with_deps
@@ -238,6 +245,11 @@ class CollectionDependencyProviderBase(AbstractProvider):
         # The fqcn is guaranteed to be the same
         version_req = "A SemVer-compliant version or '*' is required. See https://semver.org to learn how to compose it correctly. "
         version_req += "This is an issue with the collection."
+
+        if first_req.type == "requires_ansible":
+            if all(req.supports_ansible for req in requirements):
+                return [Candidate("Ansible", _ANSIBLE_CANDIDATE_VERSION, None, "requires_ansible", None)]
+            return []
 
         # If we're upgrading collections, we can't calculate preinstalled_candidates until the latest matches are found.
         # Otherwise, we can potentially avoid a Galaxy API call by doing this first.
@@ -431,6 +443,9 @@ class CollectionDependencyProviderBase(AbstractProvider):
         :returns: A collection of requirements that `candidate` \
                   specifies as its dependencies.
         """
+        if candidate.type == "requires_ansible":
+            return []
+
         # FIXME: If there's several galaxy servers set, there may be a
         # FIXME: situation when the metadata of the same collection
         # FIXME: differs. So how do we resolve this case? Priority?
@@ -449,14 +464,16 @@ class CollectionDependencyProviderBase(AbstractProvider):
         #
         # NOTE: Virtual candidates should always return dependencies
         # NOTE: because they are ephemeral and non-installable.
-        if not self._with_deps and not candidate.is_virtual:
-            return []
+        for dep_name, dep_req in req_map.items():
+            if not (self._with_deps or candidate.is_virtual):
+                continue
+            dependency = self._make_req_from_dict({'name': dep_name, 'version': dep_req})
+            dependency._parent = candidate  # Used by requires_ansible error handling, to display whether the error was caused by direct request or dependency
+            yield dependency
 
-        return [
-            self._make_req_from_dict({'name': dep_name, 'version': dep_req})
-            for dep_name, dep_req in req_map.items()
-        ]
-
+        if (requires_ansible := self._get_ansible_requirement(candidate)):
+            requires_ansible._parent = candidate
+            yield requires_ansible
 
 # Classes to handle resolvelib API changes between minor versions for 0.X
 class CollectionDependencyProvider050(CollectionDependencyProviderBase):

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -45,13 +45,6 @@ RESOLVELIB_UPPERBOUND = SemanticVersion("2.0.0")
 RESOLVELIB_VERSION = SemanticVersion.from_loose_version(LooseVersion(resolvelib_version))
 
 
-# This is used by requires_ansible requirement error handling.
-# ResolutionImpossible causes have access to the parent,
-# i.e. the incompatible collection containing the metadata,
-# but not its origin.
-_dependency_origin: dict[str, Candidate] = {}
-
-
 class CollectionDependencyProviderBase(AbstractProvider):
     """Delegate providing a requirement interface for the resolver."""
 
@@ -474,10 +467,11 @@ class CollectionDependencyProviderBase(AbstractProvider):
             if not (self._with_deps or candidate.is_virtual):
                 continue
             dependency = self._make_req_from_dict({'name': dep_name, 'version': dep_req})
-            _dependency_origin[repr(dependency)] = candidate
+            dependency._parent = candidate
             yield dependency
 
         if (requires_ansible := self._get_ansible_requirement(candidate)):
+            requires_ansible._parent = candidate
             yield requires_ansible
 
 

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -44,6 +44,10 @@ RESOLVELIB_LOWERBOUND = SemanticVersion("0.5.3")
 RESOLVELIB_UPPERBOUND = SemanticVersion("2.0.0")
 RESOLVELIB_VERSION = SemanticVersion.from_loose_version(LooseVersion(resolvelib_version))
 
+# ResolutionImpossible does not share the full dependency tree of a failed requirement, only the parent.
+# This is used by requires_ansible error handling to display the origin of the incompatible collection.
+_dependency_origin: dict[str, Candidate] = {}
+
 
 class CollectionDependencyProviderBase(AbstractProvider):
     """Delegate providing a requirement interface for the resolver."""
@@ -467,11 +471,10 @@ class CollectionDependencyProviderBase(AbstractProvider):
             if not (self._with_deps or candidate.is_virtual):
                 continue
             dependency = self._make_req_from_dict({'name': dep_name, 'version': dep_req})
-            dependency._parent = candidate  # Used by requires_ansible error handling, to display whether the error was caused by direct request or dependency
+            _dependency_origin[f"{dependency}"] = candidate
             yield dependency
 
         if (requires_ansible := self._get_ansible_requirement(candidate)):
-            requires_ansible._parent = candidate
             yield requires_ansible
 
 

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -44,9 +44,12 @@ RESOLVELIB_LOWERBOUND = SemanticVersion("0.5.3")
 RESOLVELIB_UPPERBOUND = SemanticVersion("2.0.0")
 RESOLVELIB_VERSION = SemanticVersion.from_loose_version(LooseVersion(resolvelib_version))
 
-# ResolutionImpossible does not share the full dependency tree of a failed requirement, only the parent.
-# This is used by requires_ansible error handling to display the origin of the incompatible collection.
-_dependency_origin: dict[str, Candidate] = {}
+
+# This is used by requires_ansible requirement error handling.
+# ResolutionImpossible causes have access to the parent,
+# i.e. the incompatible collection containing the metadata,
+# but not its origin.
+_dependency_origin: dict[Requirement, Candidate] = {}
 
 
 class CollectionDependencyProviderBase(AbstractProvider):
@@ -471,7 +474,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
             if not (self._with_deps or candidate.is_virtual):
                 continue
             dependency = self._make_req_from_dict({'name': dep_name, 'version': dep_req})
-            _dependency_origin[f"{dependency}"] = candidate
+            _dependency_origin[dependency] = candidate
             yield dependency
 
         if (requires_ansible := self._get_ansible_requirement(candidate)):

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -49,7 +49,7 @@ RESOLVELIB_VERSION = SemanticVersion.from_loose_version(LooseVersion(resolvelib_
 # ResolutionImpossible causes have access to the parent,
 # i.e. the incompatible collection containing the metadata,
 # but not its origin.
-_dependency_origin: dict[Requirement, Candidate] = {}
+_dependency_origin: dict[str, Candidate] = {}
 
 
 class CollectionDependencyProviderBase(AbstractProvider):
@@ -474,7 +474,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
             if not (self._with_deps or candidate.is_virtual):
                 continue
             dependency = self._make_req_from_dict({'name': dep_name, 'version': dep_req})
-            _dependency_origin[dependency] = candidate
+            _dependency_origin[repr(dependency)] = candidate
             yield dependency
 
         if (requires_ansible := self._get_ansible_requirement(candidate)):

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -17,7 +17,7 @@ if t.TYPE_CHECKING:
 
 from ansible.galaxy.collection.gpg import get_signature_from_source
 from ansible.galaxy.dependency_resolution.dataclasses import (
-    _ANSIBLE_CANDIDATE_VERSION,
+    _ANSIBLE_RUNTIME_VERSION,
     Candidate,
     Requirement,
     AnsibleRequirement,
@@ -255,7 +255,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
 
         if first_req.type == "requires_ansible":
             if all(req.supports_ansible for req in requirements):
-                return [Candidate("Ansible", _ANSIBLE_CANDIDATE_VERSION, None, "requires_ansible", None)]
+                return [Candidate(first_req.fqcn, _ANSIBLE_RUNTIME_VERSION, None, "requires_ansible", None)]
             return []
 
         # If we're upgrading collections, we can't calculate preinstalled_candidates until the latest matches are found.
@@ -443,7 +443,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
             requirements=requirement.ver,
         )
 
-    def get_dependencies(self, candidate: Candidate) -> t.Generator[Requirement]:
+    def get_dependencies(self, candidate: Candidate) -> t.Iterator[Requirement]:
         r"""Get direct dependencies of a candidate.
 
         :returns: A collection of requirements that `candidate` \

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/download.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/download.yml
@@ -12,11 +12,16 @@
   args:
     chdir: '{{ galaxy_dir }}/download'
   register: download_collection
+  # TODO: remove external dependencies and define requires_ansible based on the current version
+  environment:
+    ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
 
 - name: check that the amazon.aws collection was downloaded
   stat:
     path: '{{ galaxy_dir }}/download/collections/amazon-aws-1.0.0.tar.gz'
   register: download_collection_amazon_actual
+  environment:
+    ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
 
 - name: check that the awx.awx collection was downloaded
   stat:
@@ -34,6 +39,8 @@
   command: 'ansible-galaxy collection install -r requirements.yml --no-deps'
   args:
     chdir: '{{ galaxy_dir }}/download/collections/'
+  environment:
+    ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
 
 - name: list installed collections
   command: 'ansible-galaxy collection list'

--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -55,6 +55,16 @@ options:
         - The dependencies of the collection.
         type: dict
         default: '{}'
+      use_symlink:
+        description:
+        - Create a symlink in the collection.
+        type: bool
+        default: False
+      runtime:
+        description:
+        - File content for meta/runtime.yml.
+        type: str
+        default: 'requires_ansible: ">=2.9"'
 author:
 - Jordan Borean (@jborean93)
 """
@@ -100,6 +110,7 @@ def publish_collection(module, collection):
     version = collection['version']
     dependencies = collection['dependencies']
     use_symlink = collection['use_symlink']
+    runtime = collection['runtime']
 
     result = {}
     collection_dir = os.path.join(module.tmpdir, "%s-%s-%s" % (namespace, name, version))
@@ -123,7 +134,7 @@ def publish_collection(module, collection):
     with open(os.path.join(b_collection_dir, b'galaxy.yml'), mode='wb') as fd:
         fd.write(to_bytes(yaml.safe_dump(galaxy_meta), errors='surrogate_or_strict'))
     with open(os.path.join(b_collection_dir, b'meta/runtime.yml'), mode='wb') as fd:
-        fd.write(b'requires_ansible: ">=1.0.0"')
+        fd.write(to_bytes(runtime))
 
     with tempfile.NamedTemporaryFile(mode='wb') as temp_fd:
         temp_fd.write(b"data")
@@ -238,6 +249,7 @@ def run_module():
                 version=dict(type='str', default='1.0.0'),
                 dependencies=dict(type='dict', default={}),
                 use_symlink=dict(type='bool', default=False),
+                runtime=dict(type='str', default='requires_ansible: ">=2.9"'),
             ),
         ),
         signature_dir=dict(type='path', default=None),

--- a/test/integration/targets/ansible-galaxy-collection/tasks/check_requires_ansible.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/check_requires_ansible.yml
@@ -8,33 +8,34 @@
     install_or_download: "ansible-galaxy collection {{ subcommand }}{{ (subcommand == 'install') | ternary(' --force', '')}}"
     failed_error: |
         \[ERROR\]: Failed to resolve the requested dependencies map\. Could not satisfy the following requirements:
-        \* ns_requires_ansible\.name_requires_ansible:1\.0\.0 \(direct request\) requires Ansible <{{ ansible_version.major }}\.{{ ansible_version.minor }}
+        \* ns_requires_ansible\.name_requires_ansible:1\.0\.0 \(direct request\) requires ansible-core <{{ ansible_version.major }}\.{{ ansible_version.minor }}
     hint: >-
-        Hint: To disregard whether the collection supports the current version of Ansible, configure
-        COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH as "ignore"
-    undocumented_from_server_warning: >-
-        \[WARNING\]: Galaxy server .* didn't return 'requires_ansible' metadata for
-        <ns_requires_ansible\.name_requires_ansible:.* of type 'galaxy' from .*> or
-        <ns_requires_ansible\.name_requires_ansible:.* of type 'galaxy' from .*> has not
-        documented 'requires_ansible' in the meta/runtime\.yml.
-        Assuming compatibility with Ansible {{ ansible_version.major }}\.{{ ansible_version.minor }}\.{{ ansible_version.revision }}\.
+        Hint: To disregard whether the collection supports the current version
+        of ansible-core, configure COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH as "ignore"
     undocumented_warning: >-
       \[WARNING\]: <ns_requires_ansible\.name_requires_ansible:.* of type .*> has not
-      documented 'requires_ansible' in the meta/runtime\.yml. Assuming compatibility with Ansible
+      documented 'requires_ansible' in the meta/runtime\.yml. Assuming compatibility with ansible-core
       {{ ansible_version.major }}\.{{ ansible_version.minor }}\.{{ ansible_version.revision }}\.
   block:
-  # TODO: Once the test server is updated, this should fail as expected.
   - name: "{{ subcommand }} incompatible collection"
     command: "{{ install_or_download }} -p {{ temp1 }} ns_requires_ansible.name_requires_ansible"
-    register: expected_warning
-    # register: expected_fail
-    # failed_when: expected_fail is success
+    register: expected_fail
+    failed_when: expected_fail is success
 
   - assert:
       that:
-        - expected_warning.stderr is search(undocumented_from_server_warning)
-        # - expected_fail.stderr is search(failed_error, multiline=True)
-        # - expected_fail.stderr is search(hint)
+        - expected_fail.stderr is search(failed_error, multiline=True)
+        - expected_fail.stderr is search(hint)
+
+  - name: "{{ subcommand }} specific version of incompatible collection"
+    command: "{{ install_or_download }} -p {{ temp1 }} 'ns_requires_ansible.name_requires_ansible:1.0.0'"
+    register: expected_fail
+    failed_when: expected_fail is success
+
+  - assert:
+      that:
+        - expected_fail.stderr is search(failed_error, multiline=True)
+        - expected_fail.stderr is search(hint)
 
   - name: "{{ subcommand }} collection and allow mismatched version"
     command: ansible-galaxy collection download -p {{ temp1 }} ns_requires_ansible.name_requires_ansible

--- a/test/integration/targets/ansible-galaxy-collection/tasks/check_requires_ansible.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/check_requires_ansible.yml
@@ -1,0 +1,103 @@
+- environment:
+    ANSIBLE_NOCOLOR: True
+    ANSIBLE_FORCE_COLOR: false
+  vars:
+    test_base_dir: "{{ [remote_tmp_dir, 'requires_ansible_' ~ subcommand] | path_join }}"
+    temp1: "{{ [test_base_dir, 'collections'] | path_join }}"
+    temp2: "{{ [test_base_dir, 'other_collections'] | path_join }}"
+    install_or_download: "ansible-galaxy collection {{ subcommand }}{{ (subcommand == 'install') | ternary(' --force', '')}}"
+    failed_error: |
+        \[ERROR\]: Failed to resolve the requested dependencies map\. Could not satisfy the following requirements:
+        \* ns_requires_ansible\.name_requires_ansible:1\.0\.0 \(direct request\) requires Ansible <{{ ansible_version.major }}\.{{ ansible_version.minor }}
+    hint: >-
+        Hint: To disregard whether the collection supports the current version of Ansible, configure
+        COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH as "ignore"
+    undocumented_from_server_warning: >-
+        \[WARNING\]: Galaxy server .* didn't return 'requires_ansible' metadata for
+        <ns_requires_ansible\.name_requires_ansible:.* of type 'galaxy' from .*> or
+        <ns_requires_ansible\.name_requires_ansible:.* of type 'galaxy' from .*> has not
+        documented 'requires_ansible' in the meta/runtime\.yml.
+        Assuming compatibility with Ansible {{ ansible_version.major }}\.{{ ansible_version.minor }}\.{{ ansible_version.revision }}\.
+    undocumented_warning: >-
+      \[WARNING\]: <ns_requires_ansible\.name_requires_ansible:.* of type .*> has not
+      documented 'requires_ansible' in the meta/runtime\.yml. Assuming compatibility with Ansible
+      {{ ansible_version.major }}\.{{ ansible_version.minor }}\.{{ ansible_version.revision }}\.
+  block:
+  # TODO: Once the test server is updated, this should fail as expected.
+  - name: "{{ subcommand }} incompatible collection"
+    command: "{{ install_or_download }} -p {{ temp1 }} ns_requires_ansible.name_requires_ansible"
+    register: expected_warning
+    # register: expected_fail
+    # failed_when: expected_fail is success
+
+  - assert:
+      that:
+        - expected_warning.stderr is search(undocumented_from_server_warning)
+        # - expected_fail.stderr is search(failed_error, multiline=True)
+        # - expected_fail.stderr is search(hint)
+
+  - name: "{{ subcommand }} collection and allow mismatched version"
+    command: ansible-galaxy collection download -p {{ temp1 }} ns_requires_ansible.name_requires_ansible
+    environment:
+      ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
+
+  - name: "{{ subcommand }} incompatible tarfile"
+    command: "{{ install_or_download }} -p {{ temp2 }} {{ temp1 }}/ns_requires_ansible-name_requires_ansible-1.0.0.tar.gz"
+    register: expected_fail
+    failed_when: expected_fail is success
+
+  - assert:
+      that:
+        - expected_fail.stderr is search(failed_error, multiline=True)
+        - expected_fail.stderr is search(hint)
+
+  - name: "{{ subcommand }} tarfile and allow mismatched version"
+    command: "{{ install_or_download }} -p {{ temp2 }} {{ temp1 }}/ns_requires_ansible-name_requires_ansible-1.0.0.tar.gz"
+    environment:
+      ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
+
+  - name: setup - {{ subcommand }} build directory
+    block:
+      - name: setup - init collection build directory
+        command: ansible-galaxy collection init ns_requires_ansible.name_requires_ansible --init-path {{ temp2 }}/ansible_collections
+
+      - name: setup - add  requires_ansible in the runtime file
+        shell: >-
+          echo 'requires_ansible: "{{ incompatible_version }}"' > {{ temp2 }}/ansible_collections/ns_requires_ansible/name_requires_ansible/meta/runtime.yml
+        vars:
+          incompatible_version: "<{{ ansible_version.major }}.{{ ansible_version.minor }}"
+    when: subcommand == 'download'
+
+  - name: "{{ subcommand }} incompatible directory"
+    command: "{{ install_or_download }} -p {{ temp1 }} {{ temp2 }}/ansible_collections/ns_requires_ansible/name_requires_ansible"
+    register: expected_fail
+    failed_when: expected_fail is success
+
+  - assert:
+      that:
+        - expected_fail.stderr is search(failed_error, multiline=True)
+        - expected_fail.stderr is search(hint)
+
+  - name: "{{ subcommand }} directory and allow mismatched version"
+    command: "{{ install_or_download }} -p {{ temp1 }} {{ temp2 }}/ansible_collections/ns_requires_ansible/name_requires_ansible"
+    environment:
+      ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
+
+  - name: setup - {{ subcommand }} remove requires_ansible metadata
+    file:
+      path: "{{ temp2 }}/ansible_collections/ns_requires_ansible/name_requires_ansible/meta/runtime.yml"
+      state: absent
+
+  - name: "{{ subcommand }} directory with undocumented, optional requires_ansible metadata"
+    command: "{{ install_or_download }} -p {{ temp1 }} {{ temp2 }}/ansible_collections/ns_requires_ansible/name_requires_ansible"
+    register: expected_success
+
+  - assert:
+      that:
+        - expected_success.stderr is search(undocumented_warning)
+
+  always:
+  - name: Clean up test dir
+    file:
+      path: "{{ test_base_dir }}"
+      state: absent

--- a/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
@@ -210,9 +210,15 @@
 - name: run ansible-galaxy collection list tests
   include_tasks: list.yml
 
-- include_tasks: upgrade.yml
-  args:
-    apply:
-      environment:
-        ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
-        ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
+- environment:
+    ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+  block:
+  - include_tasks: upgrade.yml
+
+  - include_tasks: check_requires_ansible.yml
+    loop:
+      - install
+      - download
+    loop_control:
+      loop_var: subcommand

--- a/test/integration/targets/ansible-galaxy-collection/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/vars/main.yml
@@ -205,3 +205,9 @@ collection_list:
     version: 4.5.6
     dependencies:
       ns_with_wildcard_dep.name_with_wildcard_dep: 5.6.7-beta.3
+
+  - namespace: ns_requires_ansible
+    name: name_requires_ansible
+    version: 1.0.0
+    runtime: |-
+      requires_ansible: "<{{ ansible_version.major }}.{{ ansible_version.minor }}"

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -39,8 +39,8 @@ class RequirementCandidates():
 
     def func_wrapper(self, func):
         def run(*args, **kwargs):
-            self.candidates = func(*args, **kwargs)
-            return self.candidates
+            self.candidates.append(func(*args, **kwargs))
+            return self.candidates[-1]
         return run
 
 
@@ -81,6 +81,11 @@ def collection_artifact(request, tmp_path_factory):
         galaxy_obj.seek(0)
         galaxy_obj.write(to_bytes(yaml.safe_dump(existing_yaml)))
         galaxy_obj.truncate()
+
+    os.mkdir(os.path.join(collection_path, 'meta'))
+    runtime = os.path.join(collection_path, 'meta/runtime.yml')
+    with open(runtime, 'wb') as runtime_obj:
+        runtime_obj.write(b"requires_ansible: '>=2.8.0'\n")
 
     # Create a file with +x in the collection so we can test the permissions
     execute_path = os.path.join(collection_path, 'runme.sh')
@@ -635,7 +640,12 @@ def test_build_requirement_from_name_single_version(galaxy_server, monkeypatch, 
     assert actual.name == u'collection'
     assert actual.src == galaxy_server
     assert actual.ver == u'2.0.0'
-    assert [c.ver for c in matches.candidates] == [u'2.0.0']
+    assert len(matches.candidates) == 2
+    assert len(matches.candidates[0]) == 1
+    assert len(matches.candidates[1]) == 1
+    assert matches.candidates[0][0].fqcn == u'namespace.collection'
+    assert matches.candidates[0][0].ver == u'2.0.0'
+    assert matches.candidates[1][0].fqcn == u'Ansible'
 
     assert mock_get_info.call_count == 1
     assert mock_get_info.mock_calls[0][1] == ('namespace', 'collection', '2.0.0')
@@ -672,7 +682,13 @@ def test_build_requirement_from_name_multiple_versions_one_match(galaxy_server, 
     assert actual.name == u'collection'
     assert actual.src == galaxy_server
     assert actual.ver == u'2.0.1'
-    assert [c.ver for c in matches.candidates] == [u'2.0.1']
+
+    assert len(matches.candidates) == 2
+    assert len(matches.candidates[0]) == 1
+    assert len(matches.candidates[1]) == 1
+    assert matches.candidates[0][0].fqcn == u'namespace.collection'
+    assert matches.candidates[0][0].ver == u'2.0.1'
+    assert matches.candidates[1][0].fqcn == u'Ansible'
 
     assert mock_get_versions.call_count == 1
     assert mock_get_versions.mock_calls[0][1] == ('namespace', 'collection')
@@ -714,8 +730,14 @@ def test_build_requirement_from_name_multiple_version_results(galaxy_server, mon
     assert actual.name == u'collection'
     assert actual.src == galaxy_server
     assert actual.ver == u'2.0.5'
+
+    assert len(matches.candidates) == 2
+    assert len(matches.candidates[0]) == 5
+    assert len(matches.candidates[1]) == 1
+    assert all(c.fqcn == u'namespace.collection' for c in matches.candidates[0])
     # should be ordered latest to earliest
-    assert [c.ver for c in matches.candidates] == [u'2.0.5', u'2.0.4', u'2.0.3', u'2.0.1', u'2.0.0']
+    assert [c.ver for c in matches.candidates[0]] == [u'2.0.5', u'2.0.4', u'2.0.3', u'2.0.1', u'2.0.0']
+    assert matches.candidates[1][0].fqcn == u'Ansible'
 
     assert mock_get_versions.call_count == 1
     assert mock_get_versions.mock_calls[0][1] == ('namespace', 'collection')
@@ -818,7 +840,7 @@ def test_install_collection(collection_artifact, monkeypatch):
 
     actual_files = os.listdir(collection_path)
     actual_files.sort()
-    assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'playbooks', b'plugins', b'roles',
+    assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'meta', b'playbooks', b'plugins', b'roles',
                             b'runme.sh']
 
     assert stat.S_IMODE(os.stat(os.path.join(collection_path, b'plugins')).st_mode) == S_IRWXU_RXG_RXO
@@ -854,7 +876,7 @@ def test_install_collection_with_download(galaxy_server, collection_artifact, mo
 
     actual_files = os.listdir(collection_path)
     actual_files.sort()
-    assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'playbooks', b'plugins', b'roles',
+    assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'meta', b'playbooks', b'plugins', b'roles',
                             b'runme.sh']
 
     assert mock_display.call_count == 2
@@ -885,7 +907,7 @@ def test_install_collections_from_tar(collection_artifact, monkeypatch):
 
     actual_files = os.listdir(collection_path)
     actual_files.sort()
-    assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'playbooks', b'plugins', b'roles',
+    assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'meta', b'playbooks', b'plugins', b'roles',
                             b'runme.sh']
 
     with open(os.path.join(collection_path, b'MANIFEST.json'), 'rb') as manifest_obj:
@@ -924,7 +946,7 @@ def test_install_collection_with_circular_dependency(collection_artifact, monkey
 
     actual_files = os.listdir(collection_path)
     actual_files.sort()
-    assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'playbooks', b'plugins', b'roles',
+    assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'meta', b'playbooks', b'plugins', b'roles',
                             b'runme.sh']
 
     with open(os.path.join(collection_path, b'MANIFEST.json'), 'rb') as manifest_obj:

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -645,7 +645,7 @@ def test_build_requirement_from_name_single_version(galaxy_server, monkeypatch, 
     assert len(matches.candidates[1]) == 1
     assert matches.candidates[0][0].fqcn == u'namespace.collection'
     assert matches.candidates[0][0].ver == u'2.0.0'
-    assert matches.candidates[1][0].fqcn == u'Ansible'
+    assert matches.candidates[1][0].fqcn == u'ansible-core'
 
     assert mock_get_info.call_count == 1
     assert mock_get_info.mock_calls[0][1] == ('namespace', 'collection', '2.0.0')
@@ -688,7 +688,7 @@ def test_build_requirement_from_name_multiple_versions_one_match(galaxy_server, 
     assert len(matches.candidates[1]) == 1
     assert matches.candidates[0][0].fqcn == u'namespace.collection'
     assert matches.candidates[0][0].ver == u'2.0.1'
-    assert matches.candidates[1][0].fqcn == u'Ansible'
+    assert matches.candidates[1][0].fqcn == u'ansible-core'
 
     assert mock_get_versions.call_count == 1
     assert mock_get_versions.mock_calls[0][1] == ('namespace', 'collection')
@@ -737,7 +737,7 @@ def test_build_requirement_from_name_multiple_version_results(galaxy_server, mon
     assert all(c.fqcn == u'namespace.collection' for c in matches.candidates[0])
     # should be ordered latest to earliest
     assert [c.ver for c in matches.candidates[0]] == [u'2.0.5', u'2.0.4', u'2.0.3', u'2.0.1', u'2.0.0']
-    assert matches.candidates[1][0].fqcn == u'Ansible'
+    assert matches.candidates[1][0].fqcn == u'ansible-core'
 
     assert mock_get_versions.call_count == 1
     assert mock_get_versions.mock_calls[0][1] == ('namespace', 'collection')


### PR DESCRIPTION
##### SUMMARY

Fixes #78539

* Make ansible-galaxy consider existing `COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH`  configuration. Now collections with mismatched requirements are only installed/downloaded if it's set to "ignore".

##### ISSUE TYPE

- Bugfix Pull Request
