### PR TITLE
Fix incorrect behavior when a Jinja test returns Marker

### DIFF
--- a/lib/ansible/_internal/_templating/_jinja_plugins.py
+++ b/lib/ansible/_internal/_templating/_jinja_plugins.py
@@ -128,6 +128,9 @@ class JinjaPluginIntercept(c.MutableMapping):
         def wrapper(*args, **kwargs) -> bool | Marker:
             result = self._invoke_plugin(instance, *args, **kwargs)
 
+            if isinstance(result, Marker):
+                return result
+
             if not isinstance(result, bool):
                 template = TemplateContext.current().template_value
 

--- a/test/units/_internal/templating/test_templar.py
+++ b/test/units/_internal/templating/test_templar.py
@@ -1074,3 +1074,9 @@ def test_unsafe_attr_access(template: str, expected: object) -> None:
 
     with unittest.mock.patch.object(_TemplateConfig, 'sandbox_mode', _SandboxMode.ALLOW_UNSAFE_ATTRIBUTES):
         assert TemplateEngine().template(TRUST.tag(template)) == expected
+
+
+def test_marker_from_test_plugin() -> None:
+    """Verify test plugins can raise MarkerError to return a Marker, and that no warnings or deprecations are emitted."""
+    with emits_warnings(deprecation_pattern=[], warning_pattern=[]):
+        assert TemplateEngine(variables=dict(something=TRUST.tag("{{ nope }}"))).template(TRUST.tag("{{ (something is eq {}) is undefined }}"))


### PR DESCRIPTION
##### SUMMARY
* Avoid Marker trip in plugin wrapper that causes unnecessary early template bailout.
* Remove spurious non-boolean result deprecation warning ([noticed while validating](https://github.com/ansible/ansible/issues/85203#issuecomment-2938212516) 85203).
* Add test.

##### ISSUE TYPE
- Bugfix Pull Request
