### PR TITLE
Clean up TE error handling, wrap sigalrm handler

### DIFF
--- a/changelogs/fragments/task-error-and-timeout.yml
+++ b/changelogs/fragments/task-error-and-timeout.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - task timeout - Specifying a negative task timeout now results in an error.
+  - error handling - Error details and tracebacks from connection and built-in action exceptions are preserved.
+    Previously, much of the detail was lost or mixed into the error message.
+
+minor_changes:
+  - task timeout - Specifying a timeout greater than 100,000,000 now results in an error.

--- a/lib/ansible/_internal/_errors/_alarm_timeout.py
+++ b/lib/ansible/_internal/_errors/_alarm_timeout.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import contextlib
+import signal
+import types
+import typing as _t
+
+from ansible.module_utils import datatag
+
+
+class AnsibleTimeoutError(BaseException):
+    """A general purpose timeout."""
+
+    _MAX_TIMEOUT = 100_000_000
+    """
+    The maximum supported timeout value.
+    This value comes from BSD's alarm limit, which is due to that function using setitimer.
+    """
+
+    def __init__(self, timeout: int) -> None:
+        self.timeout = timeout
+
+        super().__init__(f"Timed out after {timeout} second(s).")
+
+    @classmethod
+    @contextlib.contextmanager
+    def alarm_timeout(cls, timeout: int | None) -> _t.Iterator[None]:
+        """
+        Context for running code under an optional timeout.
+        Raises an instance of this class if the timeout occurs.
+
+        New usages of this timeout mechanism are discouraged.
+        """
+        if timeout is not None:
+            if not isinstance(timeout, int):
+                raise TypeError(f"Timeout requires 'int' argument, not {datatag.native_type_name(timeout)!r}.")
+
+            if timeout < 0 or timeout > cls._MAX_TIMEOUT:
+                # On BSD based systems, alarm is implemented using setitimer.
+                # If out-of-bounds values are passed to alarm, they will return -1, which would be interpreted as an existing timer being set.
+                # To avoid that, bounds checking is performed in advance.
+                raise ValueError(f'Timeout {timeout} is invalid, it must be between 0 and {cls._MAX_TIMEOUT}.')
+
+        if not timeout:
+            yield  # execute the context manager's body
+            return  # no timeout to deal with, exit immediately
+
+        def on_alarm(_signal: int, _frame: types.FrameType) -> None:
+            raise cls(timeout)
+
+        if signal.signal(signal.SIGALRM, on_alarm):
+            raise RuntimeError("An existing alarm handler was present.")
+
+        try:
+            try:
+                if signal.alarm(timeout):
+                    raise RuntimeError("An existing alarm was set.")
+
+                yield  # execute the context manager's body
+            finally:
+                # Disable the alarm.
+                # If the alarm fires inside this finally block, the alarm is still disabled.
+                # This guarantees the cleanup code in the outer finally block runs without risk of encountering the `TaskTimeoutError` from the alarm.
+                signal.alarm(0)
+        finally:
+            signal.signal(signal.SIGALRM, signal.SIG_DFL)

--- a/lib/ansible/_internal/_errors/_task_timeout.py
+++ b/lib/ansible/_internal/_errors/_task_timeout.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from collections import abc as _c
+
+from ansible._internal._errors._alarm_timeout import AnsibleTimeoutError
+from ansible._internal._errors._error_utils import ContributesToTaskResult
+from ansible.module_utils.datatag import deprecate_value
+
+
+class TaskTimeoutError(AnsibleTimeoutError, ContributesToTaskResult):
+    """
+    A task-specific timeout.
+
+    This exception provides a result dictionary via the ContributesToTaskResult mixin.
+    """
+
+    @property
+    def result_contribution(self) -> _c.Mapping[str, object]:
+        help_text = "Configure `DISPLAY_TRACEBACK` to see a traceback on timeout errors."
+
+        frame = deprecate_value(
+            value=help_text,
+            msg="The `timedout.frame` task result key is deprecated.",
+            help_text=help_text,
+            version="2.23",
+        )
+
+        return dict(timedout=dict(frame=frame, period=self.timeout))

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -15,7 +15,7 @@ import typing as t
 
 from ansible import constants as C
 from ansible.errors import AnsibleFileNotFound, AnsibleParserError
