### PR TITLE
[2.19] ansible-doc: fix indent and line wrapping for first line of (sub-)option and (sub-)return value descriptions

### DIFF
--- a/changelogs/fragments/84690-ansible-doc-indent-wrapping.yml
+++ b/changelogs/fragments/84690-ansible-doc-indent-wrapping.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "ansible-doc - fix indentation for first line of descriptions of suboptions and sub-return values (https://github.com/ansible/ansible/pull/84690)."
+  - "ansible-doc - fix line wrapping for first line of description of options and return values (https://github.com/ansible/ansible/pull/84690)."

--- a/test/integration/targets/ansible-doc/randommodule-text-verbose.output
+++ b/test/integration/targets/ansible-doc/randommodule-text-verbose.output
@@ -23,13 +23,13 @@ OPTIONS (= indicates it is required):
         type: dict
         options:
 
-        - subtest2          Another suboption.
+        - subtest2  Another suboption.
           default: null
           type: float
           added in: version 1.1.0
         suboptions:
 
-        - subtest          A suboption.
+        - subtest  A suboption.
           default: null
           type: int
           added in: version 1.1.0 of testns.testcol
@@ -67,7 +67,7 @@ RETURN VALUES:
         type: dict
         contains:
 
-        - suboption          A suboption.
+        - suboption  A suboption.
           choices: [ARF, BARN, c_without_capital_first_letter]
           type: str
           added in: version 1.4.0 of testns.testcol

--- a/test/integration/targets/ansible-doc/randommodule-text.output
+++ b/test/integration/targets/ansible-doc/randommodule-text.output
@@ -17,8 +17,8 @@ DEPRECATED:
 
 OPTIONS (= indicates it is required):
 
-- sub     Suboptions. Contains `sub.subtest', which can be set to `123'.
-           You can use `TEST_ENV' to set this.
+- sub     Suboptions. Contains `sub.subtest', which can be set to
+           `123'. You can use `TEST_ENV' to set this.
         set_via:
           env:
           - deprecated:
@@ -31,15 +31,17 @@ OPTIONS (= indicates it is required):
         type: dict
         options:
 
-        - subtest2          Another suboption. Useful when [[ansible.builtin.shuffle]]
-                     is used with value `[a,b,),d\]'.
+        - subtest2  Another suboption. Useful when
+                     [[ansible.builtin.shuffle]] is used with value
+                     `[a,b,),d\]'.
           default: null
           type: float
           added in: version 1.1.0
         suboptions:
 
-        - subtest          A suboption. Not compatible to `path=c:\foo(1).txt' (of
-                    module ansible.builtin.copy).
+        - subtest  A suboption. Not compatible to
+                    `path=c:\foo(1).txt' (of module
+                    ansible.builtin.copy).
           default: null
           type: int
           added in: version 1.1.0 of testns.testcol
@@ -102,7 +104,7 @@ RETURN VALUES:
         type: dict
         contains:
 
-        - suboption          A suboption.
+        - suboption  A suboption.
           choices: [ARF, BARN, c_without_capital_first_letter]
           type: str
           added in: version 1.4.0 of testns.testcol

--- a/test/integration/targets/ansible-doc/test_docs_returns.output
+++ b/test/integration/targets/ansible-doc/test_docs_returns.output
@@ -17,7 +17,7 @@ RETURN VALUES:
         type: dict
         contains:
 
-        - suboption          A suboption.
+        - suboption  A suboption.
           choices: [ARF, BARN, c_without_capital_first_letter]
           type: str
 

--- a/test/integration/targets/ansible-doc/test_docs_suboptions.output
+++ b/test/integration/targets/ansible-doc/test_docs_suboptions.output
@@ -8,20 +8,20 @@ OPTIONS (= indicates it is required):
         type: dict
         suboptions:
 
-        - a_first          The first suboption.
+        - a_first  The first suboption.
           default: null
           type: str
 
-        - m_middle          The suboption in the middle.
+        - m_middle  The suboption in the middle.
                      Has its own suboptions.
           default: null
           suboptions:
 
-          - a_suboption            A sub-suboption.
+          - a_suboption  A sub-suboption.
             default: null
             type: str
 
-        - z_last          The last suboption.
+        - z_last  The last suboption.
           default: null
           type: str
 

--- a/test/integration/targets/ansible-doc/test_docs_yaml_anchors.output
+++ b/test/integration/targets/ansible-doc/test_docs_yaml_anchors.output
@@ -12,7 +12,7 @@ OPTIONS (= indicates it is required):
         type: list
         suboptions:
 
-        = port          Rule port
+        = port  Rule port
           type: int
 
 - ingress  Ingress firewall rules
@@ -21,7 +21,7 @@ OPTIONS (= indicates it is required):
         type: list
         suboptions:
 
-        = port          Rule port
+        = port  Rule port
           type: int
 
 - last_one  Short desc


### PR DESCRIPTION
##### SUMMARY
Backport of #84690 to stable-2.19.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
