### PR TITLE
dnf5 tests: do not remove attr

### DIFF
--- a/test/integration/targets/dnf/tasks/gpg.yml
+++ b/test/integration/targets/dnf/tasks/gpg.yml
@@ -61,11 +61,10 @@
           - "'is not signed' in res.msg"
 
   always:
-    - name: Remove rpm-sign and attr (and test package if it got installed)
+    - name: Remove rpm-sign and test package if it got installed
       dnf:
         name:
           - rpm-sign
-          - attr
           - "{{ pkg_name }}"
         state: absent
 


### PR DESCRIPTION
##### SUMMARY
On RHEL 10, the attr package is in the dependency tree of dnf itself and cannot be removed.
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Test Pull Request
