### PR TITLE
[stable-2.19] Ensure config env/ini values are tagged (#85404)

### DIFF
--- a/test/integration/targets/lookup_template/tasks/ansible_managed.yml
+++ b/test/integration/targets/lookup_template/tasks/ansible_managed.yml
@@ -1,4 +1,3 @@
-# deprecated: description='ansible_managed has been removed' core_version='2.23'
 - name: invoke template lookup with content using default injected `ansible_managed`
   debug:
     msg: "{{ lookup('template', 'uses_ansible_managed.j2') }}"


### PR DESCRIPTION
##### SUMMARY

Backport of #85404

* Ensure config env/ini values are tagged

Config env and ini values now have origin and trust tags applied.

* Remove unused import (cherry picked from commit 6ff63391917cb62f0ebec338c2183d79143e9070)

##### ISSUE TYPE

Bugfix Pull Request
