### PR TITLE
Special Handling For Bundled Collections Without Manifests

### DIFF
--- a/changelogs/fragments/85711-handing-for-collection-without-mainifests.yml
+++ b/changelogs/fragments/85711-handing-for-collection-without-mainifests.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- >-
+  ansible-doc  - fix in the ansible-doc process error output _protomatter related Warning log(https://github.com/ansible/ansible/pull/85711).

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -25,7 +25,7 @@ if t.TYPE_CHECKING:
         'Candidate', 'Requirement',
         '_ComputedReqKindsMixin',
     )
-
+import ansible
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.collection import HAS_PACKAGING, PkgReq
@@ -39,6 +39,7 @@ _ALLOW_CONCRETE_POINTER_IN_SOURCE = False  # NOTE: This is a feature flag
 _GALAXY_YAML = b'galaxy.yml'
 _MANIFEST_JSON = b'MANIFEST.json'
 _SOURCE_METADATA_FILE = b'GALAXY.yml'
+_ANSIBLE_PACKAGE_PATH = pathlib.Path(ansible.__file__).parent
 
 display = Display()
 
@@ -225,6 +226,12 @@ class _ComputedReqKindsMixin:
             dir_path = dir_path.rstrip(to_bytes(os.path.sep))
         if not _is_collection_dir(dir_path):
             dir_pathlib = pathlib.Path(to_text(dir_path))
+
+            # special handling for bundled collections without manifests, e.g., ansible._protomatter
+            if dir_pathlib.is_relative_to(_ANSIBLE_PACKAGE_PATH):
+                req_name = f'{dir_pathlib.parent.name}.{dir_pathlib.name}'
+                return cls(req_name, ansible.release.__version__, dir_path, 'dir', None)
+
             display.warning(
                 u"Collection at '{path!s}' does not have a {manifest_json!s} "
                 u'file, nor has it {galaxy_yml!s}: cannot detect version.'.


### PR DESCRIPTION
##### SUMMARY

reference #85689 

`ansible-doc --metadata-dump > /dev/null` prints a lot of deprecation warnings for all deprecated plugins it finds, but it also prints:
```
[WARNING]: Collection at '/path/to/ansible/lib/ansible/_internal/ansible_collections/ansible/_protomatter' does not have a MANIFEST.json file, nor has it galaxy.yml: cannot detect version.
```

`_protomatter` does not have configuration files, so it should not be output. #84621 has been designed for this, but there are no corresponding modifications in `devel`. This PR aims to revert the corresponding judgment.

Fixes #85689

##### ISSUE TYPE

- Bugfix Pull Request
