### PR TITLE
[stable-2.18] Limit respawn to supported python versions (#83662)

### DIFF
--- a/changelogs/fragments/respawn-min-python.yml
+++ b/changelogs/fragments/respawn-min-python.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- module respawn - limit to supported Python versions

--- a/lib/ansible/module_utils/common/respawn.py
+++ b/lib/ansible/module_utils/common/respawn.py
@@ -4,10 +4,13 @@
 from __future__ import annotations
 
 import os
+import pathlib
 import subprocess
 import sys
 
 from ansible.module_utils.common.text.converters import to_bytes
+
+_ANSIBLE_PARENT_PATH = pathlib.Path(__file__).parents[3]
 
 
 def has_respawned():
@@ -54,11 +57,20 @@ def probe_interpreters_for_module(interpreter_paths, module_name):
     be returned (or ``None`` if probing fails for all supplied paths).
     :arg module_name: fully-qualified Python module name to probe for (eg, ``selinux``)
     """
+    PYTHONPATH = os.getenv('PYTHONPATH', '')
+    env = os.environ | {'PYTHONPATH': f'{_ANSIBLE_PARENT_PATH}:{PYTHONPATH}'.rstrip(': ')}
     for interpreter_path in interpreter_paths:
         if not os.path.exists(interpreter_path):
             continue
         try:
-            rc = subprocess.call([interpreter_path, '-c', 'import {0}'.format(module_name)])
+            rc = subprocess.call(
+                [
+                    interpreter_path,
+                    '-c',
+                    f'import {module_name}, ansible.module_utils.basic',
+                ],
+                env=env,
+            )
             if rc == 0:
                 return interpreter_path
         except Exception:


### PR DESCRIPTION
* Limit respawn to supported python versions
(cherry picked from commit 00067f1)

Co-authored-by: Matt Martz <matt@sivel.net>