### PR TITLE
respawn: Update ENV dict copy with PYTHONPATH value

### DIFF
--- a/changelogs/fragments/respawn_os_env.yml
+++ b/changelogs/fragments/respawn_os_env.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+   - respawn - use copy of env variables to update existing PYTHONPATH value (https://github.com/ansible/ansible/issues/84954).

--- a/lib/ansible/module_utils/common/respawn.py
+++ b/lib/ansible/module_utils/common/respawn.py
@@ -56,10 +56,13 @@ def probe_interpreters_for_module(interpreter_paths, module_name):
     :arg interpreter_paths: iterable of paths to Python interpreters. The paths will be probed
     in order, and the first path that exists and can successfully import the named module will
     be returned (or ``None`` if probing fails for all supplied paths).
-    :arg module_name: fully-qualified Python module name to probe for (eg, ``selinux``)
+    :arg module_name: fully-qualified Python module name to probe for (for example, ``selinux``)
     """
     PYTHONPATH = os.getenv('PYTHONPATH', '')
-    env = os.environ | {'PYTHONPATH': f'{_ANSIBLE_PARENT_PATH}:{PYTHONPATH}'.rstrip(': ')}
+    env = os.environ.copy()
+    env.update({
+        'PYTHONPATH': f'{_ANSIBLE_PARENT_PATH}:{PYTHONPATH}'.rstrip(': ')
+    })
     for interpreter_path in interpreter_paths:
         if not os.path.exists(interpreter_path):
             continue


### PR DESCRIPTION
##### SUMMARY

* Use shallow copy of os.environ to update PYTHONPATH value
  instead of using '|' operator

Fixes: #84954

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE



