### PR TITLE
Fix AnsibleModule.human_to_bytes

### DIFF
--- a/changelogs/fragments/85259-fix-human_to_bytes.yml
+++ b/changelogs/fragments/85259-fix-human_to_bytes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix ``AnsibleModule.human_to_bytes()``, which was never adjusted after the standalone ``human_to_bytes()`` got a new parameter ``default_unit`` (https://github.com/ansible/ansible/pull/85259)."

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2160,7 +2160,7 @@ class AnsibleModule(object):
     pretty_bytes = bytes_to_human
 
     def human_to_bytes(self, number, isbits=False):
-        return human_to_bytes(number, isbits)
+        return human_to_bytes(number, isbits=isbits)
 
     #
     # Backwards compat

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2153,13 +2153,15 @@ class AnsibleModule(object):
         with open(filename, 'a') as fh:
             fh.write(str)
 
-    def bytes_to_human(self, size):
+    @staticmethod
+    def bytes_to_human(size):
         return bytes_to_human(size)
 
     # for backwards compatibility
     pretty_bytes = bytes_to_human
 
-    def human_to_bytes(self, number, isbits=False):
+    @staticmethod
+    def human_to_bytes(number, isbits=False):
         return human_to_bytes(number, isbits=isbits)
 
     #

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2154,14 +2154,14 @@ class AnsibleModule(object):
             fh.write(str)
 
     @staticmethod
-    def bytes_to_human(size):
+    def bytes_to_human(size: int) -> str:
         return bytes_to_human(size)
 
     # for backwards compatibility
     pretty_bytes = bytes_to_human
 
     @staticmethod
-    def human_to_bytes(number, isbits=False):
+    def human_to_bytes(number: str, isbits: bool = False) -> int:
         return human_to_bytes(number, isbits=isbits)
 
     #

--- a/lib/ansible/module_utils/common/text/formatters.py
+++ b/lib/ansible/module_utils/common/text/formatters.py
@@ -60,7 +60,7 @@ def human_to_bytes(number, default_unit=None, isbits=False):
         if 'Mb'/'Kb'/... is passed, the ValueError will be rased.
 
     When isbits is True, converts bits from a human-readable format to integer.
-        example: human_to_bytes('1Mb', isbits=True) returns 8388608 (int) -
+        example: human_to_bytes('1Mb', isbits=True) returns 1048576 (int) -
         string bits representation was passed and return as a number or bits.
         The function expects 'b' (lowercase) as a bit identifier, e.g. 'Mb'/'Kb'/etc.
         if 'MB'/'KB'/... is passed, the ValueError will be rased.

--- a/test/units/module_utils/basic/test_human_to_bytes.py
+++ b/test/units/module_utils/basic/test_human_to_bytes.py
@@ -1,29 +1,47 @@
 # -*- coding: utf-8 -*-
-# (c) 2025 Ansible Project
+# Copyright: (c) 2025 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import annotations
 
-import unittest
-
 import pytest
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+DATA = [
+    ("4KB", False, 4096),
+    ("4KB", None, 4096),
+    ("4Kb", True, 4096),
+]
+
+WO_ISBITS_DATA = [
+    ("4KB", 4096),
+]
+
+EXCEPTION_DATA = [
+    ("4Kb", False),
+    ("4KB", True),
+]
 
 
 @pytest.mark.usefixtures("stdin")
-class TestOtherFilesystem(unittest.TestCase):
-    def test_human_to_bytes(self):
-        from ansible.module_utils import basic
+@pytest.mark.parametrize('input, isbits, expected', DATA)
+def test_validator_function(input, isbits, expected):
+    am = AnsibleModule(argument_spec=dict())
+    assert am.human_to_bytes(input, isbits=isbits) == expected
 
-        am = basic.AnsibleModule(
-            argument_spec=dict(),
-        )
 
-        self.assertEqual(am.human_to_bytes("4KB"), 4096)
-        self.assertEqual(am.human_to_bytes("4KB", False), 4096)
-        self.assertEqual(am.human_to_bytes("4KB", isbits=False), 4096)
-        with pytest.raises(ValueError):
-            am.human_to_bytes("4Kb", isbits=False)
-        self.assertEqual(am.human_to_bytes("4Kb", True), 4096)
-        self.assertEqual(am.human_to_bytes("4Kb", isbits=True), 4096)
-        with pytest.raises(ValueError):
-            am.human_to_bytes("4KB", isbits=True)
+@pytest.mark.usefixtures("stdin")
+@pytest.mark.parametrize('input, expected', WO_ISBITS_DATA)
+def test_validator_functio(input, expected):
+    am = AnsibleModule(argument_spec=dict())
+    assert am.human_to_bytes(input) == expected
+
+
+@pytest.mark.usefixtures("stdin")
+@pytest.mark.parametrize('input, isbits', EXCEPTION_DATA)
+def test_validator_functions(input, isbits):
+    am = AnsibleModule(argument_spec=dict())
+    with pytest.raises(ValueError):
+        am.human_to_bytes(input, isbits=isbits)

--- a/test/units/module_utils/basic/test_human_to_bytes.py
+++ b/test/units/module_utils/basic/test_human_to_bytes.py
@@ -9,39 +9,26 @@ import pytest
 from ansible.module_utils.basic import AnsibleModule
 
 
-DATA = [
+@pytest.mark.parametrize('value, isbits, expected', [
     ("4KB", False, 4096),
     ("4KB", None, 4096),
     ("4Kb", True, 4096),
-]
+])
+def test_validator_function(value: str, isbits: bool | None, expected: int) -> None:
+    assert AnsibleModule.human_to_bytes(value, isbits=isbits) == expected
 
-WO_ISBITS_DATA = [
+
+@pytest.mark.parametrize('value, expected', [
     ("4KB", 4096),
-]
+])
+def test_validator_function_default_isbits(value: str, expected: int) -> None:
+    assert AnsibleModule.human_to_bytes(value) == expected
 
-EXCEPTION_DATA = [
+
+@pytest.mark.parametrize('value, isbits', [
     ("4Kb", False),
     ("4KB", True),
-]
-
-
-@pytest.mark.usefixtures("stdin")
-@pytest.mark.parametrize('input, isbits, expected', DATA)
-def test_validator_function(input, isbits, expected):
-    am = AnsibleModule(argument_spec=dict())
-    assert am.human_to_bytes(input, isbits=isbits) == expected
-
-
-@pytest.mark.usefixtures("stdin")
-@pytest.mark.parametrize('input, expected', WO_ISBITS_DATA)
-def test_validator_functio(input, expected):
-    am = AnsibleModule(argument_spec=dict())
-    assert am.human_to_bytes(input) == expected
-
-
-@pytest.mark.usefixtures("stdin")
-@pytest.mark.parametrize('input, isbits', EXCEPTION_DATA)
-def test_validator_functions(input, isbits):
-    am = AnsibleModule(argument_spec=dict())
+])
+def test_validator_functions(value: str, isbits: bool) -> None:
     with pytest.raises(ValueError):
-        am.human_to_bytes(input, isbits=isbits)
+        AnsibleModule.human_to_bytes(value, isbits=isbits)

--- a/test/units/module_utils/basic/test_human_to_bytes.py
+++ b/test/units/module_utils/basic/test_human_to_bytes.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# (c) 2025 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import unittest
+
+import pytest
+
+
+@pytest.mark.usefixtures("stdin")
+class TestOtherFilesystem(unittest.TestCase):
+    def test_human_to_bytes(self):
+        from ansible.module_utils import basic
+
+        am = basic.AnsibleModule(
+            argument_spec=dict(),
+        )
+
+        self.assertEqual(am.human_to_bytes("4KB"), 4096)
+        self.assertEqual(am.human_to_bytes("4KB", False), 4096)
+        self.assertEqual(am.human_to_bytes("4KB", isbits=False), 4096)
+        with pytest.raises(ValueError):
+            am.human_to_bytes("4Kb", isbits=False)
+        self.assertEqual(am.human_to_bytes("4Kb", True), 4096)
+        self.assertEqual(am.human_to_bytes("4Kb", isbits=True), 4096)
+        with pytest.raises(ValueError):
+            am.human_to_bytes("4KB", isbits=True)


### PR DESCRIPTION
##### SUMMARY
While working on adding some more type hints for some module utils, I found a bug: `human_to_bytes()` got a new argument `default_unit` a longer time ago, which broke `AnsibleModule.human_to_bytes`.

##### ISSUE TYPE
- Bugfix Pull Request
