### PR TITLE
[stable-2.18] Changed human_to_bytes input to a string (#84336)

### DIFF
--- a/lib/ansible/plugins/filter/human_to_bytes.yml
+++ b/lib/ansible/plugins/filter/human_to_bytes.yml
@@ -8,7 +8,7 @@ DOCUMENTATION:
   options:
     _input:
       description: human-readable description of a number of bytes.
-      type: int
+      type: string
       required: true
     default_unit:
       description: Unit to assume when input does not specify it.


### PR DESCRIPTION
For it to be a human readable description it can't be an int.

(cherry picked from commit df0fe813835344281e5f3e605712fde581cd7b27)

##### ISSUE TYPE

- Docs Pull Request
