### PR TITLE
Do not re-add tags on blocks from within import_tasks

### DIFF
--- a/changelogs/fragments/import_tasks-dont-readd-tags.yml
+++ b/changelogs/fragments/import_tasks-dont-readd-tags.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Do not re-add ``tags`` on blocks from within ``import_tasks``.

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -229,13 +229,6 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         variable_manager=variable_manager,
                     )
 
-                    tags = ti_copy.tags[:]
-
-                    # now we extend the tags on each of the included blocks
-                    for b in included_blocks:
-                        b.tags = list(set(b.tags).union(tags))
-                    # FIXME - END
-
                     # FIXME: handlers shouldn't need this special handling, but do
                     #        right now because they don't iterate blocks correctly
                     if use_handlers:


### PR DESCRIPTION
##### SUMMARY
The attribute inheritance should take care of that.

ci_complete
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
