### PR TITLE
service: Fix order of arguments in FreeBSD

### DIFF
--- a/changelogs/fragments/freebsd_service.yml
+++ b/changelogs/fragments/freebsd_service.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - service - fix the arguments' order when invoking service command in FreeBSD with and without Jail (https://github.com/ansible/ansible/issues/85156).

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -153,6 +153,12 @@ EXAMPLES = r"""
     name: network
     state: restarted
     args: eth0
+
+- name: Restart nginx service in the jail called 'myjail' in FreeBSD
+  ansible.builtin.service:
+    name: nginx
+    state: restarted
+    args: -j myjail
 """
 
 RETURN = r"""#"""
@@ -1005,7 +1011,15 @@ class FreeBsdService(Service):
         self.sysrc_cmd = self.module.get_bin_path('sysrc')
 
     def get_service_status(self):
-        rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.arguments, self.name, 'onestatus'))
+        cmd = f"{self.svc_cmd} "
+
+        # Jail name takes precedence over other arguments
+        if self.arguments.startswith(('-j', '-v')):
+            cmd += f"{self.arguments} {self.name} onestatus"
+        else:
+            cmd += f"{self.name} onestatus {self.arguments}"
+
+        rc, stdout, dummy = self.execute_command(cmd)
         if self.name == "pf":
             self.running = "Enabled" in stdout
         else:
@@ -1025,15 +1039,15 @@ class FreeBsdService(Service):
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile
 
-        rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.arguments, self.name, 'rcvar'))
-        try:
-            rcvars = shlex.split(stdout, comments=True)
-        except Exception:
-            # TODO: add a warning to the output with the failure
-            pass
+        cmd = f"{self.svc_cmd} "
+        # Jail name and verbose takes precedence over other arguments
+        if self.arguments.startswith(('-j', '-v')):
+            cmd += f"{self.arguments} {self.name} rcvar"
+        else:
+            cmd += f"{self.name} rcvar {self.arguments}"
 
-        if not rcvars:
-            self.module.fail_json(msg="unable to determine rcvar", stdout=stdout, stderr=stderr)
+        rc, stdout, stderr = self.execute_command(cmd)
+        rcvars = shlex.split(stdout, comments=True)
 
         # In rare cases, i.e. sendmail, rcvar can return several key=value pairs
         # Usually there is just one, however.  In other rare cases, i.e. uwsgi,
@@ -1090,7 +1104,13 @@ class FreeBsdService(Service):
         if self.action == "reload":
             self.action = "onereload"
 
-        ret = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.arguments, self.name, self.action))
+        cmd = f"{self.svc_cmd} "
+        # Jail name and verbose take precedence over other arguments
+        if self.arguments.startswith(('-j', '-v')):
+            cmd += f"{self.arguments} {self.name} {self.action}"
+        else:
+            cmd += f"{self.name} {self.action} {self.arguments}"
+        ret = self.execute_command(cmd)
 
         if self.sleep:
             time.sleep(self.sleep)

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -173,6 +173,7 @@ import shlex
 import subprocess
 import tempfile
 import time
+import typing as t
 
 # The distutils module is not shipped with SUNWPython on Solaris.
 # It's in the SUNWPython-devel package which also contains development files
@@ -1010,7 +1011,7 @@ class FreeBsdService(Service):
 
         self.sysrc_cmd = self.module.get_bin_path('sysrc')
 
-    def run_service_cmd(self, *, status: str) -> Tuple[int, str, str]:
+    def run_service_cmd(self, *, status: str) -> t.Tuple[int, str, str]:
         """Run a service command with various options considering jail parameter."""
         # Jail name or verbose takes precedence over other arguments
         if self.arguments.startswith(('-j', '-v')):

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -1010,16 +1010,21 @@ class FreeBsdService(Service):
 
         self.sysrc_cmd = self.module.get_bin_path('sysrc')
 
-    def get_service_status(self):
-        cmd = f"{self.svc_cmd} "
+    def run_service_cmd(self, status=None):
+        if not status:
+            return (None, '', '')
 
+        cmd = f"{self.svc_cmd} "
         # Jail name takes precedence over other arguments
         if self.arguments.startswith(('-j', '-v')):
-            cmd += f"{self.arguments} {self.name} onestatus"
+            cmd += f"{self.arguments} {self.name} {status}"
         else:
