### PR TITLE
command: deprecate stdout in return while using creates/removes

### DIFF
--- a/changelogs/fragments/command_skip_stdout.yml
+++ b/changelogs/fragments/command_skip_stdout.yml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+    - command - deprecate unnecessary stdout when creates or removes is used (https://github.com/ansible/ansible/issues/84107).

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -228,6 +228,11 @@ stderr_lines:
   returned: always
   type: list
   sample: [u'ls cannot access foo: No such file or directory', u'ls …']
+skip_reason:
+  description: The reason why the task was skipped.
+  returned: when task is skipped
+  type: str
+  sample: 'skipped, since /tmp/file exists'
 """
 
 import datetime
@@ -313,15 +318,14 @@ def main():
     if creates:
         if glob.glob(creates):
             r['msg'] = "%s not run command since '%s' exists" % (shoulda, creates)
-            r['stdout'] = "skipped, since %s exists" % creates  # TODO: deprecate
-
+            r['stdout'] = "skipped, since %s exists" % creates  # Deprecated using action plugin
             r['rc'] = 0
 
     # special skips for idempotence if file does not exist (assumes command removes)
     if not r['msg'] and removes:
         if not glob.glob(removes):
             r['msg'] = "%s not run command since '%s' does not exist" % (shoulda, removes)
-            r['stdout'] = "skipped, since %s does not exist" % removes  # TODO: deprecate
+            r['stdout'] = "skipped, since %s does not exist" % removes  # Deprecated using action plugin
             r['rc'] = 0
 
     if r['msg']:
@@ -343,6 +347,7 @@ def main():
         if creates is None and removes is None:
             r['skipped'] = True
             # skipped=True and changed=True are mutually exclusive
+            r['skip_reason'] = r['msg']
             r['changed'] = False
 
     # convert to text for jsonization and usability

--- a/lib/ansible/plugins/action/command.py
+++ b/lib/ansible/plugins/action/command.py
@@ -5,6 +5,16 @@ from __future__ import annotations
 
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import merge_hash
+from ansible.module_utils._internal import _deprecator
+from ansible.module_utils._internal._datatag import _tags
+
+
+_DEPRECATE_SKIPPED_STDOUT = _tags.Deprecated(
+    msg='Using `stdout` when creates/removes is used is deprecated',
+    version='2.25',
+    deprecator=_deprecator.ANSIBLE_CORE_DEPRECATOR,
+    help_text='Use `skip_reason` instead.',
+)
 
 
 class ActionModule(ActionBase):
@@ -22,5 +32,10 @@ class ActionModule(ActionBase):
         if not wrap_async:
             # remove a temporary path we created
             self._remove_tmp_path(self._connection._shell.tmpdir)
+
+        if results.get('stdout', '').startswith('skipped'):
+            results['skip_reason'] = results['stdout']
+            results['stdout_lines'] = _DEPRECATE_SKIPPED_STDOUT.tag(results['stdout_lines'])
+            results['stdout'] = _DEPRECATE_SKIPPED_STDOUT.tag(results['stdout'])
 
         return results

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -204,6 +204,28 @@
     that:
       - command_result3 is not changed
 
+- name: verify that skip.txt is absent
+  file:
+    path: "{{ remote_tmp_dir_test }}/skip.txt"
+    state: absent
+
+- name: Create a file which allow to skip the command execution
+  file:
+    state: touch
+    path: "{{ remote_tmp_dir_test }}/skip.txt"
+
+- name: Skip running command as the file already exists
+  command:
+    cmd: echo "Hello"
+    creates: "{{ remote_tmp_dir_test }}/skip.txt"
+  register: command_skip_reason
+
+- name: Check if we present skip_reason in output
+  assert:
+    that:
+      - command_skip_reason.skip_reason == "skipped, since " ~ remote_tmp_dir_test ~ "/skip.txt exists"
+      - not command_skip_reason.changed
+
 # removes
 
 - name: remove afile.txt with remote_afile.sh via command (check mode)
@@ -254,6 +276,23 @@
   assert:
     that:
       - command_result4.changed != True
+
+- name: verify that skip.txt is absent
+  file:
+    path: "{{ remote_tmp_dir_test }}/skip.txt"
+    state: absent
+
+- name: Skip running command as the file does not exist
+  command:
+    cmd: echo "Hello"
+    removes: "{{ remote_tmp_dir_test }}/skip.txt"
+  register: command_skip_reason
+
+- name: Check if we present skip_reason in output
+  assert:
+    that:
+      - command_skip_reason.skip_reason == "skipped, since " ~ remote_tmp_dir_test ~ "/skip.txt does not exist"
+      - not command_skip_reason.changed
 
 - name: pass stdin to cat via command
   command: cat


### PR DESCRIPTION
##### SUMMARY

* When command module is used with creates/removes, unnecessary
  stdout is populated. Deprecate this stdout from returning in module
  return.

Fixes: #84107

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/command_skip_stdout.yml
lib/ansible/modules/command.py
test/integration/targets/command_shell/tasks/main.yml


