### PR TITLE
Usage of 'sleep' parameter in ansible.builtin.wait_for_connection

### DIFF
--- a/lib/ansible/modules/wait_for_connection.py
+++ b/lib/ansible/modules/wait_for_connection.py
@@ -108,10 +108,10 @@ EXAMPLES = r"""
     ansible.builtin.wait_for_connection:
       timeout: 900
       
- - name: Wait for server to become reachable, polling every 10 seconds
-   ansible.builtin.wait_for_connection:
-    timeout: 300
-    sleep: 10
+  - name: Wait for server to become reachable, polling every 10 seconds
+    ansible.builtin.wait_for_connection:
+      timeout: 300
+      sleep: 10
 
   - name: Gather facts for first time
     ansible.builtin.setup:

--- a/lib/ansible/modules/wait_for_connection.py
+++ b/lib/ansible/modules/wait_for_connection.py
@@ -103,7 +103,6 @@ EXAMPLES = r"""
         runonce:
         - cmd.exe /c winrm.cmd quickconfig -quiet -force
     delegate_to: localhost
-    
 
   - name: Wait for system to become reachable over WinRM
     ansible.builtin.wait_for_connection:

--- a/lib/ansible/modules/wait_for_connection.py
+++ b/lib/ansible/modules/wait_for_connection.py
@@ -107,7 +107,6 @@ EXAMPLES = r"""
   - name: Wait for system to become reachable over WinRM
     ansible.builtin.wait_for_connection:
       timeout: 900
-      
   - name: Wait for server to become reachable, polling every 10 seconds
     ansible.builtin.wait_for_connection:
       timeout: 300

--- a/lib/ansible/modules/wait_for_connection.py
+++ b/lib/ansible/modules/wait_for_connection.py
@@ -104,13 +104,9 @@ EXAMPLES = r"""
         - cmd.exe /c winrm.cmd quickconfig -quiet -force
     delegate_to: localhost
 
-  - name: Wait for system to become reachable over WinRM
+  - name: Wait for system to become reachable over WinRM, polling every 10 seconds
     ansible.builtin.wait_for_connection:
       timeout: 900
-
-  - name: Wait for server to become reachable, polling every 10 seconds
-    ansible.builtin.wait_for_connection:
-      timeout: 300
       sleep: 10
 
   - name: Gather facts for first time

--- a/lib/ansible/modules/wait_for_connection.py
+++ b/lib/ansible/modules/wait_for_connection.py
@@ -103,10 +103,16 @@ EXAMPLES = r"""
         runonce:
         - cmd.exe /c winrm.cmd quickconfig -quiet -force
     delegate_to: localhost
+    
 
   - name: Wait for system to become reachable over WinRM
     ansible.builtin.wait_for_connection:
       timeout: 900
+      
+ - name: Wait for server to become reachable, polling every 10 seconds
+   ansible.builtin.wait_for_connection:
+    timeout: 300
+    sleep: 10
 
   - name: Gather facts for first time
     ansible.builtin.setup:

--- a/lib/ansible/modules/wait_for_connection.py
+++ b/lib/ansible/modules/wait_for_connection.py
@@ -107,6 +107,7 @@ EXAMPLES = r"""
   - name: Wait for system to become reachable over WinRM
     ansible.builtin.wait_for_connection:
       timeout: 900
+
   - name: Wait for server to become reachable, polling every 10 seconds
     ansible.builtin.wait_for_connection:
       timeout: 300


### PR DESCRIPTION
##### SUMMARY

- Adds a task demonstrating the use of the 'sleep' parameter to control polling intervals when waiting for target hosts to become reachable. 
- 
##### ISSUE TYPE
- Docs Pull Request
