### PR TITLE
Ensure ansible-config properly validates all entries

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,5 @@
+[galaxy]
+server_list=my_org_hub
+
+[galaxy_server.my_org_hub]
+# url missing

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,0 @@
-[galaxy]
-server_list=my_org_hub
-
-[galaxy_server.my_org_hub]
-# url missing

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -712,8 +712,7 @@ class ConfigCLI(CLI):
                         if s.startswith("galaxy_server.") and s in sections:
                             if 'url' not in p.options(s):
                                 display.error(f"Missing required key 'url' in section '{s}' in '{C.CONFIG_FILE}'.")
-                                found = True
-                                
+                                found = True                   
         elif context.CLIARGS['format'] == 'env':
             # validate any 'ANSIBLE_' env vars found
             evars = [varname for varname in os.environ.keys() if _ansible_env_vars(varname)]

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -708,6 +708,12 @@ class ConfigCLI(CLI):
                                 display.error(f"Found unknown key '{k}' in section '{s}' in '{C.CONFIG_FILE}.")
                                 found = True
 
+                        # Validate only the required key for galaxy servers
+                        if s.startswith("galaxy_server.") and s in sections:
+                            if 'url' not in p.options(s):
+                                display.error(f"Missing required key 'url' in section '{s}' in '{C.CONFIG_FILE}'.")
+                                found = True
+                                
         elif context.CLIARGS['format'] == 'env':
             # validate any 'ANSIBLE_' env vars found
             evars = [varname for varname in os.environ.keys() if _ansible_env_vars(varname)]

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -711,8 +711,8 @@ class ConfigCLI(CLI):
                         # Validate only the required key for galaxy servers
                         if s.startswith("galaxy_server.") and s in sections:
                             if 'url' not in p.options(s):
-                                display.error(f"Missing required key 'url' in section '{s}' in '{C.CONFIG_FILE}.")
-                                found = True                   
+                                display.error(f"Missing required key 'url' in section '{s}' in '{C.CONFIG_FILE}'.")
+                                found = True                
         elif context.CLIARGS['format'] == 'env':
             # validate any 'ANSIBLE_' env vars found
             evars = [varname for varname in os.environ.keys() if _ansible_env_vars(varname)]

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -711,7 +711,7 @@ class ConfigCLI(CLI):
                         # Validate only the required key for galaxy servers
                         if s.startswith("galaxy_server.") and s in sections:
                             if 'url' not in p.options(s):
-                                display.error(f"Missing required key 'url' in section '{s}' in '{C.CONFIG_FILE}'.")
+                                display.error(f"Missing required key 'url' in section '{s}' in '{C.CONFIG_FILE}.")
                                 found = True                   
         elif context.CLIARGS['format'] == 'env':
             # validate any 'ANSIBLE_' env vars found


### PR DESCRIPTION
##### SUMMARY

This PR improves the validation mechanism in `ansible-config` to correctly handle dynamic 'galaxy server' entries. Previously, configurations missing mandatory fields, such as the 'url' in galaxy server definitions, were not flagged as errors. This fix ensures that such missing fields are properly detected and reported during validation.

Fixes #84843

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
