### PR TITLE
Forming a Boolean Filter, with the Standard Definition of Booleans in…

### DIFF
--- a/changelogs/fragments/fix-bool-filter.yml
+++ b/changelogs/fragments/fix-bool-filter.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - bool - Changed redefinition of value from integer to boolean on bool filter.

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -101,7 +101,7 @@ def to_bool(value: object) -> bool:
     if isinstance(value, str):
         value_to_check = value.lower()  # accept mixed case variants
     elif isinstance(value, int):  # bool is also an int
-        value_to_check = str(value).lower()  # accept int (0, 1) and bool (True, False) -- not just string versions
+        value_to_check = str(bool(value)).lower()  # accept int (0, 1) and bool (True, False) -- not just string versions
     else:
         value_to_check = value
 

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -365,7 +365,7 @@
       - (None|bool)==false
       - (1.0|bool)==true
       - (0.0|bool)==false
-      - (7|bool)==false
+      - (7|bool)==true
       - ({}|bool)==false
 
 - name: Verify to_datetime


### PR DESCRIPTION
##### SUMMARY

Now there is a logical problem when, when converting an integer value to a Boolean value, the bool filter outputs an incorrect value.

For an example: 

```
 - ansible.builtin.set_fact:
       a: "{{ 1 | bool }}"
```

Outputs true, which is generally logical. 
But if you do 

```
- ansible.builtin.set_fact:
      a: "{{ 2 | bool }}"
```

Outputs false, which is not logical as in most programming languages. Must be set to true. 

Using the example of Python itself, translating the same number to 2 will return true. 

```
>>> bool(2)
True
```

- Bugfix Pull Request
