### PR TITLE
Short-circuit legacy network module prefix->action mapping

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -1129,7 +1129,7 @@ class TaskExecutor:
         # let action plugin override module, fallback to 'normal' action plugin otherwise
         elif self._shared_loader_obj.action_loader.has_plugin(self._task.action, collection_list=collections):
             handler_name = self._task.action
-        elif all((module_prefix in C.NETWORK_GROUP_MODULES, self._shared_loader_obj.action_loader.has_plugin(network_action, collection_list=collections))):
+        elif module_prefix in C.NETWORK_GROUP_MODULES and self._shared_loader_obj.action_loader.has_plugin(network_action, collection_list=collections):
             handler_name = network_action
             display.vvvv("Using network group action {handler} for {action}".format(handler=handler_name,
                                                                                     action=self._task.action),

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -273,8 +273,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         self.assertIs(mock.sentinel.handler, handler)
 
-        action_loader.has_plugin.assert_has_calls([mock.call(action, collection_list=te._task.collections),
-                                                   mock.call(module_prefix, collection_list=te._task.collections)])
+        action_loader.has_plugin.assert_has_calls([mock.call(action, collection_list=te._task.collections)])
 
         action_loader.get.assert_called_with(
             'ansible.legacy.normal', task=te._task, connection=te._connection,


### PR DESCRIPTION
##### SUMMARY
* Modified a non-short-circuit compound conditional in a legacy networking path that attempted to resolve an action for any module name containing `_`. The bug was always present, but the typical presentation (an ImportError) was ignored prior to 2.19.
* The legacy networking path should be deprecated and removed in 2.20- a module could still be run under the wrong action if one with a matching prefix is found.

fixes #85394


##### ISSUE TYPE
Bugfix Pull Request
