### PR TITLE
[stable-2.18] dnf5: avoid generating excessive history entries (#85065)

### DIFF
--- a/changelogs/fragments/85046-dnf5-history-entries.yml
+++ b/changelogs/fragments/85046-dnf5-history-entries.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf5 - avoid generating excessive transaction entries in the dnf5 history (https://github.com/ansible/ansible/issues/85046)

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -776,7 +776,7 @@ class Dnf5Module(YumDnf):
         if self.module.check_mode:
             if results:
                 msg = "Check mode: No changes made, but would have if not in check mode"
-        else:
+        elif changed:
             transaction.download()
             if not self.download_only:
                 transaction.set_description("ansible dnf5 module")

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -19,6 +19,9 @@
       assert:
         that:
             - "'results' in dnf_result"
+
+    - shell: dnf history list | wc -l
+      register: dnf_history_lines_before
     # ============================================================================
     - name: Install dinginessentail-1.0-1 again
       dnf:
@@ -40,6 +43,13 @@
       assert:
         that:
             - "'msg' in dnf_result"
+
+    - shell: dnf history list | wc -l
+      register: dnf_history_lines_after
+
+    - assert:
+        that:
+          - dnf_history_lines_before.stdout == dnf_history_lines_after.stdout
     # ============================================================================
     - name: Install dinginessentail again (noop, module is idempotent)
       dnf:


### PR DESCRIPTION
##### SUMMARY
(cherry picked from commit cff49a62ecb0857c23de60cbb9e6b021dd017bf7)
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
