### PR TITLE
Add type annotations to set_module_args

### DIFF
--- a/test/units/modules/conftest.py
+++ b/test/units/modules/conftest.py
@@ -15,16 +15,16 @@ assert module_env_mocker is not None  # avoid unused imports
 
 
 @pytest.fixture
-def set_module_args():
+def set_module_args() -> t.Iterator[t.Callable[[dict[str, t.Any] | None], None]]:
     ctx: t.ContextManager | None = None
 
-    def set_module_args(args):
+    def set_module_args(args: dict[str, t.Any] | None = None) -> None:
         nonlocal ctx
 
         args['_ansible_remote_tmp'] = '/tmp'
         args['_ansible_keep_remote_files'] = False
 
-        ctx = patch_module_args(args)
+        ctx = t.cast(t.ContextManager, patch_module_args(args))
         ctx.__enter__()
 
     try:


### PR DESCRIPTION
##### SUMMARY

Add type annotations to set_module_args.

This should hopefully correct the mypy error reported here: https://github.com/ansible/ansible/pull/85327#issuecomment-2972565665

##### ISSUE TYPE

Bugfix Pull Request
