### PR TITLE
Improve password lookup lock acquisition so it checks the error type

### DIFF
--- a/changelogs/fragments/fix-lookup-password-lock-acquisition.yml
+++ b/changelogs/fragments/fix-lookup-password-lock-acquisition.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - password lookup - fix acquiring the lock when human-readable FileExistsError error message is not English.

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -270,7 +270,7 @@ def _get_lock(b_path):
     b_pathdir = os.path.dirname(b_path)
     lockfile_name = to_bytes("%s.ansible_lockfile" % hashlib.sha1(b_path).hexdigest())
     lockfile = os.path.join(b_pathdir, lockfile_name)
-    if b_path != to_bytes('/dev/null'):
+    if b_path != b'/dev/null':
         makedirs_safe(b_pathdir, mode=0o700)
         with contextlib.suppress(FileExistsError):
             fd = os.open(lockfile, os.O_CREAT | os.O_EXCL)

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -126,6 +126,7 @@ _raw:
   elements: str
 """
 
+import contextlib
 import os
 import string
 import time
@@ -269,15 +270,12 @@ def _get_lock(b_path):
     b_pathdir = os.path.dirname(b_path)
     lockfile_name = to_bytes("%s.ansible_lockfile" % hashlib.sha1(b_path).hexdigest())
     lockfile = os.path.join(b_pathdir, lockfile_name)
-    if not os.path.exists(lockfile) and b_path != to_bytes('/dev/null'):
-        try:
-            makedirs_safe(b_pathdir, mode=0o700)
+    if b_path != to_bytes('/dev/null'):
+        makedirs_safe(b_pathdir, mode=0o700)
+        with contextlib.suppress(FileExistsError):
             fd = os.open(lockfile, os.O_CREAT | os.O_EXCL)
             os.close(fd)
             first_process = True
-        except OSError as e:
-            if e.strerror != 'File exists':
-                raise
 
     counter = 0
     # if the lock is got by other process, wait until it's released


### PR DESCRIPTION
##### SUMMARY

Might fix #85312, but also might be unrelated.

If I target the same password file in parallel, and the error message is in English, each task correctly waits for the lock. However if I run the same playbook with `LC_ALL=fr_FR.UTF-8`, a race condition doesn't result in waiting for the lock, it causes a task failure:

fatal: [host-1]: FAILED! => {"changed": false, "msg": "Task failed: Finalization of task args for 'ansible.builtin.set_fact' failed: Error while resolving value for 'newpass': The lookup plugin 'password' failed: [Errno 17] Le fichier existe: b'/tmp/test_password_lookup/defad067c7eb7a2a2b98164ca3d8517ed54a6eef.ansible_lockfile'"}

I'm not sure how to add a test to prevent regression, but tested it manually...

##### ISSUE TYPE

- Bugfix Pull Request
