### PR TITLE
Added Popen warning to lines.py documentation

### DIFF
--- a/lib/ansible/plugins/lookup/lines.py
+++ b/lib/ansible/plugins/lookup/lines.py
@@ -19,6 +19,11 @@ DOCUMENTATION = """
       - Like all lookups, this runs on the Ansible controller and is unaffected by other keywords such as 'become'.
         If you need to use different permissions, you must change the command or run Ansible as another user.
       - Alternatively, you can use a shell/command task that runs against localhost and registers the result.
+      - Lines lookup internally invokes Popen with shell=True (this is required and intentional).
+        This type of invocation is considered a security issue if appropriate care is not taken to sanitize any user provided or variable input.
+        It is strongly recommended to pass user input or variable input via quote filter before using with pipe lookup.
+        See example section for this.
+        Read more about this L(Bandit B602 docs,https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html)
       - The directory of the play is used as the current working directory.
 """
 


### PR DESCRIPTION
##### SUMMARY

builtin.pipe lookup plugin has the same case of using Popen with shell=True as builtin.lines does, and its documentation has a warning about it:

`Pipe lookup internally invokes Popen with shell=True (this is required and intentional).
        This type of invocation is considered a security issue if appropriate care is not taken to sanitize any user provided or variable input.
        It is strongly recommended to pass user input or variable input via quote filter before using with pipe lookup.
        See example section for this.
        Read more about this L(Bandit B602 docs,https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html)`

This commit adds the same warning to builtin.lines docs.

##### ISSUE TYPE

- Docs Pull Request
