### PR TITLE
Recognize virtualization type correctly on Linode

### DIFF
--- a/changelogs/fragments/85184-add-linode-for-linux-facts.yml
+++ b/changelogs/fragments/85184-add-linode-for-linux-facts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - facts - add "Linode" for Linux VM in virtual facts

--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -201,7 +201,7 @@ class LinuxVirtual(Virtual):
                 virtual_facts['virtualization_type'] = 'virtualbox'
                 found_virt = True
 
-        if bios_vendor in ('Amazon EC2', 'DigitalOcean', 'Hetzner'):
+        if bios_vendor in ('Amazon EC2', 'DigitalOcean', 'Hetzner', 'Linode'):
             guest_tech.add('kvm')
             if not found_virt:
                 virtual_facts['virtualization_type'] = 'kvm'


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

After upgrading a VM running on Linode to Debian 13, its virtualization type was no longer detected correctly. I chose to inspect `bios_vendor` for the value of `Linode` to fix this, following prior art for other cloud platforms.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
