### PR TITLE
[2.18] ansible-test - Replace FreeBSD 13.3 with 13.5

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -92,8 +92,8 @@ stages:
               test: rhel/9.4@3.12
             - name: RHEL 10.0
               test: rhel/10.0
-            - name: FreeBSD 13.4
-              test: freebsd/13.4
+            - name: FreeBSD 13.5
+              test: freebsd/13.5
             - name: FreeBSD 14.1
               test: freebsd/14.1
           groups:
@@ -108,8 +108,8 @@ stages:
               test: rhel/9.4
             - name: RHEL 10.0
               test: rhel/10.0
-            - name: FreeBSD 13.4
-              test: freebsd/13.4
+            - name: FreeBSD 13.5
+              test: freebsd/13.5
             - name: FreeBSD 14.1
               test: freebsd/14.1
           groups:

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -92,8 +92,8 @@ stages:
               test: rhel/9.4@3.12
             - name: RHEL 10.0
               test: rhel/10.0
-            - name: FreeBSD 13.3
-              test: freebsd/13.3
+            - name: FreeBSD 13.4
+              test: freebsd/13.4
             - name: FreeBSD 14.1
               test: freebsd/14.1
           groups:
@@ -108,8 +108,8 @@ stages:
               test: rhel/9.4
             - name: RHEL 10.0
               test: rhel/10.0
-            - name: FreeBSD 13.3
-              test: freebsd/13.3
+            - name: FreeBSD 13.4
+              test: freebsd/13.4
             - name: FreeBSD 14.1
               test: freebsd/14.1
           groups:

--- a/changelogs/fragments/ansible-test-remotes.yml
+++ b/changelogs/fragments/ansible-test-remotes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Replace remote FreeBSD 13.3 with 13.4.

--- a/changelogs/fragments/ansible-test-remotes.yml
+++ b/changelogs/fragments/ansible-test-remotes.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ansible-test - Replace remote FreeBSD 13.3 with 13.4.
+  - ansible-test - Replace remote FreeBSD 13.3 with 13.5.

--- a/test/integration/targets/cron/defaults/main.yml
+++ b/test/integration/targets/cron/defaults/main.yml
@@ -1,1 +1,0 @@
-faketime_pkg: libfaketime

--- a/test/integration/targets/setup_cron/defaults/main.yml
+++ b/test/integration/targets/setup_cron/defaults/main.yml
@@ -1,1 +1,2 @@
 remote_dir: "{{ remote_tmp_dir }}"
+faketime_pkg: libfaketime

--- a/test/integration/targets/setup_cron/tasks/main.yml
+++ b/test/integration/targets/setup_cron/tasks/main.yml
@@ -7,6 +7,7 @@
   vars:
     search:
       files:
+        - '{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version }}.yml'
         - '{{ ansible_distribution | lower }}.yml'
         - '{{ ansible_os_family | lower }}.yml'
         - '{{ ansible_system | lower }}.yml'

--- a/test/integration/targets/setup_cron/vars/freebsd-14.yml
+++ b/test/integration/targets/setup_cron/vars/freebsd-14.yml
@@ -1,4 +1,4 @@
 cron_pkg:
 cron_service: cron
 list_pkg_files: pkg info --list-files
-faketime_pkg: ~
+faketime_pkg: libfaketime

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -2,7 +2,7 @@ alpine/3.20 python=3.12 become=doas_sudo provider=aws arch=x86_64
 alpine become=doas_sudo provider=aws arch=x86_64
 fedora/40 python=3.12 become=sudo provider=aws arch=x86_64
 fedora become=sudo provider=aws arch=x86_64
-freebsd/13.3 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
+freebsd/13.4 python=3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd/14.1 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 macos/14.3 python=3.11 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -2,7 +2,7 @@ alpine/3.20 python=3.12 become=doas_sudo provider=aws arch=x86_64
 alpine become=doas_sudo provider=aws arch=x86_64
 fedora/40 python=3.12 become=sudo provider=aws arch=x86_64
 fedora become=sudo provider=aws arch=x86_64
-freebsd/13.4 python=3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
+freebsd/13.5 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd/14.1 python=3.9,3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 macos/14.3 python=3.11 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -26,13 +26,13 @@ install_ssh_keys()
         echo "${ssh_private_key}" > "${ssh_private_key_path}"
 
         # add public key to authorized_keys
-        authoried_keys_path="${HOME}/.ssh/authorized_keys"
+        authorized_keys_path="${HOME}/.ssh/authorized_keys"
 
         # the existing file is overwritten to avoid conflicts (ex: RHEL on EC2 blocks root login)
-        cat "${public_key_path}" > "${authoried_keys_path}"
-        chmod 0600 "${authoried_keys_path}"
+        cat "${public_key_path}" > "${authorized_keys_path}"
+        chmod 0600 "${authorized_keys_path}"
 
-        # add localhost's server keys to known_hosts
+        # add localhost server keys to known_hosts
         known_hosts_path="${HOME}/.ssh/known_hosts"
 
         for key in /etc/ssh/ssh_host_*_key.pub; do
@@ -168,16 +168,8 @@ bootstrap_remote_freebsd()
         # Declare platform/python version combinations which do not have supporting OS packages available.
         # For these combinations ansible-test will use pip to install the requirements instead.
         case "${platform_version}/${python_version}" in
-            13.3/3.9)
-                # defaults above 'just work'TM
-                ;;
-            13.3/3.11)
-                jinja2_pkg=""  # not available
-                cryptography_pkg=""  # not available
-                pyyaml_pkg=""  # not available
-                ;;
-            14.1/3.9)
-                # defaults above 'just work'TM
+            13.4/3.11)
+                # defaults available
                 ;;
             14.1/3.11)
                 cryptography_pkg=""  # not available

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -168,8 +168,8 @@ bootstrap_remote_freebsd()
         # Declare platform/python version combinations which do not have supporting OS packages available.
         # For these combinations ansible-test will use pip to install the requirements instead.
         case "${platform_version}/${python_version}" in
-            13.4/3.11)
-                # defaults available
+            14.1/3.9)
+                # defaults above 'just work'TM
                 ;;
             14.1/3.11)
                 cryptography_pkg=""  # not available


### PR DESCRIPTION
This is a partial backport of PR #84236 and #84812 as merged into `devel`.

(cherry picked from commit a98801903df4a9a3af65ad917e96fc4f3e3437a6)

(cherry picked from commit 4efb01c2f3dd17a18cd79a04d584633751b8a537)

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
FreeBSD 13.3 is no longer available, breaking the CI in stable-2.18, stable-2.17 and stable-2.16.

##### ISSUE TYPE

- Maintenance Pull Request
- Test Pull Request
