### PR TITLE
[WIP] Add some typing hints for module_utils

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1500,7 +1500,7 @@ def modify_module(
             b_lines = b_module_data.split(b"\n", 1)
 
             if interpreter != new_interpreter:
-                b_lines[0] = to_bytes(shebang, errors='surrogate_or_strict', nonstring='passthru')
+                b_lines[0] = to_bytes(shebang, errors='surrogate_or_strict', nonstring='strict')
 
             b_module_data = b"\n".join(b_lines)
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -212,7 +212,7 @@ USERS_RE = re.compile(r'^[ugo]+$')
 PERMS_RE = re.compile(r'^[rwxXstugo]*$')
 
 
-def get_platform():
+def get_platform() -> str:
     """
     :returns: Name of the platform the module is running on in a native string
 
@@ -349,7 +349,7 @@ def _load_params():
     return ansible_module_args
 
 
-def missing_required_lib(library, reason=None, url=None):
+def missing_required_lib(library: str, reason: str | None = None, url: str | None = None) -> str:
     hostname = platform.node()
     msg = "Failed to import the required Python library (%s) on %s's Python %s." % (library, hostname, sys.executable)
     if reason:
@@ -364,10 +364,20 @@ def missing_required_lib(library, reason=None, url=None):
 
 
 class AnsibleModule(object):
-    def __init__(self, argument_spec, bypass_checks=False, no_log=False,
+    # The following properties come from PASS_VARS, but aren't set directly in the constructor.
+    _keep_remote_files: bool
+    _ignore_unknown_opts: bool
+    _remote_tmp: str | None
+    _target_log_info: str | None
+    _selinux_special_fs: list[str]
+    _tmpdir: str | None
+    _tracebacks_for: frozenset
+    ansible_version: str
+
+    def __init__(self, argument_spec, bypass_checks: bool = False, no_log: bool = False,
                  mutually_exclusive=None, required_together=None,
-                 required_one_of=None, add_file_common_args=False,
-                 supports_check_mode=False, required_if=None, required_by=None):
+                 required_one_of=None, add_file_common_args: bool = False,
+                 supports_check_mode: bool = False, required_if=None, required_by=None):
 
         """
         Common code for quickly building an ansible module in Python
@@ -389,21 +399,21 @@ class AnsibleModule(object):
         self.required_one_of = required_one_of
         self.required_if = required_if
         self.required_by = required_by
-        self.cleanup_files = []
+        self.cleanup_files: list[str | bytes | os.PathLike] = []
         self._debug = False
         self._diff = False
-        self._socket_path = None
-        self._shell = None
+        self._socket_path: str | None = None
+        self._shell: str | None = None
         self._syslog_facility = 'LOG_USER'
         self._verbosity = 0
         # May be used to set modifications to the environment for any
         # run_command invocation
-        self.run_command_environ_update = {}
-        self._clean = {}
+        self.run_command_environ_update: dict[str, str] = {}
+        self._clean: dict | str | None = {}
 
         self.aliases = {}
-        self._legal_inputs = []
-        self._options_context = list()
+        self._legal_inputs: list = []  # no longer used?
+        self._options_context: list = list()  # no longer used?
         self._tmpdir = None
 
         if add_file_common_args:
@@ -459,15 +469,15 @@ class AnsibleModule(object):
             self._log_invocation()
 
         # selinux state caching
-        self._selinux_enabled = None
-        self._selinux_mls_enabled = None
-        self._selinux_initial_context = None
+        self._selinux_enabled: bool | None = None
+        self._selinux_mls_enabled: bool | None = None
+        self._selinux_initial_context: list[None] | None = None
 
         # finally, make sure we're in a logical working dir
         self._set_cwd()
 
     @property
-    def tmpdir(self):
+    def tmpdir(self) -> str:
         # if _ansible_tmpdir was not set and we have a remote_tmp,
         # the module needs to create it and clean it up once finished.
         # otherwise we create our own module tmp dir from the system defaults
@@ -617,20 +627,20 @@ class AnsibleModule(object):
     # will get the selevel as part of the context returned
     # by selinux.lgetfilecon().
 
-    def selinux_mls_enabled(self):
+    def selinux_mls_enabled(self) -> bool:
         if self._selinux_mls_enabled is None:
             self._selinux_mls_enabled = HAVE_SELINUX and selinux.is_selinux_mls_enabled() == 1
 
         return self._selinux_mls_enabled
 
-    def selinux_enabled(self):
+    def selinux_enabled(self) -> bool:
         if self._selinux_enabled is None:
             self._selinux_enabled = HAVE_SELINUX and selinux.is_selinux_enabled() == 1
 
         return self._selinux_enabled
 
     # Determine whether we need a placeholder for selevel/mls
-    def selinux_initial_context(self):
+    def selinux_initial_context(self) -> list[None]:
         if self._selinux_initial_context is None:
             self._selinux_initial_context = [None, None, None]
             if self.selinux_mls_enabled():
@@ -1224,22 +1234,22 @@ class AnsibleModule(object):
         if module_parameters is None:
             module_parameters = self.params
 
-        for k in PASS_VARS:
+        for k, (attr_name, default_value) in PASS_VARS.items():
             # handle setting internal properties from internal ansible vars
             param_key = '_ansible_%s' % k
             if param_key in module_parameters:
                 if k in PASS_BOOLS:
-                    setattr(self, PASS_VARS[k][0], self.boolean(module_parameters[param_key]))
+                    setattr(self, attr_name, self.boolean(module_parameters[param_key]))
                 else:
-                    setattr(self, PASS_VARS[k][0], module_parameters[param_key])
+                    setattr(self, attr_name, module_parameters[param_key])
 
                 # clean up internal top level params:
                 if param_key in self.params:
                     del self.params[param_key]
             else:
                 # use defaults if not already set
-                if not hasattr(self, PASS_VARS[k][0]):
-                    setattr(self, PASS_VARS[k][0], PASS_VARS[k][1])
+                if not hasattr(self, attr_name):
+                    setattr(self, attr_name, default_value)
 
     def _load_params(self):
         """ read the input and set the params attribute.
@@ -1265,11 +1275,11 @@ class AnsibleModule(object):
                     msg_to_log=msg,
                 )
 
-    def debug(self, msg):
+    def debug(self, msg: str) -> None:
         if self._debug:
             self.log('[debug] %s' % msg)
 
-    def log(self, msg, log_args=None):
+    def log(self, msg: str, log_args=None) -> None:
 
         if not self.no_log:
 
@@ -1331,7 +1341,7 @@ class AnsibleModule(object):
             else:
                 self._log_to_syslog(journal_msg)
 
-    def _log_invocation(self):
+    def _log_invocation(self) -> None:
         """ log that ansible ran the module """
         # TODO: generalize a separate log function and make log_invocation use it
         # Sanitize possible password argument when logging.
@@ -1356,15 +1366,15 @@ class AnsibleModule(object):
                     param_val = param_val.encode('utf-8')
                 log_args[param] = heuristic_log_sanitize(param_val, self.no_log_values)
 
-        msg = ['%s=%s' % (to_native(arg), to_native(val)) for arg, val in log_args.items()]
-        if msg:
-            msg = 'Invoked with %s' % ' '.join(msg)
+        msg_list = ['%s=%s' % (to_native(arg), to_native(val)) for arg, val in log_args.items()]
+        if msg_list:
+            msg = 'Invoked with %s' % ' '.join(msg_list)
         else:
             msg = 'Invoked'
 
         self.log(msg, log_args=log_args)
 
-    def _set_cwd(self):
+    def _set_cwd(self) -> str | None:
         try:
             cwd = os.getcwd()
             if not os.access(cwd, os.F_OK | os.R_OK):
@@ -1384,7 +1394,15 @@ class AnsibleModule(object):
         # and we don't want to break modules unnecessarily
         return None
 
-    def get_bin_path(self, arg, required=False, opt_dirs=None):
+    @t.overload
+    def get_bin_path(self, arg: str, required: t.Literal[True], opt_dirs: list[str] = None) -> str:
+        ...
+
+    @t.overload
+    def get_bin_path(self, arg: str, required: bool = False, opt_dirs: list[str] = None) -> str | None:
+        ...
+
+    def get_bin_path(self, arg: str, required: bool = False, opt_dirs: list[str] = None) -> str | None:
         """
         Find system executable in PATH.
 
@@ -1404,7 +1422,7 @@ class AnsibleModule(object):
 
         return bin_path
 
-    def boolean(self, arg):
+    def boolean(self, arg: object) -> bool:
         """Convert the argument to a boolean"""
         if arg is None:
             return arg
@@ -1414,7 +1432,7 @@ class AnsibleModule(object):
         except TypeError as e:
             self.fail_json(msg=to_native(e))
 
-    def jsonify(self, data):
+    def jsonify(self, data: object) -> str:
         # deprecated: description='deprecate AnsibleModule.jsonify()' core_version='2.23'
         # deprecate(
         #     msg="The `AnsibleModule.jsonify' method is deprecated.",
@@ -1427,7 +1445,7 @@ class AnsibleModule(object):
         except UnicodeError as e:
             self.fail_json(msg=to_text(e))
 
-    def from_json(self, data):
+    def from_json(self, data: str) -> object:
         return json.loads(data)
 
     def add_cleanup_file(self, path):
@@ -1652,7 +1670,7 @@ class AnsibleModule(object):
         """ Return SHA-256 hex digest of local file using digest_from_file(). """
         return self.digest_from_file(filename, 'sha256')
 
-    def backup_local(self, fn):
+    def backup_local(self, fn: str | os.PathLike[str]) -> str:
         """make a date-marked backup of the specified file, return True or False on success or failure"""
 
         backupdest = ''
@@ -2182,7 +2200,7 @@ class AnsibleModule(object):
         return buffer_size
 
 
-def get_module_path():
+def get_module_path() -> str:
     return os.path.dirname(os.path.realpath(__file__))
 
 

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -76,7 +76,7 @@ _ADDITIONAL_CHECKS = (
 # if adding boolean attribute, also add to PASS_BOOL
 # some of this dupes defaults from controller config
 # keep in sync with copy in lib/ansible/module_utils/csharp/Ansible.Basic.cs
-PASS_VARS: dict[str, t.Any] = {
+PASS_VARS: dict[str, tuple[str, t.Any]] = {
     'check_mode': ('check_mode', False),
     'debug': ('_debug', False),
     'diff': ('_diff', False),

--- a/lib/ansible/module_utils/common/text/converters.py
+++ b/lib/ansible/module_utils/common/text/converters.py
@@ -157,8 +157,8 @@ def to_bytes(
                 # surrogate_then_escape and errors was surrogateescape
 
                 # Slow but works
-                return_string = obj.encode('utf-8', 'surrogateescape')
-                return_string = return_string.decode('utf-8', 'replace')
+                return_bytes = obj.encode('utf-8', 'surrogateescape')
+                return_string = return_bytes.decode('utf-8', 'replace')
                 return return_string.encode(encoding, 'replace')
             raise
 
@@ -319,7 +319,7 @@ def to_text(
 to_native = to_text
 
 
-def jsonify(data, **kwargs):
+def jsonify(data: _t.Any, **kwargs) -> str:
     from ansible.module_utils.common import json as _common_json
     # from ansible.module_utils.common.warnings import deprecate
 
@@ -333,7 +333,7 @@ def jsonify(data, **kwargs):
     return json.dumps(data, cls=_common_json._get_legacy_encoder(), _decode_bytes=True, **kwargs)
 
 
-def container_to_bytes(d, encoding='utf-8', errors='surrogate_or_strict'):
+def container_to_bytes(d: _t.Any, encoding: str = 'utf-8', errors='surrogate_or_strict') -> _t.Any:
     """ Recursively convert dict keys and values to byte str
 
         Specialized for json return because this only handles, lists, tuples,
@@ -353,7 +353,7 @@ def container_to_bytes(d, encoding='utf-8', errors='surrogate_or_strict'):
         return d
 
 
-def container_to_text(d, encoding='utf-8', errors='surrogate_or_strict'):
+def container_to_text(d: _t.Any, encoding: str = 'utf-8', errors='surrogate_or_strict') -> _t.Any:
     """Recursively convert dict keys and values to text str
 
     Specialized for json return because this only handles, lists, tuples,

--- a/lib/ansible/module_utils/common/text/formatters.py
+++ b/lib/ansible/module_utils/common/text/formatters.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import re
 
+from ansible.module_utils.compat import typing as _t
 from ansible.module_utils._internal import _no_six
 
 SIZE_RANGES = {
@@ -33,7 +34,7 @@ VALID_UNITS = {
 }
 
 
-def lenient_lowercase(lst):
+def lenient_lowercase(lst: _t.Iterable[_t.Any]) -> list[_t.Any]:
     """Lowercase elements of a list.
 
     If an element is not a string, pass it through untouched.
@@ -47,7 +48,7 @@ def lenient_lowercase(lst):
     return lowered
 
 
-def human_to_bytes(number, default_unit=None, isbits=False):
+def human_to_bytes(number: str, default_unit: str | None = None, isbits: bool = False) -> int:
     """Convert number in string format into bytes (ex: '2K' => 2048) or using unit argument.
 
     example: human_to_bytes('10M') <=> human_to_bytes(10, 'M').
@@ -111,7 +112,7 @@ def human_to_bytes(number, default_unit=None, isbits=False):
     return int(round(num * limit))
 
 
-def bytes_to_human(size, isbits=False, unit=None):
+def bytes_to_human(size: int, isbits: bool = False, unit: str | None = None) -> str:
     base = 'Bytes'
     if isbits:
         base = 'bits'

--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import decimal
 import json
 import os
+import typing as _t
 
 from ast import literal_eval
 from ansible.module_utils._internal import _no_six
@@ -294,7 +295,7 @@ def check_required_if(requirements, parameters, options_context=None):
     return results
 
 
-def check_missing_parameters(parameters, required_parameters=None):
+def check_missing_parameters(parameters: dict[str, _t.Any], required_parameters: _t.Sequence[str] | None = None) -> list[str]:
     """This is for checking for required params when we can not check via
     argspec because we need more information than is simply given in the argspec.
 
@@ -305,7 +306,7 @@ def check_missing_parameters(parameters, required_parameters=None):
 
     :returns: Empty list or raises :class:`TypeError` if the check fails.
     """
-    missing_params = []
+    missing_params: list[str] = []
     if required_parameters is None:
         return missing_params
 
@@ -323,7 +324,7 @@ def check_missing_parameters(parameters, required_parameters=None):
 # FIXME: The param and prefix parameters here are coming from AnsibleModule._check_type_string()
 #        which is using those for the warning messaged based on string conversion warning settings.
 #        Not sure how to deal with that here since we don't have config state to query.
-def check_type_str(value, allow_conversion=True, param=None, prefix=''):
+def check_type_str(value: _t.Any, allow_conversion: bool = True, param: str | None = None, prefix: str = '') -> str:
     """Verify that the value is a string or convert to a string.
 
     Since unexpected changes can sometimes happen when converting to a string,
@@ -350,11 +351,11 @@ def check_type_str(value, allow_conversion=True, param=None, prefix=''):
     raise TypeError(to_native(msg))
 
 
-def _check_type_str_no_conversion(value) -> str:
+def _check_type_str_no_conversion(value: _t.Any) -> str:
     return check_type_str(value, allow_conversion=False)
 
 
-def check_type_list(value):
+def check_type_list(value: _t.Any) -> list:
     """Verify that the value is a list or convert to a list
 
     A comma separated string will be split into a list. Raises a :class:`TypeError`
@@ -378,7 +379,7 @@ def check_type_list(value):
     raise TypeError('%s cannot be converted to a list' % type(value))
 
 
-def _check_type_list_strict(value):
+def _check_type_list_strict(value: _t.Any) -> list:
     # FUTURE: this impl should replace `check_type_list`
     if isinstance(value, list):
         return value
@@ -386,7 +387,7 @@ def _check_type_list_strict(value):
     return [value]
 
 
-def check_type_dict(value):
+def check_type_dict(value: _t.Any) -> dict:
     """Verify that value is a dict or convert it to a dict and return it.
 
     Raises :class:`TypeError` if unable to convert to a dict
@@ -414,7 +415,7 @@ def check_type_dict(value):
         elif '=' in value:
             fields = []
             field_buffer = []
-            in_quote = False
+            in_quote: _t.Literal[False, '\'', '"'] = False
             in_escape = False
             for c in value.strip():
                 if in_escape:
@@ -423,7 +424,7 @@ def check_type_dict(value):
                 elif c == '\\':
                     in_escape = True
                 elif not in_quote and c in ('\'', '"'):
-                    in_quote = c
+                    in_quote = _t.cast(_t.Literal['\'', '"'], c)
                 elif in_quote and in_quote == c:
                     in_quote = False
                 elif not in_quote and c in (',', ' '):
@@ -448,7 +449,7 @@ def check_type_dict(value):
     raise TypeError('%s cannot be converted to a dict' % type(value))
 
 
-def check_type_bool(value):
+def check_type_bool(value: _t.Any) -> bool:
     """Verify that the value is a bool or convert it to a bool and return it.
 
     Raises :class:`TypeError` if unable to convert to a bool
@@ -467,7 +468,7 @@ def check_type_bool(value):
     raise TypeError('%s cannot be converted to a bool' % type(value))
 
 
-def check_type_int(value):
+def check_type_int(value: _t.Any) -> int:
     """Verify that the value is an integer and return it or convert the value
     to an integer and return it
 
@@ -488,7 +489,7 @@ def check_type_int(value):
     return value
 
 
-def check_type_float(value):
+def check_type_float(value: _t.Any) -> float:
     """Verify that value is a float or convert it to a float and return it
 
     Raises :class:`TypeError` if unable to convert to a float
@@ -505,7 +506,7 @@ def check_type_float(value):
     return value
 
 
-def check_type_path(value,):
+def check_type_path(value: _t.Any) -> str:
     """Verify the provided value is a string or convert it to a string,
     then return the expanded path
     """
@@ -513,12 +514,12 @@ def check_type_path(value,):
     return os.path.expanduser(os.path.expandvars(value))
 
 
-def check_type_raw(value):
+def check_type_raw(value: _t.Any) -> _t.Any:
     """Returns the raw value"""
     return value
 
 
-def check_type_bytes(value):
+def check_type_bytes(value: _t.Any) -> int:
     """Convert a human-readable string value to bytes
 
     Raises :class:`TypeError` if unable to convert the value
@@ -529,7 +530,7 @@ def check_type_bytes(value):
         raise TypeError('%s cannot be converted to a Byte value' % type(value))
 
 
-def check_type_bits(value):
+def check_type_bits(value: _t.Any) -> int:
     """Convert a human-readable string bits value to bits in integer.
 
     Example: ``check_type_bits('1Mb')`` returns integer 1048576.
@@ -542,7 +543,7 @@ def check_type_bits(value):
         raise TypeError('%s cannot be converted to a Bit value' % type(value))
 
 
-def check_type_jsonarg(value):
+def check_type_jsonarg(value: _t.Any) -> str | bytes:
     """
     JSON serialize dict/list/tuple, strip str and bytes.
     Previously required for cases where Ansible/Jinja classic-mode literal eval pass could inadvertently deserialize objects.

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -131,23 +131,23 @@ class DataLoader:
         else:
             return copy.deepcopy(parsed_data)
 
-    def path_exists(self, path: str) -> bool:
+    def path_exists(self, path: str | bytes) -> bool:
         path = self.path_dwim(path)
         return os.path.exists(path)
 
-    def is_file(self, path: str) -> bool:
+    def is_file(self, path: str | bytes) -> bool:
         path = self.path_dwim(path)
         return os.path.isfile(path) or path == os.devnull
 
-    def is_directory(self, path: str) -> bool:
+    def is_directory(self, path: str | bytes) -> bool:
         path = self.path_dwim(path)
         return os.path.isdir(path)
 
-    def list_directory(self, path: str) -> list[str]:
+    def list_directory(self, path: str | bytes) -> list[str]:
         path = self.path_dwim(path)
         return os.listdir(path)
 
-    def is_executable(self, path: str) -> bool:
+    def is_executable(self, path: str) -> int:
         """is the given path executable?"""
         path = self.path_dwim(path)
         return is_executable(path)
@@ -229,7 +229,7 @@ class DataLoader:
         """ sets the base directory, used to find files when a relative path is given """
         self._basedir = os.path.abspath(basedir)
 
-    def path_dwim(self, given: str) -> str:
+    def path_dwim(self, given: str | bytes) -> str:
         """
         make relative paths work like folks expect.
         """


### PR DESCRIPTION
##### SUMMARY
Adds some typing hints for module_utils.

I was originally providing more, but didn't manage to get all of them into a good shape. For example, `strict_optional = False` prevents proper overloads for `AnsibleModule.run_command()` since the return types depend on whether `encoding` is `None` or a string; with `strict_optional = False` mypy always complains that the overloads do not differ since `str` includes `None`.

Not sure how to properly classify this (bugfix, feature, ...), for that reason I also didn't add a changelog fragment yet.

Right now the PR contains #85259, for that reason I've marked it WIP.

##### ISSUE TYPE
- Refactoring Pull Request
