### PR TITLE
Windows - Support WDAC Audit Mode

### DIFF
--- a/changelogs/fragments/win-wdac-audit.yml
+++ b/changelogs/fragments/win-wdac-audit.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    Windows - add support for running on system where WDAC is in audit mode with
+    ``Dynamic Code Security`` enabled.


### PR DESCRIPTION
##### SUMMARY
Fix up bug when attempting to run any module on a Windows host that has been configured with WDAC and Dynamic Code Security in audit mode. This does not enable WDAC support with signed scripts so Ansible will still not pass the audit events but it no longer fails to run.

Some background info can be found in https://github.com/ansible-collections/ansible.windows/issues/588.

##### ISSUE TYPE
- Bugfix Pull Request