### PR TITLE
doc - Dynamically document jinja builtins

### DIFF
--- a/changelogs/fragments/ansible-doc-jinja-builtins.yml
+++ b/changelogs/fragments/ansible-doc-jinja-builtins.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-doc - Return dynamic stub when reporting on Jinja filters and tests not explicitly documented in Ansible
+

--- a/changelogs/fragments/ansible-doc-jinja-builtins.yml
+++ b/changelogs/fragments/ansible-doc-jinja-builtins.yml
@@ -1,3 +1,2 @@
 minor_changes:
   - ansible-doc - Return dynamic stub when reporting on Jinja filters and tests not explicitly documented in Ansible
-

--- a/lib/ansible/_internal/_templating/_jinja_bits.py
+++ b/lib/ansible/_internal/_templating/_jinja_bits.py
@@ -1069,23 +1069,3 @@ def _finalize_template_result(o: t.Any, mode: FinalizeMode) -> t.Any:
         return result
 
     raise AnsibleVariableTypeError.from_value(obj=o)
-
-
-@dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
-class Jinja2BuiltinMetadata:
-    """Jinja2 builtin filter and test metadata."""
-
-    name: str
-    """Name of the plugin."""
-    doc: str | None = None
-    """Function docstring, if available."""
-
-
-def get_jinja2_builtin_filters() -> list[Jinja2BuiltinMetadata]:
-    """Returns a list of builtin Jinja2 filters."""
-    return [Jinja2BuiltinMetadata(name=n, doc=f.__doc__) for n, f in Environment().filters.items()]
-
-
-def get_jinja2_builtin_tests() -> list[Jinja2BuiltinMetadata]:
-    """Returns a list of builtin Jinja2 tests."""
-    return [Jinja2BuiltinMetadata(name=n, doc=f.__doc__) for n, f in Environment().tests.items()]

--- a/lib/ansible/_internal/_templating/_jinja_bits.py
+++ b/lib/ansible/_internal/_templating/_jinja_bits.py
@@ -1069,3 +1069,27 @@ def _finalize_template_result(o: t.Any, mode: FinalizeMode) -> t.Any:
         return result
 
     raise AnsibleVariableTypeError.from_value(obj=o)
+
+
+@dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
+class Jinja2BuiltinMetadata:
+    """Jinja2 builtin filter and test metadata."""
+    name: str
+    """Name of the plugin."""
+    doc: str | None = None
+    """Function docstring, if available."""
+
+
+def get_jinja2_builtin_filters() -> list[Jinja2BuiltinMetadata]:
+    """Returns a list of builtin Jinja2 filters."""
+    return [
+        Jinja2BuiltinMetadata(name=n, doc=f.__doc__)
+        for n, f in Environment().filters.items()
+    ]
+
+def get_jinja2_builtin_tests() -> list[Jinja2BuiltinMetadata]:
+    """Returns a list of builtin Jinja2 tests."""
+    return [
+        Jinja2BuiltinMetadata(name=n, doc=f.__doc__)
+        for n, f in Environment().tests.items()
+    ]

--- a/lib/ansible/_internal/_templating/_jinja_bits.py
+++ b/lib/ansible/_internal/_templating/_jinja_bits.py
@@ -1074,6 +1074,7 @@ def _finalize_template_result(o: t.Any, mode: FinalizeMode) -> t.Any:
 @dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
 class Jinja2BuiltinMetadata:
     """Jinja2 builtin filter and test metadata."""
+
     name: str
     """Name of the plugin."""
     doc: str | None = None
@@ -1082,14 +1083,9 @@ class Jinja2BuiltinMetadata:
 
 def get_jinja2_builtin_filters() -> list[Jinja2BuiltinMetadata]:
     """Returns a list of builtin Jinja2 filters."""
-    return [
-        Jinja2BuiltinMetadata(name=n, doc=f.__doc__)
-        for n, f in Environment().filters.items()
-    ]
+    return [Jinja2BuiltinMetadata(name=n, doc=f.__doc__) for n, f in Environment().filters.items()]
+
 
 def get_jinja2_builtin_tests() -> list[Jinja2BuiltinMetadata]:
     """Returns a list of builtin Jinja2 tests."""
-    return [
-        Jinja2BuiltinMetadata(name=n, doc=f.__doc__)
-        for n, f in Environment().tests.items()
-    ]
+    return [Jinja2BuiltinMetadata(name=n, doc=f.__doc__) for n, f in Environment().tests.items()]

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -878,7 +878,7 @@ class DocCLI(CLI, RoleMixin):
         loader: t.Any,
         fragment_loader: t.Any,
         jinja_builtins: dict[str, Jinja2BuiltinMetadata],
-    ) -> tuple[dict, dict | None, str | None, dict | None]:
+    ) -> tuple[dict, str | None, dict | None, dict | None]:
         try:
             return get_plugin_docs(plugin_name, plugin_type, loader, fragment_loader, (context.CLIARGS['verbosity'] > 0))
         except Exception:

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -37,7 +37,7 @@ from ansible.parsing.plugin_docs import read_docstub
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible._internal._yaml._loader import AnsibleInstrumentedLoader
-from ansible.plugins.list import _list_plugins_with_info, _PluginInfo
+from ansible.plugins.list import _list_plugins_with_info, _PluginDocMetadata
 from ansible.plugins.loader import action_loader, fragment_loader
 from ansible.utils.collection_loader import AnsibleCollectionConfig, AnsibleCollectionRef
 from ansible.utils.collection_loader._collection_finder import _get_collection_name_from_path
