### PR TITLE
Remove excessive apostrophe in documentation of package_facts.py

### DIFF
--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -18,7 +18,7 @@ options:
         This is a list and can support multiple package managers per system, since version 2.8.
       - The V(portage) and V(pkg) options were added in version 2.8.
       - The V(apk) option was added in version 2.11.
-      - The V(pkg_info)' option was added in version 2.13.
+      - The V(pkg_info) option was added in version 2.13.
       - Aliases were added in 2.18, to support using C(manager={{ansible_facts['pkg_mgr']}})
     default: ['auto']
     choices:


### PR DESCRIPTION
##### SUMMARY

Change:
The pkg_info‘ option was added in version 2.13.

To:
The pkg_info option was added in version 2.13.

##### ISSUE TYPE

- Docs Pull Request
