### PR TITLE
Enhance to_nice_json filter to support custom separators

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -85,7 +85,6 @@ def to_json(a, profile: str | None = None, vault_to_text: t.Any = ..., preproces
 
 def to_nice_json(a, indent=4, sort_keys=True, separators=None, **kwargs):
     """Make verbose, human-readable JSON.
-    
     Args:
         a: The object to serialize
         indent: Number of spaces for indentation (default: 4)

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -83,11 +83,19 @@ def to_json(a, profile: str | None = None, vault_to_text: t.Any = ..., preproces
     return json.dumps(a, cls=cls, **kwargs)
 
 
-def to_nice_json(a, indent=4, sort_keys=True, **kwargs):
-    """Make verbose, human-readable JSON."""
-    # TODO separators can be potentially exposed to the user as well
-    kwargs.pop('separators', None)
-    return to_json(a, indent=indent, sort_keys=sort_keys, separators=(',', ': '), **kwargs)
+def to_nice_json(a, indent=4, sort_keys=True, separators=None, **kwargs):
+    """Make verbose, human-readable JSON.
+    
+    Args:
+        a: The object to serialize
+        indent: Number of spaces for indentation (default: 4)
+        sort_keys: Whether to sort dictionary keys (default: True)
+        separators: Tuple of (item_separator, key_separator) strings (default: (',', ': '))
+        **kwargs: Additional arguments passed to the JSON encoder
+    """
+    if separators is None:
+        separators = (',', ': ')
+    return to_json(a, indent=indent, sort_keys=sort_keys, separators=separators, **kwargs)
 
 
 # CAUTION: Do not put non-string values here since they can have unwanted logical equality, such as 1.0 (equal to 1 and True) or 0.0 (equal to 0 and False).

--- a/lib/ansible/plugins/filter/to_nice_json.yml
+++ b/lib/ansible/plugins/filter/to_nice_json.yml
@@ -47,9 +47,17 @@ DOCUMENTATION:
       description: Specifies an indentation level. Passed to an underlying C(json.dumps) call.
       default: 4
       type: int
+    separators:
+      description: |
+        A tuple of (item_separator, key_separator) strings to use when serializing.
+        If not specified, defaults to (',', ': ') for nice formatting.
+        Common alternatives are (',', ':') for compact output or custom separators for special formatting needs.
+      default: "(',', ': ')"
+      type: list
+      version_added: '2.18'
   notes:
     - Both O(vault_to_text) and O(preprocess_unsafe) defaulted to V(False) between Ansible 2.9 and 2.12.
-    - 'These parameters to C(json.dumps) will be ignored, they are overridden for internal use: I(cls), I(default), I(separators).'
+    - 'These parameters to C(json.dumps) will be ignored, they are overridden for internal use: I(cls), I(default).'
 
 EXAMPLES: |
   # dump variable in a template to create a nicely formatted JSON document

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -462,6 +462,9 @@
       - 'thing | to_nice_yaml == "subdict:\n    k1: v1\nsublist:\n- howdy\n"'
       - 'thing | to_json == "{\"sublist\": [\"howdy\"], \"subdict\": {\"k1\": \"v1\"}}"'
       - 'thing | to_nice_json == "{\n    \"subdict\": {\n        \"k1\": \"v1\"\n    },\n    \"sublist\": [\n        \"howdy\"\n    ]\n}"'
+      # Test custom separators
+      - 'thing | to_nice_json(separators=[",", ":"]) == "{\n    \"subdict\":{\n        \"k1\":\"v1\"\n    },\n    \"sublist\":[\n        \"howdy\"\n    ]\n}"'
+      - 'thing | to_nice_json(separators=[";  ", " = "]) == "{\n    \"subdict\" = {\n        \"k1\" = \"v1\"\n    };  \n    \"sublist\" = [\n        \"howdy\"\n    ]\n}"'
 
 - name: Verify from_yaml and from_yaml_all
   assert:


### PR DESCRIPTION
## Summary
This PR enhances the `to_nice_json` filter to support custom separators for JSON formatting.

## Changes
- Added `separators` parameter to `to_nice_json` function
- Updated documentation to include the new parameter
- Added comprehensive tests for custom separators functionality
- Maintains backward compatibility with default separators `(',', ': ')`

## Use Cases
- Compact JSON output using `(',', ':')`
- Custom separator formats for special formatting needs
- Improved flexibility while maintaining existing behavior

## Testing
- Added integration tests covering default, compact, and custom separator scenarios
- All existing tests continue to pass