### PR TITLE
[stable-2.18] ansible-doc display docs for modules w/o ext (#85299)

### DIFF
--- a/changelogs/fragments/adoc_noext_fix.yml
+++ b/changelogs/fragments/adoc_noext_fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-doc will no longer ignore docs for modules without an extension (https://github.com/ansible/ansible/issues/85279).

--- a/lib/ansible/plugins/list.py
+++ b/lib/ansible/plugins/list.py
@@ -42,7 +42,7 @@ def get_composite_name(collection, name, path, depth):
     return '.'.join(composite)
 
 
-def _list_plugins_from_paths(ptype, dirs, collection, depth=0):
+def _list_plugins_from_paths(ptype, dirs, collection, depth=0, docs=False):
     # TODO: update to use importlib.resources
 
     plugins = {}
@@ -77,14 +77,15 @@ def _list_plugins_from_paths(ptype, dirs, collection, depth=0):
                                 continue
 
                         # actually recurse dirs
-                        plugins.update(_list_plugins_from_paths(ptype, [to_native(full_path)], collection, depth=depth + 1))
+                        plugins.update(_list_plugins_from_paths(ptype, [to_native(full_path)], collection, depth=depth + 1, docs=docs))
                     else:
                         if any([
                                 plugin in C.IGNORE_FILES,                # general files to ignore
                                 to_native(b_ext) in C.REJECT_EXTS,       # general extensions to ignore
-                                b_ext in (b'.yml', b'.yaml', b'.json'),  # ignore docs files TODO: constant!
+                                b_ext in (b'.yml', b'.yaml', b'.json'),  # ignore docs files
                                 plugin in IGNORE.get(bkey, ()),          # plugin in reject list
                                 os.path.islink(full_path),               # skip aliases, author should document in 'aliases' field
+                                not docs and b_ext in (b''),             # ignore no ext when looking for docs files
                         ]):
                             continue
 
@@ -147,7 +148,7 @@ def list_collection_plugins(ptype, collections, search_paths=None):
 
             #     raise Exception('bad acr for %s, %s' % (collection, ptype))
 
-        plugins.update(_list_plugins_from_paths(ptype, dirs, collection))
+        plugins.update(_list_plugins_from_paths(ptype, dirs, collection, docs=True))
 
     #  return plugin and it's class object, None for those not verifiable or failing
     if ptype in ('module',):

--- a/test/integration/targets/ansible-doc/library/bogus_facts
+++ b/test/integration/targets/ansible-doc/library/bogus_facts
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo '{
+    "changed": false,
+    "ansible_facts": {"nothing": "to report"},
+}'

--- a/test/integration/targets/ansible-doc/library/bogus_facts.py
+++ b/test/integration/targets/ansible-doc/library/bogus_facts.py
@@ -1,0 +1,6 @@
+DOCUMENTATION = """
+    module: bogus_facts
+    short_description: bad facts returned
+    version_added: historical
+    description: bogus facts for testing
+"""

--- a/test/integration/targets/ansible-doc/library/facts_one
+++ b/test/integration/targets/ansible-doc/library/facts_one
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+echo '{
+    "changed": false,
+    "ansible_facts": {"factsone": "from facts_one module"}
+}'

--- a/test/integration/targets/ansible-doc/library/facts_one.yml
+++ b/test/integration/targets/ansible-doc/library/facts_one.yml
@@ -1,0 +1,5 @@
+DOCUMENTATION:
+    module: facts_one
+    short_description: random facts returned
+    version_added: historical
+    description: random facts for testing

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -277,3 +277,9 @@ test "$(ansible-doc -l -t module --playbook-dir ./ 2>&1 1>/dev/null |grep -c "no
 
 echo "testing without playbook dir, builtin should return"
 ansible-doc -t filter split -v 2>&1 |grep "${GREP_OPTS[@]}" -v histerical
+
+echo "test 'sidecar' for no extension module  with .py doc"
+[ "$(ansible-doc -M ./library -l ansible.legacy |grep -v 'UNDOCUMENTED' |grep -c bogus_facts)" == "1" ]
+
+echo "test 'sidecar' for no extension module  with .yml doc"
+[ "$(ansible-doc -M ./library -l ansible.legacy |grep -v 'UNDOCUMENTED' |grep -c facts_one)" == "1" ]

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -61,6 +61,8 @@ lib/ansible/plugins/cache/base.py ansible-doc!skip  # not a plugin, but a stub f
 lib/ansible/plugins/callback/__init__.py pylint:arguments-renamed
 lib/ansible/plugins/inventory/advanced_host_list.py pylint:arguments-renamed
 lib/ansible/plugins/inventory/host_list.py pylint:arguments-renamed
+test/integration/targets/ansible-doc/library/bogus_facts shebang
+test/integration/targets/ansible-doc/library/facts_one shebang
 test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/integration/targets/hello/files/bad.py pylint:ansible-bad-function # ignore, required for testing
 test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/integration/targets/hello/files/bad.py pylint:ansible-bad-import-from # ignore, required for testing
 test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/integration/targets/hello/files/bad.py pylint:ansible-bad-import # ignore, required for testing


### PR DESCRIPTION
Fixed case in which listing modules for docs failed to get sidecar


(cherry picked from commit 7e495f4b2053ee133900e9b29688f106a8be5be4)

##### ISSUE TYPE

- Bugfix Pull Request
