### PR TITLE
Add AnsiballZ debugging support with debugpy

### DIFF
--- a/lib/ansible/_internal/_ansiballz/_builder.py
+++ b/lib/ansible/_internal/_ansiballz/_builder.py
@@ -96,8 +96,8 @@ class ExtensionManager:
     def create(cls, task_vars: dict[str, object]) -> t.Self:
         """Create an instance using the provided task vars."""
         return cls(
-            pydevd=cls._get_options('_ANSIBALLZ_DEBUGGER_CONFIG_PYDEVD', _pydevd.Options, task_vars),
-            debugpy=cls._get_options('_ANSIBALLZ_DEBUGGER_CONFIG_DEBUGPY', _debugpy.Options, task_vars),
+            pydevd=cls._get_options('_ANSIBALLZ_PYDEVD_CONFIG', _pydevd.Options, task_vars),
+            debugpy=cls._get_options('_ANSIBALLZ_DEBUGPY_CONFIG', _debugpy.Options, task_vars),
             coverage=cls._get_options('_ANSIBALLZ_COVERAGE_CONFIG', _coverage.Options, task_vars),
         )
 

--- a/lib/ansible/_internal/_ansiballz/_builder.py
+++ b/lib/ansible/_internal/_ansiballz/_builder.py
@@ -57,13 +57,13 @@ class ExtensionManager:
         if self._debugpy:
             extension_options['_debugpy'] = dataclasses.replace(
                 self._debugpy,
-                source_mapping=self._get_source_mapping(),
+                source_mapping=self._get_source_mapping(self._debugpy.source_mapping),
             )
 
         if self._pydevd:
             extension_options['_pydevd'] = dataclasses.replace(
                 self._pydevd,
-                source_mapping=self._get_source_mapping(),
+                source_mapping=self._get_source_mapping(self._pydevd.source_mapping),
             )
 
         if self._coverage:
@@ -73,18 +73,17 @@ class ExtensionManager:
 
         return extensions
 
-    def _get_source_mapping(self) -> dict[str, str]:
+    def _get_source_mapping(self, debugger_mapping: dict[str, str]) -> dict[str, str]:
         """Get the source mapping, adjusting the source root as needed."""
-        if self._pydevd and self._pydevd.source_mapping:
-            source_mapping = {self._translate_path(key, self._pydevd.source_mapping): value for key, value in self.source_mapping.items()}
-        elif self._debugpy and self._debugpy.source_mapping:
-            source_mapping = {self._translate_path(key, self._debugpy.source_mapping): value for key, value in self.source_mapping.items()}
+        if debugger_mapping:
+            source_mapping = {self._translate_path(key, debugger_mapping): value for key, value in self.source_mapping.items()}
         else:
             source_mapping = self.source_mapping
 
         return source_mapping
 
-    def _translate_path(self, path: str, debugger_mapping: dict[str, str]) -> str:
+    @staticmethod
+    def _translate_path(path: str, debugger_mapping: dict[str, str]) -> str:
         """Translate a local path to a foreign path."""
         for replace, match in debugger_mapping.items():
             if path.startswith(match):

--- a/lib/ansible/_internal/_ansiballz/_builder.py
+++ b/lib/ansible/_internal/_ansiballz/_builder.py
@@ -6,7 +6,7 @@ import json
 import typing as t
 
 from ansible.module_utils._internal._ansiballz import _extensions
-from ansible.module_utils._internal._ansiballz._extensions import _pydevd, _coverage
+from ansible.module_utils._internal._ansiballz._extensions import _debugpy, _pydevd, _coverage
 from ansible.constants import config
 
 _T = t.TypeVar('_T')
@@ -17,15 +17,18 @@ class ExtensionManager:
 
     def __init__(
         self,
-        debugger: _pydevd.Options | None = None,
+        pydevd: _pydevd.Options | None = None,
+        debugpy: _debugpy.Options | None = None,
         coverage: _coverage.Options | None = None,
     ) -> None:
         options = dict(
-            _pydevd=debugger,
+            _pydevd=pydevd,
+            _debugpy=debugpy,
             _coverage=coverage,
         )
 
-        self._debugger = debugger
+        self._pydevd = pydevd
+        self._debugpy = debugpy
         self._coverage = coverage
         self._extension_names = tuple(name for name, option in options.items() if option)
         self._module_names = tuple(f'{_extensions.__name__}.{name}' for name in self._extension_names)
@@ -35,7 +38,7 @@ class ExtensionManager:
     @property
     def debugger_enabled(self) -> bool:
         """Returns True if the debugger extension is enabled, otherwise False."""
-        return bool(self._debugger)
+        return bool(self._pydevd or self._debugpy)
 
     @property
     def extension_names(self) -> tuple[str, ...]:
@@ -51,9 +54,15 @@ class ExtensionManager:
         """Return the configured extensions and their options."""
         extension_options: dict[str, t.Any] = {}
 
-        if self._debugger:
+        if self._debugpy:
+            extension_options['_debugpy'] = dataclasses.replace(
+                self._debugpy,
+                source_mapping=self._get_source_mapping(),
+            )
+
+        if self._pydevd:
             extension_options['_pydevd'] = dataclasses.replace(
-                self._debugger,
+                self._pydevd,
                 source_mapping=self._get_source_mapping(),
             )
 
@@ -66,16 +75,18 @@ class ExtensionManager:
 
     def _get_source_mapping(self) -> dict[str, str]:
         """Get the source mapping, adjusting the source root as needed."""
-        if self._debugger.source_mapping:
-            source_mapping = {self._translate_path(key): value for key, value in self.source_mapping.items()}
+        if self._pydevd and self._pydevd.source_mapping:
+            source_mapping = {self._translate_path(key, self._pydevd.source_mapping): value for key, value in self.source_mapping.items()}
+        elif self._debugpy and self._debugpy.source_mapping:
+            source_mapping = {self._translate_path(key, self._debugpy.source_mapping): value for key, value in self.source_mapping.items()}
         else:
             source_mapping = self.source_mapping
 
         return source_mapping
 
-    def _translate_path(self, path: str) -> str:
+    def _translate_path(self, path: str, debugger_mapping: dict[str, str]) -> str:
         """Translate a local path to a foreign path."""
-        for replace, match in self._debugger.source_mapping.items():
+        for replace, match in debugger_mapping.items():
             if path.startswith(match):
                 return replace + path[len(match) :]
 
@@ -85,7 +96,8 @@ class ExtensionManager:
     def create(cls, task_vars: dict[str, object]) -> t.Self:
         """Create an instance using the provided task vars."""
         return cls(
-            debugger=cls._get_options('_ANSIBALLZ_DEBUGGER_CONFIG', _pydevd.Options, task_vars),
+            pydevd=cls._get_options('_ANSIBALLZ_DEBUGGER_CONFIG_PYDEVD', _pydevd.Options, task_vars),
+            debugpy=cls._get_options('_ANSIBALLZ_DEBUGGER_CONFIG_DEBUGPY', _debugpy.Options, task_vars),
             coverage=cls._get_options('_ANSIBALLZ_COVERAGE_CONFIG', _coverage.Options, task_vars),
         )
 

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -11,26 +11,26 @@ _ANSIBALLZ_COVERAGE_CONFIG:
   vars:
   - {name: _ansible_ansiballz_coverage_config}
   version_added: '2.19'
-_ANSIBALLZ_DEBUGGER_CONFIG_DEBUGPY:
+_ANSIBALLZ_DEBUGPY_CONFIG:
   name: Configure the AnsiballZ remote debugging extension for Debugpy
   description:
     - Enables and configures the AnsiballZ remote debugging extension for Debugpy.
     - This is for internal use only.
   env:
-  - {name: _ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG_DEBUGPY}
+  - {name: _ANSIBLE_ANSIBALLZ_DEBUGPY_CONFIG}
   vars:
-  - {name: _ansible_ansiballz_debugger_config_debugpy}
+  - {name: _ansible_ansiballz_debugpy_config}
   version_added: '2.20'
-_ANSIBALLZ_DEBUGGER_CONFIG_PYDEVD:
+_ANSIBALLZ_PYDEVD_CONFIG:
   name: Configure the AnsiballZ remote debugging extension for PyDevD
   description:
     - Enables and configures the AnsiballZ remote debugging extension for PyDevD.
     - This is for internal use only.
   env:
-  - {name: _ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG_PYDEVD}
+  - {name: _ANSIBLE_ANSIBALLZ_PYDEVD_CONFIG}
   vars:
-  - {name: _ansible_ansiballz_debugger_config_pydevd}
-  version_added: '2.19'
+  - {name: _ansible_ansiballz_pydevd_config}
+  version_added: '2.20'
 _ANSIBLE_CONNECTION_PATH:
   env:
   - name: _ANSIBLE_CONNECTION_PATH

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -11,15 +11,25 @@ _ANSIBALLZ_COVERAGE_CONFIG:
   vars:
   - {name: _ansible_ansiballz_coverage_config}
   version_added: '2.19'
-_ANSIBALLZ_DEBUGGER_CONFIG:
-  name: Configure the AnsiballZ remote debugging extension
+_ANSIBALLZ_DEBUGGER_CONFIG_DEBUGPY:
+  name: Configure the AnsiballZ remote debugging extension for Debugpy
   description:
-    - Enables and configures the AnsiballZ remote debugging extension.
+    - Enables and configures the AnsiballZ remote debugging extension for Debugpy.
     - This is for internal use only.
   env:
-  - {name: _ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG}
+  - {name: _ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG_DEBUGPY}
   vars:
-  - {name: _ansible_ansiballz_debugger_config}
+  - {name: _ansible_ansiballz_debugger_config_debugpy}
+  version_added: '2.20'
+_ANSIBALLZ_DEBUGGER_CONFIG_PYDEVD:
+  name: Configure the AnsiballZ remote debugging extension for PyDevD
+  description:
+    - Enables and configures the AnsiballZ remote debugging extension for PyDevD.
+    - This is for internal use only.
+  env:
+  - {name: _ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG_PYDEVD}
+  vars:
+  - {name: _ansible_ansiballz_debugger_config_pydevd}
   version_added: '2.19'
 _ANSIBLE_CONNECTION_PATH:
   env:

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -12,9 +12,9 @@ _ANSIBALLZ_COVERAGE_CONFIG:
   - {name: _ansible_ansiballz_coverage_config}
   version_added: '2.19'
 _ANSIBALLZ_DEBUGPY_CONFIG:
-  name: Configure the AnsiballZ remote debugging extension for Debugpy
+  name: Configure the AnsiballZ remote debugging extension for debugpy
   description:
-    - Enables and configures the AnsiballZ remote debugging extension for Debugpy.
+    - Enables and configures the AnsiballZ remote debugging extension for debugpy.
     - This is for internal use only.
   env:
   - {name: _ANSIBLE_ANSIBALLZ_DEBUGPY_CONFIG}
@@ -22,9 +22,9 @@ _ANSIBALLZ_DEBUGPY_CONFIG:
   - {name: _ansible_ansiballz_debugpy_config}
   version_added: '2.20'
 _ANSIBALLZ_PYDEVD_CONFIG:
-  name: Configure the AnsiballZ remote debugging extension for PyDevD
+  name: Configure the AnsiballZ remote debugging extension for pydevd
   description:
-    - Enables and configures the AnsiballZ remote debugging extension for PyDevD.
+    - Enables and configures the AnsiballZ remote debugging extension for pydevd.
     - This is for internal use only.
   env:
   - {name: _ANSIBLE_ANSIBALLZ_PYDEVD_CONFIG}

--- a/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugpy.py
+++ b/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugpy.py
@@ -60,14 +60,6 @@ import pathlib
 
 import typing as t
 
-HAS_DEBUGPY = False
-try:
-    import debugpy  # type: ignore[import-not-found]  # Not type stubs available for debugpy
-
-    HAS_DEBUGPY = True
-except ImportError:
-    pass
-
 
 @dataclasses.dataclass(frozen=True)
 class Options:
@@ -92,8 +84,7 @@ class Options:
 
 def run(args: dict[str, t.Any]) -> None:  # pragma: nocover
     """Enable remote debugging."""
