### PR TITLE
Add typing_extensions for core unit tests on <3.11

### DIFF
--- a/test/units/requirements.txt
+++ b/test/units/requirements.txt
@@ -2,3 +2,4 @@ bcrypt ; python_version >= '3.11'  # controller only
 passlib ; python_version >= '3.11'  # controller only
 pexpect ; python_version >= '3.11'  # controller only
 pywinrm ; python_version >= '3.11'  # controller only
+typing_extensions; python_version < '3.11'  # some unit tests need Annotated and get_type_hints(include_extras=True)


### PR DESCRIPTION
##### SUMMARY

This originated in https://github.com/ansible/ansible/pull/84621/, but was pulled out to allow earlier container rebuilds.

##### ISSUE TYPE

Test Pull Request
