### PR TITLE
Fix async_dir variable expansion to match remote_tmp

### DIFF
--- a/changelogs/fragments/85370-async-dir-variable-expansion-fix.yml
+++ b/changelogs/fragments/85370-async-dir-variable-expansion-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - async_wrapper - fix variable expansion in async_dir to match remote_tmp behavior (https://github.com/ansible/ansible/issues/85370).

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -241,7 +241,7 @@ def main():
     async_dir = os.environ.get('ANSIBLE_ASYNC_DIR', '~/.ansible_async')
 
     # setup job output directory
-    jobdir = os.path.expanduser(async_dir)
+    jobdir = os.path.expanduser(os.path.expandvars(async_dir))
     global job_path
     job_path = os.path.join(jobdir, jid)
 

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -279,7 +279,18 @@
   - name: remove custom tmp dir after test
     file:
       path: '{{ custom_async_tmp }}'
-      state: absent
+
+- name: test async with $HOME variable expansion
+  command: echo "test"
+  async: 5
+  poll: 1
+  vars:
+    ansible_async_dir: "$HOME/.ansible_test_var_expansion"
+
+- name: verify $HOME was expanded and cleanup
+  file:
+    path: "{{ ansible_env.HOME }}/.ansible_test_var_expansion"
+    state: absent
 
 - name: Test that async has stdin
   command: >


### PR DESCRIPTION
##### SUMMARY

Fix async_dir variable expansion to match remote_tmp behavior.

The async_wrapper module was using `os.path.expanduser()`. This caused shell variables like `$HOME` to be treated as literal directory names, resulting in directories like `/home/admin/$HOME` being created.

Adds `os.path.expandvars()` to the async directory setup in async_wrapper.py, and hopefully better aligns with the expansion behavior used by remote_tmp in basic.py.

I haven't addressed any ownership issues or made any changes to async_dir default, but can take a look at this if happy with current PR and this would be helpful.

Fixes #85370

##### ISSUE TYPE

- Bugfix Pull Request