@@ -46,7 +46,7 @@ from ansible.utils.display import Display
 from ansible.utils.plugin_docs import get_plugin_docs, get_docstring, get_versioned_doclink
 from ansible.template import trust_as_template
 from ansible._internal import _json
-from ansible._internal._templating._jinja_bits import get_jinja2_builtin_filters, get_jinja2_builtin_tests, Jinja2BuiltinMetadata
+from ansible._internal._templating import _jinja_plugins
 
 display = Display()
 
@@ -791,8 +791,6 @@ class DocCLI(CLI, RoleMixin):
         return coll_filter
 
     def _list_plugins(self, plugin_type, content):
-
-        results = {}
         DocCLI._prep_loader(plugin_type)
 
         coll_filter = self._get_collection_filter()
@@ -813,15 +811,14 @@ class DocCLI(CLI, RoleMixin):
 
         return results
 
-    def _get_plugins_docs(self, plugin_type: str, names: collections.abc.Iterable[str], fail_ok=False, fail_on_errors=True) -> dict[str, dict]:
-
+    def _get_plugins_docs(self, plugin_type: str, names: collections.abc.Iterable[str], fail_ok: bool = False, fail_on_errors: bool = True) -> dict[str, dict]:
         loader = DocCLI._prep_loader(plugin_type)
 
-        jinja2_builtins = {}
-        if plugin_type == 'filter':
-            jinja2_builtins = {f"ansible.builtin.{p.name}": p for p in get_jinja2_builtin_filters()}
-        elif plugin_type == 'test':
-            jinja2_builtins = {f"ansible.builtin.{p.name}": p for p in get_jinja2_builtin_tests()}
+        if plugin_type in ('filter', 'test'):
+            jinja2_builtins = _jinja_plugins.get_jinja_builtin_plugin_descriptions(plugin_type)
+            jinja2_builtins.update({name.split('.')[-1]: value for name, value in jinja2_builtins.items()})  # add short-named versions for lookup
+        else:
+            jinja2_builtins = {}
 
         # get the docs for plugins in the command line list
         plugin_docs = {}
@@ -877,27 +874,28 @@ class DocCLI(CLI, RoleMixin):
         plugin_type: str,
         loader: t.Any,
         fragment_loader: t.Any,
-        jinja_builtins: dict[str, Jinja2BuiltinMetadata],
+        jinja_builtins: dict[str, str],
     ) -> tuple[dict, str | None, dict | None, dict | None]:
         try:
             return get_plugin_docs(plugin_name, plugin_type, loader, fragment_loader, (context.CLIARGS['verbosity'] > 0))
         except Exception:
-            if info := jinja_builtins.get(plugin_name, None):
+            if (desc := jinja_builtins.get(plugin_name, ...)) is not ...:
+                short_name = plugin_name.split('.')[-1]
+                long_name = f'ansible.builtin.{short_name}'
                 # Dynamically build a doc stub for any Jinja2 builtin plugin we haven't
                 # explicitly documented.
