### PR TITLE
Add install_python_debian parameter to deb822_repository

### DIFF
--- a/changelogs/fragments/85487-add-dependency-installation-to-deb822_repository.yml
+++ b/changelogs/fragments/85487-add-dependency-installation-to-deb822_repository.yml
@@ -1,2 +1,2 @@
-minor_change:
+minor_changes:
   - deb822_repository - Add automatic installation of the ``python3-debian`` package if it is missing by adding the parameter ``install_python_debian``

--- a/changelogs/fragments/85487-add-dependency-installation-to-deb822_repository.yml
+++ b/changelogs/fragments/85487-add-dependency-installation-to-deb822_repository.yml
@@ -1,0 +1,2 @@
+minor_change:
+  - deb822_repository - Add automatic installation of the ``python3-debian`` package if it is missing by adding the parameter ``install_python_debian``

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -69,11 +69,11 @@ options:
         type: str
     install_python_debian:
         description:
-        - Whether to automatically try to install the Python debian library or not, if it is not already installed.
+        - Whether to automatically try to install the Python C(debian) library or not, if it is not already installed.
           Without this library, the module does not work.
             - Runs C(apt install python3-debian).
             - Only works with the system Python. If you are using a Python on the remote that is not
-              the system Python, set O(install_python_debian=false) and ensure that the Python debian library
+              the system Python, set O(install_python_debian=false) and ensure that the Python C(debian) library
               for your Python version is installed some other way.
         type: bool
         default: false

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -76,7 +76,7 @@ options:
               the system Python, set O(install_python_debian=false) and ensure that the Python debian library
               for your Python version is installed some other way.
         type: bool
-        default: true
+        default: false
         version_added: '2.20'
     languages:
         description:
