### PR TITLE
get_bin_path('ssh-agent'): required is deprecated

### DIFF
--- a/changelogs/fragments/get_bin_path-remove-use-of-deprecated-param.yml
+++ b/changelogs/fragments/get_bin_path-remove-use-of-deprecated-param.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Remove use of `required` parameter in `get_bin_path` which has been deprecated."

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -139,7 +139,7 @@ def _launch_ssh_agent() -> None:
             return
         case 'auto':
             try:
-                ssh_agent_bin = get_bin_path('ssh-agent', required=True)
+                ssh_agent_bin = get_bin_path('ssh-agent')
             except ValueError as e:
                 raise AnsibleError('SSH_AGENT set to auto, but cannot find ssh-agent binary') from e
             ssh_agent_dir = os.path.join(C.DEFAULT_LOCAL_TMP, 'ssh_agent')


### PR DESCRIPTION
##### SUMMARY
The deprecation warning wasn't displayed before DT was merged.
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
