### PR TITLE
Add testing helpers to extract warnings and deprecations from module results

### DIFF
--- a/changelogs/fragments/85327-extract-warnings-deprecations.yml
+++ b/changelogs/fragments/85327-extract-warnings-deprecations.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - "Add test helpers ``extract_warnings_messages()`` and ``extract_deprecation_records()`` to ``ansible.module_utils.testing``
+     that allow to extract warnings and deprecation messages from module results without having to access ansible-core internals
+     (https://github.com/ansible/ansible/pull/85327)."

--- a/lib/ansible/module_utils/testing.py
+++ b/lib/ansible/module_utils/testing.py
@@ -12,6 +12,7 @@ import typing as _t
 from unittest import mock as _mock
 
 from ansible.module_utils.common import json as _common_json
+from ansible.module_utils._internal import _messages
 from . import basic as _basic
 
 
@@ -29,3 +30,33 @@ def patch_module_args(args: dict[str, _t.Any] | None = None) -> _t.Iterator[None
 
     with _mock.patch.object(_basic, '_ANSIBLE_ARGS', args), _mock.patch.object(_basic, '_ANSIBLE_PROFILE', profile):
         yield
+
+
+def extract_warnings_messages(results: dict[str, _t.Any]) -> list[str]:
+    """Given the results dictionary of a module, extracts the warning messages as a list of strings."""
+    result = []
+    if isinstance(results.get("warnings"), list):
+        for warning in results["warnings"]:
+            if isinstance(warning, _messages.WarningSummary):
+                result.append(warning.event.msg)
+    return result
+
+
+class DeprecationMessage(_t.TypedDict):
+    msg: str
+    version: _t.Optional[str]
+    date: _t.Optional[str]
+
+
+def extract_deprecation_records(results: dict[str, _t.Any]) -> list[DeprecationMessage]:
+    """Given the results dictionary of a module, extracts the deprecation messages as a list of DeprecationMessage dicts."""
+    result: list[DeprecationMessage] = []
+    if isinstance(results.get("deprecations"), list):
+        for deprecation in results["deprecations"]:
+            if isinstance(deprecation, _messages.DeprecationSummary):
+                result.append({
+                    "msg": deprecation.event.msg,
+                    "version": deprecation.version,
+                    "date": deprecation.date,
+                })
+    return result


### PR DESCRIPTION
##### SUMMARY
Right now I have to use hacks like https://github.com/ansible-collections/community.internal_test_tools/blob/577f37c5402e0e0c352f9841ac582bd94ae7457a/tests/unit/plugins/modules/utils.py#L95-L114 to extract the warning messages, and this can break any time when internals of ansible-core change.

Ref: https://github.com/ansible/ansible/pull/85181#issuecomment-2893136560

##### ISSUE TYPE
- Feature Pull Request
- Test Pull Request
