### PR TITLE
[stable-2.19] ansible-test - Use OS packages on FreeBSD 13.5 (#85530)

### DIFF
--- a/changelogs/fragments/ansible-test-freebsd-bootstrap.yml
+++ b/changelogs/fragments/ansible-test-freebsd-bootstrap.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Use OS packages to satisfy controller requirements on FreeBSD 13.5 during managed instance bootstrapping.

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -169,6 +169,9 @@ bootstrap_remote_freebsd()
         # Declare platform/python version combinations which do not have supporting OS packages available.
         # For these combinations ansible-test will use pip to install the requirements instead.
         case "${platform_version}/${python_version}" in
+            13.5/3.11)
+                # defaults available
+                ;;
             14.2/3.11)
                 # defaults available
                 ;;


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/85530

(cherry picked from commit cdb7af094bcd293b49ac2ff7cc03bc867b2e07d0)

##### ISSUE TYPE

Feature Pull Request
