### PR TITLE
Improve SUSE distribution detection using VARIANT_ID with fallback to…

### DIFF
--- a/changelogs/fragments/detect-variantid-suse.yaml
+++ b/changelogs/fragments/detect-variantid-suse.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Improved SUSE distribution detection in distribution.py by parsing VARIANT_ID from /etc/os-release
+    for identifying SLES_SAP and SL-Micro. Falls back to /etc/products.d/baseproduct symlink for older systems.

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -310,9 +310,22 @@ class DistributionFiles:
                         suse_facts['distribution_release'] = release.group(1)
                         suse_facts['distribution_version'] = collected_facts['distribution_version'] + '.' + release.group(1)
 
-        # See https://www.suse.com/support/kb/doc/?id=000019341 for SLES for SAP
-        if os.path.islink('/etc/products.d/baseproduct') and os.path.realpath('/etc/products.d/baseproduct').endswith('SLES_SAP.prod'):
-            suse_facts['distribution'] = 'SLES_SAP'
+        # Check VARIANT_ID first for SLES4SAP or SL-Micro
+        variant_id_match = re.search(r'^VARIANT_ID="?([^"\n]*)"?', data, re.MULTILINE)
+        if variant_id_match:
+            variant_id = variant_id_match.group(1)
+            if variant_id == 'server-sap':
+                suse_facts['distribution'] = 'SLES_SAP'
+            elif variant_id == 'transactional':
+                suse_facts['distribution'] = 'SL-Micro'
+        else:
+            # Fallback for older SLES 15 using baseproduct symlink
+            if os.path.islink('/etc/products.d/baseproduct'):
+                resolved = os.path.realpath('/etc/products.d/baseproduct')
+                if resolved.endswith('SLES_SAP.prod'):
+                    suse_facts['distribution'] = 'SLES_SAP'
+                elif resolved.endswith('SL-Micro.prod'):
+                    suse_facts['distribution'] = 'SL-Micro'
 
         return True, suse_facts
 

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -314,9 +314,7 @@ class DistributionFiles:
         variant_id_match = re.search(r'^VARIANT_ID="?([^"\n]*)"?', data, re.MULTILINE)
         if variant_id_match:
             variant_id = variant_id_match.group(1)
-            if variant_id == 'server-sap':
-                suse_facts['distribution'] = 'SLES_SAP'
-            elif variant_id == 'sles-sap':
+            if variant_id in ('server-sap', 'sles-sap'):
                 suse_facts['distribution'] = 'SLES_SAP'
             elif variant_id == 'transactional':
                 suse_facts['distribution'] = 'SL-Micro'

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -316,6 +316,8 @@ class DistributionFiles:
             variant_id = variant_id_match.group(1)
             if variant_id == 'server-sap':
                 suse_facts['distribution'] = 'SLES_SAP'
+            elif variant_id == 'sles-sap':
+                suse_facts['distribution'] = 'SLES_SAP'
             elif variant_id == 'transactional':
                 suse_facts['distribution'] = 'SL-Micro'
         else:

--- a/test/units/module_utils/facts/system/distribution/fixtures/sles_15_6.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/sles_15_6.json
@@ -1,0 +1,39 @@
+{
+    "name": "SLES 15.6",
+    "distro": {
+        "codename": "",
+        "id": "sles",
+        "name": "SLES",
+        "version": "15.6",
+        "version_best": "15.6",
+        "lsb_release_info": {},
+        "os_release_info": {
+            "name": "SLES",
+            "version": "15-SP6",
+            "version_id": "15.6",
+            "pretty_name": "SUSE Linux Enterprise Server 15 SP6",
+            "id": "sles",
+            "id_like": "suse",
+            "ansi_color": "0;32",
+            "cpe_name": "cpe:/o:suse:sles:15:sp6",
+            "documentation_url": "https://documentation.suse.com/"
+        }
+    },
+    "input": {
+        "/etc/os-release": "NAME=\"SLES\"\nVERSION=\"15-SP6\"\nVERSION_ID=\"15.6\"\nPRETTY_NAME=\"SUSE Linux Enterprise Server 15 SP6\"\nID=\"sles\"\nID_LIKE=\"suse\"\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:suse:sles:15:sp6\"\nDOCUMENTATION_URL=\"https://documentation.suse.com/\"\n"
+    },
+    "platform.dist": [
+        "sles",
+        "15.6",
+        ""
+    ],
+    "result": {
+        "distribution": "SLES",
+        "distribution_version": "15.6",
+        "distribution_release": "6",
+        "distribution_major_version": "15",
+        "os_family": "Suse"
+    },
+    "platform.release": "6.4.0-150600.21-default"
+}
+

