### PR TITLE
Fix uri form-multipart to not overwrite filename to allow retries

### DIFF
--- a/changelogs/fragments/85010-uri-multipart-file-on-retry.yml
+++ b/changelogs/fragments/85010-uri-multipart-file-on-retry.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - uri - fix form-multipart file not being found when task is retried (https://github.com/ansible/ansible/issues/85009)

--- a/lib/ansible/plugins/action/uri.py
+++ b/lib/ansible/plugins/action/uri.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import collections.abc as _c
 import os
+from copy import deepcopy
 
 from ansible.errors import AnsibleActionFail
 from ansible.module_utils.parsing.convert_bool import boolean
@@ -53,6 +54,7 @@ class ActionModule(ActionBase):
                     raise AnsibleActionFail(
                         'body must be mapping, cannot be type %s' % body.__class__.__name__
                     )
+                new_body = deepcopy(body)
                 for field, value in body.items():
                     if not isinstance(value, _c.MutableMapping):
                         continue
@@ -61,20 +63,16 @@ class ActionModule(ActionBase):
                     if not filename or content:
                         continue
 
-                    if not value.get('original_filename'):
-                        value['original_filename'] = value.get('filename')
-                    filename = value.get('original_filename')
-
                     filename = self._find_needle('files', filename)
 
                     tmp_src = self._connection._shell.join_path(
                         self._connection._shell.tmpdir,
                         os.path.basename(filename)
                     )
-                    value['filename'] = tmp_src
+                    new_body[field].update({'filename': tmp_src})
                     self._transfer_file(filename, tmp_src)
                     self._fixup_perms2((self._connection._shell.tmpdir, tmp_src))
-                kwargs['body'] = body
+                kwargs['body'] = new_body
 
             new_module_args = self._task.args | kwargs
 

--- a/lib/ansible/plugins/action/uri.py
+++ b/lib/ansible/plugins/action/uri.py
@@ -55,7 +55,7 @@ class ActionModule(ActionBase):
                         'body must be mapping, cannot be type %s' % body.__class__.__name__
                     )
                 new_body = deepcopy(body)
-                for field, value in body.items():
+                for field, value in new_body.items():
                     if not isinstance(value, _c.MutableMapping):
                         continue
                     content = value.get('content')
@@ -69,10 +69,10 @@ class ActionModule(ActionBase):
                         self._connection._shell.tmpdir,
                         os.path.basename(filename)
                     )
-                    new_body[field].update({'filename': tmp_src})
+                    value['filename'] = tmp_src
                     self._transfer_file(filename, tmp_src)
                     self._fixup_perms2((self._connection._shell.tmpdir, tmp_src))
-                kwargs['body'] = new_body
+                kwargs['body'] = body
 
             new_module_args = self._task.args | kwargs
 

--- a/lib/ansible/plugins/action/uri.py
+++ b/lib/ansible/plugins/action/uri.py
@@ -72,7 +72,7 @@ class ActionModule(ActionBase):
                     value['filename'] = tmp_src
                     self._transfer_file(filename, tmp_src)
                     self._fixup_perms2((self._connection._shell.tmpdir, tmp_src))
-                kwargs['body'] = body
+                kwargs['body'] = new_body
 
             new_module_args = self._task.args | kwargs
 

--- a/lib/ansible/plugins/action/uri.py
+++ b/lib/ansible/plugins/action/uri.py
@@ -61,6 +61,10 @@ class ActionModule(ActionBase):
                     if not filename or content:
                         continue
 
+                    if not value.get('original_filename'):
+                        value['original_filename'] = value.get('filename')
+                    filename = value.get('original_filename')
+
                     filename = self._find_needle('files', filename)
 
                     tmp_src = self._connection._shell.join_path(

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -477,6 +477,19 @@
   register: multipart_invalid
   failed_when: '"failed to parse body as form-multipart: value must be a string, or mapping, cannot be type" not in multipart_invalid.msg'
 
+- name: multipart/form-data with file and retry
+  uri:
+    url: https://{{ httpbin_host }}/post
+    method: POST
+    body_format: form-multipart
+    body:
+      file:
+        filename: formdata.txt
+  retries: 1
+  delay: 0.01
+  register: result
+  failed_when: result is failed or result.attempts == 1
+
 - name: Validate invalid method
   uri:
     url: https://{{ httpbin_host }}/anything

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -490,6 +490,12 @@
   register: result
   failed_when: result is failed or result.attempts == 1
 
+- name: Assert multipart/form-data with file and retry
+  assert:
+    that:
+      - result.json.files.file | b64decode == '_multipart/form-data_\n'
+      - result.attempts == 2
+
 - name: Validate invalid method
   uri:
     url: https://{{ httpbin_host }}/anything


### PR DESCRIPTION
##### SUMMARY

Save original filename to file in uri form-multipart to restore it when the task is retried.

Fixes https://github.com/ansible/ansible/issues/85009

##### ISSUE TYPE

- Bugfix Pull Request

