### PR TITLE
Correct Access of renamed attributes in RoleMetadata.serialize()

### DIFF
--- a/lib/ansible/playbook/role/metadata.py
+++ b/lib/ansible/playbook/role/metadata.py
@@ -108,8 +108,8 @@ class RoleMetadata(Base, CollectionSearch):
 
     def serialize(self):
         return dict(
-            allow_duplicates=self._allow_duplicates,
-            dependencies=self._dependencies
+            allow_duplicates=self.allow_duplicates,
+            dependencies=self.dependencies
         )
 
     def deserialize(self, data):


### PR DESCRIPTION
##### SUMMARY



In 43153c58310d02223f2cb0964f4255ba1ac4ed53 , some attributes of `ansible.playbook.role.metadata.RoleMetadata` were renamed but their access was not updated.

##### Description

The relevant renamed attributes are:

 - `_allow_duplicates` → `allow_duplicates`
 - `_dependencies` → `dependencies`

However, it seems to it was forgotten to also update their access in `RoleMetadata.serialize()` and so you currently get:

```
self = <ansible.playbook.role.metadata.RoleMetadata object at 0x7f246b5ea440>

    def serialize(self):
        return dict(
>           allow_duplicates=self._allow_duplicates,
            dependencies=self._dependencies
        )
E       AttributeError: 'RoleMetadata' object has no attribute '_allow_duplicates'. Did you mean: 'allow_duplicates'?
```

This PR updates the renames also in `serialize()`.

##### ISSUE TYPE

- Bugfix Pull Request
