### PR TITLE
[stable-2.19] Rewrite exception key on failed_when: false (#85516)

### DIFF
--- a/changelogs/fragments/failed-when-exception.yml
+++ b/changelogs/fragments/failed-when-exception.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - failed_when - When using ``failed_when`` to suppress an error, the ``exception`` key in the result is renamed to ``failed_when_suppressed_exception``.
+    This prevents the error from being displayed by callbacks after being suppressed.
+    (https://github.com/ansible/ansible/issues/85505)

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -712,7 +712,10 @@ class TaskExecutor:
                     condname = 'failed'
 
                     if self._task.failed_when:
-                        result['failed_when_result'] = result['failed'] = self._task._resolve_conditional(self._task.failed_when, vars_copy)
+                        is_failed = result['failed_when_result'] = result['failed'] = self._task._resolve_conditional(self._task.failed_when, vars_copy)
+
+                        if not is_failed and (suppressed_exception := result.pop('exception', None)):
+                            result['failed_when_suppressed_exception'] = suppressed_exception
 
                 except AnsibleError as e:
                     result['failed'] = True

--- a/test/integration/targets/failed_when/aliases
+++ b/test/integration/targets/failed_when/aliases
@@ -1,2 +1,3 @@
+gather_facts/no
 shippable/posix/group4
 context/controller

--- a/test/integration/targets/failed_when/tasks/main.yml
+++ b/test/integration/targets/failed_when/tasks/main.yml
@@ -24,6 +24,8 @@
 - assert:
     that:
       - "'failed' in result and not result.failed"
+      - result.exception is undefined
+      - result.failed_when_suppressed_exception is undefined
 
 - name: command rc 0 failed_when_result False
   shell: exit 0
@@ -35,6 +37,8 @@
     that:
       - "'failed' in result and not result.failed"
       - "'failed_when_result' in result and not result.failed_when_result"
+      - result.exception is undefined
+      - result.failed_when_suppressed_exception is undefined
 
 - name: command rc 1 failed_when_result True
   shell: exit 1
@@ -46,6 +50,8 @@
     that:
       - "'failed' in result and result.failed"
       - "'failed_when_result' in result and result.failed_when_result"
+      - result.exception is defined
+      - result.failed_when_suppressed_exception is undefined
 
 - name: command rc 1 failed_when_result undef
   shell: exit 1
@@ -55,6 +61,8 @@
 - assert:
     that:
       - "'failed' in result and result.failed"
+      - result.exception is defined
+      - result.failed_when_suppressed_exception is undefined
 
 - name: command rc 1 failed_when_result False
   shell: exit 1
@@ -66,6 +74,8 @@
     that:
       - "'failed' in result and not result.failed"
       - "'failed_when_result' in result and not result.failed_when_result"
+      - result.exception is undefined
+      - result.failed_when_suppressed_exception is defined
 
 - name: invalid conditional
   command: echo foo


### PR DESCRIPTION
##### SUMMARY
* Prevents callback handle_exception from displaying the captured exception when the task is not failed.
* Added tests.


(cherry picked from commit 2fbd7c114efe7dfc6795d5553f866e6a2b002a3c)

##### ISSUE TYPE
- Bugfix Pull Request
