### PR TITLE
[stable-2.18] import_role docs: fix markup for config variable reference

### DIFF
--- a/lib/ansible/modules/import_role.py
+++ b/lib/ansible/modules/import_role.py
@@ -59,7 +59,7 @@ options:
     description:
       - This option dictates whether the role's C(vars) and C(defaults) are exposed to the play.
       - Variables are exposed to the play at playbook parsing time, and available to earlier roles and tasks as well unlike C(include_role).
-      - The default depends on the configuration option :ref:`default_private_role_vars`.
+      - The default depends on the configuration option R(DEFAULT_PRIVATE_ROLE_VARS, DEFAULT_PRIVATE_ROLE_VARS).
     type: bool
     default: yes
     version_added: '2.17'


### PR DESCRIPTION
##### SUMMARY
Backport of #84901 to stable-2.18.

##### ISSUE TYPE
- Docs Pull Request
