### PR TITLE
galaxy : use advice.detachedHead=false for git_switch_cmd

### DIFF
--- a/changelogs/fragments/85290-suppress_advice_detachedHead.yml
+++ b/changelogs/fragments/85290-suppress_advice_detachedHead.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - galaxy - use advice.detachedHead=false for git_switch_cmd (https://github.com/ansible/ansible/pull/85290).

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -443,7 +443,7 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
             format(repo_url=to_native(git_url)),
         ) from proc_err
 
-    git_switch_cmd = git_executable, 'checkout', to_text(version)
+    git_switch_cmd = git_executable, '-c', 'advice.detachedHead=false', 'checkout', to_text(version)
     try:
         subprocess.check_call(git_switch_cmd, cwd=b_checkout_path)
     except subprocess.CalledProcessError as proc_err:

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -444,8 +444,6 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
         ) from proc_err
 
     git_switch_cmd = git_executable, '-c', 'advice.detachedHead=false', 'checkout', to_text(version)
-    if display.verbosity > 0:
-        git_switch_cmd = git_executable, 'checkout', to_text(version)
 
     try:
         subprocess.check_call(git_switch_cmd, cwd=b_checkout_path)

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -444,6 +444,9 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
         ) from proc_err
 
     git_switch_cmd = git_executable, '-c', 'advice.detachedHead=false', 'checkout', to_text(version)
+    if display.verbosity > 0:
+        git_switch_cmd = git_executable, 'checkout', to_text(version)
+
     try:
         subprocess.check_call(git_switch_cmd, cwd=b_checkout_path)
     except subprocess.CalledProcessError as proc_err:

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -147,7 +147,7 @@ def test_concrete_artifact_manager_scm_cmd(url, version, trailing_slash, monkeyp
     clone_cmd = [git_executable, 'clone', repo, '']
 
     assert mock_subprocess_check_call.call_args_list[0].args[0] == clone_cmd
-    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, 'checkout', 'commitish')
+    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, '-c', 'advice.detachedHead=false', 'checkout', 'commitish')
 
 
 @pytest.mark.parametrize(

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -147,7 +147,7 @@ def test_concrete_artifact_manager_scm_cmd(url, version, trailing_slash, monkeyp
     clone_cmd = [git_executable, 'clone', repo, '']
 
     assert mock_subprocess_check_call.call_args_list[0].args[0] == clone_cmd
-    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, '-c', 'advice.detachedHead=false', 'checkout', 'commitish')
+    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, 'checkout', 'commitish')
 
 
 @pytest.mark.parametrize(

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -147,7 +147,7 @@ def test_concrete_artifact_manager_scm_cmd(url, version, trailing_slash, monkeyp
     clone_cmd = [git_executable, 'clone', repo, '']
 
     assert mock_subprocess_check_call.call_args_list[0].args[0] == clone_cmd
-    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, 'checkout', 'commitish')
+    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, '-c', 'advice.detachedHead=false', 'checkout', 'commitish')
 
 
 @pytest.mark.parametrize(
@@ -178,7 +178,7 @@ def test_concrete_artifact_manager_scm_cmd_shallow(url, version, trailing_slash,
     shallow_clone_cmd = [git_executable, 'clone', '--depth=1', repo, '']
 
     assert mock_subprocess_check_call.call_args_list[0].args[0] == shallow_clone_cmd
-    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, 'checkout', 'HEAD')
+    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, '-c', 'advice.detachedHead=false', 'checkout', 'HEAD')
 
 
 @pytest.mark.parametrize(
@@ -210,7 +210,7 @@ def test_concrete_artifact_manager_scm_cmd_validate_certs(ignore_certs_cli, igno
         clone_cmd.extend(['-c', 'http.sslVerify=false'])
 
     assert mock_subprocess_check_call.call_args_list[0].args[0] == clone_cmd
-    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, 'checkout', 'HEAD')
+    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, '-c', 'advice.detachedHead=false', 'checkout', 'HEAD')
 
 
 def test_build_requirement_from_path(collection_artifact):


### PR DESCRIPTION
##### ansible-galaxy command : avoid unnecessary warnings regarding 'detached HEAD state'

<!--- Describe the change below, including rationale and design decisions -->
This PR suppresses the annoying output regarding the `'detached HEAD' state` if the version field of the collection/role to install is a tag value or a commit hash.

In sich cases the detached head state is intended and the message displayed contains no useful information and only clutters the screen.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

diff of the output of a `ansible-galaxy collection install ...` run with the new setting compared to the original one:
```diff
-
-You are in 'detached HEAD' state. You can look around, make experimental
-changes and commit them, and you can discard any commits you make in this
-state without impacting any branches by switching back to a branch.
-
-If you want to create a new branch to retain commits you create, you may
-do so (now or later) by using -c with the switch command. Example:
-
-  git switch -c <new-branch-name>
-
-Or undo this operation with:
-
-  git switch -
-
-Turn off this advice by setting config variable advice.detachedHead to false
-
```

If you have a requirements file with several collections pinned to a git tag, that's adding up ...

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request