### PR TITLE
Fail loud if ansible.cfg is in a world-writable directory (#85087)

### DIFF
--- a/changelogs/fragments/85087-fail-loud-if-config-in-world-write-dir.yml
+++ b/changelogs/fragments/85087-fail-loud-if-config-in-world-write-dir.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "lib/ansible/config/manager.py:306 - fail loud if ansible.cfg is in a global writable directory. (https://github.com/ansible/ansible/issues/85087)"

--- a/changelogs/fragments/85087-fail-loud-if-config-in-world-write-dir.yml
+++ b/changelogs/fragments/85087-fail-loud-if-config-in-world-write-dir.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "lib/ansible/config/manager.py:306 - fail loud if ansible.cfg is in a global writable directory. (https://github.com/ansible/ansible/issues/85087)"
+  - "config manager - fail loud if ansible.cfg is in a global writable directory. (https://github.com/ansible/ansible/issues/85087)"

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -299,33 +299,31 @@ def find_ini_config_file(warnings=None):
     else:
         path = None
 
-    # Emit a warning if all the following are true:
+    # If all the following are true:
     # * We did not use a config from ANSIBLE_CONFIG
     # * There's an ansible.cfg in the current working directory that we skipped
+    # then the program will:
+    # * If user didn't set a environment variable named ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG, throw an exception
+    # * otherwise, print a warning
     if path_from_env != path and warn_cmd_public:
         ignore_cwd_config = os.getenv("ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG", Sentinel)
         if ignore_cwd_config is Sentinel:
             raise AnsibleError(
-                u"Ansible is being run in a world writable directory (%s),"
-                u" and an ansible.cfg is inside."
-                u" Using it as an ansible.cfg source causes security issues."
-                u" We are not sure about what you want,"
-                u" so we decide to fail loud."
-                u" If you want to ignore the ansible.cfg and continue the search,"
-                u" please set an environment variable ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG to any non-empty value."
-                u" For more information see"
-                u" https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir"
-                % to_text(cwd)
+                f"Ansible is being run in a world writable directory ({to_text(cwd)}), and an ansible.cfg is inside."
+                f" Using it as an ansible.cfg source causes security issues."
+                f" We are not sure about what you want, so we decide to fail loud."
+                f" If you want to ignore the ansible.cfg and continue the search,"
+                f" please set an environment variable ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG to any non-empty value."
+                f" For more information see"
+                f" https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir"
             )
         else:
             warnings.add(
-                u"Ansible is being run in a world writable directory (%s),"
-                u" ignoring it as an ansible.cfg source."
-                u" If you want to fail loud,"
-                u" please unset the environment variable ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG."
-                u" For more information see"
-                u" https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir"
-                % to_text(cwd)
+                f"Ansible is being run in a world writable directory ({to_text(cwd)}),"
+                f" ignoring it as an ansible.cfg source. If you want to fail loud,"
+                f" please unset the environment variable ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG."
+                f" For more information see"
+                f" https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir"
             )
 
     return path

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -303,11 +303,30 @@ def find_ini_config_file(warnings=None):
     # * We did not use a config from ANSIBLE_CONFIG
     # * There's an ansible.cfg in the current working directory that we skipped
     if path_from_env != path and warn_cmd_public:
-        warnings.add(u"Ansible is being run in a world writable directory (%s),"
-                     u" ignoring it as an ansible.cfg source."
-                     u" For more information see"
-                     u" https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir"
-                     % to_text(cwd))
+        ignore_cwd_config = os.getenv("ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG", Sentinel)
+        if ignore_cwd_config is Sentinel:
+            raise AnsibleError(
+                u"Ansible is being run in a world writable directory (%s),"
+                u" and an ansible.cfg is inside."
+                u" Using it as an ansible.cfg source causes security issues."
+                u" We are not sure about what you want,"
+                u" so we decide to fail loud."
+                u" If you want to ignore the ansible.cfg and continue the search,"
+                u" please set an environment variable ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG to any non-empty value."
+                u" For more information see"
+                u" https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir"
+                % to_text(cwd)
+            )
+        else:
+            warnings.add(
+                u"Ansible is being run in a world writable directory (%s),"
+                u" ignoring it as an ansible.cfg source."
+                u" If you want to fail loud,"
+                u" please unset the environment variable ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG."
+                u" For more information see"
+                u" https://docs.ansible.com/ansible/devel/reference_appendices/config.html#cfg-in-world-writable-dir"
+                % to_text(cwd)
+            )
 
     return path
 

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -303,11 +303,12 @@ def find_ini_config_file(warnings=None):
     # * We did not use a config from ANSIBLE_CONFIG
     # * There's an ansible.cfg in the current working directory that we skipped
     # then the program will:
-    # * If user didn't set a environment variable named ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG, throw an exception
-    # * otherwise, print a warning
+    # * If user didn't set an environment variable named ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG to any non-empty value, throw an exception
+    # * otherwise, emit a warning
     if path_from_env != path and warn_cmd_public:
-        ignore_cwd_config = os.getenv("ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG", Sentinel)
-        if ignore_cwd_config is Sentinel:
+        ignore_cwd_config = os.getenv("ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG")
+        # Test ignore_cwd_config not exists or is empty
+        if not ignore_cwd_config:
             raise AnsibleError(
                 f"Ansible is being run in a world writable directory ({to_text(cwd)}), and an ansible.cfg is inside."
                 f" Using it as an ansible.cfg source causes security issues."

--- a/test/units/config/manager/test_find_ini_config_file.py
+++ b/test/units/config/manager/test_find_ini_config_file.py
@@ -35,13 +35,14 @@ def setup_env(request, monkeypatch):
     else:
         monkeypatch.setenv('ANSIBLE_CONFIG', request.param[0])
 
-    cur_ignore = os.environ.get('ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG', None)
+    cur_ignore = os.environ.get('ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG')
     ignore_env = request.param[1]
 
-    if ignore_env is not None:
-        monkeypatch.setenv('ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG', request.param[0])
-    elif cur_ignore:
+    # If ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG exists, we will delete it
+    if ignore_env is None and cur_ignore is not None:
         monkeypatch.delenv('ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG')
+    elif ignore_env is not None:
+        monkeypatch.setenv('ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG', ignore_env)
 
     yield
 
@@ -179,8 +180,8 @@ class TestFindIniFile:
     @pytest.mark.parametrize('setup_existing_files',
                              [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_in_cwd, cfg_file, alt_cfg_file)]],
                              indirect=['setup_existing_files'])