-            cmd += f"{self.name} onestatus {self.arguments}"
+            cmd += f"{self.name} {status} {self.arguments}"
+        return self.execute_command(cmd)
 
-        rc, stdout, dummy = self.execute_command(cmd)
+    def get_service_status(self):
+        rc, stdout, _dummy = self.run_service_cmd(status="onestatus")
+
         if self.name == "pf":
             self.running = "Enabled" in stdout
         else:
@@ -1039,14 +1044,7 @@ class FreeBsdService(Service):
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile
 
-        cmd = f"{self.svc_cmd} "
-        # Jail name and verbose takes precedence over other arguments
-        if self.arguments.startswith(('-j', '-v')):
-            cmd += f"{self.arguments} {self.name} rcvar"
-        else:
-            cmd += f"{self.name} rcvar {self.arguments}"
-
-        rc, stdout, stderr = self.execute_command(cmd)
+        rc, stdout, _dummy = self.run_service_cmd(status="rcvar")
         rcvars = shlex.split(stdout, comments=True)
 
         # In rare cases, i.e. sendmail, rcvar can return several key=value pairs
@@ -1082,7 +1080,7 @@ class FreeBsdService(Service):
                     self.module.fail_json(msg="unable to set rcvar using sysrc", stdout=change_stdout, stderr=change_stderr)
 
                 # sysrc does not exit with code 1 on permission error => validate successful change using service(8)
-                rc, check_stdout, check_stderr = self.execute_command("%s %s %s" % (self.svc_cmd, self.name, "enabled"))
+                rc, _dummy, _dummy = self.run_service_cmd(status="enabled")
                 if self.enable != (rc == 0):  # rc = 0 indicates enabled service, rc = 1 indicates disabled service
                     self.module.fail_json(msg="unable to set rcvar: sysrc did not change value", stdout=change_stdout, stderr=change_stderr)
 
@@ -1104,13 +1102,7 @@ class FreeBsdService(Service):
         if self.action == "reload":
             self.action = "onereload"
 
-        cmd = f"{self.svc_cmd} "
-        # Jail name and verbose take precedence over other arguments
-        if self.arguments.startswith(('-j', '-v')):
-            cmd += f"{self.arguments} {self.name} {self.action}"
-        else:
-            cmd += f"{self.name} {self.action} {self.arguments}"
-        ret = self.execute_command(cmd)
+        ret, _dummy, _dummy = self.run_service_cmd(status=self.action)
 
         if self.sleep:
             time.sleep(self.sleep)

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -173,7 +173,6 @@ import shlex
 import subprocess
 import tempfile
 import time
-import typing as t
 
 # The distutils module is not shipped with SUNWPython on Solaris.
 # It's in the SUNWPython-devel package which also contains development files
@@ -1011,7 +1010,7 @@ class FreeBsdService(Service):
 
         self.sysrc_cmd = self.module.get_bin_path('sysrc')
 
-    def run_service_cmd(self, *, status: str) -> t.Tuple[int, str, str]:
+    def run_service_cmd(self, *, status: str) -> tuple[int, str, str]:
         """Run a service command with various options considering jail parameter."""
         # Jail name or verbose takes precedence over other arguments
         if self.arguments.startswith(('-j', '-v')):

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -1010,16 +1010,13 @@ class FreeBsdService(Service):
 
         self.sysrc_cmd = self.module.get_bin_path('sysrc')
 
-    def run_service_cmd(self, status=None):
-        if not status:
-            return (None, '', '')
-
-        cmd = f"{self.svc_cmd} "
-        # Jail name takes precedence over other arguments
+    def run_service_cmd(self, *, status: str) -> Tuple[int, str, str]:
+        """Run a service command with various options considering jail parameter."""
+        # Jail name or verbose takes precedence over other arguments
         if self.arguments.startswith(('-j', '-v')):
-            cmd += f"{self.arguments} {self.name} {status}"
+            cmd = shlex.join([self.svc_cmd, self.arguments, self.name, status])
         else:
-            cmd += f"{self.name} {status} {self.arguments}"
+            cmd = shlex.join([self.svc_cmd, self.name, status, self.arguments])
         return self.execute_command(cmd)
 
     def get_service_status(self):
