### PR TITLE
Add minimal yum_repository task using countme flag to help estimate the number of systems consuming the repository.

### DIFF
--- a/lib/ansible/modules/yum_repository.py
+++ b/lib/ansible/modules/yum_repository.py
@@ -419,6 +419,13 @@ EXAMPLES = """
     name: epel
     file: external_repos
     state: absent
+
+- name: Add EPEL repo with countme enabled for reporting anonymous usage metrics
+  ansible.builtin.yum_repository:
+    name: epel
+    baseurl: https://download.fedoraproject.org/pub/epel/$releasever/$basearch/
+    countme: true
+    state: present
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY

- Add a `ansible.builtin.yum_repository` task demonstrating the use of the `countme` parameter. 
- This helps repository maintainers estimate the number of systems consuming the repository by anonymously 

##### ISSUE TYPE

- Docs Pull Request