-    def test_cwd_exception_on_writable(self, setup_env, setup_existing_files, monkeypatch):
-        """If the cwd is writable, and env is not set, throw an exception and exit """
+    def test_cwd_on_writable_no_env(self, setup_env, setup_existing_files, monkeypatch):
+        """If the cwd is writable, and ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG is not set, throw an exception and exit """
         real_stat = os.stat
 
         def _os_stat(path):
@@ -196,14 +197,14 @@ class TestFindIniFile:
         with pytest.raises(Exception) as e:
             find_ini_config_file(warnings)
 
-    # ANSIBLE_CONFIG not specified
+    # ANSIBLE_CONFIG not specified, but ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG is set to True
     @pytest.mark.parametrize('setup_env', [[None, 'True']], indirect=['setup_env'])
     # All config files are present
     @pytest.mark.parametrize('setup_existing_files',
                              [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_in_cwd, cfg_file, alt_cfg_file)]],
                              indirect=['setup_existing_files'])
-    def test_cwd_warning_on_writable(self, setup_env, setup_existing_files, monkeypatch):
-        """If the cwd is writable, warn and skip it """
+    def test_cwd_on_writable_with_env(self, setup_env, setup_existing_files, monkeypatch):
+        """If the cwd is writable, and ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG is not empty, warn and skip it """
         real_stat = os.stat
 
         def _os_stat(path):
@@ -221,6 +222,29 @@ class TestFindIniFile:
         warning = warnings.pop()
         assert u'Ansible is being run in a world writable directory' in warning
         assert u'ignoring it as an ansible.cfg source' in warning
+
+    # ANSIBLE_CONFIG not specified, but ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG is set to empty string
+    @pytest.mark.parametrize('setup_env', [[None, '']], indirect=['setup_env'])
+    # All config files are present
+    @pytest.mark.parametrize('setup_existing_files',
+                             [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_in_cwd, cfg_file, alt_cfg_file)]],
+                             indirect=['setup_existing_files'])
+    def test_cwd_on_writable_with_empty_env(self, setup_env, setup_existing_files, monkeypatch):
+        """If the cwd is writable, and ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG is empty, throw an exception and exit """
+        real_stat = os.stat
+
+        def _os_stat(path):
+            assert path == working_dir
+            from posix import stat_result
+            stat_info = list(real_stat(path))
+            stat_info[stat.ST_MODE] |= stat.S_IWOTH
+            return stat_result(stat_info)
+
+        monkeypatch.setattr('os.stat', _os_stat)
+
+        warnings = set()
+        with pytest.raises(Exception) as e:
+            find_ini_config_file(warnings)
 
     # ANSIBLE_CONFIG is sepcified
     @pytest.mark.parametrize('setup_env, expected', (([alt_cfg_file, None], alt_cfg_file), ([cfg_in_cwd, None], cfg_in_cwd)), indirect=['setup_env'])

