### PR TITLE
Update apt test, hello-traditional is removed in Debian trixie

### DIFF
--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -222,39 +222,39 @@
   apt: pkg=hello state=absent purge=yes
 
 # INSTALL WITHOUT REMOVALS
-- name: Install hello, that conflicts with hello-traditional
+- name: Install postfix, that conflicts with exim4
   apt:
-    pkg: hello
+    pkg: postfix
     state: present
     update_cache: no
 
-- name: check hello
-  shell: dpkg-query -l hello
+- name: check postfix
+  shell: dpkg-query -l postfix
   register: dpkg_result
 
-- name: verify installation of hello
+- name: verify installation of postfix
   assert:
     that:
         - "apt_result.changed"
         - "dpkg_result.rc == 0"
 
-- name: Try installing hello-traditional, that conflicts with hello
+- name: Try installing exim4, that conflicts with postfix
   apt:
-    pkg: hello-traditional
+    pkg: exim4
     state: present
     fail_on_autoremove: yes
   ignore_errors: yes
   register: apt_result
 
-- name: verify failure of installing hello-traditional, because it is required to remove hello to install.
+- name: verify failure of installing exim4, because it is required to remove hello to install.
   assert:
     that:
       - apt_result is failed
       - '"Packages need to be removed but remove is disabled." in apt_result.msg'
 
-- name: uninstall hello with apt
+- name: uninstall postfix with apt
   apt:
-    pkg: hello
+    pkg: postfix
     state: absent
     purge: yes
     update_cache: no


### PR DESCRIPTION
##### SUMMARY
hello-traditional is unavailable in the upcoming Debian trixie release, and very likely Ubuntu >= 25.10 will follow suit.

So instead, use postfix and exim4 as package conflicts examples, as those two packages conflict each other, are available in all supported Debian and Ubuntu releases, and will exist in this form in the foreseeable future.

This is a stop-gap measure. A better way to test this is to use equivs and install the resulting .deb packages. However, "fail_on_autoremove" has no effect when using the deb: parameter (bug to be filed).

This should ideally also go in the stable-2.19 branch.
##### ISSUE TYPE

- Test Pull Request
