### PR TITLE
Create become timeout

### DIFF
--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -387,7 +387,7 @@ def add_connect_options(parser):
                                help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
     connect_group.add_argument('-T', '--timeout', default=None, type=int, dest='timeout',
                                help="override the connection timeout in seconds (default depends on connection)")
-    connect_group.add_argument('-TBE', '--become-timeout', default=None, type=int, dest='become_timeout',
+    connect_group.add_argument('--become-timeout', default=None, type=int, dest='become_timeout',
                                help="change the become connection timeout in seconds")
     # ssh only
     connect_group.add_argument('--ssh-common-args', default=None, dest='ssh_common_args',

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -387,7 +387,8 @@ def add_connect_options(parser):
                                help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
     connect_group.add_argument('-T', '--timeout', default=None, type=int, dest='timeout',
                                help="override the connection timeout in seconds (default depends on connection)")
-
+    connect_group.add_argument('-TBE', '--become-timeout', default=None, type=int, dest='become_timeout',
+                               help="override the connection timeout in seconds (default depends on connection)")
     # ssh only
     connect_group.add_argument('--ssh-common-args', default=None, dest='ssh_common_args',
                                help="specify common arguments to pass to sftp/scp/ssh (e.g. ProxyCommand)")

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -388,7 +388,7 @@ def add_connect_options(parser):
     connect_group.add_argument('-T', '--timeout', default=None, type=int, dest='timeout',
                                help="override the connection timeout in seconds (default depends on connection)")
     connect_group.add_argument('-TBE', '--become-timeout', default=None, type=int, dest='become_timeout',
-                               help="override the connection timeout in seconds (default depends on connection)")
+                               help="change the become connection timeout in seconds")
     # ssh only
     connect_group.add_argument('--ssh-common-args', default=None, dest='ssh_common_args',
                                help="specify common arguments to pass to sftp/scp/ssh (e.g. ProxyCommand)")

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -2248,6 +2248,7 @@ _Z_TEST_ENTRY_2:
     - section: testing
       key: valid2
 BECOME_TIMEOUT:
+  version_added: '2.20'
   name: Connection timeout
   default: 10
   description: This is the default timeout for privilege escalation operations

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -2250,7 +2250,7 @@ _Z_TEST_ENTRY_2:
 BECOME_TIMEOUT:
   version_added: '2.20'
   name: Connection timeout
-  default: 10
+  default: ~
   description: This is the default timeout for privilege escalation operations
   env: [{ name: ANSIBLE_BECOME_TIMEOUT }]
   ini:

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -2247,3 +2247,11 @@ _Z_TEST_ENTRY_2:
   ini:
     - section: testing
       key: valid2
+BECOME_TIMEOUT:
+  name: Connection timeout
+  default: 10
+  description: This is the default timeout for privilege escalation operations
+  env: [{ name: ANSIBLE_BECOME_TIMEOUT }]
+  ini:
+    - { key: become_timeout, section: defaults }
+  type: integer

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -181,6 +181,8 @@ MAGIC_VARIABLE_MAPPING = dict(
     become_pass=('ansible_become_password', 'ansible_become_pass'),
     become_exe=('ansible_become_exe', ),
     become_flags=('ansible_become_flags', ),
+    become_timeout=('ansible_become_timeout', 'become_timeout'),
+
 )
 
 # POPULATE SETTINGS FROM CONFIG ###

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -182,7 +182,6 @@ MAGIC_VARIABLE_MAPPING = dict(
     become_exe=('ansible_become_exe', ),
     become_flags=('ansible_become_flags', ),
     become_timeout=('ansible_become_timeout', 'become_timeout'),
-
 )
 
 # POPULATE SETTINGS FROM CONFIG ###

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1222,7 +1222,7 @@ class Connection(ConnectionBase):
         # timeout usually fails
         default_timeout = 2 + self.get_option('timeout')
         privilege_esc_timeout = self.get_option("become_timeout")
-        timeout = privilege_esc_timeout if privilege_esc_timeout > default_timeout else default_timeout
+        timeout = privilege_esc_timeout if privilege_esc_timeout and privilege_esc_timeout > default_timeout else default_timeout
 
         for fd in (p.stdout, p.stderr):
             fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -409,6 +409,19 @@ DOCUMENTATION = """
           - {key: verbosity, section: ssh_connection}
         vars:
           - name: ansible_ssh_verbosity
+      become_timeout:
+            description: Timeout for privilege escalation operations
+            default: 10
+            type: int
+            env:
+              - name: ANSIBLE_BECOME_TIMEOUT
+            ini:
+              - key: become_timeout
+                section: defaults
+              - key: become_timeout
+                section: ssh_connection
+            vars:
+              - name: ansible_become_timeout
 """
 
 import collections.abc as c
@@ -1207,7 +1220,10 @@ class Connection(ConnectionBase):
         # select timeout should be longer than the connect timeout, otherwise
         # they will race each other when we can't connect, and the connect
         # timeout usually fails
-        timeout = 2 + self.get_option('timeout')
+        default_timeout = 2 + self.get_option('timeout')
+        privilege_esc_timeout = self.get_option("become_timeout")
+        timeout = privilege_esc_timeout if privilege_esc_timeout > default_timeout else default_timeout
+
         for fd in (p.stdout, p.stderr):
             fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK)
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -410,18 +410,19 @@ DOCUMENTATION = """
         vars:
           - name: ansible_ssh_verbosity
       become_timeout:
-            description: Timeout for privilege escalation operations
-            default: 10
-            type: int
-            env:
-              - name: ANSIBLE_BECOME_TIMEOUT
-            ini:
-              - key: become_timeout
-                section: defaults
-              - key: become_timeout
-                section: ssh_connection
-            vars:
-              - name: ansible_become_timeout
+        version_added: '2.20'
+        description: Timeout for privilege escalation operations
+        default: 10
+        type: int
+        env:
+            - name: ANSIBLE_BECOME_TIMEOUT
+        ini:
+            - key: become_timeout
+            section: defaults
+            - key: become_timeout
+            section: ssh_connection
+        vars:
+            - name: ansible_become_timeout
 """
 
 import collections.abc as c

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -413,8 +413,8 @@ DOCUMENTATION = """
         version_added: '2.20'
         default: 10
         type: int
-        description: 
-          - Timeout for privilege escalation operations
+        description:
+            - Timeout for privilege escalation operations
         env:
             - name: ANSIBLE_BECOME_TIMEOUT
         ini:

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -411,9 +411,10 @@ DOCUMENTATION = """
           - name: ansible_ssh_verbosity
       become_timeout:
         version_added: '2.20'
