### PR TITLE
apt_repository: modify comment line in sources.list 

### DIFF
--- a/changelogs/fragments/54403-apt_repository.yml
+++ b/changelogs/fragments/54403-apt_repository.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - apt_repository - parse function is now whitespace aware and the save/dump function no longer insert spaces between double hashed comments.  (https://github.com/ansible/ansible/issues/54403).

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -296,14 +296,12 @@ class SourcesList(object):
         # Check for another "#" in the line and treat a part after it as a comment.
         i = line.find('#')
         if i > 0:
-            comment = line[i + 1:].strip()
-            line = line[:i]
+            line, comment = re.split('#', line, maxsplit=1)
 
-        # Split a source into substring to make sure that it is source spec.
-        # Duplicated whitespaces in a valid source spec will be removed.
-        source = line.strip()
+        # Check if a line is a source spec and if it is, mark it as a valid source line.
+        source = line
         if source:
-            chunks = source.split()
+            chunks = re.split(' ', source, maxsplit=1)
             if chunks[0] in VALID_SOURCE_TYPES:
                 valid = True
                 source = ' '.join(chunks)
@@ -362,10 +360,10 @@ class SourcesList(object):
                 for n, valid, enabled, source, comment in sources:
                     chunks = []
                     if not enabled:
-                        chunks.append('# ')
+                        chunks.append('#')
                     chunks.append(source)
                     if comment:
-                        chunks.append(' # ')
+                        chunks.append('#')
                         chunks.append(comment)
                     chunks.append('\n')
                     line = ''.join(chunks)
@@ -397,10 +395,10 @@ class SourcesList(object):
                 for n, valid, enabled, source, comment in sources:
                     chunks = []
                     if not enabled:
-                        chunks.append('# ')
+                        chunks.append('#')
                     chunks.append(source)
                     if comment:
-                        chunks.append(' # ')
+                        chunks.append('#')
                         chunks.append(comment)
                     chunks.append('\n')
                     lines.append(''.join(chunks))

--- a/test/integration/targets/apt_repository/tasks/apt.yml
+++ b/test/integration/targets/apt_repository/tasks/apt.yml
@@ -57,8 +57,7 @@
     - name: verify the comment in the test source was preserved
       assert:
         that:
-          - '"# # comment\n" in test_source_content'  # bug, see: https://github.com/ansible/ansible/issues/54403
-          # - '"## comment\n" in test_source_content'  # correct behavior
+          - '"## comment\n" in test_source_content'
   always:
     - name: ensure the test source is absent
       file:


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

Rebuild the SourceList from its parsed chunks. Use re.split() instead of split(), so it will not make additional spaces disappear. Furthermore, join the comment and source lines without additional spaces before and after the hash.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->
Fixes #54403

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION  
This PR is a copy of #82087 that got closed because of inactivity from the original contributer. 