### PR TITLE
Disable retries on ansible-galaxy-collection

### DIFF
--- a/test/integration/targets/ansible-galaxy-collection/aliases
+++ b/test/integration/targets/ansible-galaxy-collection/aliases
@@ -2,3 +2,4 @@ shippable/galaxy/group1
 shippable/galaxy/smoketest
 cloud/galaxy
 context/controller
+retry/never


### PR DESCRIPTION
##### SUMMARY

This will make debugging test failures easier, since we'll only be dealing with the initial failure and not any failures induced by running the tests a second time against the same container.

##### ISSUE TYPE

Test Pull Request
