### PR TITLE
[stable-2.17] Use f39 official repo for libdnf5

### DIFF
--- a/test/integration/targets/dnf5/playbook.yml
+++ b/test/integration/targets/dnf5/playbook.yml
@@ -1,9 +1,7 @@
 - hosts: localhost
   tasks:
     - block:
-        - command: "dnf install -y 'dnf-command(copr)'"
-        - command: dnf copr enable -y rpmsoftwaremanagement/dnf-nightly
-        - command: dnf install -y -x condor python3-libdnf5
+        - command: dnf install -y python3-libdnf5
 
         - include_role:
             name: dnf
@@ -13,7 +11,7 @@
               - /var/log/dnf5.log
       when:
         - ansible_distribution == 'Fedora'
-        - ansible_distribution_major_version is version('37', '>=')
+        - ansible_distribution_major_version is version('39', '>=')
       module_defaults:
         dnf:
           use_backend: dnf5


### PR DESCRIPTION
##### SUMMARY
The nightly repo is no longer available.

This is not a backport.

Ref. we did the same for `stable-2.16`: https://github.com/ansible/ansible/commit/afcaaeb9f6abcf667fe74e4191fed89d6392948b.
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Test Pull Request
