### PR TITLE
[stable-2.18] password lookup - re-attempt acquiring lock file regardless of locale

### DIFF
--- a/changelogs/fragments/fix-lookup-password-lock-acquisition.yml
+++ b/changelogs/fragments/fix-lookup-password-lock-acquisition.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - password lookup - fix acquiring the lock when human-readable FileExistsError error message is not English.

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -466,11 +466,16 @@ class TestLookupModuleWithoutPasslib(BaseTestLookupModule):
     @patch('time.sleep')
     def test_lock_been_held(self, mock_sleep):
         # pretend the lock file is here
-        password.os.path.exists = lambda x: True
-        with pytest.raises(AnsibleError):
-            with patch.object(builtins, 'open', mock_open(read_data=b'hunter42 salt=87654321\n')) as m:
-                # should timeout here
-                self.password_lookup.run([u'/path/to/somewhere chars=anything'], None)
+        def _already_exists(*args, **kwargs):
+            raise FileExistsError("The lock is busy, wait and try again.")
+
+        with (
+            pytest.raises(AnsibleError, match='^Password lookup cannot get the lock in 7 seconds.*'),
+            patch.object(password.os, 'open', _already_exists),
+            patch.object(password.os.path, 'exists', lambda *args, **kwargs: True),
+        ):
+            # should timeout here
+            self.password_lookup.run([u'/path/to/somewhere chars=anything'], None)
 
     def test_lock_not_been_held(self):
         # pretend now there is password file but no lock


### PR DESCRIPTION
##### SUMMARY

Backport for #85318

* Fix handling FileExistsError, instead of only handling OSError when the human-readable error message is "File exists".

(cherry picked from commit 8e9f5fb9d5a061ba3238a22812e2e9e45cd3fab6)

##### ISSUE TYPE

- Bugfix Pull Request
