### PR TITLE
ansible-test - Support target testing with black

### DIFF
--- a/test/sanity/code-smell/black.json
+++ b/test/sanity/code-smell/black.json
@@ -1,10 +1,12 @@
 {
     "prefixes": [
+        "lib/ansible/utils/collection_loader/__init__.py",
         "test/sanity/code-smell/black."
     ],
     "extensions": [
         ".py"
     ],
+    "split_targets": true,
     "error_code": "ansible-test",
     "output": "path-message"
 }


### PR DESCRIPTION
##### SUMMARY

Extend the `black` sanity test to support target files. The initial implementation only supported controller files.

##### ISSUE TYPE

Feature Pull Request
