### PR TITLE
[PoC] Implement fast paths in galaxy dep resolution

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -36,6 +36,7 @@ from ansible.galaxy.collection import (
     find_existing_collections,
     install_collections,
     publish_collection,
+    resolve_collection_dependencies,
     validate_collection_name,
     validate_collection_path,
     verify_collections,
@@ -293,6 +294,7 @@ class GalaxyCLI(CLI):
         self.add_build_options(collection_parser, parents=[common, force])
         self.add_publish_options(collection_parser, parents=[common])
         self.add_install_options(collection_parser, parents=[common, force, cache_options])
+        self.add_graph_options(collection_parser, parents=[common, cache_options])
         self.add_list_options(collection_parser, parents=[common, collections_path])
         self.add_verify_options(collection_parser, parents=[common, collections_path])
 
@@ -587,6 +589,21 @@ class GalaxyCLI(CLI):
             install_parser.add_argument('-g', '--keep-scm-meta', dest='keep_scm_meta', action='store_true',
                                         default=False,
                                         help='Use tar instead of the scm archive option when packaging the role.')
+
+    def add_graph_options(self, parser, parents=None):
+        graph_parser = parser.add_parser('graph', parents=parents,
+                                         help='Display a dependency graph of collections.')
+        graph_parser.set_defaults(func=self.execute_graph)
+
+        graph_parser.add_argument('args', metavar='collection_name', nargs='*',
+                                  help='The collection(s) name or path/url to a tar.gz collection artifact. This is '
+                                       'mutually exclusive with --requirements-file.')
+        graph_parser.add_argument('-r', '--requirements-file', dest='requirements',
+                                  help='A file containing a list of collections to be resolved.')
+        graph_parser.add_argument('--pre', dest='allow_pre_release', action='store_true',
+                                  help='Include pre-release versions. Semantic versioning pre-releases are ignored by default')
+        graph_parser.add_argument('--format', dest='output_format', choices=['text', 'dot'], default='text',
+                                  help='Output format for the dependency graph (text or dot).')
 
     def add_build_options(self, parser, parents=None):
         build_parser = parser.add_parser('build', parents=parents,
@@ -1885,6 +1902,101 @@ class GalaxyCLI(CLI):
         display.display(resp['status'])
 
         return 0
+
+    @with_collection_artifacts_manager
+    def execute_graph(self, artifacts_manager=None):
+        """
+        Display a dependency graph of collections.
+        """
+        requirements = self._require_one_of_collections_requirements(
+            context.CLIARGS['args'],
+            context.CLIARGS['requirements'],
+            artifacts_manager=artifacts_manager,
+        )
+
+        collection_requirements = requirements['collections']
+        if not collection_requirements:
+            display.display("No collection requirements found")
+            return
+
+        allow_pre_release = context.CLIARGS.get('allow_pre_release', False)
+        output_format = context.CLIARGS.get('output_format', 'text')
+
+        try:
+            result = resolve_collection_dependencies(
+                collection_requirements,
+                self.api_servers,
+                allow_pre_release=allow_pre_release,
+                concrete_artifacts_manager=artifacts_manager,
+                offline=context.CLIARGS.get('offline', False),
+            )
+
+            self._display_dependency_graph(result, output_format)
+        except Exception as e:
+            display.error(f"Failed to resolve collection dependencies: {e}")
+            return 1
+
+        return 0
+
+    def _display_dependency_graph(self, result, output_format):
+        """Display the dependency graph in the specified format."""
+        if output_format == 'dot':
+            self._display_dot_graph(result)
+        else:
+            self._display_text_graph(result)
+
+    def _display_text_graph(self, result):
+        """Display the dependency graph in text format."""
+        all_collections = set(result.mapping.keys())
+        dependencies = set()
+        for collection in all_collections:
+            dependencies.update(result.graph.iter_children(collection))
+
+        root_collections = all_collections - dependencies
+
+        for collection in sorted(root_collections):
+            candidate = result.mapping[collection]
+            display.display(f"{candidate.fqcn}:{candidate.ver}")
+            self._display_dependency_tree(result, collection, "    ", set())
+            display.display("")
+
+    def _display_dependency_tree(self, result, collection, prefix, visited):
+        """Recursively display the dependency tree for a collection."""
+        if collection in visited:
+            return
+
+        visited.add(collection)
+        dependencies = sorted(result.graph.iter_children(collection))
+
+        for i, dep in enumerate(dependencies):
+            dep_candidate = result.mapping[dep]
+            is_last = i == len(dependencies) - 1
+
+            tree_char = "└── " if is_last else "├── "
+            display.display(f"{prefix}{tree_char}{dep_candidate.fqcn}:{dep_candidate.ver}")
+
+            next_prefix = prefix + ("    " if is_last else "│   ")
+            self._display_dependency_tree(result, dep, next_prefix, visited.copy())
+
+    def _display_dot_graph(self, result):
+        """Display the dependency graph in DOT format for Graphviz."""
+        display.display("digraph dependencies {")
+        display.display('  rankdir=TB;')
+        display.display('  node [shape=box];')
+        display.display("")
+
+        for collection, candidate in result.mapping.items():
+            display.display(f'  "{candidate.fqcn}" [label="{candidate.fqcn}\\n{candidate.ver}"];')
+
+        display.display("")
+
+        for collection, candidate in result.mapping.items():
+            dependencies = list(result.graph.iter_children(collection))
+            for dep in dependencies:
+                dep_candidate = result.mapping[dep]
+                display.display(f'  "{candidate.fqcn}" -> "{dep_candidate.fqcn}";')
+
+        display.display("}")
 
 
 def main(args=None):

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -240,7 +240,7 @@ class GalaxyError(AnsibleError):
 
 # Keep the raw string results for the date. It's too complex to parse as a datetime object and the various APIs return
 # them in different formats.
-CollectionMetadata = collections.namedtuple('CollectionMetadata', ['namespace', 'name', 'created_str', 'modified_str'])
+CollectionMetadata = collections.namedtuple('CollectionMetadata', ['namespace', 'name', 'created_str', 'modified_str', 'highest_version'])
 
 
 class CollectionVersionMetadata:
@@ -769,6 +769,7 @@ class GalaxyAPI:
                 ('created_str', 'created'),
                 ('modified_str', 'modified'),
             ]
+        field_map.append(('highest_version', 'highest_version'))
 
         info_url = _urljoin(self.api_server, api_path, 'collections', namespace, name, '/')
         error_context_msg = 'Error when getting the collection info for %s.%s from %s (%s)' \
@@ -782,6 +783,7 @@ class GalaxyAPI:
         return CollectionMetadata(namespace, name, **metadata)
 
     @g_connect(['v2', 'v3'])
+    @functools.lru_cache(maxsize=128)
     def get_collection_version_metadata(self, namespace, name, version):
         """
         Gets the collection information from the Galaxy server about a specific Collection version.
@@ -911,16 +913,9 @@ class GalaxyAPI:
         :param version: Version of the collection to get the information for.
         :return: A list of signature strings.
         """
-        api_path = self.available_api_versions.get('v3', self.available_api_versions.get('v2'))
-        url_paths = [self.api_server, api_path, 'collections', namespace, name, 'versions', version, '/']
+        version_metadata = self.get_collection_version_metadata(namespace, name, version)
 
-        n_collection_url = _urljoin(*url_paths)
-        error_context_msg = 'Error when getting collection version metadata for %s.%s:%s from %s (%s)' \
-                            % (namespace, name, version, self.name, self.api_server)
-        data = self._call_galaxy(n_collection_url, error_context_msg=error_context_msg, cache=True)
-        self._set_cache()
-
-        signatures = [signature_info["signature"] for signature_info in data.get("signatures") or []]
+        signatures = [signature_info["signature"] for signature_info in version_metadata.signatures or []]
         if not signatures:
             display.vvvv(f"Server {self.api_server} has not signed {namespace}.{name}:{version}")
         return signatures

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -32,6 +32,7 @@ from io import BytesIO
 from importlib.metadata import distribution
 from importlib.resources import files
 from itertools import chain
+from types import SimpleNamespace
 
 try:
     from packaging.requirements import Requirement as PkgReq
@@ -793,7 +794,7 @@ def install_collections(
         )
 
     keyring_exists = artifacts_manager.keyring is not None
-    with _display_progress("Starting collection install process"):
+    with _display_progress("Starting collection install process") as progress:
         for fqcn in _topological_sort_collections(result):
             concrete_coll_pin = result.mapping[fqcn]
             if concrete_coll_pin.is_virtual:
@@ -824,6 +825,7 @@ def install_collections(
             if concrete_coll_pin.type == 'galaxy':
                 concrete_coll_pin = concrete_coll_pin.with_signatures_repopulated()
 
+            progress.pause()
             try:
                 install(concrete_coll_pin, output_path, artifacts_manager)
             except AnsibleError as err:
@@ -1019,35 +1021,55 @@ def _display_progress(msg=None):
     display_wheel = sys.stdout.isatty() if config_display is None else config_display
 
     global display
-    if msg is not None:
-        display.display(msg)
 
-    if not display_wheel:
-        yield
+    if not display_wheel or display.verbosity:
+        if msg:
+            display.display(msg)
+        yield SimpleNamespace(pause=lambda: None, unpause=lambda: None)
         return
 
-    def progress(display_queue, actual_display):
-        actual_display.debug("Starting display_progress display thread")
-        t = threading.current_thread()
+    class Progress(threading.Thread):
+        def __init__(self, display_queue, actual_display):
+            self.display_queue = display_queue
+            self.actual_display = actual_display
+            self._paused = False
+            super().__init__()
 
-        while True:
-            for c in "|/-\\":
-                actual_display.display(c + "\b", newline=False)
-                time.sleep(0.1)
+        def pause(self):
+            if self._paused:
+                return
+            self.actual_display.display('', stderr=True)
+            self._paused = True
 
-                # Display a message from the main thread
-                while True:
-                    try:
-                        method, args, kwargs = display_queue.get(block=False, timeout=0.1)
-                    except queue.Empty:
-                        break
-                    else:
-                        func = getattr(actual_display, method)
-                        func(*args, **kwargs)
+        def unpause(self):
+            self._paused = False
 
-                if getattr(t, "finish", False):
-                    actual_display.debug("Received end signal for display_progress display thread")
-                    return
+        def run(self):
+            actual_display = self.actual_display
+            display_queue = self.display_queue
+
+            actual_display.debug("Starting display_progress display thread")
+            t = threading.current_thread()
+
+            while True:
+                for c in ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']:
+                    if not self._paused:
+                        actual_display.display(f'\r{c} {msg or ""}', newline=False, stderr=True)
+                        time.sleep(0.1)
+
+                    # Display a message from the main thread
+                    while True:
+                        try:
+                            method, args, kwargs = display_queue.get(block=False, timeout=0.1)
+                        except queue.Empty:
+                            break
+                        else:
+                            func = getattr(actual_display, method)
+                            func(*args, **kwargs)
+
+                    if getattr(t, "finish", False):
+                        actual_display.debug("Received end signal for display_progress display thread")
+                        return
 
     class DisplayThread(object):
 
@@ -1065,12 +1087,12 @@ def _display_progress(msg=None):
     try:
         display_queue = queue.Queue()
         display = DisplayThread(display_queue)
-        t = threading.Thread(target=progress, args=(display_queue, old_display))
+        t = Progress(display_queue, old_display)
         t.daemon = True
         t.start()
 
         try:
-            yield
+            yield t
         finally:
             t.finish = True
             t.join()
@@ -1079,6 +1101,7 @@ def _display_progress(msg=None):
         raise
     finally:
         display = old_display
+    display.display('', stderr=True)
 
 
 def _verify_file_hash(b_path, filename, expected_hash, error_queue):

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -24,7 +24,7 @@ import threading
 import time
 import typing as t
 
-from collections import namedtuple
+from collections import namedtuple, deque
 from contextlib import contextmanager
 from dataclasses import dataclass
 from hashlib import sha256
@@ -55,6 +55,7 @@ if t.TYPE_CHECKING:
     from ansible.galaxy.collection.concrete_artifact_manager import (
         ConcreteArtifactsManager,
     )
+    from resolvelib.resolvers import Result
 
     ManifestKeysType = t.Literal[
         'collection_info', 'file_manifest_file', 'format',
@@ -540,7 +541,7 @@ def download_collections(
             # Avoid overhead getting signatures since they are not currently applicable to downloaded collections
             include_signatures=False,
             offline=False,
-        )
+        ).mapping
 
     b_output_path = to_bytes(output_path, errors='surrogate_or_strict')
 
@@ -636,6 +637,37 @@ def publish_collection(collection_path, api, wait, timeout):
                         % (api.name, api.api_server, import_uri))
 
 
+def _topological_sort_collections(result):
+    # type: (Result) -> t.Iterator[str]
+    """
+    Yield collections in topological order using Kahn's algorithm.
+    Dependencies will be yielded before their dependents.
+    """
+    in_degree = {}
+
+    for collection in result.mapping:
+        dependencies = list(result.graph.iter_children(collection))
+        in_degree[collection] = len([dep for dep in dependencies if dep in result.mapping])
+
+    queue = deque((collection for collection, degree in in_degree.items() if degree == 0))
+    processed = set()
+
+    while queue:
+        current = queue.popleft()
+        processed.add(current)
+        yield current
+
+        for dependent in result.graph.iter_parents(current):
+            if dependent in in_degree:
+                in_degree[dependent] -= 1
+                if in_degree[dependent] == 0:
+                    queue.append(dependent)
+
+    missing = set(result.mapping.keys()) - processed
+    if missing:
+        yield from missing
+
+
 def install_collections(
         collections,  # type: t.Iterable[Requirement]
         output_path,  # type: str
@@ -719,7 +751,7 @@ def install_collections(
         for coll in preferred_requirements
     }
     with _display_progress("Process install dependency map"):
-        dependency_map = _resolve_depenency_map(
+        result = _resolve_depenency_map(
             collections,
             galaxy_apis=apis,
             preferred_candidates=preferred_collections,
@@ -733,7 +765,8 @@ def install_collections(
 
     keyring_exists = artifacts_manager.keyring is not None
     with _display_progress("Starting collection install process"):
-        for fqcn, concrete_coll_pin in dependency_map.items():
+        for fqcn in _topological_sort_collections(result):
+            concrete_coll_pin = result.mapping[fqcn]
             if concrete_coll_pin.is_virtual:
                 display.vvvv(
                     "Encountered {coll!s}, skipping.".
@@ -885,7 +918,7 @@ def verify_collections(
                 if local_verify_only:
                     remote_collection = None
                 else:
-                    signatures = api_proxy.get_signatures(local_collection)
+                    signatures = api_proxy.get_signatures(local_collection).data
                     signatures.extend([
                         get_signature_from_source(source, display)
                         for source in collection.signature_sources or []
@@ -1796,8 +1829,8 @@ def _resolve_depenency_map(
         upgrade,  # type: bool
         include_signatures,  # type: bool
         offline,  # type: bool
-):  # type: (...) -> dict[str, Candidate]
-    """Return the resolved dependency map."""
+):  # type: (...) -> Result
+    """Return the resolved dependency result."""
     if not HAS_RESOLVELIB:
         raise AnsibleError("Failed to import resolvelib, check that a supported version is installed")
     if not HAS_PACKAGING:
@@ -1842,7 +1875,7 @@ def _resolve_depenency_map(
         return collection_dep_resolver.resolve(
             requested_requirements,
             max_rounds=2000000,  # NOTE: same constant pip uses
-        ).mapping
+        )
     except CollectionDependencyResolutionImpossible as dep_exc:
         conflict_causes = (
             '* {req.fqcn!s}:{req.ver!s} ({dep_origin!s})'.format(

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -668,6 +668,35 @@ def _topological_sort_collections(result):
         yield from missing
 
 
+def resolve_collection_dependencies(
+        requirements: t.Iterable[Requirement],
+        galaxy_apis: t.Iterable[GalaxyAPI],
+        allow_pre_release: bool = False,
+        concrete_artifacts_manager: ConcreteArtifactsManager | None = None,
+        offline: bool = False,
+) -> Result:
+    """
+    Resolve collection dependencies and return the result object.
+    Used by the graph command to get dependency information without installation.
+    """
+    with _display_progress("Process dependency resolution"):
+        collection_dep_resolver = build_collection_dependency_resolver(
+            galaxy_apis=galaxy_apis,
+            concrete_artifacts_manager=concrete_artifacts_manager,
+            preferred_candidates=None,
+            with_deps=True,
+            with_pre_releases=allow_pre_release,
+            upgrade=False,
+            include_signatures=False,
+            offline=offline,
+        )
+
+        return collection_dep_resolver.resolve(
+            requirements,
+            max_rounds=2000000,
+        )
+
+
 def install_collections(
         collections,  # type: t.Iterable[Requirement]
         output_path,  # type: str

--- a/lib/ansible/galaxy/collection/galaxy_api_proxy.py
+++ b/lib/ansible/galaxy/collection/galaxy_api_proxy.py
@@ -5,7 +5,9 @@
 
 from __future__ import annotations
 
+import functools
 import typing as t
+from dataclasses import dataclass
 
 if t.TYPE_CHECKING:
     from ansible.galaxy.api import CollectionVersionMetadata
@@ -16,12 +18,20 @@ if t.TYPE_CHECKING:
         Candidate, Requirement,
     )
 
+from ansible.errors import AnsibleError
 from ansible.galaxy.api import GalaxyAPI, GalaxyError
 from ansible.module_utils.common.text.converters import to_text
 from ansible.utils.display import Display
 
 
 display = Display()
+
+
+@dataclass(slots=True, frozen=True)
+class ProxyResponse[T]:
+    """Wrapper for proxy responses that includes both data and the API that succeeded."""
+    data: T
+    api: GalaxyAPI | None
 
 
 class MultiGalaxyAPIProxy:
@@ -41,6 +51,49 @@ class MultiGalaxyAPIProxy:
         if self.is_offline_mode_requested:
             raise NotImplementedError("The calling code is not supposed to be invoked in 'offline' mode.")
 
+    def _get_api_lookup_order(self, src: t.Union[GalaxyAPI, t.Any]) -> tuple[GalaxyAPI, ...]:
+        """Get the API lookup order for a given source."""
+        return (
+            (src, )
+            if isinstance(src, GalaxyAPI)
+            else tuple(self._apis)
+        )
+
+    def _try_apis[T](
+        self,
+        src: t.Union[GalaxyAPI, t.Any],
+        collection_identifier: str,
+        api_callback: t.Callable[[GalaxyAPI], T],
+        operation_description: str = "operation"
+    ) -> ProxyResponse[T]:
+        """Try multiple APIs and return the first successful result."""
+        last_err: t.Optional[Exception] = None
+
+        for api in self._get_api_lookup_order(src):
+            try:
+                result = api_callback(api)
+                return ProxyResponse(result, api)
+            except GalaxyError as api_err:
+                last_err = api_err
+            except Exception as unknown_err:
+                last_err = unknown_err
+                display.warning(
+                    "Skipping Galaxy server {server!s}. "
+                    "Got an unexpected error when {operation} "
+                    "for collection {collection}: {err!s}".
+                    format(
+                        server=api.api_server,
+                        operation=operation_description,
+                        collection=collection_identifier,
+                        err=to_text(unknown_err),
+                    )
+                )
+
+        if last_err is not None:
+            raise last_err
+        else:
+            raise AnsibleError(f"No APIs available for {operation_description} on {collection_identifier}")
+
     def _get_collection_versions(self, requirement: Requirement) -> t.Iterator[tuple[GalaxyAPI, str]]:
         """Helper for get_collection_versions.
 
@@ -53,13 +106,7 @@ class MultiGalaxyAPIProxy:
         found_api = False
         last_error: Exception | None = None
 
-        api_lookup_order = (
-            (requirement.src, )
-            if isinstance(requirement.src, GalaxyAPI)
-            else self._apis
-        )
-
-        for api in api_lookup_order:
+        for api in self._get_api_lookup_order(requirement.src):
             try:
                 versions = api.get_collection_versions(requirement.namespace, requirement.name)
             except GalaxyError as api_err:
@@ -84,126 +131,92 @@ class MultiGalaxyAPIProxy:
         if not found_api and last_error is not None:
             raise last_error
 
-    def get_collection_versions(self, requirement: Requirement) -> t.Iterable[tuple[str, GalaxyAPI]]:
+    @functools.lru_cache(maxsize=128)
+    def get_collection_versions(self, requirement: Requirement) -> t.Iterable[ProxyResponse[str]]:
         """Get a set of unique versions for FQCN on Galaxy servers."""
         if requirement.is_concrete_artifact:
+            version = self._concrete_art_mgr.get_direct_collection_version(requirement)
             return {
-                (
-                    self._concrete_art_mgr.
-                    get_direct_collection_version(requirement),
-                    requirement.src,
-                ),
+                ProxyResponse(version, requirement.src)
             }
 
-        api_lookup_order = (
-            (requirement.src, )
-            if isinstance(requirement.src, GalaxyAPI)
-            else self._apis
-        )
         return set(
-            (version, api)
+            ProxyResponse(version, api)
             for api, version in self._get_collection_versions(
                 requirement,
             )
         )
 
-    def get_collection_version_metadata(self, collection_candidate: Candidate) -> CollectionVersionMetadata:
+    @functools.lru_cache(maxsize=128)
+    def get_collection_metadata(self, requirement: Requirement) -> ProxyResponse[dict]:
+        """Retrieve general collection metadata."""
+        self._assert_that_offline_mode_is_not_requested()
+
+        return self._try_apis(
+            requirement.src,
+            requirement.fqcn,
+            lambda api: api.get_collection_metadata(requirement.namespace, requirement.name),
+            "getting collection metadata"
+        )
+
+    @functools.lru_cache(maxsize=128)
+    def get_collection_version_metadata(self, collection_candidate: Candidate) -> ProxyResponse[CollectionVersionMetadata]:
         """Retrieve collection metadata of a given candidate."""
         self._assert_that_offline_mode_is_not_requested()
 
-        api_lookup_order = (
-            (collection_candidate.src, )
-            if isinstance(collection_candidate.src, GalaxyAPI)
-            else self._apis
+        def get_and_save_metadata(api):
+            version_metadata = api.get_collection_version_metadata(
+                collection_candidate.namespace,
+                collection_candidate.name,
+                collection_candidate.ver,
+            )
+            self._concrete_art_mgr.save_collection_source(
+                collection_candidate,
+                version_metadata.download_url,
+                version_metadata.artifact_sha256,
+                api.token,
+                version_metadata.signatures_url,
+                version_metadata.signatures,
+            )
+            return version_metadata
+
+        return self._try_apis(
+            collection_candidate.src,
+            collection_candidate.fqcn,
+            get_and_save_metadata,
+            "getting collection version metadata"
         )
 
-        last_err: t.Optional[Exception]
-
-        for api in api_lookup_order:
-            try:
-                version_metadata = api.get_collection_version_metadata(
-                    collection_candidate.namespace,
-                    collection_candidate.name,
-                    collection_candidate.ver,
-                )
-            except GalaxyError as api_err:
-                last_err = api_err
-            except Exception as unknown_err:
-                # `verify` doesn't use `get_collection_versions` since the version is already known.
-                # Do the same as `install` and `download` by trying all APIs before failing.
-                # Warn for debugging purposes, since the Galaxy server may be unexpectedly down.
-                last_err = unknown_err
-                display.warning(
-                    "Skipping Galaxy server {server!s}. "
-                    "Got an unexpected error when getting "
-                    "available versions of collection {fqcn!s}: {err!s}".
-                    format(
-                        server=api.api_server,
-                        fqcn=collection_candidate.fqcn,
-                        err=to_text(unknown_err),
-                    )
-                )
-            else:
-                self._concrete_art_mgr.save_collection_source(
-                    collection_candidate,
-                    version_metadata.download_url,
-                    version_metadata.artifact_sha256,
-                    api.token,
-                    version_metadata.signatures_url,
-                    version_metadata.signatures,
-                )
-                return version_metadata
-
-        raise last_err
-
-    def get_collection_dependencies(self, collection_candidate: Candidate) -> dict[str, str]:
+    @functools.lru_cache(maxsize=128)
+    def get_collection_dependencies(self, collection_candidate: Candidate) -> ProxyResponse[dict[str, str]]:
         # FIXME: return Requirement instances instead?
         """Retrieve collection dependencies of a given candidate."""
         if collection_candidate.is_concrete_artifact:
-            return (
+            dependencies = (
                 self.
                 _concrete_art_mgr.
                 get_direct_collection_dependencies
             )(collection_candidate)
+            return ProxyResponse(dependencies, collection_candidate.src)
 
-        return (
-            self.
-            get_collection_version_metadata(collection_candidate).
-            dependencies
-        )
+        response = self.get_collection_version_metadata(collection_candidate)
+        return ProxyResponse(response.data.dependencies, response.api)
 
-    def get_signatures(self, collection_candidate: Candidate) -> list[str]:
+    @functools.lru_cache(maxsize=128)
+    def get_signatures(self, collection_candidate: Candidate) -> ProxyResponse[list[str]]:
         self._assert_that_offline_mode_is_not_requested()
-        namespace = collection_candidate.namespace
-        name = collection_candidate.name
-        version = collection_candidate.ver
-        last_err: Exception | None = None
 
-        api_lookup_order = (
-            (collection_candidate.src, )
-            if isinstance(collection_candidate.src, GalaxyAPI)
-            else self._apis
-        )
-
-        for api in api_lookup_order:
-            try:
-                return api.get_collection_signatures(namespace, name, version)
-            except GalaxyError as api_err:
-                last_err = api_err
-            except Exception as unknown_err:
-                # Warn for debugging purposes, since the Galaxy server may be unexpectedly down.
-                last_err = unknown_err
-                display.warning(
-                    "Skipping Galaxy server {server!s}. "
-                    "Got an unexpected error when getting "
-                    "available versions of collection {fqcn!s}: {err!s}".
-                    format(
-                        server=api.api_server,
-                        fqcn=collection_candidate.fqcn,
-                        err=to_text(unknown_err),
-                    )
-                )
-        if last_err:
-            raise last_err
-
-        return []
+        try:
+            response = self._try_apis(
+                collection_candidate.src,
+                collection_candidate.fqcn,
+                lambda api: api.get_collection_signatures(
+                    collection_candidate.namespace,
+                    collection_candidate.name,
+                    collection_candidate.ver
+                ),
+                "getting collection signatures"
+            )
+            return response
+        except Exception:
+            return ProxyResponse([], None)

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -166,7 +166,7 @@ def _is_concrete_artifact_pointer(tested_str):
 
 
 class _ComputedReqKindsMixin:
-    UNIQUE_ATTRS = ('fqcn', 'ver', 'src', 'type')
+    UNIQUE_ATTRS = ('fqcn', 'ver', 'type')
 
     def __init__(self, *args, **kwargs):
         if not self.may_have_offline_galaxy_info:
@@ -182,7 +182,11 @@ class _ComputedReqKindsMixin:
             )
 
     def __hash__(self):
-        return hash(tuple(getattr(self, attr) for attr in _ComputedReqKindsMixin.UNIQUE_ATTRS))
+        # Only include src for concrete artifacts to allow lru_cache to work for GalaxyAPI
+        # since src will be None before any API request has been made, but should be equivalent
+        # to later requests that have GalaxyAPI as src
+        attrs = _ComputedReqKindsMixin.UNIQUE_ATTRS + (('src',) if self.is_concrete_artifact else ())
+        return hash(tuple(getattr(self, attr) for attr in attrs))
 
     def __eq__(self, candidate):
         return hash(self) == hash(candidate)

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -13,8 +13,9 @@ if t.TYPE_CHECKING:
         ConcreteArtifactsManager,
     )
     from ansible.galaxy.collection.galaxy_api_proxy import MultiGalaxyAPIProxy
-    from ansible.galaxy.api import GalaxyAPI
 
+from ansible.galaxy.api import GalaxyAPI
+from ansible.galaxy.collection.galaxy_api_proxy import ProxyResponse
 from ansible.galaxy.collection.gpg import get_signature_from_source
 from ansible.galaxy.dependency_resolution.dataclasses import (
     Candidate,
@@ -24,6 +25,7 @@ from ansible.galaxy.dependency_resolution.versioning import (
     is_pre_release,
     meets_requirements,
 )
+from ansible.utils.display import Display
 from ansible.utils.version import SemanticVersion, LooseVersion
 
 try:
@@ -37,9 +39,11 @@ except ImportError:
 
 
 # TODO: add python requirements to ansible-test's ansible-core distribution info and remove the hardcoded lowerbound/upperbound fallback
-RESOLVELIB_LOWERBOUND = SemanticVersion("0.5.3")
+RESOLVELIB_LOWERBOUND = SemanticVersion("0.6.0")
 RESOLVELIB_UPPERBOUND = SemanticVersion("2.0.0")
 RESOLVELIB_VERSION = SemanticVersion.from_loose_version(LooseVersion(resolvelib_version))
+
+display = Display()
 
 
 class CollectionDependencyProviderBase(AbstractProvider):
@@ -89,6 +93,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
         self._with_pre_releases = with_pre_releases
         self._upgrade = upgrade
         self._include_signatures = include_signatures
+        self._fast_path_used = set()  # type: set[str]
 
     def identify(self, requirement_or_candidate):
         # type: (t.Union[Candidate, Requirement]) -> str
@@ -111,7 +116,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
         The lower the return value is, the more preferred this
         group of arguments is.
 
-        resolvelib >=0.5.3, <0.7.0
+        resolvelib >=0.6.0, <0.7.0
 
         :param resolution: Currently pinned candidate, or ``None``.
 
@@ -191,8 +196,8 @@ class CollectionDependencyProviderBase(AbstractProvider):
             return float('-inf')
         return len(candidates)
 
-    def find_matches(self, *args, **kwargs):
-        # type: (t.Any, t.Any) -> list[Candidate]
+    def find_matches(self, identifier, requirements, incompatibilities):
+        # type: (str, t.Mapping[str, t.Iterator[Requirement]], t.Mapping[str, t.Iterator[Requirement]]) -> list[Candidate]
         r"""Find all possible candidates satisfying given requirements.
 
         This tries to get candidates based on the requirements' types.
@@ -203,16 +208,6 @@ class CollectionDependencyProviderBase(AbstractProvider):
         For a "named" requirement, Galaxy-compatible APIs are consulted
         to find concrete candidates for this requirement. If there's a
         pre-installed candidate, it's prepended in front of others.
-
-        resolvelib >=0.5.3, <0.6.0
-
-        :param requirements: A collection of requirements which all of \
-                             the returned candidates must match. \
-                             All requirements are guaranteed to have \
-                             the same identifier. \
-                             The collection is never empty.
-
-        resolvelib >=0.6.0
 
         :param identifier: The value returned by ``identify()``.
 
@@ -225,7 +220,10 @@ class CollectionDependencyProviderBase(AbstractProvider):
         :returns: An iterable that orders candidates by preference, \
                   e.g. the most preferred candidate comes first.
         """
-        raise NotImplementedError
+        return [
+            match for match in self._find_matches(list(requirements[identifier]))
+            if not any(match.ver == incompat.ver for incompat in incompatibilities[identifier])
+        ]
 
     def _find_matches(self, requirements):
         # type: (list[Requirement]) -> list[Candidate]
@@ -249,7 +247,12 @@ class CollectionDependencyProviderBase(AbstractProvider):
                 all(self.is_satisfied_by(requirement, candidate) for requirement in requirements)
             }
         try:
-            coll_versions = [] if preinstalled_candidates else self._api_proxy.get_collection_versions(first_req)  # type: t.Iterable[t.Tuple[str, GalaxyAPI]]
+            coll_versions = []  # type: t.Iterable[t.Tuple[str, GalaxyAPI]]
+            if not preinstalled_candidates:
+                coll_versions.extend(
+                    (response.data, response.api) for response in
+                    self._get_collection_versions_with_fast_paths(first_req, requirements)
+                )
         except TypeError as exc:
             if first_req.is_concrete_artifact:
                 # Non hashable versions will cause a TypeError
@@ -397,6 +400,81 @@ class CollectionDependencyProviderBase(AbstractProvider):
 
         return list(preinstalled_candidates) + latest_matches
 
+    def _try_exact_version_fast_path(self, first_req):
+        # type: (Requirement) -> t.Optional[list[ProxyResponse[str]]]
+        """Attempt fast path for exact version specifications."""
+        exact_version = first_req.ver.lstrip('=').strip()
+
+        if not (exact_version and exact_version[0].isdigit()):
+            return None
+
+        test_candidate = Candidate(
+            first_req.fqcn,
+            exact_version,
+            first_req.src,
+            'galaxy',
+            None
+        )
+
+        try:
+            response = self._api_proxy.get_collection_version_metadata(test_candidate)
+        except Exception:
+            return None
+
+        return [ProxyResponse(exact_version, response.api)]
+
+    def _try_unconstrained_version_fast_path(self, first_req):
+        # type: (Requirement) -> t.Optional[list[ProxyResponse[str]]]
+        """Attempt fast path for unconstrained version specifications."""
+        # If we've already used fast path for this collection, don't try again
+        if first_req.fqcn in self._fast_path_used:
+            return None
+
+        try:
+            response = self._api_proxy.get_collection_metadata(first_req)
+        except Exception:
+            return None
+
+        highest_version = response.data.highest_version
+        if highest_version:
+            latest_version = highest_version.get('version')
+            if latest_version:
+                if is_pre_release(latest_version) and not self._with_pre_releases:
+                    return None
+
+                self._fast_path_used.add(first_req.fqcn)
+
+                return [ProxyResponse(latest_version, response.api)]
+
+        return None
+
+    def _get_collection_versions_with_fast_paths(self, first_req, requirements):
+        # type: (Requirement, list[Requirement]) -> t.Iterable[ProxyResponse[str]]
+        """Get collection versions using fast paths when possible.
+
+        Fast paths:
+        1. Exact version: Skip full version list, try direct version metadata lookup
+        2. Unconstrained: Try collection metadata first to get latest non-prerelease
+        3. Complex constraints: Fall back to full version list
+        """
+        if first_req.type != 'galaxy':
+            return self._api_proxy.get_collection_versions(first_req)
+
+        if len(requirements) != 1:
+            return self._api_proxy.get_collection_versions(first_req)
+
+        if first_req.is_pinned:
+            exact_versions = self._try_exact_version_fast_path(first_req)
+            if exact_versions is not None:
+                return exact_versions
+
+        if first_req.ver == '*' or not first_req.ver:
+            unconstrained_versions = self._try_unconstrained_version_fast_path(first_req)
+            if unconstrained_versions is not None:
+                return unconstrained_versions
+
+        return self._api_proxy.get_collection_versions(first_req)
+
     def is_satisfied_by(self, requirement, candidate):
         # type: (Requirement, Candidate) -> bool
         r"""Whether the given requirement is satisfiable by a candidate.
@@ -437,7 +515,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
         # FIXME: Taking into account a pinned hash? Exploding on
         # FIXME: any differences?
         # NOTE: The underlying implementation currently uses first found
-        req_map = self._api_proxy.get_collection_dependencies(candidate)
+        req_map = self._api_proxy.get_collection_dependencies(candidate).data
 
         # NOTE: This guard expression MUST perform an early exit only
         # NOTE: after the `get_collection_dependencies()` call because
@@ -459,24 +537,7 @@ class CollectionDependencyProviderBase(AbstractProvider):
 
 
 # Classes to handle resolvelib API changes between minor versions for 0.X
-class CollectionDependencyProvider050(CollectionDependencyProviderBase):
-    def find_matches(self, requirements):  # type: ignore[override]
-        # type: (list[Requirement]) -> list[Candidate]
-        return self._find_matches(requirements)
-
-    def get_preference(self, resolution, candidates, information):  # type: ignore[override]
-        # type: (t.Optional[Candidate], list[Candidate], list[t.NamedTuple]) -> t.Union[float, int]
-        return self._get_preference(candidates)
-
-
 class CollectionDependencyProvider060(CollectionDependencyProviderBase):
-    def find_matches(self, identifier, requirements, incompatibilities):  # type: ignore[override]
-        # type: (str, t.Mapping[str, t.Iterator[Requirement]], t.Mapping[str, t.Iterator[Requirement]]) -> list[Candidate]
-        return [
-            match for match in self._find_matches(list(requirements[identifier]))
-            if not any(match.ver == incompat.ver for incompat in incompatibilities[identifier])
-        ]
-
     def get_preference(self, resolution, candidates, information):  # type: ignore[override]
         # type: (t.Optional[Candidate], list[Candidate], list[t.NamedTuple]) -> t.Union[float, int]
         return self._get_preference(candidates)
@@ -499,9 +560,7 @@ def _get_provider():  # type () -> CollectionDependencyProviderBase
         return CollectionDependencyProvider080
     if RESOLVELIB_VERSION >= SemanticVersion("0.7.0"):
         return CollectionDependencyProvider070
-    if RESOLVELIB_VERSION >= SemanticVersion("0.6.0"):
-        return CollectionDependencyProvider060
-    return CollectionDependencyProvider050
+    return CollectionDependencyProvider060
 
 
 CollectionDependencyProvider = _get_provider()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ packaging
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, < 2.0.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.6.0, < 2.0.0  # dependency resolver used by ansible-galaxy

--- a/test/integration/targets/ansible-galaxy-collection-scm/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/vars/main.yml
@@ -5,7 +5,6 @@ test_repo_path: "{{ galaxy_dir }}/development/ansible_test"
 test_error_repo_path: "{{ galaxy_dir }}/development/error_test"
 
 supported_resolvelib_versions:
-  - "0.5.3"  # Oldest supported
-  - "0.6.0"
+  - "0.6.0"  # Oldest supported
   - "0.7.0"
   - "0.8.0"

--- a/test/integration/targets/ansible-galaxy-collection/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/vars/main.yml
@@ -9,7 +9,6 @@ offline_server: https://test-hub.demolab.local/api/galaxy/content/api/
 # It would be redundant to test every minor version since 0.8.0, so we just test against the latest minor release.
 # NOTE: If ansible-galaxy incorporates new resolvelib features, this matrix should be updated to verify the features work on all supported versions.
 supported_resolvelib_versions:
-  - "0.5.3"  # test CollectionDependencyProvider050
   - "0.6.0"  # test CollectionDependencyProvider060
   - "0.7.0"  # test CollectionDependencyProvider070
   - "<2.0.0"  # test CollectionDependencyProvider080

--- a/test/lib/ansible_test/_data/requirements/ansible.txt
+++ b/test/lib/ansible_test/_data/requirements/ansible.txt
@@ -12,4 +12,4 @@ packaging
 # NOTE: Ref: https://github.com/sarugaku/resolvelib/issues/69
 # NOTE: When updating the upper bound, also update the latest version used
 # NOTE: in the ansible-galaxy-collection test suite.
-resolvelib >= 0.5.3, < 2.0.0  # dependency resolver used by ansible-galaxy
+resolvelib >= 0.6.0, < 2.0.0  # dependency resolver used by ansible-galaxy

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -62,6 +62,20 @@ def cache_dir(tmp_path_factory, monkeypatch):
     yield cache_dir
 
 
+def get_collection_version_metadata_mock(namespace='namespace', name='collection', version='1.0.0', signatures=None):
+    """Helper function to create a complete Galaxy API collection version metadata response."""
+    return {
+        'download_url': f'https://galaxy.server.com/download/{namespace}-{name}-{version}.tar.gz',
+        'artifact': {'sha256': 'abc123'},
+        'namespace': {'name': namespace},
+        'collection': {'name': name},
+        'version': version,
+        'metadata': {'dependencies': {}},
+        'href': f'https://galaxy.server.com/api/v3/collections/{namespace}/{name}/versions/{version}/',
+        'signatures': signatures,
+    }
+
+
 def get_test_galaxy_api(url, version, token_ins=None, token_value=None, no_cache=True):
     token_value = token_value or "my token"
     token_ins = token_ins or GalaxyToken(token_value)
@@ -791,7 +805,12 @@ def test_get_collection_signatures_backwards_compat(api_version, token_type, tok
 
     mock_open = MagicMock()
     mock_open.side_effect = [
-        StringIO("{}")
+        StringIO(json.dumps(get_collection_version_metadata_mock(
+            namespace='namespace',
+            name='collection',
+            version=version,
+            signatures=None
+        )))
     ]
     monkeypatch.setattr(galaxy_api, 'open_url', mock_open)
 
@@ -819,24 +838,29 @@ def test_get_collection_signatures(api_version, token_type, token_ins, version, 
         mock_token_get.return_value = 'my token'
         monkeypatch.setattr(token_ins, 'get', mock_token_get)
 
+    signatures_data = [
+        {
+            "signature": "-----BEGIN PGP SIGNATURE-----\nSIGNATURE1\n-----END PGP SIGNATURE-----\n",
+            "pubkey_fingerprint": "FINGERPRINT",
+            "signing_service": "ansible-default",
+            "pulp_created": "2022-01-14T14:05:53.835605Z",
+        },
+        {
+            "signature": "-----BEGIN PGP SIGNATURE-----\nSIGNATURE2\n-----END PGP SIGNATURE-----\n",
+            "pubkey_fingerprint": "FINGERPRINT",
+            "signing_service": "ansible-default",
+            "pulp_created": "2022-01-14T14:05:53.835605Z",
+        },
+    ]
+
     mock_open = MagicMock()
     mock_open.side_effect = [
-        StringIO(to_text(json.dumps({
-            'signatures': [
-                {
-                    "signature": "-----BEGIN PGP SIGNATURE-----\nSIGNATURE1\n-----END PGP SIGNATURE-----\n",
-                    "pubkey_fingerprint": "FINGERPRINT",
-                    "signing_service": "ansible-default",
-                    "pulp_created": "2022-01-14T14:05:53.835605Z",
-                },
-                {
-                    "signature": "-----BEGIN PGP SIGNATURE-----\nSIGNATURE2\n-----END PGP SIGNATURE-----\n",
-                    "pubkey_fingerprint": "FINGERPRINT",
-                    "signing_service": "ansible-default",
-                    "pulp_created": "2022-01-14T14:05:53.835605Z",
-                },
-            ],
-        }))),
+        StringIO(json.dumps(get_collection_version_metadata_mock(
+            namespace='namespace',
+            name='collection',
+            version=version,
+            signatures=signatures_data
+        ))),
     ]
     monkeypatch.setattr(galaxy_api, 'open_url', mock_open)
 

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -457,7 +457,7 @@ def test_build_requirement_from_name(galaxy_server, monkeypatch, tmp_path_factor
     )['collections']
     actual = collection._resolve_depenency_map(
         requirements, [galaxy_server], concrete_artifact_cm, None, True, False, False, False, False
-    )['namespace.collection']
+    ).mapping['namespace.collection']
 
     assert actual.namespace == u'namespace'
     assert actual.name == u'collection'
@@ -486,7 +486,7 @@ def test_build_requirement_from_name_with_prerelease(galaxy_server, monkeypatch,
     )['collections']
     actual = collection._resolve_depenency_map(
         requirements, [galaxy_server], concrete_artifact_cm, None, True, False, False, False, False
-    )['namespace.collection']
+    ).mapping['namespace.collection']
 
     assert actual.namespace == u'namespace'
     assert actual.name == u'collection'
@@ -516,7 +516,7 @@ def test_build_requirement_from_name_with_prerelease_explicit(galaxy_server, mon
     )['collections']
     actual = collection._resolve_depenency_map(
         requirements, [galaxy_server], concrete_artifact_cm, None, True, False, False, False, False
-    )['namespace.collection']
+    ).mapping['namespace.collection']
 
     assert actual.namespace == u'namespace'
     assert actual.name == u'collection'
@@ -551,7 +551,7 @@ def test_build_requirement_from_name_second_server(galaxy_server, monkeypatch, t
     )['collections']
     actual = collection._resolve_depenency_map(
         requirements, [broken_server, galaxy_server], concrete_artifact_cm, None, True, False, False, False, False
-    )['namespace.collection']
+    ).mapping['namespace.collection']
 
     assert actual.namespace == u'namespace'
     assert actual.name == u'collection'
@@ -629,7 +629,7 @@ def test_build_requirement_from_name_single_version(galaxy_server, monkeypatch, 
     )['collections']
 
     actual = collection._resolve_depenency_map(
-        requirements, [galaxy_server], concrete_artifact_cm, None, False, True, False, False, False)['namespace.collection']
+        requirements, [galaxy_server], concrete_artifact_cm, None, False, True, False, False, False).mapping['namespace.collection']
 
     assert actual.namespace == u'namespace'
     assert actual.name == u'collection'
@@ -637,7 +637,7 @@ def test_build_requirement_from_name_single_version(galaxy_server, monkeypatch, 
     assert actual.ver == u'2.0.0'
     assert [c.ver for c in matches.candidates] == [u'2.0.0']
 
-    assert mock_get_info.call_count == 1
+    assert mock_get_info.call_count == 2
     assert mock_get_info.mock_calls[0][1] == ('namespace', 'collection', '2.0.0')
 
 
@@ -666,7 +666,7 @@ def test_build_requirement_from_name_multiple_versions_one_match(galaxy_server, 
     )['collections']
 
     actual = collection._resolve_depenency_map(
-        requirements, [galaxy_server], concrete_artifact_cm, None, False, True, False, False, False)['namespace.collection']
+        requirements, [galaxy_server], concrete_artifact_cm, None, False, True, False, False, False).mapping['namespace.collection']
 
     assert actual.namespace == u'namespace'
     assert actual.name == u'collection'
@@ -708,7 +708,7 @@ def test_build_requirement_from_name_multiple_version_results(galaxy_server, mon
     )['collections']
 
     actual = collection._resolve_depenency_map(
-        requirements, [galaxy_server], concrete_artifact_cm, None, False, True, False, False, False)['namespace.collection']
+        requirements, [galaxy_server], concrete_artifact_cm, None, False, True, False, False, False).mapping['namespace.collection']
 
     assert actual.namespace == u'namespace'
     assert actual.name == u'collection'
@@ -751,12 +751,16 @@ def test_dep_candidate_with_conflict(monkeypatch, tmp_path_factory, galaxy_serve
 
     mock_get_info_return = [
         api.CollectionVersionMetadata('parent', 'collection', '2.0.5', None, None, {'namespace.collection': '!=1.0.0'}, None, None),
+        api.CollectionVersionMetadata('parent', 'collection', '2.0.5', None, None, {'namespace.collection': '!=1.0.0'}, None, None),
         api.CollectionVersionMetadata('namespace', 'collection', '1.0.0', None, None, {}, None, None),
     ]
     mock_get_info = MagicMock(side_effect=mock_get_info_return)
     monkeypatch.setattr(galaxy_server, 'get_collection_version_metadata', mock_get_info)
 
-    mock_get_versions = MagicMock(side_effect=[['2.0.5'], ['1.0.0']])
+    # Only one response needed for get_collection_versions because the fast path
+    # optimization skips the version list call for parent.collection:2.0.5 (exact version),
+    # so only the dependency resolution for namespace.collection makes this call
+    mock_get_versions = MagicMock(side_effect=[['1.0.0']])
     monkeypatch.setattr(galaxy_server, 'get_collection_versions', mock_get_versions)
 
     cli = GalaxyCLI(args=['ansible-galaxy', 'collection', 'install', 'parent.collection:2.0.5'])
@@ -1012,3 +1016,217 @@ def test_verify_file_signatures(signatures: list[str], required_successful_count
                 required_successful_count,
                 ignore_errors
             ) == expected_success
+
+
+@pytest.mark.parametrize(
+    'dependency_map,expected_order',
+    [
+        # No dependencies - all collections independent
+        (
+            {
+                'namespace.a': [],
+                'namespace.b': [],
+            },
+            [{'namespace.a', 'namespace.b'}]
+        ),
+        # Linear dependency chain: A -> B -> C
+        (
+            {
+                'namespace.a': ['namespace.b'],
+                'namespace.b': ['namespace.c'],
+                'namespace.c': [],
+            },
+            ['namespace.c', 'namespace.b', 'namespace.a']
+        ),
+        # Complex dependencies: D depends on B,C; B,C depend on A
+        (
+            {
+                'namespace.d': ['namespace.b', 'namespace.c'],
+                'namespace.b': ['namespace.a'],
+                'namespace.c': ['namespace.a'],
+                'namespace.a': [],
+            },
+            ['namespace.a', ['namespace.b', 'namespace.c'], 'namespace.d']  # B,C can be in any order
+        ),
+        # External dependencies (not in mapping) - should be ignored
+        (
+            {
+                'namespace.a': ['external.collection'],  # external not in mapping
+                'namespace.b': ['namespace.a'],
+            },
+            ['namespace.a', 'namespace.b']
+        ),
+        # Single collection
+        (
+            {
+                'namespace.only': [],
+            },
+            ['namespace.only']
+        ),
+        # Empty mapping
+        (
+            {},
+            []
+        ),
+    ]
+)
+def test_topological_sort_collections(dependency_map, expected_order):
+    """Test topological sorting of collections with various dependency patterns."""
+
+    mock_graph = MagicMock()
+
+    def mock_iter_children(collection):
+        return dependency_map.get(collection, [])
+
+    def mock_iter_parents(collection):
+        parents = []
+        for coll, deps in dependency_map.items():
+            if collection in deps:
+                parents.append(coll)
+        return parents
+
+    mock_graph.iter_children.side_effect = mock_iter_children
+    mock_graph.iter_parents.side_effect = mock_iter_parents
+
+    mapping = {coll: MagicMock() for coll in dependency_map.keys()}
+
+    mock_result = MagicMock()
+    mock_result.graph = mock_graph
+    mock_result.mapping = mapping
+
+    result = list(collection._topological_sort_collections(mock_result))
+
+    # Validate the result based on expected_order format
+    if not expected_order:
+        assert result == []
+    elif len(expected_order) == 1 and isinstance(expected_order[0], set):
+        # Unordered case - all collections should be present, order doesn't matter
+        assert set(result) == expected_order[0]
+    elif any(isinstance(item, list) for item in expected_order):
+        # Mixed ordering case - validate constraints
+        assert len(result) == sum(len(item) if isinstance(item, list) else 1 for item in expected_order)
+
+        result_index = 0
+        for constraint in expected_order:
+            if isinstance(constraint, list):
+                # These items can be in any order relative to each other
+                items_in_result = result[result_index:result_index + len(constraint)]
+                assert set(items_in_result) == set(constraint)
+                result_index += len(constraint)
+            else:
+                # This item must be in this exact position
+                assert result[result_index] == constraint
+                result_index += 1
+    else:
+        # Exact ordering case
+        assert result == expected_order
+
+
+def test_topological_sort_circular_dependencies():
+    """Test that circular dependencies fall back to yielding remaining collections."""
+
+    mock_graph = MagicMock()
+
+    def mock_iter_children(collection):
+        deps = {
+            'namespace.a': ['namespace.b'],
+            'namespace.b': ['namespace.a'],  # Circular
+            'namespace.c': []  # Independent collection
+        }
+        return deps.get(collection, [])
+
+    def mock_iter_parents(collection):
+        dependents = {
+            'namespace.a': ['namespace.b'],
+            'namespace.b': ['namespace.a'],  # Circular
+            'namespace.c': []
+        }
+        return dependents.get(collection, [])
+
+    mock_graph.iter_children.side_effect = mock_iter_children
+    mock_graph.iter_parents.side_effect = mock_iter_parents
+
+    mapping = {
+        'namespace.a': MagicMock(),
+        'namespace.b': MagicMock(),
+        'namespace.c': MagicMock(),
+    }
+
+    mock_result = MagicMock()
+    mock_result.graph = mock_graph
+    mock_result.mapping = mapping
+
+    result = list(collection._topological_sort_collections(mock_result))
+
+    # All collections should be included (C processed normally, A+B in fallback)
+    assert len(result) == 3
+    assert set(result) == {'namespace.a', 'namespace.b', 'namespace.c'}
+    # C should come first since it has no dependencies
+    assert result[0] == 'namespace.c'
+
+
+def test_fast_path_backtracking_with_dependency_conflict(monkeypatch, tmp_path_factory, galaxy_server):
+    """Test that fast path backtracking works when dependency conflicts require different versions.
+
+    Scenario:
+    - foo.bar has versions 1.0.0 and 2.0.0 (fast path picks 2.0.0)
+    - bar.baz has version 1.0.0
+    - foo.bar:1.0.0 depends on baz.qux:0.5.0
+    - foo.bar:2.0.0 depends on baz.qux:1.0.0
+    - bar.baz:1.0.0 depends on baz.qux:0.5.0
+    - Only solution: foo.bar:1.0.0, bar.baz:1.0.0, baz.qux:0.5.0
+    """
+    test_dir = to_bytes(tmp_path_factory.mktemp('test-backtrack'))
+    concrete_artifact_cm = collection.concrete_artifact_manager.ConcreteArtifactsManager(test_dir, validate_certs=False)
+
+    def mock_get_versions(namespace, name):
+        versions = {
+            ('foo', 'bar'): ['1.0.0', '2.0.0'],
+            ('bar', 'baz'): ['1.0.0'],
+            ('baz', 'qux'): ['0.5.0', '1.0.0']
+        }
+        return versions.get((namespace, name), [])
+
+    def mock_get_metadata(namespace, name):
+        if namespace == 'foo' and name == 'bar':
+            return api.CollectionMetadata('foo', 'bar', None, None, {'version': '2.0.0'})
+        return api.CollectionMetadata(namespace, name, None, None, {'version': '1.0.0'})
+
+    def mock_get_version_metadata(namespace, name, version):
+        dependencies = {
+            ('foo', 'bar', '1.0.0'): {'baz.qux': '0.5.0'},
+            ('foo', 'bar', '2.0.0'): {'baz.qux': '1.0.0'},
+            ('bar', 'baz', '1.0.0'): {'baz.qux': '0.5.0'},
+            ('baz', 'qux', '0.5.0'): {},
+            ('baz', 'qux', '1.0.0'): {},
+        }
+        deps = dependencies.get((namespace, name, version), {})
+        return api.CollectionVersionMetadata(namespace, name, version, None, None, deps, None, [])
+
+    monkeypatch.setattr(galaxy_server, 'get_collection_versions', mock_get_versions)
+    monkeypatch.setattr(galaxy_server, 'get_collection_metadata', mock_get_metadata)
+    monkeypatch.setattr(galaxy_server, 'get_collection_version_metadata', mock_get_version_metadata)
+
+    requirements = [
+        Requirement.from_requirement_dict({'name': 'foo.bar'}, concrete_artifact_cm),
+        Requirement.from_requirement_dict({'name': 'bar.baz'}, concrete_artifact_cm)
+    ]
+
+    result = collection._resolve_depenency_map(
+        requirements,
+        [galaxy_server],
+        concrete_artifact_cm,
+        None,
+        False,
+        False,
+        False,
+        False,
+        False
+    )
+
+    mapping = result.mapping
+    assert len(mapping) == 3
+
+    assert mapping['foo.bar'].ver == '1.0.0'
+    assert mapping['bar.baz'].ver == '1.0.0'
+    assert mapping['baz.qux'].ver == '0.5.0'


### PR DESCRIPTION
##### SUMMARY

This PR implements fast paths in galaxy dep resolution for the following:

1. Exact version: Skip full version list, try direct version metadata lookup
2. Unconstrained: Try collection metadata first to get latest non-prerelease

Otherwise, the code will fall back to getting full version lists

Tests using https://github.com/ansible-community/ansible-build-data/blob/da249fb2a53484319d97dcc17c2e3bc8d3eaee9c/12/galaxy-requirements.yaml

ansible-galaxy collection install -p . -vvvvv --force --clear-response-cache -r galaxy-requirements.yaml

(I only ran each 1 time, not sitting around all day for this)
devel: 6m16s
this pr: 3m20s

Removing the version pins:

devel: 11m43s
this pr: 7m36s


##### ISSUE TYPE

- Feature Pull Request