### PR TITLE
Skip executing flush_handlers only when play tags are in --skip-tags

### DIFF
--- a/changelogs/fragments/85475-fix-flush_handlers-play-tags.yml
+++ b/changelogs/fragments/85475-fix-flush_handlers-play-tags.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix issue where play tags prevented executing notified handlers (https://github.com/ansible/ansible/issues/85475)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -307,6 +307,12 @@ class Play(Base, Taggable, CollectionSearch):
         t.implicit = True
         t.set_loader(self._loader)
 
+        # Avoid calling flush_handlers in case the whole play is skipped on tags,
+        # this could be performance improvement since calling flush_handlers on
+        # large inventories could be expensive even if no hosts are notified
+        # since we call flush_handlers per host.
+        # Block.filter_tagged_tasks ignores evaluating tags on implicit meta
+        # tasks so we need to explicitly call Task.evaluate_tags here.
         if (
             not self.tags
             or not self.skip_tags
@@ -316,12 +322,6 @@ class Play(Base, Taggable, CollectionSearch):
                 all_vars=self.vars,
             )
         ):
-            # Avoid calling flush_handlers in case the whole play is skipped on tags,
-            # this could be performance improvement since calling flush_handlers on
-            # large inventories could be expensive even if no hosts are notified
-            # since we call flush_handlers per host.
-            # Block.filter_tagged_tasks ignores evaluating tags on implicit meta
-            # tasks so we need to explicitly call Task.evaluate_tags here.
             flush_block.block = [t]
 
         # NOTE keep flush_handlers tasks even if a section has no regular tasks,

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -307,15 +307,19 @@ class Play(Base, Taggable, CollectionSearch):
         t.implicit = True
         t.set_loader(self._loader)
 
-        if self.tags:
+        if self.tags and self.skip_tags:
             # Avoid calling flush_handlers in case the whole play is skipped on tags,
             # this could be performance improvement since calling flush_handlers on
             # large inventories could be expensive even if no hosts are notified
             # since we call flush_handlers per host.
             # Block.filter_tagged_tasks ignores evaluating tags on implicit meta
             # tasks so we need to explicitly call Task.evaluate_tags here.
-            t.tags = self.tags
-            if t.evaluate_tags(self.only_tags, self.skip_tags, all_vars=self.vars):
+            if t.evaluate_tags(
+                only_tags=[],
+                skip_tags=self.skip_tags,
+                all_vars=self.vars,
+            ):
+                t.tags = self.tags[:]
                 flush_block.block = [t]
         else:
             flush_block.block = [t]

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -307,21 +307,21 @@ class Play(Base, Taggable, CollectionSearch):
         t.implicit = True
         t.set_loader(self._loader)
 
-        if self.tags and self.skip_tags:
+        if (
+            not self.tags
+            or not self.skip_tags
+            or t.evaluate_tags(
+                only_tags=[],
+                skip_tags=self.skip_tags,
+                all_vars=self.vars,
+            )
+        ):
             # Avoid calling flush_handlers in case the whole play is skipped on tags,
             # this could be performance improvement since calling flush_handlers on
             # large inventories could be expensive even if no hosts are notified
             # since we call flush_handlers per host.
             # Block.filter_tagged_tasks ignores evaluating tags on implicit meta
             # tasks so we need to explicitly call Task.evaluate_tags here.
-            if t.evaluate_tags(
-                only_tags=[],
-                skip_tags=self.skip_tags,
-                all_vars=self.vars,
-            ):
-                t.tags = self.tags[:]
-                flush_block.block = [t]
-        else:
             flush_block.block = [t]
 
         # NOTE keep flush_handlers tasks even if a section has no regular tasks,

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -232,3 +232,10 @@ ANSIBLE_DEBUG=1 ansible-playbook tagged_play.yml --skip-tags the_whole_play "$@"
 [ "$(grep out.txt -ce 'handler_ran')" = "0" ]
 
 ansible-playbook rescue_flush_handlers.yml "$@"
+
+[ "$(grep out.txt -ce 'handler1_ran')" = "0" ]
+
+ANSIBLE_DEBUG=1 ansible-playbook tagged_play.yml --tags task_tag "$@" 2>&1 | tee out.txt
+[ "$(grep out.txt -ce 'META: triggered running handlers')" = "1" ]
+[ "$(grep out.txt -ce 'handler_ran')" = "0" ]
+[ "$(grep out.txt -ce 'handler1_ran')" = "1" ]

--- a/test/integration/targets/handlers/tagged_play.yml
+++ b/test/integration/targets/handlers/tagged_play.yml
@@ -2,9 +2,19 @@
   gather_facts: false
   tags: the_whole_play
   tasks:
-    - command: echo
+    - debug:
+      changed_when: true
       notify: h
+
+    - debug:
+      changed_when: true
+      notify: h1
+      tags: task_tag
   handlers:
     - name: h
       debug:
         msg: handler_ran
+
+    - name: h1
+      debug:
+        msg: handler1_ran


### PR DESCRIPTION
##### SUMMARY
Fixes #85475

ci_complete
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
