### PR TITLE
[stable-2.19] ansible-galaxy, dont display internals (#85571)

### DIFF
--- a/changelogs/fragments/hide_proto.yml
+++ b/changelogs/fragments/hide_proto.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy no longer shows the internal protomatter collection when listing.

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -84,6 +84,7 @@ if t.TYPE_CHECKING:
     FileManifestEntryType = t.Dict[FileMetaKeysType, t.Union[str, int, None]]
     FilesManifestType = t.Dict[t.Literal['files', 'format'], t.Union[t.List[FileManifestEntryType], int]]
 
+import ansible
 import ansible.constants as C
 from ansible.errors import AnsibleError
 from ansible.galaxy.api import GalaxyAPI
@@ -142,6 +143,8 @@ MANIFEST_FILENAME = 'MANIFEST.json'
 ModifiedContent = namedtuple('ModifiedContent', ['filename', 'expected', 'installed'])
 
 SIGNATURE_COUNT_RE = r"^(?P<strict>\+)?(?:(?P<count>\d+)|(?P<all>all))$"
+
+_ANSIBLE_PACKAGE_PATH = pathlib.Path(ansible.__file__).parent
 
 
 @dataclass
@@ -1442,9 +1445,12 @@ def find_existing_collections(path_filter, artifacts_manager, namespace_filter=N
     paths = set()
     for path in files('ansible_collections').glob('*/*/'):
         path = _normalize_collection_path(path)
-        if not path.is_dir():
+        if path.is_relative_to(_ANSIBLE_PACKAGE_PATH):
+            # skip internal path, those collections are not for galaxy use
             continue
-        if path_filter:
+        elif not path.is_dir():
+            continue
+        elif path_filter:
             for pf in path_filter:
                 try:
                     path.relative_to(_normalize_collection_path(pf))

--- a/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
@@ -155,9 +155,12 @@
   environment:
     ANSIBLE_COLLECTIONS_PATH: "i_dont_exist"
 
-- assert:
+- name: Ensure we get the expected error
+  assert:
     that:
-      - "'{}' not in list_result_error.stdout"
+      # FIXME: This test is currently incorrect, but not a fix to do in this PR, proper test is the commented out one.
+      - "'{}' in list_result_error.stdout"
+      #- "'None of the provided paths were usable' in list_result_error.stderr"
 
 - name: install an artifact to the second collections path
   command: ansible-galaxy collection install namespace1.name1 -s galaxy_ng {{ galaxy_verbosity }} -p "{{ galaxy_dir }}/prod"


### PR DESCRIPTION
Also note broken test for invalid collection paths


(cherry picked from commit 5faa256178173d7e4cbbd66d08df518631b2515b)

##### ISSUE TYPE

- Bugfix Pull Request
