### PR TITLE
Fix vars lookup plugin re-templating issue with select('defined')

### DIFF
--- a/changelogs/fragments/vars-lookup-select-defined-fix.yml
+++ b/changelogs/fragments/vars-lookup-select-defined-fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "vars lookup plugin - Fixed issue where the plugin would re-template already-processed template results containing ``select('defined')`` filters, causing ``'var' is undefined`` errors when undefined variables were referenced in the original template. The plugin now only templates string values that contain template syntax, preventing re-evaluation of processed results (https://github.com/ansible/ansible/issues/XXXXX)."

--- a/changelogs/fragments/vars-lookup-select-defined-fix.yml
+++ b/changelogs/fragments/vars-lookup-select-defined-fix.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - "vars lookup plugin - Fixed issue where the plugin would re-template already-processed template results containing ``select('defined')`` filters, causing ``'var' is undefined`` errors when undefined variables were referenced in the original template. The plugin now only templates string values that contain template syntax, preventing re-evaluation of processed results (https://github.com/ansible/ansible/issues/XXXXX)."
+  - "vars lookup plugin - Fixed issue where the plugin would re-template already-processed template results containing ``select('defined')`` filters, causing ``'var' is undefined`` errors when undefined variables were referenced in the original template. The plugin now only templates string values that contain template syntax, preventing re-evaluation of processed results (https://github.com/ansible/ansible/issues/85685)."

--- a/lib/ansible/plugins/lookup/vars.py
+++ b/lib/ansible/plugins/lookup/vars.py
@@ -77,6 +77,7 @@ from ansible.errors import AnsibleTypeError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils.datatag import native_type_name
 from ansible._internal._templating import _jinja_bits
+from ansible._internal._templating._jinja_bits import is_possibly_template
 
 
 class LookupModule(LookupBase):
@@ -101,4 +102,13 @@ class LookupModule(LookupBase):
 
             ret.append(value)
 
-        return self._templar._engine.template(ret)
+        # Only template values that are strings and contain template syntax
+        # This prevents re-templating of already-processed template results
+        templated_ret = []
+        for value in ret:
+            if isinstance(value, str) and is_possibly_template(value):
+                templated_ret.append(self._templar._engine.template(value))
+            else:
+                templated_ret.append(value)
+        
+        return templated_ret

--- a/test/units/plugins/lookup/test_vars.py
+++ b/test/units/plugins/lookup/test_vars.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2025, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import pytest
+
+from ansible.plugins.lookup.vars import LookupModule
+from ansible._internal._templating._engine import TemplateEngine
+from ansible._internal._datatag._tags import TrustedAsTemplate
+from ansible.errors import AnsibleUndefinedVariable
+
+
+class TestVarsLookupPlugin:
+    """Test the vars lookup plugin, particularly the fix for select('defined') issue"""
+
+    def test_vars_lookup_with_select_defined(self):
+        """
+        Test that vars lookup doesn't re-template select('defined') results.
+        
+        This addresses the bug where:
+        1. A variable uses select('defined') to filter out undefined variables
+        2. The vars lookup plugin retrieves this variable
+        3. The plugin re-templates the result, causing undefined variable errors
+        
+        See: https://github.com/ansible/ansible/issues/XXXXX
+        """
+        # Set up the scenario from the bug report
+        variables = {
+            'var1': 'foo',
+            # var2 is intentionally undefined
+        }
+        
+        # Create templar and set variables
+        templar = TemplateEngine()
+        templar.set_available_variables(variables)
+        
+        # First, template the select('defined') expression
+        # This should work and filter out undefined var2
+        template_expr = "{{ [var1, var2] | select('defined') }}"
+        defined_vals_result = templar.template(TrustedAsTemplate().tag(template_expr))
+        
+        # The result should be ['foo'] (var2 filtered out)
+        assert defined_vals_result == ['foo']
+        
+        # Add the result to variables (simulating what happens in a playbook)
+        variables['defined_vals'] = defined_vals_result
+        templar.set_available_variables(variables)
+        
+        # Now test the vars lookup - this should NOT re-template the result
+        lookup = LookupModule()
+        lookup._templar = templar
+        
+        # This should work without throwing AnsibleUndefinedVariable
+        result = lookup.run(['defined_vals'], variables)
+        
+        # Verify the result is correct
+        assert result == [['foo']]
+        assert len(result) == 1
+        assert result[0] == ['foo']
+    
+    def test_vars_lookup_still_templates_strings(self):
+        """Test that the vars lookup still templates string values that need templating"""
+        variables = {
+            'var1': 'world',
+            'template_string': 'Hello {{ var1 }}!',
+        }
+        
+        templar = TemplateEngine()
+        templar.set_available_variables(variables)
+        
+        lookup = LookupModule()
+        lookup._templar = templar
+        
+        result = lookup.run(['template_string'], variables)
+        
+        # The template string should be templated
+        assert result == ['Hello world!']
+    
+    def test_vars_lookup_with_non_string_values(self):
+        """Test that non-string values are returned as-is"""
+        variables = {
+            'list_val': ['item1', 'item2'],
+            'dict_val': {'key': 'value'},
+            'int_val': 42,
+            'bool_val': True,
+            'none_val': None,
+        }
+        
+        templar = TemplateEngine()
+        templar.set_available_variables(variables)
+        
+        lookup = LookupModule()
+        lookup._templar = templar
+        
+        # Test each type
+        for var_name, expected in variables.items():
+            result = lookup.run([var_name], variables)
+            assert result == [expected], f"Failed for {var_name}: got {result}, expected {[expected]}"
+    
+    def test_vars_lookup_with_plain_strings(self):
+        """Test that plain strings without template syntax are not re-templated"""
+        variables = {
+            'plain_string': 'just a plain string',
+            'string_with_braces': 'not a {template} at all',
+        }
+        
+        templar = TemplateEngine()
+        templar.set_available_variables(variables)
+        
+        lookup = LookupModule()
+        lookup._templar = templar
+        
+        for var_name, expected in variables.items():
+            result = lookup.run([var_name], variables)
+            assert result == [expected], f"Failed for {var_name}: got {result}, expected {[expected]}"
+
+
+if __name__ == '__main__':
+    # Simple test runner for standalone execution
+    test_class = TestVarsLookupPlugin()
+    
+    try:
+        print("Running vars lookup plugin tests...")
+        
+        print("1. Testing select('defined') scenario...")
+        test_class.test_vars_lookup_with_select_defined()
+        print("   ✓ PASSED")
+        
+        print("2. Testing template strings...")
+        test_class.test_vars_lookup_still_templates_strings()
+        print("   ✓ PASSED")
+        
+        print("3. Testing non-string values...")
+        test_class.test_vars_lookup_with_non_string_values()
+        print("   ✓ PASSED")
+        
+        print("4. Testing plain strings...")
+        test_class.test_vars_lookup_with_plain_strings()
+        print("   ✓ PASSED")
+        
+        print("\n🎉 All tests passed!")
+        
+    except Exception as e:
+        print(f"\n❌ Test failed: {e}")
+        import traceback
+        traceback.print_exc()

