### PR TITLE
Fix typos in test files

### DIFF
--- a/test/integration/targets/callback-dispatch/callback_plugins/legacy_warning_display.py
+++ b/test/integration/targets/callback-dispatch/callback_plugins/legacy_warning_display.py
@@ -27,7 +27,7 @@ class CallbackModule(CallbackBase):
         'v2_playbook_on_include', 'v2_runner_on_start',
     }
 
-    # we're abusing runtime assertions to signify failure in this integration test component; ensure they're not disabled by opimizations
+    # we're abusing runtime assertions to signify failure in this integration test component; ensure they're not disabled by optimizations
     try:
         assert False
     except AssertionError:

--- a/test/units/module_utils/basic/test_atomic_move.py
+++ b/test/units/module_utils/basic/test_atomic_move.py
@@ -135,7 +135,7 @@ def test_no_tty_fallback(atomic_am, atomic_mocks, fake_stat, mocker):
 
 @pytest.mark.parametrize('stdin', [{}], indirect=['stdin'])
 def test_existing_file_stat_failure(atomic_am, atomic_mocks, mocker):
-    """Failure to stat an existing file in order to copy permissions propogates the error (unless EPERM)"""
+    """Failure to stat an existing file in order to copy permissions propagates the error (unless EPERM)"""
     atomic_mocks['copystat'].side_effect = FileNotFoundError('testing os copystat with non EPERM error')
     atomic_mocks['path_exists'].return_value = True
 


### PR DESCRIPTION


### Description

This PR corrects a couple of typos found in comments and docstrings within the test suite.

- Fixed a typo (`opimizations` → `optimizations`) in a comment in `test/integration/targets/callback-dispatch/callback_plugins/legacy_warning_display.py`.
- Fixed a typo (`propogates` → `propagates`) in a docstring in `test/units/module_utils/basic/test_atomic_move.py`.