### PR TITLE
Add playbook to create git archive with custom archive_prefix

### DIFF
--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -279,6 +279,13 @@ EXAMPLES = """
     dest: /tmp/checkout
     archive: /tmp/ansible.zip
 
+- name: Create a tar.gz archive of the Git repo with prefix
+  ansible.builtin.git:
+    repo: https://github.com/example-org/demo-project.git
+    dest: /tmp/demo-project
+    archive: /tmp/demo-project.tar.gz
+    archive_prefix: demo-project/
+
 - name: Clone a repo with separate git directory
   ansible.builtin.git:
     repo: 'https://github.com/ansible/ansible.git'


### PR DESCRIPTION
##### SUMMARY  
- Added a playbook using the `ansible.builtin.git` module to create a `.tar.gz` archive of a Git repository with a custom `archive_prefix`.  
- This ensures all archived file paths are prefixed with a directory name

##### ISSUE TYPE  
- Docs Pull Request

##### COMPONENT NAME  
`ansible.builtin.git` example

##### ADDITIONAL INFORMATION  

```yaml
- name: Create a tar.gz archive of the Git repo with prefix
  ansible.builtin.git:
    repo: https://github.com/ex
