### PR TITLE
[stable-2.19] Include result origin in broken conditional message instead of result (#85695)

### DIFF
--- a/changelogs/fragments/elide_broken_conditional_result.yml
+++ b/changelogs/fragments/elide_broken_conditional_result.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - conditionals - When displaying a broken conditional error or deprecation warning, 
+    the origin of the non-boolean result is included (if available), and the raw result is omitted.

--- a/lib/ansible/_internal/_templating/_engine.py
+++ b/lib/ansible/_internal/_templating/_engine.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import copy
 import dataclasses
 import enum
-import textwrap
 import typing as t
 import collections.abc as c
 import re
@@ -560,9 +559,11 @@ class TemplateEngine:
 
         bool_result = bool(result)
 
+        result_origin = Origin.get_tag(result) or Origin.UNKNOWN
+
         msg = (
-            f'Conditional result was {textwrap.shorten(str(result), width=40)!r} of type {native_type_name(result)!r}, '
-            f'which evaluates to {bool_result}. Conditionals must have a boolean result.'
+            f'Conditional result ({bool_result}) was derived from value of type {native_type_name(result)!r} at {str(result_origin)!r}. '
+            'Conditionals must have a boolean result.'
         )
 
         if _TemplateConfig.allow_broken_conditionals:


### PR DESCRIPTION
##### SUMMARY

(cherry picked from commit b1fc98c8ad9d56ee65cc43fb46de87f2ee52b18c)

##### ISSUE TYPE
- Bugfix Pull Request
