### PR TITLE
Add docs for wrapper jinja builtin filters

### DIFF
--- a/lib/ansible/plugins/filter/d.yml
+++ b/lib/ansible/plugins/filter/d.yml
@@ -1,0 +1,7 @@
+DOCUMENTATION:
+  name: d
+  version_added: "2.19"
+  short_description: builtin Jinja default filter
+  description:
+    - The builtin Jinja default filter.
+    - See U(https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.default) for the input options, return value, and examples.

--- a/lib/ansible/plugins/filter/default.yml
+++ b/lib/ansible/plugins/filter/default.yml
@@ -1,0 +1,7 @@
+DOCUMENTATION:
+  name: default
+  version_added: "2.19"
+  short_description: builtin Jinja default filter
+  description:
+    - The builtin Jinja default filter.
+    - See U(https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.default) for the input options, return value, and examples.

--- a/lib/ansible/plugins/filter/groupby.yml
+++ b/lib/ansible/plugins/filter/groupby.yml
@@ -1,0 +1,7 @@
+DOCUMENTATION:
+  name: groupby
+  version_added: "2.19"
+  short_description: builtin Jinja groupby filter
+  description:
+    - The builtin Jinja groupby filter.
+    - See U(https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.groupby) for the input options, return value, and examples.

--- a/lib/ansible/plugins/filter/map.yml
+++ b/lib/ansible/plugins/filter/map.yml
@@ -1,0 +1,7 @@
+DOCUMENTATION:
+  name: map
+  version_added: "2.19"
+  short_description: builtin Jinja map filter
+  description:
+    - The builtin Jinja map filter.
+    - See U(https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.map) for the input options, return value, and examples.

--- a/lib/ansible/plugins/filter/reject.yml
+++ b/lib/ansible/plugins/filter/reject.yml
@@ -1,0 +1,7 @@
+DOCUMENTATION:
+  name: reject
+  version_added: "2.19"
+  short_description: builtin Jinja reject filter
+  description:
+    - The builtin Jinja reject filter.
+    - See U(https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.reject) for the input options, return value, and examples.

--- a/lib/ansible/plugins/filter/rejectattr.yml
+++ b/lib/ansible/plugins/filter/rejectattr.yml
@@ -1,0 +1,7 @@
+DOCUMENTATION:
+  name: rejectattr
+  version_added: "2.19"
+  short_description: builtin Jinja rejectattr filter
+  description:
+    - The builtin Jinja rejectattr filter.
+    - See U(https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.rejectattr) for the input options, return value, and examples.

--- a/lib/ansible/plugins/filter/select.yml
+++ b/lib/ansible/plugins/filter/select.yml
@@ -1,0 +1,7 @@
+DOCUMENTATION:
+  name: select
+  version_added: "2.19"
+  short_description: builtin Jinja select filter
+  description:
+    - The builtin Jinja select filter.
+    - See U(https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.select) for the input options, return value, and examples.

--- a/lib/ansible/plugins/filter/selectattr.yml
+++ b/lib/ansible/plugins/filter/selectattr.yml
@@ -1,0 +1,7 @@
+DOCUMENTATION:
+  name: selectattr
+  version_added: "2.19"
+  short_description: builtin Jinja selectattr filter
+  description:
+    - The builtin Jinja selectattr filter.
+    - See U(https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.selectattr) for the input options, return value, and examples.


### PR DESCRIPTION
##### SUMMARY
Adds a basic doc stub with a link to the Jinja docs for filters we wrap and expose through `ansible.builtin.*`.

##### ISSUE TYPE
- Docs Pull Request