### PR TITLE
[stable-2.17] uri - fix return value 'location' from relative redirect (#84541)

### DIFF
--- a/changelogs/fragments/84540-uri-relative-redirect.yml
+++ b/changelogs/fragments/84540-uri-relative-redirect.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - uri - Form location correctly when the server returns a relative redirect (https://github.com/ansible/ansible/issues/84540)

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -448,7 +448,7 @@ import tempfile
 
 from ansible.module_utils.basic import AnsibleModule, sanitize_keys
 from ansible.module_utils.six import binary_type, iteritems, string_types
-from ansible.module_utils.six.moves.urllib.parse import urlencode, urlsplit
+from ansible.module_utils.six.moves.urllib.parse import urlencode, urljoin
 from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.compat.datetime import utcnow, utcfromtimestamp
 from ansible.module_utils.six.moves.collections_abc import Mapping, Sequence
@@ -503,27 +503,6 @@ def write_file(module, dest, content, resp):
 
     if os.path.exists(tmpsrc):
         os.remove(tmpsrc)
-
-
-def absolute_location(url, location):
-    """Attempts to create an absolute URL based on initial URL, and
-    next URL, specifically in the case of a ``Location`` header.
-    """
-
-    if '://' in location:
-        return location
-
-    elif location.startswith('/'):
-        parts = urlsplit(url)
-        base = url.replace(parts[2], '')
-        return '%s%s' % (base, location)
-
-    elif not location.startswith('/'):
-        base = os.path.dirname(url)
-        return '%s/%s' % (base, location)
-
-    else:
-        return location
 
 
 def kv_list(data):
@@ -760,7 +739,7 @@ def main():
         uresp[ukey] = value
 
     if 'location' in uresp:
-        uresp['location'] = absolute_location(url, uresp['location'])
+        uresp['location'] = urljoin(url, uresp['location'])
 
     # Default content_encoding to try
     if isinstance(content, binary_type):

--- a/test/integration/targets/uri/tasks/redirect-none.yml
+++ b/test/integration/targets/uri/tasks/redirect-none.yml
@@ -293,4 +293,25 @@
     - "'Status code was 308 and not [200]: HTTP Error 308: ' in http_308_post.msg"
     - http_308_post.redirected == false
     - http_308_post.status == 308
-    - http_308_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'
+    - http_308_post.url == 'https://' + httpbin_host + '/redirect-to?status_code=308&url=https://' + httpbin_host + '/anything'
+
+- name: Test HTTP return value for location using relative redirects
+  uri:
+    url: https://{{ httpbin_host }}/redirect-to?url={{ item }}
+    status_code: 302
+    follow_redirects: none
+  register: http_302
+  loop:
+    - "/anything?foo=bar"
+    - "status/302"
+    - "./status/302"
+    - "/status/302"
+    - "//{{ httpbin_host }}/status/302"
+    - "https:status/302"
+
+- assert:
+    that:
+      - item.location == ('https://' + httpbin_host + ((idx == 0) | ternary('/anything?foo=bar', '/status/302')))
+  loop: "{{ http_302.results }}"
+  loop_control:
+    index_var: idx

--- a/test/integration/targets/uri/tasks/redirect-safe.yml
+++ b/test/integration/targets/uri/tasks/redirect-safe.yml
@@ -271,4 +271,28 @@
     - "'Status code was 308 and not [200]: HTTP Error 308: ' in http_308_post.msg"
     - http_308_post.redirected == false
     - http_308_post.status == 308
-    - http_308_post.url == 'https://{{ httpbin_host }}/redirect-to?status_code=308&url=https://{{ httpbin_host }}/anything'
+    - http_308_post.url == 'https://' + httpbin_host + '/redirect-to?status_code=308&url=https://' + httpbin_host + '/anything'
+
+
+- name: Test HTTP using HEAD with relative path in redirection
+  uri:
+    url: https://{{ httpbin_host }}/redirect-to?status_code={{ item }}&url=/anything?foo=bar
+    follow_redirects: safe
+    return_content: yes
+    method: HEAD
+  register: http_head
+  loop:
+    - '301'
+    - '302'
+    - '303'
+    - '307'
+    - '308'
+
+- assert:
+    that:
+    - item.changed is false
+    - item.json is not defined
+    - item.redirected
+    - item.status == 200
+    - item.url == 'https://' + httpbin_host + '/anything?foo=bar'
+  loop: "{{ http_head.results }}"


### PR DESCRIPTION
##### SUMMARY

* uri: form location correctly from relative redirect

Previously, the original URL would be combined with the relative location incorrectly, especially for URL of any complexity.

Add simple tests demonstrating the problem that fail without the fix

* fix pylint error, import the method similar to other uri methods

* add changelog fragment

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>
(cherry picked from commit 61a6222e0e5200137c828da277e1d70aa1c31836)

##### ISSUE TYPE

- Bugfix Pull Request
