### PR TITLE
Add AnsiballZ debugging support with debugpy

### DIFF
--- a/lib/ansible/_internal/_ansiballz/_builder.py
+++ b/lib/ansible/_internal/_ansiballz/_builder.py
@@ -5,8 +5,9 @@ import json
 
 import typing as t
 
+from ansible.errors import AnsibleError
 from ansible.module_utils._internal._ansiballz import _extensions
-from ansible.module_utils._internal._ansiballz._extensions import _pydevd, _coverage
+from ansible.module_utils._internal._ansiballz._extensions import _debugger, _debugpy, _pydevd, _coverage
 from ansible.constants import config
 
 _T = t.TypeVar('_T')
@@ -17,13 +18,14 @@ class ExtensionManager:
 
     def __init__(
         self,
-        debugger: _pydevd.Options | None = None,
+        debugger: _debugger.Options | None = None,
         coverage: _coverage.Options | None = None,
     ) -> None:
-        options = dict(
-            _pydevd=debugger,
+        options: dict[str, object] = dict(
             _coverage=coverage,
         )
+        if debugger:
+            options[debugger.ansiballz_extension] = debugger
 
         self._debugger = debugger
         self._coverage = coverage
@@ -52,7 +54,7 @@ class ExtensionManager:
         extension_options: dict[str, t.Any] = {}
 
         if self._debugger:
-            extension_options['_pydevd'] = dataclasses.replace(
+            extension_options[self._debugger.ansiballz_extension] = dataclasses.replace(
                 self._debugger,
                 source_mapping=self._get_source_mapping(),
             )
@@ -66,16 +68,16 @@ class ExtensionManager:
 
     def _get_source_mapping(self) -> dict[str, str]:
         """Get the source mapping, adjusting the source root as needed."""
-        if self._debugger.source_mapping:
-            source_mapping = {self._translate_path(key): value for key, value in self.source_mapping.items()}
+        if self._debugger and self._debugger.source_mapping:
+            source_mapping = {self._translate_path(key, self._debugger.source_mapping): value for key, value in self.source_mapping.items()}
         else:
             source_mapping = self.source_mapping
 
         return source_mapping
 
-    def _translate_path(self, path: str) -> str:
+    def _translate_path(self, path: str, debugger_mappings: dict[str, str]) -> str:
         """Translate a local path to a foreign path."""
-        for replace, match in self._debugger.source_mapping.items():
+        for replace, match in debugger_mappings.items():
             if path.startswith(match):
                 return replace + path[len(match) :]
 
@@ -85,7 +87,7 @@ class ExtensionManager:
     def create(cls, task_vars: dict[str, object]) -> t.Self:
         """Create an instance using the provided task vars."""
         return cls(
-            debugger=cls._get_options('_ANSIBALLZ_DEBUGGER_CONFIG', _pydevd.Options, task_vars),
+            debugger=cls._get_options('_ANSIBALLZ_DEBUGGER_CONFIG', _debugger.Options, task_vars),
             coverage=cls._get_options('_ANSIBALLZ_COVERAGE_CONFIG', _coverage.Options, task_vars),
         )
 
@@ -96,6 +98,21 @@ class ExtensionManager:
             return None
 
         data = json.loads(value) if isinstance(value, str) else value
+
+        if config_type == _debugger.Options:
+            if not (ext_name := data.get('ansiballz_extension', None)):
+                raise AnsibleError(f"Missing 'ansiballz_extension' in debugger config option {name!r}")
+
+            option_map = {
+                '_debugpy': _debugpy.Options,
+                '_pydevd': _pydevd.Options,
+            }
+            if config_sub_type := option_map.get(ext_name, None):
+                config_type = config_sub_type
+            else:
+                valid_options = ", ".join(option_map.keys())
+                raise AnsibleError(f"Unknown ansiballz_extension {ext_name!r} in debugger config option {name!r}. Must be one of {valid_options!r}.")
+
         options = config_type(**data)
 
         return options

--- a/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugger.py
+++ b/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugger.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import pathlib
+
+
+@dataclasses.dataclass(frozen=True)
+class Options:
+    """Base Debugger options for any debugging extension modules."""
+
+    ansiballz_extension: str
+    """The name of the AnsiballZ extension module to use."""
+    host: str = 'localhost'
+    """The host to connect the debugger to."""
+    port: int = 5678
+    """The port to connect the debugger to."""
+    source_mapping: dict[str, str] = dataclasses.field(default_factory=dict)
+    """
+    A mapping of source paths to provide to the debugger.
+    This setting is used internally by AnsiballZ and is not required unless Ansible CLI commands are run from a different system than your IDE.
+    In that scenario, use this setting instead of configuring source mapping in your IDE.
+    The key is a path known to the IDE.
+    The value is the same path as known to the Ansible CLI.
+    Both file paths and directories are supported.
+    """
+
+
+def setup_pydevd_source_mapping(options: Options) -> None:
+    """Setup the source mapping for pydevd based debuggers."""
+    temp_dir = pathlib.Path(__file__).parent.parent.parent.parent.parent.parent
+    path_mapping = [[key, str(temp_dir / value)] for key, value in options.source_mapping.items()]
+
+    os.environ['PATHS_FROM_ECLIPSE_TO_PYTHON'] = json.dumps(path_mapping)

--- a/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugpy.py
+++ b/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugpy.py
@@ -1,0 +1,88 @@
+"""
+Remote debugging support for AnsiballZ modules with debugpy.
+
+To use with VSCode:
+
+1) Choose an available port for VSCode to listen on (e.g. 5678).
+2) Ensure `debugpy` is installed for the interpreter(s) which will run the code being debugged.
+3) Create the following launch.json configuration
+
+    {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Python Debug Server",
+                "type": "debugpy",
+                "request": "attach",
+                "listen": {
+                    "host": "localhost",
+                    "port": 5678,
+                },
+            },
+            {
+                "name": "ansible-playbook main.yml",
+                "type": "debugpy",
+                "request": "launch",
+                "module": "ansible",
+                "args": [
+                    "playbook",
+                    "main.yml"
+                ],
+                "env": {
+                    "_ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG": "{\"ansiballz_extension\": \"_debugpy\", \"port\": 5678}"
+                },
+                "console": "integratedTerminal",
+            }
+        ],
+        "compounds": [
+            {
+                "name": "Test Module Debugging",
+                "configurations": [
+                    "Python Debug Server",
+                    "ansible-playbook main.yml"
+                ],
+                "stopAll": true
+            }
+        ]
+    }
+
+4) Set any desired breakpoints.
+5) Configure the Run and Debug view to use the "Test Module Debugging" compound configuration.
+6) Press F5 to start debugging.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import typing as t
+
+from . import _debugger
+
+HAS_DEBUGPY = False
+try:
+    import debugpy
+
+    HAS_DEBUGPY = True
+except ImportError:
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class Options(_debugger.Options):
+    """Debugger options for debugpy."""
+
+    connect: dict[str, object] = dataclasses.field(default_factory=dict)
+    """The options to pass to `debugpy.connect`."""
+
+
+def run(args: dict[str, t.Any]) -> None:  # pragma: nocover
+    """Enable remote debugging with debugpy."""
+
+    options = Options(**args)
+
+    _debugger.setup_pydevd_source_mapping(options)
+
+    debugpy.connect((options.host, options.port), **options.connect)
+
+    pass  # a convenient place to put a breakpoint post connection.

--- a/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_pydevd.py
+++ b/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_pydevd.py
@@ -1,5 +1,5 @@
 """
-Remote debugging support for AnsiballZ modules.
+Remote debugging support for AnsiballZ modules with pydevd.
 
 To use with PyCharm:
 
@@ -10,53 +10,38 @@ To use with PyCharm:
 5) Configure Ansible with the `_ANSIBALLZ_DEBUGGER_CONFIG` option.
    See `Options` below for the structure of the debugger configuration.
    Example configuration using an environment variable:
-     export _ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG='{"module": "pydevd_pycharm", "settrace": {"host": "localhost", "port": 5678, "suspend": false}}'
+     export _ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG='{"ansiballz_extension": "_pydevd", "port": 5978, "module": "pydevd_pycharm", "settrace": {"suspend": false}}'
 6) Set any desired breakpoints.
 7) Run Ansible commands.
