### PR TITLE
Update autoremove example

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -322,11 +322,11 @@ EXAMPLES = """
 
 - name: Remove dependencies that are no longer required
   ansible.builtin.apt:
-    autoremove: yes
+    autoremove: true
 
 - name: Remove dependencies that are no longer required and purge their configuration files
   ansible.builtin.apt:
-    autoremove: yes
+    autoremove: true
     purge: true
 
 - name: Run the equivalent of "apt-get clean" as a separate step


### PR DESCRIPTION
##### SUMMARY
`autoremove` is a boolean, using yes fails ansible-lint with
```
 yaml[truthy]: Truthy value should be one of [false, true]
```
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

- Bugfix Pull Request
