### PR TITLE
Docs: fix small typo

### DIFF
--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -34,7 +34,7 @@ options:
         choices: [ reloaded, restarted, started, stopped ]
     enabled:
         description:
-            - Whether the unit should start on boot. At least one of O(state) and O(enabled) are required.
+            - Whether the unit should start on boot. At least one of O(state) or O(enabled) are required.
             - If set, requires O(name).
         type: bool
     force:


### PR DESCRIPTION
##### SUMMARY

Small typo on `systemd_service` doc


##### ISSUE TYPE

- Docs Pull Request
