### PR TITLE
[stable-2.18] meta: Avoid traceback when retrieving the meta task name

### DIFF
--- a/changelogs/fragments/meta_raw_params.yml
+++ b/changelogs/fragments/meta_raw_params.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+   - meta - avoid traceback when retrieving the meta task name (https://github.com/ansible/ansible/issues/85367).

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -137,9 +137,8 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
     def __repr__(self):
         ''' returns a human-readable representation of the task '''
         if self.action in C._ACTION_META:
-            return "TASK: meta (%s)" % self.args['_raw_params']
-        else:
-            return "TASK: %s" % self.get_name()
+            return "TASK: meta (%s)" % self.args.get('_raw_params')
+        return "TASK: %s" % self.get_name()
 
     def _preprocess_with_loop(self, ds, new_ds, k, v):
         ''' take a lookup plugin name and store it correctly '''


### PR DESCRIPTION
##### SUMMARY

Fixes: #85367

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/meta_raw_params.yml
lib/ansible/playbook/task.py


