### PR TITLE
Warn when using seuser on alpine or buildroot

### DIFF
--- a/changelogs/fragments/85542-warning-when-using-seuser-on-alpine.yml
+++ b/changelogs/fragments/85542-warning-when-using-seuser-on-alpine.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - The seuser parameter will be ignored on Alpine and print warning

--- a/changelogs/fragments/85542-warning-when-using-seuser-on-alpine.yml
+++ b/changelogs/fragments/85542-warning-when-using-seuser-on-alpine.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - user - The seuser parameter will be ignored on Alpine and print warning
+  - user - The seuser parameter will be ignored on Alpine and print a warning (https://github.com/ansible/ansible/issues/85542).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1346,6 +1346,12 @@ class User(object):
             return None
         return ssh_public_key
 
+    def check_seuser_support(self):
+        # Now only Generic platform supports the seuser parameter
+        if self.platform != 'Generic':
+            self.module.warn(f"The 'seuser' parameter is not supported on {self.distribution or self.platform} "
+                             "as it lacks SELinux support and has been ignored.")
+
     def create_user(self):
         # by default we use the create_user_useradd method
         return self.create_user_useradd()
@@ -3165,9 +3171,6 @@ class BusyBox(User):
             cmd.append('-K')
             cmd.append('UID_MAX=' + str(self.uid_max))
 
-        if self.seuser is not None:
-            self.module.warn(f"The 'seuser' parameter is not supported on {self.distribution} as it lacks SELinux support and has been ignored.")
-
         cmd.append(self.name)
 
         rc, out, err = self.execute_command(cmd)
@@ -3358,6 +3361,9 @@ def main():
                 parent = os.path.dirname(user.home)
                 if not os.path.isdir(parent):
                     path_needs_parents = True
+
+            if user.seuser:
+                user.check_seuser_support()
 
             (rc, out, err) = user.create_user()
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -44,6 +44,7 @@ options:
     seuser:
         description:
             - Optionally sets the C(seuser) type C(user_u) on SELinux enabled systems.
+            - This parameter will be ignored on Alpine and Buildroot.
         type: str
         version_added: "2.1"
     group:
@@ -3163,6 +3164,9 @@ class BusyBox(User):
         if self.uid_max is not None:
             cmd.append('-K')
             cmd.append('UID_MAX=' + str(self.uid_max))
+
+        if self.seuser is not None:
+            self.module.warn(f"The 'seuser' parameter is not supported on {self.distribution} as it lacks SELinux support and has been ignored.")
 
         cmd.append(self.name)
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -44,7 +44,7 @@ options:
     seuser:
         description:
             - Optionally sets the C(seuser) type C(user_u) on SELinux enabled systems.
-            - This parameter will be ignored on Alpine and Buildroot.
+            - This parameter will be ignored on macOS, *BSD, BusyBox-based distros and Buildroot.
         type: str
         version_added: "2.1"
     group:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -36,4 +36,4 @@
 - import_tasks: ssh_keygen.yml
 - import_tasks: test_seuser.yml
   when:
-    - ansible_distribution == 'Alpine'
+    - ansible_facts.system in ['FreeBSD', 'OpenBSD', 'Darwin'] or ansible_distribution == 'Alpine'

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -34,3 +34,6 @@
     - ansible_facts.system == 'Linux'
     - ansible_distribution != 'Alpine'
 - import_tasks: ssh_keygen.yml
+- import_tasks: test_seuser.yml
+  when:
+    - ansible_distribution == 'Alpine'

--- a/test/integration/targets/user/tasks/test_seuser.yml
+++ b/test/integration/targets/user/tasks/test_seuser.yml
@@ -1,0 +1,10 @@
+- name: Try creating user with nonexistent SELinux user
+  user:
+    name: badseuser
+    seuser: nonexistent_u
+    state: present
+  register: test_seuser
+
+- name: there should be warnings
+  assert:
+    that: "'warnings' in test_seuser"

--- a/test/integration/targets/user/tasks/test_seuser.yml
+++ b/test/integration/targets/user/tasks/test_seuser.yml
@@ -7,4 +7,10 @@
 
 - name: there should be warnings
   assert:
-    that: "'warnings' in test_seuser"
+    that: test_seuser.warnings[0] is contains "lacks SELinux support"
+
+- name: Cleanup test account
+  user:
+    name: badseuser
+    state: absent
+    remove: yes


### PR DESCRIPTION
##### SUMMARY

In module `user`, when the distribution is alpine or buildroot, ignore the `seuser` parameter and print a warning message.

Not entirely sure what the expected behavior here should be, we follow Ansible's current behavior by ignoring this parameter.

fixes #85542 

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