--- a/test/units/config/manager/test_find_ini_config_file.py
+++ b/test/units/config/manager/test_find_ini_config_file.py
@@ -35,6 +35,14 @@ def setup_env(request, monkeypatch):
     else:
         monkeypatch.setenv('ANSIBLE_CONFIG', request.param[0])
 
+    cur_ignore = os.environ.get('ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG', None)
+    ignore_env = request.param[1]
+
+    if ignore_env is not None:
+        monkeypatch.setenv('ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG', request.param[0])
+    elif cur_ignore:
+        monkeypatch.delenv('ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG')
+
     yield
 
 
@@ -59,7 +67,7 @@ def setup_existing_files(request, monkeypatch):
 
 class TestFindIniFile:
     # This tells us to run twice, once with a file specified and once with a directory
-    @pytest.mark.parametrize('setup_env, expected', (([alt_cfg_file], alt_cfg_file), ([cfg_dir], cfg_file)), indirect=['setup_env'])
+    @pytest.mark.parametrize('setup_env, expected', (([alt_cfg_file, None], alt_cfg_file), ([cfg_dir, None], cfg_file)), indirect=['setup_env'])
     # This just passes the list of files that exist to the fixture
     @pytest.mark.parametrize('setup_existing_files',
                              [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_in_cwd, alt_cfg_file, cfg_file)]],
@@ -70,7 +78,7 @@ class TestFindIniFile:
         assert find_ini_config_file(warnings) == expected
         assert warnings == set()
 
-    @pytest.mark.parametrize('setup_env', ([alt_cfg_file], [cfg_dir]), indirect=['setup_env'])
+    @pytest.mark.parametrize('setup_env', ([alt_cfg_file, None], [cfg_dir, None]), indirect=['setup_env'])
     @pytest.mark.parametrize('setup_existing_files',
                              [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_in_cwd)]],
                              indirect=['setup_existing_files'])
@@ -84,7 +92,7 @@ class TestFindIniFile:
         assert warnings == set()
 
     # ANSIBLE_CONFIG not specified
-    @pytest.mark.parametrize('setup_env', [[None]], indirect=['setup_env'])
+    @pytest.mark.parametrize('setup_env', [[None, None]], indirect=['setup_env'])
     # All config files are present
     @pytest.mark.parametrize('setup_existing_files',
                              [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_in_cwd, cfg_file, alt_cfg_file)]],
@@ -96,7 +104,7 @@ class TestFindIniFile:
         assert warnings == set()
 
     # ANSIBLE_CONFIG not specified
-    @pytest.mark.parametrize('setup_env', [[None]], indirect=['setup_env'])
+    @pytest.mark.parametrize('setup_env', [[None, None]], indirect=['setup_env'])
     # No config in cwd
     @pytest.mark.parametrize('setup_existing_files',
                              [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_file, alt_cfg_file)]],
@@ -108,7 +116,7 @@ class TestFindIniFile:
         assert warnings == set()
 
     # ANSIBLE_CONFIG not specified
-    @pytest.mark.parametrize('setup_env', [[None]], indirect=['setup_env'])
+    @pytest.mark.parametrize('setup_env', [[None, None]], indirect=['setup_env'])
     # No config in cwd
     @pytest.mark.parametrize('setup_existing_files', [[('/etc/ansible/ansible.cfg', cfg_file, alt_cfg_file)]], indirect=['setup_existing_files'])
     def test_ini_in_systemdir(self, setup_env, setup_existing_files):
@@ -118,7 +126,7 @@ class TestFindIniFile:
         assert warnings == set()
 
     # ANSIBLE_CONFIG not specified
-    @pytest.mark.parametrize('setup_env', [[None]], indirect=['setup_env'])
+    @pytest.mark.parametrize('setup_env', [[None, None]], indirect=['setup_env'])
     # No config in cwd
     @pytest.mark.parametrize('setup_existing_files',
                              [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_file, alt_cfg_file)]],
@@ -133,7 +141,7 @@ class TestFindIniFile:
         assert find_ini_config_file(warnings) == cfg_in_homedir
         assert warnings == set()
 
-    @pytest.mark.parametrize('setup_env', [[None]], indirect=['setup_env'])
+    @pytest.mark.parametrize('setup_env', [[None, None]], indirect=['setup_env'])
     # No config in cwd
     @pytest.mark.parametrize('setup_existing_files', [[list()]], indirect=['setup_existing_files'])
     def test_no_config(self, setup_env, setup_existing_files):
