### PR TITLE
Fix collections nested role name

### DIFF
--- a/changelogs/fragments/84796-fix-collection-nested-role-name.yml
+++ b/changelogs/fragments/84796-fix-collection-nested-role-name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Nested role directories in collections won't cut off intermediate directory names in task output

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -1133,16 +1133,7 @@ def _get_collection_playbook_path(playbook):
 
 
 def _get_collection_role_path(role_name, collection_list=None):
-    return _get_collection_resource_path(role_name, u'role', collection_list)
-
-
-def _get_collection_resource_path(name, ref_type, collection_list=None):
-
-    if ref_type == u'playbook':
-        # they are handled a bit diff due to 'extension variance' and no collection_list
-        return _get_collection_playbook_path(name)
-
-    acr = AnsibleCollectionRef.try_parse_fqcr(name, ref_type)
+    acr = AnsibleCollectionRef.try_parse_fqcr(role_name, u'role')
     if acr:
         # looks like a valid qualified collection ref; skip the collection_list
         collection_list = [acr.collection]
@@ -1151,19 +1142,20 @@ def _get_collection_resource_path(name, ref_type, collection_list=None):
     elif not collection_list:
         return None  # not a FQ and no collection search list spec'd, nothing to do
     else:
-        resource = name  # treat as unqualified, loop through the collection search list to try and resolve
+        resource = role_name  # treat as unqualified, loop through the collection search list to try and resolve
         subdirs = ''
 
     for collection_name in collection_list:
         try:
-            acr = AnsibleCollectionRef(collection_name=collection_name, subdirs=subdirs, resource=resource, ref_type=ref_type)
+            acr = AnsibleCollectionRef(collection_name=collection_name, subdirs=subdirs, resource=resource, ref_type=u'role')
             # FIXME: error handling/logging; need to catch any import failures and move along
             pkg = import_module(acr.n_python_package_name)
 
             if pkg is not None:
                 # the package is now loaded, get the collection's package and ask where it lives
                 path = os.path.dirname(to_bytes(sys.modules[acr.n_python_package_name].__file__, errors='surrogate_or_strict'))
-                return resource, to_text(path, errors='surrogate_or_strict'), collection_name
+                subdir_resource = "%s.%s" % (subdirs, resource) if subdirs else resource
+                return subdir_resource, to_text(path, errors='surrogate_or_strict'), collection_name
 
         except (IOError, ModuleNotFoundError) as e:
             continue

--- a/test/units/utils/collection_loader/test_collection_loader.py
+++ b/test/units/utils/collection_loader/test_collection_loader.py
@@ -579,16 +579,17 @@ def test_default_collection_detection():
 
 
 @pytest.mark.parametrize(
-    'role_name,collection_list,expected_collection_name,expected_path_suffix',
+    'role_name,collection_list,expected_collection_name,expected_role_name,expected_path_suffix',
     [
-        ('some_role', ['testns.testcoll', 'ansible.bogus'], 'testns.testcoll', 'testns/testcoll/roles/some_role'),
-        ('testns.testcoll.some_role', ['ansible.bogus', 'testns.testcoll'], 'testns.testcoll', 'testns/testcoll/roles/some_role'),
-        ('testns.testcoll.some_role', [], 'testns.testcoll', 'testns/testcoll/roles/some_role'),
-        ('testns.testcoll.some_role', None, 'testns.testcoll', 'testns/testcoll/roles/some_role'),
-        ('some_role', [], None, None),
-        ('some_role', None, None, None),
+        ('some_role', ['testns.testcoll', 'ansible.bogus'], 'testns.testcoll', 'some_role', 'testns/testcoll/roles/some_role'),
+        ('testns.testcoll.some_role', ['ansible.bogus', 'testns.testcoll'], 'testns.testcoll', 'some_role', 'testns/testcoll/roles/some_role'),
+        ('testns.testcoll.some_role', [], 'testns.testcoll', 'some_role', 'testns/testcoll/roles/some_role'),
+        ('testns.testcoll.some_role', None, 'testns.testcoll', 'some_role', 'testns/testcoll/roles/some_role'),
+        ('testns.testcoll.nested_role.inner_role', None, 'testns.testcoll', 'nested_role.inner_role', 'testns/testcoll/roles/nested_role/inner_role'),
+        ('some_role', [], None, None, None),
+        ('some_role', None, None, None, None),
     ])
-def test_collection_role_name_location(role_name, collection_list, expected_collection_name, expected_path_suffix):
+def test_collection_role_name_location(role_name, collection_list, expected_collection_name, expected_role_name, expected_path_suffix):
     finder = get_default_finder()
     reset_collections_loader_state(finder)
 
@@ -599,11 +600,11 @@ def test_collection_role_name_location(role_name, collection_list, expected_coll
     found = _get_collection_role_path(role_name, collection_list)
 
     if found:
-        assert found[0] == role_name.rpartition('.')[2]
+        assert found[0] == expected_role_name
         assert found[1] == expected_path
         assert found[2] == expected_collection_name
     else:
-        assert expected_collection_name is None and expected_path_suffix is None
+        assert expected_collection_name is None and expected_role_name is None and expected_path_suffix is None
 
 
 def test_bogus_imports():


### PR DESCRIPTION
##### SUMMARY

When using nested role directories in a collection invalid role name gets printed.

```yaml
hosts: localhost
roles:
  - name: example.collection.nested.role

# Prints
# TASK [example.collection.role : ansible.builtin.debug] ***
```

Fix by including subdirectory name in the name result.

Also migrated `_get_collection_resource_path` method to `_get_collection_role_path` as no other usages of it (probably historically used).

Don't know if nested roles are supported or not, but the fix was easy to just fire off the pr :) Fingers crossed.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request (maybe?)
