### PR TITLE
fix Marker handling on Jinja macro invocations

### DIFF
--- a/changelogs/fragments/macro_support.yml
+++ b/changelogs/fragments/macro_support.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - templating - Jinja macros returned from a template expression can now be called from another template expression.
+  - templating - Fixed cases where template expression blocks halted prematurely when a Jinja macro invocation returned an undefined value.

--- a/lib/ansible/_internal/_templating/_jinja_plugins.py
+++ b/lib/ansible/_internal/_templating/_jinja_plugins.py
@@ -163,7 +163,7 @@ class JinjaPluginIntercept(c.MutableMapping):
 class _DirectCall:
     """Functions/methods marked `_DirectCall` bypass Jinja Environment checks for `Marker`."""
 
-    _marker_attr: str = "_directcall"
+    _marker_attr: t.Final[str] = "_directcall"
 
     @classmethod
     def mark(cls, src: _TCallable) -> _TCallable:
@@ -172,7 +172,7 @@ class _DirectCall:
 
     @classmethod
     def is_marked(cls, value: t.Callable) -> bool:
-        return callable(value) and getattr(value, "_directcall", False)
+        return callable(value) and getattr(value, cls._marker_attr, False)
 
 
 @_DirectCall.mark


### PR DESCRIPTION
##### SUMMARY
* always allow Marker args to pass through
* always disable pre-emptive trip-on-retrieval for Macro JinjaCallContext
* add macro-callable template expression result test cases

##### ISSUE TYPE
- Bugfix Pull Request
