### PR TITLE
Fix AnsibleModule.tmpdir base dir race condition

### DIFF
--- a/changelogs/fragments/AnsibleModule.Basic-tmpdir-race-condition.yml
+++ b/changelogs/fragments/AnsibleModule.Basic-tmpdir-race-condition.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - AnsibleModule.tmpdir - Fix race condition by passing exist_ok=True when creating the base directory of the temporary directory (https://github.com/ansible/ansible/issues/84907).
+  - AnsibleModule.tmpdir - Fix using the remote temp directory as the base directory (https://github.com/ansible/ansible/issues/84907).

--- a/changelogs/fragments/AnsibleModule.Basic-tmpdir-race-condition.yml
+++ b/changelogs/fragments/AnsibleModule.Basic-tmpdir-race-condition.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - AnsibleModule.tmpdir - Fix race condition by passing exist_ok=True when creating the base directory of the temporary directory (https://github.com/ansible/ansible/issues/84907).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -473,7 +473,11 @@ class AnsibleModule(object):
 
             if basedir is not None and not os.path.exists(basedir):
                 try:
-                    os.makedirs(basedir, mode=0o700, exist_ok=True)
+                    os.makedirs(basedir, mode=0o700)
+                except FileExistsError:
+                    # Skipping the warning in the else statement since the directory was not created here.
+                    # Add a warning about the race condition?
+                    pass
                 except (OSError, IOError) as e:
                     self.warn("Unable to use %s as temporary directory, "
                               "failing back to system: %s" % (basedir, to_native(e)))

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -471,12 +471,12 @@ class AnsibleModule(object):
             if self._remote_tmp is not None:
                 basedir = os.path.expanduser(os.path.expandvars(self._remote_tmp))
 
-            basedir_exists = basedir is not None and os.path.exists(basedir)
             if basedir is not None and not os.path.exists(basedir):
                 try:
                     os.makedirs(basedir, mode=0o700)
                 except FileExistsError:
-                    basedir_exists = True
+                    self.warn("Unable to create remote_tmp %s. "
+                              "This is either an attempt to use parallelism or an attack." % basedir)
                 except (OSError, IOError) as e:
                     self.warn("Unable to use %s as temporary directory, "
                               "failing back to system: %s" % (basedir, to_native(e)))
@@ -487,9 +487,6 @@ class AnsibleModule(object):
                               " issues when running as another user. To "
                               "avoid this, create the remote_tmp dir with "
                               "the correct permissions manually" % basedir)
-
-            if basedir_exists:
-                self.warn(f"Module remote_tmp {basedir} already exists. This could cause issues if created by another user.")
 
             basefile = "ansible-moduletmp-%s-" % time.time()
             try:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -471,13 +471,12 @@ class AnsibleModule(object):
             if self._remote_tmp is not None:
                 basedir = os.path.expanduser(os.path.expandvars(self._remote_tmp))
 
+            basedir_exists = basedir is not None and os.path.exists(basedir)
             if basedir is not None and not os.path.exists(basedir):
                 try:
                     os.makedirs(basedir, mode=0o700)
                 except FileExistsError:
-                    # Skipping the warning in the else statement since the directory was not created here.
-                    # Add a warning about the race condition?
-                    pass
+                    basedir_exists = True
                 except (OSError, IOError) as e:
                     self.warn("Unable to use %s as temporary directory, "
                               "failing back to system: %s" % (basedir, to_native(e)))
@@ -488,6 +487,9 @@ class AnsibleModule(object):
                               " issues when running as another user. To "
                               "avoid this, create the remote_tmp dir with "
                               "the correct permissions manually" % basedir)
+
+            if basedir_exists:
+                self.warn(f"Module remote_tmp {basedir} already exists. This could cause issues if created by another user.")
 
             basefile = "ansible-moduletmp-%s-" % time.time()
             try:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -473,7 +473,7 @@ class AnsibleModule(object):
 
             if basedir is not None and not os.path.exists(basedir):
                 try:
-                    os.makedirs(basedir, mode=0o700)
+                    os.makedirs(basedir, mode=0o700, exist_ok=True)
                 except (OSError, IOError) as e:
                     self.warn("Unable to use %s as temporary directory, "
                               "failing back to system: %s" % (basedir, to_native(e)))

--- a/test/units/module_utils/basic/test_tmpdir.py
+++ b/test/units/module_utils/basic/test_tmpdir.py
@@ -64,7 +64,7 @@ class TestAnsibleModuleTmpDir:
         def mock_mkdtemp(prefix, dir):
             return os.path.join(dir, prefix)
 
-        def mock_makedirs(path, mode):
+        def mock_makedirs(path, mode, exist_ok=False):
             makedirs['called'] = True
             makedirs['path'] = path
             makedirs['mode'] = mode
@@ -106,8 +106,24 @@ class TestAnsibleModuleTmpDir:
         actual = am.tmpdir
         assert actual == "/tmp/path"
         assert mock_makedirs.call_args[0] == (os.path.expanduser(os.path.expandvars("$HOME/.test")),)
-        assert mock_makedirs.call_args[1] == {"mode": 0o700}
+        assert mock_makedirs.call_args[1] == {"mode": 0o700, "exist_ok": True}
 
         # because makedirs failed the dir should be None so it uses the System tmp
         assert mock_mkdtemp.call_args[1]['dir'] is None
         assert mock_mkdtemp.call_args[1]['prefix'].startswith("ansible-moduletmp-")
+
+    # https://github.com/ansible/ansible/issues/84907
+    @pytest.mark.parametrize('stdin', ({},), indirect=['stdin'])
+    def test_tmpdir_makedirs_race(self, am, monkeypatch):
+        with tempfile.TemporaryDirectory(prefix='ansible-test-units-') as test_dir:
+            remote_tmp = os.path.join(test_dir, 'test_tmpdir_makedirs_race')
+            am._remote_tmp = remote_tmp
+
+            # simulate race condition
+            os.mkdir(remote_tmp)
+            monkeypatch.setattr(os.path, 'exists', lambda x: False)
+
+            result = am.tmpdir
+
+        basedir = os.path.dirname(result)
+        assert basedir == remote_tmp

--- a/test/units/module_utils/basic/test_tmpdir.py
+++ b/test/units/module_utils/basic/test_tmpdir.py
@@ -64,7 +64,7 @@ class TestAnsibleModuleTmpDir:
         def mock_mkdtemp(prefix, dir):
             return os.path.join(dir, prefix)
 
-        def mock_makedirs(path, mode, exist_ok=False):
+        def mock_makedirs(path, mode):
             makedirs['called'] = True
             makedirs['path'] = path
             makedirs['mode'] = mode
@@ -106,7 +106,7 @@ class TestAnsibleModuleTmpDir:
         actual = am.tmpdir
         assert actual == "/tmp/path"
         assert mock_makedirs.call_args[0] == (os.path.expanduser(os.path.expandvars("$HOME/.test")),)
-        assert mock_makedirs.call_args[1] == {"mode": 0o700, "exist_ok": True}
+        assert mock_makedirs.call_args[1] == {"mode": 0o700}
 
         # because makedirs failed the dir should be None so it uses the System tmp
         assert mock_mkdtemp.call_args[1]['dir'] is None


### PR DESCRIPTION
##### SUMMARY

If the base directory of the temporary directory is created between [checking if it doesn't exist](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py#L474) and [trying to create it](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py#L476), dir=None is passed to [tempfile.mkdtemp](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py#L490).

Now the race condition behaves the same as if [checking it doesn't exist](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py#L474) evaluated to False.

Fixes #84907

##### ISSUE TYPE

- Bugfix Pull Request
