### PR TITLE
Fix Typos in Integration Test Comments and Documentation

### DIFF
--- a/test/integration/targets/git/tasks/specific-revision.yml
+++ b/test/integration/targets/git/tasks/specific-revision.yml
@@ -139,7 +139,7 @@
     that:
       - 'git_result.stdout == test_branch_ref_head_id'
 
-# Test that a forced shallow checkout referincing branch only always fetches latest head
+# Test that a forced shallow checkout referencing branch only always fetches latest head
 
 - name: SPECIFIC-REVISION | clear checkout_dir
   file:

--- a/test/integration/targets/task-args/tasks/main.yml
+++ b/test/integration/targets/task-args/tasks/main.yml
@@ -1,4 +1,4 @@
-# DTFIX-FUTURE: finish the full precedence decscription in DT docs and include it here
+# DTFIX-FUTURE: finish the full precedence description in DT docs and include it here
 
 - name: validate templated raw params from the action statement and the args keyword are merged
   echo: '{{ vp }}'


### PR DESCRIPTION


**Description:**
This pull request corrects minor typographical errors in the integration test files:
- Fixed the spelling of "description" in `test/integration/targets/task-args/tasks/main.yml`.
- Fixed the spelling of "referencing" in a comment in `test/integration/targets/git/tasks/specific-revision.yml`.