@@ -143,7 +151,7 @@ class TestFindIniFile:
         assert warnings == set()
 
     # ANSIBLE_CONFIG not specified
-    @pytest.mark.parametrize('setup_env', [[None]], indirect=['setup_env'])
+    @pytest.mark.parametrize('setup_env', [[None, None]], indirect=['setup_env'])
     # All config files are present except in cwd
     @pytest.mark.parametrize('setup_existing_files',
                              [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_file, alt_cfg_file)]],
@@ -166,7 +174,30 @@ class TestFindIniFile:
         assert len(warnings) == 0
 
     # ANSIBLE_CONFIG not specified
-    @pytest.mark.parametrize('setup_env', [[None]], indirect=['setup_env'])
+    @pytest.mark.parametrize('setup_env', [[None, None]], indirect=['setup_env'])
+    # All config files are present
+    @pytest.mark.parametrize('setup_existing_files',
+                             [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_in_cwd, cfg_file, alt_cfg_file)]],
+                             indirect=['setup_existing_files'])
+    def test_cwd_exception_on_writable(self, setup_env, setup_existing_files, monkeypatch):
+        """If the cwd is writable, and env is not set, throw an exception and exit """
+        real_stat = os.stat
+
+        def _os_stat(path):
+            assert path == working_dir
+            from posix import stat_result
+            stat_info = list(real_stat(path))
+            stat_info[stat.ST_MODE] |= stat.S_IWOTH
+            return stat_result(stat_info)
+
+        monkeypatch.setattr('os.stat', _os_stat)
+
+        warnings = set()
+        with pytest.raises(Exception) as e:
+            find_ini_config_file(warnings)
+
+    # ANSIBLE_CONFIG not specified
+    @pytest.mark.parametrize('setup_env', [[None, 'True']], indirect=['setup_env'])
     # All config files are present
     @pytest.mark.parametrize('setup_existing_files',
                              [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_in_cwd, cfg_file, alt_cfg_file)]],
@@ -192,7 +223,7 @@ class TestFindIniFile:
         assert u'ignoring it as an ansible.cfg source' in warning
 
     # ANSIBLE_CONFIG is sepcified
-    @pytest.mark.parametrize('setup_env, expected', (([alt_cfg_file], alt_cfg_file), ([cfg_in_cwd], cfg_in_cwd)), indirect=['setup_env'])
+    @pytest.mark.parametrize('setup_env, expected', (([alt_cfg_file, None], alt_cfg_file), ([cfg_in_cwd, None], cfg_in_cwd)), indirect=['setup_env'])
     # All config files are present
     @pytest.mark.parametrize('setup_existing_files',
                              [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_in_cwd, cfg_file, alt_cfg_file)]],
@@ -215,24 +246,3 @@ class TestFindIniFile:
         warnings = set()
         assert find_ini_config_file(warnings) == expected
         assert warnings == set()
-
-    # ANSIBLE_CONFIG not specified
-    @pytest.mark.parametrize('setup_env', [[None]], indirect=['setup_env'])
-    # All config files are present
-    @pytest.mark.parametrize('setup_existing_files',
-                             [[('/etc/ansible/ansible.cfg', cfg_in_homedir, cfg_in_cwd, cfg_file, alt_cfg_file)]],
-                             indirect=['setup_existing_files'])
-    def test_cwd_warning_on_writable_no_warning_set(self, setup_env, setup_existing_files, monkeypatch):
-        """Smoketest that the function succeeds even though no warning set was passed in"""
-        real_stat = os.stat
-
-        def _os_stat(path):
-            assert path == working_dir
-            from posix import stat_result
-            stat_info = list(real_stat(path))
-            stat_info[stat.ST_MODE] |= stat.S_IWOTH
-            return stat_result(stat_info)
-
-        monkeypatch.setattr('os.stat', _os_stat)
-
-        assert find_ini_config_file() == cfg_in_homedir


### PR DESCRIPTION
This PR is migrated from [#85666 ](https://github.com/ansible/ansible/pull/85666)

#### SUMMARY

This PR will throw an exception when the `ansible.cfg` is in a global writable directory, instead of ignoring it. 

It should make the diagnosis easier, because the program fails loud so that the user won't ignore the warning.

It added an environment variable `ANSIBLE_IGNORE_WORLD_WRITABLE_CWD_CONFIG` to allow users fallback to the original behavior. They need to set this environment variable to any non-empty value to enable it.

Fixes [#85087 ](https://github.com/ansible/ansible/issues/85087)

#### ISSUE TYPE

- Feature Pull Request

#### COMPONENT NAME

lib/ansible/config/manager.py
test/units/config/manager/test_find_ini_config_file.py

