### PR TITLE
apt: Mark dependencies as auto

### DIFF
--- a/changelogs/fragments/apt_deb_install.yml
+++ b/changelogs/fragments/apt_deb_install.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - apt - mark dependencies installed as part of deb file installation as auto (https://github.com/ansible/ansible/issues/78123).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -372,6 +372,7 @@ import locale as locale_module
 import os
 import re
 import secrets
+import shlex
 import shutil
 import sys
 import tempfile

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -708,7 +708,7 @@ def mark_installed(m, packages, manual=True):
         m.warn("Could not find apt-mark binary, not marking package(s) as %s installed." % mark_msg)
         return
 
-    cmd = "%s %s %s" % (apt_mark_cmd_path, state, ' '.join(packages))
+    cmd = "%s %s %s" % (apt_mark_cmd_path, mark_state, ' '.join(packages))
     rc, out, err = m.run_command(cmd)
 
     if any(x in err for x in [APT_MARK_INVALID_OP, APT_MARK_INVALID_OP_DEB6]):

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -690,26 +690,42 @@ def parse_diff(output):
     return {'prepared': '\n'.join(diff[diff_start:diff_end])}
 
 
-def mark_installed_manually(m, packages):
+def mark_installed(m, packages, state="manual"):
     if not packages:
         return
 
+    if state == "manual":
+        mark_state = "unmarkauto"
+        mark_msg = "manually"
+    elif state == "auto":
+        mark_state = "markauto"
+        mark_msg = "auto"
+    else:
+        m.fail_json(msg="Invalid state: %s" % state)
     apt_mark_cmd_path = m.get_bin_path("apt-mark")
 
     # https://github.com/ansible/ansible/issues/40531
     if apt_mark_cmd_path is None:
-        m.warn("Could not find apt-mark binary, not marking package(s) as manually installed.")
+        m.warn("Could not find apt-mark binary, not marking package(s) as %s installed." % mark_msg)
         return
 
-    cmd = "%s manual %s" % (apt_mark_cmd_path, ' '.join(packages))
+    cmd = "%s %s %s" % (apt_mark_cmd_path, state, ' '.join(packages))
     rc, out, err = m.run_command(cmd)
 
-    if APT_MARK_INVALID_OP in err or APT_MARK_INVALID_OP_DEB6 in err:
-        cmd = "%s unmarkauto %s" % (apt_mark_cmd_path, ' '.join(packages))
+    if any(x in err for x in [APT_MARK_INVALID_OP, APT_MARK_INVALID_OP_DEB6]):
+        cmd = "%s %s %s" % (apt_mark_cmd_path, mark_state, ' '.join(packages))
         rc, out, err = m.run_command(cmd)
 
     if rc != 0:
         m.fail_json(msg="'%s' failed: %s" % (cmd, err), stdout=out, stderr=err, rc=rc)
+
+
+def mark_installed_manually(m, packages):
+    mark_installed(m, packages, state="manual")
+
+
+def mark_installed_auto(m, packages):
+    mark_installed(m, packages, state="auto")
 
 
 def install(m, pkgspec, cache, upgrade=False, default_release=None,
@@ -912,6 +928,9 @@ def install_deb(
                                      dpkg_options=expand_dpkg_options(dpkg_options))
         if not success:
             m.fail_json(**retvals)
+        # Mark the dependencies as auto installed
+        # https://github.com/ansible/ansible/issues/78123
+        mark_installed_auto(m, deps_to_install)
         changed = retvals.get('changed', False)
 
     if pkgs_to_install:

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -690,7 +690,8 @@ def parse_diff(output):
     return {'prepared': '\n'.join(diff[diff_start:diff_end])}
 
 
-def mark_installed(m, packages, manual=True):
+def mark_installed(m: Any, packages: List[str], manual: bool = True) -> None:
+    """Mark packages as manually or automatically installed."""
     if not packages:
         return
 
@@ -698,7 +699,7 @@ def mark_installed(m, packages, manual=True):
         mark_state = "unmarkauto"
         mark_msg = "manually"
         mark_op = "manual"
-    elif not manual:
+    else:
         mark_state = "markauto"
         mark_msg = "auto"
         mark_op = "auto"
@@ -707,26 +708,18 @@ def mark_installed(m, packages, manual=True):
 
     # https://github.com/ansible/ansible/issues/40531
     if apt_mark_cmd_path is None:
-        m.warn("Could not find apt-mark binary, not marking package(s) as %s installed." % mark_msg)
+        m.warn(f"Could not find apt-mark binary, not marking package(s) as {mark_msg} installed.")
         return
 
-    cmd = "%s %s %s" % (apt_mark_cmd_path, mark_op, ' '.join(packages))
+    cmd = [apt_mark_cmd_path, mark_op] + packages
     rc, out, err = m.run_command(cmd)
 
-    if any(x in err for x in [APT_MARK_INVALID_OP, APT_MARK_INVALID_OP_DEB6]):
-        cmd = "%s %s %s" % (apt_mark_cmd_path, mark_state, ' '.join(packages))
+    if APT_MARK_INVALID_OP in err or APT_MARK_INVALID_OP_DEB6 in err:
+        cmd = [apt_mark_cmd_path, mark_state] + packages
         rc, out, err = m.run_command(cmd)
 
     if rc != 0:
-        m.fail_json(msg="'%s' failed: %s" % (cmd, err), stdout=out, stderr=err, rc=rc)
-
-
-def mark_installed_manually(m, packages):
-    mark_installed(m, packages)
-
-
-def mark_installed_auto(m, packages):
-    mark_installed(m, packages, manual=False)
+        m.fail_json(msg=f"'{cmd}' failed: {err}", stdout=out, stderr=err, rc=rc)
 
 
 def install(m, pkgspec, cache, upgrade=False, default_release=None,
@@ -852,7 +845,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         data = dict(changed=False)
 
     if not build_dep and not m.check_mode:
-        mark_installed_manually(m, package_names)
+        mark_installed(m, package_names)
 
     return (status, data)
 
@@ -931,7 +924,7 @@ def install_deb(
             m.fail_json(**retvals)
         # Mark the dependencies as auto installed
         # https://github.com/ansible/ansible/issues/78123
-        mark_installed_auto(m, deps_to_install)
+        mark_installed(m, deps_to_install, manual=False)
         changed = retvals.get('changed', False)
 
     if pkgs_to_install:

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -376,7 +376,6 @@ import shutil
 import sys
 import tempfile
 import time
-import typing as t
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.file import S_IRWXU_RXG_RXO
@@ -691,7 +690,7 @@ def parse_diff(output):
     return {'prepared': '\n'.join(diff[diff_start:diff_end])}
 
 
-def mark_installed(m: t.Any, packages: t.List[str], manual: bool = True) -> None:
+def mark_installed(m: AnsibleModule, packages: list[str], manual: bool) -> None:
     """Mark packages as manually or automatically installed."""
     if not packages:
         return
@@ -720,7 +719,7 @@ def mark_installed(m: t.Any, packages: t.List[str], manual: bool = True) -> None
         rc, out, err = m.run_command(cmd)
 
     if rc != 0:
-        m.fail_json(msg=f"'{cmd}' failed: {err}", stdout=out, stderr=err, rc=rc)
+        m.fail_json(msg=f"Command {shlex.join(cmd)!r} failed.", stdout=out, stderr=err, rc=rc)
 
 
 def install(m, pkgspec, cache, upgrade=False, default_release=None,
@@ -846,7 +845,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         data = dict(changed=False)
 
     if not build_dep and not m.check_mode:
-        mark_installed(m, package_names)
+        mark_installed(m, package_names, manual=True)
 
     return (status, data)
 

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -690,18 +690,17 @@ def parse_diff(output):
     return {'prepared': '\n'.join(diff[diff_start:diff_end])}
 
 
-def mark_installed(m, packages, state="manual"):
+def mark_installed(m, packages, manual=True):
     if not packages:
         return
 
-    if state == "manual":
+    if manual:
         mark_state = "unmarkauto"
         mark_msg = "manually"
-    elif state == "auto":
+    elif not manual:
         mark_state = "markauto"
         mark_msg = "auto"
-    else:
-        m.fail_json(msg="Invalid state: %s" % state)
+
     apt_mark_cmd_path = m.get_bin_path("apt-mark")
 
     # https://github.com/ansible/ansible/issues/40531
@@ -721,11 +720,11 @@ def mark_installed(m, packages, state="manual"):
 
 
 def mark_installed_manually(m, packages):
-    mark_installed(m, packages, state="manual")
+    mark_installed(m, packages)
 
 
 def mark_installed_auto(m, packages):
-    mark_installed(m, packages, state="auto")
+    mark_installed(m, packages, manual=False)
 
 
 def install(m, pkgspec, cache, upgrade=False, default_release=None,

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -697,9 +697,11 @@ def mark_installed(m, packages, manual=True):
     if manual:
         mark_state = "unmarkauto"
         mark_msg = "manually"
+        mark_op = "manual"
     elif not manual:
         mark_state = "markauto"
         mark_msg = "auto"
+        mark_op = "auto"
 
     apt_mark_cmd_path = m.get_bin_path("apt-mark")
 
@@ -708,7 +710,7 @@ def mark_installed(m, packages, manual=True):
         m.warn("Could not find apt-mark binary, not marking package(s) as %s installed." % mark_msg)
         return
 
-    cmd = "%s %s %s" % (apt_mark_cmd_path, mark_state, ' '.join(packages))
+    cmd = "%s %s %s" % (apt_mark_cmd_path, mark_op, ' '.join(packages))
     rc, out, err = m.run_command(cmd)
 
     if any(x in err for x in [APT_MARK_INVALID_OP, APT_MARK_INVALID_OP_DEB6]):

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -376,6 +376,7 @@ import shutil
 import sys
 import tempfile
 import time
+import typing as t
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.file import S_IRWXU_RXG_RXO
@@ -690,7 +691,7 @@ def parse_diff(output):
     return {'prepared': '\n'.join(diff[diff_start:diff_end])}
 
 
-def mark_installed(m: Any, packages: List[str], manual: bool = True) -> None:
+def mark_installed(m: t.Any, packages: t.List[str], manual: bool = True) -> None:
     """Mark packages as manually or automatically installed."""
     if not packages:
         return

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -391,8 +391,6 @@ APT_GET_ZERO = "\n0 upgraded, 0 newly installed, 0 to remove"
 APTITUDE_ZERO = "\n0 packages upgraded, 0 newly installed, 0 to remove"
 APT_LISTS_PATH = "/var/lib/apt/lists"
 APT_UPDATE_SUCCESS_STAMP_PATH = "/var/lib/apt/periodic/update-success-stamp"
-APT_MARK_INVALID_OP = 'Invalid operation'
-APT_MARK_INVALID_OP_DEB6 = 'Usage: apt-mark [options] {markauto|unmarkauto} packages'
 
 CLEAN_OP_CHANGED_STR = dict(
     autoremove='The following packages will be REMOVED',
@@ -697,11 +695,9 @@ def mark_installed(m: AnsibleModule, packages: list[str], manual: bool) -> None:
         return
 
     if manual:
-        mark_state = "unmarkauto"
         mark_msg = "manually"
         mark_op = "manual"
     else:
-        mark_state = "markauto"
         mark_msg = "auto"
         mark_op = "auto"
 
@@ -714,10 +710,6 @@ def mark_installed(m: AnsibleModule, packages: list[str], manual: bool) -> None:
 
     cmd = [apt_mark_cmd_path, mark_op] + packages
     rc, out, err = m.run_command(cmd)
-
-    if APT_MARK_INVALID_OP in err or APT_MARK_INVALID_OP_DEB6 in err:
-        cmd = [apt_mark_cmd_path, mark_state] + packages
-        rc, out, err = m.run_command(cmd)
 
     if rc != 0:
         m.fail_json(msg=f"Command {shlex.join(cmd)!r} failed.", stdout=out, stderr=err, rc=rc)

--- a/test/integration/targets/apt/tasks/apt_deb_depend.yml
+++ b/test/integration/targets/apt/tasks/apt_deb_depend.yml
@@ -5,7 +5,6 @@
         - packageone
         - packagetwo
       state: absent
-    ignore_errors: true
 
   - name: Install packageone from deb URL and make sure it installs depend
     apt:
@@ -14,22 +13,26 @@
     register: packageone_installed
 
   - name: Check if packagetwo is installed as part of packageone installation
-    shell: dpkg -l | grep packagetwo
+    shell: dpkg -s packagetwo
     register: packagetwo_installed
+
+  - name: Make sure packagetwo is installed
+    assert:
+      that:
+        - packagetwo_installed.rc == 0
 
   - name: Check if the packagetwo is marked as auto
     shell: apt-mark showauto
     register: packagetwo_auto
 
-  - name: Make sure packageone and packagetwo is installed
+  - name: Make sure packageone is installed and packagetwo is marked as auto
     assert:
       that:
         - packageone_installed.changed
-        - packagetwo_installed.rc == 0
         - "'packagetwo' in packagetwo_auto.stdout"
 
   always:
-    - name: Remove packageone and packagetwo
+    - name: Clean up after tests
       apt:
         name:
           - packageone

--- a/test/integration/targets/apt/tasks/apt_deb_depend.yml
+++ b/test/integration/targets/apt/tasks/apt_deb_depend.yml
@@ -6,16 +6,13 @@
         - packagetwo
       state: absent
 
-  - name: Install packageone from deb URL and make sure it installs depend
+  - name: Install packageone from deb URL
     apt:
       deb: https://ci-files.testing.ansible.com/test/integration/targets/apt/packageone_1.0_all.deb
-      state: present
     register: packageone_installed
 
   - name: Check if packagetwo is installed as part of packageone installation
     shell: dpkg -s packagetwo
-    register: packagetwo_installed
-
 
   - name: Check if packageone and packagetwo are marked as auto
     shell: apt-mark showauto packageone packagetwo

--- a/test/integration/targets/apt/tasks/apt_deb_depend.yml
+++ b/test/integration/targets/apt/tasks/apt_deb_depend.yml
@@ -9,7 +9,7 @@
 
   - name: Install packageone from deb URL and make sure it installs depend
     apt:
-      deb: https://github.com/Akasurde/ansible_pull_test_repo/raw/refs/heads/main/packageone.deb
+      deb: https://ci-files.testing.ansible.com/test/integration/targets/apt/packageone_1.0_all.deb
       state: present
     register: packageone_installed
 

--- a/test/integration/targets/apt/tasks/apt_deb_depend.yml
+++ b/test/integration/targets/apt/tasks/apt_deb_depend.yml
@@ -1,0 +1,38 @@
+- block:
+  - name: Clean up before running tests
+    apt:
+      name:
+        - packageone
+        - packagetwo
+      state: absent
+    ignore_errors: true
+
+  - name: Install packageone from deb URL and make sure it installs depend
+    apt:
+      deb: https://github.com/Akasurde/ansible_pull_test_repo/raw/refs/heads/main/packageone.deb
+      state: present
+    register: packageone_installed
+
+  - name: Check if packagetwo is installed as part of packageone installation
+    shell: dpkg -l | grep packagetwo
+    register: packagetwo_installed
+
+  - name: Check if the packagetwo is marked as auto
+    shell: apt-mark showauto
+    register: packagetwo_auto
+
+  - name: Make sure packageone and packagetwo is installed
+    assert:
+      that:
+        - packageone_installed.changed
+        - packagetwo_installed.rc == 0
+        - "'packagetwo' in packagetwo_auto.stdout"
+
+  always:
+    - name: Remove packageone and packagetwo
+      apt:
+        name:
+          - packageone
+          - packagetwo
+        state: absent
+      ignore_errors: true

--- a/test/integration/targets/apt/tasks/apt_deb_depend.yml
+++ b/test/integration/targets/apt/tasks/apt_deb_depend.yml
@@ -16,20 +16,16 @@
     shell: dpkg -s packagetwo
     register: packagetwo_installed
 
-  - name: Make sure packagetwo is installed
-    assert:
-      that:
-        - packagetwo_installed.rc == 0
 
-  - name: Check if the packagetwo is marked as auto
-    shell: apt-mark showauto
-    register: packagetwo_auto
+  - name: Check if packageone and packagetwo are marked as auto
+    shell: apt-mark showauto packageone packagetwo
+    register: auto_installed
 
-  - name: Make sure packageone is installed and packagetwo is marked as auto
+  - name: Make sure packageone is installed manually and packagetwo is marked as auto
     assert:
       that:
         - packageone_installed.changed
-        - "'packagetwo' in packagetwo_auto.stdout"
+        - auto_installed.stdout_lines == ["packagetwo"]
 
   always:
     - name: Clean up after tests
@@ -38,4 +34,3 @@
           - packageone
           - packagetwo
         state: absent
-      ignore_errors: true

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -22,6 +22,8 @@
 - block:
   - import_tasks: 'apt.yml'
 
+  - import_tasks: 'apt_deb_depend.yml'
+
   - import_tasks: 'url-with-deps.yml'
 
   - import_tasks: 'apt-multiarch.yml'

--- a/test/integration/targets/setup_deb_repo/files/package_specs/stable/packagetwo-1.0.0
+++ b/test/integration/targets/setup_deb_repo/files/package_specs/stable/packagetwo-1.0.0
@@ -1,0 +1,10 @@
+Section: misc
+Priority: optional
+Standards-Version: 2.3.3
+
+Package: packagetwo
+Version: 1.0
+Section: system
+Maintainer: John Doe <john@doe.com>
+Architecture: all
+Description: Dummy package upon which packageone depends


### PR DESCRIPTION
##### SUMMARY

* Mark dependented packages as auto which are installed as part of
  deb file installation

Fixes: #78123

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


