### PR TITLE
special_vars are a flavor of host specific task vars

### DIFF
--- a/changelogs/fragments/36978-include-special-vars.yml
+++ b/changelogs/fragments/36978-include-special-vars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- includes - Looped hostvars in includes no longer breaks task serialization (https://github.com/ansible/ansible/issues/36978)

--- a/lib/ansible/playbook/handler.py
+++ b/lib/ansible/playbook/handler.py
@@ -71,3 +71,8 @@ class Handler(Task):
 
     def is_host_notified(self, host):
         return host in self.notified_hosts
+
+    def copy(self, exclude_parent: bool = False, exclude_tasks: bool = False) -> Task:
+        new_me = super().copy(exclude_parent, exclude_tasks)
+        new_me.notified_hosts = self.notified_hosts.copy()
+        return new_me

--- a/lib/ansible/playbook/handler.py
+++ b/lib/ansible/playbook/handler.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import typing as _t
+
 from ansible.errors import AnsibleAssertionError
 from ansible.playbook.attribute import NonInheritableFieldAttribute
 from ansible.playbook.task import Task
@@ -72,7 +74,7 @@ class Handler(Task):
     def is_host_notified(self, host):
         return host in self.notified_hosts
 
-    def copy(self, exclude_parent: bool = False, exclude_tasks: bool = False) -> Task:
-        new_me = super().copy(exclude_parent, exclude_tasks)
+    def copy(self, exclude_parent: bool = False, exclude_tasks: bool = False) -> Handler:
+        new_me = _t.cast(Handler, super().copy(exclude_parent, exclude_tasks))
         new_me.notified_hosts = self.notified_hosts.copy()
         return new_me

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -36,7 +36,7 @@ from ansible.vars.manager import VariableManager
 display = Display()
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class HV:
     host: Host
     vars: dict = field(compare=False, hash=False)

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass, field
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
@@ -35,6 +36,12 @@ from ansible.vars.manager import VariableManager
 display = Display()
 
 
+@dataclass(frozen=True)
+class HV:
+    host: Host
+    vars: dict = field(compare=False, hash=False)
+
+
 class IncludedFile:
     """Recombines include task results from multiple hosts into consolidated IncludedFile objects.
 
@@ -44,18 +51,26 @@ class IncludedFile:
     IncludedFile, allowing the strategy to load and process the included tasks once for all affected hosts.
     """
 
-    def __init__(self, filename, args, vars, task, is_role: bool = False) -> None:
+    def __init__(self, filename, args, task, is_role: bool = False) -> None:
         self._filename = filename
         self._args = args
-        self._vars = vars
         self._task = task
-        self._hosts: list[Host] = []
+        self._hvs: set[HV] = set()
         self._is_role = is_role
         self._results: list[HostTaskResult] = []
 
-    def add_host(self, host: Host) -> None:
-        if host not in self._hosts:
-            self._hosts.append(host)
+    @property
+    def _hosts(self) -> list[Host]:
+        return sorted((hv.host for hv in self._hvs), key=lambda host: host.name)
+
+    @property
+    def _vars(self) -> dict:
+        display.deprecated("The `IncludedFile._vars` attribute is no longer used.", version="2.25")
+        return {}
+
+    def add_host(self, host: HV) -> None:
+        if host not in self._hvs:
+            self._hvs.add(host)
             return
 
         raise ValueError()
@@ -66,12 +81,11 @@ class IncludedFile:
 
         return (other._filename == self._filename and
                 other._args == self._args and
-                other._vars == self._vars and
                 other._task._uuid == self._task._uuid and
                 other._task._parent._uuid == self._task._parent._uuid)
 
     def __repr__(self):
-        return "%s (args=%s vars=%s): %s" % (self._filename, self._args, self._vars, self._hosts)
+        return "%s (args=%s): %s" % (self._filename, self._args, self._hosts)
 
     @staticmethod
     def process_include_results(
@@ -202,7 +216,7 @@ class IncludedFile:
                             else:
                                 include_file = loader.path_dwim(include_utr.include_file)
 
-                        inc_file = IncludedFile(include_file, include_args, special_vars, original_task)
+                        inc_file = IncludedFile(include_file, include_args, original_task)
                     else:
                         # template the included role's name here
                         role_name = include_args.pop('name', include_args.pop('role', None))
@@ -214,7 +228,7 @@ class IncludedFile:
                                 from_key = from_arg.removesuffix('_from')
                                 new_task._from_files[from_key] = include_args.get(from_arg)
 
-                        inc_file = IncludedFile(role_name, include_args, special_vars, new_task, is_role=True)
+                        inc_file = IncludedFile(role_name, include_args, new_task, is_role=True)
 
                     # Deduplication loop handles multiple facets:
                     # 1. Cross-host consolidation: merge hosts with same (filename, args, vars, task) into one IncludedFile
@@ -235,7 +249,7 @@ class IncludedFile:
                             inc_file = orig_inc_file
 
                         try:
-                            inc_file.add_host(original_host)
+                            inc_file.add_host(HV(original_host, special_vars))
                             inc_file._results.append(res)
                         except ValueError:
                             # The host already exists for this include, advance forward, this is a new include

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -301,9 +301,12 @@ class CallbackModule(CallbackBase):
             return
 
         msg = 'included: %s for %s' % (included_file._filename, ", ".join([h.name for h in included_file._hosts]))
-        label = self._get_item_label(included_file._vars)
-        if label:
-            msg += " => (item=%s)" % label
+        labels = {self._get_item_label(hv.vars) for hv in included_file._hvs}
+        labels.discard(None)
+        if len(labels) == 1:
+            msg += " => (item=%s)" % labels.pop()
+        elif labels:
+            msg += " => (item=<various>)"
         self._display.display(msg, color=C.COLOR_INCLUDED)
 
     def v2_playbook_on_stats(self, stats):

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -776,11 +776,6 @@ class StrategyBase:
         """
         ti_copy = included_file._task.copy(exclude_parent=True)
         ti_copy._parent = included_file._task._parent
-
-        temp_vars = ti_copy.vars | included_file._vars
-
-        ti_copy.vars = temp_vars
-
         return ti_copy
 
     def _load_included_file(self, included_file: IncludedFile, iterator, is_handler=False):

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -770,14 +770,6 @@ class StrategyBase:
 
         return ret_results
 
-    def _copy_included_file(self, included_file: IncludedFile) -> TaskInclude | IncludeRole:
-        """
-        A proven safe and performant way to create a copy of an included file
-        """
-        ti_copy = included_file._task.copy(exclude_parent=True)
-        ti_copy._parent = included_file._task._parent
-        return ti_copy
-
     def _load_included_file(self, included_file: IncludedFile, iterator, is_handler=False):
         """
         Loads an included YAML file of tasks, applying the optional set of variables.
@@ -793,13 +785,13 @@ class StrategyBase:
         elif not isinstance(data, list):
             raise AnsibleError("included task files must contain a list of tasks", obj=data)
 
-        ti_copy = self._copy_included_file(included_file)
+        task = included_file._task
 
         block_list = load_list_of_blocks(
             data,
             play=iterator._play,
-            parent_block=ti_copy.build_parent_block(),
-            role=included_file._task._role,
+            parent_block=task.build_parent_block(),
+            role=task._role,
             use_handlers=is_handler,
             loader=self._loader,
             variable_manager=self._variable_manager,

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -230,9 +230,9 @@ class StrategyModule(StrategyBase):
                     is_handler = False
                     try:
                         if included_file._is_role:
-                            new_ir = self._copy_included_file(included_file)
+                            ir = included_file._task
 
-                            new_blocks, handler_blocks = new_ir.get_block_list(
+                            new_blocks, handler_blocks = ir.get_block_list(
                                 play=iterator._play,
                                 variable_manager=self._variable_manager,
                                 loader=self._loader,

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -266,8 +266,8 @@ class StrategyModule(StrategyBase):
                     else:
                         # since we skip incrementing the stats when the task result is
                         # first processed, we do so now for each host in the list
-                        for host in included_file._hosts:
-                            self._tqm._stats.increment('ok', host.name)
+                        for hv in included_file._hvs:
+                            self._tqm._stats.increment('ok', hv.host.name)
                         self._tqm.send_callback('v2_playbook_on_include', included_file)
 
                     for new_block in new_blocks:
@@ -283,9 +283,13 @@ class StrategyModule(StrategyBase):
                                 _hosts_all=self._hosts_cache_all,
                             )
                             final_block = new_block.filter_tagged_tasks(task_vars)
-                        for host in hosts_left:
-                            if host in included_file._hosts:
-                                all_blocks[host].append(final_block)
+
+                        for hv in included_file._hvs:
+                            if hv.host in hosts_left:
+                                fb_copy = final_block.copy(exclude_parent=True)
+                                fb_copy._parent = final_block._parent
+                                fb_copy.vars |= hv.vars
+                                all_blocks[hv.host].append(fb_copy)
                     display.debug("done collecting new blocks for %s" % included_file)
 
                 for host in failed_includes_hosts:

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -296,9 +296,12 @@ class StrategyModule(StrategyBase):
 
                                 included_tasks.extend(final_block.get_tasks())
 
-                                for host in hosts_left:
-                                    if host in included_file._hosts:
-                                        all_blocks[host].append(final_block)
+                                for hv in included_file._hvs:
+                                    if hv.host in hosts_left:
+                                        fb_copy = final_block.copy(exclude_parent=True)
+                                        fb_copy._parent = final_block._parent
+                                        fb_copy.vars |= hv.vars
+                                        all_blocks[hv.host].append(fb_copy)
 
                             display.debug("done iterating over new_blocks loaded from include file")
                         except AnsibleParserError:
@@ -318,8 +321,8 @@ class StrategyModule(StrategyBase):
                         else:
                             # since we skip incrementing the stats when the task result is
                             # first processed, we do so now for each host in the list
-                            for host in included_file._hosts:
-                                self._tqm._stats.increment('ok', host.name)
+                            for hv in included_file._hvs:
+                                self._tqm._stats.increment('ok', hv.host.name)
                             self._tqm.send_callback('v2_playbook_on_include', included_file)
 
                     for host in failed_includes_hosts:

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -258,9 +258,9 @@ class StrategyModule(StrategyBase):
                         is_handler = False
                         try:
                             if included_file._is_role:
-                                new_ir = self._copy_included_file(included_file)
+                                ir = included_file._task
 
-                                new_blocks, handler_blocks = new_ir.get_block_list(
+                                new_blocks, handler_blocks = ir.get_block_list(
                                     play=iterator._play,
                                     variable_manager=self._variable_manager,
                                     loader=self._loader,

--- a/test/integration/targets/include_deduplication/aliases
+++ b/test/integration/targets/include_deduplication/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group4
+context/controller

--- a/test/integration/targets/include_deduplication/hosts
+++ b/test/integration/targets/include_deduplication/hosts
@@ -1,0 +1,7 @@
+localhost0
+localhost1
+localhost3
+
+[all:vars]
+ansible_connection=local
+ansible_python_interpreter={{ansible_playbook_python}}

--- a/test/integration/targets/include_deduplication/runme.sh
+++ b/test/integration/targets/include_deduplication/runme.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -eux
+
+export ANSIBLE_ROLES_PATH=../
+
+ansible-playbook -i hosts runme.yml "$@"

--- a/test/integration/targets/include_deduplication/runme.yml
+++ b/test/integration/targets/include_deduplication/runme.yml
@@ -1,0 +1,5 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: include_deduplication

--- a/test/integration/targets/include_deduplication/tasks/include_count.yml
+++ b/test/integration/targets/include_deduplication/tasks/include_count.yml
@@ -1,0 +1,2 @@
+- set_fact:
+    '{{ item }}': '{{ lookup("vars", item)|default(0)|int + 1}}'

--- a/test/integration/targets/include_deduplication/tasks/include_hostvar_based.yml
+++ b/test/integration/targets/include_deduplication/tasks/include_hostvar_based.yml
@@ -1,0 +1,6 @@
+- set_fact:
+    host_based_check: true
+
+- assert:
+    that:
+      - hostvars|dictsort|selectattr('1.host_based_check', 'defined')|map(attribute='0') == groups.all

--- a/test/integration/targets/include_deduplication/tasks/main.yml
+++ b/test/integration/targets/include_deduplication/tasks/main.yml
@@ -1,0 +1,22 @@
+- include_tasks:
+    file: include_count.yml
+  loop:
+    - apple
+    - banana
+    - orange
+    - banana
+    - apple
+    - apple
+
+- assert:
+    that:
+      - apple|int == 3
+      - banana|int == 2
+      - orange|int == 1
+
+- include_tasks:
+    file: include_hostvar_based.yml
+  loop:
+    - '{{ hostvar_based_loop_item }}'
+  vars:
+    hostvar_based_loop_item: '{{ groups.all.index(inventory_hostname) }}'


### PR DESCRIPTION
##### SUMMARY

special_vars are a flavor of host specific task vars. ci_complete

The issue here is that `IncludedVars` uses 5 things for uniqueness:

1. Included filename
2. Include args
3. "special" vars (primarily loop related variables)
4. task uuid
5. parent task uuid

There is currently a 1:1 relationship between `IncludedFile` and `special_vars`. So if the `loop` is dependent on a host variable, `special_vars` will differ per host, creating a 1:1 relationship between `IncludedFile` and `Host`. Whereas the expectation is to have a 1:many relationship.

This PR creates a new dataclass specifically for handling this, and removing the `vars` comparison, but continuing to link it with the host, but without changing the existing variable precedence.

So this change tracks the vars with the host, but doesn't use the vars for comparisons. It then creates copies of the task for the hosts, and merges the vars.

Another solution may be to add a new step in the variable precendence rules for this use, instead of copying the task, and merging the task vars.

Reproducer:

```yaml
---
- hosts: all
  gather_facts: false
  vars:
    test_variable:
      - "{{ inventory_hostname[-1]|int }}"
  tasks:
    - include_tasks: do_something.yml
      loop: "{{ test_variable }}"
```

```ini
localhost0 ansible_connection=local
localhost1 ansible_connection=local
localhost2 ansible_connection=local
localhost3 ansible_connection=local
localhost4 ansible_connection=local

[all:vars]
ansible_python_interpreter={{ansible_playbook_python}}
```

##### ISSUE TYPE

- Bugfix Pull Request

##### Addditional Context

Outputs:

<details>
<summary>devel...</summary>
<p>

```
TASK [include_tasks] ***********************************************************
included: /Users/sivel/projects/ansibledev/playbooks/36978/do_something.yml for localhost0
included: /Users/sivel/projects/ansibledev/playbooks/36978/do_something.yml for localhost1 => (item=1)
included: /Users/sivel/projects/ansibledev/playbooks/36978/do_something.yml for localhost2 => (item=2)
included: /Users/sivel/projects/ansibledev/playbooks/36978/do_something.yml for localhost3 => (item=3)
included: /Users/sivel/projects/ansibledev/playbooks/36978/do_something.yml for localhost4 => (item=4)

TASK [debug] *******************************************************************
ok: [localhost0] => {
    "msg": "0 something"
}

TASK [debug] *******************************************************************
ok: [localhost1] => {
    "msg": "1 something"
}

TASK [debug] *******************************************************************
ok: [localhost2] => {
    "msg": "2 something"
}

TASK [debug] *******************************************************************
ok: [localhost3] => {
    "msg": "3 something"
}

TASK [debug] *******************************************************************
ok: [localhost4] => {
    "msg": "4 something"
}
```

</p>
</details>

<details>
<summary>This PR...</summary>
<p>

```
TASK [include_tasks] ***********************************************************
included: /Users/sivel/projects/ansibledev/playbooks/36978/do_something.yml for localhost0, localhost1, localhost2, localhost3, localhost4 => (item=<various>)

TASK [debug] *******************************************************************
ok: [localhost0] => {
    "msg": "0 something"
}
ok: [localhost1] => {
    "msg": "1 something"
}
ok: [localhost2] => {
    "msg": "2 something"
}
ok: [localhost3] => {
    "msg": "3 something"
}
ok: [localhost4] => {
    "msg": "4 something"
}
```

</p>
</details>