-from ansible._internal._errors import _utils
+from ansible._internal._errors import _error_utils
 from ansible.module_utils.basic import is_executable
 from ansible._internal._datatag._tags import Origin, TrustedAsTemplate, SourceWasEncrypted
 from ansible.module_utils._internal._datatag import AnsibleTagHelper
@@ -86,7 +86,7 @@ class DataLoader:
             json_only: bool = False,
     ) -> t.Any:
         """Backwards compat for now"""
-        with _utils.RedactAnnotatedSourceContext.when(not show_content):
+        with _error_utils.RedactAnnotatedSourceContext.when(not show_content):
             return from_yaml(data=data, file_name=file_name, json_only=json_only)
 
     def load_from_file(self, file_name: str, cache: str = 'all', unsafe: bool = False, json_only: bool = False, trusted_as_template: bool = False) -> t.Any:

--- a/lib/ansible/parsing/utils/yaml.py
+++ b/lib/ansible/parsing/utils/yaml.py
@@ -11,7 +11,7 @@ import typing as t
 import yaml
 
 from ansible.errors import AnsibleJSONParserError
-from ansible._internal._errors import _utils
+from ansible._internal._errors import _error_utils
 from ansible.parsing.vault import VaultSecret
 from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible._internal._yaml._errors import AnsibleYAMLParserError
