### PR TITLE
ansible-test - Replace FreeBSD 13.4 with 13.5

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -94,8 +94,8 @@ stages:
               test: rhel/9.5@3.9
             - name: RHEL 9.5 py312
               test: rhel/9.5@3.12
-            - name: FreeBSD 13.4
-              test: freebsd/13.4
+            - name: FreeBSD 13.5
+              test: freebsd/13.5
             - name: FreeBSD 14.2
               test: freebsd/14.2
           groups:
@@ -108,8 +108,8 @@ stages:
               test: macos/15.3
             - name: RHEL 9.5
               test: rhel/9.5
-            - name: FreeBSD 13.4
-              test: freebsd/13.4
+            - name: FreeBSD 13.5
+              test: freebsd/13.5
             - name: FreeBSD 14.2
               test: freebsd/14.2
           groups:

--- a/changelogs/fragments/ansible-test-remotes.yml
+++ b/changelogs/fragments/ansible-test-remotes.yml
@@ -1,5 +1,5 @@
 minor_changes:
-  - ansible-test - Replace remote FreeBSD 13.3 with 13.4.
+  - ansible-test - Replace remote FreeBSD 13.3 with 13.5.
   - ansible-test - Replace remote FreeBSD 14.1 with 14.2.
   - ansible-test - Replace remote Fedora 40 with 41.
   - ansible-test - Replace remote Alpine 3.20 with 3.21.

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -2,7 +2,7 @@ alpine/3.21 python=3.12 become=doas_sudo provider=aws arch=x86_64
 alpine become=doas_sudo provider=aws arch=x86_64
 fedora/41 python=3.13 become=sudo provider=aws arch=x86_64
 fedora become=sudo provider=aws arch=x86_64
-freebsd/13.4 python=3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
+freebsd/13.5 python=3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd/14.2 python=3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 macos/15.3 python=3.13 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -169,9 +169,6 @@ bootstrap_remote_freebsd()
         # Declare platform/python version combinations which do not have supporting OS packages available.
         # For these combinations ansible-test will use pip to install the requirements instead.
         case "${platform_version}/${python_version}" in
-            13.4/3.11)
-                pyyaml_pkg="py${python_package_version}-yaml"  # older naming scheme
-                ;;
             14.2/3.11)
                 # defaults available
                 ;;


### PR DESCRIPTION
##### SUMMARY

ansible-test - Replace FreeBSD 13.4 with 13.5.

Resolves https://github.com/ansible/ansible/issues/84224

##### ISSUE TYPE

Feature Pull Request
