### PR TITLE
[stable-2.19] tqm: Use correct warning methods (#85434)

### DIFF
--- a/changelogs/fragments/tqm.yml
+++ b/changelogs/fragments/tqm.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+    - tqm - use display.error_as_warning instead of self.warning.
+    - tqm - use display.error_as_warning instead of display.warning_as_error.

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -179,7 +179,7 @@ class TaskQueueManager:
             for fd in (STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO):
                 os.set_inheritable(fd, False)
         except Exception as ex:
-            self.warning(f"failed to set stdio as non inheritable: {ex}")
+            display.error_as_warning("failed to set stdio as non inheritable", exception=ex)
 
         self._callback_lock = threading.Lock()
 
@@ -269,7 +269,7 @@ class TaskQueueManager:
                     display.warning("Skipping callback '%s', as it does not create a valid plugin instance." % callback_name)
                     continue
             except Exception as ex:
-                display.warning_as_error(f"Failed to load callback plugin {callback_name!r}.", exception=ex)
+                display.error_as_warning(f"Failed to load callback plugin {callback_name!r}.", exception=ex)
                 continue
 
     def run(self, play):


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/85434

(cherry picked from commit ea238c9eb5e46d63b99f9bd81209eaa3d5e6ab9e)

##### ISSUE TYPE

Bugfix Pull Request
