### PR TITLE
fix from_yaml_all filter inconsistent None handling

### DIFF
--- a/changelogs/fragments/from_yaml_all.yml
+++ b/changelogs/fragments/from_yaml_all.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - from_yaml_all filter - `None` and empty string inputs now always return an empty list. Previously, `None` was returned in Jinja native mode and empty list in classic mode.

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -256,6 +256,9 @@ def from_yaml(data):
 
 
 def from_yaml_all(data):
+    if data is None:
+        return []  # backward compatibility; ensure consistent result between classic/native Jinja for None/empty string input
+
     if isinstance(data, string_types):
         # The ``text_type`` call here strips any custom
         # string wrapper class, so that CSafeLoader can

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -247,11 +247,16 @@ def regex_escape(string, re_type='python'):
 
 
 def from_yaml(data):
+    if data is None:
+        return None
+
     if isinstance(data, string_types):
         # The ``text_type`` call here strips any custom
         # string wrapper class, so that CSafeLoader can
         # read the data
         return yaml_load(text_type(to_text(data, errors='surrogate_or_strict')))
+
+    display.deprecated(f"The from_yaml filter ignored non-string input of type {native_type_name(data)!r}.", version='2.23', obj=data)
     return data
 
 
@@ -264,6 +269,8 @@ def from_yaml_all(data):
         # string wrapper class, so that CSafeLoader can
         # read the data
         return yaml_load_all(text_type(to_text(data, errors='surrogate_or_strict')))
+
+    display.deprecated(f"The from_yaml_all filter ignored non-string input of type {native_type_name(data)!r}.", version='2.23', obj=data)
     return data
 
 

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -471,6 +471,8 @@
       - "2|from_yaml_all == 2"
       - "unsafe_fruit|from_yaml == {'bananas': 'yellow', 'apples': 'red'}"
       - "unsafe_fruit_all|from_yaml_all|list == [{'bananas': 'yellow'}, {'apples': 'red'}]"
+      - None | from_yaml is none
+      - None | from_yaml_all == []
   vars:
     unsafe_fruit: !unsafe |
       ---


### PR DESCRIPTION
##### SUMMARY
* always returns empty list for None or empty string input

fixes #85205 

##### ISSUE TYPE

- Bugfix Pull Request
