### PR TITLE
[stable-2.19] Task.resolved_action - fix resolving static actions for callbacks

### DIFF
--- a/changelogs/fragments/85524-resolve-task-resolved_action-early.yml
+++ b/changelogs/fragments/85524-resolve-task-resolved_action-early.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - callback plugins - improve consistency accessing the Task object's resolved_action attribute.

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -130,6 +130,7 @@ class ModuleArgsParser:
         # HACK: why are these not FieldAttributes on task with a post-validate to check usage?
         self._task_attrs.update(['local_action', 'static'])
         self._task_attrs = frozenset(self._task_attrs)
+        self._resolved_action = None
 
     def _split_module_string(self, module_string: str) -> tuple[str, str]:
         """
@@ -344,6 +345,8 @@ class ModuleArgsParser:
                     raise e
 
                 is_action_candidate = context.resolved and bool(context.redirect_list)
+                if is_action_candidate:
+                    self._resolved_action = context.resolved_fqcn
 
             if is_action_candidate:
                 # finding more than one module name is a problem

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -303,7 +303,7 @@ class Play(Base, Taggable, CollectionSearch):
 
         t = Task(block=flush_block)
         t.action = 'meta'
-        t.resolved_action = 'ansible.builtin.meta'
+        t._resolved_action = 'ansible.builtin.meta'
         t.args['_raw_params'] = 'flush_handlers'
         t.implicit = True
         t.set_loader(self._loader)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -900,7 +900,7 @@ class StrategyBase:
         display.warning("%s task does not support when conditional" % task_name)
 
     def _execute_meta(self, task: Task, play_context, iterator, target_host: Host):
-        task.resolved_action = 'ansible.builtin.meta'  # _post_validate_args is never called for meta actions, so resolved_action hasn't been set
+        task._resolved_action = 'ansible.builtin.meta'  # _post_validate_args is never called for meta actions, so resolved_action hasn't been set
 
         # meta tasks store their args in the _raw_params field of args,
         # since they do not use k=v pairs, so get that

--- a/test/integration/targets/collections/test_task_resolved_plugin/dynamic_action.yml
+++ b/test/integration/targets/collections/test_task_resolved_plugin/dynamic_action.yml
@@ -1,0 +1,10 @@
+---
+- hosts: all
+  gather_facts: no
+  tasks:
+    - name: Run dynamic action
+      action: "{{ inventory_hostname }}"
+
+    - name: Run dynamic action in loop
+      action: "{{ inventory_hostname }}"
+      loop: [1]

--- a/test/integration/targets/collections/test_task_resolved_plugin/unqualified.yml
+++ b/test/integration/targets/collections/test_task_resolved_plugin/unqualified.yml
@@ -4,5 +4,5 @@
   tasks:
     - legacy_action:
     - legacy_module:
-    - debug:
-    - ping:
+    - local_action: debug
+    - action: ping


### PR DESCRIPTION
##### SUMMARY

Backport for #85524

* Resolve static actions when the FQCN is already known or demanded by a callback plugin

shorthand syntax (e.g. "- ping:") is resolved by ModuleArgsParser

action/local_action syntax (e.g. "- action: ping") is resolved on demand

* Emit a warning if a callback plugin accesses the property when it's None. This is expected if action/local_action is a template and a callback plugin uses this value too early (like in v2_playbook_on_task_start) or late (like in v2_runner_on_ok for a task with a loop).

(cherry picked from commit 15e9f51e2d00b069f50a028948b1d35945fc9b39)

##### ISSUE TYPE

- Bugfix Pull Request
