### PR TITLE
Drop incidental network tests from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -220,15 +220,6 @@ stages:
               test: 2025/psrp/http
             - name: 2025 SSH Key
               test: 2025/ssh/key
-  - stage: Incidental
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: i/{0}/1
-          targets:
-            - name: IOS Python
-              test: ios/csr1000v/
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
@@ -240,6 +231,5 @@ stages:
       - Galaxy
       - Generic
       - Incidental_Windows
-      - Incidental
     jobs:
       - template: templates/coverage.yml


### PR DESCRIPTION
##### SUMMARY

Support for provisioning the remote instance required for this test is going away.

##### ISSUE TYPE

Test Pull Request
