### PR TITLE
Exclude ansible._protomatter from ansible-doc output by default

### DIFF
--- a/changelogs/fragments/ansible-doc-protomatter.yml
+++ b/changelogs/fragments/ansible-doc-protomatter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-doc - Skip listing the internal ``ansible._protomatter`` plugins unless explicitly requested

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -794,7 +794,13 @@ class DocCLI(CLI, RoleMixin):
         loader = DocCLI._prep_loader(plugin_type)
 
         coll_filter = self._get_collection_filter()
-        self.plugins.update(list_plugins(plugin_type, coll_filter))
+        plugin_list = list_plugins(plugin_type, coll_filter)
+
+        # Remove the internal ansible._protomatter plugins if getting all plugins
+        if not coll_filter:
+            plugin_list = {k: v for k, v in plugin_list.items() if not k.startswith('ansible._protomatter.')}
+
+        self.plugins.update(plugin_list)
 
         # get appropriate content depending on option
         if content == 'dir':

--- a/test/integration/targets/ansible-doc/test.yml
+++ b/test/integration/targets/ansible-doc/test.yml
@@ -191,3 +191,19 @@
     - assert:
         that:
           - "'plugin broken_docs has malformed documentation' in r.msg"
+
+    - name: check ansible._protomatter excluded from output by default
+      command: ansible-doc -t filter --list
+      register: result
+
+    - assert:
+        that:
+          - result.stdout_lines | select("match", "^ansible\\._protomatter\\.") | length == 0
+
+    - name: check ansible._protomatter is shown when requested
+      command: ansible-doc ansible._protomatter -t filter --list
+      register: result
+
+    - assert:
+        that:
+          - result.stdout_lines | select("match", "^ansible\\._protomatter\\.") | length == result.stdout_lines | length


### PR DESCRIPTION
##### SUMMARY
The `ansible._protomatter.*` plugins are designed for internal use only so shouldn't be listed by default by `ansible-doc`. They will still appear if requested explicitly.

##### ISSUE TYPE
- Docs Pull Request