-
-A similar process should work for other pydevd based debuggers, such as Visual Studio Code, but they have not been tested.
 """
 
 from __future__ import annotations
 
 import dataclasses
 import importlib
-import json
-import os
-import pathlib
 
 import typing as t
 
+from . import _debugger
+
 
 @dataclasses.dataclass(frozen=True)
-class Options:
+class Options(_debugger.Options):
     """Debugger options for pydevd and its derivatives."""
 
     module: str = 'pydevd'
     """The Python module which will be imported and which provides the `settrace` method."""
     settrace: dict[str, object] = dataclasses.field(default_factory=dict)
     """The options to pass to the `{module}.settrace` method."""
-    source_mapping: dict[str, str] = dataclasses.field(default_factory=dict)
-    """
-    A mapping of source paths to provide to pydevd.
-    This setting is used internally by AnsiballZ and is not required unless Ansible CLI commands are run from a different system than your IDE.
-    In that scenario, use this setting instead of configuring source mapping in your IDE.
-    The key is a path known to the IDE.
-    The value is the same path as known to the Ansible CLI.
-    Both file paths and directories are supported.
-    """
-
 
 def run(args: dict[str, t.Any]) -> None:  # pragma: nocover
-    """Enable remote debugging."""
+    """Enable remote debugging for pydevd."""
 
     options = Options(**args)
-    temp_dir = pathlib.Path(__file__).parent.parent.parent.parent.parent.parent
-    path_mapping = [[key, str(temp_dir / value)] for key, value in options.source_mapping.items()]
 
-    os.environ['PATHS_FROM_ECLIPSE_TO_PYTHON'] = json.dumps(path_mapping)
+    _debugger.setup_pydevd_source_mapping(options)
 
     debugging_module = importlib.import_module(options.module)
-    debugging_module.settrace(**options.settrace)
+    debugging_module.settrace(host=options.host, port=options.port, **options.settrace)
 
     pass  # when suspend is True, execution pauses here -- it's also a convenient place to put a breakpoint

--- a/test/lib/ansible_test/_internal/commands/shell/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/shell/__init__.py
@@ -109,8 +109,8 @@ def command_shell(args: ShellConfig) -> None:
         return
 
     if isinstance(con, LocalConnection) and isinstance(target_profile, DebuggableProfile) and target_profile.debugging_enabled:
-        # HACK: ensure the pydevd port visible in the shell is the forwarded port, not the original
-        args.metadata.debugger_settings = dataclasses.replace(args.metadata.debugger_settings, port=target_profile.pydevd_port)
+        # HACK: ensure the debugger port visible in the shell is the forwarded port, not the original
+        args.metadata.debugger_settings = dataclasses.replace(args.metadata.debugger_settings, port=target_profile.debugger_port)
 
     with metadata_context(args):
         interactive_shell(args, target_profile, con)

--- a/test/lib/ansible_test/_internal/debugging.py
+++ b/test/lib/ansible_test/_internal/debugging.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import dataclasses
+import importlib
 import json
 import os
 import re
+
+import typing as t
 
 from .util import (
     cache,
@@ -33,6 +36,154 @@ from . import (
     CommonConfig,
 )
 
+HAS_DEBUGPY = False
+try:
+    import debugpy as _debugpy
+    from debugpy.server import cli as _debugpy_cli
+
+    HAS_DEBUGPY = True
+except ImportError:
+    pass
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class PyDevDSettings(DebuggerSettings):
+    debug_type: str = 'pydevd'
+    package: str | None = None  # Auto-detected in post_init
+    port: int = 5678
+
+    module: str = ''  # Default set in post_init
+    """
+    The Python module to import.
+    This should be pydevd or a derivative.
+    If not provided it will be auto-detected.
+    """
+
+    args: list[str] = dataclasses.field(default_factory=list)
+    """
+    Arguments to pass to `pydevd` on the command line.
+    Used for running Ansible CLI programs only.
+    The `--client` and `--port` options will be provided by ansible-test.
+    """
+
+    settrace: dict[str, t.Any] = dataclasses.field(default_factory=dict)
+    """
+    Options to pass to the `{module}.settrace` method.
+    Used for running or ansible-test or AnsiballZ modules only.
+    The `host` and `port` options will be provided by ansible-test.
+    The `suspend` option defaults to `False`.
+    """
+
+    def __post_init__(self) -> None:
+        if not self.module:
+            if not self.package or 'pydevd-pycharm' in self.package:
+                module = 'pydevd_pycharm'
+            else:
+                module = 'pydevd'
+
+            object.__setattr__(self, 'module', module)
+
+        if self.package is None:
+            if self.module == 'pydevd_pycharm':
+                if pycharm_version := detect_pycharm_version():
+                    package = f'pydevd-pycharm~={pycharm_version}'
+                else:
+                    package = None
+            else:
+                package = 'pydevd'
+
+            object.__setattr__(self, 'package', package)
+
+        self.settrace.setdefault('suspend', False)
+
+        if port := detect_pydevd_port():
+            object.__setattr__(self, 'port', port)
+
+            if detect_pycharm_process():
+                # This only works with the default PyCharm debugger.
+                # Using it with PyCharm's "Python Debug Server" results in hangs in Ansible workers.
+                # Further investigation is required to understand the cause.
+                self.args + ['--multiprocess']
+
+
+    def activate_debugger(self, host: str, port: int) -> None:
+        module_name = self.module
+        debugging_module = importlib.import_module(module_name)
+        debugging_module.settrace(**self._get_settrace_arguments(host, port))
+
+    def get_ansiballz_config(self) -> dict[str, object]:
+        return dict(settrace=self.settrace)
+
+    def get_cli_arguments(self, host: str, port: int) -> list[str]:
+        return ['-m', 'pydevd', '--client', host, '--port', str(port)] + self.args + ['--file']
+
+    def get_environment_variables(self, source_mapping: dict[str, str]) -> dict[str, str]:
+        return dict(
+            PATHS_FROM_ECLIPSE_TO_PYTHON=json.dumps(list(source_mapping.items())),
+            PYDEVD_DISABLE_FILE_VALIDATION="1",
+        )
+
+    def _get_settrace_arguments(self, host: str, port: int) -> dict[str, object]:
+        """Get settrace arguments for pydevd."""
+        return self.settrace | dict(
+            host=host,
+            port=port,
+        )
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class DebugpySettings(DebuggerSettings):
+    debug_type: str = 'debugpy'
+    package: str | None = 'debugpy'
+    port: int = 5678
+
+    args: list[str] = dataclasses.field(default_factory=list)
+    """
+    Arguments to pass to `debugpy` on the command line.
+    Used for running Ansible CLI programs only.
+    The `--connect`, `--parent-session-pid`, and `--adapter-access-token` options will be provided by ansible-test.
+    """
+
+    connect: dict[str, object] = dataclasses.field(default_factory=dict)
+    """
+    Options to pass to the `debugpy.connect` method.
+    Used for running or ansible-test or AnsiballZ modules only.
+    The endpoint addr, `access_token`, and `parent_session_pid` options will be provided by ansible-test.
+    """
+
+    def __post_init__(self) -> None:
+        self.connect.setdefault('parent_session_pid', os.getpid())
+
+        if token := get_debugpy_access_token():
+            self.connect.setdefault('access_token', token)
+
+        if port := detect_debugpy_port():
+            object.__setattr__(self, 'port', port)
+
+    def activate_debugger(self, host: str, port: int) -> None:
+        if not HAS_DEBUGPY:
+            raise ImportError("debugpy is not installed, cannot activate debugger.")
+
+        _debugpy.connect((host, port), **self.connect)
+
+    def get_ansiballz_config(self) -> dict[str, object]:
+        return dict(connect=self.connect)
+
+    def get_cli_arguments(self, host: str, port: int) -> list[str]:
+        cli_args = ['-m', 'debugpy', '--connect', f"{host}:{port}", "--parent-session-pid", str(self.connect['parent_session_pid'])]
+        if access_token := self.connect.get('access_token'):
+            cli_args += ['--adapter-access-token', access_token]
+        if self.args:
+            cli_args += self.args
+
+        return cli_args
+
+    def get_environment_variables(self, source_mapping: dict[str, str]) -> dict[str, str]:
+        return dict(
+            PATHS_FROM_ECLIPSE_TO_PYTHON=json.dumps(list(source_mapping.items())),
+            PYDEVD_DISABLE_FILE_VALIDATION="1",
+        )
+
 
 def initialize_debugger(args: CommonConfig) -> None:
     """Initialize the debugger settings before delegation."""
@@ -48,52 +199,39 @@ def initialize_debugger(args: CommonConfig) -> None:
     load_debugger_settings(args)
 
 
-def parse_debugger_settings(value: str) -> DebuggerSettings:
+def parse_debugger_settings(value: str, debugger_type: type[DebuggerSettings] | None) -> DebuggerSettings:
     """Parse remote debugger settings and apply defaults."""
     try:
-        settings = DebuggerSettings(**json.loads(value))
+        debugger_values = json.loads(value)
+        if not debugger_type:
+            selected_type = debugger_values.get('debug_type', None)
+            match selected_type:
+                case 'pydevd':
+                    debugger_type = PyDevDSettings
+                case 'debugpy':
+                    debugger_type = DebugpySettings
+                case _:
+                    raise ApplicationError(f"Invalid debugger setting: unsupported debug_type '{selected_type}' for remote debugging.")
+
+        return debugger_type(**debugger_values)
+    except ApplicationError:
+        raise
     except Exception as ex:
         raise ApplicationError(f"Invalid debugger settings: {ex}") from ex
-
-    if not settings.module:
-        if not settings.package or 'pydevd-pycharm' in settings.package:
-            module = 'pydevd_pycharm'
-        else:
-            module = 'pydevd'
-
-        settings = dataclasses.replace(settings, module=module)
-
-    if settings.package is None:
-        if settings.module == 'pydevd_pycharm':
-            if pycharm_version := detect_pycharm_version():
-                package = f'pydevd-pycharm~={pycharm_version}'
-            else:
-                package = None
-        else:
-            package = 'pydevd'
-
-        settings = dataclasses.replace(settings, package=package)
-
-    settings.settrace.setdefault('suspend', False)
-
-    if port := detect_pydevd_port():
-        settings = dataclasses.replace(settings, port=port)
-
-        if detect_pycharm_process():
-            # This only works with the default PyCharm debugger.
-            # Using it with PyCharm's "Python Debug Server" results in hangs in Ansible workers.
-            # Further investigation is required to understand the cause.
-            settings = dataclasses.replace(settings, args=settings.args + ['--multiprocess'])
-
-    return settings
 
 
 def load_debugger_settings(args: EnvironmentConfig) -> None:
     """Load the remote debugger settings."""
+    debugger_type: type[DebuggerSettings] | None = None
+
     if args.metadata.debugger_flags.on_demand:
         # On-demand debugging only enables debugging if we're running under a debugger, otherwise it's a no-op.
 
-        if not detect_pydevd_port():
+        if detect_pydevd_port():
+            debugger_type = PyDevDSettings
+        elif detect_debugpy_port():
+            debugger_type = DebugpySettings
+        else:
             display.info('Debugging disabled because no debugger was detected.', verbosity=1)
             args.metadata.debugger_flags = DebuggerFlags.all(False)
             return
@@ -108,7 +246,7 @@ def load_debugger_settings(args: EnvironmentConfig) -> None:
         return
 
     value = os.environ.get('ANSIBLE_TEST_REMOTE_DEBUGGER') or '{}'
-    settings = parse_debugger_settings(value)
+    settings = parse_debugger_settings(value, debugger_type)
 
     display.info(f'>>> Debugger Settings\n{json.dumps(dataclasses.asdict(settings), indent=4)}', verbosity=3)
 
@@ -164,3 +302,20 @@ def detect_pycharm_process() -> Process | None:
 def get_current_process_cached() -> Process:
     """Return the current process. The result is cached."""
     return get_current_process()
+
+
+@cache
+def detect_debugpy_port() -> int | None:
+    """Return the port for the debugpy instance hosting this process, or `None` if not detected."""
+    if HAS_DEBUGPY and _debugpy.is_client_connected():
+        return _debugpy_cli.options.address[1]
+
+    return None
+
+@cache
+def get_debugpy_access_token() -> str | None:
+    """Return the access token for the debugpy instance hosting this process, or `None` if not detected."""
+    if HAS_DEBUGPY and _debugpy.is_client_connected():
+        return _debugpy_cli.options.adapter_access_token
+
+    return None

--- a/test/lib/ansible_test/_internal/host_profiles.py
+++ b/test/lib/ansible_test/_internal/host_profiles.py
@@ -295,7 +295,7 @@ class HostProfile(t.Generic[THostConfig], metaclass=abc.ABCMeta):
 class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
     """Base class for profiles remote debugging."""
 
-    __PYDEVD_PORT_KEY = 'pydevd_port'
+    __DEBUGGER_PORT_KEY = 'debugger_port'
     __DEBUGGING_FORWARDER_KEY = 'debugging_forwarder'
 
     @property
@@ -307,9 +307,9 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         return self.args.metadata.debugger_flags.ansiballz
 
     @property
-    def pydevd_port(self) -> int:
-        """The pydevd port to use."""
-        return self.state.get(self.__PYDEVD_PORT_KEY) or self.origin_pydev_port
+    def debugger_port(self) -> int:
+        """The debugger port to use."""
+        return self.state.get(self.__DEBUGGER_PORT_KEY) or self.origin_debugger_port
 
     @property
     def debugging_forwarder(self) -> SshProcess | None:
@@ -322,23 +322,23 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         self.cache[self.__DEBUGGING_FORWARDER_KEY] = value
 
     @property
-    def origin_pydev_port(self) -> int:
-        """The pydevd port on the origin."""
+    def origin_debugger_port(self) -> int:
+        """The debugger port on the origin."""
         return self.args.metadata.debugger_settings.port
 
     def enable_debugger_forwarding(self, ssh: SshConnectionDetail) -> None:
-        """Enable pydevd port forwarding from the origin."""
+        """Enable debugging port forwarding from the origin."""
         if not self.debugging_enabled:
             return
 
-        endpoint = ('localhost', self.origin_pydev_port)
+        endpoint = ('localhost', self.origin_debugger_port)
         forwards = [endpoint]
 
         self.debugging_forwarder = create_ssh_port_forwards(self.args, ssh, forwards)
 
         port_forwards = self.debugging_forwarder.collect_port_forwards()
 
-        self.state[self.__PYDEVD_PORT_KEY] = port = port_forwards[endpoint]
+        self.state[self.__DEBUGGER_PORT_KEY] = port = port_forwards[endpoint]
 
         display.info(f'Remote debugging of {self.name!r} is available on port {port}.', verbosity=1)
 
@@ -354,19 +354,6 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         display.info(f'Waiting for the {self.name!r} remote debugging SSH port forwarding process to terminate.', verbosity=1)
 
         self.debugging_forwarder.wait()
-
-    def get_pydevd_settrace_arguments(self) -> dict[str, object]:
-        """Get settrace arguments for pydevd."""
-        return self.args.metadata.debugger_settings.settrace | dict(
-            host="localhost",
-            port=self.pydevd_port,
-        )
-
-    def get_pydevd_environment_variables(self) -> dict[str, str]:
-        """Get environment variables needed to configure pydevd for debugging."""
-        return dict(
-            PATHS_FROM_ECLIPSE_TO_PYTHON=json.dumps(list(self.get_source_mapping().items())),
-        )
 
     def get_source_mapping(self) -> dict[str, str]:
         """Get the source mapping from the given metadata."""
@@ -396,10 +383,10 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
 
         display.info('Activating remote debugging of ansible-test.', verbosity=1)
 
-        os.environ.update(self.get_pydevd_environment_variables())
+        debugger_env = self.args.metadata.debugger_settings.get_environment_variables(self.get_source_mapping())
+        os.environ.update(debugger_env)
 
-        debugging_module = importlib.import_module(self.args.metadata.debugger_settings.module)
-        debugging_module.settrace(**self.get_pydevd_settrace_arguments())
+        self.args.metadata.debugger_settings.activate_debugger('localhost', self.debugger_port)
 
         pass  # pylint: disable=unnecessary-pass  # when suspend is True, execution pauses here -- it's also a convenient place to put a breakpoint
 
@@ -432,11 +419,16 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         Return config for remote debugging of AnsiballZ modules.
         When delegating, this function must be called after delegation.
         """
