### PR TITLE
Fixed: ansible-test show a nice log message on non-executable runme.sh.

### DIFF
--- a/changelogs/fragments/84598_better_log_for_non_exec_runme.yaml
+++ b/changelogs/fragments/84598_better_log_for_non_exec_runme.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Show a user-friendly error message when a target's `runme.sh` script is not executable, instead of a Python traceback.

--- a/changelogs/fragments/84843-validate-all-config-entries.yml
+++ b/changelogs/fragments/84843-validate-all-config-entries.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-config - Improved validation logic to ensure all configuration entries, including those under `galaxy_server`, are properly validated for required fields and correct value types.

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -13,6 +13,7 @@ import shlex
 import subprocess
 import sys
 import yaml
+import re
 
 from collections.abc import Mapping
 
@@ -21,7 +22,7 @@ import ansible.plugins.loader as plugin_loader
 
 from ansible import constants as C
 from ansible.cli.arguments import option_helpers as opt_help
-from ansible.config.manager import ConfigManager
+from ansible.config.manager import ConfigManager, GALAXY_SERVER_DEF
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleRequiredOptionError
 from ansible.module_utils.common.text.converters import to_native, to_text, to_bytes
 from ansible.module_utils.common.json import json_dump
@@ -36,6 +37,14 @@ display = Display()
 
 
 _IGNORE_CHANGED = frozenset({'_terms', '_input'})
+
+Field_Type_Validators = {
+    'int': r'^-?\d+$',
+    'bool': r'^(true|false)$',
+    'str': r'^.*$',
+    'url': r'https?://[^\s]+',
+    'token': r'^[A-Za-z0-9\-_]+$',
+}
 
 
 def yaml_dump(data, default_flow_style=False, default_style=None):
@@ -79,8 +88,8 @@ def _get_ini_entries(settings):
         if 'ini' in settings[setting] and settings[setting]['ini']:
             for kv in settings[setting]['ini']:
                 if not kv['section'] in data:
-                    data[kv['section']] = set()
-                data[kv['section']].add(kv['key'])
+                    data[kv['section']] = {}
+                data[kv['section']][kv['key']] = None
     return data
 
 
@@ -678,23 +687,19 @@ class ConfigCLI(CLI):
                 # Also from plugins
                 if plugin_types:
                     for ptype in plugin_types:
-                        for plugin in plugin_types[ptype].keys():
+                        for plugin in plugin_types[ptype]:
                             plugin_sections = _get_ini_entries(plugin_types[ptype][plugin])
                             for s in plugin_sections:
-                                if s in sections:
-                                    sections[s].update(plugin_sections[s])
-                                else:
-                                    sections[s] = plugin_sections[s]
+                                sections.setdefault(s, {}).update(plugin_sections[s])
                 if galaxy_servers:
-                    for server in galaxy_servers:
-                        server_sections = _get_ini_entries(galaxy_servers[server])
-                        for s in server_sections:
-                            if s in sections:
-                                sections[s].update(server_sections[s])
-                            else:
-                                sections[s] = server_sections[s]
-                if sections:
-                    p = C.config._parsers[C.CONFIG_FILE]
+                    for server, settings in galaxy_servers.items():
+                        section_name = f"galaxy_server.{server}"
+                        sections[section_name] = {}
+                        for key, meta in settings.items():
+                            sections[section_name][key] = meta
+
+                p = C.config._parsers.get(C.CONFIG_FILE)
+                if p:
                     for s in p.sections():
                         # check for valid sections
                         if s not in sections:
@@ -707,6 +712,21 @@ class ConfigCLI(CLI):
                             if k not in sections[s]:
                                 display.error(f"Found unknown key '{k}' in section '{s}' in '{C.CONFIG_FILE}.")
                                 found = True
+                    for section in p.sections():
+                        if section.startswith("galaxy_server."):
+                            for key, required, expected_type in GALAXY_SERVER_DEF:
+                                if required and not p.has_option(section, key):
+                                    display.error(f"[{section}] missing required field: {key}")
+                                    found = True
+                                elif p.has_option(section, key):
+                                    input_value = p.get(section, key).strip().lower()
+                                    pattern = Field_Type_Validators.get(expected_type)
+                                    if pattern:
+                                        if not re.fullmatch(pattern, input_value):
+                                            display.error(
+                                                f"[{section}] {key} should be of type '{expected_type}', but got {type(input_value).__name__} - {input_value}"
+                                            )
+                                            found = True
 
         elif context.CLIARGS['format'] == 'env':
             # validate any 'ANSIBLE_' env vars found

--- a/test/integration/targets/ansible_config_validate/aliases
+++ b/test/integration/targets/ansible_config_validate/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group5
+context/controller

