### PR TITLE
dnf tests: unique environment/group name

### DIFF
--- a/test/integration/targets/setup_rpm_repo/files/comps.xml
+++ b/test/integration/targets/setup_rpm_repo/files/comps.xml
@@ -14,7 +14,7 @@
 
   <group>
     <id>customenvgroup</id>
-    <name>Custom Environment Group</name>
+    <name>Custom Group in Environment</name>
     <description></description>
     <default>false</default>
     <uservisible>false</uservisible>


### PR DESCRIPTION
##### SUMMARY
Prevents `Group state for \"customenvgroup\" not found` error which may or may not be a regression in dnf5. Just name groups/envs uniquely to workaround the issue.
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Test Pull Request
