### PR TITLE
Set IPv4 and IPv6 simultaneously in iptables module

### DIFF
--- a/changelogs/fragments/set_ipv4_and_ipv6_simultaneously.yml
+++ b/changelogs/fragments/set_ipv4_and_ipv6_simultaneously.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module - set ipv4 and ipv6 rules simultaneously in iptables module (https://github.com/ansible/ansible/issues/84404).


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

Fixes: #84404

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->


- Feature Pull Request

##### ADDITIONAL INFORMATION

Added `both` option to `ip_version`.

Looped over the iptables_path to set rules for ipv4 and ipv6.

Added unit test for `both` option.