### PR TITLE
Added _TEMPLAR_SANDBOX_MODE config

### DIFF
--- a/changelogs/fragments/sandbox_config.yml
+++ b/changelogs/fragments/sandbox_config.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - templating - Added ``_ANSIBLE_TEMPLAR_SANDBOX_MODE=allow_unsafe_attributes`` environment variable to disable Jinja template attribute sandbox. (https://github.com/ansible/ansible/issues/85202)

--- a/lib/ansible/_internal/_templating/_jinja_bits.py
+++ b/lib/ansible/_internal/_templating/_jinja_bits.py
@@ -49,6 +49,7 @@ from ._jinja_common import (
     TruncationMarker,
     validate_arg_type,
     JinjaCallContext,
+    _SandboxMode,
 )
 from ._jinja_plugins import JinjaPluginIntercept, _query, _lookup, _now, _wrap_plugin_output, get_first_marker_arg, _DirectCall, _jinja_const_template_warning
 from ._lazy_containers import (
@@ -587,6 +588,13 @@ class AnsibleEnvironment(ImmutableSandboxedEnvironment):
                 template_obj._python_source_temp_path = ctx.python_source_temp_path  # facilitate deletion of the temp file when template_obj is deleted
 
             return template_obj
+
+    def is_safe_attribute(self, obj: t.Any, attr: str, value: t.Any) -> bool:
+        # deprecated: description="remove relaxed template sandbox mode support", core_version="2.23"
+        if _TemplateConfig.sandbox_mode == _SandboxMode.ALLOW_UNSAFE_ATTRIBUTES:
+            return True
+
+        return super().is_safe_attribute(obj, attr, value)
 
     @property
     def lexer(self) -> AnsibleLexer:

--- a/lib/ansible/_internal/_templating/_jinja_bits.py
+++ b/lib/ansible/_internal/_templating/_jinja_bits.py
@@ -590,7 +590,7 @@ class AnsibleEnvironment(ImmutableSandboxedEnvironment):
             return template_obj
 
     def is_safe_attribute(self, obj: t.Any, attr: str, value: t.Any) -> bool:
-        # deprecated: description="remove relaxed template sandbox mode support", core_version="2.23"
+        # deprecated: description="remove relaxed template sandbox mode support" core_version="2.23"
         if _TemplateConfig.sandbox_mode == _SandboxMode.ALLOW_UNSAFE_ATTRIBUTES:
             return True
 

--- a/lib/ansible/_internal/_templating/_jinja_common.py
+++ b/lib/ansible/_internal/_templating/_jinja_common.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import abc
 import collections.abc as c
+import enum
 import inspect
 import itertools
 import typing as t
@@ -24,10 +25,16 @@ from ...module_utils.datatag import native_type_name
 _patch_jinja()  # apply Jinja2 patches before types are declared that are dependent on the changes
 
 
+class _SandboxMode(enum.Enum):
+    DEFAULT = enum.auto()
+    ALLOW_UNSAFE_ATTRIBUTES = enum.auto()
+
+
 class _TemplateConfig:
     allow_embedded_templates: bool = config.get_config_value("ALLOW_EMBEDDED_TEMPLATES")
     allow_broken_conditionals: bool = config.get_config_value('ALLOW_BROKEN_CONDITIONALS')
     jinja_extensions: list[str] = config.get_config_value('DEFAULT_JINJA2_EXTENSIONS')
+    sandbox_mode: _SandboxMode = _SandboxMode.__members__[config.get_config_value('_TEMPLAR_SANDBOX_MODE').upper()]
 
     unknown_type_encountered_handler = ErrorHandler.from_config('_TEMPLAR_UNKNOWN_TYPE_ENCOUNTERED')
     unknown_type_conversion_handler = ErrorHandler.from_config('_TEMPLAR_UNKNOWN_TYPE_CONVERSION')

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -2036,6 +2036,19 @@ TASK_TIMEOUT:
   - {key: task_timeout, section: defaults}
   type: integer
   version_added: '2.10'
+_TEMPLAR_SANDBOX_MODE:
+  name: Control Jinja template sandbox behavior
+  default: default
+  description:
+    - The default Jinja sandbox behavior blocks template access to all `_` prefixed object attributes and known collection mutation methods (e.g., `dict.clear()`, `list.append()`).
+  type: choices
+  choices:
+    - default
+    - allow_unsafe_attributes
+  env: [{name: _ANSIBLE_TEMPLAR_SANDBOX_MODE}]
+  deprecated:
+    why: controlling sandbox behavior is a temporary workaround
+    version: '2.23'
 _TEMPLAR_UNKNOWN_TYPE_CONVERSION:
   name: Templar unknown type conversion behavior
   default: warning


### PR DESCRIPTION
##### SUMMARY
* allows unsafe attribute checks to be temporarily disabled in Jinja sandbox by setting `_ANSIBLE_TEMPLAR_SANDBOX_MODE=allow_unsafe_attributes` envvar

fixes #85202 

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Feature Pull Request
