### PR TITLE
[stable-2.18] Use f40 official repo for libdnf5

### DIFF
--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -892,8 +892,6 @@
         that:
           - enable_plugin_result is failed
           - disable_plugin_result is failed
-          - '"No matches were found for the following plugin name patterns while enabling libdnf5 plugins: " in enable_plugin_result.msg'
-          - '"No matches were found for the following plugin name patterns while disabling libdnf5 plugins: " in disable_plugin_result.msg'
-          - '"nonexisting" in enable_plugin_result.msg'
-          - '"nonexisting" in disable_plugin_result.msg'
+          - enable_plugin_result.msg is contains("'enable_plugin' requires python3-libdnf5 5.2.0.0+")
+          - disable_plugin_result.msg is contains("'disable_plugin' requires python3-libdnf5 5.2.0.0+")
   when: dnf5|default(false)

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -651,7 +651,7 @@
     - assert:
         that:
           - r is failed
-          - r.msg is contains("Couldn't open file")
+          - r.msg is contains("Couldn't open file") or r.msg is contains("Failed to download metadata")
   always:
     - file:
         name: /etc/yum.repos.d/{{ repo_name }}.repo

--- a/test/integration/targets/dnf5/playbook.yml
+++ b/test/integration/targets/dnf5/playbook.yml
@@ -1,9 +1,7 @@
 - hosts: localhost
   tasks:
     - block:
-        - command: "dnf install -y 'dnf-command(copr)'"
-        - command: dnf copr enable -y rpmsoftwaremanagement/dnf-nightly
-        - command: dnf install -y -x condor python3-libdnf5
+        - command: dnf install -y python3-libdnf5
 
         - include_role:
             name: dnf


### PR DESCRIPTION
##### SUMMARY
The dnf5 nightly repo for Fedora 40 is EOL.
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Test Pull Request
