### PR TITLE
[stable-2.16] default svn URL to 127.0.0.1 for subversion integration tests (#82551)

### DIFF
--- a/test/integration/targets/subversion/roles/subversion/defaults/main.yml
+++ b/test/integration/targets/subversion/roles/subversion/defaults/main.yml
@@ -3,7 +3,9 @@ apache_port: 11386  # cannot use 80 as httptester overrides this
 subversion_test_dir: /tmp/ansible-svn-test-dir
 subversion_server_dir: /tmp/ansible-svn  # cannot use a path in the home dir without userdir or granting exec permission to the apache user
 subversion_repo_name: ansible-test-repo
-subversion_repo_url: https://localhost:{{ apache_port }}/svn/{{ subversion_repo_name }}  # svn can't verify TLS certificates against IP addresses
-subversion_repo_auth_url: https://localhost:{{ apache_port }}/svnauth/{{ subversion_repo_name }}
+# default to explicit IPv4; svn doesn't handle IPv4 fallback if eg "localhost" -> [::1, 127.0.0.1] and ::1 doesn't answer
+subversion_repo_ip: 127.0.0.1
+subversion_repo_url: https://{{ subversion_repo_ip }}:{{ apache_port }}/svn/{{ subversion_repo_name }}
+subversion_repo_auth_url: https://{{ subversion_repo_ip }}:{{ apache_port }}/svnauth/{{ subversion_repo_name }}
 subversion_username: subsvn_user'''
 subversion_password: Password123!

--- a/test/integration/targets/subversion/roles/subversion/tasks/setup.yml
+++ b/test/integration/targets/subversion/roles/subversion/tasks/setup.yml
@@ -70,6 +70,8 @@
       - -{%- if ansible_python.version.major != 2 -%}I{%- endif -%}m
       - trustme
       - --dir={{ subversion_server_dir }}
+      - --identities={{ subversion_repo_ip }}
+      - --common-name={{ subversion_repo_ip }}
 
 - name: symlink trustme certificates into apache config dir - Red Hat
   when: ansible_os_family in ['RedHat']

--- a/test/integration/targets/subversion/roles/subversion/templates/subversion.conf.j2
+++ b/test/integration/targets/subversion/roles/subversion/templates/subversion.conf.j2
@@ -50,10 +50,7 @@ Include /etc/httpd/conf/httpd.conf
 {% endif %}
 
 PidFile {{ subversion_server_dir }}/apache.pid
-Listen 127.0.0.1:{{ apache_port }} https
-{% if ansible_distribution not in ["Alpine", "CentOS", "Fedora", "openSUSE Leap", "Ubuntu"] %}
-Listen [::1]:{{ apache_port }} https
-{% endif %}
+Listen {{ subversion_repo_ip }}:{{ apache_port }} https
 SSLEngine on
 SSLCertificateFile	{{ subversion_server_dir }}/server.pem
 SSLCertificateKeyFile {{ subversion_server_dir }}/server.key


### PR DESCRIPTION
* default svn URL to 127.0.0.1 for subversion integration tests

* svn client gives up before trying IPv4 addresses when localhost->(::1,127.0.0.1) in dual-stack envs (eg podman, most real hosts)
* svn client also requires legacy CN match on cert
* IPv6 works, but setup playbook would need a bunch more templating exceptions to conditionally manage `[::1]`

* explain IPv4 defaults

(cherry picked from commit 4aa109897fec936f11ab0799336a07bb5b93111b)

##### SUMMARY
* svn client gives up before trying IPv4 addresses when localhost->(::1,127.0.0.1) in dual-stack envs (eg podman, most real hosts)
* svn client also requires legacy CN match on cert
* IPv6 works, but setup playbook would need a bunch more templating exceptions to conditionally manage `[::1]`

##### ISSUE TYPE
- Test Pull Request

