### PR TITLE
Allow module_defaults to be defined as a dictionary variable or omitted

### DIFF
--- a/changelogs/fragments/module_defaults-templating.yml
+++ b/changelogs/fragments/module_defaults-templating.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Support setting module_defaults to a template that evaluates to a dictionary or omit.

--- a/lib/ansible/_internal/_task.py
+++ b/lib/ansible/_internal/_task.py
@@ -18,6 +18,11 @@ if t.TYPE_CHECKING:
     from ansible.playbook.task import Task
 
 
+# FIXME: put these here at random
+action_groups: dict[str, list[str]] = {}
+group_actions: dict[str, list[str]] = {}
+
+
 @dataclasses.dataclass
 class TaskContext(AmbientContextBase):
     """Ambient context that wraps task execution on workers. It provides access to the currently executing task."""

--- a/lib/ansible/_internal/_task.py
+++ b/lib/ansible/_internal/_task.py
@@ -18,11 +18,6 @@ if t.TYPE_CHECKING:
     from ansible.playbook.task import Task
 
 
-# FIXME: put these here at random
-action_groups: dict[str, list[str]] = {}
-group_actions: dict[str, list[str]] = {}
-
-
 @dataclasses.dataclass
 class TaskContext(AmbientContextBase):
     """Ambient context that wraps task execution on workers. It provides access to the currently executing task."""

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -85,6 +85,12 @@ class PromptSend:
     complete_input: t.Iterable[bytes] = None
 
 
+class ActionGroups:
+    def __init__(self, action_groups=None, group_actions=None):
+        self.action_groups = action_groups
+        self.group_actions = group_actions
+
+
 class FinalQueue(multiprocessing.queues.SimpleQueue):
     def __init__(self, *args, **kwargs):
         kwargs['ctx'] = multiprocessing_context
@@ -104,6 +110,11 @@ class FinalQueue(multiprocessing.queues.SimpleQueue):
     def send_prompt(self, **kwargs):
         self.put(
             PromptSend(**kwargs),
+        )
+
+    def send_action_groups(self, action_groups, group_actions):
+        self.put(
+            ActionGroups(action_groups=action_groups, group_actions=group_actions)
         )
 
 

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -237,62 +237,6 @@ class FieldAttributeBase:
 
         self._validated = True
 
-    def _load_module_defaults(self, name, value):
-        if value is None:
-            return
-
-        if not isinstance(value, list):
-            value = [value]
-
-        validated_module_defaults = []
-        for defaults_dict in value:
-            if not isinstance(defaults_dict, dict):
-                raise AnsibleParserError(
-                    "The field 'module_defaults' is supposed to be a dictionary or list of dictionaries, "
-                    "the keys of which must be static action, module, or group names. Only the values may contain "
-                    "templates. For example: {'ping': \"{{ ping_defaults }}\"}",
-                    obj=defaults_dict,
-                )
-
-            validated_defaults_dict = {}
-            for defaults_entry, defaults in defaults_dict.items():
-                # module_defaults do not use the 'collections' keyword, so actions and
-                # action_groups that are not fully qualified are part of the 'ansible.legacy'
-                # collection. Update those entries here, so module_defaults contains
-                # fully qualified entries.
-                if defaults_entry.startswith('group/'):
-                    group_name = defaults_entry.split('group/')[-1]
-
-                    # The resolved action_groups cache is associated saved on the current Play
-                    if self.play is not None:
-                        group_name, dummy = self._resolve_group(group_name)
-
-                    defaults_entry = 'group/' + group_name
-                    validated_defaults_dict[defaults_entry] = defaults
-
-                else:
-                    if len(defaults_entry.split('.')) < 3:
-                        defaults_entry = 'ansible.legacy.' + defaults_entry
-
-                    resolved_action = self._resolve_action(defaults_entry)
-                    if resolved_action:
-                        validated_defaults_dict[resolved_action] = defaults
-
-                    # If the defaults_entry is an ansible.legacy plugin, these defaults
-                    # are inheritable by the 'ansible.builtin' subset, but are not
-                    # required to exist.
-                    if defaults_entry.startswith('ansible.legacy.'):
-                        resolved_action = self._resolve_action(
-                            defaults_entry.replace('ansible.legacy.', 'ansible.builtin.'),
-                            mandatory=False
-                        )
-                        if resolved_action:
-                            validated_defaults_dict[resolved_action] = defaults
-
-            validated_module_defaults.append(validated_defaults_dict)
-
-        return validated_module_defaults
-
     @property
     def play(self):
         if hasattr(self, '_play'):

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -21,7 +21,6 @@ from ansible import constants as C
 from ansible import context
 from ansible.errors import AnsibleError
 from ansible.errors import AnsibleParserError, AnsibleAssertionError
-from ansible._internal import _task
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.six import binary_type, string_types, text_type
 from ansible.playbook.attribute import NonInheritableFieldAttribute
