### PR TITLE
docs(config): Clarify deprecation warning for ansible_managed

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -946,9 +946,10 @@ DEFAULT_MANAGED_STR:
   - {key: ansible_managed, section: defaults}
   yaml: {key: defaults.ansible_managed}
   deprecated:
-    why: The `ansible_managed` variable can be set just like any other variable, or a different variable can be used.
-    version: "2.23"
-    alternatives: Set the `ansible_managed` variable, or use any custom variable in templates.
+    why: The 'ansible_managed' setting in ansible.cfg is deprecated. Its name was confusing and it's better to set 'ansible_managed' as a normal variable.
+    alternative: To control the content of the 'ansible_managed' magic variable, set it as a variable in your inventory, playbooks, or roles instead of using this setting.
+    version: '2.23'
+    removed: False
 DEFAULT_MODULE_ARGS:
   name: Adhoc default arguments
   default: ~


### PR DESCRIPTION
Fixes #85539

### Summary

This PR addresses a confusing deprecation warning for the `ansible_managed` setting in `ansible.cfg`. The original message referenced the internal constant `DEFAULT_MANAGED_STR`, which was not clear to the end-user.

The `why` and `alternative` fields for this setting's definition in `lib/ansible/config/base.yml` have been updated to provide a more direct and helpful warning.

### How to test

1. Create an `ansible.cfg` file in the root of the repository with the following content:
   ```ini
   [defaults]
   ansible_managed = "This is a test"

2. Source the development environment: 
```source ./hacking/env-setup```

4. Run a simple ansible command, for example: 
 ```ansible-playbook --version```

6. Observe that the new, clearer deprecation warning is displayed in the output.