### PR TITLE
encryption: Raise an error when vaultid is used

### DIFF
--- a/changelogs/fragments/encryption.yml
+++ b/changelogs/fragments/encryption.yml
@@ -1,0 +1,3 @@
+---
+removed_features:
+    - encryption - raise error when deprecated option vaultid is used.

--- a/lib/ansible/plugins/filter/encryption.py
+++ b/lib/ansible/plugins/filter/encryption.py
@@ -13,15 +13,12 @@ from ansible.utils.display import Display
 display = Display()
 
 
-def do_vault(data, secret, salt=None, vault_id='filter_default', wrap_object=False, vaultid=None):
+def do_vault(data, secret, salt=None, vault_id='filter_default', wrap_object=False):
     if not isinstance(secret, (str, bytes)):
         raise TypeError(f"Secret passed is required to be a string, instead we got {type(secret)}.")
 
     if not isinstance(data, (str, bytes)):
         raise TypeError(f"Can only vault strings, instead we got {type(data)}.")
-
-    if vaultid is not None:
-        raise AnsibleError("Using option 'vaultid' is deprecated. Use 'vault_id' instead.")
 
     vs = VaultSecret(to_bytes(secret))
     vl = VaultLib()
@@ -39,11 +36,11 @@ def do_vault(data, secret, salt=None, vault_id='filter_default', wrap_object=Fal
 
 
 @_template.accept_args_markers
-def do_unvault(vault, secret, vault_id='filter_default', vaultid=None):
+def do_unvault(vault, secret, vault_id='filter_default'):
     if isinstance(vault, VaultExceptionMarker):
         vault = vault._disarm()
 
-    if (first_marker := _template.get_first_marker_arg((vault, secret, vault_id, vaultid), {})) is not None:
+    if (first_marker := _template.get_first_marker_arg((vault, secret, vault_id), {})) is not None:
         return first_marker
 
     if not isinstance(secret, (str, bytes)):
@@ -51,9 +48,6 @@ def do_unvault(vault, secret, vault_id='filter_default', vaultid=None):
 
     if not isinstance(vault, (str, bytes)):
         raise TypeError(f"Vault should be in the form of a string, instead we got {type(vault)}.")
-
-    if vaultid is not None:
-        raise AnsibleError("Using option 'vaultid' is deprecated. Use 'vault_id' instead.")
 
     vs = VaultSecret(to_bytes(secret))
     vl = VaultLib([(vault_id, vs)])
@@ -72,7 +66,7 @@ def do_unvault(vault, secret, vault_id='filter_default', vaultid=None):
     return to_native(data)
 
 
-class FilterModule(object):
+class FilterModule:
     """ Ansible vault jinja2 filters """
 
     def filters(self):

--- a/lib/ansible/plugins/filter/encryption.py
+++ b/lib/ansible/plugins/filter/encryption.py
@@ -21,16 +21,7 @@ def do_vault(data, secret, salt=None, vault_id='filter_default', wrap_object=Fal
         raise TypeError(f"Can only vault strings, instead we got {type(data)}.")
 
     if vaultid is not None:
-        display.deprecated(
-            msg="Use of undocumented `vaultid`.",
-            version="2.20",
-            help_text="Use `vault_id` instead.",
-        )
-
-        if vault_id == 'filter_default':
-            vault_id = vaultid
-        else:
-            display.warning("Ignoring vaultid as vault_id is already set.")
+        raise AnsibleError("Using option 'vaultid' is deprecated. Use 'vault_id' instead.")
 
     vs = VaultSecret(to_bytes(secret))
     vl = VaultLib()
@@ -62,16 +53,7 @@ def do_unvault(vault, secret, vault_id='filter_default', vaultid=None):
         raise TypeError(f"Vault should be in the form of a string, instead we got {type(vault)}.")
 
     if vaultid is not None:
-        display.deprecated(
-            msg="Use of undocumented `vaultid`.",
-            version="2.20",
-            help_text="Use `vault_id` instead.",
-        )
-
-        if vault_id == 'filter_default':
-            vault_id = vaultid
-        else:
-            display.warning("Ignoring vaultid as vault_id is already set.")
+        raise AnsibleError("Using option 'vaultid' is deprecated. Use 'vault_id' instead.")
 
     vs = VaultSecret(to_bytes(secret))
     vl = VaultLib([(vault_id, vs)])

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -234,7 +234,6 @@ test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:a
 test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:ansible-deprecated-collection-name-not-permitted  # required to verify plugin against core
 lib/ansible/cli/doc.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/galaxy/api.py pylint:ansible-deprecated-version  # TODO: 2.20
-lib/ansible/plugins/filter/encryption.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/utils/encrypt.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/utils/ssh_functions.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/vars/manager.py pylint:ansible-deprecated-version-comment  # TODO: 2.20


### PR DESCRIPTION
##### SUMMARY

Raise an exception when using deprecated vaultid option

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/encryption.yml
lib/ansible/plugins/filter/encryption.py
test/sanity/ignore.txt


