### PR TITLE
ansible-test - Move metadata to environment

### DIFF
--- a/test/lib/ansible_test/_internal/cli/commands/__init__.py
+++ b/test/lib/ansible_test/_internal/cli/commands/__init__.py
@@ -163,11 +163,6 @@ def do_commands(
     )
 
     testing.add_argument(
-        '--metadata',
-        help=argparse.SUPPRESS,
-    )
-
-    testing.add_argument(
         '--base-branch',
         metavar='BRANCH',
         help='base branch used for change detection',

--- a/test/lib/ansible_test/_internal/cli/environments.py
+++ b/test/lib/ansible_test/_internal/cli/environments.py
@@ -166,6 +166,11 @@ def add_composite_environment_options(
         help=argparse.SUPPRESS,
     )
 
+    parser.add_argument(
+        '--metadata',
+        help=argparse.SUPPRESS,
+    )
+
     action_types: list[t.Type[CompositeAction]] = []
 
     def register_action_type(action_type: t.Type[CompositeAction]) -> t.Type[CompositeAction]:

--- a/test/lib/ansible_test/_internal/config.py
+++ b/test/lib/ansible_test/_internal/config.py
@@ -118,6 +118,19 @@ class EnvironmentConfig(CommonConfig):
         self.dev_systemd_debug: bool = args.dev_systemd_debug
         self.dev_probe_cgroups: t.Optional[str] = args.dev_probe_cgroups
 
+        self.metadata = Metadata.from_file(args.metadata) if args.metadata else Metadata()
+        self.metadata_path: t.Optional[str] = None
+
+        def metadata_callback(payload_config: PayloadConfig) -> None:
+            """Add the metadata file to the payload file list."""
+            config = self
+            files = payload_config.files
+
+            if config.metadata_path:
+                files.append((os.path.abspath(config.metadata_path), config.metadata_path))
+
+        data_context().register_payload_callback(metadata_callback)
+
         def host_callback(payload_config: PayloadConfig) -> None:
             """Add the host files to the payload file list."""
             config = self
@@ -220,21 +233,8 @@ class TestConfig(EnvironmentConfig):
         self.junit: bool = getattr(args, 'junit', False)
         self.failure_ok: bool = getattr(args, 'failure_ok', False)
 
-        self.metadata = Metadata.from_file(args.metadata) if args.metadata else Metadata()
-        self.metadata_path: t.Optional[str] = None
-
         if self.coverage_check:
             self.coverage = True
-
-        def metadata_callback(payload_config: PayloadConfig) -> None:
-            """Add the metadata file to the payload file list."""
-            config = self
-            files = payload_config.files
-
-            if config.metadata_path:
-                files.append((os.path.abspath(config.metadata_path), config.metadata_path))
-
-        data_context().register_payload_callback(metadata_callback)
 
 
 class ShellConfig(EnvironmentConfig):

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -113,21 +113,18 @@ def delegate(args: CommonConfig, host_state: HostState, exclude: list[str], requ
     assert isinstance(args, EnvironmentConfig)
 
     with delegation_context(args, host_state):
-        if isinstance(args, TestConfig):
-            args.metadata.ci_provider = get_ci_provider().code
+        args.metadata.ci_provider = get_ci_provider().code
 
-            make_dirs(ResultType.TMP.path)
+        make_dirs(ResultType.TMP.path)
 
-            with tempfile.NamedTemporaryFile(prefix='metadata-', suffix='.json', dir=ResultType.TMP.path) as metadata_fd:
-                args.metadata_path = os.path.join(ResultType.TMP.relative_path, os.path.basename(metadata_fd.name))
-                args.metadata.to_file(args.metadata_path)
+        with tempfile.NamedTemporaryFile(prefix='metadata-', suffix='.json', dir=ResultType.TMP.path) as metadata_fd:
+            args.metadata_path = os.path.join(ResultType.TMP.relative_path, os.path.basename(metadata_fd.name))
+            args.metadata.to_file(args.metadata_path)
 
-                try:
-                    delegate_command(args, host_state, exclude, require)
-                finally:
-                    args.metadata_path = None
-        else:
-            delegate_command(args, host_state, exclude, require)
+            try:
+                delegate_command(args, host_state, exclude, require)
+            finally:
+                args.metadata_path = None
 
 
 def delegate_command(args: EnvironmentConfig, host_state: HostState, exclude: list[str], require: list[str]) -> None:
@@ -334,6 +331,7 @@ def filter_options(
         ('--redact', 0, False),
         ('--no-redact', 0, not args.redact),
         ('--host-path', 1, args.host_path),
+        ('--metadata', 1, args.metadata_path),
     ]
 
     if isinstance(args, TestConfig):
@@ -346,7 +344,6 @@ def filter_options(
             ('--ignore-unstaged', 0, False),
             ('--changed-from', 1, False),
             ('--changed-path', 1, False),
-            ('--metadata', 1, args.metadata_path),
             ('--exclude', 1, exclude),
             ('--require', 1, require),
             ('--base-branch', 1, False),

--- a/test/lib/ansible_test/_internal/metadata.py
+++ b/test/lib/ansible_test/_internal/metadata.py
@@ -55,7 +55,7 @@ class Metadata:
             changes=self.changes,
             cloud_config=self.cloud_config,
             ci_provider=self.ci_provider,
-            change_description=self.change_description.to_dict(),
+            change_description=self.change_description.to_dict() if self.change_description else None,
             session_id=self.session_id,
         )
 
@@ -80,7 +80,7 @@ class Metadata:
         metadata.changes = data['changes']
         metadata.cloud_config = data['cloud_config']
         metadata.ci_provider = data['ci_provider']
-        metadata.change_description = ChangeDescription.from_dict(data['change_description'])
+        metadata.change_description = ChangeDescription.from_dict(data['change_description']) if data['change_description'] else None
         metadata.session_id = data['session_id']
 
         return metadata


### PR DESCRIPTION
##### SUMMARY

This will allow commands such as `shell` to take advantage of metadata during delegation.

##### ISSUE TYPE

Feature Pull Request
