### PR TITLE
ansible-test - Upgrade coverage to 7.9.1

### DIFF
--- a/changelogs/fragments/ansible-test-coverage-upgrade.yml
+++ b/changelogs/fragments/ansible-test-coverage-upgrade.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - ansible-test - Upgrade to ``coverage`` version 7.9.1 for Python 3.9 and later.

--- a/test/lib/ansible_test/_data/requirements/ansible-test.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible-test.txt
@@ -1,2 +1,3 @@
 # The test-constraints sanity test verifies this file, but changes must be made manually to keep it in up-to-date.
-coverage == 7.6.1 ; python_version >= '3.8' and python_version <= '3.13'
+coverage == 7.9.1 ; python_version >= '3.9' and python_version <= '3.14'
+coverage == 7.6.1 ; python_version >= '3.8' and python_version <= '3.8'

--- a/test/lib/ansible_test/_internal/coverage_util.py
+++ b/test/lib/ansible_test/_internal/coverage_util.py
@@ -70,7 +70,8 @@ class CoverageVersion:
 
 COVERAGE_VERSIONS = (
     # IMPORTANT: Keep this in sync with the ansible-test.txt requirements file.
-    CoverageVersion('7.6.1', 7, (3, 8), (3, 13)),
+    CoverageVersion('7.9.1', 7, (3, 9), (3, 14)),
+    CoverageVersion('7.6.1', 7, (3, 8), (3, 8)),
 )
 """
 This tuple specifies the coverage version to use for Python version ranges.


### PR DESCRIPTION
##### SUMMARY

Upgrade to ``coverage`` version 7.9.1 for Python 3.9 and later.

##### ISSUE TYPE

Feature Pull Request
