### PR TITLE
[stable-2.19] ternary: evaluate values lazily (#85752)

### DIFF
--- a/changelogs/fragments/85743-lazy-ternary.yml
+++ b/changelogs/fragments/85743-lazy-ternary.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "``ternary`` filter - evaluate values lazily (https://github.com/ansible/ansible/issues/85743)"

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -221,6 +221,7 @@ def regex_search(value, regex, *args, **kwargs):
             return items
 
 
+@accept_args_markers
 def ternary(value, true_val, false_val, none_val=None):
     """  value ? true_val : false_val """
     if value is None and none_val is not None:

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -430,6 +430,13 @@
       - '123|ternary("seven", "eight") == "seven"'
       - '"haha"|ternary("seven", "eight") == "seven"'
 
+- name: Verify ternary does not evaluate unused values
+  assert:
+    that:
+      - (false | ternary(undefined_variable, 'seven')) == (false | ternary(d.no_such_key, 'seven'))
+  vars:
+    d: {}
+
 - name: Verify regex_escape raises on posix_extended (failure expected)
   set_fact:
     foo: '{{"]]^"|regex_escape(re_type="posix_extended")}}'


### PR DESCRIPTION
##### SUMMARY
Backport of #85752

(cherry picked from commit 6976e130757cd9e8b1346c21c28174e2903585b9)
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request