### PR TITLE
Optimize retrieving role variables

### DIFF
--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -497,7 +497,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
 
         default_vars = dict()
         for dep in self.get_all_dependencies():
-            default_vars = combine_vars(default_vars, dep.get_default_vars())
+            default_vars = combine_vars(default_vars, dep._default_vars)
         if dep_chain:
             for parent in dep_chain:
                 default_vars = combine_vars(default_vars, parent._default_vars)
@@ -536,13 +536,17 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
         all_vars = self.get_inherited_vars(dep_chain, only_exports=only_exports)
 
         # get exported variables from meta/dependencies
+        # FIXME Combining deps' _role_vars can be optimized by moving it
+        #       into _load_role_data so it is done just once.
+        #       Same for _default_vars in self.get_default_vars().
+        #       Needs investigation.
         seen = []
         for dep in self.get_all_dependencies():
             # Avoid rerunning dupe deps since they can have vars from previous invocations and they accumulate in deps
             # TODO: re-examine dep loading to see if we are somehow improperly adding the same dep too many times
             if dep not in seen:
                 # only take 'exportable' vars from deps
-                all_vars = combine_vars(all_vars, dep.get_vars(include_params=False, only_exports=True))
+                all_vars = combine_vars(all_vars, dep._role_vars)
                 seen.append(dep)
 
         # role_vars come from vars/ in a role


### PR DESCRIPTION
##### SUMMARY
Optimize retrieving role variables

This patch optimizes performance of getting variables for a role by
changing two things:

1. In Role.get_default_vars() we called get_default_vars() recursively
   for all dependencies duplicating efforts. It is sufficient to just
   process _default_vars for all dependencies instead.

2. In Role.get_vars() we called dep.get_vars(include_params=False, only_exports=True)
   for all dependencies. Looking at what the call returns given the values
   of its arguments more closely it is just the dep's _role_vars. So
   replace the expensive call with dep._role_vars.

With these two changes the time to run a testing playbook with many
roles and variables goes down from:

35,19s user 4,15s system 100% cpu 39,185 total

to:

7,53s user 3,58s system 101% cpu 10,960 total

I also added a FIXME that would make the execution a bit more faster:

6,34s user 3,17s system 101% cpu 9,351 total

at the expense of the change being more invasive. Since the performance
improvement is very good with minimal changes already, we can do that
as a part of future changes.

ci_complete

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request