### PR TITLE
Add jfrog_token role downloads from Artifactory servers

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -227,6 +227,8 @@ class GalaxyCLI(CLI):
         common.add_argument('--token', '--api-key', dest='api_key',
                             help='The Ansible Galaxy API key which can be found at '
                                  'https://galaxy.ansible.com/me/preferences.')
+        common.add_argument('--jfrog-token', dest='jfrog_token', default=False,
+                            help='The JFrog API token for authenticating to Artifactory servers.')
         common.add_argument('-c', '--ignore-certs', action='store_true', dest='ignore_certs', help='Ignore SSL certificate validation errors.', default=None)
 
         # --timeout uses the default None to handle two different scenarios.
@@ -630,6 +632,8 @@ class GalaxyCLI(CLI):
                 galaxy_options[optional_key] = context.CLIARGS[optional_key]
 
         config_servers = []
+        jfrog_token = context.CLIARGS.get('jfrog_token')
+
         # Need to filter out empty strings or non truthy values as an empty server list env var is equal to [''].
         server_list = [s for s in C.GALAXY_SERVER_LIST or [] if s]
         for server_priority, server_key in enumerate(server_list, start=1):
@@ -683,6 +687,7 @@ class GalaxyCLI(CLI):
             config_servers.append(GalaxyAPI(
                 self.galaxy, server_key,
                 priority=server_priority,
+                jfrog_token=jfrog_token,
                 **server_options
             ))
 
@@ -710,6 +715,7 @@ class GalaxyCLI(CLI):
                     priority=len(config_servers) + 1,
                     validate_certs=validate_certs,
                     timeout=default_server_timeout,
+                    jfrog_token=jfrog_token,
                     **galaxy_options
                 ))
         else:
@@ -1460,6 +1466,7 @@ class GalaxyCLI(CLI):
         no_deps = context.CLIARGS['no_deps']
         force_deps = context.CLIARGS['force_with_deps']
         force = context.CLIARGS['force'] or force_deps
+        jfrog_token = context.CLIARGS.get('jfrog_token')
 
         for role in requirements:
             # only process roles in roles files when names matches if given

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1773,6 +1773,13 @@ INJECT_FACTS_AS_VARS:
   - {key: inject_facts_as_vars, section: defaults}
   type: boolean
   version_added: "2.5"
+JFROG_TOKEN:
+  default: null
+  description: The JFrog Artifactory API token for authenticating to Artifactory servers when downloading roles or collections.
+  env: [{name: ANSIBLE_GALAXY_JFROG_TOKEN}]
+  ini:
+    - {key: jfrog_token, section: galaxy}
+  type: string
 MODULE_IGNORE_EXTS:
   name: Module ignore extensions
   default: "{{ REJECT_EXTS + ['.yaml', '.yml', '.ini'] }}"

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -276,7 +276,7 @@ class GalaxyAPI:
 
     def __init__(
             self, galaxy, name, url,
-            username=None, password=None, token=None, validate_certs=True,
+            username=None, password=None, token=None, jfrog_token=None, validate_certs=True,
             available_api_versions=None,
             clear_response_cache=False, no_cache=True,
             priority=float('inf'),
@@ -287,6 +287,7 @@ class GalaxyAPI:
         self.username = username
         self.password = password
         self.token = token
+        self.jfrog_token = jfrog_token
         self.api_server = url
         self.validate_certs = validate_certs
         self.timeout = timeout


### PR DESCRIPTION
##### SUMMARY

This PR introduces support for authenticating with JFrog Artifactory servers when downloading Ansible roles using ansible-galaxy. A new `--jfrog-token` CLI option and `JFROG_TOKEN` configuration setting allow users to specify a JFrog Artifactory API token for authenticated downloads.

The implementation is intended to be forward-compatible with potential future enhancements to roles/requirements.yml. Currently, the X-JFrog-Art-Api header is added for any URL. In the event that a `type` field is introduced in requirements.yml (e.g., `type: artifactory`), the logic can be updated to restrict `jfrog_token` usage to entries explicitly so marked.

##### ISSUE TYPE

- Feature Pull Request
