### PR TITLE
fetch: Return `file` attribute on file change

### DIFF
--- a/changelogs/fragments/fix-fetch-return-file.yml
+++ b/changelogs/fragments/fix-fetch-return-file.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fetch - also return ``file`` in the result when changed is ``True`` (https://github.com/ansible/ansible/pull/85729).

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -193,7 +193,7 @@ class ActionModule(ActionBase):
                                        msg="checksum mismatch", file=source, dest=dest, remote_md5sum=None,
                                        checksum=new_checksum, remote_checksum=remote_checksum))
                 else:
-                    result.update({'changed': True, 'md5sum': new_md5, 'dest': dest,
+                    result.update({'changed': True, 'md5sum': new_md5, 'file': source, 'dest': dest,
                                    'remote_md5sum': None, 'checksum': new_checksum,
                                    'remote_checksum': remote_checksum})
             else:

--- a/test/integration/targets/fetch/roles/fetch_tests/tasks/normal.yml
+++ b/test/integration/targets/fetch/roles/fetch_tests/tasks/normal.yml
@@ -30,8 +30,10 @@
     that:
       - fetched is changed
       - fetched.checksum == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
+      - fetched.file == remote_tmp_dir ~ "/orig"
       - fetched_again is not changed
       - fetched_again.checksum == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
+      - fetched_again.file == remote_tmp_dir ~ "/orig"
       - fetched.remote_checksum == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
       - lookup("file", output_dir + "/fetched/" + inventory_hostname + remote_tmp_dir + "/orig") == "test"
       - fetch_check_mode is skipped


### PR DESCRIPTION
Set the (source) `file` attribute in the return value if the file changed (e.g. on initial fetch). The attribute is already set in all other cases.

##### SUMMARY

I found that the `ansible.builtin.fetch` module does not always return the `file` attribute.
A bit of debugging showed that it was missing when the file get fetched for the first time, but is there on subsequent runs (unless the source file changed).

The following play reproduces the issue:

```yaml
- hosts: localhost
  tasks:
    - name: 'Remove local file'
      ansible.builtin.file:
        path: '/tmp/test'
        state: absent

    - name: 'Initial fetch'
      ansible.builtin.fetch:
        src: '/etc/issue'
        dest: '/tmp/test'
      register: initial_fetch

    - ansible.builtin.debug:
        var: initial_fetch

    - name: 'Second fetch'
      ansible.builtin.fetch:
        src: '/etc/issue'
        dest: '/tmp/test'
      register: second_fetch

    - ansible.builtin.debug:
        var: second_fetch
```

Without this PR, I get the following output:

```
TASK [Remove local file] **********************************************************************************
ok: [localhost]

TASK [Initial fetch] **************************************************************************************
changed: [localhost]

TASK [ansible.builtin.debug] ******************************************************************************
ok: [localhost] => {
    "initial_fetch": {
        "changed": true,
        "checksum": "82cc1760b79b5feebadeb049e089a7709b720ec8",
        "dest": "/tmp/test/localhost/etc/issue",
        "failed": false,
        "md5sum": "f2321b0cda1591471121e24855fad24e",
        "remote_checksum": "82cc1760b79b5feebadeb049e089a7709b720ec8",
        "remote_md5sum": null
    }
}

TASK [Second fetch] ***************************************************************************************
ok: [localhost]

TASK [ansible.builtin.debug] ******************************************************************************
ok: [localhost] => {
    "second_fetch": {
        "changed": false,
        "checksum": "82cc1760b79b5feebadeb049e089a7709b720ec8",
        "dest": "/tmp/test/localhost/etc/issue",
        "failed": false,
        "file": "/etc/issue",
        "md5sum": "f2321b0cda1591471121e24855fad24e"
    }
}

PLAY RECAP ************************************************************************************************
localhost                  : ok=6    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0 
```

Note the different attributes in the output of both debug tasks.
Also note that `remote_checksum` and `remote_md5` are only returned when the file changed. However, `checksum` and `md5sum` contain (more or less) the same information.

##### ISSUE TYPE

- Bugfix Pull Request