### PR TITLE
fix template spacing

### DIFF
--- a/lib/ansible/galaxy/data/apb/Dockerfile.j2
+++ b/lib/ansible/galaxy/data/apb/Dockerfile.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 FROM ansibleplaybookbundle/apb-base
 
 LABEL "com.redhat.apb.spec"=\

--- a/lib/ansible/galaxy/data/apb/Makefile.j2
+++ b/lib/ansible/galaxy/data/apb/Makefile.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 DOCKERHOST = DOCKERHOST
 DOCKERORG = DOCKERORG
 IMAGENAME = {{ role_name }}

--- a/lib/ansible/galaxy/data/apb/apb.yml.j2
+++ b/lib/ansible/galaxy/data/apb/apb.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 version: '1.0.0'
 name: {{ role_name }}
 description: {{ description }}

--- a/lib/ansible/galaxy/data/apb/defaults/main.yml.j2
+++ b/lib/ansible/galaxy/data/apb/defaults/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # defaults file for {{ role_name }}

--- a/lib/ansible/galaxy/data/apb/handlers/main.yml.j2
+++ b/lib/ansible/galaxy/data/apb/handlers/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # handlers file for {{ role_name }}

--- a/lib/ansible/galaxy/data/apb/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/apb/meta/main.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 galaxy_info:
   author: {{ author }}
   description: {{ description }}

--- a/lib/ansible/galaxy/data/apb/playbooks/deprovision.yml.j2
+++ b/lib/ansible/galaxy/data/apb/playbooks/deprovision.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 - name: "{{ role_name }} playbook to deprovision the application"
   hosts: localhost
   gather_facts: false

--- a/lib/ansible/galaxy/data/apb/playbooks/provision.yml.j2
+++ b/lib/ansible/galaxy/data/apb/playbooks/provision.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 - name: "{{ role_name }} playbook to provision the application"
   hosts: localhost
   gather_facts: false

--- a/lib/ansible/galaxy/data/apb/tasks/main.yml.j2
+++ b/lib/ansible/galaxy/data/apb/tasks/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # tasks file for {{ role_name }}

--- a/lib/ansible/galaxy/data/apb/tests/ansible.cfg
+++ b/lib/ansible/galaxy/data/apb/tests/ansible.cfg
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 [defaults]
 inventory=./inventory

--- a/lib/ansible/galaxy/data/apb/tests/inventory
+++ b/lib/ansible/galaxy/data/apb/tests/inventory
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 localhost
 
 

--- a/lib/ansible/galaxy/data/apb/tests/test.yml.j2
+++ b/lib/ansible/galaxy/data/apb/tests/test.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 - hosts: localhost
   gather_facts: no

--- a/lib/ansible/galaxy/data/apb/vars/main.yml.j2
+++ b/lib/ansible/galaxy/data/apb/vars/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # vars file for {{ role_name }}

--- a/lib/ansible/galaxy/data/collections_galaxy_meta.yml
+++ b/lib/ansible/galaxy/data/collections_galaxy_meta.yml
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 # Copyright (c) 2019 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/lib/ansible/galaxy/data/container/defaults/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/defaults/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # defaults file for {{ role_name }}

--- a/lib/ansible/galaxy/data/container/handlers/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/handlers/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # handlers file for {{ role_name }}

--- a/lib/ansible/galaxy/data/container/meta/container.yml.j2
+++ b/lib/ansible/galaxy/data/container/meta/container.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 # Add your Ansible Container service definitions here.
 # For example:
   #

--- a/lib/ansible/galaxy/data/container/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/meta/main.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 galaxy_info:
   author: {{ author }}
   description: {{ description }}

--- a/lib/ansible/galaxy/data/container/tasks/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/tasks/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # tasks file for {{ role_name }}

--- a/lib/ansible/galaxy/data/container/tests/ansible.cfg
+++ b/lib/ansible/galaxy/data/container/tests/ansible.cfg
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 [defaults]
 inventory=./inventory

--- a/lib/ansible/galaxy/data/container/tests/inventory
+++ b/lib/ansible/galaxy/data/container/tests/inventory
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 localhost
 
 

--- a/lib/ansible/galaxy/data/container/tests/test.yml.j2
+++ b/lib/ansible/galaxy/data/container/tests/test.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 - hosts: localhost
   gather_facts: no

--- a/lib/ansible/galaxy/data/container/vars/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/vars/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # vars file for {{ role_name }}

--- a/lib/ansible/galaxy/data/default/collection/galaxy.yml.j2
+++ b/lib/ansible/galaxy/data/default/collection/galaxy.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ### REQUIRED
 {% for option in required_config %}
 {{ option.description | comment_ify }}

--- a/lib/ansible/galaxy/data/default/collection/meta/runtime.yml
+++ b/lib/ansible/galaxy/data/default/collection/meta/runtime.yml
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # Collections must specify a minimum required ansible version to upload
 # to galaxy

