### PR TITLE
Convert TestPlaybookExecutor to pytest and add missing coverage

### DIFF
--- a/test/units/executor/test_playbook_executor.py
+++ b/test/units/executor/test_playbook_executor.py
@@ -17,9 +17,6 @@
 
 from __future__ import annotations
 
-import unittest
-from unittest.mock import MagicMock
-
 from ansible.executor.playbook_executor import PlaybookExecutor
 from ansible.playbook import Playbook
 from ansible._internal._templating._engine import TemplateEngine
@@ -28,17 +25,17 @@ from ansible.utils import context_objects as co
 from units.mock.loader import DictDataLoader
 
 
-class TestPlaybookExecutor(unittest.TestCase):
+class TestPlaybookExecutor():
 
-    def setUp(self):
+    def setup_method(self):
         # Reset command line args for every test
         co.GlobalCLIArgs._Singleton__instance = None
 
-    def tearDown(self):
+    def teardown_method(self):
         # And cleanup after ourselves too
         co.GlobalCLIArgs._Singleton__instance = None
 
-    def test_get_serialized_batches(self):
+    def test_get_serialized_batches(self, mocker):
         fake_loader = DictDataLoader({
             'no_serial.yml': """
             - hosts: all
@@ -76,8 +73,8 @@ class TestPlaybookExecutor(unittest.TestCase):
             """,
         })
 
-        mock_inventory = MagicMock()
-        mock_var_manager = MagicMock()
+        mock_inventory = mocker.MagicMock()
+        mock_var_manager = mocker.MagicMock()
 
         templar = TemplateEngine(loader=fake_loader)
 
@@ -93,54 +90,109 @@ class TestPlaybookExecutor(unittest.TestCase):
         play = playbook.get_plays()[0]
         play.post_validate(templar)
         mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']
-        self.assertEqual(pbe._get_serialized_batches(play), [['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']])
+        assert pbe._get_serialized_batches(play) == [['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']]
 
         playbook = Playbook.load(pbe._playbooks[1], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
         mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']
-        self.assertEqual(
-            pbe._get_serialized_batches(play),
-            [['host0', 'host1'], ['host2', 'host3'], ['host4', 'host5'], ['host6', 'host7'], ['host8', 'host9']]
-        )
+        assert pbe._get_serialized_batches(play) == [
+            ['host0', 'host1'],
+            ['host2', 'host3'],
+            ['host4', 'host5'],
+            ['host6', 'host7'],
+            ['host8', 'host9']
+        ]
 
         playbook = Playbook.load(pbe._playbooks[2], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
         mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']
-        self.assertEqual(
-            pbe._get_serialized_batches(play),
-            [['host0', 'host1'], ['host2', 'host3'], ['host4', 'host5'], ['host6', 'host7'], ['host8', 'host9']]
-        )
+        assert pbe._get_serialized_batches(play) == [
+            ['host0', 'host1'],
+            ['host2', 'host3'],
+            ['host4', 'host5'],
+            ['host6', 'host7'],
+            ['host8', 'host9']
+        ]
 
         playbook = Playbook.load(pbe._playbooks[3], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
         mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']
-        self.assertEqual(
-            pbe._get_serialized_batches(play),
-            [['host0'], ['host1', 'host2'], ['host3', 'host4', 'host5'], ['host6', 'host7', 'host8'], ['host9']]
-        )
+        assert pbe._get_serialized_batches(play) == [
+            ['host0'],
+            ['host1', 'host2'],
+            ['host3', 'host4', 'host5'],
+            ['host6', 'host7', 'host8'],
+            ['host9']
+        ]
 
         playbook = Playbook.load(pbe._playbooks[4], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
         mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']
-        self.assertEqual(pbe._get_serialized_batches(play), [['host0'], ['host1', 'host2'], ['host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']])
+        assert pbe._get_serialized_batches(play) == [
+            ['host0'],
+            ['host1', 'host2'],
+            ['host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9']
+        ]
 
         # Test when serial percent is under 1.0
         playbook = Playbook.load(pbe._playbooks[2], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
         mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2']
-        self.assertEqual(pbe._get_serialized_batches(play), [['host0'], ['host1'], ['host2']])
+        assert pbe._get_serialized_batches(play) == [['host0'], ['host1'], ['host2']]
 
         # Test when there is a remainder for serial as a percent
         playbook = Playbook.load(pbe._playbooks[2], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
         mock_inventory.get_hosts.return_value = ['host0', 'host1', 'host2', 'host3', 'host4', 'host5', 'host6', 'host7', 'host8', 'host9', 'host10']
-        self.assertEqual(
-            pbe._get_serialized_batches(play),
-            [['host0', 'host1'], ['host2', 'host3'], ['host4', 'host5'], ['host6', 'host7'], ['host8', 'host9'], ['host10']]
+        assert pbe._get_serialized_batches(play) == [
+            ['host0', 'host1'],
+            ['host2', 'host3'],
+            ['host4', 'host5'],
+            ['host6', 'host7'],
+            ['host8', 'host9'],
+            ['host10']
+        ]
+
+    def test_generate_retry_inventory_success(self, mocker, tmp_path):
+        """Assert that successful creation of the retry file returns True
+        and contents are as expected.
+        """
+        retry_path = tmp_path / 'retry'
+
+        fake_loader = DictDataLoader({})
+        mock_inventory = mocker.MagicMock()
+        mock_var_manager = mocker.MagicMock()
+
+        pbe = PlaybookExecutor(
+            playbooks=[],
+            inventory=mock_inventory,
+            variable_manager=mock_var_manager,
+            loader=fake_loader,
+            passwords=[],
         )
+
+        assert pbe._generate_retry_inventory(str(retry_path), ['host1', 'host2'])
+        assert retry_path.read_text() == 'host1\nhost2\n'
+
+    def test_generate_retry_inventory_failure(self, mocker):
+        """Assert that failure to create the retry file returns False."""
+        fake_loader = DictDataLoader({})
+        mock_inventory = mocker.MagicMock()
+        mock_var_manager = mocker.MagicMock()
+
+        pbe = PlaybookExecutor(
+            playbooks=[],
+            inventory=mock_inventory,
+            variable_manager=mock_var_manager,
+            loader=fake_loader,
+            passwords=[],
+        )
+
+        mocker.patch('os.makedirs', side_effect=OSError)
+        assert not pbe._generate_retry_inventory("/some/path", ['host1', 'host2'])


### PR DESCRIPTION
##### SUMMARY

Converts tests in TestPlaybookExecutor from unittest to pytest.

Adds missing test coverage for `PlaybookExecutor._generate_retry_inventory()` method.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Test Pull Request
