### PR TITLE
 Ensure ansible-config properly validates all entries

### DIFF
--- a/changelogs/fragments/84843-validate-all-config-entries.yml
+++ b/changelogs/fragments/84843-validate-all-config-entries.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-config - Improved validation logic to ensure all configuration entries, including those under `galaxy_server`, are properly validated for required fields and correct value types.

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -13,6 +13,7 @@ import shlex
 import subprocess
 import sys
 import yaml
+import re
 
 from collections.abc import Mapping
 
@@ -21,7 +22,7 @@ import ansible.plugins.loader as plugin_loader
 
 from ansible import constants as C
 from ansible.cli.arguments import option_helpers as opt_help
-from ansible.config.manager import ConfigManager
+from ansible.config.manager import ConfigManager, GALAXY_SERVER_DEF
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleRequiredOptionError
 from ansible.module_utils.common.text.converters import to_native, to_text, to_bytes
 from ansible.module_utils.common.json import json_dump
@@ -36,6 +37,14 @@ display = Display()
 
 
 _IGNORE_CHANGED = frozenset({'_terms', '_input'})
+
+Field_Type_Validators = {
+    'int': r'^-?\d+$',
+    'bool': r'^(true|false)$',
+    'str': r'^.*$',
+    'url': r'https?://[^\s]+',
+    'token': r'^[A-Za-z0-9\-_]+$',
+}
 
 
 def yaml_dump(data, default_flow_style=False, default_style=None):
@@ -79,8 +88,8 @@ def _get_ini_entries(settings):
         if 'ini' in settings[setting] and settings[setting]['ini']:
             for kv in settings[setting]['ini']:
                 if not kv['section'] in data:
-                    data[kv['section']] = set()
-                data[kv['section']].add(kv['key'])
+                    data[kv['section']] = {}
+                data[kv['section']][kv['key']] = None
     return data
 
 
@@ -678,23 +687,19 @@ class ConfigCLI(CLI):
                 # Also from plugins
                 if plugin_types:
                     for ptype in plugin_types:
-                        for plugin in plugin_types[ptype].keys():
+                        for plugin in plugin_types[ptype]:
                             plugin_sections = _get_ini_entries(plugin_types[ptype][plugin])
                             for s in plugin_sections:
-                                if s in sections:
-                                    sections[s].update(plugin_sections[s])
-                                else:
-                                    sections[s] = plugin_sections[s]
+                                sections.setdefault(s, {}).update(plugin_sections[s])
                 if galaxy_servers:
-                    for server in galaxy_servers:
-                        server_sections = _get_ini_entries(galaxy_servers[server])
-                        for s in server_sections:
-                            if s in sections:
-                                sections[s].update(server_sections[s])
-                            else:
-                                sections[s] = server_sections[s]
-                if sections:
-                    p = C.config._parsers[C.CONFIG_FILE]
+                    for server, settings in galaxy_servers.items():
+                        section_name = f"galaxy_server.{server}"
+                        sections[section_name] = {}
+                        for key, meta in settings.items():
+                            sections[section_name][key] = meta
+
+                p = C.config._parsers.get(C.CONFIG_FILE)
+                if p:
                     for s in p.sections():
                         # check for valid sections
                         if s not in sections:
@@ -707,6 +712,21 @@ class ConfigCLI(CLI):
                             if k not in sections[s]:
                                 display.error(f"Found unknown key '{k}' in section '{s}' in '{C.CONFIG_FILE}.")
                                 found = True
+                    for section in p.sections():
+                        if section.startswith("galaxy_server."):
+                            for key, required, expected_type in GALAXY_SERVER_DEF:
+                                if required and not p.has_option(section, key):
+                                    display.error(f"[{section}] missing required field: {key}")
+                                    found = True
+                                elif p.has_option(section, key):
+                                    input_value = p.get(section, key).strip().lower()
+                                    pattern = Field_Type_Validators.get(expected_type)
+                                    if pattern:
+                                        if not re.fullmatch(pattern, input_value):
+                                            display.error(
+                                                f"[{section}] {key} should be of type '{expected_type}', but got {type(input_value).__name__} - {input_value}"
+                                            )
+                                            found = True
 
         elif context.CLIARGS['format'] == 'env':
             # validate any 'ANSIBLE_' env vars found

