### PR TITLE
[stable-2.19] ansible-galaxy - remove internal path earlier

### DIFF
--- a/changelogs/fragments/85596-hide-proto.yml
+++ b/changelogs/fragments/85596-hide-proto.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- >-
+  ``ansible-galaxy collection list`` - fail when none of the configured collection paths exist.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -213,6 +213,18 @@ class GalaxyCLI(CLI):
         self.lazy_role_api = None
         super(GalaxyCLI, self).__init__(args)
 
+    @property
+    def collection_paths(self):
+        """
+        Exclude lib/ansible/_internal/ansible_collections/.
+        """
+        # exclude bundled collections, e.g. ansible._protomatter
+        return [
+            path
+            for path in AnsibleCollectionConfig.collection_paths
+            if path != AnsibleCollectionConfig._internal_collections
+        ]
+
     def init_parser(self):
         """ create an options parser for bin/ansible """
 
@@ -1281,7 +1293,7 @@ class GalaxyCLI(CLI):
         """Compare checksums with the collection(s) found on the server and the installed copy. This does not verify dependencies."""
 
         collections = context.CLIARGS['args']
-        search_paths = AnsibleCollectionConfig.collection_paths
+        search_paths = self.collection_paths
         ignore_errors = context.CLIARGS['ignore_errors']
         local_verify_only = context.CLIARGS['offline']
         requirements_file = context.CLIARGS['requirements']
@@ -1423,7 +1435,7 @@ class GalaxyCLI(CLI):
         collections_path = C.COLLECTIONS_PATHS
 
         managed_paths = set(validate_collection_path(p) for p in C.COLLECTIONS_PATHS)
-        read_req_paths = set(validate_collection_path(p) for p in AnsibleCollectionConfig.collection_paths)
+        read_req_paths = set(validate_collection_path(p) for p in self.collection_paths)
 
         unexpected_path = C.GALAXY_COLLECTIONS_PATH_WARNING and not any(p.startswith(path) for p in managed_paths)
         if unexpected_path and any(p.startswith(path) for p in read_req_paths):
@@ -1639,7 +1651,7 @@ class GalaxyCLI(CLI):
         collection_name = context.CLIARGS['collection']
         default_collections_path = set(C.COLLECTIONS_PATHS)
         collections_search_paths = (
-            set(context.CLIARGS['collections_path'] or []) | default_collections_path | set(AnsibleCollectionConfig.collection_paths)
+            set(context.CLIARGS['collections_path'] or []) | default_collections_path | set(self.collection_paths)
         )
         collections_in_paths = {}
 

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -26,9 +26,6 @@ if t.TYPE_CHECKING:
         '_ComputedReqKindsMixin',
     )
 
-import ansible
-import ansible.release
-
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.collection import HAS_PACKAGING, PkgReq
@@ -42,7 +39,6 @@ _ALLOW_CONCRETE_POINTER_IN_SOURCE = False  # NOTE: This is a feature flag
 _GALAXY_YAML = b'galaxy.yml'
 _MANIFEST_JSON = b'MANIFEST.json'
 _SOURCE_METADATA_FILE = b'GALAXY.yml'
-_ANSIBLE_PACKAGE_PATH = pathlib.Path(ansible.__file__).parent
 
 display = Display()
 
@@ -229,12 +225,6 @@ class _ComputedReqKindsMixin:
             dir_path = dir_path.rstrip(to_bytes(os.path.sep))
         if not _is_collection_dir(dir_path):
             dir_pathlib = pathlib.Path(to_text(dir_path))
-
-            # special handling for bundled collections without manifests, e.g., ansible._protomatter
-            if dir_pathlib.is_relative_to(_ANSIBLE_PACKAGE_PATH):
-                req_name = f'{dir_pathlib.parent.name}.{dir_pathlib.name}'
-                return cls(req_name, ansible.release.__version__, dir_path, 'dir', None)
-
             display.warning(
                 u"Collection at '{path!s}' does not have a {manifest_json!s} "
                 u'file, nor has it {galaxy_yml!s}: cannot detect version.'.

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -1674,7 +1674,7 @@ def _configure_collection_loader(prefix_collections_path=None):
 
     # insert the internal ansible._protomatter collection up front
     paths = [os.path.dirname(_internal.__file__)] + list(prefix_collections_path) + C.COLLECTIONS_PATHS
-    finder = _AnsibleCollectionFinder(paths, C.COLLECTIONS_SCAN_SYS_PATH)
+    finder = _AnsibleCollectionFinder(paths, C.COLLECTIONS_SCAN_SYS_PATH, internal_collections=paths[0])
     finder._install()
 
     # this should succeed now

--- a/lib/ansible/utils/collection_loader/_collection_config.py
+++ b/lib/ansible/utils/collection_loader/_collection_config.py
@@ -63,6 +63,11 @@ class _AnsibleCollectionConfig(type):
         return [_to_text(p) for p in cls._collection_finder._n_collection_paths]
 
     @property
+    def _internal_collections(cls):
+        cls._require_finder()
+        return cls._collection_finder._internal_collections
+
+    @property
     def default_collection(cls):
         return cls._default_collection
 

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -186,7 +186,7 @@ class _AnsibleTraversableResources(TraversableResources):
 
 
 class _AnsibleCollectionFinder:
-    def __init__(self, paths=None, scan_sys_paths=True):
+    def __init__(self, paths=None, scan_sys_paths=True, internal_collections=None):
         # TODO: accept metadata loader override
         self._ansible_pkg_path = _to_text(os.path.dirname(_to_bytes(sys.modules['ansible'].__file__)))
 
@@ -213,6 +213,7 @@ class _AnsibleCollectionFinder:
             if p not in good_paths and os.path.isdir(_to_bytes(os.path.join(p, 'ansible_collections'))):
                 good_paths.append(p)
 
+        self._internal_collections = internal_collections
         self._n_configured_paths = good_paths
         self._n_cached_collection_paths = None
         self._n_cached_collection_qualified_paths = None

--- a/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
@@ -67,6 +67,7 @@
       - 'list_result.stdout is regex "dev.collection4\s+\*"'
       - 'list_result.stdout is regex "dev.collection5\s+\*"'
       - 'list_result.stdout is regex "dev.collection6\s+\*"'
+      - 'list_result.stdout is not regex "ansible._protomatter\s+.*"'
 
 - name: list collections in human format
   command: ansible-galaxy collection list --format human
@@ -158,6 +159,7 @@
 - assert:
     that:
       - "'{}' not in list_result_error.stdout"
+      - "'None of the provided paths were usable' in list_result_error.stderr"
 
 - name: install an artifact to the second collections path
   command: ansible-galaxy collection install namespace1.name1 -s galaxy_ng {{ galaxy_verbosity }} -p "{{ galaxy_dir }}/prod"


### PR DESCRIPTION
##### SUMMARY

This could be cherry picked onto #85595, or merged after.

Backport for #85596

* remove internal collections earlier to ignore consistently for different sub-commands

* remove internal collection handling from the dependency resolver

* add a test to ensure ansible._protomatter is not in the output of ansible-galaxy collection list

* fix existing test to ensure an error is given if no valid collection path is configured

* changelog

(cherry picked from commit 945516c209268a91cc1f7169bf7d20517e398561)

##### ISSUE TYPE

- Bugfix Pull Request
