### PR TITLE
fix: change the BOOT_TIME_COMMAND for macOS to get higher time precision

### DIFF
--- a/changelogs/fragments/85537-macos-reboot-sysctl-boottime.yml
+++ b/changelogs/fragments/85537-macos-reboot-sysctl-boottime.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - reboot - change the BOOT_TIME_COMMAND for macOS to use ``/usr/sbin/sysctl kern.boottime`` instead of ``who -b`` to get higher time precision (https://github.com/ansible/ansible/issues/85070).

--- a/lib/ansible/plugins/action/reboot.py
+++ b/lib/ansible/plugins/action/reboot.py
@@ -52,7 +52,7 @@ class ActionModule(ActionBase):
     BOOT_TIME_COMMANDS = {
         'freebsd': '/sbin/sysctl kern.boottime',
         'openbsd': '/sbin/sysctl kern.boottime',
-        'macosx': 'who -b',
+        'macosx': '/usr/sbin/sysctl kern.boottime',
         'solaris': 'who -b',
         'sunos': 'who -b',
         'vmkernel': 'grep booted /var/log/vmksummary.log | tail -n 1',

--- a/test/integration/targets/reboot/vars/main.yml
+++ b/test/integration/targets/reboot/vars/main.yml
@@ -1,3 +1,3 @@
 _boot_time_command:
   freebsd: '/sbin/sysctl kern.boottime'
-  macosx: 'who -b'
+  macosx: '/usr/sbin/sysctl kern.boottime'


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Fix the issue https://github.com/ansible/ansible/issues/85070 "macOS boot time command incorrectly checks boot time if last reboot was at same minute".

Use `/usr/sbin/sysctl kern.boottime` to replace the `who -b` for the BOOT_TIME_COMMAND of macOS, to get higher time precision.

##### ISSUE TYPE


- Bugfix Pull Request
