### PR TITLE
[stable-2.18 Fix old_style_cache_plugins test failure using latest redis

### DIFF
--- a/test/integration/targets/old_style_cache_plugins/setup_redis_cache.yml
+++ b/test/integration/targets/old_style_cache_plugins/setup_redis_cache.yml
@@ -20,22 +20,22 @@
 
     - name: get the latest stable redis server release
       get_url:
-        url: https://download.redis.io/redis-stable.tar.gz
+        url: https://download.redis.io/releases/redis-7.4.3.tar.gz
         dest: ./
         timeout: 60
 
     - name: unzip download
       unarchive:
-        src: redis-stable.tar.gz
+        src: redis-7.4.3.tar.gz
         dest: ./
 
     - command: "{{ make }}"
       args:
-        chdir: redis-stable
+        chdir: redis-7.4.3
 
     - name: copy the executable into the path
       copy:
-        src: "redis-stable/src/{{ item }}"
+        src: "redis-7.4.3/src/{{ item }}"
         dest: /usr/local/bin/
         mode: 755
       become: yes


### PR DESCRIPTION
##### SUMMARY
Tests are failing after redis 8.0.0 was published

Pin last working version instead

##### ISSUE TYPE

- Test Pull Request
