### PR TITLE
Decouple SSH client verbosity from Ansible display

### DIFF
--- a/changelogs/fragments/ssh_verbosity.yml
+++ b/changelogs/fragments/ssh_verbosity.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - ssh connection plugin - Added ``verbosity`` config to decouple SSH debug output verbosity from Ansible verbosity.
+    Previously, the Ansible verbosity value was always applied to the SSH client command-line, leading to excessively verbose output.
+    Set the ``ANSIBLE_SSH_VERBOSITY`` envvar or ``ansible_ssh_verbosity`` Ansible variable to a positive integer to increase SSH client verbosity.

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -398,6 +398,17 @@ DOCUMENTATION = """
           - {key: pkcs11_provider, section: ssh_connection}
         vars:
           - name: ansible_ssh_pkcs11_provider
+      verbosity:
+        version_added: '2.19'
+        default: 0
+        type: int
+        description:
+          - Requested verbosity level for the SSH CLI.
+        env: [{name: ANSIBLE_SSH_VERBOSITY}]
+        ini:
+          - {key: verbosity, section: ssh_connection}
+        vars:
+          - name: ansible_ssh_verbosity
 """
 
 import collections.abc as c
@@ -855,8 +866,8 @@ class Connection(ConnectionBase):
                 self._add_args(b_command, b_args, u'disable batch mode for password auth')
             b_command += [b'-b', b'-']
 
-        if display.verbosity:
-            b_command.append(b'-' + (b'v' * display.verbosity))
+        if (verbosity := self.get_option('verbosity')) > 0:
+            b_command.append(b'-' + (b'v' * verbosity))
 
         # Next, we add ssh_args
         ssh_args = self.get_option('ssh_args')

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -86,3 +86,14 @@ ANSIBLE_SSH_CONTROL_PATH='/tmp/ssh cp with spaces' ansible -m ping all -e ansibl
 ansible-playbook test_unreachable_become_timeout.yml "$@"
 
 ANSIBLE_ROLES_PATH=../ ansible-playbook "$@" -i ../../inventory test_ssh_askpass.yml
+
+# ensure that SSH client verbosity is independent of Ansible verbosity - no `debugN:` lines at high Ansible verbosity
+ansible ssh -m raw -a whoami -i test_connection.inventory -vvvvv | grep -v 'debug.:'
+
+# enable SSH client verbosity level 1 via env; ensure debugN: but no debug2 or debug3 lines
+ANSIBLE_SSH_VERBOSITY=1 ansible ssh -m raw -a whoami -i test_connection.inventory -vvvvv | grep 'debug.:' | grep -v 'debug(2|3):'
+
+# enable SSH client verbosity level 3 via var; ensure debug3 lines
+ansible ssh -m raw -a whoami -i test_connection.inventory -vvvvv -e ansible_ssh_verbosity=3 2>&1 | grep 'debug3:'
+
+echo PASS

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -56,13 +56,6 @@ class TestConnectionBaseClass(unittest.TestCase):
         conn.close()
         self.assertFalse(conn._connected)
 
-    def test_plugins_connection_ssh__build_command(self):
-        pc = PlayContext()
-        conn = connection_loader.get('ssh', pc)
-        conn.get_option = MagicMock()
-        conn.get_option.return_value = ""
-        conn._build_command('ssh', 'ssh')
-
     def test_plugins_connection_ssh_exec_command(self):
         pc = PlayContext()
         conn = connection_loader.get('ssh', pc)


### PR DESCRIPTION
##### SUMMARY
Increased Ansible verbosity should not automatically increase SSH client verbosity- the additional noise is annoying when not debugging an SSH issue, and can cause difficult to diagnose failures for direct consumers of the raw connection output (e.g., the `script` and `raw` actions).

* Added dedicated `verbosity` config option to the SSH connection plugin for independent control.

##### ISSUE TYPE
- Feature Pull Request