### PR TITLE
hostname module: fix transient error with special character

### DIFF
--- a/changelogs/fragments/hostname-sanitize-invalid-characters.yaml
+++ b/changelogs/fragments/hostname-sanitize-invalid-characters.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostname - add hostname character sanitization function to prevent invalid hostname errors

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -297,6 +297,24 @@ class SystemdStrategy(BaseStrategy):
         super(SystemdStrategy, self).__init__(module)
         self.hostnamectl_cmd = self.module.get_bin_path(self.COMMAND, True)
 
+    def _scrub_hostname(self, name):
+        """
+        Clean hostname by replacing invalid characters with dashes
+        and removing multiple consecutive dashes
+        """
+        name = to_text(name)
+        replace_chars = u'\'"~`!@#$%^&*(){}[]/=?+\\|-_ '
+        delete_chars = u".'"
+        table = str.maketrans(replace_chars, '-' * len(replace_chars), delete_chars)
+        name = name.translate(table)
+
+        # Replace multiple dashes with a single dash
+        while '-' * 2 in name:
+            name = name.replace('-' * 2, '')
+
+        name = name.rstrip('-')
+        return name
+
     def get_current_hostname(self):
         cmd = [self.hostnamectl_cmd, '--transient', 'status']
         rc, out, err = self.module.run_command(cmd)


### PR DESCRIPTION
##### SUMMARY

###### Description and design :

This pull request fixes the behavior of the hostname module when using the SystemdStrategy. 
Currently, when the hostname contains special characters, the --transient option uses the raw name without any cleaning, which cause compatibility issues.

 This PR adds a _scrub_hostname method to the SystemdStrategy class to clean hostnames by replacing special characters with dashes, similar to what is done on macOS in the DarwinStrategy.


###### How to reproduce :


Entry:
```yaml
---

- name: "Configure OS hostname."
  ansible.builtin.hostname:
    name: "test_erwanclx"
  become: true
```
Result:
```
Could not set transient hostname
```

--> Bash equivalent which return the same error :
```
hostnamectl set-hostname test_erwanclx --transient
```

##### ISSUE TYPE

- Bugfix Pull Request
