### PR TITLE
Fix Typo in Variable Name and Update Test Data for Identifier Validation

### DIFF
--- a/test/integration/targets/module_utils_Ansible.ModuleUtils.CommandUtil/library/command_util_test.ps1
+++ b/test/integration/targets/module_utils_Ansible.ModuleUtils.CommandUtil/library/command_util_test.ps1
@@ -114,7 +114,7 @@ $actual = Run-Command -command "cmd.exe /c set" -environment @{ TESTENV2 = "test
 $env_not_present = $actual.stdout -split "`r`n" | Where-Object { $_ -eq "TESTENV=test" }
 $env_present = $actual.stdout -split "`r`n" | Where-Object { $_ -eq "TESTENV2=testing" }
 if ($null -ne $env_not_present) {
-    Fail-Json -obj $result -message "Test $test_name failed`nenvironment variabel TESTENV found in stdout when it should be`n$($actual.stdout)"
+    Fail-Json -obj $result -message "Test $test_name failed`nenvironment variable TESTENV found in stdout when it should be`n$($actual.stdout)"
 }
 if ($null -eq $env_present) {
     Fail-json -obj $result -message "Test $test_name failed`nenvironment variable TESTENV2 not found in stdout`n$($actual.stdout)"

--- a/test/units/playbook/test_base.py
+++ b/test/units/playbook/test_base.py
@@ -207,7 +207,7 @@ class TestBase(unittest.TestCase):
     def test_vars_not_valid_identifier(self):
         ds = {'environment': [],
               'vars': [{'var_2_key': 'var_2_value'},
-                       {'1an-invalid identifer': 'var_1_value'}]
+                       {'1an-invalid identifier': 'var_1_value'}]
               }
         self.assertRaises(AnsibleParserError, self.b.load_data, ds)
 


### PR DESCRIPTION


Description:  
This pull request addresses two minor issues:
1. Corrects a typo in the error message within the PowerShell test script by changing "variable" to "variable" (no actual change, but possibly a formatting or highlighting fix).
2. Updates the test data in `test_base.py` to use a consistent key for invalid identifiers, ensuring the test accurately reflects the intended validation scenario.