-                doc = {
-                    'collection': 'ansible.builtin',
-                    'plugin_name': info.name,
-                    'filename': '',
-                    'short_description': f"builtin Jinja {plugin_type} plugin {info.name}",
-                    "description": [
-                        f"The builtin Jinja {plugin_type} plugin {info.name}",
-                        f"See U(https://jinja.palletsprojects.com/en/stable/templates/#jinja-{plugin_type}s.{info.name})",
+                doc = dict(
+                    collection='ansible.builtin',
+                    plugin_name=long_name,
+                    filename='',
+                    short_description=desc,
+                    description=[
+                        desc,
+                        '',
+                        f"This is the Jinja builtin {plugin_type} plugin {short_name!r}.",
+                        f"See: U(https://jinja.palletsprojects.com/en/stable/templates/#jinja-{plugin_type}s.{short_name})",
                     ],
-                }
-
-                if info.doc:
-                    doc['description'].insert(1, info.doc)
+                )
 
                 return doc, None, None, None
 
@@ -1151,7 +1149,7 @@ class DocCLI(CLI, RoleMixin):
 
         return text
 
-    def _get_plugin_list_descriptions(self, plugins: dict[str, _PluginInfo]) -> dict[str, str]:
+    def _get_plugin_list_descriptions(self, plugins: dict[str, _PluginDocMetadata]) -> dict[str, str]:
 
         descs = {}
         for plugin, plugin_info in plugins.items():
@@ -1163,7 +1161,6 @@ class DocCLI(CLI, RoleMixin):
                 filename = Path(to_native(plugin_info.path))
                 try:
                     doc = read_docstub(filename)
-
                 except Exception as e:
                     docerror = e
 
@@ -1182,13 +1179,12 @@ class DocCLI(CLI, RoleMixin):
 
                 # Do a final fallback to see if the plugin is a shadowed Jinja2 plugin
                 # without any explicit documentation.
-                if doc is None and plugin_info.is_jinja_plugin:
-                    plugin_name = plugin.split('.')[-1]
-                    descs[plugin] = f"builtin Jinja plugin {plugin_name}"
+                if doc is None and plugin_info.jinja_builtin_short_description:
+                    descs[plugin] = plugin_info.jinja_builtin_short_description
                     continue
 
                 if docerror:
-                    display.warning("%s has a documentation formatting error: %s" % (plugin, docerror))
+                    display.error_as_warning(f"{plugin} has a documentation formatting error.", exception=docerror)
                     continue
 
             if not doc or not isinstance(doc, dict):

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -9,12 +9,14 @@ from __future__ import annotations
 # ansible.cli needs to be imported first, to ensure the source bin/* scripts run that code first
 from ansible.cli import CLI
 
+import collections.abc
 import importlib
 import pkgutil
 import os
 import os.path
 import re
 import textwrap
+import typing as t
 
 import yaml
 
@@ -35,7 +37,7 @@ from ansible.parsing.plugin_docs import read_docstub
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible._internal._yaml._loader import AnsibleInstrumentedLoader
-from ansible.plugins.list import list_plugins
+from ansible.plugins.list import _list_plugins_with_info, _PluginInfo
 from ansible.plugins.loader import action_loader, fragment_loader
 from ansible.utils.collection_loader import AnsibleCollectionConfig, AnsibleCollectionRef
 from ansible.utils.collection_loader._collection_finder import _get_collection_name_from_path
@@ -44,6 +46,7 @@ from ansible.utils.display import Display
 from ansible.utils.plugin_docs import get_plugin_docs, get_docstring, get_versioned_doclink
 from ansible.template import trust_as_template
 from ansible._internal import _json
+from ansible._internal._templating._jinja_bits import get_jinja2_builtin_filters, get_jinja2_builtin_tests, Jinja2BuiltinMetadata
 
 display = Display()
 
@@ -790,39 +793,48 @@ class DocCLI(CLI, RoleMixin):
     def _list_plugins(self, plugin_type, content):
 
         results = {}
-        self.plugins = {}
-        loader = DocCLI._prep_loader(plugin_type)
+        DocCLI._prep_loader(plugin_type)
 
         coll_filter = self._get_collection_filter()
-        plugin_list = list_plugins(plugin_type, coll_filter)
+        plugins = _list_plugins_with_info(plugin_type, coll_filter)
 
         # Remove the internal ansible._protomatter plugins if getting all plugins
         if not coll_filter:
-            plugin_list = {k: v for k, v in plugin_list.items() if not k.startswith('ansible._protomatter.')}
-
-        self.plugins.update(plugin_list)
+            plugins = {k: v for k, v in plugins.items() if not k.startswith('ansible._protomatter.')}
 
         # get appropriate content depending on option
         if content == 'dir':
-            results = self._get_plugin_list_descriptions(loader)
+            results = self._get_plugin_list_descriptions(plugins)
         elif content == 'files':
-            results = {k: self.plugins[k][0] for k in self.plugins.keys()}
+            results = {k: v.path for k, v in plugins.items()}
         else:
-            results = {k: {} for k in self.plugins.keys()}
+            results = {k: {} for k in plugins.keys()}
             self.plugin_list = set()  # reset for next iteration
 
         return results
 
-    def _get_plugins_docs(self, plugin_type, names, fail_ok=False, fail_on_errors=True):
+    def _get_plugins_docs(self, plugin_type: str, names: collections.abc.Iterable[str], fail_ok=False, fail_on_errors=True) -> dict[str, dict]:
 
         loader = DocCLI._prep_loader(plugin_type)
+
+        jinja2_builtins = {}
+        if plugin_type == 'filter':
+            jinja2_builtins = {f"ansible.builtin.{p.name}": p for p in get_jinja2_builtin_filters()}
+        elif plugin_type == 'test':
+            jinja2_builtins = {f"ansible.builtin.{p.name}": p for p in get_jinja2_builtin_tests()}
 
         # get the docs for plugins in the command line list
         plugin_docs = {}
         for plugin in names:
-            doc = {}
+            doc: dict[str, t.Any] = {}
             try:
-                doc, plainexamples, returndocs, metadata = get_plugin_docs(plugin, plugin_type, loader, fragment_loader, (context.CLIARGS['verbosity'] > 0))
+                doc, plainexamples, returndocs, metadata = self._get_plugin_docs_with_jinja2_builtins(
+                    plugin,
+                    plugin_type,
+                    loader,
+                    fragment_loader,
+                    jinja2_builtins,
+                )
             except AnsiblePluginNotFound as e:
                 display.warning(to_native(e))
                 continue
@@ -858,6 +870,38 @@ class DocCLI(CLI, RoleMixin):
             plugin_docs[plugin] = docs
 
         return plugin_docs
+
+    def _get_plugin_docs_with_jinja2_builtins(
+        self,
+        plugin_name: str,
+        plugin_type: str,
+        loader: t.Any,
+        fragment_loader: t.Any,
+        jinja_builtins: dict[str, Jinja2BuiltinMetadata],
+    ) -> tuple[dict, dict | None, str | None, dict | None]:
+        try:
+            return get_plugin_docs(plugin_name, plugin_type, loader, fragment_loader, (context.CLIARGS['verbosity'] > 0))
+        except Exception:
+            if info := jinja_builtins.get(plugin_name, None):
+                # Dynamically build a doc stub for any Jinja2 builtin plugin we haven't
+                # explicitly documented.
+                doc = {
+                    'collection': 'ansible.builtin',
+                    'plugin_name': info.name,
+                    'filename': '',
+                    'short_description': f"builtin Jinja {plugin_type} plugin {info.name}",
+                    "description": [
+                        f"The builtin Jinja {plugin_type} plugin {info.name}",
+                        f"See U(https://jinja.palletsprojects.com/en/stable/templates/#jinja-{plugin_type}s.{info.name})",
+                    ],
+                }
+
+                if info.doc:
+                    doc['description'].insert(1, info.doc)
+
+                return doc, None, None, None
+
+            raise
 
     def _get_roles_path(self):
         """
@@ -1007,10 +1051,10 @@ class DocCLI(CLI, RoleMixin):
     def get_all_plugins_of_type(plugin_type):
         loader = getattr(plugin_loader, '%s_loader' % plugin_type)
         paths = loader._get_paths_with_context()
-        plugins = {}
+        plugins = []
         for path_context in paths:
-            plugins.update(list_plugins(plugin_type))
-        return sorted(plugins.keys())
+            plugins += _list_plugins_with_info(plugin_type).keys()
+        return sorted(plugins)
 
     @staticmethod
     def get_plugin_metadata(plugin_type, plugin_name):
@@ -1107,18 +1151,21 @@ class DocCLI(CLI, RoleMixin):
 
         return text
 
-    def _get_plugin_list_descriptions(self, loader):
+    def _get_plugin_list_descriptions(self, plugins: dict[str, _PluginInfo]) -> dict[str, str]:
 
         descs = {}
-        for plugin in self.plugins.keys():
+        for plugin, plugin_info in plugins.items():
             # TODO: move to plugin itself i.e: plugin.get_desc()
             doc = None
-            filename = Path(to_native(self.plugins[plugin][0]))
+
             docerror = None
-            try:
-                doc = read_docstub(filename)
-            except Exception as e:
-                docerror = e
+            if plugin_info.path:
+                filename = Path(to_native(plugin_info.path))
+                try:
+                    doc = read_docstub(filename)
+
+                except Exception as e:
+                    docerror = e
 
             # plugin file was empty or had error, lets try other options
             if doc is None:
@@ -1133,9 +1180,16 @@ class DocCLI(CLI, RoleMixin):
                     except Exception as e:
                         docerror = e
 
-            if docerror:
-                display.warning("%s has a documentation formatting error: %s" % (plugin, docerror))
-                continue
+                # Do a final fallback to see if the plugin is a shadowed Jinja2 plugin
+                # without any explicit documentation.
+                if doc is None and plugin_info.is_jinja_plugin:
+                    plugin_name = plugin.split('.')[-1]
+                    descs[plugin] = f"builtin Jinja plugin {plugin_name}"
+                    continue
+
+                if docerror:
+                    display.warning("%s has a documentation formatting error: %s" % (plugin, docerror))
+                    continue
 
             if not doc or not isinstance(doc, dict):
                 desc = 'UNDOCUMENTED'

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -816,7 +816,6 @@ class FilterModule(object):
             'groupby': _cleansed_groupby,
 
             # Jinja builtins that need special arg handling
-            # DTFIX1: document these now that they're overridden, or hide them so they don't show up as undocumented
             'd': ansible_default,  # replaces the implementation instead of wrapping it
             'default': ansible_default,  # replaces the implementation instead of wrapping it
             'map': wrapped_map,

--- a/lib/ansible/plugins/list.py
+++ b/lib/ansible/plugins/list.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 
+import dataclasses
 import os
 
 from ansible import context
@@ -14,6 +15,7 @@ from ansible.module_utils.common.text.converters import to_native, to_bytes
 from ansible.plugins import loader
 from ansible.utils.display import Display
 from ansible.utils.collection_loader._collection_finder import _get_collection_path
+from ansible._internal._templating._jinja_bits import get_jinja2_builtin_filters, get_jinja2_builtin_tests
 
 display = Display()
 
@@ -23,6 +25,18 @@ IGNORE = {
     'module': ('async_wrapper', ),
     'cache': ('base', ),
 }
+
+@dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
+class _PluginInfo:
+    """Information about a plugin."""
+    name: str
+    """The fully qualified name of the plugin."""
+    path: bytes | None
+    """The path to the plugin file, or None if not available."""
+    plugin_obj: object | None = None
+    """The loaded plugin object, or None if not loaded."""
+    is_jinja_plugin: bool = False
+    """Whether the plugin shadows a Jinja2 plugin (filter or test)."""
 
 
 def get_composite_name(collection, name, path, depth):
@@ -116,21 +130,39 @@ def _list_j2_plugins_from_file(collection, plugin_path, ptype, plugin_name):
     return file_plugins
 
 
-def list_collection_plugins(ptype, collections, search_paths=None):
+def list_collection_plugins(ptype: str, collections: dict[str, bytes], search_paths: list[str] | None = None) -> dict[str, tuple[bytes, object | None]]:
+    # Kept for backwards compatibility.
+    return {
+        name: (info.path, info.plugin_obj)
+        for name, info in _list_collection_plugins_with_info(ptype, collections).items()
+    }
+
+
+def _list_collection_plugins_with_info(
+    ptype: str,
+    collections: dict[str, bytes],
+) -> dict[str, _PluginInfo]:
     # TODO: update to use importlib.resources
 
-    # starts at  {plugin_name: filepath, ...}, but changes at the end
-    plugins = {}
     try:
         ploader = getattr(loader, '{0}_loader'.format(ptype))
     except AttributeError:
         raise AnsibleError(f"Cannot list plugins, incorrect plugin type {ptype!r} supplied.") from None
 
+    builtin_jinja_plugins = set()
+    plugin_paths = {}
+
     # get plugins for each collection
-    for collection in collections.keys():
+    for collection, path in collections.items():
         if collection == 'ansible.builtin':
             # dirs from ansible install, but not configured paths
             dirs = [d.path for d in ploader._get_paths_with_context() if d.internal]
+
+            if ptype == 'filter':
+                builtin_jinja_plugins = set(f"ansible.builtin.{p.name}" for p in get_jinja2_builtin_filters())
+            elif ptype == 'test':
+                builtin_jinja_plugins = set(f"ansible.builtin.{p.name}" for p in get_jinja2_builtin_tests())
+
         elif collection == 'ansible.legacy':
             # configured paths + search paths (should include basedirs/-M)
             dirs = [d.path for d in ploader._get_paths_with_context() if not d.internal]
@@ -139,7 +171,7 @@ def list_collection_plugins(ptype, collections, search_paths=None):
         else:
             # search path in this case is for locating collection itselfA
             b_ptype = to_bytes(C.COLLECTION_PTYPE_COMPAT.get(ptype, ptype))
-            dirs = [to_native(os.path.join(collections[collection], b'plugins', b_ptype))]
+            dirs = [to_native(os.path.join(path, b'plugins', b_ptype))]
             # acr = AnsibleCollectionRef.try_parse_fqcr(collection, ptype)
             # if acr:
             #     dirs = acr.subdirs
@@ -147,30 +179,56 @@ def list_collection_plugins(ptype, collections, search_paths=None):
 
             #     raise Exception('bad acr for %s, %s' % (collection, ptype))
 
-        plugins.update(_list_plugins_from_paths(ptype, dirs, collection))
+        plugin_paths.update(_list_plugins_from_paths(ptype, dirs, collection))
 
-    #  return plugin and it's class object, None for those not verifiable or failing
+    plugins = {}
     if ptype in ('module',):
         # no 'invalid' tests for modules
-        for plugin in plugins.keys():
-            plugins[plugin] = (plugins[plugin], None)
+        for plugin, plugin_path in plugin_paths.items():
+            plugins[plugin] = _PluginInfo(name=plugin, path=plugin_path)
     else:
         # detect invalid plugin candidates AND add loaded object to return data
-        for plugin in list(plugins.keys()):
+        for plugin, plugin_path in plugin_paths.items():
             pobj = None
             try:
                 pobj = ploader.get(plugin, class_only=True)
             except Exception as e:
-                display.vvv("The '{0}' {1} plugin could not be loaded from '{2}': {3}".format(plugin, ptype, plugins[plugin], to_native(e)))
+                display.vvv("The '{0}' {1} plugin could not be loaded from '{2}': {3}".format(plugin, ptype, plugin_path, to_native(e)))
 
-            # sets final {plugin_name: (filepath, class|NONE if not loaded), ...}
-            plugins[plugin] = (plugins[plugin], pobj)
+            plugins[plugin] = _PluginInfo(
+                name=plugin,
+                path=plugin_path,
+                plugin_obj=pobj,
+                is_jinja_plugin=plugin in builtin_jinja_plugins,
+            )
 
-    # {plugin_name: (filepath, class), ...}
+        for plugin in builtin_jinja_plugins:
+            # Add in any builtin Jinja2 plugins that have not been shadowed in Ansible.
+            if plugin in plugins:
+                continue
+
+            plugins[plugin] = _PluginInfo(
+                name=plugin,
+                path=None,
+                is_jinja_plugin=True,
+            )
+
     return plugins
 
 
-def list_plugins(ptype, collections=None, search_paths=None):
+def list_plugins(ptype: str, collections: list[str] | None = None, search_paths: list[str] | None = None) -> dict[str, tuple[bytes, object | None]]:
+    # Kept for backwards compatibility.
+    return {
+        name: (info.path, info.plugin_obj)
+        for name, info in _list_plugins_with_info(ptype, collections, search_paths).items()
+    }
+
+
+def _list_plugins_with_info(
+    ptype: str,
+    collections: list[str] = None,
+    search_paths: list[str] | None = None,
+) -> dict[str, _PluginInfo]:
     if isinstance(collections, str):
         collections = [collections]
 
@@ -195,7 +253,7 @@ def list_plugins(ptype, collections=None, search_paths=None):
                     raise AnsibleError(f"Cannot use supplied collection {collection!r}.") from ex
 
     if plugin_collections:
-        plugins.update(list_collection_plugins(ptype, plugin_collections))
+        plugins.update(_list_collection_plugins_with_info(ptype, plugin_collections))
 
     return plugins
 

--- a/lib/ansible/plugins/list.py
+++ b/lib/ansible/plugins/list.py
@@ -26,6 +26,7 @@ IGNORE = {
     'cache': ('base', ),
 }
 
+
 @dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
 class _PluginInfo:
     """Information about a plugin."""

--- a/lib/ansible/plugins/list.py
+++ b/lib/ansible/plugins/list.py
@@ -15,7 +15,7 @@ from ansible.module_utils.common.text.converters import to_native, to_bytes
 from ansible.plugins import loader
 from ansible.utils.display import Display
 from ansible.utils.collection_loader._collection_finder import _get_collection_path
-from ansible._internal._templating._jinja_bits import get_jinja2_builtin_filters, get_jinja2_builtin_tests
+from ansible._internal._templating._jinja_plugins import get_jinja_builtin_plugin_descriptions
 
 display = Display()
 
@@ -28,16 +28,17 @@ IGNORE = {
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
-class _PluginInfo:
+class _PluginDocMetadata:
     """Information about a plugin."""
+
     name: str
     """The fully qualified name of the plugin."""
-    path: bytes | None
+    path: bytes | None = None
     """The path to the plugin file, or None if not available."""
     plugin_obj: object | None = None
     """The loaded plugin object, or None if not loaded."""
-    is_jinja_plugin: bool = False
-    """Whether the plugin shadows a Jinja2 plugin (filter or test)."""
+    jinja_builtin_short_description: str | None = None
+    """The short description of the plugin if it is a Jinja builtin, otherwise None."""
 
 
 def get_composite_name(collection, name, path, depth):
@@ -142,7 +143,7 @@ def list_collection_plugins(ptype: str, collections: dict[str, bytes], search_pa
 def _list_collection_plugins_with_info(
     ptype: str,
     collections: dict[str, bytes],
-) -> dict[str, _PluginInfo]:
+) -> dict[str, _PluginDocMetadata]:
     # TODO: update to use importlib.resources
 
     try:
@@ -150,7 +151,7 @@ def _list_collection_plugins_with_info(
     except AttributeError:
         raise AnsibleError(f"Cannot list plugins, incorrect plugin type {ptype!r} supplied.") from None
 
-    builtin_jinja_plugins = set()
+    builtin_jinja_plugins = {}
     plugin_paths = {}
 
     # get plugins for each collection
@@ -159,10 +160,8 @@ def _list_collection_plugins_with_info(
             # dirs from ansible install, but not configured paths
             dirs = [d.path for d in ploader._get_paths_with_context() if d.internal]
 
-            if ptype == 'filter':
-                builtin_jinja_plugins = set(f"ansible.builtin.{p.name}" for p in get_jinja2_builtin_filters())
-            elif ptype == 'test':
-                builtin_jinja_plugins = set(f"ansible.builtin.{p.name}" for p in get_jinja2_builtin_tests())
+            if ptype in ('filter', 'test'):
+                builtin_jinja_plugins = get_jinja_builtin_plugin_descriptions(ptype)
 
         elif collection == 'ansible.legacy':
             # configured paths + search paths (should include basedirs/-M)
@@ -186,7 +185,7 @@ def _list_collection_plugins_with_info(
     if ptype in ('module',):
         # no 'invalid' tests for modules
         for plugin, plugin_path in plugin_paths.items():
-            plugins[plugin] = _PluginInfo(name=plugin, path=plugin_path)
+            plugins[plugin] = _PluginDocMetadata(name=plugin, path=plugin_path)
     else:
         # detect invalid plugin candidates AND add loaded object to return data
         for plugin, plugin_path in plugin_paths.items():
@@ -196,23 +195,18 @@ def _list_collection_plugins_with_info(
             except Exception as e:
                 display.vvv("The '{0}' {1} plugin could not be loaded from '{2}': {3}".format(plugin, ptype, plugin_path, to_native(e)))
 
-            plugins[plugin] = _PluginInfo(
+            plugins[plugin] = _PluginDocMetadata(
                 name=plugin,
                 path=plugin_path,
                 plugin_obj=pobj,
-                is_jinja_plugin=plugin in builtin_jinja_plugins,
+                jinja_builtin_short_description=builtin_jinja_plugins.get(plugin),
             )
 
-        for plugin in builtin_jinja_plugins:
-            # Add in any builtin Jinja2 plugins that have not been shadowed in Ansible.
-            if plugin in plugins:
-                continue
-
-            plugins[plugin] = _PluginInfo(
-                name=plugin,
-                path=None,
-                is_jinja_plugin=True,
-            )
+        # Add in any builtin Jinja2 plugins that have not been shadowed in Ansible.
+        plugins.update(
+            (plugin_name, _PluginDocMetadata(name=plugin_name, jinja_builtin_short_description=plugin_description))
+            for plugin_name, plugin_description in builtin_jinja_plugins.items() if plugin_name not in plugins
+        )
 
     return plugins
 
@@ -229,7 +223,7 @@ def _list_plugins_with_info(
     ptype: str,
     collections: list[str] = None,
     search_paths: list[str] | None = None,
-) -> dict[str, _PluginInfo]:
+) -> dict[str, _PluginDocMetadata]:
     if isinstance(collections, str):
         collections = [collections]
 

--- a/test/integration/targets/ansible-doc/test.yml
+++ b/test/integration/targets/ansible-doc/test.yml
@@ -207,3 +207,105 @@
     - assert:
         that:
           - result.stdout_lines | select("match", "^ansible\\._protomatter\\.") | length == result.stdout_lines | length
+
+    - name: List all filter plugins without any filter
+      command: ansible-doc -t filter --list --json
+      register: filter_list_all_raw
+
+    - set_fact:
+        filter_list_all: "{{ filter_list_all_raw.stdout | from_json }}"
+
+    - name: Check Jinja2 filters have a short description on list without any filter
+      assert:
+        that:
+        - filter_list_all['ansible.builtin.default'] is contains("builtin Jinja plugin default")
+        - filter_list_all['ansible.builtin.sum'] is contains("builtin Jinja plugin sum")
+
+    - name: List only ansible.builtin filter plugins
+      command: ansible-doc ansible.builtin -t filter --list --json
+      register: filter_list_builtin_raw
+
+    - set_fact:
+        filter_list_builtin: "{{ filter_list_builtin_raw.stdout | from_json }}"
+
+    - name: Check Jinja2 filters have a short description on list with builtin filter
+      assert:
+        that:
+        - filter_list_builtin['ansible.builtin.default'] is contains("builtin Jinja plugin default")
+        - filter_list_builtin['ansible.builtin.sum'] is contains("builtin Jinja plugin sum")
+
+    - name: List only ansible.builtin filter plugin files
+      command: ansible-doc ansible.builtin -t filter --list_files
+      register: filter_list_builtin_files
+
+    - name: Verify files for Jinja2 filters
+      assert:
+        that:
+        - filter_list_builtin_files.stdout_lines | select("match", "^ansible\\.builtin\\.default\\s+.*/core\\.py") | length == 1
+        - filter_list_builtin_files.stdout_lines | select("match", "^ansible\\.builtin\\.sum\\s+None") | length == 1
+
+    - name: Get jinja2 filter docs shadowed by Ansible
+      command: ansible-doc ansible.builtin.default -t filter
+      register: filter_jinja2_default
+
+    - name: Assert jinja2 filter docs shadowed by Ansible
+      assert:
+        that:
+        - filter_jinja2_default.stdout is search("\\s+FILTER default\\s+")
+        - filter_jinja2_default.stdout is search("The builtin Jinja filter plugin default")
+        - filter_jinja2_default.stdout is search("https://jinja\\.palletsprojects\\.com/.*")
+
+    - name: Get jinja2 filter docs not shadowed by Ansible
+      command: ansible-doc ansible.builtin.sum -t filter
+      register: filter_jinja2_sum
+
+    - name: Assert jinja2 filter docs not shadowed by Ansible
+      assert:
+        that:
+        - filter_jinja2_sum.stdout is search("\\s+FILTER sum\\s+")
+        - filter_jinja2_sum.stdout is search("The builtin Jinja filter plugin sum")
+        - filter_jinja2_sum.stdout is search("https://jinja\\.palletsprojects\\.com/.*")
+
+    - name: List all test plugins without any filter
+      command: ansible-doc -t test --list --json
+      register: test_list_all_raw
+
+    - set_fact:
+        test_list_all: "{{ test_list_all_raw.stdout | from_json }}"
+
+    - name: Check Jinja2 tests have a short description on list without any filter
+      assert:
+        that:
+        - test_list_all['ansible.builtin.number'] is contains("builtin Jinja plugin number")
+
+    - name: List only ansible.builtin test plugins
+      command: ansible-doc ansible.builtin -t test --list --json
+      register: test_list_builtin_raw
+
+    - set_fact:
+        test_list_builtin: "{{ test_list_builtin_raw.stdout | from_json }}"
+
+    - name: Check Jinja2 tests have a short description on list with builtin tests
+      assert:
+        that:
+        - test_list_builtin['ansible.builtin.number'] is contains("builtin Jinja plugin number")
+
+    - name: List only ansible.builtin test plugin files
+      command: ansible-doc ansible.builtin -t test --list_files
+      register: test_list_builtin_files
+
+    - name: Verify files for Jinja2 filters
+      assert:
+        that:
+        - test_list_builtin_files.stdout_lines | select("match", "^ansible\\.builtin\\.number\\s+None") | length == 1
+
+    - name: Get jinja2 test docs
+      command: ansible-doc ansible.builtin.number -t test
+      register: test_jinja2_number
+
+    - name: Assert jinja2 test docs
+      assert:
+        that:
+        - test_jinja2_number.stdout is search("\\s+TEST number\\s+")
+        - test_jinja2_number.stdout is search("The builtin Jinja test plugin number")
+        - test_jinja2_number.stdout is search("https://jinja\\.palletsprojects\\.com/.*")

--- a/test/integration/targets/ansible-doc/test.yml
+++ b/test/integration/targets/ansible-doc/test.yml
@@ -218,8 +218,8 @@
     - name: Check Jinja2 filters have a short description on list without any filter
       assert:
         that:
-        - filter_list_all['ansible.builtin.default'] is contains("builtin Jinja plugin default")
-        - filter_list_all['ansible.builtin.sum'] is contains("builtin Jinja plugin sum")
+        - filter_list_all['ansible.builtin.default'] is contains("the passed default value")
+        - filter_list_all['ansible.builtin.sum'] is contains("sum of a sequence")
 
     - name: List only ansible.builtin filter plugins
       command: ansible-doc ansible.builtin -t filter --list --json
@@ -231,8 +231,8 @@
     - name: Check Jinja2 filters have a short description on list with builtin filter
       assert:
         that:
-        - filter_list_builtin['ansible.builtin.default'] is contains("builtin Jinja plugin default")
-        - filter_list_builtin['ansible.builtin.sum'] is contains("builtin Jinja plugin sum")
+        - filter_list_builtin['ansible.builtin.default'] is contains("the passed default value")
+        - filter_list_builtin['ansible.builtin.sum'] is contains("sum of a sequence")
 
     - name: List only ansible.builtin filter plugin files
       command: ansible-doc ansible.builtin -t filter --list_files
@@ -251,8 +251,9 @@
     - name: Assert jinja2 filter docs shadowed by Ansible
       assert:
         that:
-        - filter_jinja2_default.stdout is search("\\s+FILTER default\\s+")
-        - filter_jinja2_default.stdout is search("The builtin Jinja filter plugin default")
+        - filter_jinja2_default.stdout is search("\\s+FILTER ansible.builtin.default\\s+")
+        - filter_jinja2_default.stdout is search("the Jinja builtin filter plugin 'default'")
+        - filter_jinja2_default.stdout is search("the passed default value")
         - filter_jinja2_default.stdout is search("https://jinja\\.palletsprojects\\.com/.*")
 
     - name: Get jinja2 filter docs not shadowed by Ansible
@@ -262,8 +263,9 @@
     - name: Assert jinja2 filter docs not shadowed by Ansible
       assert:
         that:
-        - filter_jinja2_sum.stdout is search("\\s+FILTER sum\\s+")
-        - filter_jinja2_sum.stdout is search("The builtin Jinja filter plugin sum")
+        - filter_jinja2_sum.stdout is search("\\s+FILTER ansible.builtin.sum\\s+")
+        - filter_jinja2_sum.stdout is search("the Jinja builtin filter plugin 'sum'")
+        - filter_jinja2_sum.stdout is search("sum of a sequence")
         - filter_jinja2_sum.stdout is search("https://jinja\\.palletsprojects\\.com/.*")
 
     - name: List all test plugins without any filter
@@ -276,7 +278,7 @@
     - name: Check Jinja2 tests have a short description on list without any filter
       assert:
         that:
-        - test_list_all['ansible.builtin.number'] is contains("builtin Jinja plugin number")
+        - test_list_all['ansible.builtin.number'] is contains("is a number")
 
     - name: List only ansible.builtin test plugins
       command: ansible-doc ansible.builtin -t test --list --json
@@ -288,7 +290,7 @@
     - name: Check Jinja2 tests have a short description on list with builtin tests
       assert:
         that:
-        - test_list_builtin['ansible.builtin.number'] is contains("builtin Jinja plugin number")
+        - test_list_builtin['ansible.builtin.number'] is contains("is a number")
 
     - name: List only ansible.builtin test plugin files
       command: ansible-doc ansible.builtin -t test --list_files
@@ -306,6 +308,19 @@
     - name: Assert jinja2 test docs
       assert:
         that:
-        - test_jinja2_number.stdout is search("\\s+TEST number\\s+")
-        - test_jinja2_number.stdout is search("The builtin Jinja test plugin number")
+        - test_jinja2_number.stdout is search("\\s+TEST ansible.builtin.number\\s+")
+        - test_jinja2_number.stdout is search("the Jinja builtin test plugin 'number'")
+        - test_jinja2_number.stdout is contains("is a number")
         - test_jinja2_number.stdout is search("https://jinja\\.palletsprojects\\.com/.*")
+
+    - name: Get jinja2 test docs for an unqualified builtin
+      command: ansible-doc number -t test
+      register: test_jinja2_number_short
+
+    - name: Assert jinja2 test docs
+      assert:
+        that:
+        - test_jinja2_number_short.stdout is search("\\s+TEST ansible.builtin.number\\s+")
+        - test_jinja2_number_short.stdout is search("the Jinja builtin test plugin 'number'")
+        - test_jinja2_number_short.stdout is contains("is a number")
+        - test_jinja2_number_short.stdout is search("https://jinja\\.palletsprojects\\.com/.*")


### PR DESCRIPTION
##### SUMMARY
This change has `ansible-doc` dynamically generate the documentation for any Jinja builtin filter and test plugins. These dynamic stubs will point to the official Jinja documentation pages for more information.

Alternative to https://github.com/ansible/ansible/pull/85114.

##### ISSUE TYPE
- Feature Pull Request