### PR TITLE
[stable-2.17] ansible-test - Use `-t` for container stop timeout

### DIFF
--- a/changelogs/fragments/ansible-test-container-stop.yml
+++ b/changelogs/fragments/ansible-test-container-stop.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - Use the ``-t`` option to set the stop timeout when stopping a container.
+    This avoids use of the ``--time`` option which was deprecated in Docker v28.0.

--- a/test/lib/ansible_test/_internal/docker_util.py
+++ b/test/lib/ansible_test/_internal/docker_util.py
@@ -721,9 +721,10 @@ def docker_rm(args: CommonConfig, container_id: str) -> None:
     """Remove the specified container."""
     try:
         # Stop the container with SIGKILL immediately, then remove the container.
-        # Podman supports the `--time` option on `rm`, but only since version 4.0.0.
-        # Docker does not support the `--time` option on `rm`.
-        docker_command(args, ['stop', '--time', '0', container_id], capture=True)
+        # Docker supports `--timeout` for stop. The `--time` option was deprecated in v28.0.
+        # Podman supports `--time` for stop. The `--timeout` option was deprecated in 1.9.0.
+        # Both Docker and Podman support the `-t` option for stop.
+        docker_command(args, ['stop', '-t', '0', container_id], capture=True)
         docker_command(args, ['rm', container_id], capture=True)
     except SubprocessError as ex:
         # Both Podman and Docker report an error if the container does not exist.


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/85019

(cherry picked from commit 0aa8afbaf4739510a96c9727237792a95c8855c3)

##### ISSUE TYPE

Feature Pull Request
