### PR TITLE
Fix uncaught exception in dnf module

### DIFF
--- a/changelogs/fragments/85693-fix-dnf-conf-file-error-handling.yml
+++ b/changelogs/fragments/85693-fix-dnf-conf-file-error-handling.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf - Fail gracefully with json output when an invalid ``conf_file`` is used instead of dumping raw exception and traceback. (https://github.com/ansible/ansible/issues/85681)

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -521,7 +521,10 @@ class DnfModule(YumDnf):
                 conf.config_file_path = conf_file
 
         # Read the configuration file
-        conf.read()
+        try:
+            conf.read()
+        except dnf.exceptions.ConfigError as e:
+            self.module.fail_json(msg="Failed to read configuration file", exception=e, conf_file=conf_file)
 
         # Turn off debug messages in the output
         conf.debuglevel = 0

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -569,7 +569,7 @@ class Dnf5Module(YumDnf):
         try:
             base.load_config()
         except libdnf5.exception.InvalidConfigErrorNested as e:
-            self.module.fail_json(msg=f"Failed to load configuration file", exception=e, conf_file=conf.config_file_path)
+            self.module.fail_json(msg="Failed to load configuration file", exception=e, conf_file=conf.config_file_path)
 
         if self.releasever is not None:
             variables = base.get_vars()

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -568,8 +568,8 @@ class Dnf5Module(YumDnf):
 
         try:
             base.load_config()
-        except libdnf5.exception.InvalidConfigError as e:
-            self.module.fail_json(msg="Failed to load configuration file", exception=e, conf_file=conf.config_file_path)
+        except libdnf5.exception.InvalidConfigErrorNested as e:
+            self.module.fail_json(msg=f"Failed to load configuration file", exception=e, conf_file=conf.config_file_path)
 
         if self.releasever is not None:
             variables = base.get_vars()

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -566,7 +566,10 @@ class Dnf5Module(YumDnf):
         if self.conf_file:
             conf.config_file_path = self.conf_file
 
-        base.load_config()
+        try:
+            base.load_config()
+        except libdnf5.exception.InvalidConfigError as e:
+            self.module.fail_json(msg="Failed to load configuration file", exception=e, conf_file=conf.config_file_path)
 
         if self.releasever is not None:
             variables = base.get_vars()

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -910,7 +910,7 @@
     - name: Make bad conf file
       copy:
         dest: "{{ remote_tmp_dir }}/bad_conf_file"
-        contents: '[broken_section\nname=value'
+        content: '[broken_section\nname=value'
 
     - name: Run dnf with bad conf file
       dnf:

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -911,13 +911,15 @@
       copy:
         dest: "{{ remote_tmp_dir }}/bad_conf_file"
         contents: '[broken_section\nname=value'
+
     - name: Run dnf with bad conf file
       dnf:
         conf_file: "{{ remote_tmp_dir }}/bad_conf_file"
       ignore_errors: true
       register: bad_conf_file_error
+
     - name: Assert failure
       assert:
         that:
           - bad_conf_file_error is failed
-          - "configuration file" in bad_conf_file_error.msg
+          - '"configuration file" in bad_conf_file_error.msg'

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -904,3 +904,20 @@
           - '"nonexisting" in enable_plugin_result.msg'
           - '"nonexisting" in disable_plugin_result.msg'
   when: dnf5
+
+- name: test an invalid conf_file
+  block:
+    - name: Make bad conf file
+      copy:
+        dest: "{{ remote_tmp_dir }}/bad_conf_file"
+        contents: '[broken_section\nname=value'
+    - name: Run dnf with bad conf file
+      dnf:
+        conf_file: "{{ remote_tmp_dir }}/bad_conf_file"
+      ignore_errors: true
+      register: bad_conf_file_error
+    - name: Assert failure
+      assert:
+        that:
+          - bad_conf_file_error is failed
+          - "configuration file" in bad_conf_file_error.msg


### PR DESCRIPTION
##### SUMMARY

When run with an invalid configuration file, the dnf module
does not catch parse errors when reading/loading the file.
This catches the error and makes the module fail gracefully
with correct json output.

This PR also adds tests for this failure. 

Fixes #85681

##### ISSUE TYPE

- Bugfix Pull Request
- Test Pull Request
