### PR TITLE
Fix typos in documentation and test ignore list

### DIFF
--- a/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/invalid_choice_value.py
+++ b/test/integration/targets/ansible-test-sanity-validate-modules/ansible_collections/ns/col/plugins/modules/invalid_choice_value.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 DOCUMENTATION = """
 module: invalid_choice_value
-short_description: Test for equal length of chocies with correct options
-description: Test for equal length of chocies with correct options
+short_description: Test for equal length of choices with correct options
+description: Test for equal length of choices with correct options
 author:
   - Ansible Core Team
 options:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -104,7 +104,7 @@ test/integration/targets/win_app_control/files/New-AnsiblePowerShellSignature.ps
 test/integration/targets/win_app_control/files/Set-ManifestSignature.ps1 shebang  # We want to run with pwsh from the environment in the test
 test/integration/targets/win_exec_wrapper/library/test_fail.ps1 pslint:PSCustomUseLiteralPath
 test/integration/targets/win_exec_wrapper/tasks/main.yml no-smart-quotes  # We are explicitly testing smart quote support for env vars
-test/integration/targets/win_fetch/tasks/main.yml no-smart-quotes  # We are explictly testing smart quotes in the file name to fetch
+test/integration/targets/win_fetch/tasks/main.yml no-smart-quotes  # We are explicitly testing smart quotes in the file name to fetch
 test/integration/targets/win_module_utils/library/legacy_only_new_way_win_line_ending.ps1 line-endings  # Explicitly tests that we still work with Windows line endings
 test/integration/targets/win_module_utils/library/legacy_only_old_way_win_line_ending.ps1 line-endings  # Explicitly tests that we still work with Windows line endings
 test/integration/targets/win_script/files/test_script.ps1 pslint:PSAvoidUsingWriteHost # Keep


### PR DESCRIPTION


Description:  
This pull request corrects several typos in the codebase:
- Fixed the spelling of "choices" in the documentation for the invalid_choice_value module.
- Corrected the spelling of "explicitly" in the test/sanity/ignore.txt file.

These changes improve the clarity and accuracy of the documentation and comments. No functional code was modified.