### PR TITLE
chore: Fix typos

### DIFF
--- a/lib/ansible/_internal/_wrapt.py
+++ b/lib/ansible/_internal/_wrapt.py
@@ -788,7 +788,7 @@ class FunctionWrapper(_FunctionWrapperBase):
         #
         # 4. The wrapper is being applied when performing monkey
         # patching of an instance of a class. In this case binding will
-        # have been perfomed where the instance was not None.
+        # have been performed where the instance was not None.
         #
         # This case is a problem because we can no longer tell if the
         # method was a static method.

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -175,7 +175,7 @@ def add_fragments(doc, filename, fragment_loader, is_module=False, section='DOCU
         add_collection_to_versions_and_dates(fragment, real_collection_name, is_module=is_module, return_docs=(section == 'RETURN'))
 
         if section == 'DOCUMENTATION':
-            # notes, seealso, options and attributes entries are specificly merged, but only occur in documentation section
+            # notes, seealso, options and attributes entries are specifically merged, but only occur in documentation section
             for doc_key in ['notes', 'seealso']:
                 if doc_key in fragment:
                     entries = fragment.pop(doc_key)


### PR DESCRIPTION
##### SUMMARY

Fix typos:
 - From `perfomed` to `performed`
 - From `specificly` to `specifically`