+        debugger_settings = self.args.metadata.debugger_settings
+        assert debugger_settings is not None
+
         debugger_config = dict(
-            module=self.args.metadata.debugger_settings.module,
-            settrace=self.get_pydevd_settrace_arguments(),
+            ansiballz_extension=f"_{debugger_settings.debug_type}",
+            host='localhost',
+            port=self.debugger_port,
             source_mapping=self.get_source_mapping(),
         )
+        debugger_config |= debugger_settings.get_ansiballz_config()
 
         display.info(f'>>> Debugger Config ({self.name} AnsiballZ)\n{json.dumps(debugger_config, indent=4)}', verbosity=3)
 
@@ -451,8 +443,8 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
             return {}
 
         debugger_config = dict(
-            args=['-m', 'pydevd', '--client', 'localhost', '--port', str(self.pydevd_port)] + self.args.metadata.debugger_settings.args + ['--file'],
-            env=self.get_pydevd_environment_variables(),
+            args=self.args.metadata.debugger_settings.get_cli_arguments('localhost', self.debugger_port),
+            env=self.args.metadata.debugger_settings.get_environment_variables(self.get_source_mapping()),
         )
 
         display.info(f'>>> Debugger Config ({self.name} Ansible CLI)\n{json.dumps(debugger_config, indent=4)}', verbosity=3)
