### PR TITLE
ansible-test - Improve runme.sh error handling

### DIFF
--- a/changelogs/fragments/ansible-test-no-exec-script.yml
+++ b/changelogs/fragments/ansible-test-no-exec-script.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Show a more user-friendly error message when a ``runme.sh`` script is not executable.

--- a/test/integration/targets/ansible-test-integration-no-exec-script/aliases
+++ b/test/integration/targets/ansible-test-integration-no-exec-script/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group3  # runs in the distro test containers
+shippable/generic/group1  # runs in the default test container
+context/controller
+needs/target/collection

--- a/test/integration/targets/ansible-test-integration-no-exec-script/ansible_collections/ns/col/tests/integration/targets/hello/aliases
+++ b/test/integration/targets/ansible-test-integration-no-exec-script/ansible_collections/ns/col/tests/integration/targets/hello/aliases
@@ -1,0 +1,1 @@
+context/controller

--- a/test/integration/targets/ansible-test-integration-no-exec-script/ansible_collections/ns/col/tests/integration/targets/hello/runme.sh
+++ b/test/integration/targets/ansible-test-integration-no-exec-script/ansible_collections/ns/col/tests/integration/targets/hello/runme.sh
@@ -1,0 +1,1 @@
+# shellcheck shell=bash

--- a/test/integration/targets/ansible-test-integration-no-exec-script/runme.sh
+++ b/test/integration/targets/ansible-test-integration-no-exec-script/runme.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+source ../collection/setup.sh
+
+set -x +o pipefail
+
+ansible-test integration --venv --color --truncate 0 "${@}" 2>&1 | grep "Unable to run non-executable script"
+
+echo "SUCCESS: Non-executable script error correctly handled."

--- a/test/lib/ansible_test/_internal/commands/integration/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/integration/__init__.py
@@ -591,6 +591,9 @@ def command_integration_script(
     """Run an integration test script."""
     display.info('Running %s integration test script' % target.name)
 
+    if not os.access(target.script_path, os.X_OK):
+        raise ApplicationError(f'Unable to run non-executable script {target.script_path!r}. Did you forget to run "chmod +x" on it?')
+
     env_config = None
 
     if isinstance(args, PosixIntegrationConfig):


### PR DESCRIPTION
##### SUMMARY

Show a more user-friendly error message when a ``runme.sh`` script is not executable.

Resolves https://github.com/ansible/ansible/issues/84598

##### ISSUE TYPE

Feature Pull Request
