### PR TITLE
[stable-2.18] dnf5: use new pkg_gpgcheck option, fallback to deprecated one (#84791)

### DIFF
--- a/changelogs/fragments/dnf5-remove-usage-deprecated-option.yml
+++ b/changelogs/fragments/dnf5-remove-usage-deprecated-option.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf5 - libdnf5 - use ``conf.pkg_gpgcheck`` instead of deprecated ``conf.gpgcheck`` which is used only as a fallback

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -567,7 +567,14 @@ class Dnf5Module(YumDnf):
         elif self.best is not None:
             conf.best = self.best
         conf.install_weak_deps = self.install_weak_deps
-        conf.gpgcheck = not self.disable_gpg_check
+        try:
+            # raises AttributeError only on getter if not available
+            conf.pkg_gpgcheck   # pylint: disable=pointless-statement
+        except AttributeError:
+            # dnf5 < 5.2.7.0
+            conf.gpgcheck = not self.disable_gpg_check
+        else:
+            conf.pkg_gpgcheck = not self.disable_gpg_check
         conf.localpkg_gpgcheck = not self.disable_gpg_check
         conf.sslverify = self.sslverify
         conf.clean_requirements_on_remove = self.autoremove


### PR DESCRIPTION
##### SUMMARY
(cherry picked from commit f11dfa7cce0f939a5dc1e11addc6cfbb5c7fe030)
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