--- a/test/integration/targets/ansible_config_validate/files/empty.cfg
+++ b/test/integration/targets/ansible_config_validate/files/empty.cfg
@@ -1,0 +1,1 @@
+# Empty configuration file

--- a/test/integration/targets/ansible_config_validate/files/empty.cfg
+++ b/test/integration/targets/ansible_config_validate/files/empty.cfg
@@ -1,1 +1,1 @@
-# Empty configuration file
+# Empty config file

--- a/test/integration/targets/ansible_config_validate/files/invalid_galaxy.cfg
+++ b/test/integration/targets/ansible_config_validate/files/invalid_galaxy.cfg
@@ -1,0 +1,5 @@
+[galaxy]
+server_list=my_org_hub
+
+[galaxy_server.my_org_hub]
+# url missing

--- a/test/integration/targets/ansible_config_validate/files/valid_galaxy.cfg
+++ b/test/integration/targets/ansible_config_validate/files/valid_galaxy.cfg
@@ -1,0 +1,21 @@
+[galaxy]
+server_list = my_org_hub, release_galaxy, test_galaxy, my_galaxy_ng
+
+[galaxy_server.my_org_hub]
+url=https://automation.my_org/
+username=my_user
+password=my_pass
+
+[galaxy_server.release_galaxy]
+url=https://galaxy.ansible.com/
+token=my_token
+
+[galaxy_server.test_galaxy]
+url=https://galaxy-dev.ansible.com/
+token=my_test_token
+
+[galaxy_server.my_galaxy_ng]
+url=http://my_galaxy_ng:8000/api/automation-hub/
+auth_url=http://my_keycloak:8080/auth/realms/myco/protocol/openid-connect/token
+client_id=galaxy-ng
+token=my_keycloak_access_token

--- a/test/integration/targets/ansible_config_validate/tasks/main.yml
+++ b/test/integration/targets/ansible_config_validate/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+- name: Test valid galaxy configuration
+  ansible.builtin.command: "ansible-config validate -t all"
+  environment:
+    ANSIBLE_CONFIG: "{{ role_path }}/files/valid_galaxy.cfg"
+  register: valid_test
+  changed_when: false
+
+- name: Verify valid config passes
+  ansible.builtin.assert:
+    that:
+      - valid_test.rc == 0
+      - "'All configurations seem valid' in valid_test.stdout"
+
+- name: Test invalid galaxy configuration (missing url)
+  ansible.builtin.command: "ansible-config validate -t all"
+  environment:
+    ANSIBLE_CONFIG: "{{ role_path }}/files/invalid_galaxy.cfg"
+  register: invalid_test
+  changed_when: false
+  ignore_errors: yes
+
+- name: Verify invalid config fails
+  ansible.builtin.assert:
+    that:
+      - invalid_test.rc != 0
+      - "'missing required field' in invalid_test.stderr"
+      - "'url' in invalid_test.stderr"
+
+- name: Test empty configuration file
+  ansible.builtin.command: "ansible-config validate -t all"
+  environment:
+    ANSIBLE_CONFIG: "{{ role_path }}/files/empty.cfg"
+  register: empty_test
+  changed_when: false
+
+- name: Verify empty config passes
+  ansible.builtin.assert:
+    that:
+      - empty_test.rc == 0
+      - "'All configurations seem valid' in empty_test.stdout"

--- a/test/integration/targets/non_executable_runme/aliases
+++ b/test/integration/targets/non_executable_runme/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group5
+context/controller

--- a/test/integration/targets/non_executable_runme/runme.sh
+++ b/test/integration/targets/non_executable_runme/runme.sh
@@ -1,0 +1,5 @@
+cat > test/integration/targets/non_executable_script/runme.sh <<EOF
+#!/bin/bash
+echo "This should fail"
+EOF
+chmod -x test/integration/targets/non_executable_script/runme.sh

