### PR TITLE
lookup: check type of filename variable before processing

### DIFF
--- a/changelogs/fragments/lookup_file.yml
+++ b/changelogs/fragments/lookup_file.yml
@@ -1,4 +1,3 @@
 ---
 minor_changes:
     - lookup - check the type of filename variable before processing in file lookup.
-

--- a/changelogs/fragments/lookup_file.yml
+++ b/changelogs/fragments/lookup_file.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+    - lookup - check the type of filename variable before processing in file lookup.
+

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -51,7 +51,8 @@ RETURN = """
     elements: str
 """
 
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleError, AnsibleTypeError
+from ansible.module_utils.datatag import native_type_name
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display
 
@@ -67,6 +68,9 @@ class LookupModule(LookupBase):
 
         for term in terms:
             display.debug("File lookup term: %s" % term)
+            if not isinstance(term, str):
+                raise AnsibleTypeError(f'File name must be {native_type_name(str)!r} not {native_type_name(term)!r}.', obj=term)
+
             # Find the file in the expected search path
             try:
                 lookupfile = self.find_file_in_search_path(variables, 'files', term, ignore_missing=True)

--- a/test/integration/targets/lookup_file/tasks/main.yml
+++ b/test/integration/targets/lookup_file/tasks/main.yml
@@ -11,3 +11,15 @@
   assert:
     that:
         - "foo == 'bar'"
+
+- name: load the file name as a list
+  set_fact:
+    foo: "{{ lookup('file', ['hello.txt']) }}"
+  ignore_errors: yes
+  register: file_list
+
+- name: assert that file raises an error
+  assert:
+    that:
+        - file_list.failed
+        - "'File name must be' in file_list.msg"


### PR DESCRIPTION
##### SUMMARY

* Check datatype of filename variable before processing
  in file lookup plugin.

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/lookup_file.yml
lib/ansible/plugins/lookup/file.py
test/integration/targets/lookup_file/tasks/main.yml


