### PR TITLE
Restore 2.18 vault tag YAML dump behavior

### DIFF
--- a/changelogs/fragments/templates_types_datatagging.yml
+++ b/changelogs/fragments/templates_types_datatagging.yml
@@ -140,8 +140,6 @@ deprecated_features:
   - conditionals - Conditionals using Jinja templating delimiters (e.g., ``{{``, ``{%``) should be rewritten as expressions without delimiters, unless the entire conditional value is a single template that resolves to a trusted string expression.
     This is useful for dynamic indirection of conditional expressions, but is limited to trusted literal string expressions.
   - templating - The ``disable_lookups`` option has no effect, since plugins must be updated to apply trust before any templating can be performed.
-  - to_yaml/to_nice_yaml filters - Implicit YAML dumping of vaulted value ciphertext is deprecated.
-    Set `dump_vault_tags` to explicitly specify the desired behavior.
   - plugin error handling - The ``AnsibleError`` constructor arg ``suppress_extended_error`` is deprecated.
     Using ``suppress_extended_error=True`` has the same effect as ``show_content=False``.
   - config - The ``ACTION_WARNINGS`` config has no effect. It previously disabled command warnings, which have since been removed.

--- a/lib/ansible/_internal/_yaml/_dumper.py
+++ b/lib/ansible/_internal/_yaml/_dumper.py
@@ -34,12 +34,6 @@ class _BaseDumper(SafeDumper, metaclass=abc.ABCMeta):
 class AnsibleDumper(_BaseDumper):
     """A simple stub class that allows us to add representers for our custom types."""
 
-    # DTFIX0: need a better way to handle serialization controls during YAML dumping
-    def __init__(self, *args, dump_vault_tags: bool | None = None, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-
-        self._dump_vault_tags = dump_vault_tags
-
     @classmethod
     def _register_representers(cls) -> None:
         cls.add_multi_representer(AnsibleTaggedObject, cls.represent_ansible_tagged_object)
@@ -49,15 +43,7 @@ class AnsibleDumper(_BaseDumper):
         cls.add_multi_representer(_jinja_common.VaultExceptionMarker, cls.represent_vault_exception_marker)
 
     def get_node_from_ciphertext(self, data: object) -> ScalarNode | None:
-        if self._dump_vault_tags is not False and (ciphertext := VaultHelper.get_ciphertext(data, with_tags=False)):
-            # deprecated: description='enable the deprecation warning below' core_version='2.23'
-            # if self._dump_vault_tags is None:
-            #     Display().deprecated(
-            #         msg="Implicit YAML dumping of vaulted value ciphertext is deprecated.",
-            #         version="2.27",
-            #         help_text="Set `dump_vault_tags` to explicitly specify the desired behavior.",
-            #     )
-
+        if ciphertext := VaultHelper.get_ciphertext(data, with_tags=False):
             return self.represent_scalar('!vault', ciphertext, style='|')
 
         return None

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -14,7 +14,6 @@ import sys
 import typing as t
 
 import argparse
-import functools
 
 from ansible import constants as C
 from ansible import context
@@ -162,11 +161,10 @@ class InventoryCLI(CLI):
     def dump(stuff):
         if context.CLIARGS['yaml']:
             import yaml
+
             from ansible.parsing.yaml.dumper import AnsibleDumper
 
-            # DTFIX0: need shared infra to smuggle custom kwargs to dumpers, since yaml.dump cannot (as of PyYAML 6.0.1)
-            dumper = functools.partial(AnsibleDumper, dump_vault_tags=True)
-            results = to_text(yaml.dump(stuff, Dumper=dumper, default_flow_style=False, allow_unicode=True))
+            results = to_text(yaml.dump(stuff, Dumper=AnsibleDumper, default_flow_style=False, allow_unicode=True))
         elif context.CLIARGS['toml']:
             results = toml_dumps(stuff)
         else:

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -48,11 +48,9 @@ UUID_NAMESPACE_ANSIBLE = uuid.UUID('361E6D51-FAEC-444A-9079-341386DA8E2E')
 
 
 @accept_lazy_markers
-def to_yaml(a, *_args, default_flow_style: bool | None = None, dump_vault_tags: bool | None = None, **kwargs) -> str:
+def to_yaml(a, *_args, default_flow_style: bool | None = None, **kwargs) -> str:
     """Serialize input as terse flow-style YAML."""
-    dumper = partial(AnsibleDumper, dump_vault_tags=dump_vault_tags)
-
-    return yaml.dump(a, Dumper=dumper, allow_unicode=True, default_flow_style=default_flow_style, **kwargs)
+    return yaml.dump(a, Dumper=AnsibleDumper, allow_unicode=True, default_flow_style=default_flow_style, **kwargs)
 
 
 @accept_lazy_markers

--- a/test/integration/targets/templating/tasks/main.yml
+++ b/test/integration/targets/templating/tasks/main.yml
@@ -234,29 +234,6 @@
         - result is failed
         - result.msg is contains("undecryptable variable")
 
-  - name: undecryptable vault values in a scalar template should trip on YAML serialization
-    debug:
-      msg: '{{ dict_with_undecryptable_vault | to_yaml(dump_vault_tags=False) }}'
-    ignore_errors: true
-    register: result
-
-  - assert:
-      that:
-        - result is failed
-        - result.msg is contains("undecryptable variable")
-
-  - name: undecryptable vault values in a list of templates should trip on YAML serialization
-    debug:
-      msg:
-      - '{{ dict_with_undecryptable_vault | to_yaml(dump_vault_tags=False) }}'
-    ignore_errors: true
-    register: result
-
-  - assert:
-      that:
-        - result is failed
-        - result.msg is contains("undecryptable variable")
-
   - name: vaulted values are not trusted for templating
     vars:
       # value is {{ "not trusted" }} encrypted with "blarblar"

--- a/test/units/parsing/yaml/test_dumper.py
+++ b/test/units/parsing/yaml/test_dumper.py
@@ -86,20 +86,14 @@ class TestAnsibleDumper(unittest.TestCase, YamlTestUtils):
             self._dump_string(_DEFAULT_UNDEF, dumper=self.dumper)
 
 
-@pytest.mark.parametrize("filter_impl, dump_vault_tags, expected_output, expected_warning", [
-    (to_yaml, True, "!vault |-\n  ciphertext\n", None),
-    (to_yaml, None, "!vault |-\n  ciphertext\n", "Implicit YAML dumping"),
-    (to_yaml, False, "secret plaintext\n", None),
-    (to_nice_yaml, True, "!vault |-\n    ciphertext\n", None),
-    (to_nice_yaml, None, "!vault |-\n    ciphertext\n", "Implicit YAML dumping"),
-    (to_nice_yaml, False, "secret plaintext\n", None),
+@pytest.mark.parametrize("filter_impl, expected_output", [
+    (to_yaml, "!vault |-\n  ciphertext\n"),
+    (to_nice_yaml, "!vault |-\n    ciphertext\n"),
 ])
 def test_vaulted_value_dump(
-        filter_impl: t.Callable,
-        dump_vault_tags: bool | None,
-        expected_output: str,
-        expected_warning: str | None,
-        mocker: pytest_mock.MockerFixture
+    filter_impl: t.Callable,
+    expected_output: str,
+    mocker: pytest_mock.MockerFixture
 ) -> None:
     """Validate that strings tagged VaultedValue are represented properly."""
     value = VaultedValue(ciphertext="ciphertext").tag("secret plaintext")
@@ -108,14 +102,9 @@ def test_vaulted_value_dump(
 
     _deprecated_spy = mocker.spy(Display(), 'deprecated')
 
-    res = filter_impl(value, dump_vault_tags=dump_vault_tags)
+    res = filter_impl(value)
 
     assert res == expected_output
-
-    # deprecated: description='enable the assertion for the deprecation warning below' core_version='2.21'
-    # if expected_warning:
-    #     assert _deprecated_spy.call_count == 1
-    #     assert expected_warning in _deprecated_spy.call_args.kwargs['msg']
 
 
 _test_tag = Deprecated(msg="test")


### PR DESCRIPTION
##### SUMMARY
* Doing conditional redaction/formatting needs other bits that aren't ready for 2.19.

##### ISSUE TYPE
- Feature Pull Request
