### PR TITLE
dnf: Check if installroot is directory or not

### DIFF
--- a/changelogs/fragments/dnf_installroot_dir.yml
+++ b/changelogs/fragments/dnf_installroot_dir.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - dnf - Check if installroot is directory or not (https://github.com/ansible/ansible/issues/85680).

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -538,7 +538,7 @@ class DnfModule(YumDnf):
 
         # Set installroot
         if not os.path.isdir(installroot):
-            self.module.fail_json(msg=f"Installroot {installroot} must be a directory")
+            raise ValueError(f"Installroot {installroot} must be a directory")
 
         conf.installroot = installroot
 

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -537,8 +537,9 @@ class DnfModule(YumDnf):
         conf.sslverify = sslverify
 
         # Set installroot
-        if os.path.isfile(installroot):
-            self.module.fail_json(msg="Installroot must be a directory")
+        if not os.path.isdir(installroot):
+            self.module.fail_json(msg=f"Installroot {installroot} must be a directory")
+
         conf.installroot = installroot
 
         # Load substitutions from the filesystem

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -537,6 +537,8 @@ class DnfModule(YumDnf):
         conf.sslverify = sslverify
 
         # Set installroot
+        if os.path.isfile(installroot):
+            self.module.fail_json(msg="Installroot must be a directory")
         conf.installroot = installroot
 
         # Load substitutions from the filesystem

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -538,7 +538,7 @@ class DnfModule(YumDnf):
 
         # Set installroot
         if not os.path.isdir(installroot):
-            raise ValueError(f"Installroot {installroot} must be a directory")
+            self.module.fail_json(msg=f"Installroot {installroot} must be a directory")
 
         conf.installroot = installroot
 

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -597,7 +597,7 @@ class Dnf5Module(YumDnf):
         conf.clean_requirements_on_remove = self.autoremove
 
         if not os.path.isdir(self.installroot):
-            self.module.fail_json(msg=f"Installroot {self.installroot} must be a directory")
+            raise ValueError(f"Installroot {self.installroot} must be a directory")
 
         conf.installroot = self.installroot
         conf.use_host_config = True  # needed for installroot

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -595,8 +595,9 @@ class Dnf5Module(YumDnf):
         conf.localpkg_gpgcheck = not self.disable_gpg_check
         conf.sslverify = self.sslverify
         conf.clean_requirements_on_remove = self.autoremove
-        if os.path.isfile(self.installroot):
-            self.module.fail_json(msg="Installroot must be a directory")
+
+        if not os.path.isdir(self.installroot):
+            self.module.fail_json(msg=f"Installroot {self.installroot} must be a directory")
 
         conf.installroot = self.installroot
         conf.use_host_config = True  # needed for installroot

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -595,6 +595,9 @@ class Dnf5Module(YumDnf):
         conf.localpkg_gpgcheck = not self.disable_gpg_check
         conf.sslverify = self.sslverify
         conf.clean_requirements_on_remove = self.autoremove
+        if os.path.isfile(self.installroot):
+            self.module.fail_json(msg="Installroot must be a directory")
+
         conf.installroot = self.installroot
         conf.use_host_config = True  # needed for installroot
         conf.cacheonly = "all" if self.cacheonly else "none"

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -597,7 +597,7 @@ class Dnf5Module(YumDnf):
         conf.clean_requirements_on_remove = self.autoremove
 
         if not os.path.isdir(self.installroot):
-            raise ValueError(f"Installroot {self.installroot} must be a directory")
+            self.module.fail_json(msg=f"Installroot {self.installroot} must be a directory")
 
         conf.installroot = self.installroot
         conf.use_host_config = True  # needed for installroot

--- a/test/integration/targets/dnf/tasks/dnfinstallroot.yml
+++ b/test/integration/targets/dnf/tasks/dnfinstallroot.yml
@@ -46,7 +46,7 @@
         dest: "{{ remote_tmp_dir }}/file_root"
 
     - name: Try with invalid installroot
-      ansible.builtin.dnf:
+      dnf:
         name: bash
         state: present
         installroot: "{{ remote_tmp_dir }}/file_root"

--- a/test/integration/targets/dnf/tasks/dnfinstallroot.yml
+++ b/test/integration/targets/dnf/tasks/dnfinstallroot.yml
@@ -57,7 +57,7 @@
       assert:
         that:
             - invalid_install_root.failed
-            - "'Installroot must be a directory' in invalid_install_root.msg"
+            - "'Installroot ' ~ remote_tmp_dir ~ '/file_root must be a directory' in invalid_install_root.msg"
   always:
     - name: Cleanup invalid installroot
       file:

--- a/test/integration/targets/dnf/tasks/dnfinstallroot.yml
+++ b/test/integration/targets/dnf/tasks/dnfinstallroot.yml
@@ -33,3 +33,33 @@
   file:
     path: "/{{ dnfroot.stdout }}/"
     state: absent
+
+- block:
+    - name: Clean setup
+      file:
+        path: "{{ remote_tmp_dir }}/file_root"
+        state: absent
+
+    - name: Setup - create invalid installroot file (not a dir)
+      copy:
+        content: ''
+        dest: "{{ remote_tmp_dir }}/file_root"
+
+    - name: Try with invalid installroot
+      ansible.builtin.dnf:
+        name: bash
+        state: present
+        installroot: "{{ remote_tmp_dir }}/file_root"
+      ignore_errors: yes
+      register: invalid_install_root
+
+    - name: Check if invalid installroot failed
+      assert:
+        that:
+            - invalid_install_root.failed
+            - "'Installroot must be a directory' in invalid_install_root.msg"
+  always:
+    - name: Cleanup invalid installroot
+      file:
+        path: "{{ remote_tmp_dir }}/file_root"
+        state: absent


### PR DESCRIPTION
##### SUMMARY

* dnf library creates installroot if it is missing.
  check if installroot is directory or not.

Fixes: #85680

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/dnf_installroot_dir.yml
lib/ansible/modules/dnf.py
lib/ansible/modules/dnf5.py
test/integration/targets/dnf/tasks/dnfinstallroot.yml