--- a/test/units/module_utils/facts/system/distribution/fixtures/sles_16_0.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/sles_16_0.json
@@ -1,0 +1,46 @@
+{
+    "name": "SLES 16.0",
+    "distro": {
+        "codename": "",
+        "id": "sles",
+        "name": "SLES",
+        "version": "16.0",
+        "version_best": "16.0",
+        "lsb_release_info": {},
+        "os_release_info": {
+            "name": "SLES",
+            "pretty_name": "SUSE Linux Enterprise Server 16.0",
+            "variant": "Enterprise Server",
+            "variant_id": "server",
+            "version": "16.0 Beta4",
+            "version_id": "16.0",
+            "ansi_color": "0;32",
+            "id": "sles",
+            "id_like": "suse opensuse",
+            "cpe_name": "cpe:/o:suse:sles:16:16.0",
+            "suse_support_product": "SUSE Linux Enterprise Server",
+            "suse_support_product_version": "16.0",
+            "home_url": "https://www.suse.com/products/server/",
+            "documentation_url": "https://documentation.suse.com/sles/16.0/",
+            "logo": "distributor-logo"
+        }
+    },
+    "input": {
+        "/etc/os-release": "# The NAME and PRETTY_NAME fields have been chosen to state compatibility between our products.\n# The use of \"SLES\" and \"SUSE Linux Enterprise\" rather than a more generic name is due to backward compatibility with existing OS detection code in applications of third party vendors.\nNAME=\"SLES\"\nPRETTY_NAME=\"SUSE Linux Enterprise Server 16.0\"\nVARIANT=\"Enterprise Server\"\nVARIANT_ID=\"server\"\nVERSION=\"16.0 Beta4\"\nVERSION_ID=\"16.0\"\nANSI_COLOR=\"0;32\"\nID=\"sles\"\nID_LIKE=\"suse opensuse\"\nCPE_NAME=\"cpe:/o:suse:sles:16:16.0\"\nSUSE_SUPPORT_PRODUCT=\"SUSE Linux Enterprise Server\"\nSUSE_SUPPORT_PRODUCT_VERSION=\"16.0\"\nHOME_URL=\"https://www.suse.com/products/server/\"\nDOCUMENTATION_URL=\"https://documentation.suse.com/sles/16.0/\"\nLOGO=\"distributor-logo\"\n",
+        "/usr/lib/os-release": "# The NAME and PRETTY_NAME fields have been chosen to state compatibility between our products.\n# The use of \"SLES\" and \"SUSE Linux Enterprise\" rather than a more generic name is due to backward compatibility with existing OS detection code in applications of third party vendors.\nNAME=\"SLES\"\nPRETTY_NAME=\"SUSE Linux Enterprise Server 16.0\"\nVARIANT=\"Enterprise Server\"\nVARIANT_ID=\"server\"\nVERSION=\"16.0 Beta4\"\nVERSION_ID=\"16.0\"\nANSI_COLOR=\"0;32\"\nID=\"sles\"\nID_LIKE=\"suse opensuse\"\nCPE_NAME=\"cpe:/o:suse:sles:16:16.0\"\nSUSE_SUPPORT_PRODUCT=\"SUSE Linux Enterprise Server\"\nSUSE_SUPPORT_PRODUCT_VERSION=\"16.0\"\nHOME_URL=\"https://www.suse.com/products/server/\"\nDOCUMENTATION_URL=\"https://documentation.suse.com/sles/16.0/\"\nLOGO=\"distributor-logo\"\n"
+    },
+    "platform.dist": [
+        "sles",
+        "16.0",
+        ""
+    ],
+    "result": {
+        "distribution": "SLES",
+        "distribution_version": "16.0",
+        "distribution_release": "0",
+        "distribution_major_version": "16",
+        "os_family": "Suse"
+    },
+    "platform.release": "6.12.0-160000.11-default"
+}
+

--- a/test/units/module_utils/facts/system/distribution/fixtures/sles_sap_15_6.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/sles_sap_15_6.json
@@ -1,0 +1,39 @@
+{
+    "name": "SLES_SAP 15.6",
+    "distro": {
+        "codename": "",
+        "id": "sles",
+        "name": "SLES",
+        "version": "15.6",
+        "version_best": "15.6",
+        "lsb_release_info": {},
+        "os_release_info": {
+            "name": "SLES",
+            "version": "15-SP6",
+            "version_id": "15.6",
+            "pretty_name": "SUSE Linux Enterprise Server 15 SP6",
+            "id": "sles",
+            "id_like": "suse",
+            "ansi_color": "0;32",
+            "cpe_name": "cpe:/o:suse:sles:15:sp6",
+            "variant_id": "sles-sap"
+        }
+    },
+    "input": {
+        "/etc/os-release": "NAME=\"SLES\"\nVERSION=\"15-SP6\"\nVERSION_ID=\"15.6\"\nPRETTY_NAME=\"SUSE Linux Enterprise Server 15 SP6\"\nID=\"sles\"\nID_LIKE=\"suse\"\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:suse:sles:15:sp6\"\nVARIANT_ID=\"sles-sap\"\n"
+    },
+    "platform.dist": [
+        "sles",
+        "15.6",
+        ""
+    ],
+    "result": {
+        "distribution": "SLES_SAP",
+        "distribution_version": "15.6",
+        "distribution_release": "6",
+        "distribution_major_version": "15",
+        "os_family": "Suse"
+    },
+    "platform.release": "6.4.0-150600.23.33-default"
+}
+

