### PR TITLE
module_utils/basic.py: properly deprecate importing `text_type`

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2198,7 +2198,7 @@ def __getattr__(importable_name):
         importable = repeat
     elif importable_name in {
         'PY2', 'PY3', 'b', 'binary_type', 'integer_types',
-        'iteritems', 'string_types', 'test_type'
+        'iteritems', 'string_types', 'text_type',
     }:
         import importlib
         importable = getattr(


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
