### PR TITLE
Fix ansible-config dump to mask sensitive values

### DIFF
--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -447,7 +447,7 @@ class ConfigCLI(CLI):
                         color = 'red'
                     else:
                         color = 'yellow'
-                    
+
                     # Mask sensitive values
                     masked_value = _mask_sensitive_value(setting, value)
                     msg = "%s(%s) = %s" % (setting, config[setting]['origin'], masked_value)

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -36,6 +36,9 @@ display = Display()
 
 _IGNORE_CHANGED = frozenset({'_terms', '_input'})
 
+# Settings that should be masked when displaying values
+_SENSITIVE_SETTINGS = frozenset({'token', 'password', 'client_secret'})
+
 
 def yaml_dump(data, default_flow_style=False, default_style=None):
     return yaml.dump(data, Dumper=AnsibleDumper, default_flow_style=default_flow_style, default_style=default_style)
@@ -43,6 +46,19 @@ def yaml_dump(data, default_flow_style=False, default_style=None):
 
 def yaml_short(data):
     return yaml_dump(data, default_flow_style=True, default_style="''")
+
+
+def _mask_sensitive_value(setting_name, value):
+    """Mask sensitive configuration values for display."""
+    if setting_name in _SENSITIVE_SETTINGS and value:
+        if isinstance(value, str) and len(value) > 8:
+            # Show first 3 and last 3 characters with asterisks in between
+            middle_length = len(value) - 6
+            return value[:3] + '*' * middle_length + value[-3:]
+        elif isinstance(value, str) and len(value) > 0:
+            # For shorter values, show fewer characters
+            return value[:1] + '*' * (len(value) - 1)
+    return value
 
 
 def get_constants():
@@ -431,10 +447,15 @@ class ConfigCLI(CLI):
                         color = 'red'
                     else:
                         color = 'yellow'
-                    msg = "%s(%s) = %s" % (setting, config[setting]['origin'], value)
+                    
+                    # Mask sensitive values
+                    masked_value = _mask_sensitive_value(setting, value)
+                    msg = "%s(%s) = %s" % (setting, config[setting]['origin'], masked_value)
                 else:
                     color = 'green'
-                    msg = "%s(%s) = %s" % (setting, 'default', config[setting].get('default'))
+                    default_value = config[setting].get('default')
+                    masked_default = _mask_sensitive_value(setting, default_value)
+                    msg = "%s(%s) = %s" % (setting, 'default', masked_default)
 
                 entry = stringc(msg, color)
             else:
@@ -442,7 +463,11 @@ class ConfigCLI(CLI):
                 for key in config[setting].keys():
                     if key == 'type':
                         continue
-                    entry[key] = config[setting][key]
+                    if key == 'value':
+                        # Mask sensitive values in non-display formats too
+                        entry[key] = _mask_sensitive_value(setting, config[setting][key])
+                    else:
+                        entry[key] = config[setting][key]
 
             if not context.CLIARGS['only_changed'] or changed:
                 entries.append(entry)

