### PR TITLE
[stable-2.17] - script fix become on Windows (#85077)

### DIFF
--- a/changelogs/fragments/win-script-become.yml
+++ b/changelogs/fragments/win-script-become.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    script - Fix up become support for Windows scripts when become was set through host variables and not on the task
+    directly - https://github.com/ansible/ansible/issues/85076

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -150,11 +150,23 @@ class ActionModule(ActionBase):
             # like become and environment args
             if getattr(self._connection._shell, "_IS_WINDOWS", False):
                 # FUTURE: use a more public method to get the exec payload
-                pc = self._task
+                become = False
+                become_method = None
+                become_user = None
+                become_pass = None
+                become_flags = None
+                if self._connection.become:
+                    become_plugin = self._connection.become
+                    become = True
+                    become_method = become_plugin.name
+                    become_user = become_plugin.get_option('become_user', playcontext=self._play_context)
+                    become_pass = become_plugin.get_option('become_pass', playcontext=self._play_context)
+                    become_flags = become_plugin.get_option('become_flags', playcontext=self._play_context)
+
                 exec_data = ps_manifest._create_powershell_wrapper(
                     to_bytes(script_cmd), source, {}, env_dict, self._task.async_val,
-                    pc.become, pc.become_method, pc.become_user,
-                    self._play_context.become_pass, pc.become_flags, "script", task_vars, None
+                    become, become_method, become_user,
+                    become_pass, become_flags, "script", task_vars, None
                 )
                 # build the necessary exec wrapper command
                 # FUTURE: this still doesn't let script work on Windows with non-pipelined connections or

--- a/test/integration/targets/win_script/tasks/main.yml
+++ b/test/integration/targets/win_script/tasks/main.yml
@@ -314,3 +314,17 @@
     that:
     - test_script_result_become.stdout_lines[0]|lower == 'nt authority\\system'
     - test_script_result_become.stdout_lines[1] == 'finished'
+
+- name: run test script with become set by vars
+  script: test_script_whoami.ps1
+  register: test_script_result_become_vars
+  vars:
+    ansible_become: yes
+    ansible_become_user: SYSTEM
+    ansible_become_method: runas
+
+- name: check that the script ran and we get both outputs on new lines
+  assert:
+    that:
+    - test_script_result_become_vars.stdout_lines[0]|lower == 'nt authority\\system'
+    - test_script_result_become_vars.stdout_lines[1] == 'finished'


### PR DESCRIPTION
##### SUMMARY
Fixes become when using script on Windows and the become options were set through host vars or sources that was not set on the task directives itself.

(cherry picked from commit 59e2ddcae0f70b2d01d9bef8c192f7bebd7b76b5)

Backport of https://github.com/ansible/ansible/pull/85077

##### ISSUE TYPE
- Bugfix Pull Request