### PR TITLE
fix handler include_tasks templating

### DIFF
--- a/changelogs/fragments/85015-fix-handler-include_tasks-templating.yml
+++ b/changelogs/fragments/85015-fix-handler-include_tasks-templating.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - include_tasks - fix templating options when used as a handler (https://github.com/ansible/ansible/pull/85015).

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -84,7 +84,10 @@ class _ClassProperty:
 class FieldAttributeBase:
 
     _post_validate_object = False
-
+    """
+    `False` skips FieldAttribute post-validation on intermediate objects and mixins for attributes without `always_post_validate`.
+    Leaf objects (e.g., `Task`) should set this attribute `True` to opt-in to post-validation.
+    """
     fattributes = _ClassProperty()
 
     @classmethod

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -569,7 +569,7 @@ class FieldAttributeBase:
             return Sentinel
 
         # FIXME: compare types, not strings
-        if not attribute.always_post_validate and not self.__class__._post_validate_object:
+        if not attribute.always_post_validate and not self._post_validate_object:
             # Intermediate objects like Play() won't have their fields validated by
             # default, as their values are often inherited by other objects and validated
             # later, so we don't want them to fail out early

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -568,7 +568,7 @@ class FieldAttributeBase:
             # only import_role is checked here because import_tasks never reaches this point
             return Sentinel
 
-        # FIXME: compare types, not strings
+        # Skip post validation unless always_post_validate is True, or the object requires post validation.
         if not attribute.always_post_validate and not self._post_validate_object:
             # Intermediate objects like Play() won't have their fields validated by
             # default, as their values are often inherited by other objects and validated

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -83,6 +83,8 @@ class _ClassProperty:
 
 class FieldAttributeBase:
 
+    _post_validate_object = False
+
     fattributes = _ClassProperty()
 
     @classmethod
@@ -567,7 +569,7 @@ class FieldAttributeBase:
             return Sentinel
 
         # FIXME: compare types, not strings
-        if not attribute.always_post_validate and self.__class__.__name__ not in ('Task', 'Handler', 'PlayContext', 'IncludeRole', 'TaskInclude'):
+        if not attribute.always_post_validate and not self.__class__._post_validate_object:
             # Intermediate objects like Play() won't have their fields validated by
             # default, as their values are often inherited by other objects and validated
             # later, so we don't want them to fail out early

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -71,6 +71,8 @@ class PlayContext(Base):
     connection/authentication information.
     """
 
+    _post_validate_object = True
+
     # base
     module_compression = FieldAttribute(isa='string', default=C.DEFAULT_MODULE_COMPRESSION)
     shell = FieldAttribute(isa='string')

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -65,6 +65,8 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
        Task.something(...)
     """
 
+    _post_validate_object = True
+
     # =================================================================================
     # ATTRIBUTES
     # load_<attribute_name> and

--- a/test/integration/targets/handlers/test_handlers_including_task.yml
+++ b/test/integration/targets/handlers/test_handlers_including_task.yml
@@ -9,8 +9,15 @@
       debug:
         msg: notifying handler
       changed_when: yes
-      notify: include a task from the handlers section
+      notify:
+        - include a task from the handlers section
+        - include a task in a loop from the handlers section
 
   handlers:
     - name: include a task from the handlers section
       include_tasks: handlers.yml
+
+    - name: include a task in a loop from the handlers section
+      include_tasks: "{{ item }}"
+      with_first_found:
+        - handlers.yml


### PR DESCRIPTION
##### SUMMARY

This works as a task:

```yaml
- name: cleanup
  include_tasks: "{{ item }}"
  with_first_found:
    - foo
    - bar
```

But as a handler, the include is never templated:

```console
RUNNING HANDLER [cleanup] ************************************************************************************************************************************************************************************
[ERROR]: Could not find or access '/home/shertel/ansible/{{ item }}' on the Ansible Controller: Unable to retrieve file contents.
Could not find or access '/home/shertel/ansible/{{ item }}' on the Ansible Controller.
If you are using a module and expect the file to exist on the remote, see the remote_src option: [Errno 2] No such file or directory: '/home/shertel/ansible/{{ item }}'
```

This worked prior to data tagging.

##### ISSUE TYPE

- Bugfix Pull Request
