### PR TITLE
apt: Consider timeout while invoking apt-get command

### DIFF
--- a/changelogs/fragments/apt_timeout.yml
+++ b/changelogs/fragments/apt_timeout.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+   - apt - consider lock timeout while invoking apt-get command (https://github.com/ansible/ansible/issues/78658).

--- a/changelogs/fragments/password_hash_encrypt.yml
+++ b/changelogs/fragments/password_hash_encrypt.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - encrypt - Check salt_size type in password_hash filter.

--- a/changelogs/fragments/password_hash_encrypt.yml
+++ b/changelogs/fragments/password_hash_encrypt.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - encrypt - Check salt_size type in password_hash filter.

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1475,8 +1475,8 @@ def main():
                             force=force_yes,
                             fail_on_autoremove=fail_on_autoremove,
                             dpkg_options=p['dpkg_options'],
-                            lock_timeout=p['lock_timeout'],
-                )
+                            lock_timeout=p['lock_timeout']
+                            )
 
             unfiltered_packages = p['package'] or ()
             packages = [package.strip() for package in unfiltered_packages if package != '*']

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -904,7 +904,7 @@ def install_deb(
     # install the deps through apt
     retvals = {}
     if deps_to_install:
-        install_dpkg_options = expand_dpkg_options(dpkg_options) + " -o DPkg::Lock::Timeout=%s" % lock_timeout
+        install_dpkg_options = f"{expand_dpkg_options(dpkg_options)} -o DPkg::Lock::Timeout={lock_timeout}"
         (success, retvals) = install(m=m, pkgspec=deps_to_install, cache=cache,
                                      install_recommends=install_recommends,
                                      fail_on_autoremove=fail_on_autoremove,
@@ -1271,7 +1271,7 @@ def main():
 
     p = module.params
     install_recommends = p['install_recommends']
-    dpkg_options = "%s -o DPkg::Lock::Timeout=%s" % (expand_dpkg_options(p['dpkg_options']), p['lock_timeout'])
+    dpkg_options = f"{expand_dpkg_options(p['dpkg_options'])} -o DPkg::Lock::Timeout={p['lock_timeout']}"
 
     if not HAS_PYTHON_APT:
         # This interpreter can't see the apt Python library- we'll do the following to try and fix that:

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -855,6 +855,7 @@ def install_deb(
         allow_downgrade,
         allow_change_held_packages,
         dpkg_options,
+        lock_timeout,
 ):
     changed = False
     deps_to_install = []
@@ -903,13 +904,14 @@ def install_deb(
     # install the deps through apt
     retvals = {}
     if deps_to_install:
+        install_dpkg_options = expand_dpkg_options(dpkg_options) + " -o DPkg::Lock::Timeout=%s" % lock_timeout
         (success, retvals) = install(m=m, pkgspec=deps_to_install, cache=cache,
                                      install_recommends=install_recommends,
                                      fail_on_autoremove=fail_on_autoremove,
                                      allow_unauthenticated=allow_unauthenticated,
                                      allow_downgrade=allow_downgrade,
                                      allow_change_held_packages=allow_change_held_packages,
-                                     dpkg_options=expand_dpkg_options(dpkg_options))
+                                     dpkg_options=install_dpkg_options)
         if not success:
             m.fail_json(**retvals)
         changed = retvals.get('changed', False)
@@ -1269,7 +1271,7 @@ def main():
 
     p = module.params
     install_recommends = p['install_recommends']
-    dpkg_options = expand_dpkg_options(p['dpkg_options'])
+    dpkg_options = "%s -o DPkg::Lock::Timeout=%s" % (expand_dpkg_options(p['dpkg_options']), p['lock_timeout'])
 
     if not HAS_PYTHON_APT:
         # This interpreter can't see the apt Python library- we'll do the following to try and fix that:
@@ -1470,7 +1472,11 @@ def main():
                             allow_unauthenticated=allow_unauthenticated,
                             allow_change_held_packages=allow_change_held_packages,
                             allow_downgrade=allow_downgrade,
-                            force=force_yes, fail_on_autoremove=fail_on_autoremove, dpkg_options=p['dpkg_options'])
+                            force=force_yes,
+                            fail_on_autoremove=fail_on_autoremove,
+                            dpkg_options=p['dpkg_options'],
+                            lock_timeout=p['lock_timeout'],
+                )
 
             unfiltered_packages = p['package'] or ()
             packages = [package.strip() for package in unfiltered_packages if package != '*']


### PR DESCRIPTION
##### SUMMARY
* Apply timeout specified by user to apt-get command
      using '-o DPkg::Lock::Timeout=' syntax

    Fixes: #78658

    Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
changelogs/fragments/apt_timeout.yml
lib/ansible/modules/apt.py

