### PR TITLE
[backport 2.16] Fix uninstall tests (#84973)

### DIFF
--- a/test/integration/targets/setup_paramiko/uninstall-dnf5.yml
+++ b/test/integration/targets/setup_paramiko/uninstall-dnf5.yml
@@ -1,0 +1,2 @@
+- name: Uninstall Paramiko using dnf history undo
+  command: dnf history undo last --assumeyes


### PR DESCRIPTION
match file name to package_manager detection of dnf5

(cherry picked from commit 6fc592df9b81efed969b9950c9fae373e2574a6a)

##### ISSUE TYPE

- Test Pull Request
