### PR TITLE
dnf5: replace glob character check with libdnf5.utils.is_glob_pattern()

### DIFF
--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -708,11 +708,8 @@ class Dnf5Module(YumDnf):
             goal.add_rpm_upgrade(settings)
         elif self.state in {"installed", "present", "latest"}:
             upgrade = self.state == "latest"
-            # FIXME use `is_glob_pattern` function when available:
-            # https://github.com/rpm-software-management/dnf5/issues/1563
-            glob_patterns = set("*[?")
             for spec in self.names:
-                if any(set(char) & glob_patterns for char in spec):
+                if libdnf5.utils.is_glob_pattern(spec):
                     # Special case for package specs that contain glob characters.
                     # For these we skip `is_installed` and `is_newer_version_installed` tests that allow for the
                     # allow_downgrade feature and pass the package specs to dnf.
@@ -727,17 +724,17 @@ class Dnf5Module(YumDnf):
                         goal.add_upgrade(spec, settings)
                     if not self.update_only:
                         goal.add_install(spec, settings)
-                elif is_newer_version_installed(base, spec):
-                    if self.allow_downgrade:
-                        goal.add_install(spec, settings)
-                elif is_installed(base, spec):
-                    if upgrade:
-                        goal.add_upgrade(spec, settings)
-                else:
-                    if self.update_only:
-                        results.append("Packages providing {} not installed due to update_only specified".format(spec))
+                    elif is_newer_version_installed(base, spec):
+                        if self.allow_downgrade:
+                            goal.add_install(spec, settings)
+                    elif is_installed(base, spec):
+                        if upgrade:
+                            goal.add_upgrade(spec, settings)
                     else:
-                        goal.add_install(spec, settings)
+                        if self.update_only:
+                            results.append("Packages providing {} not installed due to update_only specified".format(spec))
+                        else:
+                            goal.add_install(spec, settings)
         elif self.state in {"absent", "removed"}:
             for spec in self.names:
                 goal.add_remove(spec, settings)

--- a/test/integration/targets/dnf/tasks/is_glob_pattern.yml
+++ b/test/integration/targets/dnf/tasks/is_glob_pattern.yml
@@ -1,0 +1,47 @@
+- name: Ensure htop is not present
+  package:
+    name: htop
+    state: absent
+  become: true
+  ignore_errors: true
+
+- name: Install htop via glob using dnf5
+  dnf5:
+    name: "htop*"
+    state: present
+  become: true
+  when: dnf5
+
+- name: Install htop via glob using dnf
+  dnf:
+    name: "htop*"
+    state: present
+  become: true
+  when: not dnf5
+
+- name: Verify htop is installed
+  command: rpm -q htop
+  register: htop_check
+  changed_when: false
+  failed_when: htop_check.rc != 0
+
+- name: Remove htop via glob using dnf5
+  dnf5:
+    name: "htop*"
+    state: absent
+  become: true
+  when: dnf5
+
+- name: Remove htop via glob using dnf
+  dnf:
+    name: "htop*"
+    state: absent
+  become: true
+  when: not dnf5
+
+- name: Confirm htop is removed
+  command: rpm -q htop
+  register: htop_removed
+  changed_when: false
+  failed_when: htop_removed.rc == 0
+

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -40,6 +40,7 @@
     - include_tasks: repo.yml
     - include_tasks: dnf_group_remove.yml
     - include_tasks: dnfinstallroot.yml
+    - include_tasks: is_glob_pattern.yml
     - include_tasks: logging.yml
     - include_tasks: cacheonly.yml
     - include_tasks: multilib.yml


### PR DESCRIPTION
This change replaces the inline glob character check in the `dnf5` module with a call to `libdnf5.utils.is_glob_pattern()`, which addresses the following TODO comment in the code:
```
# FIXME use `is_glob_pattern` function when available:
# https://github.com/rpm-software-management/dnf5/issues/1563
```

An integration test is added to ensure expected behavior when using glob patterns with the dnf5 module (name=hto*, etc.).