--- a/test/units/plugins/lookup/test_vars.py
+++ b/test/units/plugins/lookup/test_vars.py
@@ -33,9 +33,8 @@ class TestVarsLookupPlugin:
             # var2 is intentionally undefined
         }
         
-        # Create templar and set variables
-        templar = TemplateEngine()
-        templar.set_available_variables(variables)
+    # Create templar with variables (use available_variables API)
+    templar = TemplateEngine(variables=variables)
         
         # First, template the select('defined') expression
         # This should work and filter out undefined var2
@@ -45,9 +44,9 @@ class TestVarsLookupPlugin:
         # The result should be ['foo'] (var2 filtered out)
         assert defined_vals_result == ['foo']
         
-        # Add the result to variables (simulating what happens in a playbook)
-        variables['defined_vals'] = defined_vals_result
-        templar.set_available_variables(variables)
+    # Add the result to variables (simulating what happens in a playbook)
+    variables['defined_vals'] = defined_vals_result
+    templar.available_variables = variables
         
         # Now test the vars lookup - this should NOT re-template the result
         lookup = LookupModule()
@@ -68,8 +67,7 @@ class TestVarsLookupPlugin:
             'template_string': 'Hello {{ var1 }}!',
         }
         
-        templar = TemplateEngine()
-        templar.set_available_variables(variables)
+    templar = TemplateEngine(variables=variables)
         
         lookup = LookupModule()
         lookup._templar = templar
@@ -89,8 +87,7 @@ class TestVarsLookupPlugin:
             'none_val': None,
         }
         
-        templar = TemplateEngine()
-        templar.set_available_variables(variables)
+    templar = TemplateEngine(variables=variables)
         
         lookup = LookupModule()
         lookup._templar = templar
@@ -107,8 +104,7 @@ class TestVarsLookupPlugin:
             'string_with_braces': 'not a {template} at all',
         }
         
-        templar = TemplateEngine()
-        templar.set_available_variables(variables)
+    templar = TemplateEngine(variables=variables)
         
         lookup = LookupModule()
         lookup._templar = templar

--- a/test/units/plugins/lookup/test_vars.py
+++ b/test/units/plugins/lookup/test_vars.py
@@ -25,7 +25,7 @@ class TestVarsLookupPlugin:
         2. The vars lookup plugin retrieves this variable
         3. The plugin re-templates the result, causing undefined variable errors
         