-    if not HAS_DEBUGPY:
-        return
+    import debugpy  # type: ignore[import-not-found]  # Not type stubs available for debugpy
 
     options = Options(**args)
     temp_dir = pathlib.Path(__file__).parent.parent.parent.parent.parent.parent

--- a/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugpy.py
+++ b/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugpy.py
@@ -29,7 +29,7 @@ To use with VSCode:
                     "main.yml"
                 ],
                 "env": {
-                    "_ANSIBLE_ANSIBALLZ_DEBUGPY_CONFIG\": "{\"host\": \"localhost\", \"port\": 5678}"
+                    "_ANSIBLE_ANSIBALLZ_DEBUGPY_CONFIG": "{\"host\": \"localhost\", \"port\": 5678}"
                 },
                 "console": "integratedTerminal",
             }

--- a/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugpy.py
+++ b/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugpy.py
@@ -29,7 +29,7 @@ To use with VSCode:
                     "main.yml"
                 ],
                 "env": {
-                    "_ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG_DEBUGPY": "{\"host\": \"localhost\", \"port\": 5678}"
+                    "_ANSIBLE_ANSIBALLZ_DEBUGPY_CONFIG\": "{\"host\": \"localhost\", \"port\": 5678}"
                 },
                 "console": "integratedTerminal",
             }
@@ -84,7 +84,7 @@ class Options:
 
 def run(args: dict[str, t.Any]) -> None:  # pragma: nocover
     """Enable remote debugging."""
-    import debugpy  # type: ignore[import-not-found]  # Not type stubs available for debugpy
+    import debugpy
 
     options = Options(**args)
     temp_dir = pathlib.Path(__file__).parent.parent.parent.parent.parent.parent

--- a/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugpy.py
+++ b/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugpy.py
@@ -1,0 +1,106 @@
+"""
+Remote debugging support for AnsiballZ modules with debugpy.
+
+To use with VSCode:
+
+1) Choose an available port for VSCode to listen on (e.g. 5678).
+2) Ensure `debugpy` is installed for the interpreter(s) which will run the code being debugged.
+3) Create the following launch.json configuration
+
+    {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Python Debug Server",
+                "type": "debugpy",
+                "request": "attach",
+                "listen": {
+                    "host": "localhost",
+                    "port": 5678,
+                },
+            },
+            {
+                "name": "ansible-playbook main.yml",
+                "type": "debugpy",
+                "request": "launch",
+                "module": "ansible",
+                "args": [
+                    "playbook",
+                    "main.yml"
+                ],
+                "env": {
+                    "_ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG_DEBUGPY": "{\"host\": \"localhost\", \"port\": 5678}"
+                },
+                "console": "integratedTerminal",
+            }
+        ],
+        "compounds": [
+            {
+                "name": "Test Module Debugging",
+                "configurations": [
+                    "Python Debug Server",
+                    "ansible-playbook main.yml"
+                ],
+                "stopAll": true
+            }
+        ]
+    }
+
+4) Set any desired breakpoints.
+5) Configure the Run and Debug view to use the "Test Module Debugging" compound configuration.
+6) Press F5 to start debugging.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import pathlib
+
+import typing as t
+
+HAS_DEBUGPY = False
+try:
+    import debugpy  # type: ignore[import-not-found]  # Not type stubs available for debugpy
+
+    HAS_DEBUGPY = True
+except ImportError:
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class Options:
+    """Debugger options for debugpy."""
+
+    host: str = 'localhost'
+    """The host to connect to for remote debugging."""
+    port: int = 5678
+    """The port to connect to for remote debugging."""
+    connect: dict[str, object] = dataclasses.field(default_factory=dict)
+    """The options to pass to the `debugpy.connect` method."""
+    source_mapping: dict[str, str] = dataclasses.field(default_factory=dict)
+    """
+    A mapping of source paths to provide to debugpy.
+    This setting is used internally by AnsiballZ and is not required unless Ansible CLI commands are run from a different system than your IDE.
+    In that scenario, use this setting instead of configuring source mapping in your IDE.
+    The key is a path known to the IDE.
+    The value is the same path as known to the Ansible CLI.
+    Both file paths and directories are supported.
+    """
+
+
+def run(args: dict[str, t.Any]) -> None:  # pragma: nocover
+    """Enable remote debugging."""
+    if not HAS_DEBUGPY:
+        return
+
+    options = Options(**args)
+    temp_dir = pathlib.Path(__file__).parent.parent.parent.parent.parent.parent
+    path_mapping = [[key, str(temp_dir / value)] for key, value in options.source_mapping.items()]
+
+    os.environ['PATHS_FROM_ECLIPSE_TO_PYTHON'] = json.dumps(path_mapping)
+
+    debugpy.connect((options.host, options.port), **options.connect)
+
+    pass  # A convenient place to put a breakpoint

--- a/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugpy.py
+++ b/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_debugpy.py
@@ -1,9 +1,9 @@
 """
 Remote debugging support for AnsiballZ modules with debugpy.
 
-To use with VSCode:
+To use with VS Code:
 
-1) Choose an available port for VSCode to listen on (e.g. 5678).
+1) Choose an available port for VS Code to listen on (e.g. 5678).
 2) Ensure `debugpy` is installed for the interpreter(s) which will run the code being debugged.
 3) Create the following launch.json configuration
 

--- a/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_pydevd.py
+++ b/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_pydevd.py
@@ -7,10 +7,10 @@ To use with PyCharm:
 2) Create a Python Debug Server using that port.
 3) Start the Python Debug Server.
 4) Ensure the correct version of `pydevd-pycharm` is installed for the interpreter(s) which will run the code being debugged.
-5) Configure Ansible with the `_ANSIBALLZ_DEBUGGER_CONFIG_PYDEVD` option.
+5) Configure Ansible with the `_ANSIBALLZ_PYDEVD_CONFIG` option.
    See `Options` below for the structure of the debugger configuration.
    Example configuration using an environment variable:
-     export _ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG_PYDEVD='{"module": "pydevd_pycharm", "settrace": {"host": "localhost", "port": 5678, "suspend": false}}'
+     export _ANSIBLE_ANSIBALLZ_PYDEVD_CONFIG='{"module": "pydevd_pycharm", "settrace": {"host": "localhost", "port": 5678, "suspend": false}}'
 6) Set any desired breakpoints.
 7) Run Ansible commands.
 """

--- a/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_pydevd.py
+++ b/lib/ansible/module_utils/_internal/_ansiballz/_extensions/_pydevd.py
@@ -7,14 +7,12 @@ To use with PyCharm:
 2) Create a Python Debug Server using that port.
 3) Start the Python Debug Server.
 4) Ensure the correct version of `pydevd-pycharm` is installed for the interpreter(s) which will run the code being debugged.
-5) Configure Ansible with the `_ANSIBALLZ_DEBUGGER_CONFIG` option.
+5) Configure Ansible with the `_ANSIBALLZ_DEBUGGER_CONFIG_PYDEVD` option.
    See `Options` below for the structure of the debugger configuration.
    Example configuration using an environment variable:
-     export _ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG='{"module": "pydevd_pycharm", "settrace": {"host": "localhost", "port": 5678, "suspend": false}}'
+     export _ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG_PYDEVD='{"module": "pydevd_pycharm", "settrace": {"host": "localhost", "port": 5678, "suspend": false}}'
 6) Set any desired breakpoints.
 7) Run Ansible commands.
-
-A similar process should work for other pydevd based debuggers, such as Visual Studio Code, but they have not been tested.
 """
 
 from __future__ import annotations

--- a/test/integration/targets/ansiballz_debugging/tasks/main.yml
+++ b/test/integration/targets/ansiballz_debugging/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Run a module with remote debugging configured to use a bogus debugger module
   ping:
   vars:
-    _ansible_ansiballz_debugger_config:
+    _ansible_ansiballz_debugger_config_pydevd:
       module: not_a_valid_debugger_module
   register: result
   ignore_errors: yes

--- a/test/integration/targets/ansiballz_debugging/tasks/main.yml
+++ b/test/integration/targets/ansiballz_debugging/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Run a module with remote debugging configured to use a bogus debugger module
   ping:
   vars:
-    _ansible_ansiballz_debugger_config_pydevd:
+    _ansible_ansiballz_pydevd_config:
       module: not_a_valid_debugger_module
   register: result
   ignore_errors: yes

--- a/test/integration/targets/ansible-test-debugging-env/aliases
+++ b/test/integration/targets/ansible-test-debugging-env/aliases
@@ -1,0 +1,2 @@
+shippable/generic/group1  # runs in the default test container
+context/controller

--- a/test/integration/targets/ansible-test-debugging-env/runme.sh
+++ b/test/integration/targets/ansible-test-debugging-env/runme.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Used to support the ansible-test-debugging integration test.
+
+env

--- a/test/integration/targets/ansible-test-debugging-inventory/aliases
+++ b/test/integration/targets/ansible-test-debugging-inventory/aliases
@@ -1,0 +1,2 @@
+shippable/generic/group1  # runs in the default test container
+context/controller

--- a/test/integration/targets/ansible-test-debugging-inventory/runme.sh
+++ b/test/integration/targets/ansible-test-debugging-inventory/runme.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Used to support the ansible-test-debugging integration test.
+
+cat "${INVENTORY_PATH}"

--- a/test/integration/targets/ansible-test-debugging/aliases
+++ b/test/integration/targets/ansible-test-debugging/aliases
@@ -1,0 +1,5 @@
+shippable/generic/group1  # runs in the default test container
+needs/target/ansible-test-debugging-env  # indirectly used by ansible-test, included here for change detection
+needs/target/ansible-test-debugging-inventory  # indirectly used by ansible-test, included here for change detection
+context/controller
+gather_facts/no

--- a/test/integration/targets/ansible-test-debugging/tasks/main.yml
+++ b/test/integration/targets/ansible-test-debugging/tasks/main.yml
@@ -1,0 +1,98 @@
+- name: Define supported debuggers
+  set_fact:
+    debuggers:
+      - pydevd
+      - debugpy
+
+- name: Run without debugging features enabled
+  command: ansible-test shell -v -- env
+  register: result
+
+- assert:
+    that:
+      - result.stderr_lines is not contains 'Debugging'
+
+- name: Run a command which does not support debugging
+  command: ansible-test env -v
+  register: result
+
+- assert:
+    that:
+      - result.stderr_lines is not contains 'Debugging'
+
+- name: Verify on-demand debugging gracefully handles not running under a debugger
+  command: ansible-test shell -v --dev-debug-on-demand -- env
+  register: result
+
+- assert:
+    that:
+      - result.stderr_lines is contains 'Debugging disabled because no debugger was detected.'
+
+- name: Verify manual debugging gracefully handles lack of configuration
+  command: ansible-test shell -v --dev-debug-cli -- env
+  register: result
+
+- assert:
+    that:
+      - result.stderr_lines is contains 'Debugging disabled because no debugger configuration was provided.'
+
+- name: Verify invalid debugger configuration is handled
+  command: ansible-test shell --dev-debug-cli -- env
+  environment: >
+    {% set key = "ANSIBLE_TEST_REMOTE_DEBUGGER_" + item.upper() %}{{ ('{"' + key + '": "{\"invalid_key\": true}"}') | from_json }}
+  register: result
+  loop: "{{ debuggers }}"
+  ignore_errors: yes
+
+- assert:
+    that:
+      - item.stderr is search("Invalid " + item.item + " settings.*invalid_key")
+  loop: "{{ result.results }}"
+
+- name: Verify CLI debugger can be manually enabled (shell)
+  command: ansible-test shell --dev-debug-cli -- env
+  environment: >
+    {% set key = "ANSIBLE_TEST_REMOTE_DEBUGGER_" + item.upper() %}{{ ('{"' + key + '": ""}') | from_json }}
+  register: result
+  loop: "{{ debuggers }}"
+
+- assert:
+    that:
+      - item.stdout is contains "ANSIBLE_TEST_DEBUGGER_CONFIG"
+  loop: "{{ result.results }}"
+
+- name: Verify CLI debugger can be manually enabled (integration)
+  command: ansible-test integration ansible-test-debugging-env --dev-debug-cli
+  environment: >
+    {% set key = "ANSIBLE_TEST_REMOTE_DEBUGGER_" + item.upper() %}{{ ('{"' + key + '": ""}') | from_json }}
+  register: result
+  loop: "{{ debuggers }}"
+
+- assert:
+    that:
+      - item.stdout is contains "ANSIBLE_TEST_DEBUGGER_CONFIG"
+  loop: "{{ result.results }}"
+
+- name: Verify AnsiballZ debugger can be manually enabled (shell)
+  command: ansible-test shell --dev-debug-ansiballz -- env
+  environment: >
+    {% set key = "ANSIBLE_TEST_REMOTE_DEBUGGER_" + item.upper() %}{{ ('{"' + key + '": ""}') | from_json }}
+  register: result
+  loop: "{{ debuggers }}"
+
+- assert:
+    that:
+      - item.stdout is contains("_ANSIBLE_ANSIBALLZ_" + item.item.upper() + "_CONFIG")
+  loop: "{{ result.results }}"
+
+- name: Verify AnsiballZ debugger can be manually enabled (integration)
+  command: ansible-test integration ansible-test-debugging-inventory --dev-debug-ansiballz
+  environment: >
+    {% set key = "ANSIBLE_TEST_REMOTE_DEBUGGER_" + item.upper() %}{{ ('{"' + key + '": ""}') | from_json }}
+  register: result
+  loop: "{{ debuggers }}"
+
+- assert:
+    that:
+      - item.stdout is contains("_ansible_ansiballz_" + item.item + "_config")
+  loop: "{{ result.results }}"