@@ -1102,12 +1099,12 @@ class FreeBsdService(Service):
         if self.action == "reload":
             self.action = "onereload"
 
-        ret, _dummy, _dummy = self.run_service_cmd(status=self.action)
+        ret, stdout, stderr = self.run_service_cmd(status=self.action)
 
         if self.sleep:
             time.sleep(self.sleep)
 
-        return ret
+        return ret, stdout, stderr
 
 
 class DragonFlyBsdService(FreeBsdService):

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -1041,7 +1041,7 @@ class FreeBsdService(Service):
             if os.path.isfile(rcfile):
                 self.rcconf_file = rcfile
 
-        rc, stdout, _dummy = self.run_service_cmd(status="rcvar")
+        rc, stdout, stderr = self.run_service_cmd(status="rcvar")
         rcvars = shlex.split(stdout, comments=True)
 
         # In rare cases, i.e. sendmail, rcvar can return several key=value pairs

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -1014,9 +1014,9 @@ class FreeBsdService(Service):
         """Run a service command with various options considering jail parameter."""
         # Jail name or verbose takes precedence over other arguments
         if self.arguments.startswith(('-j', '-v')):
-            cmd = shlex.join([self.svc_cmd, self.arguments, self.name, status])
+            cmd = f"{self.svc_cmd} {self.arguments} {self.name} {status}"
         else:
-            cmd = shlex.join([self.svc_cmd, self.name, status, self.arguments])
+            cmd = f"{self.svc_cmd} {self.name} {status} {self.arguments}"
         return self.execute_command(cmd)
 
     def get_service_status(self):

--- a/test/integration/targets/service/tasks/setup-testjail.yml
+++ b/test/integration/targets/service/tasks/setup-testjail.yml
@@ -1,0 +1,64 @@
+---
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#
+# Instructions for setting up a jail
+# https://www.freebsd.org/doc/en_US.ISO8859-1/books/handbook/jails-ezjail.html
+#
+- name: Setup cloned interfaces
+  lineinfile:
+    dest: /etc/rc.conf
+    regexp: ^cloned_interfaces=lo1
+    line: cloned_interfaces=lo1
+
+- name: Activate cloned interfaces
+  command: "service netif cloneup"
+  changed_when: false
+
+- name: Install ezjail
+  pkgng:
+    name: ezjail
+
+- name: Configure ezjail to use http
+  lineinfile:
+    dest: /usr/local/etc/ezjail.conf
+    regexp: ^ezjail_ftphost
+    line: ezjail_ftphost=http://ftp.freebsd.org
+
+- name: Start ezjail
+  ignore_errors: true
+  service:
+    name: ezjail
+    state: started
+    enabled: true
+
+- name: Has ezjail
+  register: ezjail_base_jail
+  stat:
+    path: /usr/jails/basejail
+
+- name: Setup ezjail base
+  when: not ezjail_base_jail.stat.exists
+  shell: "ezjail-admin install >> /tmp/ezjail.log"
+  changed_when: false
+
+- name: Has testjail
+  register: ezjail_test_jail
+  stat:
+    path: /usr/jails/testjail
+
+- name: Create testjail
+  when: not ezjail_test_jail.stat.exists
+  shell: "ezjail-admin create testjail 'lo1|127.0.1.1' >> /tmp/ezjail.log"
+  changed_when: false
+
+- name: Is testjail running
+  shell: "jls | grep testjail"
+  changed_when: false
+  failed_when: false
+  register: is_testjail_up
+
+- name: Start testjail
+  when: is_testjail_up.rc == 1
+  command: "ezjail-admin start testjail"

--- a/test/integration/targets/service/tasks/tests.yml
+++ b/test/integration/targets/service/tasks/tests.yml
@@ -314,7 +314,7 @@
         name: sshd
         state: started
         enabled: yes
-        arguments: '-j testjail'
+        arguments: -j testjail
       register: sshd_result
 
     - name: Assert that SSHD was started
@@ -326,7 +326,7 @@
       service:
         name: sshd
         state: stopped
-        arguments: '-j testjail'
+        arguments: -j testjail
       register: sshd_result
 
     - name: Assert that SSHD was stopped