-        description: Timeout for privilege escalation operations
         default: 10
         type: int
+        description: 
+          - Timeout for privilege escalation operations
         env:
             - name: ANSIBLE_BECOME_TIMEOUT
         ini:

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1221,8 +1221,8 @@ class Connection(ConnectionBase):
         # they will race each other when we can't connect, and the connect
         # timeout usually fails
         default_timeout = 2 + self.get_option('timeout')
-        privilege_esc_timeout = self.get_option("become_timeout")
-        timeout = privilege_esc_timeout if privilege_esc_timeout and privilege_esc_timeout > default_timeout else default_timeout
+        become_timeout = self.get_option("become_timeout")
+        timeout = become_timeout if become_timeout and become_timeout > default_timeout else default_timeout
 
         for fd in (p.stdout, p.stderr):
             fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -411,7 +411,7 @@ DOCUMENTATION = """
           - name: ansible_ssh_verbosity
       become_timeout:
         version_added: '2.20'
-        default: 10
+        default: ~
         type: int
         description:
             - Timeout for privilege escalation operations
@@ -1222,6 +1222,8 @@ class Connection(ConnectionBase):
         # timeout usually fails
         default_timeout = 2 + self.get_option('timeout')
         become_timeout = self.get_option("become_timeout")
+
+        print("become timeout: {become_timeout}")
         timeout = become_timeout if become_timeout and become_timeout > default_timeout else default_timeout
 
         for fd in (p.stdout, p.stderr):

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -418,10 +418,8 @@ DOCUMENTATION = """
         env:
             - name: ANSIBLE_BECOME_TIMEOUT
         ini:
-            - key: become_timeout
-            section: defaults
-            - key: become_timeout
-            section: ssh_connection
+            - { key: become_timeout, section: defaults }
+            - { key: become_timeout, section: ssh_connection }
         vars:
             - name: ansible_become_timeout
 """

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1223,7 +1223,6 @@ class Connection(ConnectionBase):
         default_timeout = 2 + self.get_option('timeout')
         become_timeout = self.get_option("become_timeout")
 
-        print("become timeout: {become_timeout}")
         timeout = become_timeout if become_timeout and become_timeout > default_timeout else default_timeout
 
         for fd in (p.stdout, p.stderr):

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -225,9 +225,8 @@ def load_options_vars(version):
                  'skip_tags': 'skip_tags',
                  'subset': 'limit',
                  'tags': 'run_tags',
-                 'verbosity': 'verbosity', 
+                 'verbosity': 'verbosity',
                  'become_timeout': 'become_timeout'}
-
         for attr, alias in attrs.items():
             opt = context.CLIARGS.get(attr)
             if opt is not None:

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -225,7 +225,8 @@ def load_options_vars(version):
                  'skip_tags': 'skip_tags',
                  'subset': 'limit',
                  'tags': 'run_tags',
-                 'verbosity': 'verbosity'}
+                 'verbosity': 'verbosity', 
+                 'become_timeout': 'become_timeout'}
 
         for attr, alias in attrs.items():
             opt = context.CLIARGS.get(attr)

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -469,6 +469,25 @@ class TestSSHConnectionRun(object):
         assert self.mock_selector.register.call_count == 2
         assert self.conn._send_initial_data.called is False
 
+    def test_become_timeout(self):
+        self.pc.prompt = b'Password:'
+        self.pc.become = True
+        self.pc.success_key = 'BECOME-SUCCESS-abcdefg'
+        self.conn.become.prompt = b'Password:'
+        self.conn.become._id = 'abcdefg'
+        self.conn._examine_output.side_effect = lambda x, s: (b'', b'')
+        self.conn.BECOME_TIMEOUT = 10
+        self.mock_popen_res.poll.return_value = None
+        self.mock_popen_res.stdout.read.return_value = b''
+        self.mock_popen_res.stderr.read.return_value = b''
+        self.mock_selector.select.return_value = []
+        self.mock_selector.get_map.side_effect = lambda: True
+
+        with pytest.raises(AnsibleError) as excinfo:
+            self.conn._run("ssh", "some data")
+
+        assert "BECOME_TIMEOUT" in str(excinfo.value) or "timeout" in str(excinfo.value).lower()
+
 
 @pytest.mark.usefixtures('mock_run_env')
 class TestSSHConnectionRetries(object):


### PR DESCRIPTION
SUMMARY
This PR adds support for a configurable timeout for privilege escalation prompts (e.g. sudo/become). 
This default isn't suitable for environments where sudo or other escalation methods take longer to respond. The new feature introduces a user-configurable parameter become_timeout that allows users to extend the timeout duration to work in slower response environments.

Rationale & Design Decisions

Unless this flag is set, the old timeout is used.
Allows configuration via CLI flag, environment variable, or configuration file setting.
Fixes: https://github.com/ansible/ansible/issues/85437 

ISSUE TYPE
Feature Pull Request
