### PR TITLE
Remove tarfile data_filter check

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import errno
 import datetime
-import functools
 import os
 import tarfile
 import tempfile
@@ -44,32 +43,6 @@ from ansible.utils.display import Display
 from ansible.utils.path import is_subpath, unfrackpath
 
 display = Display()
-
-
-@functools.cache
-def _check_working_data_filter() -> bool:
-    """
-    Check if tarfile.data_filter implementation is working
-    for the current Python version or not
-    """
-
-    # Implemented the following code to circumvent broken implementation of data_filter
-    # in tarfile. See for more information - https://github.com/python/cpython/issues/107845
-    # deprecated: description='probing broken data filter implementation' python_version='3.11'
-    ret = False
-    if hasattr(tarfile, 'data_filter'):
-        # We explicitly check if tarfile.data_filter is broken or not
-        ti = tarfile.TarInfo('docs/README.md')
-        ti.type = tarfile.SYMTYPE
-        ti.linkname = '../README.md'
-
-        try:
-            tarfile.data_filter(ti, '/foo')
-        except tarfile.LinkOutsideDestinationError:
-            pass
-        else:
-            ret = True
-    return ret
 
 
 class GalaxyRole(object):
@@ -418,12 +391,7 @@ class GalaxyRole(object):
                                 relative_path = os.path.join(*full_path.replace(relative_path_dir, "", 1).split(os.sep))
                                 setattr(member, attr, relative_path)
 
-                            if _check_working_data_filter():
-                                # deprecated: description='extract fallback without filter' python_version='3.11'
-                                role_tar_file.extract(member, to_native(self.path), filter='data')  # type: ignore[call-arg]
-                            else:
-                                # Remove along with manual path filter once Python 3.12 is minimum supported version
-                                role_tar_file.extract(member, to_native(self.path))
+                            role_tar_file.extract(member, to_native(self.path), filter='data')
 
                         # write out the install info file for later use
                         self._write_galaxy_install_info()

--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -156,12 +156,7 @@ def publish_collection(module, collection):
 
             # Extract the tarfile to sign the MANIFEST.json
             with tarfile.open(collection_path, mode='r') as collection_tar:
-                # deprecated: description='extractall fallback without filter' python_version='3.11'
-                # Replace 'tar_filter' with 'data_filter' and 'filter=tar' with 'filter=data' once Python 3.12 is minimum requirement.
-                if hasattr(tarfile, 'tar_filter'):
-                    collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)), filter='tar')
-                else:
-                    collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)))
+                collection_tar.extractall(path=os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version)), filter='data')
 
             manifest_path = os.path.join(collection_dir, '%s-%s-%s' % (namespace, name, version), 'MANIFEST.json')
             signature_path = os.path.join(module.params['signature_dir'], '%s-%s-%s-MANIFEST.json.asc' % (namespace, name, version))

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -232,4 +232,3 @@ test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:a
 lib/ansible/galaxy/api.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/utils/encrypt.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/vars/manager.py pylint:ansible-deprecated-version-comment  # TODO: 2.20
-lib/ansible/galaxy/role.py pylint:ansible-deprecated-python-version-comment  # TODO: 2.20


### PR DESCRIPTION
##### SUMMARY
Removes the now uneeded tarfile check for data_filter now that our minimum Python version on the controller is 3.12 and guarantees it will be present.

No changelog is present because the new logic is already in use, we just no longer needed the fallback check.

##### ISSUE TYPE
- Feature Pull Request