### PR TITLE
Simplify and optimize PlayIterator.is_failed

### DIFF
--- a/changelogs/fragments/playiterator-is_failed-optimize.yml
+++ b/changelogs/fragments/playiterator-is_failed-optimize.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "PlayIterator - optimize the 'is host failed' check."

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -73,7 +73,6 @@ class HostState:
         self.tasks_child_state = None
         self.rescue_child_state = None
         self.always_child_state = None
-        self.did_rescue = False
         self.did_start_at_task = False
 
     def __repr__(self):
@@ -83,7 +82,7 @@ class HostState:
         return ("HOST STATE: block=%d, task=%d, rescue=%d, always=%d, handlers=%d, run_state=%s, fail_state=%s, "
                 "pre_flushing_run_state=%s, update_handlers=%s, pending_setup=%s, "
                 "tasks child state? (%s), rescue child state? (%s), always child state? (%s), "
-                "did rescue? %s, did start at task? %s" % (
+                "did start at task? %s" % (
                     self.cur_block,
                     self.cur_regular_task,
                     self.cur_rescue_task,
@@ -97,7 +96,6 @@ class HostState:
                     self.tasks_child_state,
                     self.rescue_child_state,
                     self.always_child_state,
-                    self.did_rescue,
                     self.did_start_at_task,
                 ))
 
@@ -131,7 +129,6 @@ class HostState:
         new_state.pre_flushing_run_state = self.pre_flushing_run_state
         new_state.update_handlers = self.update_handlers
         new_state.pending_setup = self.pending_setup
-        new_state.did_rescue = self.did_rescue
         new_state.did_start_at_task = self.did_start_at_task
         if self.tasks_child_state is not None:
             new_state.tasks_child_state = self.tasks_child_state.copy()
@@ -376,7 +373,6 @@ class PlayIterator:
                         if len(block.rescue) > 0:
                             state.fail_state = FailedStates.NONE
                         state.run_state = IteratingStates.ALWAYS
-                        state.did_rescue = True
                     else:
                         task = block.rescue[state.cur_rescue_task]
                         if isinstance(task, Block):
@@ -412,7 +408,6 @@ class PlayIterator:
                             state.tasks_child_state = None
                             state.rescue_child_state = None
                             state.always_child_state = None
-                            state.did_rescue = False
                     else:
                         task = block.always[state.cur_always_task]
                         if isinstance(task, Block):
@@ -526,24 +521,8 @@ class PlayIterator:
     def _check_failed_state(self, state):
         if state is None:
             return False
-        elif state.run_state == IteratingStates.RESCUE and self._check_failed_state(state.rescue_child_state):
-            return True
-        elif state.run_state == IteratingStates.ALWAYS and self._check_failed_state(state.always_child_state):
-            return True
-        elif state.fail_state != FailedStates.NONE:
-            if state.run_state == IteratingStates.RESCUE and state.fail_state & FailedStates.RESCUE == 0:
-                return False
-            elif state.run_state == IteratingStates.ALWAYS and state.fail_state & FailedStates.ALWAYS == 0:
-                return False
-            else:
-                return not (state.did_rescue and state.fail_state & FailedStates.ALWAYS == 0)
-        elif state.run_state == IteratingStates.TASKS and self._check_failed_state(state.tasks_child_state):
-            cur_block = state._blocks[state.cur_block]
-            if len(cur_block.rescue) > 0 and state.fail_state & FailedStates.RESCUE == 0:
-                return False
-            else:
-                return True
-        return False
+
+        return state.fail_state != FailedStates.NONE and state.run_state == IteratingStates.COMPLETE
 
     def is_failed(self, host):
         s = self.get_host_state(host)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -595,8 +595,7 @@ class StrategyBase:
                 role_ran = True
                 ignore_errors = original_task.ignore_errors
                 if not ignore_errors:
-                    # save the current state before failing it for later inspection
-                    state_when_failed = iterator.get_state_for_host(original_host.name)
+                    maybe_rescued = iterator.is_any_block_rescuing(iterator.get_state_for_host(original_host.name))
                     display.debug("marking %s as failed" % original_host.name)
                     if original_task.run_once:
                         # if we're using run_once, we have to fail every host here
@@ -606,15 +605,10 @@ class StrategyBase:
                     else:
                         iterator.mark_host_failed(original_host)
 
-                    state, dummy = iterator.get_next_task_for_host(original_host, peek=True)
-
-                    if iterator.is_failed(original_host) and state and state.run_state == IteratingStates.COMPLETE:
-                        self._tqm._failed_hosts[original_host.name] = True
-
                     # if we're iterating on the rescue portion of a block then
                     # we save the failed task in a special var for use
                     # within the rescue/always
-                    if iterator.is_any_block_rescuing(state_when_failed):
+                    if maybe_rescued:
                         self._tqm._stats.increment('rescued', original_host.name)
                         iterator._play._removed_hosts.remove(original_host.name)
                         self._variable_manager.set_nonpersistent_facts(
@@ -625,6 +619,7 @@ class StrategyBase:
                             ),
                         )
                     else:
+                        self._tqm._failed_hosts[original_host.name] = True
                         self._tqm._stats.increment('failures', original_host.name)
                 else:
                     self._tqm._stats.increment('ok', original_host.name)


### PR DESCRIPTION
##### SUMMARY
There should not be a need for the complicated logic. We can say the host is failed only after it has completed and there was a failure. The completed part is important as a host can have a failure set on it but there could still be tasks to run in the rescue or always sections.

Perf test:
Iterating through N nested blocks, each block has one task and a nested block, failing the most nested block.

Before:
0.0002570152282714844 seconds, 10 blocks
0.004849910736083984 seconds, 50 blocks
0.9955852031707764 seconds, 350 blocks
21.4445219039917 seconds, 992 blocks

After:
0.00022101402282714844 seconds, 10 blocks
0.0024309158325195312 seconds, 50 blocks
0.1517040729522705 seconds, 350 blocks
1.9403960704803467 seconds, 992 blocks

ci_complete
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Feature Pull Request
