### PR TITLE
environment - stop suppressing undefined ansible_env errors for all tasks

### DIFF
--- a/changelogs/fragments/error-on-undefined-environment-ansible_env.yml
+++ b/changelogs/fragments/error-on-undefined-environment-ansible_env.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- >-
+  ``environment`` keyword - env vars defined with ``ansible_env`` are no longer
+  silently ignored when ``ansible_env`` is undefined for actions other than
+  setup and gather_facts.

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -387,7 +387,7 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
                 return
             except AnsibleUndefinedVariable as e:
                 error = to_native(e)
-                if self.action in C._ACTION_FACT_GATHERING and 'ansible_facts.env' in error or 'ansible_env' in error:
+                if self.action in C._ACTION_FACT_GATHERING and ('ansible_facts.env' in error or 'ansible_env' in error):
                     # ignore as fact gathering is required for 'env' facts
                     return
                 raise

--- a/test/integration/targets/environment/test_environment.yml
+++ b/test/integration/targets/environment/test_environment.yml
@@ -187,3 +187,19 @@
       assert:
         that:
           - test_foo.results[0].stdout == 'outer'
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - shell: echo $PATH
+      environment:
+        PATH: "/usr/local/bin/:{{ ansible_env.PATH }}"
+      ignore_errors: true
+      register: fatal
+
+    - assert:
+        that:
+          - fatal is failed
+          - fatal.msg is search(expected)
+      vars:
+        expected: "Error processing keyword 'environment': 'ansible_env' is undefined"


### PR DESCRIPTION
##### SUMMARY

Fixes the bug I describe in https://github.com/ansible/ansible/issues/85420#issuecomment-3073709387 and adds a test.

##### ISSUE TYPE

- Bugfix Pull Request