--- a/test/integration/targets/service/tasks/tests.yml
+++ b/test/integration/targets/service/tasks/tests.yml
@@ -192,7 +192,6 @@
         that:
           - "start_result.state == 'started'"
           - "start_result is changed"
-          - "'eth0' in cmdline.stdout"
 
 - name: "test for #42786 (sysvinit)"
   when: ansible_service_mgr == "sysv"

--- a/test/integration/targets/service/tasks/tests.yml
+++ b/test/integration/targets/service/tasks/tests.yml
@@ -147,6 +147,45 @@
       - "reload_result is changed"
   when: ansible_service_mgr != "systemd"
 
+- name: Test arguments in service using FreeBSD
+  when: ansible_distribution == 'FreeBSD'
+  block:
+    - name: stop the ansible test service
+      service:
+        name: ansible_test
+        state: stopped
+      register: stop_result
+
+    - name: check that the service is stopped (FreeBSD)
+      shell: 'ps -p {{ ansible_test_pid.stdout }}'
+      register: cmdline
+      failed_when: cmdline is not failed or '/usr/sbin/ansible_test_service' in cmdline.stdout
+
+    - name: assert that the service was stopped
+      assert:
+        that:
+          - "stop_result.state == 'stopped'"
+          - "stop_result is changed"
+
+    - name: Pass arguments to service
+      service:
+        name: ansible_test
+        state: started
+        arguments: 'eth0'
+      register: start_result
+
+    - name: check that the service is started (FreeBSD)
+      shell: 'ps -p {{ pid_after_restart.stdout }}'
+      register: cmdline
+      failed_when: cmdline is failed or '/usr/sbin/ansible_test_service' not in cmdline.stdout
+
+    - name: assert that the service was started
+      assert:
+        that:
+          - "start_result.state == 'started'"
+          - "start_result is changed"
+          - "'eth0' in cmdline.stdout"
+
 - name: "test for #42786 (sysvinit)"
   when: ansible_service_mgr == "sysv"
   block:
@@ -256,3 +295,40 @@
       - result is failed
       - result is search("Could not find the requested service nonexisting")
   when: ansible_distribution != 'FreeBSD'
+
+- name: Test service with jail in FreeBSD
+  when: ansible_distribution == 'FreeBSD'
+  block:
+    - name: Setup testjail
+      include_tasks: setup-testjail.yml
+
+    - name: Start SSHD in testjail
+      service:
+        name: sshd
+        state: started
+        enabled: yes
+        arguments: '-j testjail'
+      register: sshd_result
+
+    - name: Assert that SSHD was started
+      assert:
+        that:
+          - sshd_result.state == 'started'
+
+    - name: Stop SSHD in testjail
+      service:
+        name: sshd
+        state: stopped
+        arguments: '-j testjail'
+      register: sshd_result
+
+    - name: Assert that SSHD was stopped
+      assert:
+        that:
+          - sshd_result.state == 'stopped'
+
+  always:
+    - name: Stop and remove testjail
+      failed_when: false
+      changed_when: false
+      command: "ezjail-admin delete -wf testjail"

--- a/test/integration/targets/service/tasks/tests.yml
+++ b/test/integration/targets/service/tasks/tests.yml
@@ -150,6 +150,10 @@
 - name: Test arguments in service using FreeBSD
   when: ansible_distribution == 'FreeBSD'
   block:
+    - name: fetch PID for ansible_test service
+      command: 'cat /var/run/ansible_test_service.pid'
+      register: ansible_test_pid
+    
     - name: stop the ansible test service
       service:
         name: ansible_test
@@ -174,8 +178,12 @@
         arguments: 'eth0'
       register: start_result
 
+    - name: fetch PID for ansible_test service
+      command: 'cat /var/run/ansible_test_service.pid'
+      register: pid_after_start
+      
     - name: check that the service is started (FreeBSD)
-      shell: 'ps -p {{ pid_after_restart.stdout }}'
+      shell: 'ps -p {{ pid_after_start.stdout }}'
       register: cmdline
       failed_when: cmdline is failed or '/usr/sbin/ansible_test_service' not in cmdline.stdout
 


### PR DESCRIPTION
##### SUMMARY

* Jail name and verbose argument in service command has fix position.
  Specifying them at the end of the service command may result in failure.
  This fix detects and reorders the arguments based upon user input.

Fixes: #85156

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


