### PR TITLE
Fix apt and dpkg_selections tests

### DIFF
--- a/test/integration/targets/apt/defaults/main.yml
+++ b/test/integration/targets/apt/defaults/main.yml
@@ -1,2 +1,1 @@
-hello_download_version: 2.10-3build1
 hello_old_version: 2.10-2ubuntu2

--- a/test/integration/targets/apt/defaults/main.yml
+++ b/test/integration/targets/apt/defaults/main.yml
@@ -1,2 +1,2 @@
-apt_foreign_arch: i386
-hello_old_version: 2.6-1
+hello_download_version: 2.10-3build1
+hello_old_version: 2.10-2ubuntu2

--- a/test/integration/targets/apt/tasks/apt-multiarch.yml
+++ b/test/integration/targets/apt/tasks/apt-multiarch.yml
@@ -1,3 +1,19 @@
+- name: get the default arch
+  command: dpkg --print-architecture
+  register: default_arch
+
+- name: select a foreign arch for {{ default_arch.stdout }}
+  # When adding a new arch, pick a foreign arch hosted on the same repository mirror as the default arch. For example:
+  # - archive.ubuntu.com hosts both amd64 and i386
+  # - ports.ubuntu.com hosts both arm64 and armhf
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "arch/{{ default_arch.stdout }}.yml"
+
+- name: show the arch selected for multi-arch testing
+  debug:
+    msg: Using {{ apt_foreign_arch }} as the foreign arch for {{ default_arch.stdout }}
+
 # verify that apt is handling multi-arch systems properly
 
 - name: load version specific vars

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -1,13 +1,3 @@
-- name: use Debian mirror
-  set_fact:
-    distro_mirror: http://ftp.debian.org/debian
-  when: ansible_distribution == 'Debian'
-
-- name: use Ubuntu mirror
-  set_fact:
-    distro_mirror: http://archive.ubuntu.com/ubuntu
-  when: ansible_distribution == 'Ubuntu'
-
 # UNINSTALL 'python3-apt'
 #  The `apt` module has the smarts to auto-install `python3-apt`.  To test, we
 #  will first uninstall `python3-apt`.
@@ -287,7 +277,7 @@
   apt: pkg=hello state=absent purge=yes
 
 - name: install deb file from URL
-  apt: deb="{{ distro_mirror }}/pool/main/h/hello/hello_{{ hello_version.stdout }}_{{ hello_architecture.stdout }}.deb"
+  apt: "deb=https://ci-files.testing.ansible.com/test/integration/targets/apt/hello_{{ hello_download_version }}_{{ hello_architecture.stdout }}.deb"
   register: apt_url
 
 - name: verify installation of hello
@@ -468,7 +458,7 @@
 
 # https://github.com/ansible/ansible/issues/65325
 - name: Download and install old version of hello (to test allow_change_held_packages option)
-  apt: "deb=https://ci-files.testing.ansible.com/test/integration/targets/dpkg_selections/hello_{{ hello_old_version }}_amd64.deb"
+  apt: "deb=https://ci-files.testing.ansible.com/test/integration/targets/apt/hello_{{ hello_old_version }}_{{ hello_architecture.stdout }}.deb"
   notify:
     - remove package hello
 

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -277,7 +277,7 @@
   apt: pkg=hello state=absent purge=yes
 
 - name: install deb file from URL
-  apt: "deb=https://ci-files.testing.ansible.com/test/integration/targets/apt/hello_{{ hello_download_version }}_{{ hello_architecture.stdout }}.deb"
+  apt: "deb=https://ci-files.testing.ansible.com/test/integration/targets/apt/hello_{{ hello_old_version }}_{{ hello_architecture.stdout }}.deb"
   register: apt_url
 
 - name: verify installation of hello

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -15,6 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: skip test on unsupported platforms
+  meta: end_play
+  when: ansible_distribution not in ('Ubuntu', 'Debian')
+
 - block:
   - import_tasks: 'apt.yml'
 
@@ -33,9 +37,6 @@
       - file:
           name: "{{ repodir }}"
           state: absent
-
-  when:
-    - ansible_distribution in ('Ubuntu', 'Debian')
 
   always:
     - name: Check if the target is managed by ansible-test

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -21,8 +21,6 @@
   - import_tasks: 'url-with-deps.yml'
 
   - import_tasks: 'apt-multiarch.yml'
-    when:
-      - ansible_userspace_architecture != apt_foreign_arch
 
   - import_tasks: 'apt-builddep.yml'
 

--- a/test/integration/targets/apt/vars/arch/amd64.yml
+++ b/test/integration/targets/apt/vars/arch/amd64.yml
@@ -1,0 +1,1 @@
+apt_foreign_arch: i386

--- a/test/integration/targets/apt/vars/arch/arm64.yml
+++ b/test/integration/targets/apt/vars/arch/arm64.yml
@@ -1,0 +1,1 @@
+apt_foreign_arch: armhf

--- a/test/integration/targets/dpkg_selections/defaults/main.yaml
+++ b/test/integration/targets/dpkg_selections/defaults/main.yaml
@@ -1,1 +1,1 @@
-hello_old_version: 2.6-1
+hello_old_version: 2.10-2ubuntu2

--- a/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
+++ b/test/integration/targets/dpkg_selections/tasks/dpkg_selections.yaml
@@ -1,5 +1,9 @@
+- name: get the default arch
+  command: dpkg --print-architecture
+  register: default_arch
+
 - name: download and install old version of hello
-  apt: "deb=https://ci-files.testing.ansible.com/test/integration/targets/dpkg_selections/hello_{{ hello_old_version }}_amd64.deb"
+  apt: "deb=https://ci-files.testing.ansible.com/test/integration/targets/dpkg_selections/hello_{{ hello_old_version }}_{{ default_arch.stdout }}.deb"
 
 - name: freeze version for hello
   dpkg_selections:

--- a/test/integration/targets/dpkg_selections/tasks/main.yaml
+++ b/test/integration/targets/dpkg_selections/tasks/main.yaml
@@ -1,3 +1,6 @@
 ---
+ - name: skip test on unsupported platforms
+   meta: end_play
+   when: ansible_distribution not in ('Ubuntu', 'Debian')
+
  - include_tasks: file='dpkg_selections.yaml'
-   when: ansible_distribution in ('Ubuntu', 'Debian')

--- a/test/integration/targets/setup_deb_repo/tasks/main.yml
+++ b/test/integration/targets/setup_deb_repo/tasks/main.yml
@@ -69,8 +69,8 @@
     lineinfile:
       path: /etc/apt/sources.list
       backrefs: True
-      regexp: ^#\s*deb-src http://archive\.ubuntu\.com/ubuntu/ (\w*){{ item }} universe$
-      line: deb-src http://archive.ubuntu.com/ubuntu \1{{ item }} universe
+      regexp: ^#\s*deb-src (http://.*\.ubuntu\.com/ubuntu.*/) (\w*){{ item }} universe$
+      line: deb-src \1 \2{{ item }} universe
       state: present
     with_items:
     - ''


### PR DESCRIPTION
##### SUMMARY

The tests now support aarch64.
They also have reduced dependencies on URLs hosted on third-party servers.

##### ISSUE TYPE

Test Pull Request
