### PR TITLE
Fix determining the current collection name if ansible_collections is in the path more than once

### DIFF
--- a/changelogs/fragments/84909-collection-name-from-nested-ansible_collections.yml
+++ b/changelogs/fragments/84909-collection-name-from-nested-ansible_collections.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- >-
+  ansible-doc - fix detecting collection name when more than one ``ansible_collections`` directory
+  is in the plugin path (https://github.com/ansible/ansible/issues/84909).

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -1170,10 +1170,13 @@ def _get_collection_name_from_path(path):
     path = _to_text(os.path.abspath(_to_bytes(path)))
 
     path_parts = path.split('/')
-    if path_parts.count('ansible_collections') != 1:
+
+    try:
+        last_ac = path_parts[::-1].index('ansible_collections')
+    except ValueError:
         return None
 
-    ac_pos = path_parts.index('ansible_collections')
+    ac_pos = len(path_parts) - 1 - last_ac
 
     # make sure it's followed by at least a namespace and collection name
     if len(path_parts) < ac_pos + 3:

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -212,11 +212,10 @@ output=$(ANSIBLE_LIBRARY='./nolibrary' ansible-doc --metadata-dump --playbook-di
 test "${output}" -eq 1
 
 # ensure --metadata-dump does not crash if the ansible_collections is nested (https://github.com/ansible/ansible/issues/84909)
-testdir="$(pwd)"
-pbdir="collections/ansible_collections/testns/testcol/playbooks"
-cd "$pbdir"
-ANSIBLE_COLLECTIONS_PATH="$testdir/$pbdir/collections" ansible-doc -vvv --metadata-dump --no-fail-on-errors
-cd "$testdir"
+pbdir="$(pwd)/collections/ansible_collections/testns/testcol/playbooks"
+pushd "$pbdir"
+ANSIBLE_COLLECTIONS_PATH="$pbdir/collections" ansible-doc -vvv --metadata-dump --no-fail-on-errors
+popd
 
 echo "test doc list on broken role metadata"
 # ensure that role doc does not fail when --no-fail-on-errors is supplied


### PR DESCRIPTION
##### SUMMARY

Possible alternative to #85361. Also includes a test case that can be copied into #85361 if that approach is preferable.

Fixes #84909

##### ISSUE TYPE

- Bugfix Pull Request