--- a/test/units/module_utils/facts/system/distribution/fixtures/sles_sap_16_0.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/sles_sap_16_0.json
@@ -1,0 +1,46 @@
+{
+    "name": "SLES_SAP 16.0",
+    "distro": {
+        "codename": "",
+        "id": "sles",
+        "name": "SLES",
+        "version": "16.0",
+        "version_best": "16.0",
+        "lsb_release_info": {},
+        "os_release_info": {
+            "name": "SLES",
+            "pretty_name": "SUSE Linux Enterprise Server 16.0",
+            "variant": "Enterprise Server for SAP applications",
+            "variant_id": "server-sap",
+            "version": "16.0 Beta4",
+            "version_id": "16.0",
+            "ansi_color": "0;32",
+            "id": "sles",
+            "id_like": "suse opensuse",
+            "cpe_name": "cpe:/o:suse:sles:16:16.0",
+            "suse_support_product": "SUSE Linux Enterprise Server for SAP applications",
+            "suse_support_product_version": "16.0",
+            "home_url": "https://www.suse.com/products/server/",
+            "documentation_url": "https://documentation.suse.com/sles-sap/16.0/",
+            "logo": "distributor-logo"
+        }
+    },
+    "input": {
+        "/etc/os-release": "# The NAME and PRETTY_NAME fields have been chosen to state compatibility between our products.\n# The use of \"SLES\" and \"SUSE Linux Enterprise\" rather than a more generic name is due to backward compatibility with existing OS detection code in applications of third party vendors.\nNAME=\"SLES\"\nPRETTY_NAME=\"SUSE Linux Enterprise Server 16.0\"\nVARIANT=\"Enterprise Server for SAP applications\"\nVARIANT_ID=\"server-sap\"\nVERSION=\"16.0 Beta4\"\nVERSION_ID=\"16.0\"\nANSI_COLOR=\"0;32\"\nID=\"sles\"\nID_LIKE=\"suse opensuse\"\nCPE_NAME=\"cpe:/o:suse:sles:16:16.0\"\nSUSE_SUPPORT_PRODUCT=\"SUSE Linux Enterprise Server for SAP applications\"\nSUSE_SUPPORT_PRODUCT_VERSION=\"16.0\"\nHOME_URL=\"https://www.suse.com/products/server/\"\nDOCUMENTATION_URL=\"https://documentation.suse.com/sles-sap/16.0/\"\nLOGO=\"distributor-logo\"\n",
+        "/usr/lib/os-release": "# The NAME and PRETTY_NAME fields have been chosen to state compatibility between our products.\n# The use of \"SLES\" and \"SUSE Linux Enterprise\" rather than a more generic name is due to backward compatibility with existing OS detection code in applications of third party vendors.\nNAME=\"SLES\"\nPRETTY_NAME=\"SUSE Linux Enterprise Server 16.0\"\nVARIANT=\"Enterprise Server for SAP applications\"\nVARIANT_ID=\"server-sap\"\nVERSION=\"16.0 Beta4\"\nVERSION_ID=\"16.0\"\nANSI_COLOR=\"0;32\"\nID=\"sles\"\nID_LIKE=\"suse opensuse\"\nCPE_NAME=\"cpe:/o:suse:sles:16:16.0\"\nSUSE_SUPPORT_PRODUCT=\"SUSE Linux Enterprise Server for SAP applications\"\nSUSE_SUPPORT_PRODUCT_VERSION=\"16.0\"\nHOME_URL=\"https://www.suse.com/products/server/\"\nDOCUMENTATION_URL=\"https://documentation.suse.com/sles-sap/16.0/\"\nLOGO=\"distributor-logo\"\n"
+    },
+    "platform.dist": [
+        "sles",
+        "16.0",
+        ""
+    ],
+    "result": {
+        "distribution": "SLES_SAP",
+        "distribution_version": "16.0",
+        "distribution_release": "0",
+        "distribution_major_version": "16",
+        "os_family": "Suse"
+    },
+    "platform.release": "6.12.0-160000.11-default"
+}
+


### PR DESCRIPTION
SUMMARY

This change improves how Ansible detects SUSE systems. It now checks the VARIANT_ID field in /etc/os-release to recognize SLES_SAP and SL-Micro. If that field is missing (on older systems), it falls back to the previous method using /etc/products.d/baseproduct.

This helps Ansible work correctly on both older and newer SUSE versions(ie sle16).

ISSUE TYPE: Bugfix Pull Request