### PR TITLE
jinja2.__version__ is deprecated

### DIFF
--- a/changelogs/fragments/jinja2-__version__-deprecated.yml
+++ b/changelogs/fragments/jinja2-__version__-deprecated.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Use ``importlib.metadata.version()`` to detect Jinja version as jinja2.__version__ is deprecated and will be removed in Jinja 3.3."

--- a/lib/ansible/_internal/_templating/__init__.py
+++ b/lib/ansible/_internal/_templating/__init__.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import importlib.metadata
 
-_jinja2_version = importlib.metadata.version('jinja2')
+jinja2_version = importlib.metadata.version('jinja2')
 
 # DTFIX-FUTURE: sanity test to ensure this doesn't drift from requirements
 _MINIMUM_JINJA_VERSION = (3, 1)
-_CURRENT_JINJA_VERSION = tuple(map(int, _jinja2_version.split('.', maxsplit=2)[:2]))
+_CURRENT_JINJA_VERSION = tuple(map(int, jinja2_version.split('.', maxsplit=2)[:2]))
 
 if _CURRENT_JINJA_VERSION < _MINIMUM_JINJA_VERSION:
-    raise RuntimeError(f'Jinja version {".".join(map(str, _MINIMUM_JINJA_VERSION))} or higher is required (current version {_jinja2_version}).')
+    raise RuntimeError(f'Jinja version {".".join(map(str, _MINIMUM_JINJA_VERSION))} or higher is required (current version {jinja2_version}).')

--- a/lib/ansible/_internal/_templating/__init__.py
+++ b/lib/ansible/_internal/_templating/__init__.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from jinja2 import __version__ as _jinja2_version
+import importlib.metadata
+
+_jinja2_version = importlib.metadata.version('jinja2')
 
 # DTFIX-FUTURE: sanity test to ensure this doesn't drift from requirements
 _MINIMUM_JINJA_VERSION = (3, 1)

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import copy
 import dataclasses
-import importlib.metadata
 import inspect
 import operator
 import argparse
@@ -19,6 +18,7 @@ import yaml
 
 import ansible
 from ansible import constants as C
+from ansible._internal import _templating
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.common.yaml import HAS_LIBYAML, yaml_load
 from ansible.release import __version__
@@ -312,7 +312,7 @@ def version(prog=None):
     result.append("  ansible collection location = %s" % ':'.join(C.COLLECTIONS_PATHS))
     result.append("  executable location = %s" % sys.argv[0])
     result.append("  python version = %s (%s)" % (''.join(sys.version.splitlines()), to_native(sys.executable)))
-    result.append(f"  jinja version = {importlib.metadata.version('jinja2')}")
+    result.append(f"  jinja version = {_templating.jinja2_version}")
     result.append(f"  pyyaml version = {yaml.__version__} ({libyaml_fragment})")
 
     return "\n".join(result)

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import copy
 import dataclasses
+import importlib.metadata
 import inspect
 import operator
 import argparse
@@ -15,8 +16,6 @@ import time
 import typing as t
 
 import yaml
-
-from jinja2 import __version__ as j2_version
 
 import ansible
 from ansible import constants as C
@@ -313,7 +312,7 @@ def version(prog=None):
     result.append("  ansible collection location = %s" % ':'.join(C.COLLECTIONS_PATHS))
     result.append("  executable location = %s" % sys.argv[0])
     result.append("  python version = %s (%s)" % (''.join(sys.version.splitlines()), to_native(sys.executable)))
-    result.append("  jinja version = %s" % j2_version)
+    result.append(f"  jinja version = {importlib.metadata.version('jinja2')}")
     result.append(f"  pyyaml version = {yaml.__version__} ({libyaml_fragment})")
 
     return "\n".join(result)


### PR DESCRIPTION
##### SUMMARY
Prepare for its removal in Jinja 3.3.

See https://github.com/pallets/jinja/pull/2098
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
