### PR TITLE
Bandaid "fix" for the endless `ipaddr` saga

### DIFF
--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -9440,21 +9440,21 @@ plugin_routing:
     k8s_config_resource_name:
       redirect: kubernetes.core.k8s_config_resource_name
     cidr_merge:
-      redirect: ansible.netcommon.cidr_merge
+      redirect: ansible.utils.cidr_merge
     ipaddr:
-      redirect: ansible.netcommon.ipaddr
+      redirect: ansible.utils.ipaddr
     ipmath:
-      redirect: ansible.netcommon.ipmath
+      redirect: ansible.utils.ipmath
     ipwrap:
-      redirect: ansible.netcommon.ipwrap
+      redirect: ansible.utils.ipwrap
     ip4_hex:
-      redirect: ansible.netcommon.ip4_hex
+      redirect: ansible.utils.ip4_hex
     ipv4:
-      redirect: ansible.netcommon.ipv4
+      redirect: ansible.utils.ipv4
     ipv6:
-      redirect: ansible.netcommon.ipv6
+      redirect: ansible.utils.ipv6
     ipsubnet:
-      redirect: ansible.netcommon.ipsubnet
+      redirect: ansible.utils.ipsubnet
     next_nth_usable:
       redirect: ansible.netcommon.next_nth_usable
     network_in_network:


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->
Fixes #85336
##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

### Why

#85336 encapsulates all the necessary info (but was unfortunately closed), so I'll just quote from there:

from @mattclay:

> Plugins that were moved into collections have redirects in ansible-core to keep them working under their old "short names". [...]  However, many collection maintainers do not want to maintain the redirects indefinitely. When that occurs, the short names will no longer work. [...]  The necessary redirects exist in ansible-core. 

Contrary to popular belief, these three statements cannot be logically reconciled with each other: either one wants backwards compatibility or one doesn't. To paraphrase, this

> I want to keep backwards compatibility **just** for some carefully-curated set of pinned-version reqs, but if *they* (repeatedly) break `pip install ansible`, it's by definition not *my* problem

cannot, or should not, be a thing - or, in the words of @Daryes:

>  sorry, for these specific collections, such answer is not acceptable.

Given the logical paradox, this PR doesn't even try to be "proper"; it's just a hint for future lost souls wandering github in search of meaningful answers - and to spell out the hint fully: apply this patch in your virtualenv (and *don't ever update it*) and go back to managing infra as the gods intended.

I suspect the "proper" solution would be to simply remove these redirects, useless (at best) artifacts of a long-gone era; then my overly excitable heart could finally rest, secure in the knowledge that a couple hundreds of `mkdir somerole/meta && echo 'collections: ["ansible.utils"]' > somerole/meta/main.yml` by hand (I personally *love* littering my repos with hundreds of identical files) will solve the problem once and for all, or more prosaically until a future release breaks it in some other way - but again: if there's one lesson here, it's "never touch your ansible .venv"

