### PR TITLE
[stable-2.18] basic: handle exception while spliting args

### DIFF
--- a/changelogs/fragments/basic_shlex_split.yml
+++ b/changelogs/fragments/basic_shlex_split.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - basic - handle exception raised while shlex.split (https://github.com/ansible/ansible/issues/85719).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1853,7 +1853,10 @@ class AnsibleModule(object):
         else:
             # ensure args are a list
             if isinstance(args, (bytes, str)):
-                args = shlex.split(to_text(args, errors='surrogateescape'))
+                try:
+                    args = shlex.split(to_text(args, errors='surrogateescape'))
+                except ValueError as ex:
+                    self.fail_json(msg=f"failed to split args given to run_command: {ex}")
 
             # expand ``~`` in paths, and all environment vars
             if expand_user_and_vars:

--- a/test/integration/targets/assemble/tasks/main.yml
+++ b/test/integration/targets/assemble/tasks/main.yml
@@ -168,3 +168,22 @@
       - result.diff.after is defined
       - result.diff.before is defined
       - "result.state == 'file'"
+
+- name: Setup for validate test
+  ansible.builtin.file:
+    path: "{{ remote_tmp_dir }}/src_val_syntax"
+    state: directory
+
+- name: assemble with invalid validation command
+  ansible.builtin.assemble:
+    src: "{{ remote_tmp_dir }}/src_val_syntax"
+    dest: "{{ remote_tmp_dir }}/dest_val_syntax"
+    validate: "echo 'missing %s"
+  register: assemble_syntax_error
+  ignore_errors: yes
+
+- name: assert assemble failed with error
+  assert:
+    that:
+      - assemble_syntax_error.failed
+      - "'failed to split args' in assemble_syntax_error.msg"


### PR DESCRIPTION
##### SUMMARY

* Handle an exception raised while spliting args using shlex.split

Fixes: #85719

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/basic_shlex_split.yml
lib/ansible/module_utils/basic.py
test/integration/targets/assemble/tasks/main.yml


