### PR TITLE
fix typo get_url.py: missing closing parenthesis

### DIFF
--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -87,7 +87,7 @@ options:
       - 'If a checksum is passed to this parameter, the digest of the
         destination file will be calculated after it is downloaded to ensure
         its integrity and verify that the transfer completed successfully.
-        Format: <algorithm>:<checksum|url>, for example C(checksum="sha256:D98291AC[...]B6DC7B97",
+        Format: <algorithm>:<checksum|url>, for example C(checksum="sha256:D98291AC[...]B6DC7B97"),
         C(checksum="sha256:http://example.com/path/sha256sum.txt").'
       - If you worry about portability, only the sha1 algorithm is available
         on all platforms and python versions.


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale -->

<!--- Add "Fixes #1234" if there is a corresponding issue -->

- fix missing closing parenthesis
  - https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#parameter-checksum
  - ![image](https://github.com/user-attachments/assets/e0e0aa7d-1c1f-44ab-b726-3b58ac18213e)

##### ISSUE TYPE

- Docs Pull Request
