### PR TITLE
Remove redundant vars FA on PlaybookInclude

### DIFF
--- a/lib/ansible/playbook/playbook_include.py
+++ b/lib/ansible/playbook/playbook_include.py
@@ -34,7 +34,6 @@ from ansible import constants as C
 class PlaybookInclude(Base, Conditional, Taggable):
 
     import_playbook = NonInheritableFieldAttribute(isa='string', required=True)
-    vars_val = NonInheritableFieldAttribute(isa='dict', default=dict, alias='vars')
 
     _post_validate_object = True  # manually post_validate to get free arg validation/coercion
 

--- a/test/integration/targets/include_import/playbook/playbook_using_a_var.yml
+++ b/test/integration/targets/include_import/playbook/playbook_using_a_var.yml
@@ -1,0 +1,6 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Verify an imported playbook can see a var it was given
+      assert:
+        that: pb_var == 'hello'

--- a/test/integration/targets/include_import/playbook/test_import_playbook.yml
+++ b/test/integration/targets/include_import/playbook/test_import_playbook.yml
@@ -20,3 +20,15 @@
 
 # https://github.com/ansible/ansible/issues/59548
 - import_playbook: sub_playbook/sub_playbook.yml
+
+- name: Use set_fact to declare a variable
+  hosts: localhost
+  gather_facts: no
+  tasks:
+    - set_fact:
+        a_var_from_set_fact: hello
+
+- name: Verify vars for import_playbook are not templated too early
+  import_playbook: playbook_using_a_var.yml
+  vars:
+    pb_var: "{{ a_var_from_set_fact }}"


### PR DESCRIPTION
##### SUMMARY
* The redundant FA declaration was not static, which broke a number of automatic validation behaviors.
* Added tests to assert deferred validation and lack of templating on `import_playbook.vars`.

##### ISSUE TYPE
- Bugfix Pull Request
