### PR TITLE
Fix errant warning about client_secret and access_token

### DIFF
--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -67,7 +67,7 @@ class KeycloakToken(object):
             payload['client_secret'] = self.client_secret
             payload['scope'] = 'api.console'
             payload['grant_type'] = 'client_credentials'
-            if self.access_token:
+            if self.access_token not in (None, NoTokenSentinel):
                 display.warning(
                     'Found both a client_secret and access_token for galaxy authentication, ignoring access_token'
                 )


### PR DESCRIPTION
##### SUMMARY

Fix errant warning about client_secret and access_token

This code was added in development for 2.19, so no changelog needed.

##### ISSUE TYPE

- Bugfix Pull Request
