### PR TITLE
find: skip ENOENT while enumerating files

### DIFF
--- a/changelogs/fragments/find_enoent.yml
+++ b/changelogs/fragments/find_enoent.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - find - skip ENOENT error code while recursively enumerating files.
+    find module will now be tolerant to race conditions that remove files or directories
+    from the target it is currently inspecting. (https://github.com/ansible/ansible/issues/84873).

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -515,7 +515,7 @@ def main():
     skipped = {}
 
     def handle_walk_errors(e):
-        if e.errno in (errno.EPERM, errno.EACCES):
+        if e.errno in (errno.EPERM, errno.EACCES, errno.ENOENT):
             skipped[e.filename] = to_text(e)
             return
         raise e


### PR DESCRIPTION
##### SUMMARY

* skip 'no such file or directory' error code while files and
  directories and report them.

Fixes: #84873

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


