### PR TITLE
Marke dark gray a bit brighter

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -115,7 +115,7 @@ COLOR_CODES = {
     'red': u'0;31', 'bright cyan': u'1;36',
     'purple': u'0;35', 'bright red': u'1;31',
     'yellow': u'0;33', 'bright purple': u'1;35',
-    'dark gray': u'1;30', 'bright yellow': u'1;33',
+    'dark gray': u'1;2', 'bright yellow': u'1;33',
     'magenta': u'0;35', 'bright magenta': u'1;35',
     'normal': u'0',
 }


### PR DESCRIPTION
On some terminal color schemas, like for example the GNOME palette in the gnome terminal, colour 30 is exactly the same as the background colour.

ansible-doc uses dark grey by default for constants, and the fact that the name of the constant becomes invisible by *highlighting* it is a bit ironic.

Therefore, use colour 2 for dark grey, which is well visible in all palettes.

![image](https://github.com/user-attachments/assets/abe22ce5-d96a-49e9-b9d7-77e72a0fcac5)


##### SUMMARY

By default, ansible-doc on Ubuntu looks like this:

![image](https://github.com/user-attachments/assets/1f738128-6a3e-4182-973c-ddac34b8ed10)

Imho the help page is helpful, but it *could* be more helpful if one could actually read what is written. With this PR, it looks like this:

![image](https://github.com/user-attachments/assets/c9cee219-61a8-40b0-af76-03b5bd235336)

Which is (again, imho) more helpful.

##### ISSUE TYPE

- Bugfix Pull Request
