### PR TITLE
Fix test_range_templating on 32-bit architectures

### DIFF
--- a/test/units/_internal/templating/test_lazy_containers.py
+++ b/test/units/_internal/templating/test_lazy_containers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import collections.abc as c
 import copy
 import re
+import sys
 import typing as t
 
 import pytest
@@ -466,8 +467,8 @@ def test_range_templating():
     templar = TemplateEngine()
 
     # ensure that an insanely large range is not listified
-    assert templar.evaluate_conditional(TRUST.tag("range(1000000000000) | type_debug == 'range'"))
-    assert isinstance(templar.template(TRUST.tag("{{ range(1000000000000) | random }}")), int)
+    assert templar.evaluate_conditional(TRUST.tag("range(sys.maxsize) | type_debug == 'range'"))
+    assert isinstance(templar.template(TRUST.tag("{{ range(sys.maxsize) | random }}")), int)
     assert templar.template(TRUST.tag("{{ range(3) | reverse }}")) == [2, 1, 0]
 
 


### PR DESCRIPTION
##### SUMMARY
32-bit archtectures like i386, armel, armhf will fail with the error

ansible._internal._templating._errors.AnsibleTemplatePluginRuntimeError: The filter plugin 'ansible.builtin.random' failed: Python int too large to convert to C ssize_t

So instead of having a static value, just pick sys.maxsize.

This should also go to stable-2.19.
##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Test Pull Request
