### PR TITLE
Deprecate AGNOSTIC_BECOME_PROMPT by simplifying become prompt logic

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -413,7 +413,7 @@ class CLI(ABC):
         sshpass = None
         becomepass = None
 
-        become_prompt_method = "BECOME" if C.AGNOSTIC_BECOME_PROMPT else op['become_method'].upper()
+        become_prompt_method = op['become_method'].upper()
 
         try:
             become_prompt = "%s password: " % become_prompt_method


### PR DESCRIPTION
This PR addresses [issue #81501](https://github.com/ansible/ansible/issues/81501) by removing the AGNOSTIC_BECOME_PROMPT configuration logic, which was originally added as a temporary workaround in [#34761](https://github.com/ansible/ansible/pull/34761) for compatibility with older versions of Ansible Tower.

As part of this cleanup:

I simplified the prompt logic by removing the conditional use of C.AGNOSTIC_BECOME_PROMPT.
The prompt method is now always based on the uppercase form of the actual become_method, eliminating the need for the agnostic BECOME label.
This change helps clarify the prompt behavior and aligns with modern expectations and updated tooling.
Given that this flag was undocumented, confusing to users, and likely obsolete, deprecating it resolves both technical debt and usability issues.

This change affects:

lib/ansible/cli/__init__.py