--- a/test/units/cli/test_config.py
+++ b/test/units/cli/test_config.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2023 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import pytest
+
+from ansible.cli.config import _mask_sensitive_value
+
+
+class TestConfigCLI:
+    """Test ansible-config CLI functionality."""
+
+    def test_mask_sensitive_value_token(self):
+        """Test that authentication tokens are properly masked."""
+        # Test long token
+        long_token = 'very_long_authentication_token_123456789'
+        result = _mask_sensitive_value('token', long_token)
+        assert result == 'ver****************************789'
+        assert len(result) == len(long_token)
+
+    def test_mask_sensitive_value_password(self):
+        """Test that passwords are properly masked."""
+        # Test password
+        password = 'secretpassword123'
+        result = _mask_sensitive_value('password', password)
+        assert result == 'sec**********123'
+        assert len(result) == len(password)
+
+    def test_mask_sensitive_value_client_secret(self):
+        """Test that client secrets are properly masked."""
+        # Test client secret
+        client_secret = 'abcdefgh'
+        result = _mask_sensitive_value('client_secret', client_secret)
+        assert result == 'a******h'
+        assert len(result) == len(client_secret)
+
+    def test_mask_sensitive_value_short_values(self):
+        """Test masking of short sensitive values."""
+        # Test short values
+        short_token = 'ab'
+        result = _mask_sensitive_value('token', short_token)
+        assert result == 'a*'
+
+        short_password = 'x'
+        result = _mask_sensitive_value('password', short_password)
+        assert result == 'x'
+
+    def test_mask_sensitive_value_empty_values(self):
+        """Test handling of empty/None values."""
+        # Test empty string
+        result = _mask_sensitive_value('token', '')
+        assert result == ''
+
+        # Test None
+        result = _mask_sensitive_value('token', None)
+        assert result is None
+
+    def test_mask_sensitive_value_non_sensitive_settings(self):
+        """Test that non-sensitive settings are not masked."""
+        # Test non-sensitive settings
+        url = 'https://galaxy.ansible.com'
+        result = _mask_sensitive_value('url', url)
+        assert result == url
+
+        username = 'testuser'
+        result = _mask_sensitive_value('username', username)
+        assert result == username
+
+    def test_mask_sensitive_value_non_string_values(self):
+        """Test that non-string values are handled correctly."""
+        # Test integer
+        result = _mask_sensitive_value('token', 123)
+        assert result == 123
+
+        # Test boolean
+        result = _mask_sensitive_value('password', True)
+        assert result is True

--- a/test/units/cli/test_config.py
+++ b/test/units/cli/test_config.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from ansible.cli.config import _mask_sensitive_value
 
 
@@ -16,7 +14,7 @@ class TestConfigCLI:
         # Test long token
         long_token = 'very_long_authentication_token_123456789'
         result = _mask_sensitive_value('token', long_token)
-        assert result == 'ver****************************789'
+        assert result == 'ver**********************************789'
         assert len(result) == len(long_token)
 
     def test_mask_sensitive_value_password(self):
@@ -24,7 +22,7 @@ class TestConfigCLI:
         # Test password
         password = 'secretpassword123'
         result = _mask_sensitive_value('password', password)
-        assert result == 'sec**********123'
+        assert result == 'sec***********123'
         assert len(result) == len(password)
 
     def test_mask_sensitive_value_client_secret(self):
@@ -32,7 +30,7 @@ class TestConfigCLI:
         # Test client secret
         client_secret = 'abcdefgh'
         result = _mask_sensitive_value('client_secret', client_secret)
-        assert result == 'a******h'
+        assert result == 'a*******'
         assert len(result) == len(client_secret)
 
     def test_mask_sensitive_value_short_values(self):


### PR DESCRIPTION
## Summary
- Fixes #85373: ansible-config dump now masks sensitive configuration values
- Prevents accidental exposure of authentication tokens and secrets during troubleshooting
- Maintains readability by showing partial values with asterisks

## Changes Made
- Added masking functionality for sensitive configuration values in `ansible-config dump`
- Masks the following settings: `token`, `password`, `client_secret`
- For long values (>8 chars): shows first 3 and last 3 characters with asterisks between
- For shorter values: shows first character followed by asterisks
- Applies to all output formats (display, json, yaml)

## Test Plan
- [x] Added comprehensive unit tests in `test/units/cli/test_config.py`
- [x] Tested masking logic for various value lengths and types
- [x] Verified non-sensitive settings remain unmasked
- [x] Tested with empty/None values
- [x] Tested with non-string values

## Example Output
Before:
```
token(env: ANSIBLE_GALAXY_SERVER_TOKEN) = very_long_secret_token_123456
```

After:
```
token(env: ANSIBLE_GALAXY_SERVER_TOKEN) = ver***********************456
```

This change improves security by preventing accidental exposure of authentication credentials when sharing ansible-config output or during screenshare sessions.