### PR TITLE
Add temporary module result serialization hook

### DIFF
--- a/changelogs/fragments/module_direct_exec.yml
+++ b/changelogs/fragments/module_direct_exec.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - AnsibleModule - Add temporary internal monkeypatch-able hook to alter module result serialization by splitting serialization from ``_return_formatted`` into ``_record_module_result``.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1513,11 +1513,19 @@ class AnsibleModule(object):
         # strip no_log collisions
         kwargs = remove_values(kwargs, self.no_log_values)
 
-        # return preserved
+        # graft preserved values back on
         kwargs.update(preserved)
 
+        self._record_module_result(kwargs)
+
+    def _record_module_result(self, o: dict[str, t.Any]) -> None:
+        """
+        Temporary internal hook to enable modification/bypass of module result serialization.
+
+        Monkeypatched by ansible.netcommon for direct in-worker module execution.
+        """
         encoder = _json.get_module_encoder(_ANSIBLE_PROFILE, _json.Direction.MODULE_TO_CONTROLLER)
-        print('\n%s' % json.dumps(kwargs, cls=encoder))
+        print('\n%s' % json.dumps(o, cls=encoder))
 
     def exit_json(self, **kwargs) -> t.NoReturn:
         """ return from the module, without error """

--- a/test/units/module_utils/basic/test_exit_json.py
+++ b/test/units/module_utils/basic/test_exit_json.py
@@ -154,7 +154,6 @@ class TestAnsibleModuleExitValuesRemoved:
 
         assert json.loads(out) == expected
 
-
     def test_record_module_result(self, mocker: pytest_mock.MockerFixture, stdin) -> None:
         """Ensure that the temporary _record_module_result hook is called correctly."""
         recorded_result = None
@@ -168,6 +167,7 @@ class TestAnsibleModuleExitValuesRemoved:
             recorded_result = o
 
         from ansible.module_utils.basic import AnsibleModule
+
         mocker.patch.object(AnsibleModule, '_record_module_result', _record_module_result)
 
         am = AnsibleModule(argument_spec=dict())

--- a/test/units/module_utils/basic/test_exit_json.py
+++ b/test/units/module_utils/basic/test_exit_json.py
@@ -10,7 +10,7 @@ import datetime
 import typing as t
 
 import pytest
-
+import pytest_mock
 
 EMPTY_INVOCATION: dict[str, dict[str, t.Any]] = {u'module_args': {}}
 DATETIME = datetime.datetime.strptime('2020-07-13 12:50:00', '%Y-%m-%d %H:%M:%S')
@@ -153,3 +153,26 @@ class TestAnsibleModuleExitValuesRemoved:
         out, err = capfd.readouterr()
 
         assert json.loads(out) == expected
+
+
+    def test_record_module_result(self, mocker: pytest_mock.MockerFixture, stdin) -> None:
+        """Ensure that the temporary _record_module_result hook is called correctly."""
+        recorded_result = None
+
+        expected_result = dict(changed=False, worked="yay")
+
+        def _record_module_result(_self, o: object) -> None:
+            assert isinstance(o, dict)
+
+            nonlocal recorded_result
+            recorded_result = o
+
+        from ansible.module_utils.basic import AnsibleModule
+        mocker.patch.object(AnsibleModule, '_record_module_result', _record_module_result)
+
+        am = AnsibleModule(argument_spec=dict())
+
+        with pytest.raises(SystemExit):
+            am.exit_json(**expected_result)
+
+        assert expected_result.items() <= recorded_result.items()


### PR DESCRIPTION
##### SUMMARY
Temporary hook to allow `ansible.netcommon` to entirely monkeypatch away module result serialization until direct module execution in core workers is actually supported.

##### ISSUE TYPE
- Feature Pull Request
