### PR TITLE
Apply trust to declarative plugin config

### DIFF
--- a/changelogs/fragments/plugin-loader-trust-docs.yml
+++ b/changelogs/fragments/plugin-loader-trust-docs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - plugin loader - Apply template trust to strings loaded from plugin configuration definitions and doc fragments.

--- a/lib/ansible/_internal/_testing.py
+++ b/lib/ansible/_internal/_testing.py
@@ -1,0 +1,26 @@
+"""
+Testing utilities for use in integration tests, not unit tests or non-test code.
+Provides better error behavior than Python's `assert` statement.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import typing as t
+
+
+class _Checker:
+    @staticmethod
+    def check(value: object, msg: str | None = 'Value is not truthy.') -> None:
+        """Raise an `AssertionError` if the given `value` is not truthy."""
+        if not value:
+            raise AssertionError(msg)
+
+
+@contextlib.contextmanager
+def hard_fail_context(msg: str) -> t.Generator[_Checker]:
+    """Enter a context which converts all exceptions to `BaseException` and provides a `Checker` instance for making assertions."""
+    try:
+        yield _Checker()
+    except BaseException as ex:
+        raise BaseException(f"Hard failure: {msg}") from ex

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -313,6 +313,7 @@ class InventoryManager(object):
                             ex.obj = origin
                         failures.append({'src': source, 'plugin': plugin_name, 'exc': ex})
                     except Exception as ex:
+                        # DTFIX-RELEASE: fix this error handling to correctly deal with messaging
                         try:
                             # omit line number to prevent contextual display of script or possibly sensitive info
                             raise AnsibleError(str(ex), obj=origin) from ex

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -505,7 +505,8 @@ class PluginLoader:
 
             # if type name != 'module_doc_fragment':
             if type_name in C.CONFIGURABLE_PLUGINS and not C.config.has_configuration_definition(type_name, name):
-                documentation_source = getattr(module, 'DOCUMENTATION', '')
+                # trust-tagged source propagates to loaded values; expressions and templates in config require trust
+                documentation_source = _tags.TrustedAsTemplate().tag(getattr(module, 'DOCUMENTATION', ''))
                 try:
                     dstring = yaml.load(_tags.Origin(path=path).tag(documentation_source), Loader=AnsibleLoader)
                 except ParserError as e:

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -154,7 +154,8 @@ def add_fragments(doc, filename, fragment_loader, is_module=False):
             unknown_fragments.append(fragment_slug)
             continue
 
-        fragment_yaml = getattr(fragment_class, fragment_var, None)
+        # trust-tagged source propagates to loaded values; expressions and templates in config require trust
+        fragment_yaml = _tags.TrustedAsTemplate().tag(getattr(fragment_class, fragment_var, None))
         if fragment_yaml is None:
             if fragment_var != 'DOCUMENTATION':
                 # if it's asking for something specific that's missing, that's an error

--- a/test/integration/targets/inventory/doc_fragments/fragment_with_expression.py
+++ b/test/integration/targets/inventory/doc_fragments/fragment_with_expression.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+
+class ModuleDocFragment:
+    DOCUMENTATION = """
+    options:
+      fragment_expression:
+        description: a fragment hosted expression that must be trusted whose default resolves to 4
+        default: 2 + 2
+    """


### PR DESCRIPTION
##### SUMMARY

fixes #85120 

* trust strings from plugin config and loaded doc fragment YAML
* added tests
* added hard_fail_context test mechanism

##### ISSUE TYPE
- Bugfix Pull Request
