### PR TITLE
Fix deferred exception handling in fail_json calls

### DIFF
--- a/changelogs/fragments/84639-fail_json_exception_cleanup.yml
+++ b/changelogs/fragments/84639-fail_json_exception_cleanup.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Removed improper use of the `exception` argument in `fail_json()` calls in `expect` and `wait_for` modules.
+    These exceptions were not deferred and passing them prevented automatic traceback capture, violating best practices.

--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -163,7 +163,8 @@ def main():
     )
 
     if not HAS_PEXPECT:
-        module.fail_json(msg=missing_required_lib("pexpect"), exception=PEXPECT_IMP_ERR)
+        module.fail_json(msg=missing_required_lib("pexpect"))
+
 
     chdir = module.params['chdir']
     args = module.params['command']

--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -165,7 +165,6 @@ def main():
     if not HAS_PEXPECT:
         module.fail_json(msg=missing_required_lib("pexpect"))
 
-
     chdir = module.params['chdir']
     args = module.params['command']
     creates = module.params['creates']

--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -120,6 +120,7 @@ EXAMPLES = r"""
 
 import datetime
 import os
+import traceback
 
 PEXPECT_IMP_ERR = None
 try:
@@ -132,6 +133,10 @@ except ImportError as ex:
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.module_utils.common.validation import check_type_int
+
+
+def format_exception_traceback(exc):
+    return ''.join(traceback.format_exception(type(exc), exc, exc.__traceback__))
 
 
 def response_closure(module, question, responses):
@@ -163,7 +168,7 @@ def main():
     )
 
     if not HAS_PEXPECT:
-        module.fail_json(msg=missing_required_lib("pexpect"))
+        module.fail_json(msg=missing_required_lib("pexpect"), exception=format_exception_traceback(PEXPECT_IMP_ERR))
 
     chdir = module.params['chdir']
     args = module.params['command']

--- a/lib/ansible/modules/wait_for.py
+++ b/lib/ansible/modules/wait_for.py
@@ -234,6 +234,7 @@ import re
 import select
 import socket
 import time
+import traceback
 
 from datetime import datetime, timedelta, timezone
 
@@ -250,6 +251,10 @@ try:
     # just because we can import it on Linux doesn't mean we will use it
 except ImportError as ex:
     PSUTIL_IMP_ERR = ex
+
+
+def format_exception_traceback(exc):
+    return ''.join(traceback.format_exception(type(exc), exc, exc.__traceback__))
 
 
 class TCPConnectionInfo(object):
@@ -286,7 +291,7 @@ class TCPConnectionInfo(object):
         self.port = int(self.module.params['port'])
         self.exclude_ips = self._get_exclude_ips()
         if not HAS_PSUTIL:
-            module.fail_json(msg=missing_required_lib('psutil'))
+            module.fail_json(msg=missing_required_lib('psutil'), exception=format_exception_traceback(PSUTIL_IMP_ERR))
 
     def _get_exclude_ips(self):
         exclude_hosts = self.module.params['exclude_hosts']

--- a/lib/ansible/modules/wait_for.py
+++ b/lib/ansible/modules/wait_for.py
@@ -286,7 +286,7 @@ class TCPConnectionInfo(object):
         self.port = int(self.module.params['port'])
         self.exclude_ips = self._get_exclude_ips()
         if not HAS_PSUTIL:
-            module.fail_json(msg=missing_required_lib('psutil'), exception=PSUTIL_IMP_ERR)
+            module.fail_json(msg=missing_required_lib('psutil'))
 
     def _get_exclude_ips(self):
         exclude_hosts = self.module.params['exclude_hosts']

--- a/test/units/modules/test_expect.py
+++ b/test/units/modules/test_expect.py
@@ -1,0 +1,34 @@
+import pytest
+import sys
+import importlib
+import traceback
+
+from ansible.modules import expect
+
+
+class TestExpectModule:
+
+    def test_missing_pexpect_fails_with_traceback(self, monkeypatch):
+
+        monkeypatch.setitem(sys.modules, 'pexpect', None)
+
+        importlib.reload(expect)
+
+        class FakeModule:
+            def fail_json(self, **kwargs):
+                self.failed = True
+                self.kwargs = kwargs
+                raise Exception("fail_json called")
+
+        module = FakeModule()
+
+        with pytest.raises(Exception, match="fail_json called"):
+            if not expect.HAS_PEXPECT:
+                module.fail_json(
+                    msg="pexpect missing",
+                    exception=expect.format_exception_traceback(expect.PEXPECT_IMP_ERR)
+                )
+
+        assert module.failed
+        assert 'exception' in module.kwargs
+        assert 'Traceback' in module.kwargs['exception']

--- a/test/units/modules/test_expect.py
+++ b/test/units/modules/test_expect.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 import importlib
-import traceback
+
 
 from ansible.modules import expect
 

--- a/test/units/modules/test_expect.py
+++ b/test/units/modules/test_expect.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 import sys
 import importlib

--- a/test/units/modules/test_wait_for.py
+++ b/test/units/modules/test_wait_for.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 import importlib
-import traceback
+
 
 from ansible.modules import wait_for
 

--- a/test/units/modules/test_wait_for.py
+++ b/test/units/modules/test_wait_for.py
@@ -1,0 +1,34 @@
+import pytest
+import sys
+import importlib
+import traceback
+
+from ansible.modules import wait_for
+
+
+class TestWaitForModule:
+
+    def test_missing_psutil_fails_with_traceback(self, monkeypatch):
+
+        monkeypatch.setitem(sys.modules, 'psutil', None)
+
+        importlib.reload(wait_for)
+
+        class FakeModule:
+            def fail_json(self, **kwargs):
+                self.failed = True
+                self.kwargs = kwargs
+                raise Exception("fail_json called")
+
+        module = FakeModule()
+
+        with pytest.raises(Exception, match="fail_json called"):
+            if not wait_for.HAS_PSUTIL:
+                module.fail_json(
+                    msg="psutil missing",
+                    exception=wait_for.format_exception_traceback(wait_for.PSUTIL_IMP_ERR)
+                )
+
+        assert module.failed
+        assert 'exception' in module.kwargs
+        assert 'Traceback' in module.kwargs['exception']

--- a/test/units/modules/test_wait_for.py
+++ b/test/units/modules/test_wait_for.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 import sys
 import importlib


### PR DESCRIPTION
##### SUMMARY

This PR addresses the improper handling of exceptions in `fail_json()` within the expect and wait_for modules. The exception argument was previously being passed directly, causing improper traceback handling for deferred `ImportError `exceptions.

- The exception argument is now properly formatted as a traceback string using the `exception_traceback()` function.
- This change ensures that Ansible can automatically capture and display tracebacks as expected, improving error reporting.

Fixes #84639

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Task Pull Request
