### PR TITLE
import_role docs: fix markup for config variable reference

### DIFF
--- a/lib/ansible/modules/import_role.py
+++ b/lib/ansible/modules/import_role.py
@@ -59,7 +59,7 @@ options:
     description:
       - This option dictates whether the role's C(vars) and C(defaults) are exposed to the play.
       - Variables are exposed to the play at playbook parsing time, and available to earlier roles and tasks as well unlike C(include_role).
-      - The default depends on the configuration option :ref:`default_private_role_vars`.
+      - The default depends on the configuration option R(DEFAULT_PRIVATE_ROLE_VARS, DEFAULT_PRIVATE_ROLE_VARS).
     type: bool
     default: yes
     version_added: '2.17'


### PR DESCRIPTION
##### SUMMARY
The wrong markup was used (see https://docs.ansible.com/ansible/devel/collections/ansible/builtin/import_role_module.html#parameter-public for how it looks). Also the option is upper-case: https://docs.ansible.com/ansible/devel/reference_appendices/config.html#default-private-role-vars

##### ISSUE TYPE
- Docs Pull Request
