### PR TITLE
Improve vault filter documentation with clearer examples

### DIFF
--- a/changelogs/fragments/vault_docs_fix.yaml
+++ b/changelogs/fragments/vault_docs_fix.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - vault - improved vault filter documentation by adding missing example content for dump_template_data.j2, refining examples for clarity, and ensuring variable consistency

--- a/changelogs/fragments/vault_docs_fix.yaml
+++ b/changelogs/fragments/vault_docs_fix.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - vault - improved vault filter documentation by adding missing example content for dump_template_data.j2, refining examples for clarity, and ensuring variable consistency
+  - vault - improved vault filter documentation by adding missing example content for dump_template_data.j2, refining examples for clarity, and ensuring variable consistency (https://github.com/ansible/ansible/issues/83583).

--- a/lib/ansible/plugins/filter/vault.yml
+++ b/lib/ansible/plugins/filter/vault.yml
@@ -40,24 +40,13 @@ EXAMPLES: |
   vars:
     template_data: "{{ 'my_sensitive_data' | vault('another_vault_password', salt=(2**256 | random(seed=inventory_hostname))) }}"
 
-  - name: Save templated vaulted data
+  - name: Save vaulted data (template)
     template:
       src: dump_template_data.j2
       dest: /some/key/vault.txt
 
   # The dump_template_data.j2 file should contain:
   # Encrypted secret: {{ template_data }}
-
-  # Encrypt a value and store it in a YAML file
-  - name: Write encrypted secret to a file
-    lineinfile:
-      create: yes
-      line: "encrypted_secret: {{ 'another_secret' | vault('vault_passphrase') }}"
-      dest: "/etc/ansible/vaulted_secrets.yml"
-
-  # Decrypt the vaulted data using unvault
-  vars:
-    decrypted_secret: "{{ myvaultedkey | unvault('my_vault_password') }}"
 
 RETURN:
   _value:

--- a/lib/ansible/plugins/filter/vault.yml
+++ b/lib/ansible/plugins/filter/vault.yml
@@ -40,13 +40,10 @@ EXAMPLES: |
   vars:
     template_data: "{{ 'my_sensitive_data' | vault('another_vault_password', salt=(2**256 | random(seed=inventory_hostname))) }}"
 
-  - name: Save vaulted data (template)
+  - name: Save vaulted data. (dump_template_data.js: Encrypted secret: {{ template_data }})
     template:
       src: dump_template_data.j2
       dest: /some/key/vault.txt
-
-  # The dump_template_data.j2 file should contain:
-  # Encrypted secret: {{ template_data }}
 
 RETURN:
   _value:

--- a/lib/ansible/plugins/filter/vault.yml
+++ b/lib/ansible/plugins/filter/vault.yml
@@ -1,7 +1,7 @@
 DOCUMENTATION:
   name: vault
   author: Brian Coca (@bcoca)
-  version_added: "2.18"
+  version_added: "2.12"
   short_description: vault your secrets
   description:
     - Put your information into an encrypted Ansible Vault.
@@ -29,41 +29,35 @@ DOCUMENTATION:
         - This toggle can force the return of an C(AnsibleVaultEncryptedUnicode) string object, when V(False), you get a simple string.
         - Mostly useful when combining with the C(to_yaml) filter to output the 'inline vault' format.
       type: bool
-      default: false
+      default: False
 
 EXAMPLES: |
-  # Example 1: Encrypt a variable using the vault filter
+  # Encrypt a value using the vault filter
   vars:
-    keyrawdata: "my_secret_key"
-    passphrase: "my_vault_password"
-    myvaultedkey: "{{ keyrawdata | vault(passphrase) }}"
+    myvaultedkey: "{{ 'my_secret_key' | vault('my_vault_password') }}"
 
-  # Example 2: Encrypt a value and save it to a file using the template module
+  # Encrypt a value and save it to a file using the template module
   vars:
-    secretdata: "my_sensitive_data"
-    vaultsecret: "another_vault_password"
-    mysalt: "{{ 2**256 | random(seed=inventory_hostname) }}"
-    template_data: "{{ secretdata | vault(vaultsecret, salt=mysalt) }}"
+    template_data: "{{ 'my_sensitive_data' | vault('another_vault_password', salt=(2**256 | random(seed=inventory_hostname))) }}"
 
   - name: Save templated vaulted data
     template:
       src: dump_template_data.j2
       dest: /some/key/vault.txt
 
-  # Example content of dump_template_data.j2:
-  # -------------------------------------------
+  # The dump_template_data.j2 file should contain:
   # Encrypted secret: {{ template_data }}
 
-  # Example 3: Encrypt a value and store it in a YAML file
+  # Encrypt a value and store it in a YAML file
   - name: Write encrypted secret to a file
     lineinfile:
       create: yes
-      line: "encrypted_secret: {{ secretdata | vault(vaultsecret) }}"
+      line: "encrypted_secret: {{ 'another_secret' | vault('vault_passphrase') }}"
       dest: "/etc/ansible/vaulted_secrets.yml"
 
-  # Example 4: Decrypt the vaulted data (when using `unvault`)
+  # Decrypt the vaulted data using unvault
   vars:
-    decrypted_secret: "{{ myvaultedkey | unvault(passphrase) }}"
+    decrypted_secret: "{{ myvaultedkey | unvault('my_vault_password') }}"
 
 RETURN:
   _value:

--- a/lib/ansible/plugins/filter/vault.yml
+++ b/lib/ansible/plugins/filter/vault.yml
@@ -40,7 +40,9 @@ EXAMPLES: |
   vars:
     template_data: "{{ 'my_sensitive_data' | vault('another_vault_password', salt=(2**256 | random(seed=inventory_hostname))) }}"
 
-  - name: Save vaulted data. (dump_template_data.js: Encrypted secret: {{ template_data }})
+  # The content of dump_template_data.j2 looks like
+  #     Encrypted secret: {{ template_data }}
+  - name: Save vaulted data
     template:
       src: dump_template_data.j2
       dest: /some/key/vault.txt

--- a/lib/ansible/plugins/filter/vault.yml
+++ b/lib/ansible/plugins/filter/vault.yml
@@ -1,7 +1,7 @@
 DOCUMENTATION:
   name: vault
   author: Brian Coca (@bcoca)
-  version_added: "2.12"
+  version_added: "2.18"
   short_description: vault your secrets
   description:
     - Put your information into an encrypted Ansible Vault.
@@ -29,18 +29,41 @@ DOCUMENTATION:
         - This toggle can force the return of an C(AnsibleVaultEncryptedUnicode) string object, when V(False), you get a simple string.
         - Mostly useful when combining with the C(to_yaml) filter to output the 'inline vault' format.
       type: bool
-      default: False
+      default: false
 
 EXAMPLES: |
-  # simply encrypt my key in a vault
+  # Example 1: Encrypt a variable using the vault filter
   vars:
-    myvaultedkey: "{{ keyrawdata|vault(passphrase) }} "
+    keyrawdata: "my_secret_key"
+    passphrase: "my_vault_password"
+    myvaultedkey: "{{ keyrawdata | vault(passphrase) }}"
 
-  - name: save templated vaulted data
-    template: src=dump_template_data.j2 dest=/some/key/vault.txt
-    vars:
-      mysalt: '{{2**256|random(seed=inventory_hostname)}}'
-      template_data: '{{ secretdata|vault(vaultsecret, salt=mysalt) }}'
+  # Example 2: Encrypt a value and save it to a file using the template module
+  vars:
+    secretdata: "my_sensitive_data"
+    vaultsecret: "another_vault_password"
+    mysalt: "{{ 2**256 | random(seed=inventory_hostname) }}"
+    template_data: "{{ secretdata | vault(vaultsecret, salt=mysalt) }}"
+
+  - name: Save templated vaulted data
+    template:
+      src: dump_template_data.j2
+      dest: /some/key/vault.txt
+
+  # Example content of dump_template_data.j2:
+  # -------------------------------------------
+  # Encrypted secret: {{ template_data }}
+
+  # Example 3: Encrypt a value and store it in a YAML file
+  - name: Write encrypted secret to a file
+    lineinfile:
+      create: yes
+      line: "encrypted_secret: {{ secretdata | vault(vaultsecret) }}"
+      dest: "/etc/ansible/vaulted_secrets.yml"
+
+  # Example 4: Decrypt the vaulted data (when using `unvault`)
+  vars:
+    decrypted_secret: "{{ myvaultedkey | unvault(passphrase) }}"
 
 RETURN:
   _value:


### PR DESCRIPTION
##### SUMMARY
This PR updates the vault filter documentation by refining the examples section to provide clearer and more comprehensive guidance for users.

Fixes #83583 
<!--- Describe the change below, including rationale and design decisions -->
##### What's changed?
- Added missing template content for dump_template_data.j2, ensuring users understand how to use it.
- Refactored examples to include encryption, saving to files, and decryption using unvault.
- Improved variable consistency to prevent confusion.
- Reorganized the examples for better readability and logical flow.
##### Impact
Users raised concerns that the documentation lacked explicit content for the dump_template_data.j2 example. Additionally, the examples were somewhat inconsistent and unclear. This PR provides a structured, easy-to-follow guide for working with the vault filter.
<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request