--- a/test/integration/targets/ansible_config_validate/aliases
+++ b/test/integration/targets/ansible_config_validate/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group5
+context/controller

--- a/test/integration/targets/ansible_config_validate/files/empty.cfg
+++ b/test/integration/targets/ansible_config_validate/files/empty.cfg
@@ -1,0 +1,1 @@
+# Empty configuration file

--- a/test/integration/targets/ansible_config_validate/files/empty.cfg
+++ b/test/integration/targets/ansible_config_validate/files/empty.cfg
@@ -1,1 +1,1 @@
-# Empty configuration file
+# Empty config file

--- a/test/integration/targets/ansible_config_validate/files/invalid_galaxy.cfg
+++ b/test/integration/targets/ansible_config_validate/files/invalid_galaxy.cfg
@@ -1,0 +1,5 @@
+[galaxy]
+server_list=my_org_hub
+
+[galaxy_server.my_org_hub]
+# url missing

--- a/test/integration/targets/ansible_config_validate/files/valid_galaxy.cfg
+++ b/test/integration/targets/ansible_config_validate/files/valid_galaxy.cfg
@@ -1,0 +1,21 @@
+[galaxy]
+server_list = my_org_hub, release_galaxy, test_galaxy, my_galaxy_ng
+
+[galaxy_server.my_org_hub]
+url=https://automation.my_org/
+username=my_user
+password=my_pass
+
+[galaxy_server.release_galaxy]
+url=https://galaxy.ansible.com/
+token=my_token
+
+[galaxy_server.test_galaxy]
+url=https://galaxy-dev.ansible.com/
+token=my_test_token
+
+[galaxy_server.my_galaxy_ng]
+url=http://my_galaxy_ng:8000/api/automation-hub/
+auth_url=http://my_keycloak:8080/auth/realms/myco/protocol/openid-connect/token
+client_id=galaxy-ng
+token=my_keycloak_access_token

--- a/test/integration/targets/ansible_config_validate/tasks/main.yml
+++ b/test/integration/targets/ansible_config_validate/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+- name: Test valid galaxy configuration
+  ansible.builtin.command: "ansible-config validate -t all"
+  environment:
+    ANSIBLE_CONFIG: "{{ role_path }}/files/valid_galaxy.cfg"
+  register: valid_test
+  changed_when: false
+
+- name: Verify valid config passes
+  ansible.builtin.assert:
+    that:
+      - valid_test.rc == 0
+      - "'All configurations seem valid' in valid_test.stdout"
+
+- name: Test invalid galaxy configuration (missing url)
+  ansible.builtin.command: "ansible-config validate -t all"
+  environment:
+    ANSIBLE_CONFIG: "{{ role_path }}/files/invalid_galaxy.cfg"
+  register: invalid_test
+  changed_when: false
+  ignore_errors: yes
+
+- name: Verify invalid config fails
+  ansible.builtin.assert:
+    that:
+      - invalid_test.rc != 0
+      - "'missing required field' in invalid_test.stderr"
+      - "'url' in invalid_test.stderr"
+
+- name: Test empty configuration file
+  ansible.builtin.command: "ansible-config validate -t all"
+  environment:
+    ANSIBLE_CONFIG: "{{ role_path }}/files/empty.cfg"
+  register: empty_test
+  changed_when: false
+
+- name: Verify empty config passes
+  ansible.builtin.assert:
+    that:
+      - empty_test.rc == 0
+      - "'All configurations seem valid' in empty_test.stdout"


### PR DESCRIPTION
##### SUMMARY

This PR improves the validation mechanism in `ansible-config` to correctly handle dynamic 'galaxy server' entries. Previously, configurations missing mandatory fields, such as the 'url' in galaxy server definitions, were not flagged as errors. This fix ensures that such missing fields are properly detected and reported during validation.

Fixes #84843

##### ISSUE TYPE

- Bugfix Pull Request
