### PR TITLE
service_facts: Handle KeyError while processing service name

### DIFF
--- a/changelogs/fragments/openrc.yml
+++ b/changelogs/fragments/openrc.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+   - service_facts - warn user about missing service details instead of ignoring.
+   - service_facts - handle keyerror exceptions with warning.

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -228,6 +228,9 @@ class ServiceScanService(BaseService):
             if len(line_data) < 2:
                 continue
             service_name = line_data[0]
+            # Skip lines which are not service names
+            if service_name == "*":
+                continue
             service_state = line_data[1]
             try:
                 service_runlevels = all_services_runlevels[service_name]

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -228,11 +228,12 @@ class ServiceScanService(BaseService):
             if len(line_data) < 2:
                 continue
             service_name = line_data[0]
-            # Skip lines which are not service names
-            if service_name == "*":
-                continue
             service_state = line_data[1]
-            service_runlevels = all_services_runlevels[service_name]
+            try:
+                service_runlevels = all_services_runlevels[service_name]
+            except KeyError:
+                self.module.warn(f"Service {service_name} not found in the service list")
+                continue
             service_data = {"name": service_name, "runlevels": service_runlevels, "state": service_state, "source": "openrc"}
             services[service_name] = service_data
 


### PR DESCRIPTION
##### SUMMARY

As a part of follow up review,

* Handle KeyError with exception handling
* Warn user about the missing service name in the given service details

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/openrc.yml
lib/ansible/modules/service_facts.py


