### PR TITLE
Add temporary module result serialization hook

### DIFF
--- a/changelogs/fragments/module_direct_exec.yml
+++ b/changelogs/fragments/module_direct_exec.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - AnsibleModule - Add temporary internal monkeypatch-able hook to alter module result serialization by splitting serialization from ``_return_formatted`` into ``_record_module_result``.
+  

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1515,8 +1515,16 @@ class AnsibleModule(object):
         # return preserved
         kwargs.update(preserved)
 
+        self._record_module_result(kwargs)
+
+    def _record_module_result(self, o: dict[str, t.Any]) -> None:
+        """
+        Temporary internal hook to enable modification/bypass of module result serialization.
+
+        Monkeypatched by ansible.netcommon for direct in-worker module execution.
+        """
         encoder = _json.get_module_encoder(_ANSIBLE_PROFILE, _json.Direction.MODULE_TO_CONTROLLER)
-        print('\n%s' % json.dumps(kwargs, cls=encoder))
+        print('\n%s' % json.dumps(o, cls=encoder))
 
     def exit_json(self, **kwargs) -> t.NoReturn:
         """ return from the module, without error """


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/ansible/pull/85609 A CC of this PR

Temporary hook to allow ansible.netcommon to entirely monkeypatch away module result serialization until direct module execution in core workers is supported.


