### PR TITLE
ansible-test strip alias

### DIFF
--- a/test/lib/ansible_test/_internal/target.py
+++ b/test/lib/ansible_test/_internal/target.py
@@ -578,7 +578,7 @@ class IntegrationTarget(CompletionTarget):
         aliases_path = os.path.join(path, 'aliases')
 
         if aliases_path in file_paths:
-            static_aliases = tuple(read_lines_without_comments(aliases_path, remove_blank_lines=True))
+            static_aliases = tuple(read_lines_without_comments(aliases_path, remove_blank_lines=True, strip=True))
         else:
             static_aliases = tuple()
 

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -294,7 +294,7 @@ def filter_args(args: list[str], filters: dict[str, int]) -> list[str]:
     return result
 
 
-def read_lines_without_comments(path: str, remove_blank_lines: bool = False, optional: bool = False) -> list[str]:
+def read_lines_without_comments(path: str, remove_blank_lines: bool = False, optional: bool = False, strip: bool = False) -> list[str]:
     """
     Returns lines from the specified text file with comments removed.
     Comments are any content from a hash symbol to the end of a line.
@@ -309,6 +309,9 @@ def read_lines_without_comments(path: str, remove_blank_lines: bool = False, opt
 
     if remove_blank_lines:
         lines = [line for line in lines if line]
+
+    if strip:
+        lines = [line.strip() for line in lines]
 
     return lines
 


### PR DESCRIPTION
Remove meaningless whitespaces to allow for proper matching.

Fixes #85237 

##### ISSUE TYPE

- Bugfix Pull Request
