### PR TITLE
[stable-2.18] ansible-test - Fix relative import resolution (#85328)

### DIFF
--- a/changelogs/fragments/ansible-test-change-detection-fix.yml
+++ b/changelogs/fragments/ansible-test-change-detection-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix Python relative import resolution from ``__init__.py`` files when using change detection.

--- a/test/lib/ansible_test/_internal/classification/python.py
+++ b/test/lib/ansible_test/_internal/classification/python.py
@@ -220,6 +220,12 @@ def relative_to_absolute(name: str, level: int, module: str, path: str, lineno: 
     else:
         parts = module.split('.')
 
+        if path.endswith('/__init__.py'):
+            # Ensure the correct relative module is calculated for both not_init.py and __init__.py:
+            # a/b/not_init.py -> a.b.not_init  # used as-is
+            # a/b/__init__.py -> a.b           # needs "__init__" part appended to ensure relative imports work
+            parts.append('__init__')
+
         if level >= len(parts):
             display.warning('Cannot resolve relative import "%s%s" above module "%s" at %s:%d' % ('.' * level, name, module, path, lineno))
             absolute_name = 'relative.abovelevel'


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/85328

(cherry picked from commit 093ac8df2deb009f3151481a5c029fdc257cb5ec)

##### ISSUE TYPE

Bugfix Pull Request