-        See: https://github.com/ansible/ansible/issues/XXXXX
+        See: https://github.com/ansible/ansible/issues/85685
         """
         # Set up the scenario from the bug report
         variables = {
@@ -41,10 +41,8 @@ class TestVarsLookupPlugin:
         template_expr = "{{ [var1, var2] | select('defined') }}"
         defined_vals_result = templar.template(TrustedAsTemplate().tag(template_expr))
 
-        # The result should be ['foo'] (var2 filtered out)
         assert defined_vals_result == ['foo']
 
-        # Add the result to variables (simulating what happens in a playbook)
         variables['defined_vals'] = defined_vals_result
         templar.available_variables = variables
 

--- a/test/units/plugins/lookup/test_vars.py
+++ b/test/units/plugins/lookup/test_vars.py
@@ -32,29 +32,29 @@ class TestVarsLookupPlugin:
             'var1': 'foo',
             # var2 is intentionally undefined
         }
-        
-    # Create templar with variables (use available_variables API)
-    templar = TemplateEngine(variables=variables)
-        
+
+        # Create templar with variables (use available_variables API)
+        templar = TemplateEngine(variables=variables)
+
         # First, template the select('defined') expression
         # This should work and filter out undefined var2
         template_expr = "{{ [var1, var2] | select('defined') }}"
         defined_vals_result = templar.template(TrustedAsTemplate().tag(template_expr))
-        
+
         # The result should be ['foo'] (var2 filtered out)
         assert defined_vals_result == ['foo']
-        
-    # Add the result to variables (simulating what happens in a playbook)
-    variables['defined_vals'] = defined_vals_result
-    templar.available_variables = variables
-        
+
+        # Add the result to variables (simulating what happens in a playbook)
+        variables['defined_vals'] = defined_vals_result
+        templar.available_variables = variables
+
         # Now test the vars lookup - this should NOT re-template the result
         lookup = LookupModule()
         lookup._templar = templar
-        
+
         # This should work without throwing AnsibleUndefinedVariable
         result = lookup.run(['defined_vals'], variables)
-        
+
         # Verify the result is correct
         assert result == [['foo']]
         assert len(result) == 1
@@ -66,14 +66,14 @@ class TestVarsLookupPlugin:
             'var1': 'world',
             'template_string': 'Hello {{ var1 }}!',
         }
-        
-    templar = TemplateEngine(variables=variables)
-        
+
+        templar = TemplateEngine(variables=variables)
+
         lookup = LookupModule()
         lookup._templar = templar
-        
+
         result = lookup.run(['template_string'], variables)
-        
+
         # The template string should be templated
         assert result == ['Hello world!']
     
@@ -86,13 +86,12 @@ class TestVarsLookupPlugin:
             'bool_val': True,
             'none_val': None,
         }
-        
-    templar = TemplateEngine(variables=variables)
-        
+
+        templar = TemplateEngine(variables=variables)
+
         lookup = LookupModule()
         lookup._templar = templar
-        
-        # Test each type
+
         for var_name, expected in variables.items():
             result = lookup.run([var_name], variables)
             assert result == [expected], f"Failed for {var_name}: got {result}, expected {[expected]}"
@@ -103,12 +102,12 @@ class TestVarsLookupPlugin:
             'plain_string': 'just a plain string',
             'string_with_braces': 'not a {template} at all',
         }
-        
-    templar = TemplateEngine(variables=variables)
-        
+
+        templar = TemplateEngine(variables=variables)
+
         lookup = LookupModule()
         lookup._templar = templar
-        
+
         for var_name, expected in variables.items():
             result = lookup.run([var_name], variables)
             assert result == [expected], f"Failed for {var_name}: got {result}, expected {[expected]}"


### PR DESCRIPTION
Summary Fix a regression where the ansible.builtin.vars lookup re-templated all returned values and re-evaluated templates (including those using select('defined')), causing AnsibleUndefinedVariable. The lookup now templates only string values that contain template syntax, avoiding re-evaluation of already-processed results.

Root cause The plugin called self._templar._engine.template(ret), which re-templated the entire results list. If a variable’s value came from a template expression that filtered undefined values (e.g., [var1, var2] | select('defined')), re-templating re-ran the expression and re-triggered undefined-variable access.

The fix

Template only string values that appear to contain template syntax using the existing is_possibly_template() helper.
Return non-strings and already-evaluated values as-is (lists, dicts, ints, etc.).
Files changed

[vars.py](vscode-file://vscode-app/c:/Users/Dhruv%20Rastogi/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — implement selective templating
[test_vars.py](vscode-file://vscode-app/c:/Users/Dhruv%20Rastogi/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — unit tests for:
select('defined') scenario
normal string templating
non-string and plain-string cases
changelogs/fragments/vars-lookup-select-defined-fix.yml — changelog fragment
Tests / verification

Unit tests added under test/units/plugins/lookup.
Manual playbook reproduction no longer errors when using select('defined').
Backwards compatibility and risk Low risk. Restores historical behavior: only strings that look like templates are templated. Non-string results and already-evaluated values are returned unchanged.

Notes for reviewers Uses is_possibly_template() from templating helpers. Please check templating semantics around embedded templates and any edge cases; tests cover representative scenarios.