### PR TITLE
Update issue templates with note about secrets

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -105,7 +105,8 @@ body:
     label: Configuration
     description: >-
       Paste verbatim output from `ansible-config dump --only-changed -t all` below, under the prompt line.
-      (if using a version older than ansible-core 2.12 you should omit the '-t all')
+      Remember to redact secret values. You can easily filter Galaxy server secrets using grep,
+      for example `ansible-config dump --only-changed -t all | grep -Ev 'token|password|client_secret'`.
       Please don't wrap it with triple backticks — your
       whole input will be turned into a code snippet automatically.
     render: console

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -130,6 +130,8 @@ body:
     label: Configuration
     description: >-
       Paste verbatim output from `ansible-config dump --only-changed -t all` below, under the prompt line.
+      Remember to redact secret values. You can easily filter Galaxy server secrets using grep,
+      for example `ansible-config dump --only-changed -t all | grep -Ev 'token|password|client_secret'`.
       (if using a version older than ansible-core 2.12 you should omit the '-t all')
       Please don't wrap it with triple backticks — your
       whole input will be turned into a code snippet automatically.


### PR DESCRIPTION
##### SUMMARY

Follow up to https://github.com/ansible/ansible/issues/85373#issuecomment-3009697831 - we don't think this is a bug, and we don't think secrets should be obscured necessarily.

There's a related PR, #85467 which isn't backwards compatible and hardcodes hiding several config option names for Galaxy servers, but this isn't flexible enough to hide arbitrary options configuring secrets for 3rd party plugins.

Instead, I've updated the issue templates to give an example of how to exclude those options, and a more general suggestion.

Closes #85373
Closes #85467

##### ISSUE TYPE

- Bugfix Pull Request