### PR TITLE
Move location of self._identifier assignment

### DIFF
--- a/changelogs/fragments/json-rpc-fix-attribute-error.yml
+++ b/changelogs/fragments/json-rpc-fix-attribute-error.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - utils jsonrpc - assign self._identifier earlier to fix AttributeError raised by JsonRpcServer.header()

--- a/lib/ansible/utils/jsonrpc.py
+++ b/lib/ansible/utils/jsonrpc.py
@@ -22,7 +22,7 @@ class JsonRpcServer(object):
     def handle_request(self, request):
         request = json.loads(to_text(request, errors='surrogate_then_replace'))
 
-        self._identity = request.get('id')
+        self._identifier = request.get('id')
 
         method = request.get('method')
 

--- a/lib/ansible/utils/jsonrpc.py
+++ b/lib/ansible/utils/jsonrpc.py
@@ -22,6 +22,8 @@ class JsonRpcServer(object):
     def handle_request(self, request):
         request = json.loads(to_text(request, errors='surrogate_then_replace'))
 
+        self._identity = request.get('id')
+
         method = request.get('method')
 
         if method.startswith('rpc.') or method.startswith('_'):
@@ -29,7 +31,6 @@ class JsonRpcServer(object):
             return json.dumps(error)
 
         args, kwargs = request.get('params')
-        setattr(self, '_identifier', request.get('id'))
 
         rpc_method = None
         for obj in self._objects:


### PR DESCRIPTION
##### SUMMARY

Also changes setattr to a direct assignment

The call self.invalid_request() when returning an error on 
line 30 requires self._identity and throws an AttributeError.
It also changes the setattr call to a direct assignment
because both the attribute and value are already known.  

##### ISSUE TYPE

Bugfix Pull Request
