### PR TITLE
version test - add 'debian' version_type

### DIFF
--- a/changelogs/fragments/85616-debian-versions.yml
+++ b/changelogs/fragments/85616-debian-versions.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "version test: add version_type='debian' which uses the same rules dpkg (the Debian package manager) does to compare version strings"

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -35,6 +35,7 @@ from ansible.template import accept_args_markers
 from ansible.parsing.vault import is_encrypted_file, VaultHelper, VaultLib
 from ansible.utils.display import Display
 from ansible.utils.version import SemanticVersion
+from ansible.utils.dversion import Version as DebianVersion
 
 try:
     from packaging.version import Version as PEP440Version
@@ -206,6 +207,7 @@ def version_compare(value, version, operator='eq', strict=None, version_type=Non
         'semver': SemanticVersion,
         'semantic': SemanticVersion,
         'pep440': PEP440Version,
+        'debian': DebianVersion,
     }
 
     if strict is not None and version_type is not None:

--- a/lib/ansible/plugins/test/version.yml
+++ b/lib/ansible/plugins/test/version.yml
@@ -50,12 +50,14 @@ DOCUMENTATION:
         - semver
         - semantic
         - pep440
+        - debian
       default: loose
   notes:
     - V(loose) - This type corresponds to the Python C(distutils.version.LooseVersion) class. All version formats are valid for this type. The rules for comparison are simple and predictable, but may not always give expected results.
     - V(strict) - This type corresponds to the Python C(distutils.version.StrictVersion) class. A version number consists of two or three dot-separated numeric components, with an optional "pre-release" tag on the end. The pre-release tag consists of a single letter C(a) or C(b) followed by a number.  If the numeric components of two version numbers are equal, then one with a pre-release tag will always be deemed earlier (lesser) than one without.
     - V(semver)/V(semantic) - This type implements the L(Semantic Version,https://semver.org) scheme for version comparison.
     - V(pep440) - This type implements the Python L(PEP-440,https://peps.python.org/pep-0440/) versioning rules for version comparison. Added in version 2.14.
+    - V(debian) - This type implements the L(Debian package version,https://manpages.debian.org/stable/dpkg-dev/deb-version.7.en.html) comparison algorithm. Added in version 2.20.
 EXAMPLES: |
   - name: version test examples
     assert:
@@ -76,6 +78,7 @@ EXAMPLES: |
         - "'1.0' is version('1.0', '>=', strict=true)"
         - "'1.2.3' is version('2.0.0', 'lt', version_type='semver')"
         - "'2.14.0rc1' is version('2.14.0', 'lt', version_type='pep440')"
+        - "'1:2.3-4~bpo12+1' is version('1:2.3-4', 'lt', version_type='debian')"
 RETURN:
   _value:
     description: Returns V(True) or V(False) depending on the outcome of the comparison.

--- a/lib/ansible/utils/dversion.py
+++ b/lib/ansible/utils/dversion.py
@@ -1,0 +1,267 @@
+# Copyright © 2024 mirabilos
+# Adapted 2025 for Ansible by mirabilos <tglaser@b1-systems.de>
+#
+# Provided that these terms and disclaimer and all copyright notices
+# are retained or reproduced in an accompanying document, permission
+# is granted to deal in this work without restriction, including un-
+# limited rights to use, publicly perform, distribute, sell, modify,
+# merge, give away, or sublicence.
+#
+# This work is provided "AS IS" and WITHOUT WARRANTY of any kind, to
+# the utmost extent permitted by applicable law, neither express nor
+# implied; without malicious intent or gross negligence. In no event
+# may a licensor, author or contributor be held liable for indirect,
+# direct, other damage, loss, or other issues arising in any way out
+# of dealing in the work, even if advised of the possibility of such
+# damage or existence of a defect, except proven that it results out
+# of said person's immediate fault when using the work as intended.
+
+"""Implementation of sortable versions as in Debian
+
+This module offers the class Version which represents
+version strings (bytes, actually, but if you pass str
+its UTF-8 encoding is used) that are sortable.
+
+When run as main, argv is shown as sorted JSON array.
+"""
+
+from __future__ import annotations
+
+__all__ = ['Version']
+
+import re
+
+# regex to determine Debian version number flavour
+_hasepoch = re.compile(b'^(?:0|[1-9][0-9]*):')
+_hasmaint = re.compile(b'-[0-9A-Za-z+.~]+$')
+# regex to check Debian version number, [_hasepoch][_hasmaint]-indexed
+_debverre = (
+    (
+        re.compile(b'^()([0-9A-Za-z.+~]+)()$'),
+        re.compile(b'^()([0-9A-Za-z.+~-]+)-([0-9A-Za-z+.~]+)$'),
+    ), (
+        re.compile(b'^(0|[1-9][0-9]*):([0-9A-Za-z.+~]+)()$'),
+        re.compile(b'^(0|[1-9][0-9]*):([0-9A-Za-z.+~-]+)-([0-9A-Za-z+.~]+)$'),
+    ),
+)
+# split components into runs of digits and not-digits
+_cmpsplit = re.compile(b'([0-9]+)')
+
+
+# split component and normalise
+def _cmpprep(v):
+    if v is None:
+        return None
+    v = _cmpsplit.split(v)
+    # form as list of pairs of runs (nōn-digit then digit)
+    if v[-1] == b'':
+        v.pop()
+    else:
+        v.append(b'0')
+    # convert to comparison form even indexes: 0, 2, 4, …
+    for i in range(0, len(v), 2):
+        b = v[i]
+        # pylint: disable-next=consider-using-generator
+        v[i] = tuple([_alphprep(b[j:j + 1]) for j in range(len(b))])
+    # convert to number the odd indexes: 1, 3, 5, …
+    for i in range(1, len(v), 2):
+        v[i] = int(v[i])
+    return tuple(v)
+
+
+# implement alphabetic ordering (~ before end,
+# then letters, and finally everything else)
+def _alphprep(ch):
+    if ch == b'~':
+        return -1
+    if ch < b'A':
+        return 128 + ord(ch)
+    if ch <= b'Z':
+        return ord(ch)
+    if ch < b'a':
+        return 128 + ord(ch)
+    if ch <= b'z':
+        return ord(ch)
+    return 128 + ord(ch)
+
+
+# compare two Version objects ⇒ -1 or 0 or 1
+def _cmpv(self, other):
+    if not isinstance(other, Version):
+        return NotImplemented
+    # epoch, if present
+    if self._cmp[0] < other._cmp[0]:
+        return -1
+    if self._cmp[0] > other._cmp[0]:
+        return 1
+    # Debian: upstream version
+    # else: entire string
+    a = list(self._cmp[1])
+    b = list(other._cmp[1])
+    # pad with NUL equivalent at the end
+    n = max(len(a), len(b))
+    while len(a) < n:
+        a.extend(((), 0))
+    while len(b) < n:
+        b.extend(((), 0))
+    # loop over (nōn-digit run, digit run) pairs
+    for i in range(0, n, 2):
+        # the nōn-digit run
+        aa = list(a[i])
+        bb = list(b[i])
+        # pad with NUL (so ~ = -1 works)
+        nn = max(len(aa), len(bb))
+        while len(aa) < nn:
+            aa.append(0)
+        while len(bb) < nn:
+            bb.append(0)
+        for j in range(nn):
+            if aa < bb:
+                return -1
+            if aa > bb:
+                return 1
+        # and the digit run
+        if a[i + 1] < b[i + 1]:
+            return -1
+        if a[i + 1] > b[i + 1]:
+            return 1
+    # if Debian revision absent…
+    if self._cmp[2] is None:
+        if other._cmp[2] is None:
+            # in both
+            return 0
+        # the shorter is smaller then
+        return -1
+    elif other._cmp[2] is None:
+        return 1
+    # both present, like upstream version
+    a = list(self._cmp[2])
+    b = list(other._cmp[2])
+    n = max(len(a), len(b))
+    while len(a) < n:
+        a.extend(((), 0))
+    while len(b) < n:
+        b.extend(((), 0))
+    for i in range(0, n, 2):
+        aa = list(a[i])
+        bb = list(b[i])
+        nn = max(len(aa), len(bb))
+        while len(aa) < nn:
+            aa.append(0)
+        while len(bb) < nn:
+            bb.append(0)
+        for j in range(nn):
+            if aa < bb:
+                return -1
+            if aa > bb:
+                return 1
+        if a[i + 1] < b[i + 1]:
+            return -1
+        if a[i + 1] > b[i + 1]:
+            return 1
+    return 0
+
+
+class Version:
+    """Sortable representation of a version.
+
+    The usual comparisons (<, >, <=, >=, ==, !=) can be used,
+    or a containing list can be sorted; use str or bytes, not
+    repr, to output. Versions with isDebianVersion() == False
+    are sorted as "upstream version" with no epoch.
+    """
+
+    def __init__(self, ver, _only_for_testing=False):
+        if isinstance(ver, str):
+            self._repr = '"%s"' % ver
+            self._str = ver
+            ver = ver.encode('UTF-8')
+        elif isinstance(ver, bytes):
+            self._repr = str(ver)
+            self._str = self._repr
+        elif _only_for_testing:
+            # uses argument unchecked! dversion-t.py only!
+            self._deb = (ver[0], ver[1], ver[2])
+            ver = b'' + self._deb[1]
+            if self._deb[0] != 0:
+                ver = str(self._deb[0]).encode('ASCII') + b':' + ver
+            if self._deb[2] is not None:
+                ver += b'-' + self._deb[2]
+            self._repr = str(ver)
+            self._str = self._repr
+            self._cmp = (self._deb[0], _cmpprep(self._deb[1]), _cmpprep(self._deb[2]))
+            self._hash = hash(self._cmp)
+            return
+        else:
+            raise ValueError('Version is not bytes or str')
+        if ver == b'':
+            raise ValueError('empty Version')
+        self._ver = ver
+        depoch = _hasepoch.search(ver) and 1 or 0
+        dmaint = _hasmaint.search(ver) and 1 or 0
+        dparse = _debverre[depoch][dmaint].fullmatch(ver)
+        if dparse is None:
+            self._deb = False
+            dm = [0, ver, None]
+        else:
+            dm = list(dparse.groups())
+            if depoch == 0:
+                dm[0] = 0
+            else:
+                dm[0] = int(dm[0])
+            if dmaint == 0:
+                dm[2] = None
+            if dm[0] <= 2147483647:
+                self._deb = tuple(dm)
+            else:
+                self._deb = False
+        dm[1] = _cmpprep(dm[1])
+        dm[2] = _cmpprep(dm[2])
+        self._cmp = tuple(dm)
+        self._hash = hash(self._cmp)
+
+    def __repr__(self):
+        return 'Version(%s)' % self._repr
+
+    def __str__(self):
+        return self._str
+
+    def __bytes__(self):
+        return self._ver
+
+    def __hash__(self):
+        return self._hash
+
+    def __eq__(self, other):
+        return _cmpv(self, other) == 0
+
+    def __ne__(self, other):
+        return _cmpv(self, other) != 0
+
+    def __lt__(self, other):
+        return _cmpv(self, other) < 0
+
+    def __le__(self, other):
+        return _cmpv(self, other) <= 0
+
+    def __gt__(self, other):
+        return _cmpv(self, other) > 0
+
+    def __ge__(self, other):
+        return _cmpv(self, other) >= 0
+
+    def isDebianVersion(self):
+        """Return whether this is a valid Debian version.
+
+        Returns False if not, a three-tuple (epoch:int32,
+        upstream:bytes, revision:bytes-or-None) if it is.
+        """
+        return self._deb
+
+
+if __name__ == "__main__":
+    import sys
+    import json
+    lst = [Version(x) for x in sys.argv[1:]]
+    lst.sort()
+    print(json.dumps(lst, allow_nan=False, default=str))

--- a/test/integration/targets/test_core/tasks/main.yml
+++ b/test/integration/targets/test_core/tasks/main.yml
@@ -285,6 +285,8 @@
       - "'1.0' is version('1.0', '>=', true)"
       - "'1.2.3' is version('2.0.0', 'lt', version_type='semver')"
       - "'2.14.0rc1' is version('2.14.0', 'lt', version_type='pep440')"
+      - "'1:2.3-4~bpo12+1' is version('1:2.3-4', 'gt')"
+      - "'1:2.3-4~bpo12+1' is version('1:2.3-4', 'lt', version_type='debian')"
       - version_bad_operator is failed
       - version_bad_value is failed
       - version_strict_version_type is failed

--- a/test/units/utils/test_dversion.py
+++ b/test/units/utils/test_dversion.py
@@ -1,0 +1,368 @@
+# Copyright © 2024, 2025 mirabilos <tglaser@b1-systems.de>
+# Testsuite for dversion.py in Ansible, cribbed from:
+#
+# libdpkg - Debian packaging suite library routines
+# t-version.c - test version handling
+#
+# Copyright © 2009-2014 Guillem Jover <guillem@debian.org>
+#
+# GNU General Public License v2 or later (see COPYING or https://www.gnu.org/licenses/gpl-2.0.txt)
+
+from __future__ import annotations
+
+from ansible.utils.dversion import Version
+
+
+def p(v):
+    if not v:
+        raise Exception('v: ' + repr(v))
+
+
+def f(v):
+    if v:
+        raise Exception('v: ' + repr(v))
+
+
+def chkdebver(v, towhat):
+    # pycodestyle is wrong here, False need not be a singleton
+    # (even if it is in current cpython) so "is false" is wrong,
+    # and we do need the explicit comparison to False because
+    # the other values can be falsy
+    if towhat:
+        # pylint: disable-next=singleton-comparison
+        p(v.isDebianVersion() != False)  # noqa: E712 (see above)
+    else:
+        # pylint: disable-next=singleton-comparison
+        p(v.isDebianVersion() == False)  # noqa: E712 (see above)
+
+
+def doesaccept(v, should):
+    does = True
+    try:
+        a = Version(v)
+    except ValueError:
+        does = False
+    p(does == should)
+
+
+class Dummy:
+    def __str__(self):
+        return "dummy"
+
+
+def test_dversion():
+    a = Version(b"1:0")
+    b = Version(b"1:0")
+    p(a == b)
+    b = Version(b"2:0")
+    f(a == b)
+
+    a = Version((0, b"1", b"1"), True)
+    b = Version((0, b"2", b"1"), True)
+    f(a == b)
+
+    a = Version((0, b"1", b"1"), True)
+    b = Version((0, b"1", b"2"), True)
+    f(a == b)
+
+    # Test for version equality
+    a = b = Version((0, b"0", b"0"), True)
+    p(a == b)
+
+    a = Version((0, b"0", b"00"), True)
+    b = Version((0, b"00", b"0"), True)
+    p(a == b)
+
+    a = b = Version((1, b"2", b"3"), True)
+    p(a == b)
+
+    # Test for epoch difference
+    a = Version((0, b"0", b"0"), True)
+    b = Version((1, b"0", b"0"), True)
+    p(a < b)
+    p(b > a)
+
+    # Test for version component difference
+    a = Version((0, b"a", b"0"), True)
+    b = Version((0, b"b", b"0"), True)
+    p(a < b)
+    p(b > a)
+
+    # Test for revision component difference
+    a = Version((0, b"0", b"a"), True)
+    b = Version((0, b"0", b"b"), True)
+    p(a < b)
+    p(b > a)
+
+    a = Version((0, b"1", b"1"), True)
+    b = Version((0, b"1", b"1"), True)
+    p(a == b)
+    f(a < b)
+    p(a <= b)
+    f(a > b)
+    p(a >= b)
+
+    a = Version((0, b"1", b"1"), True)
+    b = Version((0, b"2", b"1"), True)
+    f(a == b)
+    p(a < b)
+    p(a <= b)
+    f(a > b)
+    f(a >= b)
+
+    a = Version((0, b"2", b"1"), True)
+    b = Version((0, b"1", b"1"), True)
+    f(a == b)
+    f(a < b)
+    f(a <= b)
+    p(a > b)
+    p(a >= b)
+
+    b = Version((0, b"0", None), True)
+    a = Version(b"0:0")
+    chkdebver(a, True)
+    p(a == b)
+
+    b = Version((0, b"0", b"0"), True)
+    a = Version(b"0:0-0")
+    chkdebver(a, True)
+    p(a == b)
+
+    b = Version((0, b"0.0", b"0.0"), True)
+    a = Version(b"0:0.0-0.0")
+    chkdebver(a, True)
+    p(a == b)
+
+    # Test epoched versions
+    b = Version((1, b"0", None), True)
+    a = Version(b"1:0")
+    chkdebver(a, True)
+    p(a == b)
+
+    b = Version((5, b"1", None), True)
+    a = Version(b"5:1")
+    chkdebver(a, True)
+    p(a == b)
+
+    # Test multiple hyphens
+    b = Version((0, b"0-0", b"0"), True)
+    a = Version(b"0:0-0-0")
+    chkdebver(a, True)
+    p(a == b)
+
+    b = Version((0, b"0-0-0", b"0"), True)
+    a = Version(b"0:0-0-0-0")
+    chkdebver(a, True)
+    p(a == b)
+
+    # Test multiple colons
+    b = Version((0, b"0:0", b"0"), True)
+    a = Version(b"0:0:0-0")
+    chkdebver(a, False)
+
+    b = Version((0, b"0:0:0", b"0"), True)
+    a = Version(b"0:0:0:0-0")
+    chkdebver(a, False)
+
+    # Test multiple hyphens and colons
+    b = Version((0, b"0:0-0", b"0"), True)
+    a = Version(b"0:0:0-0-0")
+    chkdebver(a, False)
+
+    b = Version((0, b"0-0:0", b"0"), True)
+    a = Version(b"0:0-0:0-0")
+    chkdebver(a, False)
+
+    # Test valid characters in upstream version
+    a = Version(b"0:09azAZ.-+~:-0")
+    chkdebver(a, False)
+    b = Version((0, b"09azAZ.-+~", b"0"), True)
+    a = Version(b"0:09azAZ.-+~-0")
+    chkdebver(a, True)
+    p(a == b)
+
+    # Test valid characters in revision
+    b = Version((0, b"0", b"azAZ09.+~"), True)
+    a = Version(b"0:0-azAZ09.+~")
+    chkdebver(a, True)
+    p(a == b)
+
+    # Test empty version
+    doesaccept(b"", False)
+    doesaccept(b"  ", True)
+    dummy = Dummy()
+    doesaccept(dummy, False)
+    doesaccept(None, False)
+    doesaccept(True, False)
+    doesaccept(False, False)
+    doesaccept(str, False)
+    doesaccept(bytes, False)
+    doesaccept(1, False)
+    # we accept basically any string and bytes but nothing else
+
+    # Test empty upstream version after epoch
+    a = Version(b"0:")
+    chkdebver(a, False)
+
+    # Test empty epoch in version
+    a = Version(b":1.0")
+    chkdebver(a, False)
+
+    # Test empty revision in version
+    a = Version(b"1.0-")
+    chkdebver(a, False)
+
+    # Test version with embedded spaces
+    a = Version(b"0:0 0-1")
+    chkdebver(a, False)
+
+    # Test version with negative epoch
+    a = Version(b"-1:0-1")
+    chkdebver(a, False)
+
+    # Test version with huge epoch
+    a = Version(b"999999999999999999999999:0-1")
+    chkdebver(a, False)
+
+    # Test invalid characters in epoch
+    a = Version(b"a:0-0")
+    chkdebver(a, False)
+    a = Version(b"A:0-0")
+    chkdebver(a, False)
+
+    # Test invalid empty upstream version
+    a = Version(b"-0")
+    chkdebver(a, False)
+    a = Version(b"0:-0")
+    chkdebver(a, False)
+
+    # Test upstream version not starting with a digit
+    a = Version(b"0:abc3-0")
+    chkdebver(a, True)
+
+    # Test invalid characters in upstream version
+    a = Version(b"0:0%s-0" % b"a")
+    chkdebver(a, True)
+    a = Version(b"0:0%s-0" % b"!")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"#")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"@")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"$")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"%")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"&")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"/")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"|")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"\\")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"<")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b">")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"(")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b")")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"[")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"]")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"{")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"}")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b";")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b",")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"_")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"=")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"*")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"^")
+    chkdebver(a, False)
+    a = Version(b"0:0%s-0" % b"'")
+    chkdebver(a, False)
+
+    # Test invalid characters in revision
+    a = Version(b"0:0-0%s0" % b":")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"a")
+    chkdebver(a, True)
+    a = Version(b"0:0-0%s0" % b"!")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"#")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"@")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"$")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"%")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"&")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"/")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"|")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"\\")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"<")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b">")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"(")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b")")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"[")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"]")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"{")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"}")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b";")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b",")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"_")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"=")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"*")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"^")
+    chkdebver(a, False)
+    a = Version(b"0:0-0%s0" % b"'")
+    chkdebver(a, False)
+
+    # and from me
+    a = Version(b'1.23.')
+    b = Version(b'1.23.0')
+    chkdebver(a, True)
+    chkdebver(b, True)
+    p(a == b)
+
+    a = Version(b"0-1")
+    chkdebver(a, True)
+    a = Version(b"2:0-1")
+    chkdebver(a, True)
+    a = Version(b'0:1.23.')
+    b = Version(b'1.23.0')
+    chkdebver(a, True)
+    chkdebver(b, True)
+    p(a == b)
+    a = Version(b"2147483647:0-1")
+    chkdebver(a, True)
+    a = Version(b"2147483648:0-1")
+    chkdebver(a, False)


### PR DESCRIPTION
##### SUMMARY

This implements comparison using the rules `dpkg` or `apt` use for Debian packages, but can also be used for most anything, even strings that are not valid `.deb` package versions.

I have integrated the unit tests for the Debian Version class and added an integration test like the other `version_type`s have (I used the pep440 type as basis, but also added a negative-test).

I believe this to be useful in the context of Ansible and would like to contribute this; I had written the Debian Version class for another project some time ago and manmaged to secure publication under a permissive licence (GPLv3+-compatible), and the unittests were cribbed from GPLv2+ libdpkg and as such are also suitable for inclusion.

##### ISSUE TYPE

- Feature Pull Request
