### PR TITLE
unarchive: make timezone aware timestamp

### DIFF
--- a/changelogs/fragments/unarchive.yml
+++ b/changelogs/fragments/unarchive.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - unarchive - make timezone aware timestamp for comparsion (https://github.com/ansible/ansible/issues/85779).

--- a/changelogs/fragments/unarchive.yml
+++ b/changelogs/fragments/unarchive.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-    - unarchive - make timezone aware timestamp for comparsion (https://github.com/ansible/ansible/issues/85779).
+    - unarchive - make timezone aware timestamp for comparison (https://github.com/ansible/ansible/issues/85779).

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -428,17 +428,17 @@ class ZipArchive(object):
         """ Return a valid time object from the given time string """
         DT_RE = re.compile(r'^(\d{4})(\d{2})(\d{2})\.(\d{2})(\d{2})(\d{2})$')
         match = DT_RE.match(timestamp_str)
-        epoch_date_time = (1980, 1, 1, 0, 0, 0, 0, 0, 0)
+        epoch_date_time = (1980, 1, 1, 0, 0, 0, 0, 0, -1)
         if match:
             try:
                 if int(match.groups()[0]) < 1980:
                     date_time = epoch_date_time
                 elif int(match.groups()[0]) >= 2038 and _y2038_impacted():
-                    date_time = (2038, 1, 1, 0, 0, 0, 0, 0, 0)
+                    date_time = (2038, 1, 1, 0, 0, 0, 0, 0, -1)
                 elif int(match.groups()[0]) > 2107:
-                    date_time = (2107, 12, 31, 23, 59, 59, 0, 0, 0)
+                    date_time = (2107, 12, 31, 23, 59, 59, 0, 0, -1)
                 else:
-                    date_time = (int(m) for m in match.groups() + (0, 0, 0))
+                    date_time = (int(m) for m in match.groups() + (0, 0, -1))
             except ValueError:
                 date_time = epoch_date_time
         else:

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -9,6 +9,7 @@
 - import_tasks: test_tar_gz_content_differs.yml
 - import_tasks: test_tar_zst.yml
 - import_tasks: test_zip.yml
+- import_tasks: test_zip_timezone_dst.yml
 - import_tasks: test_exclude.yml
 - import_tasks: test_include.yml
 - import_tasks: test_parent_not_writeable.yml

--- a/test/integration/targets/unarchive/tasks/prepare_tests.yml
+++ b/test/integration/targets/unarchive/tasks/prepare_tests.yml
@@ -72,7 +72,6 @@
     - created/include
     - created/exclude
     - created/other
-    - datetime-dst
 
 - name: Prepare - Create test files
   file:
@@ -92,18 +91,8 @@
     - other/other-1.ext
     - other/other-2.ext
 
-- name: Setup custom DST (date saving time) for zip test
-  # datetime must match a DST period for Europe/Paris
-  file:
-    path: "{{ remote_tmp_dir }}/datetime-dst/datetime-dst.txt"
-    state: touch
-    modification_time: 202507241203.34
-
 - name: Prepare - zip file
   shell: zip -r {{remote_tmp_dir}}/unarchive-00.zip * chdir={{remote_tmp_dir}}/created/
-
-- name: Prepare - zip file (timezone DST)
-  shell: zip -r {{remote_tmp_dir}}/test-datetime-dst.zip * chdir={{remote_tmp_dir}}/datetime-dst/
 
 - name: Prepare - tar file
   shell: tar czvf {{remote_tmp_dir}}/unarchive-00.tar * chdir={{remote_tmp_dir}}/created/

--- a/test/integration/targets/unarchive/tasks/prepare_tests.yml
+++ b/test/integration/targets/unarchive/tasks/prepare_tests.yml
@@ -72,6 +72,7 @@
     - created/include
     - created/exclude
     - created/other
+    - datetime-dst
 
 - name: Prepare - Create test files
   file:
@@ -91,8 +92,18 @@
     - other/other-1.ext
     - other/other-2.ext
 
+- name: Setup custom DST (date saving time) for zip test
+  # datetime must match a DST period for Europe/Paris
+  file:
+    path: "{{ remote_tmp_dir }}/datetime-dst/datetime-dst.txt"
+    state: touch
+    modification_time: 202507241203.34
+
 - name: Prepare - zip file
   shell: zip -r {{remote_tmp_dir}}/unarchive-00.zip * chdir={{remote_tmp_dir}}/created/
+
+- name: Prepare - zip file (timezone DST)
+  shell: zip -r {{remote_tmp_dir}}/test-datetime-dst.zip * chdir={{remote_tmp_dir}}/datetime-dst/
 
 - name: Prepare - tar file
   shell: tar czvf {{remote_tmp_dir}}/unarchive-00.tar * chdir={{remote_tmp_dir}}/created/

--- a/test/integration/targets/unarchive/tasks/test_zip_timezone_dst.yml
+++ b/test/integration/targets/unarchive/tasks/test_zip_timezone_dst.yml
@@ -14,13 +14,20 @@
         dest: '{{ remote_tmp_dir }}/test-unarchive-zip-timezone-dst'
         list_files: True
         remote_src: yes
+      register: unarchive_timezone
       environment:
         TZ: Europe/Paris
+
+    - name: Check if file is created
+      stat:
+        path: '{{ remote_tmp_dir }}/test-unarchive-zip-timezone-dst/datetime-dst.txt'
+      register: file_created
 
     - name: Verify that the file was marked as changed
       assert:
         that:
           - unarchive_timezone.changed
+          - file_created.stat.exists
 
     - name: Unarchive a zip file again
       unarchive:

--- a/test/integration/targets/unarchive/tasks/test_zip_timezone_dst.yml
+++ b/test/integration/targets/unarchive/tasks/test_zip_timezone_dst.yml
@@ -43,9 +43,6 @@
       assert:
         that:
           - not unarchive_timezone.changed
-      # FreeBSD fails because of permissions issues
-      # MacOSX fails because of group owner issues
-      when: not ansible_facts['distribution'] in ['FreeBSD', 'MacOSX']
 
   always:
     - name: Remove zip destination

--- a/test/integration/targets/unarchive/tasks/test_zip_timezone_dst.yml
+++ b/test/integration/targets/unarchive/tasks/test_zip_timezone_dst.yml
@@ -2,10 +2,8 @@
 # Setup
 - name: Prepare - Create test dirs
   file:
-    path: "{{remote_tmp_dir}}/{{item}}"
+    path: "{{remote_tmp_dir}}/datetime-dst"
     state: directory
-  with_items:
-    - datetime-dst
 
 - name: Setup custom DST (date saving time) for zip test
   # datetime must match a DST period for Europe/Paris
@@ -15,7 +13,9 @@
     modification_time: 202507241203.34
 
 - name: Prepare - zip file (timezone DST)
-  shell: zip -r {{remote_tmp_dir}}/test-datetime-dst.zip * chdir={{remote_tmp_dir}}/datetime-dst/
+  shell:
+    cmd: zip -r {{remote_tmp_dir}}/test-datetime-dst.zip *
+    chdir: "{{remote_tmp_dir}}/datetime-dst/"
 
 # Test timezone DST
 - environment:

--- a/test/integration/targets/unarchive/tasks/test_zip_timezone_dst.yml
+++ b/test/integration/targets/unarchive/tasks/test_zip_timezone_dst.yml
@@ -1,0 +1,47 @@
+---
+# Ensure timestamp verification for zip unarchive is correctly done
+- block:
+    - name: Create zip unarchive destination
+      file:
+        path: '{{ remote_tmp_dir }}/test-unarchive-zip-timezone-dst'
+        state: directory
+      environment:
+        TZ: Europe/Paris
+
+    - name: Unarchive a zip file
+      unarchive:
+        src: '{{ remote_tmp_dir }}/test-datetime-dst.zip'
+        dest: '{{ remote_tmp_dir }}/test-unarchive-zip-timezone-dst'
+        list_files: True
+        remote_src: yes
+      environment:
+        TZ: Europe/Paris
+
+    - name: Verify that the file was marked as changed
+      assert:
+        that:
+          - unarchive_timezone.changed
+
+    - name: Unarchive a zip file again
+      unarchive:
+        src: '{{ remote_tmp_dir }}/test-datetime-dst.zip'
+        dest: '{{ remote_tmp_dir }}/test-unarchive-zip-timezone-dst'
+        list_files: True
+        remote_src: yes
+      register: unarchive_timezone
+      environment:
+        TZ: Europe/Paris
+
+    - name: Verify that the task was not marked as changed
+      assert:
+        that:
+          - not unarchive_timezone.changed
+      # FreeBSD fails because of permissions issues
+      # MacOSX fails because of group owner issues
+      when: not ansible_facts['distribution'] in ['FreeBSD', 'MacOSX']
+
+  always:
+    - name: Remove zip destination
+      file:
+        path: '{{remote_tmp_dir}}/test-unarchive-zip-timezone-dst'
+        state: absent

--- a/test/integration/targets/unarchive/tasks/test_zip_timezone_dst.yml
+++ b/test/integration/targets/unarchive/tasks/test_zip_timezone_dst.yml
@@ -1,12 +1,31 @@
----
 # Ensure timestamp verification for zip unarchive is correctly done
-- block:
+# Setup
+- name: Prepare - Create test dirs
+  file:
+    path: "{{remote_tmp_dir}}/{{item}}"
+    state: directory
+  with_items:
+    - datetime-dst
+
+- name: Setup custom DST (date saving time) for zip test
+  # datetime must match a DST period for Europe/Paris
+  file:
+    path: "{{ remote_tmp_dir }}/datetime-dst/datetime-dst.txt"
+    state: touch
+    modification_time: 202507241203.34
+
+- name: Prepare - zip file (timezone DST)
+  shell: zip -r {{remote_tmp_dir}}/test-datetime-dst.zip * chdir={{remote_tmp_dir}}/datetime-dst/
+
+# Test timezone DST
+- environment:
+    TZ: Europe/Paris
+  block:
+
     - name: Create zip unarchive destination
       file:
         path: '{{ remote_tmp_dir }}/test-unarchive-zip-timezone-dst'
         state: directory
-      environment:
-        TZ: Europe/Paris
 
     - name: Unarchive a zip file
       unarchive:
@@ -15,8 +34,6 @@
         list_files: True
         remote_src: yes
       register: unarchive_timezone
-      environment:
-        TZ: Europe/Paris
 
     - name: Check if file is created
       stat:
@@ -36,16 +53,8 @@
         list_files: True
         remote_src: yes
       register: unarchive_timezone
-      environment:
-        TZ: Europe/Paris
 
     - name: Verify that the task was not marked as changed
       assert:
         that:
           - not unarchive_timezone.changed
-
-  always:
-    - name: Remove zip destination
-      file:
-        path: '{{remote_tmp_dir}}/test-unarchive-zip-timezone-dst'
-        state: absent


### PR DESCRIPTION
##### SUMMARY

* Consider the timezone offset while creating timestamp from `zipinfo -T`
  information. This information is required while comparing to mtime of the file
  on local filesystem (for idempotency purposes).

Fixes: #85779

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/unarchive.yml
lib/ansible/modules/unarchive.py