--- a/test/lib/ansible_test/_internal/commands/integration/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/integration/__init__.py
@@ -629,7 +629,32 @@ def command_integration_script(
                 cmd += ['-e', '@%s' % config_path]
 
             env.update(coverage_manager.get_environment(target.name, target.aliases))
-            cover_python(args, host_state.controller_profile.python, cmd, target.name, env, cwd=cwd, capture=False)
+            try:
+                cover_python(args, host_state.controller_profile.python, cmd, target.name, env, cwd=cwd, capture=False)
+            except (PermissionError, SubprocessError) as e:
+                if any(msg in str(e) for msg in ['runme.sh', 'Permission denied']):
+                    # Get the permanent source path
+                    source_path = os.path.join(
+                        'test/integration/targets',
+                        target.name,
+                        'runme.sh'
+                    )
+                    abs_source_path = os.path.join(data_context().content.root, source_path)
+                    # Verify the file exists at the source location
+                    if not os.path.exists(abs_source_path):
+                        raise ApplicationError(
+                            f"Cannot locate 'runme.sh' at expected path: {abs_source_path}\n"
+                            f"Please check the test target configuration."
+                        ) from e
+                    raise ApplicationError(
+                        f"Integration test script 'runme.sh' is not executable in target '{target.name}'.\n"
+                        f"\n"
+                        f"To fix this permanently, run this command from your Ansible root directory ({data_context().content.root}):\n"
+                        f"  chmod +x {source_path}\n"
+                        f"\n"
+                        f"Current permissions: {oct(os.stat(abs_source_path).st_mode & 0o777)}"
+                    ) from e
+                raise
 
 
 def command_integration_role(

--- a/test/lib/ansible_test/_internal/coverage_util.py
+++ b/test/lib/ansible_test/_internal/coverage_util.py
@@ -155,10 +155,29 @@ def cover_python(
     cwd: t.Optional[str] = None,
 ) -> tuple[t.Optional[str], t.Optional[str]]:
     """Run a command while collecting Python code coverage."""
-    if args.coverage:
-        env.update(get_coverage_environment(args, target_name, python.version))
-
-    return intercept_python(args, python, cmd, env, capture, data, cwd)
+    try:
+        if args.coverage:
+            env.update(get_coverage_environment(args, target_name, python.version))
+        return intercept_python(args, python, cmd, env, capture, data, cwd)
+    except PermissionError as e:
+        if 'runme.sh' in str(e):
+            # Get the permanent source path relative to content root
+            source_path = os.path.join('test/integration/targets', target_name, 'runme.sh')
+            abs_source_path = os.path.abspath(os.path.join(data_context().content.root, source_path))
+            if not os.path.exists(abs_source_path):
+                raise ApplicationError(
+                    f"Cannot locate 'runme.sh' for target '{target_name}' at: {source_path}"
+                ) from e
+            current_permissions = oct(os.stat(abs_source_path).st_mode & 0o777)
+            raise ApplicationError(
+                f"Test script 'runme.sh' is not executable in target '{target_name}'.\n"
+                f"Current permissions: {current_permissions}\n"
+                f"To fix this, run:\n"
+                f"  chmod +x {source_path}\n"
+                f"Or from the Ansible root directory:\n"
+                f"  chmod +x {os.path.relpath(abs_source_path)}"
+            ) from e
+        raise
 
 
 def get_coverage_platform(config: HostConfig) -> str:

--- a/test/lib/ansible_test/_internal/util_common.py
+++ b/test/lib/ansible_test/_internal/util_common.py
@@ -466,7 +466,32 @@ def intercept_python(
     env['ANSIBLE_TEST_PYTHON_VERSION'] = python.version
     env['ANSIBLE_TEST_PYTHON_INTERPRETER'] = python.path
 
-    return run_command(args, cmd, capture=capture, env=env, data=data, cwd=cwd, always=always)
+    try:
+        return run_command(args, cmd, capture=capture, env=env, data=data, cwd=cwd, always=always)
+    except PermissionError as e:
+        if len(cmd) > 0 and any(script in cmd[0] for script in ('runme.sh', 'setup.sh')):
+            script_name = os.path.basename(cmd[0])
+            target_name = os.path.basename(cwd) if cwd else 'unknown_target'
+            # Get the permanent source path
+            source_path = os.path.join(
+                'test/integration/targets',
+                target_name,
+                script_name
+            )
+            abs_source_path = os.path.join(data_context().content.root, source_path)
+            # Verify the file exists at the source location
+            if not os.path.exists(abs_source_path):
+                raise ApplicationError(
+                    f"ERROR! Cannot locate test script '{script_name}' at: {source_path}\n"
+                    f"Please check the test target configuration."
+                ) from e
+            raise ApplicationError(
+                f"ERROR! The test script '{script_name}' is not executable in target '{target_name}'.\n"
+                f"File location: {source_path}\n"
+                f"To fix this, run the following command from your Ansible source directory:\n"
+                f"  chmod +x {source_path}"
+            ) from e
+        raise
 
 
 def run_command(


### PR DESCRIPTION
##### SUMMARY

Improves error handling when integration test targets have non-executable runme.sh scripts. Now shows:
- Clear FATAL error message identifying the problematic target.
- Exact file path of the non-executable script.
- Simple chmod command to fix the permissions.

Fixes #84598


**Output:**
```
FATAL: ERROR! The test script 'runme.sh' is not executable in target 'non_executable_runme'.
File location: test/integration/targets/non_executable_runme/runme.sh
To fix this, run:
  chmod +x test/integration/targets/non_executable_runme/runme.sh
```

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
