### PR TITLE
coverage: skip output/* directory

### DIFF
--- a/test/lib/ansible_test/_internal/coverage_util.py
+++ b/test/lib/ansible_test/_internal/coverage_util.py
@@ -300,7 +300,10 @@ omit =
         coverage_config += """
 include =
      %s/*
-""" % data_context().content.root
+
+omit =
+    %s/*
+""" % (data_context().content.root, os.path.join(data_context().content.root, data_context().content.results_path))
 
     return coverage_config
 


### PR DESCRIPTION
##### SUMMARY

Skip coverage for tests/output/* directory

Fixes: #84244

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE



- Test Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_internal/coverage_util.py

