### PR TITLE
[stable-2.19] fix nested import_tasks when the parent import contains a template

### DIFF
--- a/changelogs/fragments/85599-fix-templating-import_tasks-parent-include.yml
+++ b/changelogs/fragments/85599-fix-templating-import_tasks-parent-include.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - import_tasks - fix templating parent include arguments.

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -169,6 +169,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         if not isinstance(parent_include, TaskInclude):
                             parent_include = parent_include._parent
                             continue
+                        parent_include.post_validate(templar=templar)
                         parent_include_dir = os.path.dirname(parent_include.args.get('_raw_params'))
                         if cumulative_path is None:
                             cumulative_path = parent_include_dir

--- a/test/integration/targets/include_import_tasks_nested/tasks/main.yml
+++ b/test/integration/targets/include_import_tasks_nested/tasks/main.yml
@@ -9,3 +9,5 @@
 - assert:
     that:
       - nested_adjacent_count|int == 2
+
+- import_tasks: "{{ role_path }}/tests/main.yml"

--- a/test/integration/targets/include_import_tasks_nested/tests/main.yml
+++ b/test/integration/targets/include_import_tasks_nested/tests/main.yml
@@ -1,0 +1,1 @@
+- import_tasks: tests_relative.yml


### PR DESCRIPTION
##### SUMMARY

Backport for #85599

* Test nested import_tasks when the parent import contains a template

* Fix templating the parent_include.args

(cherry picked from commit 9a6420e1d55d0947aa96c0521542cbc336ed9356)

##### ISSUE TYPE

- Bugfix Pull Request
