### PR TITLE
dnf/dnf5: remove deprecated install_repoquery option 

### DIFF
--- a/changelogs/fragments/dnf-remove-install_repoquery.yml
+++ b/changelogs/fragments/dnf-remove-install_repoquery.yml
@@ -1,0 +1,2 @@
+removed_features:
+  - dnf/dnf5 - remove deprecated ``install_repoquery`` option.

--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -32,10 +32,6 @@ yumdnf_argument_spec = dict(
         enablerepo=dict(type='list', elements='str', default=[]),
         exclude=dict(type='list', elements='str', default=[]),
         installroot=dict(type='str', default="/"),
-        install_repoquery=dict(
-            type='bool', default=True,
-            removed_in_version='2.20', removed_from_collection='ansible.builtin',
-        ),
         install_weak_deps=dict(type='bool', default=True),
         list=dict(type='str'),
         name=dict(type='list', elements='str', aliases=['pkg'], default=[]),
@@ -85,7 +81,6 @@ class YumDnf(metaclass=ABCMeta):
         self.enablerepo = self.module.params.get('enablerepo', [])
         self.exclude = self.module.params['exclude']
         self.installroot = self.module.params['installroot']
-        self.install_repoquery = self.module.params['install_repoquery']
         self.install_weak_deps = self.module.params['install_weak_deps']
         self.list = self.module.params['list']
         self.names = [p.strip() for p in self.module.params['name']]

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -211,13 +211,6 @@ options:
     type: bool
     default: "no"
     version_added: "2.7"
-  install_repoquery:
-    description:
-      - This is effectively a no-op in DNF as it is not needed with DNF.
-      - This option is deprecated and will be removed in ansible-core 2.20.
-    type: bool
-    default: "yes"
-    version_added: "2.7"
   download_only:
     description:
       - Only download the packages, do not install them.

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -180,12 +180,6 @@ options:
         in the earlier transaction).
     type: bool
     default: "no"
-  install_repoquery:
-    description:
-      - This is effectively a no-op in DNF as it is not needed with DNF.
-      - This option is deprecated and will be removed in ansible-core 2.20.
-    type: bool
-    default: "yes"
   download_only:
     description:
       - Only download the packages, do not install them.

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -240,5 +240,3 @@ lib/ansible/utils/py3compat.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/utils/ssh_functions.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/vars/manager.py pylint:ansible-deprecated-version-comment  # TODO: 2.20
 lib/ansible/vars/plugins.py pylint:ansible-deprecated-version  # TODO: 2.20
-lib/ansible/modules/dnf.py validate-modules:ansible-deprecated-version  # TODO: 2.20
-lib/ansible/modules/dnf5.py validate-modules:ansible-deprecated-version  # TODO: 2.20


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/ansible/issues/85410
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Feature Pull Request
