### PR TITLE
local connection always passes str to Popen

### DIFF
--- a/changelogs/fragments/local_popen_text.yml
+++ b/changelogs/fragments/local_popen_text.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - local connection plugin - The command-line used to create subprocesses is now always ``str`` to avoid issues with debuggers and profilers.

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -101,9 +101,9 @@ class Connection(ConnectionBase):
         display.debug("opening command with Popen()")
 
         if isinstance(cmd, (text_type, binary_type)):
-            cmd = to_bytes(cmd)
+            cmd = to_text(cmd)
         else:
-            cmd = map(to_bytes, cmd)
+            cmd = map(to_text, cmd)
 
         pty_primary = None
         stdin = subprocess.PIPE


### PR DESCRIPTION
##### SUMMARY
Change the local connection to always pass `str` to Popen. This avoids stderr noise and warnings with some debuggers and profilers and ensures they're work properly, as most Python 3-native tools require `str` args.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Bugfix Pull Request