### PR TITLE
win coverage - Fix untrusted coverage collection

### DIFF
--- a/lib/ansible/executor/powershell/module_wrapper.ps1
+++ b/lib/ansible/executor/powershell/module_wrapper.ps1
@@ -98,7 +98,9 @@ if ($ForModule) {
     $ps.Runspace.SessionStateProxy.SetVariable("ErrorActionPreference", "Stop")
 }
 else {
-    # For script files we want to ensure we load it as UTF-8
+    # For script files we want to ensure we load it as UTF-8. We don't set this
+    # for modules as they are loaded from memory whereas a script is loaded
+    # from disk as part of the script being run than by us.
     Set-WinPSDefaultFileEncoding
 }
 


### PR DESCRIPTION
##### SUMMARY
Fixes the logic when running a module through App Control when the
module is not trusted to run in Full Language Mode. This ensures
coverage will still run as expected and that the trust verification only
happens in the wrappers that actually run/prepare the code.

Also expands on a comment to clarify why only that branch is set to set
the internal file encoding to UTF-8.

This doesn't need a changelog fragment as it was only just broken as part of an unreleased change.

##### ISSUE TYPE
- Bugfix Pull Request
