### PR TITLE
Support prompt matching with ssh_askpass

### DIFF
--- a/lib/ansible/cli/_ssh_askpass.py
+++ b/lib/ansible/cli/_ssh_askpass.py
@@ -33,6 +33,13 @@ def main() -> t.Never:
         # We must be running after the ansible fork is shutting down
         sys.exit(1)
     cfg = json.loads(shm.buf.tobytes().rstrip(b'\x00'))
+
+    try:
+        if cfg['prompt'] not in sys.argv[1]:
+            sys.exit(1)
+    except IndexError:
+        sys.exit(1)
+
     sys.stdout.buffer.write(cfg['password'].encode('utf-8'))
     sys.stdout.flush()
     shm.buf[:] = b'\x00' * shm.size

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -439,6 +439,9 @@ SSH_DEBUG = re.compile(r'^debug\d+: .*')
 
 _HAS_RESOURCE_TRACK = sys.version_info[:2] >= (3, 13)
 
+PKCS11_DEFAULT_PROMPT = 'Enter PIN for '
+SSH_ASKPASS_DEFAULT_PROMPT = 'assword'
+
 
 class AnsibleControlPersistBrokenPipeError(AnsibleError):
     """ ControlPersist broken pipe """
@@ -744,7 +747,7 @@ class Connection(ConnectionBase):
             password_prompt = self.get_option('sshpass_prompt')
             if not password_prompt and pkcs11_provider:
                 # Set default password prompt for pkcs11_provider to make it clear its a PIN
-                password_prompt = 'Enter PIN for '
+                password_prompt = PKCS11_DEFAULT_PROMPT
 
             if password_prompt:
                 b_command += [b'-P', to_bytes(password_prompt, errors='surrogate_or_strict')]
@@ -974,9 +977,15 @@ class Connection(ConnectionBase):
             kwargs['track'] = False
         self.shm = shm = SharedMemory(create=True, size=16384, **kwargs)  # type: ignore[arg-type]
 
+        sshpass_prompt = self.get_option('sshpass_prompt')
+        if not sshpass_prompt and pkcs11_provider:
+            sshpass_prompt = PKCS11_DEFAULT_PROMPT
+        elif not sshpass_prompt:
+            sshpass_prompt = SSH_ASKPASS_DEFAULT_PROMPT
+
         data = json.dumps({
             'password': conn_password,
-            'prompt': self.get_option('sshpass_prompt') or 'assword',
+            'prompt': sshpass_prompt,
         }).encode('utf-8')
         shm.buf[:len(data)] = bytearray(data)
         shm.close()

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -79,17 +79,26 @@ DOCUMENTATION = """
               - name: ansible_ssh_password_mechanism
       sshpass_prompt:
           description:
-              - Password prompt that sshpass should search for. Supported by sshpass 1.06 and up.
+              - Password prompt that C(sshpass)/C(SSH_ASKPASS) should search for.
+              - Supported by sshpass 1.06 and up when O(password_mechanism) set to V(sshpass).
               - Defaults to C(Enter PIN for) when pkcs11_provider is set.
+              - Defaults to C(assword) when O(password_mechanism) set to V(ssh_askpass).
           default: ''
           type: string
           ini:
               - section: 'ssh_connection'
                 key: 'sshpass_prompt'
+              - section: 'ssh_connection'
+                key: 'ssh_askpass_prompt'
+                version_added: '2.19'
           env:
               - name: ANSIBLE_SSHPASS_PROMPT
+              - name: ANSIBLE_SSH_ASKPASS_PROMPT
+                version_added: '2.19'
           vars:
               - name: ansible_sshpass_prompt
+              - name: ansible_ssh_askpass_prompt
+                version_added: '2.19'
           version_added: '2.10'
       ssh_args:
           description: Arguments to pass to all SSH CLI tools.
@@ -965,9 +974,10 @@ class Connection(ConnectionBase):
             kwargs['track'] = False
         self.shm = shm = SharedMemory(create=True, size=16384, **kwargs)  # type: ignore[arg-type]
 
-        data = json.dumps(
-            {'password': conn_password},
-        ).encode('utf-8')
+        data = json.dumps({
+            'password': conn_password,
+            'prompt': self.get_option('sshpass_prompt') or 'assword',
+        }).encode('utf-8')
         shm.buf[:len(data)] = bytearray(data)
         shm.close()
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -88,17 +88,10 @@ DOCUMENTATION = """
           ini:
               - section: 'ssh_connection'
                 key: 'sshpass_prompt'
-              - section: 'ssh_connection'
-                key: 'ssh_askpass_prompt'
-                version_added: '2.19'
           env:
               - name: ANSIBLE_SSHPASS_PROMPT
-              - name: ANSIBLE_SSH_ASKPASS_PROMPT
-                version_added: '2.19'
           vars:
               - name: ansible_sshpass_prompt
-              - name: ansible_ssh_askpass_prompt
-                version_added: '2.19'
           version_added: '2.10'
       ssh_args:
           description: Arguments to pass to all SSH CLI tools.


### PR DESCRIPTION
##### SUMMARY

We planned to let this slide until a future release, but with the freeze date having slipped, this was relatively easy to finish up.

No changelog necessary as ssh_askpass support was added in 2.19.

`assword` matches sshpass (look for `AC_DEFINE([PASSWORD_PROMPT]` towards the bottom: https://sourceforge.net/p/sshpass/code-git/ci/main/tree/configure.ac


##### ISSUE TYPE

- Feature Pull Request
