### PR TITLE
ansible-test - Fix relative import resolution

### DIFF
--- a/changelogs/fragments/ansible-test-change-detection-fix.yml
+++ b/changelogs/fragments/ansible-test-change-detection-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix Python relative import resolution from ``__init__.py`` files when using change detection.

--- a/test/lib/ansible_test/_internal/classification/python.py
+++ b/test/lib/ansible_test/_internal/classification/python.py
@@ -221,6 +221,12 @@ def relative_to_absolute(name: str, level: int, module: str, path: str, lineno: 
     else:
         parts = module.split('.')
 
+        if path.endswith('/__init__.py'):
+            # Ensure the correct relative module is calculated for both not_init.py and __init__.py:
+            # a/b/not_init.py -> a.b.not_init  # used as-is
+            # a/b/__init__.py -> a.b           # needs "__init__" part appended to ensure relative imports work
+            parts.append('__init__')
+
         if level >= len(parts):
             display.warning('Cannot resolve relative import "%s%s" above module "%s" at %s:%d' % ('.' * level, name, module, path, lineno))
             absolute_name = 'relative.abovelevel'


### PR DESCRIPTION
##### SUMMARY

Fix Python relative import resolution from ``__init__.py`` files when using change detection.

##### ISSUE TYPE

Bugfix Pull Request
