### PR TITLE
[stable-2.19] Expose ansible_failed_task in rescue for explicit flush_handlers (#85687)

### DIFF
--- a/changelogs/fragments/85682-rescue-flush_handlers.yml
+++ b/changelogs/fragments/85682-rescue-flush_handlers.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - The ``ansible_failed_task`` variable is now correctly exposed in a rescue section, even when a failing handler is triggered by the ``flush_handlers`` task in the corresponding ``block`` (https://github.com/ansible/ansible/issues/85682)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -574,7 +574,7 @@ class PlayIterator:
         Given the current HostState state, determines if the current block, or any child blocks,
         are in rescue mode.
         """
-        if state.run_state == IteratingStates.TASKS and state.get_current_block().rescue:
+        if state.run_state in (IteratingStates.TASKS, IteratingStates.HANDLERS) and state.get_current_block().rescue:
             return True
         if state.tasks_child_state is not None:
             return self.is_any_block_rescuing(state.tasks_child_state)

--- a/test/integration/targets/handlers/rescue_flush_handlers.yml
+++ b/test/integration/targets/handlers/rescue_flush_handlers.yml
@@ -1,0 +1,16 @@
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - block:
+        - debug:
+          changed_when: true
+          notify: h1
+
+        - meta: flush_handlers
+      rescue:
+        - assert:
+            that:
+              - ansible_failed_task is defined
+  handlers:
+    - name: h1
+      fail:

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -230,3 +230,5 @@ ansible-playbook handler_notify_earlier_handler.yml "$@" 2>&1 | tee out.txt
 ANSIBLE_DEBUG=1 ansible-playbook tagged_play.yml --skip-tags the_whole_play "$@" 2>&1 | tee out.txt
 [ "$(grep out.txt -ce 'META: triggered running handlers')" = "0" ]
 [ "$(grep out.txt -ce 'handler_ran')" = "0" ]
+
+ansible-playbook rescue_flush_handlers.yml "$@"


### PR DESCRIPTION
##### SUMMARY
Backport of #85687

(cherry picked from commit c5ddc9376765f99f0f02ebe6111d1ad99374087c)
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request