@@ -39,6 +38,10 @@ display = Display()
 
 
 __all__ = ['Play']
+
+
+_action_groups: dict[str, list[str]] = {}
+_group_actions: dict[str, list[str]] = {}
 
 
 class Play(Base, Taggable, CollectionSearch):
@@ -95,8 +98,8 @@ class Play(Base, Taggable, CollectionSearch):
         self.only_tags = set(context.CLIARGS.get('tags', [])) or frozenset(('all',))
         self.skip_tags = set(context.CLIARGS.get('skip_tags', []))
 
-        self._action_groups = _task.action_groups
-        self._group_actions = _task.group_actions
+        self._action_groups = _action_groups
+        self._group_actions = _group_actions
 
     def __repr__(self):
         return self.get_name()

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -21,6 +21,7 @@ from ansible import constants as C
 from ansible import context
 from ansible.errors import AnsibleError
 from ansible.errors import AnsibleParserError, AnsibleAssertionError
+from ansible._internal import _task
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.six import binary_type, string_types, text_type
 from ansible.playbook.attribute import NonInheritableFieldAttribute
@@ -94,8 +95,8 @@ class Play(Base, Taggable, CollectionSearch):
         self.only_tags = set(context.CLIARGS.get('tags', [])) or frozenset(('all',))
         self.skip_tags = set(context.CLIARGS.get('skip_tags', []))
 
-        self._action_groups = {}
-        self._group_actions = {}
+        self._action_groups = _task.action_groups
+        self._group_actions = _task.group_actions
 
     def __repr__(self):
         return self.get_name()

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -144,8 +144,43 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
         return task.load_data(data, variable_manager=variable_manager, loader=loader)
 
     def _post_validate_module_defaults(self, attr: str, value: t.Any, templar: TemplateEngine) -> t.Any:
-        """Override module_defaults post validation to disable templating, which is handled by args post validation."""
-        return value
+        """Override module_defaults post validation to short circuit templating, which is handled by args post validation."""
+        finalized = AnsibleTagHelper.tag_copy(value, [])
+
+        for module_defaults in value:
+            _module_defaults = templar.resolve_to_container(module_defaults, options=TemplateOptions(value_for_omit={}))
+
+            if not isinstance(_module_defaults, dict):
+                raise AnsibleParserError(
+                    f"module_defaults must be a list of dictionaries, not {type(_module_defaults)._native_type}. "
+                    # Note: environment has the same limitation. Allow nested lists and flatten them like tags instead?
+                    f"A templated value must be a dictionary since the template string is cast to a list.",
+                    obj=value
+                )
+
+            finalized.append(AnsibleTagHelper.tag_copy(_module_defaults, {}))
+            for entry in _module_defaults:
+                _entry = templar.resolve_to_container(entry)
+                _value = templar.resolve_to_container(_module_defaults[entry])
+
+                if not isinstance(_value, dict):
+                    raise AnsibleParserError(f"module_defaults arguments must be a dictionary", obj=value)
+
+                if _entry.startswith("group/"):
+                    resolved_entry = "group/" + self._resolve_group(_entry.split("group/")[-1])[0]
+                else:
+                    resolved_entry = self._resolve_action(_entry)
+                    if '.' not in resolved_entry:
+                        builtin_subset = f"ansible.builtin.{resolved_entry}"
+                        if (builtin := self._resolve_action(builtin_subset, mandatory=False)):
+                            finalized[-1][builtin] = _module_defaults[entry]
+
+                finalized[-1][resolved_entry] = _module_defaults[entry]
+
+        if self.play._action_groups or self.play._group_actions:
+            display._final_q.send_action_groups(action_groups=self.play._action_groups, group_actions=self.play._group_actions)
+
+        return finalized
 
     def _post_validate_args(self, attr: str, value: t.Any, templar: TemplateEngine) -> dict[str, t.Any]:
         try:

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -144,8 +144,8 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
         return task.load_data(data, variable_manager=variable_manager, loader=loader)
 
     def _post_validate_module_defaults(self, attr: str, value: t.Any, templar: TemplateEngine) -> t.Any:
-        """Override module_defaults post validation to short circuit templating, which is handled by args post validation."""
-        finalized = AnsibleTagHelper.tag_copy(value, [])
+        """Template and resolve all actions/modules/groups in module_defaults. Argument validation is handled by args post validation."""
+        finalized = []
 
         for module_defaults in value:
             _module_defaults = templar.resolve_to_container(module_defaults, options=TemplateOptions(value_for_omit={}))
