### PR TITLE
Pin `wheel` to resolve build issues

### DIFF
--- a/changelogs/fragments/pin-wheel.yml
+++ b/changelogs/fragments/pin-wheel.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - build - Pin ``wheel`` in ``pyproject.toml`` to ensure compatibility with supported ``setuptools`` versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 66.1.0, <= 72.1.0"]  # lower bound to support controller Python versions, upper bound for latest version tested at release
+requires = ["setuptools >= 66.1.0, <= 72.1.0", "wheel == 0.45.1"]  # lower bound to support controller Python versions, upper bound for latest version tested at release
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
##### SUMMARY

Pin ``wheel`` in ``pyproject.toml`` to ensure compatibility with supported ``setuptools`` versions.

##### ISSUE TYPE

Bugfix Pull Request
