### PR TITLE
Adding unit tests for time-command.py

### DIFF
--- a/test/units/.azure-pipelines/scripts/test_time_command.py
+++ b/test/units/.azure-pipelines/scripts/test_time_command.py
@@ -1,0 +1,21 @@
+import pytest
+from unittest.mock import patch, MagicMock
+
+class TestTimeCommand:
+    def test_adds_timestamps(self):
+        
+        mock_stdin = MagicMock()
+        mock_stdout = MagicMock()
+        
+        # stdin returns one line
+        mock_stdin.__iter__ = lambda self: iter(["Hello\n"])
+        
+        with patch('sys.stdin', mock_stdin), \
+             patch('sys.stdout', mock_stdout), \
+             patch('time.time', side_effect=[0, 65]):
+            
+            exec(open('.azure-pipelines/scripts/time-command.py').read(), {'__name__': '__main__'})
+            
+            mock_stdout.write.assert_called_with("01:05 Hello\n")
+        
+       


### PR DESCRIPTION
##### SUMMARY
Add unit tests for `.azure-pipelines/scripts/time-command.py` which currently has no test coverage. This script prepends timestamps to output lines in CI/CD pipelines, helping developers understand how long each step takes.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
.azure-pipelines/scripts/time-command.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```config
devel
