### PR TITLE
apt_repository: Use correct debug method

### DIFF
--- a/changelogs/fragments/apt_repo_debug.yml
+++ b/changelogs/fragments/apt_repo_debug.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - apt_repository - use correct debug method to print debug message.

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -508,7 +508,7 @@ class UbuntuSourcesList(SourcesList):
                 try:
                     rc, out, err = self.module.run_command([self.gpg_bin, '--list-packets', key_file])
                 except OSError as ex:
-                    self.debug(f"Could check key against file {key_file!r}: {ex}")
+                    self.module.debug(f"Could check key against file {key_file!r}: {ex}")
                     continue
 
                 if key_fingerprint in out:


### PR DESCRIPTION
##### SUMMARY

* Use self.module.debug method instead of non-existent
  self.debug method

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/apt_repo_debug.yml
lib/ansible/modules/apt_repository.py


