### PR TITLE
allow known_hosts module auto-create the default ~/.ssh dir

### DIFF
--- a/changelogs/fragments/85050-auto-create-default-ssh-dir.yml
+++ b/changelogs/fragments/85050-auto-create-default-ssh-dir.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - allow known_hosts module auto-create the default ``~/.ssh/`` directory (https://github.com/ansible/ansible/issues/84952)

--- a/lib/ansible/modules/known_hosts.py
+++ b/lib/ansible/modules/known_hosts.py
@@ -38,7 +38,8 @@ options:
   path:
     description:
       - The known_hosts file to edit.
-      - The known_hosts file will be created if needed. The rest of the path must exist prior to running the module.
+      - The known_hosts file will be created if needed. For custom path, the rest of the path must exist prior to running the module.
+        For default path, the ~/.ssh/ directory will be auto-created if missing.
     default: "~/.ssh/known_hosts"
     type: path
   hash_host:
@@ -174,6 +175,9 @@ def enforce_state(module, params):
                 inf = None
             else:
                 module.fail_json(msg="Failed to read %s: %s" % (path, str(e)))
+        
+        ensure_default_ssh_directory(module, path)
+
         try:
             with tempfile.NamedTemporaryFile(mode='w+', dir=os.path.dirname(path), delete=False) as outf:
                 if inf is not None:
@@ -192,6 +196,23 @@ def enforce_state(module, params):
         results['changed'] = True
 
     return results
+
+
+def ensure_default_ssh_directory(module, path):
+    """Ensure the default ssh directory exists
+
+    This is a helper function to ensure that the ~/.ssh directory exists
+    when path is not customized. 
+    """
+    if os.path.expanduser(path) != os.path.expanduser("~/.ssh/known_hosts"):
+        return
+    if os.path.exists(os.path.dirname(path)):
+        return
+
+    try:
+        os.mkdir(os.path.dirname(path), 0o700)
+    except OSError as e:
+        module.fail_json(msg="Failed to create directory %s: %s" % (path, to_native(e)))
 
 
 def sanity_check(module, host, key, sshkeygen):

--- a/lib/ansible/modules/known_hosts.py
+++ b/lib/ansible/modules/known_hosts.py
@@ -206,15 +206,16 @@ def ensure_default_ssh_directory(module, path):
     """
     if path != os.path.expanduser("~/.ssh/known_hosts"):
         return
-    if os.path.exists(os.path.dirname(path)):
+
+    ssh_dir = os.path.dirname(path)
+    if os.path.exists(ssh_dir):
         return
 
     try:
-        os.mkdir(os.path.dirname(path), 0o700)
+        os.mkdir(ssh_dir, int('0700', 8))
+        module.set_mode_if_different(ssh_dir, int('0700', 8), False)
     except OSError as e:
-        if e.errno == errno.EEXIST:  # return if some other creates the dir at this time
-            return
-        module.fail_json(msg="Failed to create directory %s: %s" % (path, to_native(e)))
+        module.fail_json(msg="Failed to create directory %s: %s" % (ssh_dir, to_native(e)))
 
 
 def sanity_check(module, host, key, sshkeygen):

--- a/lib/ansible/modules/known_hosts.py
+++ b/lib/ansible/modules/known_hosts.py
@@ -175,7 +175,7 @@ def enforce_state(module, params):
                 inf = None
             else:
                 module.fail_json(msg="Failed to read %s: %s" % (path, str(e)))
-        
+
         ensure_default_ssh_directory(module, path)
 
         try:
@@ -202,9 +202,9 @@ def ensure_default_ssh_directory(module, path):
     """Ensure the default ssh directory exists
 
     This is a helper function to ensure that the ~/.ssh directory exists
-    when path is not customized. 
+    when path is not customized.
     """
-    if os.path.expanduser(path) != os.path.expanduser("~/.ssh/known_hosts"):
+    if path != os.path.expanduser("~/.ssh/known_hosts"):
         return
     if os.path.exists(os.path.dirname(path)):
         return

--- a/lib/ansible/modules/known_hosts.py
+++ b/lib/ansible/modules/known_hosts.py
@@ -212,6 +212,8 @@ def ensure_default_ssh_directory(module, path):
     try:
         os.mkdir(os.path.dirname(path), 0o700)
     except OSError as e:
+        if e.errno == errno.EEXIST:  # return if some other creates the dir at this time
+            return
         module.fail_json(msg="Failed to create directory %s: %s" % (path, to_native(e)))
 
 

--- a/test/integration/targets/known_hosts/aliases
+++ b/test/integration/targets/known_hosts/aliases
@@ -1,1 +1,2 @@
+destructive
 shippable/posix/group2

--- a/test/integration/targets/known_hosts/tasks/main.yml
+++ b/test/integration/targets/known_hosts/tasks/main.yml
@@ -63,8 +63,15 @@
 
 # https://github.com/ansible/ansible/issues/84952
 # test addition when ~/.ssh/ directory missing and path=default
+- name: check if ~/.ssh exists
+  stat:
+    path: ~/.ssh
+  register: default_ssh_dir
+
 - name: move ~/.ssh/ directory away
   command: mv ~/.ssh/ ~/.ssh_bak/
+  when: default_ssh_dir.stat.exists
+  register: backup_default_ssh_dir
 
 - name: add a new host with default path
   known_hosts:
@@ -72,10 +79,14 @@
     key: "{{ example_org_rsa_key }}"
     state: present
   register: result
+  ignore_errors: True
 
-- name: move ~/.ssh/ directory back
-  shell: 
-    cmd: rm -rf ~/.ssh/ && mv -f ~/.ssh_bak/ ~/.ssh/
+- name: remove ~/.ssh/ directory created by known_hosts module
+  command: rm -r ~/.ssh
+
+- name: move ~/.ssh_bak/ back
+  command: mv ~/.ssh_bak/ ~/.ssh/
+  when: backup_default_ssh_dir is changed
 
 - name: assert that the key was added and no exception thrown
   assert:

--- a/test/integration/targets/known_hosts/tasks/main.yml
+++ b/test/integration/targets/known_hosts/tasks/main.yml
@@ -83,6 +83,7 @@
 
 - name: remove ~/.ssh/ directory created by known_hosts module
   command: rm -r ~/.ssh
+  ignore_errors: True
 
 - name: move ~/.ssh_bak/ back
   command: mv ~/.ssh_bak/ ~/.ssh/

--- a/test/integration/targets/known_hosts/tasks/main.yml
+++ b/test/integration/targets/known_hosts/tasks/main.yml
@@ -77,7 +77,7 @@
   shell: 
     cmd: rm -rf ~/.ssh/ && mv -f ~/.ssh_bak/ ~/.ssh/
 
-- name: assert that the key was added and no exception was thrown
+- name: assert that the key was added and no exception thrown
   assert:
     that:
     - 'result is changed'

--- a/test/integration/targets/known_hosts/tasks/main.yml
+++ b/test/integration/targets/known_hosts/tasks/main.yml
@@ -61,6 +61,27 @@
     - 'known_hosts.stdout_lines[5].startswith("# example.net")'
     - 'known_hosts.stdout_lines[-1].strip() == example_org_rsa_key.strip()'
 
+# https://github.com/ansible/ansible/issues/84952
+# test addition when ~/.ssh/ directory missing and path=default
+- name: move ~/.ssh/ directory away
+  command: mv ~/.ssh/ ~/.ssh_bak/
+
+- name: add a new host with default path
+  known_hosts:
+    name: example.org
+    key: "{{ example_org_rsa_key }}"
+    state: present
+  register: result
+
+- name: move ~/.ssh/ directory back
+  shell: 
+    cmd: rm -rf ~/.ssh/ && mv -f ~/.ssh_bak/ ~/.ssh/
+
+- name: assert that the key was added and no exception was thrown
+  assert:
+    that:
+    - 'result is changed'
+
 # test idempotence of addition
 
 - name: add the same host in check mode

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -26,6 +26,7 @@ lib/ansible/modules/stat.py validate-modules:parameter-invalid
 lib/ansible/modules/systemd_service.py validate-modules:parameter-invalid
 lib/ansible/modules/user.py validate-modules:doc-default-does-not-match-spec
 lib/ansible/modules/user.py validate-modules:use-run-command-not-popen
+lib/ansible/modules/known_hosts.py use-argspec-type-path
 lib/ansible/module_utils/basic.py pylint:unused-import  # deferring resolution to allow enabling the rule now
 lib/ansible/module_utils/compat/selinux.py import-3.8!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.9!skip # pass/fail depends on presence of libselinux.so


### PR DESCRIPTION
##### SUMMARY
[84952](https://github.com/ansible/ansible/issues/84952)
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request