--- a/test/lib/ansible_test/_internal/commands/shell/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/shell/__init__.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import os
 import sys
 import typing as t
+
+from ...data import (
+    data_context,
+)
 
 from ...util import (
     ApplicationError,
@@ -105,7 +110,7 @@ def command_shell(args: ShellConfig) -> None:
         # HACK: ensure the debugger port visible in the shell is the forwarded port, not the original
         args.metadata.debugger_settings = dataclasses.replace(args.metadata.debugger_settings, port=target_profile.debugger_port)
 
-    with metadata_context(args):
+    with contextlib.nullcontext() if data_context().content.unsupported else metadata_context(args):
         if args.cmd:
             non_interactive_shell(args, target_profile, con)
         else:
@@ -190,6 +195,9 @@ def get_environment_variables(
     con: Connection,
 ) -> dict[str, str]:
     """Get the environment variables to expose to the shell."""
+    if data_context().content.unsupported:
+        return {}
+
     optional_vars = (
         'TERM',  # keep backspace working
     )

--- a/test/lib/ansible_test/_internal/commands/shell/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/shell/__init__.py
@@ -109,8 +109,11 @@ def command_shell(args: ShellConfig) -> None:
         return
 
     if isinstance(con, LocalConnection) and isinstance(target_profile, DebuggableProfile) and target_profile.debugging_enabled:
-        # HACK: ensure the pydevd port visible in the shell is the forwarded port, not the original
-        args.metadata.debugger_settings = dataclasses.replace(args.metadata.debugger_settings, port=target_profile.pydevd_port)
+        # HACK: ensure the pydevd/debugpy port visible in the shell is the forwarded port, not the original
+        if args.metadata.pydevd_settings:
+            args.metadata.pydevd_settings = dataclasses.replace(args.metadata.pydevd_settings, port=target_profile.debugger_port)
+        if args.metadata.debugpy_settings:
+            args.metadata.debugpy_settings = dataclasses.replace(args.metadata.debugpy_settings, port=target_profile.debugger_port)
 
     with metadata_context(args):
         interactive_shell(args, target_profile, con)

--- a/test/lib/ansible_test/_internal/commands/shell/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/shell/__init__.py
@@ -101,22 +101,33 @@ def command_shell(args: ShellConfig) -> None:
     if args.export:
         return
 
-    if args.cmd:
-        # Running a command is assumed to be non-interactive. Only a shell (no command) is interactive.
-        # If we want to support interactive commands in the future, we'll need an `--interactive` command line option.
-        # Command stderr output is allowed to mix with our own output, which is all sent to stderr.
-        con.run(args.cmd, capture=False, interactive=False, output_stream=OutputStream.ORIGINAL)
-        return
-
     if isinstance(con, LocalConnection) and isinstance(target_profile, DebuggableProfile) and target_profile.debugging_enabled:
-        # HACK: ensure the pydevd/debugpy port visible in the shell is the forwarded port, not the original
-        if args.metadata.pydevd_settings:
-            args.metadata.pydevd_settings = dataclasses.replace(args.metadata.pydevd_settings, port=target_profile.debugger_port)
-        if args.metadata.debugpy_settings:
-            args.metadata.debugpy_settings = dataclasses.replace(args.metadata.debugpy_settings, port=target_profile.debugger_port)
+        # HACK: ensure the debugger port visible in the shell is the forwarded port, not the original
+        args.metadata.debugger_settings = dataclasses.replace(args.metadata.debugger_settings, port=target_profile.debugger_port)
 
     with metadata_context(args):
-        interactive_shell(args, target_profile, con)
+        if args.cmd:
+            non_interactive_shell(args, target_profile, con)
+        else:
+            interactive_shell(args, target_profile, con)
+
+
+def non_interactive_shell(
+    args: ShellConfig,
+    target_profile: SshTargetHostProfile,
+    con: Connection,
+) -> None:
+    """Run a non-interactive shell command."""
+    if isinstance(target_profile, PosixProfile):
+        env = get_environment_variables(args, target_profile, con)
+        cmd = get_env_command(env) + args.cmd
+    else:
+        cmd = args.cmd
+
+    # Running a command is assumed to be non-interactive. Only a shell (no command) is interactive.
+    # If we want to support interactive commands in the future, we'll need an `--interactive` command line option.
+    # Command stderr output is allowed to mix with our own output, which is all sent to stderr.
+    con.run(cmd, capture=False, interactive=False, output_stream=OutputStream.ORIGINAL)
 
 
 def interactive_shell(
@@ -138,23 +149,8 @@ def interactive_shell(
             python = target_profile.python  # make sure the python interpreter has been initialized before opening a shell
             display.info(f'Target Python {python.version} is at: {python.path}')
 
-            optional_vars = (
-                'TERM',  # keep backspace working
-            )
-
-            env = {name: os.environ[name] for name in optional_vars if name in os.environ}
-
-            if isinstance(con, LocalConnection):  # configure the controller environment
-                env.update(ansible_environment(args))
-                env.update(get_injector_env(target_profile.python, env))
-                env.update(ANSIBLE_TEST_METADATA_PATH=os.path.abspath(args.metadata_path))
-
-                if isinstance(target_profile, DebuggableProfile):
-                    env.update(target_profile.get_ansiballz_environment_variables())
-                    env.update(target_profile.get_ansible_cli_environment_variables())
-
-            if env:
-                cmd = ['/usr/bin/env'] + [f'{name}={value}' for name, value in env.items()]
+            env = get_environment_variables(args, target_profile, con)
+            cmd = get_env_command(env)
 
         cmd += [shell, '-i']
     else:
@@ -178,3 +174,35 @@ def interactive_shell(
             raise HostConnectionError(f'SSH shell connection failed for host {target_profile.config}: {ex}', callback) from ex
 
         raise
+
+
+def get_env_command(env: dict[str, str]) -> list[str]:
+    """Get an `env` command to set the given environment variables, if any."""
+    if not env:
+        return []
+
+    return ['/usr/bin/env'] + [f'{name}={value}' for name, value in env.items()]
+
+
+def get_environment_variables(
+    args: ShellConfig,
+    target_profile: PosixProfile,
+    con: Connection,
+) -> dict[str, str]:
+    """Get the environment variables to expose to the shell."""
+    optional_vars = (
+        'TERM',  # keep backspace working
+    )
+
+    env = {name: os.environ[name] for name in optional_vars if name in os.environ}
+
+    if isinstance(con, LocalConnection):  # configure the controller environment
+        env.update(ansible_environment(args))
+        env.update(get_injector_env(target_profile.python, env))
+        env.update(ANSIBLE_TEST_METADATA_PATH=os.path.abspath(args.metadata_path))
+
+        if isinstance(target_profile, DebuggableProfile):
+            env.update(target_profile.get_ansiballz_environment_variables())
+            env.update(target_profile.get_ansible_cli_environment_variables())
+
+    return env

--- a/test/lib/ansible_test/_internal/debugging.py
+++ b/test/lib/ansible_test/_internal/debugging.py
@@ -318,19 +318,26 @@ def get_current_process_cached() -> Process:
     return get_current_process()
 
 
-@cache
 def detect_debugpy_port() -> int | None:
     """Return the port for the debugpy instance hosting this process, or `None` if not detected."""
-    if HAS_DEBUGPY and _debugpy.is_client_connected():
-        return _debugpy_cli.options.address[1]
+    return _get_debugpy_cli_options()[0]
 
-    return None
+
+def get_debugpy_access_token() -> str | None:
+    """Return the access token for the debugpy instance hosting this process, or `None` if not detected."""
+    return _get_debugpy_cli_options()[1]
 
 
 @cache
-def get_debugpy_access_token() -> str | None:
-    """Return the access token for the debugpy instance hosting this process, or `None` if not detected."""
-    if HAS_DEBUGPY and _debugpy.is_client_connected():
-        return _debugpy_cli.options.adapter_access_token
+def _get_debugpy_cli_options() -> tuple[int | None, str | None]:
+    if not (HAS_DEBUGPY and _debugpy.is_client_connected()):
+        return (None, None)
 
-    return None
+    # get_cli_options is the new public API introduced after debugpy 1.8.15.
+    # We should remove the _debugpy_cli fallback once the new version is released.
+    if hasattr(_debugpy, 'get_cli_options'):
+        opts = _debugpy.get_cli_options()
+    else:
+        opts = _debugpy_cli.options
+
+    return opts.address[1], opts.adapter_access_token

--- a/test/lib/ansible_test/_internal/debugging.py
+++ b/test/lib/ansible_test/_internal/debugging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import abc
 import dataclasses
 import importlib
 import json
@@ -15,7 +16,9 @@ from .util import (
     display,
     raw_command,
     ApplicationError,
+    get_subclasses,
 )
+
 from .util_common import (
     CommonConfig,
 )
@@ -30,8 +33,6 @@ from .config import (
 )
 
 from .metadata import (
-    DebugpySettings,
-    PyDevDSettings,
     DebuggerFlags,
 )
 
@@ -41,105 +42,269 @@ from .data import (
 
 
 class DebuggerProfile(t.Protocol):
-    """Commons interface for debugger profiles."""
+    """Protocol for debugger profiles."""
 
-    debug_type: str
-    """The type of debugger as known by the AnsiballZ extension config suffix."""
-    package: str | None
-    """The package name of the debugger to install by ansible-tesst, or `None` if not applicable."""
-    port: int
-    """The port on the origin host which is listening for incoming connections from the debugger."""
+    @property
+    def debugger_host(self) -> str:
+        """The hostname to expose to the debugger."""
 
-    def activate_debugger(self, host: str, port: int) -> None:
+    @property
+    def debugger_port(self) -> int:
+        """The port to expose to the debugger."""
+
+    def get_source_mapping(self) -> dict[str, str]:
+        """The source mapping to expose to the debugger."""
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class DebuggerSettings(metaclass=abc.ABCMeta):
+    """Common debugger settings."""
+
+    port: int = 5678
+    """
+    The port on the origin host which is listening for incoming connections from the debugger.
+    SSH port forwarding will be automatically configured for non-local hosts to connect to this port as needed.
+    """
+
+    def as_dict(self) -> dict[str, object]:
+        """Convert this instance to a dict."""
+        data = dataclasses.asdict(self)
+        data.update(__type__=self.__class__.__name__)
+
+        return data
+
+    @classmethod
+    def from_dict(cls, value: dict[str, t.Any]) -> t.Self:
+        """Load an instance from a dict."""
+        debug_cls = globals()[value.pop('__type__')]
+
+        return debug_cls(**value)
+
+    @classmethod
+    def get_debug_type(cls) -> str:
+        """Return the name for this debugger."""
+        return cls.__name__.removesuffix('Settings').lower()
+
+    @classmethod
+    def get_config_env_var_name(cls) -> str:
+        """Return the name of the environment variable used to customize settings for this debugger."""
+        return f'ANSIBLE_TEST_REMOTE_DEBUGGER_{cls.get_debug_type().upper()}'
+
+    @classmethod
+    def parse(cls, value: str) -> t.Self:
+        """Parse debugger settings from the given JSON and apply defaults."""
+        try:
+            settings = cls(**json.loads(value))
+        except Exception as ex:
+            raise ApplicationError(f"Invalid {cls.get_debug_type()} settings: {ex}") from ex
+
+        return cls.apply_defaults(settings)
+
+    @classmethod
+    @abc.abstractmethod
+    def is_active(cls) -> bool:
+        """Detect if the debugger is active."""
+
+    @classmethod
+    @abc.abstractmethod
+    def apply_defaults(cls, settings: t.Self) -> t.Self:
+        """Apply defaults to the given settings."""
+
+    @abc.abstractmethod
+    def get_python_package(self) -> str:
+        """The Python package to install for debugging."""
+
+    @abc.abstractmethod
+    def activate_debugger(self, profile: DebuggerProfile) -> None:
         """Activate the debugger in ansible-test after delegation."""
 
-    def get_ansiballz_config(self, host: str, port: int) -> dict[str, object]:
+    @abc.abstractmethod
+    def get_ansiballz_config(self, profile: DebuggerProfile) -> dict[str, object]:
         """Gets the extra configuration data for the AnsiballZ extension module."""
 
-    def get_cli_arguments(self, host: str, port: int) -> list[str]:
+    @abc.abstractmethod
+    def get_cli_arguments(self, profile: DebuggerProfile) -> list[str]:
         """Get command line arguments for the debugger when running Ansible CLI programs."""
 
-    def get_environment_variables(self, source_mapping: dict[str, str]) -> dict[str, str]:
+    @abc.abstractmethod
+    def get_environment_variables(self, profile: DebuggerProfile) -> dict[str, str]:
         """Get environment variables needed to configure the debugger for debugging."""
 
 
-class PydevdProfile(DebuggerProfile):
-    """Profile for the PyDevD debugger."""
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class PydevdSettings(DebuggerSettings):
+    """Settings for the pydevd debugger."""
 
-    def __init__(self, settings: PyDevDSettings) -> None:
-        self._settings = settings
-        self.debug_type = 'pydevd'
-        self.package = settings.package
-        self.port = settings.port
+    package: str | None = None
+    """
+    The Python package to install for debugging.
+    If `None` then the package will be auto-detected.
+    If an empty string, then no package will be installed.
+    """
 
-    def activate_debugger(self, host: str, port: int) -> None:
-        module_name = self._settings.module
-        debugging_module = importlib.import_module(module_name)
-        debugging_module.settrace(**self._get_settrace_arguments(host, port))
+    module: str | None = None
+    """
+    The Python module to import for debugging.
+    This should be pydevd or a derivative.
+    If not provided it will be auto-detected.
+    """
 
-    def get_ansiballz_config(self, host: str, port: int) -> dict[str, object]:
-        settrace = dict(
-            host=host,
-            port=port,
-        ) | self._settings.settrace
+    settrace: dict[str, object] = dataclasses.field(default_factory=dict)
+    """
+    Options to pass to the `{module}.settrace` method.
+    Used for running AnsiballZ modules only.
+    The `host` and `port` options will be provided by ansible-test.
+    The `suspend` option defaults to `False`.
+    """
 
+    args: list[str] = dataclasses.field(default_factory=list)
+    """
+    Arguments to pass to `pydevd` on the command line.
+    Used for running Ansible CLI programs only.
+    The `--client` and `--port` options will be provided by ansible-test.
+    """
+
+    @classmethod
+    def is_active(cls) -> bool:
+        return detect_pydevd_port() is not None
+
+    @classmethod
+    def apply_defaults(cls, settings: t.Self) -> t.Self:
+        if not settings.module:
+            if not settings.package or 'pydevd-pycharm' in settings.package:
+                module = 'pydevd_pycharm'
+            else:
+                module = 'pydevd'
+
+            settings = dataclasses.replace(settings, module=module)
+
+        if settings.package is None:
+            if settings.module == 'pydevd_pycharm':
+                if pycharm_version := detect_pycharm_version():
+                    package = f'pydevd-pycharm~={pycharm_version}'
+                else:
+                    package = None
+            else:
+                package = 'pydevd'
+
+            settings = dataclasses.replace(settings, package=package)
+
+        settings.settrace.setdefault('suspend', False)
+
+        if port := detect_pydevd_port():
+            settings = dataclasses.replace(settings, port=port)
+
+            if detect_pycharm_process():
+                # This only works with the default PyCharm debugger.
+                # Using it with PyCharm's "Python Debug Server" results in hangs in Ansible workers.
+                # Further investigation is required to understand the cause.
+                settings = dataclasses.replace(settings, args=settings.args + ['--multiprocess'])
+
+        return settings
+
+    def get_python_package(self) -> str:
+        if self.package is None and self.module == 'pydevd_pycharm':
+            display.warning('Skipping installation of `pydevd-pycharm` since the running PyCharm version was not detected.')
+
+        return self.package
+
+    def activate_debugger(self, profile: DebuggerProfile) -> None:
+        debugging_module = importlib.import_module(self.module)
+        debugging_module.settrace(**self._get_settrace_arguments(profile))
+
+    def get_ansiballz_config(self, profile: DebuggerProfile) -> dict[str, object]:
         return dict(
-            module=self._settings.module,
-            settrace=settrace,
+            module=self.module,
+            settrace=self._get_settrace_arguments(profile),
+            source_mapping=profile.get_source_mapping(),
         )
 
-    def get_cli_arguments(self, host: str, port: int) -> list[str]:
-        return ['-m', 'pydevd', '--client', host, '--port', str(port)] + self._settings.args + ['--file']
+    def get_cli_arguments(self, profile: DebuggerProfile) -> list[str]:
+        # Although `pydevd_pycharm` can be used to invoke `settrace`, it cannot be used to run the debugger on the command line.
+        return ['-m', 'pydevd', '--client', profile.debugger_host, '--port', str(profile.debugger_port)] + self.args + ['--file']
 
-    def get_environment_variables(self, source_mapping: dict[str, str]) -> dict[str, str]:
+    def get_environment_variables(self, profile: DebuggerProfile) -> dict[str, str]:
         return dict(
-            PATHS_FROM_ECLIPSE_TO_PYTHON=json.dumps(list(source_mapping.items())),
+            PATHS_FROM_ECLIPSE_TO_PYTHON=json.dumps(list(profile.get_source_mapping().items())),
             PYDEVD_DISABLE_FILE_VALIDATION="1",
         )
 
-    def _get_settrace_arguments(self, host: str, port: int) -> dict[str, object]:
+    def _get_settrace_arguments(self, profile: DebuggerProfile) -> dict[str, object]:
         """Get settrace arguments for pydevd."""
-        return self._settings.settrace | dict(
-            host=host,
-            port=port,
+        return self.settrace | dict(
+            host=profile.debugger_host,
+            port=profile.debugger_port,
         )
 
 
-class DebugpyProfile(DebuggerProfile):
-    """Profile for the debugpy debugger."""
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class DebugpySettings(DebuggerSettings):
+    """Settings for the debugpy debugger."""
 
-    def __init__(self, settings: DebugpySettings) -> None:
-        self._settings = settings
-        self.debug_type = 'debugpy'
-        self.package = 'debugpy'
-        self.port = settings.port
+    connect: dict[str, object] = dataclasses.field(default_factory=dict)
+    """
+    Options to pass to the `debugpy.connect` method.
+    Used for running AnsiballZ modules and ansible-test after delegation.
+    The endpoint addr, `access_token`, and `parent_session_pid` options will be provided by ansible-test.
+    """
 
-    def activate_debugger(self, host: str, port: int) -> None:
-        # Delays importing debugpy to avoid conflicts with pydevd under other IDEs.
+    args: list[str] = dataclasses.field(default_factory=list)
+    """
+    Arguments to pass to `debugpy` on the command line.
+    Used for running Ansible CLI programs only.
+    The `--connect`, `--adapter-access-token`, and `--parent-session-pid` options will be provided by ansible-test.
+    """
+
+    @classmethod
+    def is_active(cls) -> bool:
+        return detect_debugpy_options() is not None
+
+    @classmethod
+    def apply_defaults(cls, settings: t.Self) -> t.Self:
+        if options := detect_debugpy_options():
+            settings = dataclasses.replace(settings, port=options.port)
+            settings.connect.update(
+                access_token=options.adapter_access_token,
+                parent_session_pid=os.getpid(),
+            )
+        else:
+            display.warning('Debugging will be limited to the first connection. Run ansible-test under debugpy to support multiple connections.')
+
+        return settings
+
+    def get_python_package(self) -> str:
+        return 'debugpy'
+
+    def activate_debugger(self, profile: DebuggerProfile) -> None:
         import debugpy  # pylint: disable=import-error
-        debugpy.connect((host, port), **self._settings.connect)
 
-    def get_ansiballz_config(self, host: str, port: int) -> dict[str, object]:
+        debugpy.connect((profile.debugger_host, profile.debugger_port), **self.connect)
+
+    def get_ansiballz_config(self, profile: DebuggerProfile) -> dict[str, object]:
         return dict(
-            host=host,
-            port=port,
-            connect=self._settings.connect,
+            host=profile.debugger_host,
+            port=profile.debugger_port,
+            connect=self.connect,
+            source_mapping=profile.get_source_mapping(),
         )
 
-    def get_cli_arguments(self, host: str, port: int) -> list[str]:
-        cli_args = ['-m', 'debugpy', '--connect', f"{host}:{port}"]
-        if access_token := self._settings.connect.get('access_token'):
+    def get_cli_arguments(self, profile: DebuggerProfile) -> list[str]:
+        cli_args = ['-m', 'debugpy', '--connect', f"{profile.debugger_host}:{profile.debugger_port}"]
+
+        if access_token := self.connect.get('access_token'):
             cli_args += ['--adapter-access-token', str(access_token)]
-        if session_pid := self._settings.connect.get('parent_session_pid'):
+
+        if session_pid := self.connect.get('parent_session_pid'):
             cli_args += ['--parent-session-pid', str(session_pid)]
-        if self._settings.args:
-            cli_args += self._settings.args
+
+        if self.args:
+            cli_args += self.args
 
         return cli_args
 
-    def get_environment_variables(self, source_mapping: dict[str, str]) -> dict[str, str]:
+    def get_environment_variables(self, profile: DebuggerProfile) -> dict[str, str]:
         return dict(
-            PATHS_FROM_ECLIPSE_TO_PYTHON=json.dumps(list(source_mapping.items())),
+            PATHS_FROM_ECLIPSE_TO_PYTHON=json.dumps(list(profile.get_source_mapping().items())),
             PYDEVD_DISABLE_FILE_VALIDATION="1",
         )
 
@@ -158,76 +323,17 @@ def initialize_debugger(args: CommonConfig) -> None:
     load_debugger_settings(args)
 
 
-def parse_debugpy_debugger_settings(value: str) -> DebugpySettings:
-    """Parse debugpy remote debugger settings and apply defaults."""
-    try:
-        settings = DebugpySettings(**json.loads(value))
-    except Exception as ex:
-        raise ApplicationError(f"Invalid debugpy settings: {ex}") from ex
-
-    if port := detect_debugpy_port():
-        settings = dataclasses.replace(settings, port=port)
-
-    if token := get_debugpy_access_token():
-        settings.connect.setdefault('access_token', token)
-
-    # If not set explicitly, use the current process PID.
-    # This assumes that this ansible-test process is the one initially launched by debugpy.
-    settings.connect.setdefault('parent_session_pid', os.getpid())
-
-    return settings
-
-
-def parse_pydevd_debugger_settings(value: str) -> PyDevDSettings:
-    """Parse PyDevD remote debugger settings and apply defaults."""
-    try:
-        settings = PyDevDSettings(**json.loads(value))
-    except Exception as ex:
-        raise ApplicationError(f"Invalid debugger settings: {ex}") from ex
-
-    if not settings.module:
-        if not settings.package or 'pydevd-pycharm' in settings.package:
-            module = 'pydevd_pycharm'
-        else:
-            module = 'pydevd'
-
-        settings = dataclasses.replace(settings, module=module)
-
-    if settings.package is None:
-        if settings.module == 'pydevd_pycharm':
-            if pycharm_version := detect_pycharm_version():
-                package = f'pydevd-pycharm~={pycharm_version}'
-            else:
-                package = None
-        else:
-            package = 'pydevd'
-
-        settings = dataclasses.replace(settings, package=package)
-
-    settings.settrace.setdefault('suspend', False)
-
-    if port := detect_pydevd_port():
-        settings = dataclasses.replace(settings, port=port)
-
-        if detect_pycharm_process():
-            # This only works with the default PyCharm debugger.
-            # Using it with PyCharm's "Python Debug Server" results in hangs in Ansible workers.
-            # Further investigation is required to understand the cause.
-            settings = dataclasses.replace(settings, args=settings.args + ['--multiprocess'])
-
-    return settings
-
-
 def load_debugger_settings(args: EnvironmentConfig) -> None:
     """Load the remote debugger settings."""
-    debug_type: t.Literal['pydevd', 'debugpy'] | None = None
+    use_debugger: type[DebuggerSettings] | None = None
+
     if args.metadata.debugger_flags.on_demand:
         # On-demand debugging only enables debugging if we're running under a debugger, otherwise it's a no-op.
 
-        if detect_debugpy_port():
-            debug_type = 'debugpy'
-        elif detect_pydevd_port():
-            debug_type = 'pydevd'
+        for candidate_debugger in get_subclasses(DebuggerSettings):
+            if candidate_debugger.is_active():
+                use_debugger = candidate_debugger
+                break
         else:
             display.info('Debugging disabled because no debugger was detected.', verbosity=1)
             args.metadata.debugger_flags = DebuggerFlags.all(False)
@@ -242,20 +348,21 @@ def load_debugger_settings(args: EnvironmentConfig) -> None:
     if not args.metadata.debugger_flags.enable:
         return
 
-    if not debug_type:
-        debug_type = 'debugpy' if 'ANSIBLE_TEST_REMOTE_DEBUGGER_DEBUGPY' in os.environ else 'pydevd'
+    if not use_debugger:  # detect debug type based on env var
+        for candidate_debugger in get_subclasses(DebuggerSettings):
+            if candidate_debugger.get_config_env_var_name() in os.environ:
+                use_debugger = candidate_debugger
+                break
+        else:
+            display.info('Debugging disabled because no debugger configuration was provided.', verbosity=1)
+            args.metadata.debugger_flags = DebuggerFlags.all(False)
+            return
 
-    settings: DebugpySettings | PyDevDSettings
-    if debug_type == 'debugpy':
-        value = os.environ.get('ANSIBLE_TEST_REMOTE_DEBUGGER_DEBUGPY') or '{}'
-        settings = parse_debugpy_debugger_settings(value)
-        args.metadata.debugpy_settings = settings
-    else:
-        value = os.environ.get('ANSIBLE_TEST_REMOTE_DEBUGGER_PYDEVD') or '{}'
-        settings = parse_pydevd_debugger_settings(value)
-        args.metadata.pydevd_settings = settings
+    config = os.environ.get(use_debugger.get_config_env_var_name()) or '{}'
+    settings = use_debugger.parse(config)
+    args.metadata.debugger_settings = settings
 
-    display.info(f'>>> Debugger Settings\n{json.dumps(dataclasses.asdict(settings), indent=4)}', verbosity=3)
+    display.info(f'>>> Debugger Settings ({use_debugger.get_debug_type()})\n{json.dumps(dataclasses.asdict(settings), indent=4)}', verbosity=3)
 
 
 @cache
@@ -283,8 +390,6 @@ def detect_pycharm_version() -> str | None:
             display.info(f'Detected PyCharm version {version}.', verbosity=1)
             return version
 
-    display.warning('Skipping installation of `pydevd-pycharm` since the running PyCharm version could not be detected.')
-
     return None
 
 
@@ -309,23 +414,19 @@ def get_current_process_cached() -> Process:
     return get_current_process()
 
 
-def detect_debugpy_port() -> int | None:
-    """Return the port for the debugpy instance hosting this process, or `None` if not detected."""
-    return _get_debugpy_cli_options()[0]
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class DebugpyOptions:
+    """Options detected from the debugpy instance hosting this process."""
 
-
-def get_debugpy_access_token() -> str | None:
-    """Return the access token for the debugpy instance hosting this process, or `None` if not detected."""
-    return _get_debugpy_cli_options()[1]
+    port: int
+    adapter_access_token: str | None
 
 
 @cache
-def _get_debugpy_cli_options() -> tuple[int | None, str | None]:
-    # To avoid importing debugpy outside of a debugging session, we check to
-    # see if it's already imported. This avoids conflicts with pydevd already
-    # loaded under different IDEs like PyCharm.
+def detect_debugpy_options() -> DebugpyOptions | None:
+    """Return the options for the debugpy instance hosting this process, or `None` if not detected."""
     if "debugpy" not in sys.modules:
-        return (None, None)
+        return None
 
     import debugpy  # pylint: disable=import-error
 
@@ -340,4 +441,14 @@ def _get_debugpy_cli_options() -> tuple[int | None, str | None]:
 
     # address can be None if the debugger is not configured through the CLI as
     # we expected.
-    return opts.address[1] if opts.address else None, opts.adapter_access_token
+    if not opts.address:
+        return None
+
+    port = opts.address[1]
+
+    display.info(f'Detected debugpy debugger port {port}.', verbosity=1)
+
+    return DebugpyOptions(
+        port=port,
+        adapter_access_token=opts.adapter_access_token,
+    )

--- a/test/lib/ansible_test/_internal/debugging.py
+++ b/test/lib/ansible_test/_internal/debugging.py
@@ -3,15 +3,20 @@
 from __future__ import annotations
 
 import dataclasses
+import importlib
 import json
 import os
 import re
+import typing as t
 
 from .util import (
     cache,
     display,
     raw_command,
     ApplicationError,
+)
+from .util_common import (
+    CommonConfig,
 )
 
 from .processes import (
@@ -24,14 +29,128 @@ from .config import (
 )
 
 from .metadata import (
-    DebuggerSettings,
+    DebugpySettings,
+    PyDevDSettings,
     DebuggerFlags,
 )
 
-from . import (
+from .data import (
     data_context,
-    CommonConfig,
 )
+
+HAS_DEBUGPY = False
+try:
+    import debugpy as _debugpy  # type: ignore[import-not-found]  # Not type stubs available for debugpy
+    from debugpy.server import cli as _debugpy_cli  # type: ignore[import-not-found]  # Not type stubs available for debugpy
+
+    HAS_DEBUGPY = True
+except ImportError:
+    pass
+
+
+class DebuggerProfile(t.Protocol):
+    """Commons interface for debugger profiles."""
+
+    debug_type: str
+    """The type of debugger as known by the AnsiballZ extension config suffix."""
+    package: str | None
+    """The package name of the debugger to install by ansible-tesst, or `None` if not applicable."""
+    port: int
+    """The port on the origin host which is listening for incoming connections from the debugger."""
+
+    def activate_debugger(self, host: str, port: int) -> None:
+        """Activate the debugger in ansible-test after delegation."""
+
+    def get_ansiballz_config(self, host: str, port: int) -> dict[str, object]:
+        """Gets the extra configuration data for the AnsiballZ extension module."""
+
+    def get_cli_arguments(self, host: str, port: int) -> list[str]:
+        """Get command line arguments for the debugger when running Ansible CLI programs."""
+
+    def get_environment_variables(self, source_mapping: dict[str, str]) -> dict[str, str]:
+        """Get environment variables needed to configure the debugger for debugging."""
+
+
+class PyDevDProfile(DebuggerProfile):
+    """Profile for the PyDevD debugger."""
+
+    def __init__(self, settings: PyDevDSettings) -> None:
+        self._settings = settings
+        self.debug_type = 'pydevd'
+        self.package = settings.package
+        self.port = settings.port
+
+    def activate_debugger(self, host: str, port: int) -> None:
+        module_name = self._settings.module
+        debugging_module = importlib.import_module(module_name)
+        debugging_module.settrace(**self._get_settrace_arguments(host, port))
+
+    def get_ansiballz_config(self, host: str, port: int) -> dict[str, object]:
+        settrace = dict(
+            host=host,
+            port=port,
+        ) | self._settings.settrace
+
+        return dict(
+            module=self._settings.module,
+            settrace=settrace,
+        )
+
+    def get_cli_arguments(self, host: str, port: int) -> list[str]:
+        return ['-m', 'pydevd', '--client', host, '--port', str(port)] + self._settings.args + ['--file']
+
+    def get_environment_variables(self, source_mapping: dict[str, str]) -> dict[str, str]:
+        return dict(
+            PATHS_FROM_ECLIPSE_TO_PYTHON=json.dumps(list(source_mapping.items())),
+            PYDEVD_DISABLE_FILE_VALIDATION="1",
+        )
+
+    def _get_settrace_arguments(self, host: str, port: int) -> dict[str, object]:
+        """Get settrace arguments for pydevd."""
+        return self._settings.settrace | dict(
+            host=host,
+            port=port,
+        )
+
+
+class DebugpyProfile(DebuggerProfile):
+    """Profile for the debugpy debugger."""
+
+    def __init__(self, settings: DebugpySettings) -> None:
+        self._settings = settings
+        self.debug_type = 'debugpy'
+        self.package = 'debugpy'
+        self.port = settings.port
+
+    def activate_debugger(self, host: str, port: int) -> None:
+        if not HAS_DEBUGPY:
+            raise ImportError("debugpy is not installed, cannot activate debugger.")
+
+        _debugpy.connect((host, port), **self._settings.connect)
+
+    def get_ansiballz_config(self, host: str, port: int) -> dict[str, object]:
+        return dict(
+            host=host,
+            port=port,
+            connect=self._settings.connect,
+        )
+
+    def get_cli_arguments(self, host: str, port: int) -> list[str]:
+        cli_args = ['-m', 'debugpy', '--connect', f"{host}:{port}"]
+        if access_token := self._settings.connect.get('access_token'):
+            cli_args += ['--adapter-access-token', str(access_token)]
+        if session_pid := self._settings.connect.get('parent_session_pid'):
+            cli_args += ['--parent-session-pid', str(session_pid)]
+        if self._settings.args:
+            cli_args += self._settings.args
+
+        return cli_args
+
+    def get_environment_variables(self, source_mapping: dict[str, str]) -> dict[str, str]:
+        return dict(
+            PATHS_FROM_ECLIPSE_TO_PYTHON=json.dumps(list(source_mapping.items())),
+            PYDEVD_DISABLE_FILE_VALIDATION="1",
+        )
 
 
 def initialize_debugger(args: CommonConfig) -> None:
@@ -48,10 +167,30 @@ def initialize_debugger(args: CommonConfig) -> None:
     load_debugger_settings(args)
 
 
-def parse_debugger_settings(value: str) -> DebuggerSettings:
-    """Parse remote debugger settings and apply defaults."""
+def parse_debugpy_debugger_settings(value: str) -> DebugpySettings:
+    """Parse debugpy remote debugger settings and apply defaults."""
     try:
-        settings = DebuggerSettings(**json.loads(value))
+        settings = DebugpySettings(**json.loads(value))
+    except Exception as ex:
+        raise ApplicationError(f"Invalid debugpy settings: {ex}") from ex
+
+    if port := detect_debugpy_port():
+        settings = dataclasses.replace(settings, port=port)
+
+    if token := get_debugpy_access_token():
+        settings.connect.setdefault('access_token', token)
+
+    # If not set explicitly, use the current process PID.
+    # This assumes that this ansible-test process is the one initially launched by debugpy.
+    settings.connect.setdefault('parent_session_pid', os.getpid())
+
+    return settings
+
+
+def parse_pydevd_debugger_settings(value: str) -> PyDevDSettings:
+    """Parse PyDevD remote debugger settings and apply defaults."""
+    try:
+        settings = PyDevDSettings(**json.loads(value))
     except Exception as ex:
         raise ApplicationError(f"Invalid debugger settings: {ex}") from ex
 
@@ -90,10 +229,15 @@ def parse_debugger_settings(value: str) -> DebuggerSettings:
 
 def load_debugger_settings(args: EnvironmentConfig) -> None:
     """Load the remote debugger settings."""
+    debug_type: t.Literal['pydevd', 'debugpy'] | None = None
     if args.metadata.debugger_flags.on_demand:
         # On-demand debugging only enables debugging if we're running under a debugger, otherwise it's a no-op.
 
-        if not detect_pydevd_port():
+        if detect_debugpy_port():
+            debug_type = 'debugpy'
+        elif detect_pydevd_port():
+            debug_type = 'pydevd'
+        else:
             display.info('Debugging disabled because no debugger was detected.', verbosity=1)
             args.metadata.debugger_flags = DebuggerFlags.all(False)
             return
@@ -107,12 +251,20 @@ def load_debugger_settings(args: EnvironmentConfig) -> None:
     if not args.metadata.debugger_flags.enable:
         return
 
-    value = os.environ.get('ANSIBLE_TEST_REMOTE_DEBUGGER') or '{}'
-    settings = parse_debugger_settings(value)
+    if not debug_type:
+        debug_type = 'debugpy' if 'ANSIBLE_TEST_REMOTE_DEBUGGER_DEBUGPY' in os.environ else 'pydevd'
+
+    settings: DebugpySettings | PyDevDSettings
+    if debug_type == 'debugpy':
+        value = os.environ.get('ANSIBLE_TEST_REMOTE_DEBUGGER_DEBUGPY') or '{}'
+        settings = parse_debugpy_debugger_settings(value)
+        args.metadata.debugpy_settings = settings
+    else:
+        value = os.environ.get('ANSIBLE_TEST_REMOTE_DEBUGGER_PYDEVD') or '{}'
+        settings = parse_pydevd_debugger_settings(value)
+        args.metadata.pydevd_settings = settings
 
     display.info(f'>>> Debugger Settings\n{json.dumps(dataclasses.asdict(settings), indent=4)}', verbosity=3)
-
-    args.metadata.debugger_settings = settings
 
 
 @cache
@@ -164,3 +316,21 @@ def detect_pycharm_process() -> Process | None:
 def get_current_process_cached() -> Process:
     """Return the current process. The result is cached."""
     return get_current_process()
+
+
+@cache
+def detect_debugpy_port() -> int | None:
+    """Return the port for the debugpy instance hosting this process, or `None` if not detected."""
+    if HAS_DEBUGPY and _debugpy.is_client_connected():
+        return _debugpy_cli.options.address[1]
+
+    return None
+
+
+@cache
+def get_debugpy_access_token() -> str | None:
+    """Return the access token for the debugpy instance hosting this process, or `None` if not detected."""
+    if HAS_DEBUGPY and _debugpy.is_client_connected():
+        return _debugpy_cli.options.adapter_access_token
+
+    return None

--- a/test/lib/ansible_test/_internal/debugging.py
+++ b/test/lib/ansible_test/_internal/debugging.py
@@ -40,8 +40,8 @@ from .data import (
 
 HAS_DEBUGPY = False
 try:
-    import debugpy as _debugpy  # type: ignore[import-not-found]  # Not type stubs available for debugpy
-    from debugpy.server import cli as _debugpy_cli  # type: ignore[import-not-found]  # Not type stubs available for debugpy
+    import debugpy as _debugpy
+    from debugpy.server import cli as _debugpy_cli
 
     HAS_DEBUGPY = True
 except ImportError:

--- a/test/lib/ansible_test/_internal/debugging.py
+++ b/test/lib/ansible_test/_internal/debugging.py
@@ -63,7 +63,7 @@ class DebuggerProfile(t.Protocol):
         """Get environment variables needed to configure the debugger for debugging."""
 
 
-class PyDevDProfile(DebuggerProfile):
+class PydevdProfile(DebuggerProfile):
     """Profile for the PyDevD debugger."""
 
     def __init__(self, settings: PyDevDSettings) -> None:
@@ -116,7 +116,7 @@ class DebugpyProfile(DebuggerProfile):
 
     def activate_debugger(self, host: str, port: int) -> None:
         # Delays importing debugpy to avoid conflicts with pydevd under other IDEs.
-        import debugpy
+        import debugpy  # pylint: disable=import-error
         debugpy.connect((host, port), **self._settings.connect)
 
     def get_ansiballz_config(self, host: str, port: int) -> dict[str, object]:
@@ -327,7 +327,7 @@ def _get_debugpy_cli_options() -> tuple[int | None, str | None]:
     if "debugpy" not in sys.modules:
         return (None, None)
 
-    import debugpy
+    import debugpy  # pylint: disable=import-error
 
     # get_cli_options is the new public API introduced after debugpy 1.8.15.
     # We should remove the debugpy.server cli fallback once the new version is
@@ -335,7 +335,7 @@ def _get_debugpy_cli_options() -> tuple[int | None, str | None]:
     if hasattr(debugpy, 'get_cli_options'):
         opts = debugpy.get_cli_options()
     else:
-        from debugpy.server import cli
+        from debugpy.server import cli  # pylint: disable=import-error
         opts = cli.options
 
     # address can be None if the debugger is not configured through the CLI as

--- a/test/lib/ansible_test/_internal/debugging.py
+++ b/test/lib/ansible_test/_internal/debugging.py
@@ -7,6 +7,7 @@ import importlib
 import json
 import os
 import re
+import sys
 import typing as t
 
 from .util import (
@@ -37,15 +38,6 @@ from .metadata import (
 from .data import (
     data_context,
 )
-
-HAS_DEBUGPY = False
-try:
-    import debugpy as _debugpy
-    from debugpy.server import cli as _debugpy_cli
-
-    HAS_DEBUGPY = True
-except ImportError:
-    pass
 
 
 class DebuggerProfile(t.Protocol):
@@ -123,10 +115,9 @@ class DebugpyProfile(DebuggerProfile):
         self.port = settings.port
 
     def activate_debugger(self, host: str, port: int) -> None:
-        if not HAS_DEBUGPY:
-            raise ImportError("debugpy is not installed, cannot activate debugger.")
-
-        _debugpy.connect((host, port), **self._settings.connect)
+        # Delays importing debugpy to avoid conflicts with pydevd under other IDEs.
+        import debugpy
+        debugpy.connect((host, port), **self._settings.connect)
 
     def get_ansiballz_config(self, host: str, port: int) -> dict[str, object]:
         return dict(
@@ -330,14 +321,23 @@ def get_debugpy_access_token() -> str | None:
 
 @cache
 def _get_debugpy_cli_options() -> tuple[int | None, str | None]:
-    if not (HAS_DEBUGPY and _debugpy.is_client_connected()):
+    # To avoid importing debugpy outside of a debugging session, we check to
+    # see if it's already imported. This avoids conflicts with pydevd already
+    # loaded under different IDEs like PyCharm.
+    if "debugpy" not in sys.modules:
         return (None, None)
 
-    # get_cli_options is the new public API introduced after debugpy 1.8.15.
-    # We should remove the _debugpy_cli fallback once the new version is released.
-    if hasattr(_debugpy, 'get_cli_options'):
-        opts = _debugpy.get_cli_options()
-    else:
-        opts = _debugpy_cli.options
+    import debugpy
 
-    return opts.address[1], opts.adapter_access_token
+    # get_cli_options is the new public API introduced after debugpy 1.8.15.
+    # We should remove the debugpy.server cli fallback once the new version is
+    # released.
+    if hasattr(debugpy, 'get_cli_options'):
+        opts = debugpy.get_cli_options()
+    else:
+        from debugpy.server import cli
+        opts = cli.options
+
+    # address can be None if the debugger is not configured through the CLI as
+    # we expected.
+    return opts.address[1] if opts.address else None, opts.adapter_access_token

--- a/test/lib/ansible_test/_internal/host_profiles.py
+++ b/test/lib/ansible_test/_internal/host_profiles.py
@@ -142,7 +142,7 @@ from .dev.container_probe import (
 from .debugging import (
     DebuggerProfile,
     DebugpyProfile,
-    PyDevDProfile,
+    PydevdProfile,
 )
 
 TControllerHostConfig = t.TypeVar('TControllerHostConfig', bound=ControllerHostConfig)
@@ -310,7 +310,7 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         if self.__DEBUGGER_KEY not in self.cache:
             profile: DebuggerProfile | None = None
             if self.args.metadata.pydevd_settings:
-                profile = PyDevDProfile(self.args.metadata.pydevd_settings)
+                profile = PydevdProfile(self.args.metadata.pydevd_settings)
             elif self.args.metadata.debugpy_settings:
                 profile = DebugpyProfile(self.args.metadata.debugpy_settings)
 

--- a/test/lib/ansible_test/_internal/host_profiles.py
+++ b/test/lib/ansible_test/_internal/host_profiles.py
@@ -420,7 +420,7 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
 
         debug_type = self.debugger.debug_type.lower()
         return {
-            f"_ansible_ansiballz_debugger_config{debug_type}": json.dumps(self.get_ansiballz_debugger_config()),
+            f"_ansible_ansiballz_{debug_type}_config": json.dumps(self.get_ansiballz_debugger_config()),
         }
 
     def get_ansiballz_environment_variables(self) -> dict[str, t.Any]:
@@ -433,7 +433,7 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
 
         debug_type = self.debugger.debug_type.upper()
         return {
-            f"_ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG_{debug_type}": json.dumps(self.get_ansiballz_debugger_config()),
+            f"_ANSIBLE_ANSIBALLZ_{debug_type}_CONFIG": json.dumps(self.get_ansiballz_debugger_config()),
         }
 
     def get_ansiballz_debugger_config(self) -> dict[str, t.Any]:

--- a/test/lib/ansible_test/_internal/host_profiles.py
+++ b/test/lib/ansible_test/_internal/host_profiles.py
@@ -141,8 +141,7 @@ from .dev.container_probe import (
 
 from .debugging import (
     DebuggerProfile,
-    DebugpyProfile,
-    PydevdProfile,
+    DebuggerSettings,
 )
 
 TControllerHostConfig = t.TypeVar('TControllerHostConfig', bound=ControllerHostConfig)
@@ -297,27 +296,16 @@ class HostProfile(t.Generic[THostConfig], metaclass=abc.ABCMeta):
         return f'{self.__class__.__name__}: {self.name}'
 
 
-class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
+class DebuggableProfile(HostProfile[THostConfig], DebuggerProfile, metaclass=abc.ABCMeta):
     """Base class for profiles remote debugging."""
 
-    __DEBUGGER_KEY = 'debugger'
     __DEBUGGING_PORT_KEY = 'debugging_port'
     __DEBUGGING_FORWARDER_KEY = 'debugging_forwarder'
 
     @property
-    def debugger(self) -> DebuggerProfile | None:
-        """The debugger profile for this host if present, otherwise None."""
-        if self.__DEBUGGER_KEY not in self.cache:
-            profile: DebuggerProfile | None = None
-            if self.args.metadata.pydevd_settings:
-                profile = PydevdProfile(self.args.metadata.pydevd_settings)
-            elif self.args.metadata.debugpy_settings:
-                profile = DebugpyProfile(self.args.metadata.debugpy_settings)
-
-            self.cache[self.__DEBUGGER_KEY] = profile
-            return profile
-
-        return self.cache[self.__DEBUGGER_KEY]
+    def debugger(self) -> DebuggerSettings | None:
+        """The debugger settings for this host if present and enabled, otherwise None."""
+        return self.args.metadata.debugger_settings
 
     @property
     def debugging_enabled(self) -> bool:
@@ -328,8 +316,13 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         return self.args.metadata.debugger_flags.ansiballz
 
     @property
+    def debugger_host(self) -> str:
+        """The debugger host to use."""
+        return 'localhost'
+
+    @property
     def debugger_port(self) -> int:
-        """The pydevd/debugpy port to use."""
+        """The debugger port to use."""
         return self.state.get(self.__DEBUGGING_PORT_KEY) or self.origin_debugger_port
 
     @property
@@ -345,8 +338,7 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
     @property
     def origin_debugger_port(self) -> int:
         """The debugger port on the origin."""
-        debugger = self.debugger
-        return debugger.port if debugger else 0
+        return self.debugger.port
 
     def enable_debugger_forwarding(self, ssh: SshConnectionDetail) -> None:
         """Enable debugger port forwarding from the origin."""
@@ -400,13 +392,14 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
 
     def activate_debugger(self) -> None:
         """Activate the debugger after delegation."""
-        if not self.args.metadata.loaded or not self.args.metadata.debugger_flags.self or not self.debugger:
+        if not self.args.metadata.loaded or not self.args.metadata.debugger_flags.self:
             return
 
         display.info('Activating remote debugging of ansible-test.', verbosity=1)
 
-        os.environ.update(self.debugger.get_environment_variables(self.get_source_mapping()))
-        self.debugger.activate_debugger('localhost', self.debugger_port)
+        os.environ.update(self.debugger.get_environment_variables(self))
+
+        self.debugger.activate_debugger(self)
 
         pass  # pylint: disable=unnecessary-pass  # when suspend is True, execution pauses here -- it's also a convenient place to put a breakpoint
 
@@ -415,10 +408,11 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         Return inventory variables for remote debugging of AnsiballZ modules.
         When delegating, this function must be called after delegation.
         """
-        if not self.args.metadata.debugger_flags.ansiballz or not self.debugger:
+        if not self.args.metadata.debugger_flags.ansiballz:
             return {}
 
-        debug_type = self.debugger.debug_type.lower()
+        debug_type = self.debugger.get_debug_type()
+
         return {
             f"_ansible_ansiballz_{debug_type}_config": json.dumps(self.get_ansiballz_debugger_config()),
         }
@@ -428,10 +422,11 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         Return environment variables for remote debugging of AnsiballZ modules.
         When delegating, this function must be called after delegation.
         """
-        if not self.args.metadata.debugger_flags.ansiballz or not self.debugger:
+        if not self.args.metadata.debugger_flags.ansiballz:
             return {}
 
-        debug_type = self.debugger.debug_type.upper()
+        debug_type = self.debugger.get_debug_type().upper()
+
         return {
             f"_ANSIBLE_ANSIBALLZ_{debug_type}_CONFIG": json.dumps(self.get_ansiballz_debugger_config()),
         }
@@ -441,9 +436,7 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         Return config for remote debugging of AnsiballZ modules.
         When delegating, this function must be called after delegation.
         """
-        debugger_config = dict(
-            source_mapping=self.get_source_mapping(),
-        ) | self.debugger.get_ansiballz_config('localhost', self.debugger_port)
+        debugger_config = self.debugger.get_ansiballz_config(self)
 
         display.info(f'>>> Debugger Config ({self.name} AnsiballZ)\n{json.dumps(debugger_config, indent=4)}', verbosity=3)
 
@@ -454,12 +447,12 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         Return environment variables for remote debugging of the Ansible CLI.
         When delegating, this function must be called after delegation.
         """
-        if not self.args.metadata.debugger_flags.cli or not self.debugger:
+        if not self.args.metadata.debugger_flags.cli:
             return {}
 
         debugger_config = dict(
-            args=self.debugger.get_cli_arguments('localhost', self.debugger_port),
-            env=self.debugger.get_environment_variables(self.get_source_mapping()),
+            args=self.debugger.get_cli_arguments(self),
+            env=self.debugger.get_environment_variables(self),
         )
 
         display.info(f'>>> Debugger Config ({self.name} Ansible CLI)\n{json.dumps(debugger_config, indent=4)}', verbosity=3)

--- a/test/lib/ansible_test/_internal/host_profiles.py
+++ b/test/lib/ansible_test/_internal/host_profiles.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import abc
 import dataclasses
-import importlib
 import json
 import os
 import pathlib
@@ -138,6 +137,12 @@ from .dev.container_probe import (
     CGroupState,
     MountType,
     check_container_cgroup_status,
+)
+
+from .debugging import (
+    DebuggerProfile,
+    DebugpyProfile,
+    PyDevDProfile,
 )
 
 TControllerHostConfig = t.TypeVar('TControllerHostConfig', bound=ControllerHostConfig)
@@ -295,8 +300,24 @@ class HostProfile(t.Generic[THostConfig], metaclass=abc.ABCMeta):
 class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
     """Base class for profiles remote debugging."""
 
-    __PYDEVD_PORT_KEY = 'pydevd_port'
+    __DEBUGGER_KEY = 'debugger'
+    __DEBUGGING_PORT_KEY = 'debugging_port'
     __DEBUGGING_FORWARDER_KEY = 'debugging_forwarder'
+
+    @property
+    def debugger(self) -> DebuggerProfile | None:
+        """The debugger profile for this host if present, otherwise None."""
+        if self.__DEBUGGER_KEY not in self.cache:
+            profile: DebuggerProfile | None = None
+            if self.args.metadata.pydevd_settings:
+                profile = PyDevDProfile(self.args.metadata.pydevd_settings)
+            elif self.args.metadata.debugpy_settings:
+                profile = DebugpyProfile(self.args.metadata.debugpy_settings)
+
+            self.cache[self.__DEBUGGER_KEY] = profile
+            return profile
+
+        return self.cache[self.__DEBUGGER_KEY]
 
     @property
     def debugging_enabled(self) -> bool:
@@ -307,9 +328,9 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         return self.args.metadata.debugger_flags.ansiballz
 
     @property
-    def pydevd_port(self) -> int:
-        """The pydevd port to use."""
-        return self.state.get(self.__PYDEVD_PORT_KEY) or self.origin_pydev_port
+    def debugger_port(self) -> int:
+        """The pydevd/debugpy port to use."""
+        return self.state.get(self.__DEBUGGING_PORT_KEY) or self.origin_debugger_port
 
     @property
     def debugging_forwarder(self) -> SshProcess | None:
@@ -322,23 +343,24 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         self.cache[self.__DEBUGGING_FORWARDER_KEY] = value
 
     @property
-    def origin_pydev_port(self) -> int:
-        """The pydevd port on the origin."""
-        return self.args.metadata.debugger_settings.port
+    def origin_debugger_port(self) -> int:
+        """The debugger port on the origin."""
+        debugger = self.debugger
+        return debugger.port if debugger else 0
 
     def enable_debugger_forwarding(self, ssh: SshConnectionDetail) -> None:
-        """Enable pydevd port forwarding from the origin."""
+        """Enable debugger port forwarding from the origin."""
         if not self.debugging_enabled:
             return
 
-        endpoint = ('localhost', self.origin_pydev_port)
+        endpoint = ('localhost', self.origin_debugger_port)
         forwards = [endpoint]
 
         self.debugging_forwarder = create_ssh_port_forwards(self.args, ssh, forwards)
 
         port_forwards = self.debugging_forwarder.collect_port_forwards()
 
-        self.state[self.__PYDEVD_PORT_KEY] = port = port_forwards[endpoint]
+        self.state[self.__DEBUGGING_PORT_KEY] = port = port_forwards[endpoint]
 
         display.info(f'Remote debugging of {self.name!r} is available on port {port}.', verbosity=1)
 
@@ -354,19 +376,6 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         display.info(f'Waiting for the {self.name!r} remote debugging SSH port forwarding process to terminate.', verbosity=1)
 
         self.debugging_forwarder.wait()
-
-    def get_pydevd_settrace_arguments(self) -> dict[str, object]:
-        """Get settrace arguments for pydevd."""
-        return self.args.metadata.debugger_settings.settrace | dict(
-            host="localhost",
-            port=self.pydevd_port,
-        )
-
-    def get_pydevd_environment_variables(self) -> dict[str, str]:
-        """Get environment variables needed to configure pydevd for debugging."""
-        return dict(
-            PATHS_FROM_ECLIPSE_TO_PYTHON=json.dumps(list(self.get_source_mapping().items())),
-        )
 
     def get_source_mapping(self) -> dict[str, str]:
         """Get the source mapping from the given metadata."""
@@ -391,15 +400,13 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
 
     def activate_debugger(self) -> None:
         """Activate the debugger after delegation."""
-        if not self.args.metadata.loaded or not self.args.metadata.debugger_flags.self:
+        if not self.args.metadata.loaded or not self.args.metadata.debugger_flags.self or not self.debugger:
             return
 
         display.info('Activating remote debugging of ansible-test.', verbosity=1)
 
-        os.environ.update(self.get_pydevd_environment_variables())
-
-        debugging_module = importlib.import_module(self.args.metadata.debugger_settings.module)
-        debugging_module.settrace(**self.get_pydevd_settrace_arguments())
+        os.environ.update(self.debugger.get_environment_variables(self.get_source_mapping()))
+        self.debugger.activate_debugger('localhost', self.debugger_port)
 
         pass  # pylint: disable=unnecessary-pass  # when suspend is True, execution pauses here -- it's also a convenient place to put a breakpoint
 
@@ -408,24 +415,26 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         Return inventory variables for remote debugging of AnsiballZ modules.
         When delegating, this function must be called after delegation.
         """
-        if not self.args.metadata.debugger_flags.ansiballz:
+        if not self.args.metadata.debugger_flags.ansiballz or not self.debugger:
             return {}
 
-        return dict(
-            _ansible_ansiballz_debugger_config=json.dumps(self.get_ansiballz_debugger_config()),
-        )
+        debug_type = self.debugger.debug_type.lower()
+        return {
+            f"_ansible_ansiballz_debugger_config{debug_type}": json.dumps(self.get_ansiballz_debugger_config()),
+        }
 
     def get_ansiballz_environment_variables(self) -> dict[str, t.Any]:
         """
         Return environment variables for remote debugging of AnsiballZ modules.
         When delegating, this function must be called after delegation.
         """
-        if not self.args.metadata.debugger_flags.ansiballz:
+        if not self.args.metadata.debugger_flags.ansiballz or not self.debugger:
             return {}
 
-        return dict(
-            _ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG=json.dumps(self.get_ansiballz_debugger_config()),
-        )
+        debug_type = self.debugger.debug_type.upper()
+        return {
+            f"_ANSIBLE_ANSIBALLZ_DEBUGGER_CONFIG_{debug_type}": json.dumps(self.get_ansiballz_debugger_config()),
+        }
 
     def get_ansiballz_debugger_config(self) -> dict[str, t.Any]:
         """
@@ -433,10 +442,8 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         When delegating, this function must be called after delegation.
         """
         debugger_config = dict(
-            module=self.args.metadata.debugger_settings.module,
-            settrace=self.get_pydevd_settrace_arguments(),
             source_mapping=self.get_source_mapping(),
-        )
+        ) | self.debugger.get_ansiballz_config('localhost', self.debugger_port)
 
         display.info(f'>>> Debugger Config ({self.name} AnsiballZ)\n{json.dumps(debugger_config, indent=4)}', verbosity=3)
 
@@ -447,12 +454,12 @@ class DebuggableProfile(HostProfile[THostConfig], metaclass=abc.ABCMeta):
         Return environment variables for remote debugging of the Ansible CLI.
         When delegating, this function must be called after delegation.
         """
-        if not self.args.metadata.debugger_flags.cli:
+        if not self.args.metadata.debugger_flags.cli or not self.debugger:
             return {}
 
         debugger_config = dict(
-            args=['-m', 'pydevd', '--client', 'localhost', '--port', str(self.pydevd_port)] + self.args.metadata.debugger_settings.args + ['--file'],
-            env=self.get_pydevd_environment_variables(),
+            args=self.debugger.get_cli_arguments('localhost', self.debugger_port),
+            env=self.debugger.get_environment_variables(self.get_source_mapping()),
         )
 
         display.info(f'>>> Debugger Config ({self.name} Ansible CLI)\n{json.dumps(debugger_config, indent=4)}', verbosity=3)
@@ -597,9 +604,9 @@ class ControllerProfile(SshTargetHostProfile[ControllerConfig], PosixProfile[Con
         return self.controller_profile.name
 
     @property
-    def pydevd_port(self) -> int:
+    def debugger_port(self) -> int:
         """The pydevd port to use."""
-        return self.controller_profile.pydevd_port
+        return self.controller_profile.debugger_port
 
     def get_controller_target_connections(self) -> list[SshConnection]:
         """Return SSH connection(s) for accessing the host as a target from the controller."""

--- a/test/lib/ansible_test/_internal/metadata.py
+++ b/test/lib/ansible_test/_internal/metadata.py
@@ -37,7 +37,8 @@ class Metadata:
         self.ansible_test_root = ANSIBLE_TEST_ROOT
         self.collection_root: str | None = None
         self.debugger_flags = debugger_flags
-        self.debugger_settings: DebuggerSettings | None = None
+        self.pydevd_settings: PyDevDSettings | None = None
+        self.debugpy_settings: DebugpySettings | None = None
         self.loaded = False
 
     def populate_changes(self, diff: t.Optional[list[str]]) -> None:
@@ -71,7 +72,8 @@ class Metadata:
             ansible_test_root=self.ansible_test_root,
             collection_root=self.collection_root,
             debugger_flags=dataclasses.asdict(self.debugger_flags),
-            debugger_settings=dataclasses.asdict(self.debugger_settings) if self.debugger_settings else None,
+            pydevd_settings=dataclasses.asdict(self.pydevd_settings) if self.pydevd_settings else None,
+            debugpy_settings=dataclasses.asdict(self.debugpy_settings) if self.debugpy_settings else None,
         )
 
     def to_file(self, path: str) -> None:
@@ -103,7 +105,8 @@ class Metadata:
         metadata.ansible_lib_root = data['ansible_lib_root']
         metadata.ansible_test_root = data['ansible_test_root']
         metadata.collection_root = data['collection_root']
-        metadata.debugger_settings = DebuggerSettings(**data['debugger_settings']) if data['debugger_settings'] else None
+        metadata.pydevd_settings = PyDevDSettings(**data['pydevd_settings']) if data['pydevd_settings'] else None
+        metadata.debugpy_settings = DebugpySettings(**data['debugpy_settings']) if data['debugpy_settings'] else None
         metadata.loaded = True
 
         return metadata
@@ -156,8 +159,8 @@ class ChangeDescription:
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
-class DebuggerSettings:
-    """Settings for remote debugging."""
+class PyDevDSettings:
+    """Settings for remote debuggin with PyDevD."""
 
     module: str | None = None
     """
@@ -191,6 +194,31 @@ class DebuggerSettings:
     port: int = 5678
     """
     The port on the origin host which is listening for incoming connections from pydevd.
+    SSH port forwarding will be automatically configured for non-local hosts to connect to this port as needed.
+    """
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class DebugpySettings:
+    """Settings for debugging with debugpy."""
+
+    connect: dict[str, object] = dataclasses.field(default_factory=dict)
+    """
+    Options to pass to the `debugpy.connect` method.
+    Used for running AnsiballZ modules and ansible-test after delegation.
+    The endpoint addr, `access_token`, and `parent_session_pid` options will be provided by ansible-test.
+    """
+
+    args: list[str] = dataclasses.field(default_factory=list)
+    """
+    Arguments to pass to `debugpy` on the command line.
+    Used for running Ansible CLI programs only.
+    The `--connect`, `--adapter-access-token`, and `--parent-session-pid` options will be provided by ansible-test.
+    """
+
+    port: int = 5678
+    """
+    The port on the origin host which is listening for incoming connections from debugpy.
     SSH port forwarding will be automatically configured for non-local hosts to connect to this port as needed.
     """
 

--- a/test/lib/ansible_test/_internal/metadata.py
+++ b/test/lib/ansible_test/_internal/metadata.py
@@ -22,6 +22,9 @@ from .diff import (
     FileDiff,
 )
 
+if t.TYPE_CHECKING:
+    from .debugging import DebuggerSettings
+
 
 class Metadata:
     """Metadata object for passing data to delegated tests."""
@@ -37,8 +40,7 @@ class Metadata:
         self.ansible_test_root = ANSIBLE_TEST_ROOT
         self.collection_root: str | None = None
         self.debugger_flags = debugger_flags
-        self.pydevd_settings: PyDevDSettings | None = None
-        self.debugpy_settings: DebugpySettings | None = None
+        self.debugger_settings: DebuggerSettings | None = None
         self.loaded = False
 
     def populate_changes(self, diff: t.Optional[list[str]]) -> None:
@@ -72,8 +74,7 @@ class Metadata:
             ansible_test_root=self.ansible_test_root,
             collection_root=self.collection_root,
             debugger_flags=dataclasses.asdict(self.debugger_flags),
-            pydevd_settings=dataclasses.asdict(self.pydevd_settings) if self.pydevd_settings else None,
-            debugpy_settings=dataclasses.asdict(self.debugpy_settings) if self.debugpy_settings else None,
+            debugger_settings=self.debugger_settings.as_dict() if self.debugger_settings else None,
         )
 
     def to_file(self, path: str) -> None:
@@ -93,6 +94,8 @@ class Metadata:
     @staticmethod
     def from_dict(data: dict[str, t.Any]) -> Metadata:
         """Return metadata loaded from the specified dictionary."""
+        from .debugging import DebuggerSettings
+
         metadata = Metadata(
             debugger_flags=DebuggerFlags(**data['debugger_flags']),
         )
@@ -105,8 +108,7 @@ class Metadata:
         metadata.ansible_lib_root = data['ansible_lib_root']
         metadata.ansible_test_root = data['ansible_test_root']
         metadata.collection_root = data['collection_root']
-        metadata.pydevd_settings = PyDevDSettings(**data['pydevd_settings']) if data['pydevd_settings'] else None
-        metadata.debugpy_settings = DebugpySettings(**data['debugpy_settings']) if data['debugpy_settings'] else None
+        metadata.debugger_settings = DebuggerSettings.from_dict(data['debugger_settings']) if data['debugger_settings'] else None
         metadata.loaded = True
 
         return metadata
@@ -156,71 +158,6 @@ class ChangeDescription:
         changes.no_integration_paths = data['no_integration_paths']
 
         return changes
-
-
-@dataclasses.dataclass(frozen=True, kw_only=True)
-class PyDevDSettings:
-    """Settings for remote debuggin with PyDevD."""
-
-    module: str | None = None
-    """
-    The Python module to import.
-    This should be pydevd or a derivative.
-    If not provided it will be auto-detected.
-    """
-
-    package: str | None = None
-    """
-    The Python package to install for debugging.
-    If `None` then the package will be auto-detected.
-    If an empty string, then no package will be installed.
-    """
-
-    settrace: dict[str, object] = dataclasses.field(default_factory=dict)
-    """
-    Options to pass to the `{module}.settrace` method.
-    Used for running AnsiballZ modules only.
-    The `host` and `port` options will be provided by ansible-test.
-    The `suspend` option defaults to `False`.
-    """
-
-    args: list[str] = dataclasses.field(default_factory=list)
-    """
-    Arguments to pass to `pydevd` on the command line.
-    Used for running Ansible CLI programs only.
-    The `--client` and `--port` options will be provided by ansible-test.
-    """
-
-    port: int = 5678
-    """
-    The port on the origin host which is listening for incoming connections from pydevd.
-    SSH port forwarding will be automatically configured for non-local hosts to connect to this port as needed.
-    """
-
-
-@dataclasses.dataclass(frozen=True, kw_only=True)
-class DebugpySettings:
-    """Settings for debugging with debugpy."""
-
-    connect: dict[str, object] = dataclasses.field(default_factory=dict)
-    """
-    Options to pass to the `debugpy.connect` method.
-    Used for running AnsiballZ modules and ansible-test after delegation.
-    The endpoint addr, `access_token`, and `parent_session_pid` options will be provided by ansible-test.
-    """
-
-    args: list[str] = dataclasses.field(default_factory=list)
-    """
-    Arguments to pass to `debugpy` on the command line.
-    Used for running Ansible CLI programs only.
-    The `--connect`, `--adapter-access-token`, and `--parent-session-pid` options will be provided by ansible-test.
-    """
-
-    port: int = 5678
-    """
-    The port on the origin host which is listening for incoming connections from debugpy.
-    SSH port forwarding will be automatically configured for non-local hosts to connect to this port as needed.
-    """
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)

--- a/test/lib/ansible_test/_internal/python_requirements.py
+++ b/test/lib/ansible_test/_internal/python_requirements.py
@@ -170,11 +170,11 @@ def install_requirements(
 
     from .host_profiles import DebuggableProfile
 
-    if isinstance(host_profile, DebuggableProfile) and host_profile.debugging_enabled and (debugger := host_profile.debugger) and debugger.package:
+    if isinstance(host_profile, DebuggableProfile) and host_profile.debugger and host_profile.debugger.get_python_package():
         commands.append(PipInstall(
             requirements=[],
             constraints=[],
-            packages=[debugger.package],
+            packages=[host_profile.debugger.get_python_package()],
         ))
 
     if not commands:

--- a/test/lib/ansible_test/_internal/python_requirements.py
+++ b/test/lib/ansible_test/_internal/python_requirements.py
@@ -170,11 +170,11 @@ def install_requirements(
 
     from .host_profiles import DebuggableProfile
 
-    if isinstance(host_profile, DebuggableProfile) and host_profile.debugging_enabled and args.metadata.debugger_settings.package:
+    if isinstance(host_profile, DebuggableProfile) and host_profile.debugging_enabled and (debugger := host_profile.debugger) and debugger.package:
         commands.append(PipInstall(
             requirements=[],
             constraints=[],
-            packages=[args.metadata.debugger_settings.package],
+            packages=[debugger.package],
         ))
 
     if not commands:

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test.cfg
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/config/ansible-test.cfg
@@ -21,6 +21,7 @@ disable=
     broad-exception-raised,  # many exceptions with no need for a custom type
     too-few-public-methods,
     too-many-public-methods,
+    too-many-ancestors,
     too-many-arguments,
     too-many-branches,
     too-many-instance-attributes,

--- a/test/sanity/code-smell/mypy/ansible-core.ini
+++ b/test/sanity/code-smell/mypy/ansible-core.ini
@@ -133,3 +133,6 @@ ignore_missing_imports = True
 
 [mypy-jinja2.nativetypes]
 ignore_missing_imports = True
+
+[mypy-debugpy]
+ignore_missing_imports = True

--- a/test/sanity/code-smell/mypy/ansible-test.ini
+++ b/test/sanity/code-smell/mypy/ansible-test.ini
@@ -77,3 +77,9 @@ ignore_missing_imports = True
 
 [mypy-py._path.local]
 ignore_missing_imports = True
+
+[mypy-debugpy]
+ignore_missing_imports = True
+
+[mypy-debugpy.server]
+ignore_missing_imports = True


### PR DESCRIPTION
##### SUMMARY
Adds support for debugging AnsiballZ modules with debugpy which is used by VSCode as its Python debugger DAP. Debugging can either be done through a manual Debugpy listening server through a launch.json configuration or through the new ansible-test --dev-debug-on-deman argument.

The `ansible-test` integration requires a change in debugpy that is not currently in a public release. It can be used by cloning the debugpy repo or waiting until the next release.

##### ISSUE TYPE
- Feature Pull Request