### PR TITLE
fix displaying the delegate_to ansible_host value

### DIFF
--- a/changelogs/fragments/fix-displaying-delegate_to-ansible_host.yml
+++ b/changelogs/fragments/fix-displaying-delegate_to-ansible_host.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - callback plugins - fix displaying the rendered ``ansible_host`` variable with ``delegate_to`` (https://github.com/ansible/ansible/issues/84922).
+  - ssh connection - fix documented variables for the ``host`` option. Connection options can be configured with delegated variables in general.

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -34,8 +34,6 @@ DOCUMENTATION = """
                - name: inventory_hostname
                - name: ansible_host
                - name: ansible_ssh_host
-               - name: delegated_vars['ansible_host']
-               - name: delegated_vars['ansible_ssh_host']
       host_key_checking:
           description: Determines if SSH should reject or not a connection after checking host keys.
           default: True

--- a/test/integration/targets/delegate_to/delegate_vars_handling.yml
+++ b/test/integration/targets/delegate_to/delegate_vars_handling.yml
@@ -1,11 +1,3 @@
-- name: setup delegated host
-  hosts: localhost
-  gather_facts: false
-  tasks:
-    - add_host:
-        name: delegatetome
-        ansible_host: 127.0.0.4
-
 - name: ensure we dont use orig host vars if delegated one does not define them
   hosts: testhost
   gather_facts: false

--- a/test/integration/targets/delegate_to/delegate_vars_inventory
+++ b/test/integration/targets/delegate_to/delegate_vars_inventory
@@ -1,0 +1,2 @@
+[all]
+delegatetome ansible_host="{{ hostip }}" hostip="127.0.0.4"

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -57,7 +57,11 @@ ansible-playbook delegate_facts_block.yml -i inventory -v "$@"
 ansible-playbook test_delegate_to_loop_caching.yml -i inventory -v "$@"
 
 # ensure we are using correct settings when delegating
-ANSIBLE_TIMEOUT=3 ansible-playbook delegate_vars_handling.yml -i inventory -v "$@"
+ANSIBLE_TIMEOUT=3 ansible-playbook delegate_vars_handling.yml -i inventory -i delegate_vars_inventory -v | tee out
+if grep '{{ hostip }}' out; then
+  echo 'Callback displayed the ansible_host template instead of the rendered value.'
+  exit 1
+fi
 
 ansible-playbook has_hostvars.yml -i inventory -v "$@"
 

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -210,8 +210,8 @@ class TestConnectionBaseClass(unittest.TestCase):
         mock_ospe.return_value = True
         conn._build_command.return_value = 'some command to run'
         conn._bare_run.return_value = (0, '', '')
-        conn.host = "some_host"
 
+        conn.set_option("host", "some_host")
         conn.set_option('reconnection_retries', 9)
         conn.set_option('ssh_transfer_method', None)  # default is smart
 
@@ -261,8 +261,8 @@ class TestConnectionBaseClass(unittest.TestCase):
 
         conn._build_command.return_value = 'some command to run'
         conn._bare_run.return_value = (0, '', '')
-        conn.host = "some_host"
 
+        conn.set_option("host", "some_host")
         conn.set_option('reconnection_retries', 9)
         conn.set_option('ssh_transfer_method', None)  # default is smart
 


### PR DESCRIPTION
##### SUMMARY

Fixes #84922.

The task executor returns delegate_to variables without templating them, causing https://github.com/ansible/ansible/blob/stable-2.19/lib/ansible/plugins/callback/__init__.py#L254 to potentially result in a template string.

##### ISSUE TYPE

- Bugfix Pull Request
