### PR TITLE
Use importlib.resources to read the config from the config package

### DIFF
--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import atexit
 import decimal
 import configparser
+import importlib.resources
 import os
 import os.path
 import sys
@@ -316,7 +317,7 @@ class ConfigManager(object):
 
         self._config_file = conf_file
 
-        self._base_defs = self._read_config_yaml_file(defs_file or ('%s/base.yml' % os.path.dirname(__file__)))
+        self._base_defs = self._read_config_yaml_file(defs_file or 'base.yml', from_package=defs_file is None)
         _add_base_defs_deprecations(self._base_defs)
 
         if self._config_file is None:
@@ -378,15 +379,24 @@ class ConfigManager(object):
                 pass  # not templatable
         return value
 
-    def _read_config_yaml_file(self, yml_file):
-        # TODO: handle relative paths as relative to the directory containing the current playbook instead of CWD
-        # Currently this is only used with absolute paths to the `ansible/config` directory
-        yml_file = to_bytes(yml_file)
-        if os.path.exists(yml_file):
-            with open(yml_file, 'rb') as config_def:
-                return yaml_load(config_def) or {}
-        raise AnsibleError(
-            "Missing base YAML definition file (bad install?): %s" % to_native(yml_file))
+    def _read_config_yaml_file(self, yml_file, from_package=False):
+        if from_package:
+            try:
+                config_def = importlib.resources.read_text(__package__, yml_file)
+            except FileNotFoundError:
+                raise AnsibleError(
+                    "Missing base YAML definition file (bad install?): %s" % to_native(yml_file))
+
+            return yaml_load(config_def) or {}
+        else:
+            # TODO: handle relative paths as relative to the directory containing the current playbook instead of CWD
+            # Currently this is only used with absolute paths to the `ansible/config` directory
+            yml_file = to_bytes(yml_file)
+            if os.path.exists(yml_file):
+                with open(yml_file, 'rb') as config_def:
+                    return yaml_load(config_def) or {}
+            raise AnsibleError(
+                "Missing base YAML definition file (bad install?): %s" % to_native(yml_file))
 
     def _parse_config_file(self, cfile=None):
         """ return flat configuration settings from file(s) """

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -382,7 +382,7 @@ class ConfigManager(object):
     def _read_config_yaml_file(self, yml_file, from_package=False):
         if from_package:
             try:
-                config_def = importlib.resources.read_text(__package__, yml_file)
+                config_def = importlib.resources.files(__package__).joinpath(yml_file).read_text('utf-8')
             except FileNotFoundError:
                 raise AnsibleError(
                     "Missing base YAML definition file (bad install?): %s" % to_native(yml_file))

--- a/test/units/config/test_manager.py
+++ b/test/units/config/test_manager.py
@@ -130,6 +130,17 @@ class TestConfigManager:
 
         assert "Missing base YAML definition file (bad install?)" in str(exec_info.value)
 
+    def test_read_config_yaml_file_from_package(self):
+        actual_value = self.manager._read_config_yaml_file('base.yml', from_package=True)
+        assert isinstance(actual_value, dict)
+        assert len(actual_value) == 205
+
+    def test_read_config_yaml_file_from_package_negative(self):
+        with pytest.raises(AnsibleError) as exec_info:
+            self.manager._read_config_yaml_file('test_non_existent.yml', from_package=True)
+
+        assert "Missing base YAML definition file (bad install?)" in str(exec_info.value)
+
     def test_entry_as_vault_var(self):
         class MockVault:
 


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
The `ConfigManager` read the file `base.yaml` presents in the package `ansible.config` on initialization, if no other file is provided. Currently it expects the file to be an actual file on the disk, but python packages can come on other ways (like a zip archive) where this assumption fails.

Using `importlib.resources` is the correct way to fetch a resource in a package, independently of the actual package distribution format.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->
Fixes #84861 

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request