### PR TITLE
Use 4 spaces instead of 2 as indent in examples

### DIFF
--- a/lib/ansible/modules/sysvinit.py
+++ b/lib/ansible/modules/sysvinit.py
@@ -88,9 +88,9 @@ EXAMPLES = """
 
 - name: Sleep for 5 seconds between stop and start command of badly behaving service
   ansible.builtin.sysvinit:
-    name: apache2
-    state: restarted
-    sleep: 5
+      name: apache2
+      state: restarted
+      sleep: 5
 
 - name: Make sure apache2 is started on runlevels 3 and 5
   ansible.builtin.sysvinit:


### PR DESCRIPTION
##### SUMMARY

One example in the "examples" section only uses 2 spaces as indent after the module-call, this commit corrects that to 4 spaces.

##### ISSUE TYPE

- Docs Pull Request