@@ -597,9 +589,9 @@ class ControllerProfile(SshTargetHostProfile[ControllerConfig], PosixProfile[Con
         return self.controller_profile.name
 
     @property
-    def pydevd_port(self) -> int:
+    def debugger_port(self) -> int:
         """The pydevd port to use."""
-        return self.controller_profile.pydevd_port
+        return self.controller_profile.debugger_port
 
     def get_controller_target_connections(self) -> list[SshConnection]:
         """Return SSH connection(s) for accessing the host as a target from the controller."""

--- a/test/lib/ansible_test/_internal/metadata.py
+++ b/test/lib/ansible_test/_internal/metadata.py
@@ -155,44 +155,39 @@ class ChangeDescription:
         return changes
 
 
-@dataclasses.dataclass(frozen=True, kw_only=True)
-class DebuggerSettings:
+class DebuggerSettings(t.Protocol):
     """Settings for remote debugging."""
 
-    module: str | None = None
+    debug_type: str
     """
-    The Python module to import.
-    This should be pydevd or a derivative.
-    If not provided it will be auto-detected.
+    The name of the debugger type, e.g. `debugpy` or `pydevd`.
+    This name should be reflected by a module under the `ansible.module_utils._internal._ansiballz._extensions._{name}` namespace.
     """
 
-    package: str | None = None
+    package: str | None
     """
     The Python package to install for debugging.
     If `None` then the package will be auto-detected.
     If an empty string, then no package will be installed.
     """
 
-    settrace: dict[str, object] = dataclasses.field(default_factory=dict)
+    port: int
     """
-    Options to pass to the `{module}.settrace` method.
-    Used for running AnsiballZ modules only.
-    The `host` and `port` options will be provided by ansible-test.
-    The `suspend` option defaults to `False`.
-    """
-
-    args: list[str] = dataclasses.field(default_factory=list)
-    """
-    Arguments to pass to `pydevd` on the command line.
-    Used for running Ansible CLI programs only.
-    The `--client` and `--port` options will be provided by ansible-test.
-    """
-
-    port: int = 5678
-    """
-    The port on the origin host which is listening for incoming connections from pydevd.
+    The port on the origin host which is listening for incoming connections from the debugger.
     SSH port forwarding will be automatically configured for non-local hosts to connect to this port as needed.
     """
+
+    def activate_debugger(self, host: str, port: int) -> None:
+        """Activate the debugger in ansible-test after delegation."""
+
+    def get_ansiballz_config(self) -> dict[str, object]:
+        """Gets the extra configuration data for the AnsiballZ extension module."""
+
+    def get_cli_arguments(self, host: str, port: int) -> list[str]:
+        """Get command line arguments for the debugger when running Ansible CLI programs."""
+
+    def get_environment_variables(self, source_mapping: dict[str, str]) -> dict[str, str]:
+        """Get environment variables needed to configure the debugger for debugging."""
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)


### PR DESCRIPTION
##### SUMMARY
Adds support for debugging AnsiballZ modules with debugpy which is used by VSCode as its Python debugger DAP. Debugging can either be done through a manual Debugpy listening server through a launch.json configuration or through the new ansible-test --dev-debug-on-deman argument.

The `ansible-test` integration requires a change in debugpy that is not currently in a public release. It can be used by cloning the debugpy repo or waiting until the next release.

##### ISSUE TYPE
- Feature Pull Request