### PR TITLE
[stable-2.19] Fixed string type in tags fieldattribute (#84655)

### DIFF
--- a/lib/ansible/playbook/taggable.py
+++ b/lib/ansible/playbook/taggable.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import typing as t
 
 from ansible.errors import AnsibleError
-from ansible.module_utils.six import string_types
 from ansible.module_utils.common.sentinel import Sentinel
 from ansible.module_utils._internal._datatag import AnsibleTagHelper
 from ansible.playbook.attribute import FieldAttribute
@@ -40,7 +39,7 @@ def _flatten_tags(tags: list[str | int]) -> list[str | int]:
 class Taggable:
 
     untagged = frozenset(['untagged'])
-    tags = FieldAttribute(isa='list', default=list, listof=(string_types, int), extend=True)
+    tags = FieldAttribute(isa='list', default=list, listof=(str, int), extend=True)
 
     def _load_tags(self, attr, ds):
         if isinstance(ds, list):

--- a/test/units/playbook/test_base.py
+++ b/test/units/playbook/test_base.py
@@ -332,6 +332,7 @@ class BaseSubClass(base.Base):
     test_attr_int = FieldAttribute(isa='int', always_post_validate=True)
     test_attr_float = FieldAttribute(isa='float', default=3.14159, always_post_validate=True)
     test_attr_list = FieldAttribute(isa='list', listof=(str,), always_post_validate=True)
+    test_attr_mixed_list = FieldAttribute(isa='list', listof=(str, int), always_post_validate=True)
     test_attr_list_no_listof = FieldAttribute(isa='list', always_post_validate=True)
     test_attr_list_required = FieldAttribute(isa='list', listof=(str,), required=True,
                                              default=list, always_post_validate=True)
@@ -517,6 +518,16 @@ class TestBaseSubClass(TestBase):
         ds = {'test_attr_list': string_list}
         bsc = self._base_validate(ds)
         self.assertEqual(string_list, bsc._test_attr_list)
+
+    def test_attr_mixed_list(self):
+        mixed_list = ['foo', 1]
+        ds = {'test_attr_mixed_list': mixed_list}
+        bsc = self._base_validate(ds)
+        self.assertEqual(mixed_list, bsc._test_attr_mixed_list)
+
+    def test_attr_mixed_list_invalid(self):
+        ds = {'test_attr_mixed_list': [['foo'], 1]}
+        self.assertRaises(AnsibleParserError, self._base_validate, ds)
 
     def test_attr_list_none(self):
         ds = {'test_attr_list': None}


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/84655

(cherry picked from commit 8207406306782657c8a74f825745e6d1592828f6)

##### ISSUE TYPE

Bugfix Pull Request
