### PR TITLE
User: Raise an error when force is used to delete group

### DIFF
--- a/changelogs/fragments/alpine_group_force.yml
+++ b/changelogs/fragments/alpine_group_force.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - user - raise an error if force=true is used while deleting the group on BusyBox based distros (https://github.com/ansible/ansible/issues/85565).

--- a/lib/ansible/modules/group.py
+++ b/lib/ansible/modules/group.py
@@ -38,6 +38,7 @@ options:
         description:
             - Whether to delete a group even if it is the primary group of a user.
             - Only applicable on platforms which implement a C(--force) flag on the group deletion command.
+            - Not applicable on macOS, *BSD and BusyBox based distros.
         type: bool
         default: false
         version_added: "2.15"
@@ -400,6 +401,8 @@ class FreeBsdGroup(Group):
     GROUPFILE = '/etc/group'
 
     def group_del(self):
+        if self.module.params['force']:
+            self.module.fail_json(msg='The force option is not supported for group deletion on this platform.')
         cmd = [self.module.get_bin_path('pw', True), 'groupdel', self.name]
         return self.execute_command(cmd)
 
@@ -476,6 +479,8 @@ class DarwinGroup(Group):
         return (rc, out, err)
 
     def group_del(self):
+        if self.module.params['force']:
+            self.module.fail_json(msg='The force option is not supported for group deletion on this platform.')
         cmd = [self.module.get_bin_path('dseditgroup', True)]
         cmd += ['-o', 'delete']
         cmd += ['-L', self.name]
@@ -530,6 +535,8 @@ class OpenBsdGroup(Group):
     GROUPFILE = '/etc/group'
 
     def group_del(self):
+        if self.module.params['force']:
+            self.module.fail_json(msg='The force option is not supported for group deletion on this platform.')
         cmd = [self.module.get_bin_path('groupdel', True), self.name]
         return self.execute_command(cmd)
 
@@ -582,6 +589,8 @@ class NetBsdGroup(Group):
     GROUPFILE = '/etc/group'
 
     def group_del(self):
+        if self.module.params['force']:
+            self.module.fail_json(msg='The force option is not supported for group deletion on this platform.')
         cmd = [self.module.get_bin_path('groupdel', True), self.name]
         return self.execute_command(cmd)
 
@@ -651,6 +660,9 @@ class BusyBoxGroup(Group):
         return self.execute_command(cmd)
 
     def group_del(self):
+        if self.module.params['force']:
+            self.module.fail_json(msg='The force option is not supported for group deletion on this platform.')
+
         cmd = [self.module.get_bin_path('delgroup', True), self.name]
         return self.execute_command(cmd)
 

--- a/test/integration/targets/group/tasks/tests.yml
+++ b/test/integration/targets/group/tasks/tests.yml
@@ -388,6 +388,35 @@
             state: absent
       when: ansible_distribution not in ["MacOSX", "Alpine", "FreeBSD"]
 
+    # https://github.com/ansible/ansible/issues/85565
+    - block:
+        - name: Create a group
+          group:
+            name: groupdeltest
+            state: present
+
+        - name: Use force to delete the group
+          group:
+            name: groupdeltest
+            state: absent
+            force: true
+          ignore_errors: true
+          register: force_delete
+
+        - name: assert an error occurred while deleting the group with force=true
+          assert:
+            that:
+              - force_delete is failed
+              - "'The force option is not supported' in force_delete.msg"
+
+      always:
+        - name: Cleanup group
+          group:
+            name: groupdeltest
+            state: absent
+
+      when: ansible_distribution in ["MacOSX", "Alpine", "FreeBSD"]
+
     # create system group
 
     - name: remove group


### PR DESCRIPTION
##### SUMMARY

On platforms like Alpine and BusyBox, group delete operation
with force is not applicable. Raise an error notifying the
user about the same.

Fixes: #85565

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/alpine_group_force.yml
lib/ansible/modules/group.py
test/integration/targets/group/tasks/tests.yml


