### PR TITLE
[stable-2.18] user: Fix homedir permissions when UMASK is unset in /etc/login.defs

### DIFF
--- a/changelogs/fragments/user_module.yml
+++ b/changelogs/fragments/user_module.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - user - Use higher precedence HOME_MODE as UMASK for path provided (https://github.com/ansible/ansible/pull/84482).

--- a/test/integration/targets/user/tasks/test_no_home_fallback.yml
+++ b/test/integration/targets/user/tasks/test_no_home_fallback.yml
@@ -35,12 +35,17 @@
         import os
         try:
             for line in open('/etc/login.defs').readlines():
+                m = re.match(r'^HOME_MODE\s+(\d+)$', line)
+                if m:
+                    mode = oct(int(m.group(1), 8))
+                    break
                 m = re.match(r'^UMASK\s+(\d+)$', line)
                 if m:
                     umask = int(m.group(1), 8)
+                    mode = oct(0o777 & ~umask)
         except:
             umask = os.umask(0)
-        mode = oct(0o777 & ~umask)
+            mode = oct(0o777 & ~umask)
         print(str(mode).replace('o', ''))
       args:
         executable: "{{ ansible_python_interpreter }}"


### PR DESCRIPTION
When a user doesn't exist and user module is used to create the user and the homedir, adduser is called which parses HOME_MODE from /etc/login.defs, and when not set calculates the mode from UMASK from the same file.

When a user already exists without homedir, and the user module is used to add a home dir, it incorrectly ignores HOME_MODE, resulting in a world-readable home dir when UMASK is not set. This is for example the case in Debian trixie and later, and likely Ubuntu 25.04 and later.

(cherry picked from commit 3030c79)

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request