### PR TITLE
plugin config options are now correctly  fetched with origin (#85488)

### DIFF
--- a/changelogs/fragments/plugins_fix_origin.yml
+++ b/changelogs/fragments/plugins_fix_origin.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - plugins config, get_option_and_origin now correctly displays the value and origin of the option.

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -450,13 +450,17 @@ class ConfigManager:
         pass
 
     def get_plugin_options(self, plugin_type, name, keys=None, variables=None, direct=None):
+        options, dummy = self.get_plugin_options_and_origins(plugin_type, name, keys=keys, variables=variables, direct=direct)
+        return options
 
+    def get_plugin_options_and_origins(self, plugin_type, name, keys=None, variables=None, direct=None):
         options = {}
+        origins = {}
         defs = self.get_configuration_definitions(plugin_type=plugin_type, name=name)
         for option in defs:
-            options[option] = self.get_config_value(option, plugin_type=plugin_type, plugin_name=name, keys=keys, variables=variables, direct=direct)
-
-        return options
+            options[option], origins[option] = self.get_config_value_and_origin(option, plugin_type=plugin_type, plugin_name=name, keys=keys,
+                                                                                variables=variables, direct=direct)
+        return options, origins
 
     def get_plugin_vars(self, plugin_type, name):
 

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -228,9 +228,13 @@ class CallbackBase(AnsiblePlugin):
 
     def set_option(self, k, v):
         self._plugin_options[k] = C.config.get_config_value(k, plugin_type=self.plugin_type, plugin_name=self._load_name, direct={k: v})
+        self._origins[k] = 'direct'
 
     def get_option(self, k, hostvars=None):
         return self._plugin_options[k]
+
+    def get_option_and_origin(self, k, hostvars=None):
+        return self._plugin_options[k], self._origins[k]
 
     def has_option(self, option):
         return (option in self._plugin_options)
@@ -241,7 +245,8 @@ class CallbackBase(AnsiblePlugin):
         """
 
         # load from config
-        self._plugin_options = C.config.get_plugin_options(self.plugin_type, self._load_name, keys=task_keys, variables=var_options, direct=direct)
+        self._plugin_options, self._origins = C.config.get_plugin_options_and_origins(self.plugin_type, self._load_name,
+                                                                                      keys=task_keys, variables=var_options, direct=direct)
 
     @staticmethod
     def host_label(result: CallbackTaskResult) -> str:

--- a/test/integration/targets/config/lookup_plugins/broken.py
+++ b/test/integration/targets/config/lookup_plugins/broken.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025, Felix Fontein <felix@fontein.de>, The Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+from __future__ import annotations
+
+
+DOCUMENTATION = r"""
+name: broken
+short_description: Test input precedence
+author: Felix Fontein (@felixfontein)
+description:
+  - Test input precedence.
+options:
+  _terms:
+    description:
+      - Ignored.
+    type: list
+    elements: str
+    required: true
+  some_option:
+    description:
+      - The interesting part.
+    type: str
+    default: default value
+    env:
+      - name: PLAYGROUND_TEST_1
+      - name: PLAYGROUND_TEST_2
+    vars:
+      - name: playground_test_1
+      - name: playground_test_2
+    ini:
+      - key: playground_test_1
+        section: playground
+      - key: playground_test_2
+        section: playground
+"""
+
+EXAMPLES = r"""#"""
+
+RETURN = r"""
+_list:
+  description:
+    - The value of O(some_option).
+  type: list
+  elements: str
+"""
+
+from ansible.plugins.lookup import LookupBase
+
+
+class LookupModule(LookupBase):
+    def run(self, terms, variables=None, **kwargs):
+        """Generate list."""
+        self.set_options(var_options=variables, direct=kwargs)
+
+        return [self.get_option("some_option"), *self.get_option_and_origin("some_option")]

--- a/test/integration/targets/config/match_option_methods.yml
+++ b/test/integration/targets/config/match_option_methods.yml
@@ -1,0 +1,37 @@
+- hosts: localhost
+  gather_facts: false
+  vars:
+      direct: "{{ query('broken', some_option='foo') }}"
+      default: "{{ query('broken') }}"
+  tasks:
+    - name: Set directly but also have  vars
+      set_fact:
+        direct_with_vars: "{{ query('broken', some_option='foo') }}"
+      vars:
+        playground_test_1: var 1
+        playground_test_2: var 2
+    - name:  Set via vars only
+      set_fact:
+        vars_only: "{{ query('broken') }}"
+      vars:
+        playground_test_1: var 1
+        playground_test_2: var 2
+
+    - debug: msg={{q('vars', item)}}
+      loop:
+        - direct
+        - default
+        - direct_with_vars
+        - vars_only
+
+    - name: now ensure it all worked as expected (simple value, origin value, origin)
+      assert:
+        that:
+          - direct[0] == direct[1]
+          - direct[2] == 'Direct'
+          - default[0] == default[1]
+          - default[2] == 'default'
+          - direct_with_vars[0] == direct_with_vars[1]
+          - direct_with_vars[2] == 'Direct'
+          - vars_only[0] == vars_only[1]
+          - vars_only[2].startswith('var:')

--- a/test/integration/targets/config/runme.sh
+++ b/test/integration/targets/config/runme.sh
@@ -43,3 +43,6 @@ done
 
 # ensure we don't show default templates, but templated defaults
 [ "$(ansible-config init |grep '={{' -c )" -eq 0 ]
+
+# test seldom used '_and_origin' api 
+ansible-playbook match_option_methods.yml "$@"


### PR DESCRIPTION
* also update callbcacks, since they override these functions due to backwards compat _options being taken for CLI

(cherry picked from commit 19f9c66004c04c0479ee00bc770057ae0aae572b)

##### ISSUE TYPE

- Bugfix Pull Request
