### PR TITLE
[stable-2.19] service_facts: Handle KeyError while processing service name

### DIFF
--- a/changelogs/fragments/openrc.yml
+++ b/changelogs/fragments/openrc.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+   - service_facts - warn user about missing service details instead of ignoring.
+   - service_facts - handle keyerror exceptions with warning.

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -232,7 +232,11 @@ class ServiceScanService(BaseService):
             if service_name == "*":
                 continue
             service_state = line_data[1]
-            service_runlevels = all_services_runlevels[service_name]
+            try:
+                service_runlevels = all_services_runlevels[service_name]
+            except KeyError:
+                self.module.warn(f"Service {service_name} not found in the service list")
+                continue
             service_data = {"name": service_name, "runlevels": service_runlevels, "state": service_state, "source": "openrc"}
             services[service_name] = service_data
 


### PR DESCRIPTION

As a part of follow up review,

* Handle KeyError with exception handling
* Warn user about the missing service name in the given service details (cherry picked from commit 9ed7164)

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
