### PR TITLE
Do not require wheel for building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 66.1.0, <= 80.3.1"]  # lower bound to support controller Python versions, upper bound for latest version tested at release
+requires = ["setuptools >= 70.1, <= 80.3.1"]  # lower bound to support controller Python versions, upper bound for latest version tested at release
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 66.1.0, <= 80.3.1", "wheel == 0.45.1"]  # lower bound to support controller Python versions, upper bound for latest version tested at release
+requires = ["setuptools >= 66.1.0, <= 80.3.1"]  # lower bound to support controller Python versions, upper bound for latest version tested at release
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
##### SUMMARY

- current version of setuptools (70.1+) does not need wheel at all
- older versions of setuptools would depend on wheel when building wheels (but not sdists)

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
- Feature Pull Request

(Not sure which one, this is neither; it's just cleaning.)