### PR TITLE
Fix Typos in Comments and Task Names

### DIFF
--- a/test/integration/targets/prepare_http_tests/tasks/windows.yml
+++ b/test/integration/targets/prepare_http_tests/tasks/windows.yml
@@ -1,4 +1,4 @@
-# Server 2008 R2 uses a 3rd party program to foward the ports and it may
+# Server 2008 R2 uses a 3rd party program to forward the ports and it may
 # not be ready straight away, we give it at least 5 minutes before
 # conceding defeat
 - name: Windows - make sure the port forwarder is active

--- a/test/integration/targets/win_app_control/test_manifest.yml
+++ b/test/integration/targets/win_app_control/test_manifest.yml
@@ -125,7 +125,7 @@
   - >-
     res.msg is not contains("Failed to process signed manifest 'ansible_collections.ns.invalid_manifest.meta.powershell_signatures.psd1': expecting hash list entry for " ~ module_hash ~ " to contain a mode of 'Trusted' or 'Unsupported' but got ''.")
 
-- name: create manfiest with invalid Mode subkey value
+- name: create manifest with invalid Mode subkey value
   ansible.builtin.import_tasks: create_manifest.yml
   vars:
     manifest_file: manifest_v1_invalid_mode_subkey.psd1


### PR DESCRIPTION


Description:  
This pull request corrects two minor typos in the codebase:
- In `windows.yml`, the word "foward" is corrected to "forward" in a comment.
- In `test_manifest.yml`, the word "manfiest" is corrected to "manifest" in a task name.


