### PR TITLE
ansible-doc don't show empty paths

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1440,7 +1440,11 @@ class DocCLI(CLI, RoleMixin):
         pad = display.columns * 0.20
         limit = max(display.columns - int(pad), 70)
 
-        text.append("> %s %s (%s)" % (plugin_type.upper(), _format(doc.pop('plugin_name'), 'bold'), doc.pop('filename')))
+        fname = ''
+        if 'filename' in doc and doc['filename']:
+            # jinja provided plugins don't have a file!
+            fname = f"({doc.pop('filename')!r})"
+        text.append(f"> {plugin_type.upper()} {_format(doc.pop('plugin_name'), 'bold')} {fname}")
 
         if isinstance(doc['description'], list):
             descs = doc.pop('description')

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1440,11 +1440,7 @@ class DocCLI(CLI, RoleMixin):
         pad = display.columns * 0.20
         limit = max(display.columns - int(pad), 70)
 
-        fname = ''
-        if 'filename' in doc and doc['filename']:
-            # jinja provided plugins don't have a file!
-            fname = f"({doc.pop('filename')!r})"
-        text.append(f"> {plugin_type.upper()} {_format(doc.pop('plugin_name'), 'bold')} {fname}")
+        text.append("> %s %s (%s)" % (plugin_type.upper(), _format(doc.pop('plugin_name'), 'bold'), doc.pop('filename') or 'Jinja2'))
 
         if isinstance(doc['description'], list):
             descs = doc.pop('description')

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -287,3 +287,6 @@ echo "test 'sidecar' for no extension module  with .py doc"
 
 echo "test 'sidecar' for no extension module  with .yml doc"
 [ "$(ansible-doc -M ./library -l ansible.legacy |grep -v 'UNDOCUMENTED' |grep -c facts_one)" == "1" ]
+
+echo "Test j2 plugins get jinja2 instead of path"
+ansible-doc -t filter map 2>&1 |grep "${GREP_OPTS[@]}" '(Jinja2)'


### PR DESCRIPTION
no empty  (), normally it indicates file path for the plugin, but  J2 provided ones don't have one

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFO

before:
```
> FILTER ansible.builtin.map ()

  Applies a filter on a sequence of objects or looks up an attribute.

  This is the Jinja builtin filter plugin 'map'.
  See: https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.map

```
after:
```
> FILTER ansible.builtin.map (Jinja2)

  Applies a filter on a sequence of objects or looks up an attribute.

  This is the Jinja builtin filter plugin 'map'.
  See: https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.map

```