### PR TITLE
[stable-2.18] basic: remember the user sensitive information to use later

### DIFF
--- a/changelogs/fragments/no_log.yml
+++ b/changelogs/fragments/no_log.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - basic - remember password for later sanitization of sensitive information (https://github.com/ansible/ansible/issues/84557).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -287,6 +287,9 @@ def heuristic_log_sanitize(data, no_log_values=None):
             output.insert(0, data[end:prev_begin])
             output.insert(0, '********')
             output.insert(0, data[begin:sep + 1])
+            # Remember the password for later log sanitization
+            if no_log_values is not None:
+                no_log_values.add(data[sep + 1:end])
             prev_begin = begin
 
     output = ''.join(output)

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -21,6 +21,10 @@ options:
     repo:
         description:
             - git, SSH, or HTTP(S) protocol address of the git repository.
+            - Avoid embedding usernames and passwords within Git repository URLs.
+              This practice is insecure and can lead to unauthorized access to your repositories.
+              For secure authentication, configure SSH keys (recommended) or use a credential helper.
+              See Git documentation on SSH keys/credential helpers for instructions.
         type: str
         required: true
         aliases: [ name ]

--- a/test/integration/targets/git/tasks/formats.yml
+++ b/test/integration/targets/git/tasks/formats.yml
@@ -38,3 +38,16 @@
   assert:
     that:
       - "not git_result2.changed"
+
+- name: FORMATS | check for sensitive information in repo
+  git:
+    repo: "{{ repo_format4 }}"
+    dest: "{{ repo_dir }}/format4"
+  register: format4
+  ignore_errors: yes
+
+- name: FORMATS | assert absence of repo
+  assert:
+    that:
+      - not format4.changed
+      - "'********@https' in format4.stderr"

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -1,20 +1,6 @@
 # test code for the git module
-# (c) 2014, James Tanner <tanner.jc@gmail.com>
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2014, James Tanner <tanner.jc@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # NOTE: Moving `$HOME` to tmp dir allows this integration test be
 # NOTE: non-destructive. There is no other way to instruct Git use a custom

--- a/test/integration/targets/git/vars/main.yml
+++ b/test/integration/targets/git/vars/main.yml
@@ -33,6 +33,7 @@ separate_git_dir: '{{ remote_tmp_dir }}/sep_git_dir'
 repo_format1: 'https://github.com/jimi-c/test_role'
 repo_format2: 'git@github.com:jimi-c/test_role.git'
 repo_format3: 'ssh://git@github.com/jimi-c/test_role.git'
+repo_format4: 'username:password@https://github.com/thisdoesnotexists/test_role'  # This is an invalid Git protocol, added here for testing
 repo_submodules: 'https://github.com/abadger/test_submodules_newer.git'
 repo_submodule1: 'https://github.com/abadger/test_submodules_subm1.git'
 repo_submodule2: 'https://github.com/abadger/test_submodules_subm2.git'


### PR DESCRIPTION
* Git allows embedding a username and password in the repo URL for HTTPS authentication. This may expose the user's sensitive information to logs and unauthenticated users. Adding no_log will partially solve this.
* Added documentation warning user about URL embedded with username and password.
* Added logic to remember user-sensitive information for later sanitization

Fixes: #84557
(cherry picked from commit 19e9f3d)

##### ISSUE TYPE
- Bugfix Pull Request