@@ -34,7 +34,7 @@ def from_yaml(
 
     data = origin.tag(data)
 
-    with _utils.RedactAnnotatedSourceContext.when(not show_content):
+    with _error_utils.RedactAnnotatedSourceContext.when(not show_content):
         try:
             # we first try to load this data as JSON.
             # Fixes issues with extra vars json strings not being parsed correctly by the yaml parser

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -20,11 +20,11 @@ from abc import ABC, abstractmethod
 from collections.abc import Sequence
 
 from ansible import constants as C
-from ansible._internal._errors import _captured, _error_factory
+from ansible._internal._errors import _captured, _error_utils
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleActionSkip, AnsibleActionFail, AnsibleAuthenticationFailure
 from ansible.executor.module_common import modify_module, _BuiltModule
 from ansible.executor.interpreter_discovery import discover_interpreter, InterpreterDiscoveryRequiredError
-from ansible.module_utils._internal import _traceback, _event_utils, _messages
+from ansible.module_utils._internal import _traceback
 from ansible.module_utils.common.arg_spec import ArgumentSpecValidator
 from ansible.module_utils.errors import UnsupportedError
 from ansible.module_utils.json_utils import _filter_non_json_lines
@@ -1253,7 +1253,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
             except AnsibleError as ansible_ex:
                 sentinel = object()
 
-                data = self.result_dict_from_exception(ansible_ex)
+                data = _error_utils.result_dict_from_exception(ansible_ex)
                 data.update(
                     _ansible_parsed=False,
                     module_stdout=res.get('stdout', ''),
@@ -1434,50 +1434,3 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
 
         # if missing it will return a file not found exception
         return self._loader.path_dwim_relative_stack(path_stack, dirname, needle)
-
-    @staticmethod
-    def result_dict_from_exception(exception: BaseException) -> dict[str, t.Any]:
-        """Return a failed task result dict from the given exception."""
-        if ansible_remoted_error := _captured.AnsibleResultCapturedError.find_first_remoted_error(exception):
-            result = ansible_remoted_error._result.copy()
-        else:
-            result = {}
-
-        event = _error_factory.ControllerEventFactory.from_exception(exception, _traceback.is_traceback_enabled(_traceback.TracebackEvent.ERROR))
-
-        result.update(
-            failed=True,
-            exception=_messages.ErrorSummary(
-                event=event,
-            ),
-        )
-
-        if 'msg' not in result:
-            result.update(msg=_event_utils.format_event_brief_message(event))
-
-        return result
-
-    def _result_dict_from_captured_errors(
-        self,
-        msg: str,
-        *,
-        errors: list[_messages.ErrorSummary] | None = None,
-    ) -> dict[str, t.Any]:
-        """Return a failed task result dict from the given error message and captured errors."""
-        _skip_stackwalk = True
-
-        event = _messages.Event(
-            msg=msg,
-            formatted_traceback=_traceback.maybe_capture_traceback(msg, _traceback.TracebackEvent.ERROR),
-            events=tuple(error.event for error in errors) if errors else None,
-        )
-
-        result = dict(
-            failed=True,
-            exception=_messages.ErrorSummary(
-                event=event,
-            ),
-            msg=_event_utils.format_event_brief_message(event),
-        )
-
-        return result

--- a/lib/ansible/plugins/action/add_host.py
+++ b/lib/ansible/plugins/action/add_host.py
@@ -77,7 +77,7 @@ class ActionModule(ActionBase):
             elif isinstance(groups, string_types):
                 group_list = groups.split(",")
             else:
-                raise AnsibleActionFail("Groups must be specified as a list.", obj=self._task)
+                raise AnsibleActionFail("Groups must be specified as a list.", obj=groups)
 
             for group_name in group_list:
                 if group_name not in new_groups:

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -13,6 +13,7 @@ from ansible.executor.module_common import _apply_action_arg_defaults
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import merge_hash
+from ansible._internal._errors import _error_utils
 
 
 class ActionModule(ActionBase):
@@ -184,7 +185,7 @@ class ActionModule(ActionBase):
         if failed:
             result['failed_modules'] = failed
 
-            result.update(self._result_dict_from_captured_errors(
+            result.update(_error_utils.result_dict_from_captured_errors(
                 msg=f"The following modules failed to execute: {', '.join(failed.keys())}.",
                 errors=[r['exception'] for r in failed.values()],
             ))

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -16,7 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-from ansible.errors import AnsibleAction, AnsibleActionFail
+from ansible.errors import AnsibleActionFail
 from ansible.executor.module_common import _apply_action_arg_defaults
 from ansible.module_utils.facts.system.pkg_mgr import PKG_MGRS
 from ansible.plugins.action import ActionBase
@@ -38,7 +38,7 @@ class ActionModule(ActionBase):
         self._supports_check_mode = True
         self._supports_async = True
 
-        result = super(ActionModule, self).run(tmp, task_vars)
+        super(ActionModule, self).run(tmp, task_vars)
 
         module = self._task.args.get('use', 'auto')
 
@@ -99,11 +99,8 @@ class ActionModule(ActionBase):
                         module = 'ansible.legacy.' + module
 
                     display.vvvv("Running %s" % module)
-                    result.update(self._execute_module(module_name=module, module_args=new_module_args, task_vars=task_vars, wrap_async=self._task.async_val))
+                    return self._execute_module(module_name=module, module_args=new_module_args, task_vars=task_vars, wrap_async=self._task.async_val)
             else:
                 raise AnsibleActionFail('Could not detect which package manager to use. Try gathering facts or setting the "use" option.')
-
-        except AnsibleAction as e:
-            result.update(e.result)
-
-        return result
+        finally:
+            pass  # avoid de-dent all on refactor

--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -16,7 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-from ansible.errors import AnsibleAction, AnsibleActionFail
+from ansible.errors import AnsibleActionFail
 from ansible.executor.module_common import _apply_action_arg_defaults
 from ansible.plugins.action import ActionBase
 
@@ -39,7 +39,7 @@ class ActionModule(ActionBase):
         self._supports_check_mode = True
         self._supports_async = True
 
-        result = super(ActionModule, self).run(tmp, task_vars)
+        super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
         module = self._task.args.get('use', 'auto').lower()
@@ -84,14 +84,10 @@ class ActionModule(ActionBase):
                     module = 'ansible.legacy.' + module
 
                 self._display.vvvv("Running %s" % module)
-                result.update(self._execute_module(module_name=module, module_args=new_module_args, task_vars=task_vars, wrap_async=self._task.async_val))
+                return self._execute_module(module_name=module, module_args=new_module_args, task_vars=task_vars, wrap_async=self._task.async_val)
             else:
                 raise AnsibleActionFail('Could not detect which service manager to use. Try gathering facts or setting the "use" option.')
 
-        except AnsibleAction as e:
-            result.update(e.result)
         finally:
             if not self._task.async_val:
                 self._remove_tmp_path(self._connection._shell.tmpdir)
-
-        return result

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -20,7 +20,7 @@ from jinja2.defaults import (
 
 from ansible import constants as C
 from ansible.config.manager import ensure_type
-from ansible.errors import AnsibleError, AnsibleAction, AnsibleActionFail
+from ansible.errors import AnsibleError, AnsibleActionFail
 from ansible.module_utils.common.text.converters import to_bytes, to_text, to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six import string_types
@@ -39,7 +39,7 @@ class ActionModule(ActionBase):
         if task_vars is None:
             task_vars = dict()
 
-        result = super(ActionModule, self).run(tmp, task_vars)
+        super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
 
         # Options type validation
@@ -167,13 +167,8 @@ class ActionModule(ActionBase):
                                                                         loader=self._loader,
                                                                         templar=self._templar,
                                                                         shared_loader_obj=self._shared_loader_obj)
-                result.update(copy_action.run(task_vars=task_vars))
+                return copy_action.run(task_vars=task_vars)
             finally:
                 shutil.rmtree(to_bytes(local_tempdir, errors='surrogate_or_strict'))
-
-        except AnsibleAction as e:
-            result.update(e.result)
         finally:
             self._remove_tmp_path(self._connection._shell.tmpdir)
-
-        return result

--- a/test/integration/targets/adhoc/runme.sh
+++ b/test/integration/targets/adhoc/runme.sh
@@ -3,7 +3,7 @@
 set -eux
 
 # run type tests
-ansible -a 'sleep 5' --task-timeout 1 localhost |grep 'The command action failed to execute in the expected time frame (1) and was terminated'
+ansible -a 'sleep 5' --task-timeout 1 localhost |grep 'Timed out after'
 
 # -a parsing with json
 ansible --task-timeout 5 localhost -m command -a '{"cmd": "whoami"}' | grep 'rc=0'

--- a/test/integration/targets/ansible-galaxy-collection/tasks/fail_fast_resolvelib.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/fail_fast_resolvelib.yml
@@ -36,7 +36,7 @@
     - assert:
         that:
           - incompatible.failed
-          - not incompatible.msg.startswith("The command action failed to execute in the expected time frame")
+          - not incompatible.msg is contains 'Timed out after'
           - '"Failed to resolve the requested dependencies map" in incompatible.stderr'
           - '"* namespace1.name1:1.0.9 (direct request)" in incompatible.stderr'
           - '"* namespace1.name1:0.0.5 (dependency of ns.coll:1.0.0)" in incompatible.stderr'

--- a/test/integration/targets/connection_windows_ssh/tests.yml
+++ b/test/integration/targets/connection_windows_ssh/tests.yml
@@ -41,4 +41,4 @@
 
   - assert:
       that:
-      - timeout_cmd.msg == 'The win_shell action failed to execute in the expected time frame (5) and was terminated'
+      - timeout_cmd.msg is contains 'Timed out after'

--- a/test/integration/targets/connection_winrm/tests.yml
+++ b/test/integration/targets/connection_winrm/tests.yml
@@ -40,7 +40,7 @@
 
   - assert:
       that:
-      - timeout_cmd.msg == 'The win_shell action failed to execute in the expected time frame (5) and was terminated'
+      - timeout_cmd.msg is contains 'Timed out after'
 
   - name: Test WinRM HTTP connection
     win_ping:

--- a/test/integration/targets/playbook/timeout.yml
+++ b/test/integration/targets/playbook/timeout.yml
@@ -9,5 +9,5 @@
     - assert:
         that:
             - time is failed
-            - '"The shell action failed to execute in the expected time frame" in time["msg"]'
+            - time.msg is contains 'Timed out after'
             - '"timedout" in time'

--- a/test/integration/targets/task-timeout/aliases
+++ b/test/integration/targets/task-timeout/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group4
+context/controller

--- a/test/integration/targets/task-timeout/tasks/main.yml
+++ b/test/integration/targets/task-timeout/tasks/main.yml
@@ -1,0 +1,61 @@
+- name: run a task which times out
+  command: sleep 10
+  timeout: 1
+  register: result
+  ignore_errors: yes
+
+- name: verify the task timed out
+  assert:
+    that:
+      - result is failed
+      - result is timedout
+      - result.timedout.period == 1
+      - result.msg is contains "Timed out after 1 second"
+
+- name: run a task with a negative timeout
+  command: sleep 3
+  timeout: -1
+  register: result
+  ignore_errors: yes
+
+- name: verify the task failed
+  assert:
+    that:
+      - result is failed
+      - result is not timedout
+      - result.msg is contains "Timeout -1 is invalid"
+
+- name: run a task with a timeout that is too large
+  command: sleep 3
+  timeout: 100000001
+  register: result
+  ignore_errors: yes
+
+- name: verify the task failed
+  assert:
+    that:
+      - result is failed
+      - result is not timedout
+      - result.msg is contains "Timeout 100000001 is invalid"
+
+- name: run a task with a zero timeout
+  command: sleep 3
+  timeout: 0
+  register: result
+
+- name: verify the task did not time out
+  assert:
+    that:
+      - result is not timedout
+      - result.delta is search '^0:00:0[3-9]\.'  # delta must be between 3 and 9 seconds
+
+- name: run a task with a large timeout that is not triggered
+  command: sleep 3
+  timeout: 100000000
+  register: result
+
+- name: verify the task did not time out
+  assert:
+    that:
+      - result is not timedout
+      - result.delta is search '^0:00:0[3-9]\.'  # delta must be between 3 and 9 seconds

--- a/test/units/_internal/_errors/test_alarm_timeout.py
+++ b/test/units/_internal/_errors/test_alarm_timeout.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import contextlib
+import signal
+import time
+import typing as t
+
+import pytest
+
+from ansible._internal._errors import _alarm_timeout
+from ansible._internal._errors._alarm_timeout import AnsibleTimeoutError
+
+pytestmark = pytest.mark.usefixtures("assert_sigalrm_state")
+
+
+@pytest.fixture
+def assert_sigalrm_state() -> t.Iterator[None]:
+    """Fixture to ensure that SIGALRM state is as-expected before and after each test."""
+    assert signal.alarm(0) == 0  # disable alarm before resetting the default handler
+    assert signal.signal(signal.SIGALRM, signal.SIG_DFL) == signal.SIG_DFL
+
+    try:
+        yield
+    finally:
+        assert signal.alarm(0) == 0
+        assert signal.signal(signal.SIGALRM, signal.SIG_DFL) == signal.SIG_DFL
+
+
+@pytest.mark.parametrize("timeout", (0, 1, None))
+def test_alarm_timeout_success(timeout: int | None) -> None:
+    """Validate a non-timeout success scenario."""
+    ran = False
+
+    with _alarm_timeout.AnsibleTimeoutError.alarm_timeout(timeout):
+        time.sleep(0.01)
+        ran = True
+
+    assert ran
+
+
+def test_alarm_timeout_timeout() -> None:
+    """Validate a happy-path timeout scenario."""
+    ran = False
+    timeout_sec = 1
+
+    with pytest.raises(AnsibleTimeoutError) as error:
+        with _alarm_timeout.AnsibleTimeoutError.alarm_timeout(timeout_sec):
+            time.sleep(timeout_sec + 1)
+            ran = True  # pragma: nocover
+
+    assert not ran
+    assert error.value.timeout == timeout_sec
+
+
+@pytest.mark.parametrize("timeout,expected_error_type,expected_error_pattern", (
+    (-1, ValueError, "Timeout.*invalid.*between"),
+    (100_000_001, ValueError, "Timeout.*invalid.*between"),
+    (0.1, TypeError, "requires 'int' argument.*'float'"),
+    ("1", TypeError, "requires 'int' argument.*'str'"),
+))
+def test_alarm_timeout_bad_values(timeout: t.Any, expected_error_type: type[Exception], expected_error_pattern: str) -> None:
+    """Validate behavior for invalid inputs."""
+    ran = False
+
+    with pytest.raises(expected_error_type, match=expected_error_pattern):
+        with _alarm_timeout.AnsibleTimeoutError.alarm_timeout(timeout):
+            ran = True  # pragma: nocover
+
+    assert not ran
+
+
+def test_alarm_timeout_bad_state() -> None:
+    """Validate alarm state error handling."""
+    def call_it():
+        ran = False
+
+        with pytest.raises(RuntimeError, match="existing alarm"):
+            with _alarm_timeout.AnsibleTimeoutError.alarm_timeout(1):
+                ran = True  # pragma: nocover
+
+        assert not ran
+
+    try:
+        # non-default SIGALRM handler present
+        signal.signal(signal.SIGALRM, lambda _s, _f: None)
+        call_it()
+    finally:
+        signal.signal(signal.SIGALRM, signal.SIG_DFL)
+
+    try:
+        # alarm already set
+        signal.alarm(10000)
+        call_it()
+    finally:
+        signal.signal(signal.SIGALRM, signal.SIG_DFL)
+
+    ran_outer = ran_inner = False
+
+    # nested alarm_timeouts
+    with pytest.raises(RuntimeError, match="existing alarm"):
+        with _alarm_timeout.AnsibleTimeoutError.alarm_timeout(1):
+            ran_outer = True
+
+            with _alarm_timeout.AnsibleTimeoutError.alarm_timeout(1):
+                ran_inner = True  # pragma: nocover
+
+    assert not ran_inner
+    assert ran_outer
+
+
+def test_alarm_timeout_raise():
+    """Ensure that an exception raised in the wrapped scope propagates correctly."""
+    with pytest.raises(NotImplementedError):
+        with _alarm_timeout.AnsibleTimeoutError.alarm_timeout(1):
+            raise NotImplementedError()
+
+
+def test_alarm_timeout_escape_broad_exception():
+    """Ensure that the timeout exception can escape a broad exception handler in the wrapped scope."""
+    with pytest.raises(AnsibleTimeoutError):
+        with _alarm_timeout.AnsibleTimeoutError.alarm_timeout(1):
+            with contextlib.suppress(Exception):
+                time.sleep(3)

--- a/test/units/_internal/_errors/test_error_utils.py
+++ b/test/units/_internal/_errors/test_error_utils.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import collections.abc as c
+import typing as t
+
+import pytest
+
+from ansible._internal._errors import _error_utils
+from ansible.module_utils._internal import _messages
+from units.mock.error_helper import raise_exceptions
+
+
+class _TestContributesError(Exception, _error_utils.ContributesToTaskResult):
+    @property
+    def result_contribution(self) -> c.Mapping[str, object]:
+        return dict(some_flag=True)
+
+
+class _TestContributesUnreachable(Exception, _error_utils.ContributesToTaskResult):
+    @property
+    def omit_failed_key(self) -> bool:
+        return True
+
+    @property
+    def result_contribution(self) -> c.Mapping[str, object]:
+        return dict(unreachable=True)
+
+
+class _TestContributesMsg(Exception, _error_utils.ContributesToTaskResult):
+    @property
+    def result_contribution(self) -> c.Mapping[str, object]:
+        return dict(msg="contributed msg")
+
+
+@pytest.mark.parametrize("exceptions,expected", (
+    (
+        (Exception("e0"), _TestContributesError("e1"), ValueError("e2")),
+        dict(failed=True, some_flag=True, msg="e0: e1: e2"),
+    ),
+    (
+        (Exception("e0"), ValueError("e1"), _TestContributesError("e2")),
+        dict(failed=True, some_flag=True, msg="e0: e1: e2"),
+    ),
+    (
+        (Exception("e0"), _TestContributesUnreachable("e1")),
+        dict(unreachable=True, msg="e0: e1"),
+    ),
+    (
+        (Exception("e0"), _TestContributesMsg()),
+        dict(failed=True, msg="contributed msg"),
+    ),
+))
+def test_exception_result_contribution(exceptions: t.Sequence[BaseException], expected: dict[str, t.Any]) -> None:
+    """Validate result dict augmentation by exceptions conforming to the ContributeToTaskResult protocol."""
+
+    with pytest.raises(Exception) as error:
+        raise_exceptions(exceptions)
+
+    result = _error_utils.result_dict_from_exception(error.value, accept_result_contribution=True)
+
+    summary = result.pop('exception')
+
+    assert isinstance(summary, _messages.ErrorSummary)
+    assert result == expected

--- a/test/units/_internal/_errors/test_task_timeout.py
+++ b/test/units/_internal/_errors/test_task_timeout.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from ansible._internal._errors._task_timeout import TaskTimeoutError
+from ansible.module_utils._internal._datatag._tags import Deprecated
+
+
+def test_task_timeout_result_contribution() -> None:
+    """Validate the result contribution shape."""
+    try:
+        raise TaskTimeoutError(99)
+    except TaskTimeoutError as tte:
+        contrib = tte.result_contribution
+
+        assert isinstance(contrib, dict)
+
+        timedout = contrib.get('timedout')
+
+        assert isinstance(timedout, dict)
+
+        frame = timedout.get('frame')
+
+        assert isinstance(frame, str)
+        assert Deprecated.is_tagged_on(frame)
+
+        period = timedout.get('period')
+
+        assert period == 99

--- a/test/units/errors/test_errors.py
+++ b/test/units/errors/test_errors.py
@@ -5,7 +5,7 @@ import pathlib
 import pytest
 
 from ansible.errors import AnsibleError, AnsibleVariableTypeError
-from ansible._internal._errors._utils import SourceContext
+from ansible._internal._errors._error_utils import SourceContext
 from ansible._internal._datatag._tags import Origin
 
 from ..test_utils.controller.display import emits_warnings

--- a/test/units/errors/test_utils.py
+++ b/test/units/errors/test_utils.py
@@ -6,19 +6,10 @@ from ansible._internal._errors import _error_factory
 
 from ansible.errors import AnsibleError
 from ansible._internal._datatag._tags import Origin
-from ansible._internal._errors._utils import format_exception_message
+from ansible._internal._errors._error_utils import format_exception_message
 from ansible.utils.display import _format_message
 from ansible.module_utils._internal import _messages
-
-
-def raise_exceptions(exceptions: list[BaseException]) -> None:
-    if len(exceptions) > 1:
-        try:
-            raise_exceptions(exceptions[1:])
-        except Exception as ex:
-            raise exceptions[0] from ex
-
-    raise exceptions[0]
+from units.mock.error_helper import raise_exceptions
 
 
 _shared_cause = Exception('shared cause')

--- a/test/units/mock/error_helper.py
+++ b/test/units/mock/error_helper.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import collections.abc as c
+
+
+def raise_exceptions(exceptions: c.Sequence[BaseException]) -> None:
+    """
+    Raise a chain of exceptions from the given exception list.
+    Exceptions will be raised starting from the end of the list.
+    """
+    if len(exceptions) > 1:
+        try:
+            raise_exceptions(exceptions[1:])
+        except Exception as ex:
+            raise exceptions[0] from ex
+
+    raise exceptions[0]

--- a/test/units/parsing/utils/test_yaml.py
+++ b/test/units/parsing/utils/test_yaml.py
@@ -6,7 +6,7 @@ import tempfile
 import pytest
 
 from ansible.errors import AnsibleJSONParserError
-from ansible._internal._errors._utils import format_exception_message
+from ansible._internal._errors._error_utils import format_exception_message
 from ansible._internal._datatag._tags import Origin
 from ansible.parsing.utils.yaml import from_yaml
 

--- a/test/units/parsing/yaml/test_errors.py
+++ b/test/units/parsing/yaml/test_errors.py
@@ -11,7 +11,7 @@ import pytest
 import pytest_mock
 
 from ansible import constants as C
-from ansible._internal._errors._utils import format_exception_message
+from ansible._internal._errors._error_utils import format_exception_message
 from ansible._internal._datatag._tags import Origin
 from ansible.parsing.utils.yaml import from_yaml
 from ansible._internal._yaml._errors import AnsibleYAMLParserError

--- a/test/units/utils/test_errors.py
+++ b/test/units/utils/test_errors.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from ansible import errors
+
+from units.test_utils.controller.display import emits_warnings
+
+
+@pytest.mark.parametrize("name", (
+    "AnsibleFilterTypeError",
+    "_AnsibleActionDone",
+))
+def test_deprecated(name: str) -> None:
+    with emits_warnings(deprecation_pattern='is deprecated'):
+        getattr(errors, name)
+
+
+def test_deprecated_attribute_error() -> None:
+    with pytest.raises(AttributeError):
+        getattr(errors, 'bogus')


### PR DESCRIPTION
##### SUMMARY
* Preserve error detail on AnsibleAction and Connection exceptions.
* Remove multiple layers of unreachable or redundant error handling.
* Wrap manual alarm signal/timeout handling into a context manager, add tests.

##### ISSUE TYPE

- Bugfix Pull Request
