### PR TITLE
setup - add lvs subkey to ansible_facts['vgs'] values

### DIFF
--- a/changelogs/fragments/85632-setup-logical-volume-name-uniqueness.yml
+++ b/changelogs/fragments/85632-setup-logical-volume-name-uniqueness.yml
@@ -1,0 +1,6 @@
+minor_changes:
+- >-
+  setup - added new subkey ``lvs`` within each entry of ``ansible_facts['vgs']``
+  to provide complete logical volume data scoped by volume group.
+  The top level ``lvs`` fact by comparison, deduplicates logical volume names
+  across volume groups and may be incomplete. (https://github.com/ansible/ansible/issues/85632)

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -907,8 +907,13 @@ class LinuxHardware(Hardware):
                     # The LV name is only unique per VG, so the top level fact lvs can be misleading.
                     # TODO: deprecate lvs in favor of vgs
                     lvs[lv_name] = {'size_g': items[3], 'vg': vg_name}
-                    if vg_name in vgs:
+                    try:
                         vgs[vg_name]['lvs'][lv_name] = {'size_g': items[3]}
+                    except KeyError:
+                        module.warn(
+                            "An LVM volume group was created while gathering LVM facts, "
+                            "and is not included in ansible_facts['vgs']."
+                        )
 
             pvs_path = self.module.get_bin_path('pvs')
             # pvs fields: PV VG #Fmt #Attr PSize PFree

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -890,7 +890,8 @@ class LinuxHardware(Hardware):
                     'size_g': items[-2],
                     'free_g': items[-1],
                     'num_lvs': items[2],
-                    'num_pvs': items[1]
+                    'num_pvs': items[1],
+                    'lvs': {},
                 }
 
             lvs_path = self.module.get_bin_path('lvs')
@@ -901,7 +902,13 @@ class LinuxHardware(Hardware):
                 rc, lv_lines, err = self.module.run_command('%s %s' % (lvs_path, lvm_util_options))
                 for lv_line in lv_lines.splitlines():
                     items = lv_line.strip().split(',')
-                    lvs[items[0]] = {'size_g': items[3], 'vg': items[1]}
+                    vg_name = items[1]
+                    lv_name = items[0]
+                    # The LV name is only unique per VG, so the top level fact lvs can be misleading.
+                    # TODO: deprecate lvs in favor of vgs
+                    lvs[lv_name] = {'size_g': items[3], 'vg': vg_name}
+                    if vg_name in vgs:
+                        vgs[vg_name]['lvs'][lv_name] = {'size_g': items[3]}
 
             pvs_path = self.module.get_bin_path('pvs')
             # pvs fields: PV VG #Fmt #Attr PSize PFree

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -910,7 +910,7 @@ class LinuxHardware(Hardware):
                     try:
                         vgs[vg_name]['lvs'][lv_name] = {'size_g': items[3]}
                     except KeyError:
-                        module.warn(
+                        self.module.warn(
                             "An LVM volume group was created while gathering LVM facts, "
                             "and is not included in ansible_facts['vgs']."
                         )

--- a/test/integration/targets/hardware_facts/tasks/Linux.yml
+++ b/test/integration/targets/hardware_facts/tasks/Linux.yml
@@ -52,7 +52,22 @@
           - ansible_lvm.lvs.two.vg == 'first'
           - ansible_lvm.lvs.uno.vg == 'second'
           - ansible_lvm.vgs.first.num_lvs == "2"
+          - ansible_facts['lvm']['vgs']['first']['lvs'] | sort == ['one', 'two']
           - ansible_lvm.vgs.second.num_lvs == "1"
+          - ansible_facts['lvm']['vgs']['second']['lvs'] | sort == ['uno']
+
+    - name: Create another lv using duplicate name
+      command: lvcreate -L 4M second --name two
+
+    - name: Gather facts
+      setup:
+
+    - assert:
+        that:
+          - ansible_facts['lvm']['vgs']['first']['lvs'] | sort == ['one', 'two']
+          - ansible_facts['lvm']['vgs']['second']['lvs'] | sort == ['two', 'uno']
+          # only one lv named 'two' is represented in the top level lvs fact
+          - ansible_facts['lvm']['lvs']['two']['vg'] == 'second'
 
   always:
     - name: remove lvs

--- a/test/integration/targets/hardware_facts/tasks/Linux.yml
+++ b/test/integration/targets/hardware_facts/tasks/Linux.yml
@@ -68,6 +68,9 @@
           - ansible_facts['lvm']['vgs']['second']['lvs'] | sort == ['two', 'uno']
           # only one lv named 'two' is represented in the top level lvs fact
           - ansible_facts['lvm']['lvs']['two']['vg'] == 'second'
+          - (vgs_lvs | unique | sort) == (ansible_facts['lvm']['lvs'] | sort)
+      vars:
+        vgs_lvs: "{{ ansible_facts['lvm']['vgs'].values() | map(attribute='lvs') | map('list') | flatten }}"
 
   always:
     - name: remove lvs


### PR DESCRIPTION
##### SUMMARY

In triage we discussed deprecating ansible_facts['lvs'], which can be incomplete, in favor of extracting the logical volumes from ansible_facts['vgs'], but upon closer inspection, this data isn't available there yet. This adds that.

Fixes #85632

##### ISSUE TYPE

- Feature Pull Request