@@ -425,7 +425,7 @@ def main():
             },
             'install_python_debian': {
                 'type': 'bool',
-                'default': True,
+                'default': False,
             },
             'languages': {
                 'elements': 'str',

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -67,7 +67,7 @@ options:
         - Determines the path to the C(InRelease) file, relative to the normal
           position of an C(InRelease) file.
         type: str
-    install_python-debian:
+    install_python_debian:
         description:
         - Whether to automatically try to install the Python debian library or not, if it is not already installed. 
           Without this library, the module does not work.

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -67,6 +67,16 @@ options:
         - Determines the path to the C(InRelease) file, relative to the normal
           position of an C(InRelease) file.
         type: str
+    install_python-debian:
+        description:
+        - Whether to automatically try to install the Python debian library or not, if it is not already installed. 
+          Without this library, the module does not work.
+            - Runs C(apt-get install python3-debian).
+            - Only works with the system Python. If you are using a Python on the remote that is not
+              the system Python, set O(install_python_debian=false) and ensure that the Python debian library
+              for your Python version is installed some other way.
+        type: bool
+        default: true
     languages:
         description:
         - Defines which languages information such as translated
@@ -228,6 +238,7 @@ key_filename:
 
 import os
 import re
+import sys
 import tempfile
 import textwrap
 
@@ -235,6 +246,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.common.file import S_IRWXU_RXG_RXO, S_IRWU_RG_RO
+from ansible.module_utils.common.respawn import has_respawned, probe_interpreters_for_module, respawn_module
 from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six import raise_from  # type: ignore[attr-defined]
@@ -356,6 +368,20 @@ def write_signed_by_key(module, v, slug):
 
     return changed, filename, None
 
+def install_python_debian(module, deb_pkg_name):
+
+    if not module.check_mode:
+        apt_get_path = module.get_bin_path('apt-get')
+        if apt_get_path:
+            rc, so, se = module.run_command([apt_get_path, 'update'])
+            if rc != 0:
+                module.fail_json(msg="Failed to auto-install %s. Error was: '%s'" % (deb_pkg_name, se.strip()))
+            rc, so, se = module.run_command([apt_get_path, 'install', deb_pkg_name, '-y', '-q'])
+            if rc != 0:
+                module.fail_json(msg="Failed to auto-install %s. Error was: '%s'" % (deb_pkg_name, se.strip()))
+    else:
+        module.fail_json(msg="%s must be installed to use check mode" % deb_pkg_name)
+
 
 def main():
     module = AnsibleModule(
@@ -394,6 +420,10 @@ def main():
             },
             'inrelease_path': {
                 'type': 'str',
+            },
+            'install_python_debian': {
+                'type': 'bool',
+                'default': True,
             },
             'languages': {
                 'elements': 'str',
@@ -453,8 +483,54 @@ def main():
     )
 
     if not HAS_DEBIAN:
-        module.fail_json(msg=missing_required_lib("python3-debian"),
-                         exception=DEBIAN_IMP_ERR)
+        deb_pkg_name = 'python3-debian'
+        # This interpreter can't see the debian Python library- we'll do the following to try and fix that as per
+        # the apt_repository module:
+        # 1) look in common locations for system-owned interpreters that can see it; if we find one, respawn under it
+        # 2) finding none, try to install a matching python-debian package for the current interpreter version;
+        #    we limit to the current interpreter version to try and avoid installing a whole other Python just
+        #    for deb support
+        # 3) if we installed a support package, try to respawn under what we think is the right interpreter (could be
+        #    the current interpreter again, but we'll let it respawn anyway for simplicity)
+        # 4) if still not working, return an error and give up (some corner cases not covered, but this shouldn't be
+        #    made any more complex than it already is to try and cover more, eg, custom interpreters taking over
+        #    system locations)
+
+        if has_respawned():
+            # this shouldn't be possible; short-circuit early if it happens...
+            module.fail_json(msg="{0} must be installed and visible from {1}.".format(deb_pkg_name, sys.executable))
+
+        interpreters = ['/usr/bin/python3', '/usr/bin/python']
+
+        interpreter = probe_interpreters_for_module(interpreters, 'debian')
+
+        if interpreter:
+            # found the Python bindings; respawn this module under the interpreter where we found them
+            respawn_module(interpreter)
+            # this is the end of the line for this process, it will exit here once the respawned module has completed
+
+        # don't make changes if we're in check_mode
+        if module.check_mode:
+            module.fail_json(msg="%s must be installed to use check mode. "
+                                 "If run normally this module can auto-install it." % deb_pkg_name)
+
+        if module.params['install_python_debian']:
+            install_python_debian(module, deb_pkg_name)
+        else:
+            module.fail_json(msg='%s is not installed, and install_python_debian is False' % deb_pkg_name)
+
+        # try again to find the bindings in common places
+        interpreter = probe_interpreters_for_module(interpreters, 'apt')
+
+        if interpreter:
+            # found the Python bindings; respawn this module under the interpreter where we found them
+            # NB: respawn is somewhat wasteful if it's this interpreter, but simplifies the code
+            respawn_module(interpreter)
+            # this is the end of the line for this process, it will exit here once the respawned module has completed
+        else:
+            # we've done all we can do; just tell the user it's busted and get out
+            module.fail_json(msg=missing_required_lib("python3-debian"),
+                             exception=DEBIAN_IMP_ERR)
 
     check_mode = module.check_mode
 

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -69,7 +69,7 @@ options:
         type: str
     install_python_debian:
         description:
-        - Whether to automatically try to install the Python debian library or not, if it is not already installed. 
+        - Whether to automatically try to install the Python debian library or not, if it is not already installed.
           Without this library, the module does not work.
             - Runs C(apt-get install python3-debian).
             - Only works with the system Python. If you are using a Python on the remote that is not

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -531,7 +531,7 @@ def main():
             # this is the end of the line for this process, it will exit here once the respawned module has completed
         else:
             # we've done all we can do; just tell the user it's busted and get out
-            module.fail_json(msg=missing_required_lib("python3-debian"),
+            module.fail_json(msg=missing_required_lib(deb_pkg_name),
                              exception=DEBIAN_IMP_ERR)
 
     check_mode = module.check_mode

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -77,6 +77,7 @@ options:
               for your Python version is installed some other way.
         type: bool
         default: true
+        version_added: '2.20'
     languages:
         description:
         - Defines which languages information such as translated

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -382,7 +382,7 @@ def install_python_debian(module, deb_pkg_name):
             if rc != 0:
                 module.fail_json(msg=f"Failed to auto-install {deb_pkg_name} due to : '{se.strip()}'")
     else:
-        module.fail_json(msg="%s must be installed to use check mode" % deb_pkg_name)
+        module.fail_json(msg=f"{deb_pkg_name} must be installed to use check mode")
 
 
 def main():

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -373,12 +373,12 @@ def write_signed_by_key(module, v, slug):
 def install_python_debian(module, deb_pkg_name):
 
     if not module.check_mode:
-        apt_get_path = module.get_bin_path('apt-get')
-        if apt_get_path:
-            rc, so, se = module.run_command([apt_get_path, 'update'])
+        apt_path = module.get_bin_path('apt')
+        if apt_path:
+            rc, so, se = module.run_command([apt_path, 'update'])
             if rc != 0:
                 module.fail_json(msg="Failed to auto-install %s. Error was: '%s'" % (deb_pkg_name, se.strip()))
-            rc, so, se = module.run_command([apt_get_path, 'install', deb_pkg_name, '-y', '-q'])
+            rc, so, se = module.run_command([apt_path, 'install', deb_pkg_name, '-y', '-q'])
             if rc != 0:
                 module.fail_json(msg="Failed to auto-install %s. Error was: '%s'" % (deb_pkg_name, se.strip()))
     else:

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -368,6 +368,7 @@ def write_signed_by_key(module, v, slug):
 
     return changed, filename, None
 
+
 def install_python_debian(module, deb_pkg_name):
 
     if not module.check_mode:

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -377,10 +377,10 @@ def install_python_debian(module, deb_pkg_name):
         if apt_get_path:
             rc, so, se = module.run_command([apt_get_path, 'update'])
             if rc != 0:
-                module.fail_json(msg="Failed to auto-install %s. Error was: '%s'" % (deb_pkg_name, se.strip()))
+                module.fail_json(msg=f"Failed update while auto installing {deb_pkg_name} due to '{se.strip()}'")
             rc, so, se = module.run_command([apt_get_path, 'install', deb_pkg_name, '-y', '-q'])
             if rc != 0:
-                module.fail_json(msg="Failed to auto-install %s. Error was: '%s'" % (deb_pkg_name, se.strip()))
+                module.fail_json(msg=f"Failed to auto-install {deb_pkg_name} due to : '{se.strip()}'")
     else:
         module.fail_json(msg="%s must be installed to use check mode" % deb_pkg_name)
 
@@ -500,7 +500,7 @@ def main():
 
         if has_respawned():
             # this shouldn't be possible; short-circuit early if it happens...
-            module.fail_json(msg="{0} must be installed and visible from {1}.".format(deb_pkg_name, sys.executable))
+            module.fail_json(msg=f"{deb_pkg_name} must be installed and visible from {sys.executable}.")
 
         interpreters = ['/usr/bin/python3', '/usr/bin/python']
 
@@ -513,13 +513,13 @@ def main():
 
         # don't make changes if we're in check_mode
         if module.check_mode:
-            module.fail_json(msg="%s must be installed to use check mode. "
-                                 "If run normally this module can auto-install it." % deb_pkg_name)
+            module.fail_json(msg=f"{deb_pkg_name} must be installed to use check mode. "
+                                                  "If run normally, this module can auto-install it.")
 
         if module.params['install_python_debian']:
             install_python_debian(module, deb_pkg_name)
         else:
-            module.fail_json(msg='%s is not installed, and install_python_debian is False' % deb_pkg_name)
+            module.fail_json(msg=f'{deb_pkg_name} is not installed, and install_python_debian is False')
 
         # try again to find the bindings in common places
         interpreter = probe_interpreters_for_module(interpreters, 'apt')

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -71,7 +71,7 @@ options:
         description:
         - Whether to automatically try to install the Python debian library or not, if it is not already installed.
           Without this library, the module does not work.
-            - Runs C(apt-get install python3-debian).
+            - Runs C(apt install python3-debian).
             - Only works with the system Python. If you are using a Python on the remote that is not
               the system Python, set O(install_python_debian=false) and ensure that the Python debian library
               for your Python version is installed some other way.

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -513,8 +513,7 @@ def main():
 
         # don't make changes if we're in check_mode
         if module.check_mode:
-            module.fail_json(msg=f"{deb_pkg_name} must be installed to use check mode. "
-                                                  "If run normally, this module can auto-install it.")
+            module.fail_json(msg=f"{deb_pkg_name} must be installed to use check mode. If run with install_python_debian, this module can auto-install it.")
 
         if module.params['install_python_debian']:
             install_python_debian(module, deb_pkg_name)

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -373,7 +373,7 @@ def write_signed_by_key(module, v, slug):
 def install_python_debian(module, deb_pkg_name):
 
     if not module.check_mode:
-        apt_path = module.get_bin_path('apt')
+        apt_path = module.get_bin_path('apt', required=True)
         if apt_path:
             rc, so, se = module.run_command([apt_path, 'update'])
             if rc != 0:

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -521,7 +521,7 @@ def main():
             module.fail_json(msg=f'{deb_pkg_name} is not installed, and install_python_debian is False')
 
         # try again to find the bindings in common places
-        interpreter = probe_interpreters_for_module(interpreters, 'apt')
+        interpreter = probe_interpreters_for_module(interpreters, 'debian')
 
         if interpreter:
             # found the Python bindings; respawn this module under the interpreter where we found them

--- a/test/integration/targets/deb822_repository/tasks/main.yml
+++ b/test/integration/targets/deb822_repository/tasks/main.yml
@@ -54,7 +54,8 @@
 
     - name: assert python3-debian already installed
       assert:
-        that: py3_deb_install.changed == false
+        that:
+           - not py3_deb_install.changed
 
     - import_tasks: test.yml
 

--- a/test/integration/targets/deb822_repository/tasks/main.yml
+++ b/test/integration/targets/deb822_repository/tasks/main.yml
@@ -1,12 +1,60 @@
 - meta: end_play
   when: ansible_os_family != 'Debian'
 
+- set_fact:
+    python_debian: python3-debian
+
 - block:
+    # UNINSTALL 'python3-debian'
+    #  The `deb822_repository` module has the smarts to auto-install `python3-debian`.  To
+    # test, we will first uninstall `python3-debian`.
+    - name: check {{ python_debian }} with dpkg
+      shell: dpkg -s {{ python_debian }}
+      register: dpkg_result
+      ignore_errors: true
+
+    - name: uninstall {{ python_debian }} with apt
+      apt: pkg={{ python_debian }} state=absent purge=yes
+      register: apt_result
+      when: dpkg_result is successful
+
+    - name: check failure when python3-debian is absent
+      deb822_repository:
+        name: myrepo
+        types: deb
+        uris: "http://example.com/debian/"
+        suites: stable
+        components: main
+        install_python_debian: false
+      register: no_python3_debian
+      ignore_errors: true
+
+    - name: Assert failure with absent python3-debian
+      assert:
+        that: no_python3_debian.msg is contains 'python3-debian is not installed'
+
+    - name: run deb822 to check for python3-debian installation
+      deb822_repository:
+        name: myrepo
+        types: deb
+        uris: "http://example.com/debian/"
+        suites: stable
+        components: main
+
+    - name: Clean up the previously added basic Debian repository
+      deb822_repository:
+        name: myrepo
+        state: absent
+
     - name: install python3-debian
       apt:
         name: python3-debian
         state: present
       register: py3_deb_install
+
+    - name: assert python3-debian already installed
+      assert:
+        that: py3_deb_install.changed == false
 
     - import_tasks: test.yml
 

--- a/test/integration/targets/deb822_repository/tasks/main.yml
+++ b/test/integration/targets/deb822_repository/tasks/main.yml
@@ -25,7 +25,6 @@
         uris: "http://example.com/debian/"
         suites: stable
         components: main
-        install_python_debian: false
       register: no_python3_debian
       ignore_errors: true
 
@@ -40,6 +39,7 @@
         uris: "http://example.com/debian/"
         suites: stable
         components: main
+        install_python_debian: true
 
     - name: Clean up the previously added basic Debian repository
       deb822_repository:

--- a/test/integration/targets/deb822_repository/tasks/test.yml
+++ b/test/integration/targets/deb822_repository/tasks/test.yml
@@ -99,6 +99,10 @@
     path: /etc/apt/sources.list.d/ansible-test-focal-archive.sources
   register: deb822_create_1_stat_2
 
+- name: Inspect
+  debug:
+    var: deb822_create_1
+
 - assert:
     that:
       - deb822_check_mode_1 is changed
@@ -119,7 +123,7 @@
     focal_archive_expected: |-
       Components: main restricted
       Date-Max-Future: 10
-      Install-Python-Debian: yes
+      Install-Python-Debian: no
       X-Repolib-Name: ansible-test focal archive
       Suites: focal focal-updates
       Types: deb
@@ -193,7 +197,7 @@
   vars:
     signed_by_inline_expected: |-
       Components: main contrib non-free
-      Install-Python-Debian: yes
+      Install-Python-Debian: no
       X-Repolib-Name: ansible-test
       Signed-By:
           -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/test/integration/targets/deb822_repository/tasks/test.yml
+++ b/test/integration/targets/deb822_repository/tasks/test.yml
@@ -119,6 +119,7 @@
     focal_archive_expected: |-
       Components: main restricted
       Date-Max-Future: 10
+      Install-Python-Debian: yes
       X-Repolib-Name: ansible-test focal archive
       Suites: focal focal-updates
       Types: deb
@@ -192,6 +193,7 @@
   vars:
     signed_by_inline_expected: |-
       Components: main contrib non-free
+      Install-Python-Debian: yes
       X-Repolib-Name: ansible-test
       Signed-By:
           -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/test/integration/targets/deb822_repository/tasks/test.yml
+++ b/test/integration/targets/deb822_repository/tasks/test.yml
@@ -99,10 +99,6 @@
     path: /etc/apt/sources.list.d/ansible-test-focal-archive.sources
   register: deb822_create_1_stat_2
 
-- name: Inspect
-  debug:
-    var: deb822_create_1
-
 - assert:
     that:
       - deb822_check_mode_1 is changed


### PR DESCRIPTION
##### SUMMARY

Addresses #85479 by mimicking the functionality of the `install_python_apt` parameter
in the `apt_repository` module by adding a parameter `install_python_debian` to the
`deb822_repository` module. 

Also fixes two broken tests that depended on the previous set of parameters by adding
the new `install_python_debian` parameter to the tests.

##### ISSUE TYPE

- Feature Pull Request
- Test Pull Request