@@ -153,12 +153,12 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
             if not isinstance(_module_defaults, dict):
                 raise AnsibleParserError(
                     f"module_defaults must be a list of dictionaries, not {type(_module_defaults)._native_type}. "
-                    # Note: environment has the same limitation. Allow nested lists and flatten them like tags instead?
-                    f"A templated value must be a dictionary since the template string is cast to a list.",
+                    # FIXME: environment has the same limitation. Allow nested lists and flatten them like tags instead?
+                    "A templated value must be a dictionary since the template string is cast to a list.",
                     obj=value
                 )
 
-            finalized.append(AnsibleTagHelper.tag_copy(_module_defaults, {}))
+            finalized.append({})
             for entry in _module_defaults:
                 _entry = templar.resolve_to_container(entry)
                 _value = templar.resolve_to_container(_module_defaults[entry])

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -37,7 +37,7 @@ from ansible.errors import AnsibleError, AnsibleFileNotFound, AnsibleParserError
 from ansible.executor.play_iterator import IteratingStates, PlayIterator
 from ansible.executor.process.worker import WorkerProcess
 from ansible.executor.task_result import _RawTaskResult, _WireTaskResult
-from ansible.executor.task_queue_manager import CallbackSend, DisplaySend, PromptSend, TaskQueueManager
+from ansible.executor.task_queue_manager import ActionGroups, CallbackSend, DisplaySend, PromptSend, TaskQueueManager
 from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 from ansible.playbook.handler import Handler
@@ -47,6 +47,7 @@ from ansible.playbook.task import Task
 from ansible.playbook.task_include import TaskInclude
 from ansible.plugins import loader as plugin_loader
 from ansible._internal._templating._engine import TemplateEngine
+from ansible._internal._task import action_groups, group_actions
 from ansible.utils.display import Display
 from ansible.utils.fqcn import add_internal_fqcns
 from ansible.utils.sentinel import Sentinel
@@ -126,6 +127,12 @@ def results_thread_main(strategy: StrategyBase) -> None:
                     except AnsibleError as e:
                         value = e
                 strategy._workers[result.worker_id].worker_queue.put(value)
+            elif isinstance(result, ActionGroups):
+                for worker_cache, shared_cache in [(result.action_groups, action_groups), (result.group_actions, group_actions)]:
+                    for entity, last in worker_cache.items():
+                        prev = set(shared_cache.get(entity) or [])
+                        if (new := set(last).difference(prev)):
+                            shared_cache.setdefault(entity, []).extend(new)
             else:
                 display.warning('Received an invalid object (%s) in the result queue: %r' % (type(result), result))
         except (IOError, EOFError):

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -43,11 +43,11 @@ from ansible.module_utils.connection import Connection, ConnectionError
 from ansible.playbook.handler import Handler
 from ansible.playbook.helpers import load_list_of_blocks
 from ansible.playbook.included_file import IncludedFile
+from ansible.playbook.play import _action_groups, _group_actions
 from ansible.playbook.task import Task
 from ansible.playbook.task_include import TaskInclude
 from ansible.plugins import loader as plugin_loader
 from ansible._internal._templating._engine import TemplateEngine
-from ansible._internal._task import action_groups, group_actions
 from ansible.utils.display import Display
 from ansible.utils.fqcn import add_internal_fqcns
 from ansible.utils.sentinel import Sentinel
@@ -128,7 +128,7 @@ def results_thread_main(strategy: StrategyBase) -> None:
                         value = e
                 strategy._workers[result.worker_id].worker_queue.put(value)
             elif isinstance(result, ActionGroups):
-                for worker_cache, shared_cache in [(result.action_groups, action_groups), (result.group_actions, group_actions)]:
+                for worker_cache, shared_cache in [(result.action_groups, _action_groups), (result.group_actions, _group_actions)]:
                     for entity, last in worker_cache.items():
                         prev = set(shared_cache.get(entity) or [])
                         if (new := set(last).difference(prev)):

--- a/test/integration/targets/module_defaults/tasks/main.yml
+++ b/test/integration/targets/module_defaults/tasks/main.yml
@@ -1,14 +1,16 @@
 - name: main block
   vars:
     test_file: /tmp/ansible-test.module_defaults.foo
-  module_defaults:
-    debug:
-      msg: test {{ "default" }}
-    file:
-      path: '{{ test_file }}'
+    dynamic_module_defaults:
+      debug:
+        msg: test {{ "default" }}
+      file:
+        path: '{{ test_file }}'
+  module_defaults: "{{ dynamic_module_defaults }}"
   block:
     - debug:
       register: foo
+      module_defaults: "{{ test_omit | default(omit) }}"
 
     - local_action:
         module: debug


### PR DESCRIPTION
##### SUMMARY

Move validation from `_load_module_defaults` to `_post_validate_module_defaults`

Use `templar.resolve_to_container` to template the top level action group and module/action plugin names. The `actions_group` metadata is loaded from any referenced collections in the groups.

Relay the resolved action groups to the main thread to reuse the parsed metadata for subsequent tasks

##### ISSUE TYPE

- Feature Pull Request