--- a/lib/ansible/galaxy/data/default/role/defaults/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/role/defaults/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # defaults file for {{ role_name }}

--- a/lib/ansible/galaxy/data/default/role/handlers/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/role/handlers/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # handlers file for {{ role_name }}

--- a/lib/ansible/galaxy/data/default/role/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/role/meta/main.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 galaxy_info:
   author: {{ author }}
   description: {{ description }}

--- a/lib/ansible/galaxy/data/default/role/tasks/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/role/tasks/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # tasks file for {{ role_name }}

--- a/lib/ansible/galaxy/data/default/role/tests/inventory
+++ b/lib/ansible/galaxy/data/default/role/tests/inventory
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 localhost
 

--- a/lib/ansible/galaxy/data/default/role/tests/test.yml.j2
+++ b/lib/ansible/galaxy/data/default/role/tests/test.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 - hosts: localhost
   remote_user: root

--- a/lib/ansible/galaxy/data/default/role/vars/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/role/vars/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # vars file for {{ role_name }}

--- a/lib/ansible/galaxy/data/network/cliconf_plugins/example.py.j2
+++ b/lib/ansible/galaxy/data/network/cliconf_plugins/example.py.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 #
 # (c) 2018 Red Hat Inc.
 #

--- a/lib/ansible/galaxy/data/network/defaults/main.yml.j2
+++ b/lib/ansible/galaxy/data/network/defaults/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # defaults file for {{ role_name }}

--- a/lib/ansible/galaxy/data/network/library/example_command.py.j2
+++ b/lib/ansible/galaxy/data/network/library/example_command.py.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 #
 # (c) 2018 Red Hat Inc.
 #

--- a/lib/ansible/galaxy/data/network/library/example_config.py.j2
+++ b/lib/ansible/galaxy/data/network/library/example_config.py.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 #
 # (c) 2018 Red Hat Inc.
 #

--- a/lib/ansible/galaxy/data/network/library/example_facts.py.j2
+++ b/lib/ansible/galaxy/data/network/library/example_facts.py.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 #
 # (c) 2018 Red Hat Inc.
 #

--- a/lib/ansible/galaxy/data/network/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/network/meta/main.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 galaxy_info:
   author: {{ author }}
   description: {{ description }}

--- a/lib/ansible/galaxy/data/network/module_utils/example.py.j2
+++ b/lib/ansible/galaxy/data/network/module_utils/example.py.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 #
 # (c) 2018 Red Hat Inc.
 #

--- a/lib/ansible/galaxy/data/network/netconf_plugins/example.py.j2
+++ b/lib/ansible/galaxy/data/network/netconf_plugins/example.py.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 #
 # (c) 2018 Red Hat Inc.
 #

--- a/lib/ansible/galaxy/data/network/tasks/main.yml.j2
+++ b/lib/ansible/galaxy/data/network/tasks/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # tasks file for {{ role_name }}

--- a/lib/ansible/galaxy/data/network/terminal_plugins/example.py.j2
+++ b/lib/ansible/galaxy/data/network/terminal_plugins/example.py.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 #
 # (c) 2018 Red Hat Inc.
 #

--- a/lib/ansible/galaxy/data/network/tests/inventory
+++ b/lib/ansible/galaxy/data/network/tests/inventory
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 localhost
 

--- a/lib/ansible/galaxy/data/network/tests/test.yml.j2
+++ b/lib/ansible/galaxy/data/network/tests/test.yml.j2
@@ -1,4 +1,4 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 - hosts: localhost
   connection: network_cli

--- a/lib/ansible/galaxy/data/network/vars/main.yml.j2
+++ b/lib/ansible/galaxy/data/network/vars/main.yml.j2
@@ -1,3 +1,3 @@
-#SPDX-License-Identifier: MIT-0
+# SPDX-License-Identifier: MIT-0
 ---
 # vars file for {{ role_name }}

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -320,7 +320,7 @@ class ValidRoleTests(object):
             if self.role_name == 'delete_me_skeleton':
                 expected_string = "---\n# {0} file for {1}".format(d, self.role_name)
             else:
-                expected_string = "#SPDX-License-Identifier: MIT-0\n---\n# {0} file for {1}".format(d, self.role_name)
+                expected_string = "# SPDX-License-Identifier: MIT-0\n---\n# {0} file for {1}".format(d, self.role_name)
             with open(main_yml, 'r') as f:
                 self.assertEqual(expected_string, f.read().strip())
 


### PR DESCRIPTION
##### ISSUE TYPE

- Docs Pull Request

SPDX identifiers to templates were included in https://github.com/ansible/ansible/commit/aed8c080f677a5c9fc87974e764bc66f61c7b4e8

The lack of spacing for the SPDX identifier in the jinja templates causes ansible-lint to throw a warning when initing new roles with ansible-galaxy




