### PR TITLE
Remove deprecated vars plugin fallback

### DIFF
--- a/changelogs/fragments/vars-remove-get_hostgroup_vars.yml
+++ b/changelogs/fragments/vars-remove-get_hostgroup_vars.yml
@@ -1,0 +1,4 @@
+removed_features:
+  - >-
+    vars plugins - removed the deprecated ``get_host_vars`` or ``get_group_vars`` fallback for vars plugins that do
+    not inherit from ``BaseVarsPlugin`` and define a ``get_vars`` method.

--- a/lib/ansible/vars/plugins.py
+++ b/lib/ansible/vars/plugins.py
@@ -8,8 +8,6 @@ import os
 from functools import lru_cache
 
 from ansible import constants as C
-from ansible.errors import AnsibleError
-from ansible.inventory.group import InventoryObjectType
 from ansible.plugins.loader import vars_loader
 from ansible.utils.display import Display
 from ansible.utils.vars import combine_vars
@@ -24,34 +22,6 @@ def _prime_vars_loader():
         if not plugin_name:
             continue
         vars_loader.get(plugin_name)
-
-
-def get_plugin_vars(loader, plugin, path, entities):
-
-    data = {}
-    try:
-        data = plugin.get_vars(loader, path, entities)
-    except AttributeError:
-        if hasattr(plugin, 'get_host_vars') or hasattr(plugin, 'get_group_vars'):
-            display.deprecated(
-                msg=f"The vars plugin {plugin.ansible_name} from {plugin._original_path} is relying "
-                    "on the deprecated entrypoints `get_host_vars` and `get_group_vars`.",
-                version="2.20",
-                help_text="This plugin should be updated to inherit from `BaseVarsPlugin` and define "
-                          "a `get_vars` method as the main entrypoint instead.",
-            )
-        try:
-            for entity in entities:
-                if entity.base_type is InventoryObjectType.HOST:
-                    data |= plugin.get_host_vars(entity.name)
-                else:
-                    data |= plugin.get_group_vars(entity.name)
-        except AttributeError:
-            if hasattr(plugin, 'run'):
-                raise AnsibleError("Cannot use v1 type vars plugin %s from %s" % (plugin._load_name, plugin._original_path))
-            else:
-                raise AnsibleError("Invalid vars plugin %s from %s" % (plugin._load_name, plugin._original_path))
-    return data
 
 
 # optimized for stateless plugins; non-stateless plugin instances will fall out quickly
@@ -99,7 +69,7 @@ def get_vars_from_path(loader, path, entities, stage):
         if not _plugin_should_run(plugin, stage):
             continue
 
-        if (new_vars := get_plugin_vars(loader, plugin, path, entities)) != {}:
+        if (new_vars := plugin.get_vars(loader, path, entities)) != {}:
             data = combine_vars(data, new_vars)
 
     return data

--- a/test/integration/targets/old_style_vars_plugins/deprecation_warning/v2_vars_plugin.py
+++ b/test/integration/targets/old_style_vars_plugins/deprecation_warning/v2_vars_plugin.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-
-class VarsModule:
-    def get_host_vars(self, entity):
-        return {}
-
-    def get_group_vars(self, entity):
-        return {}

--- a/test/integration/targets/old_style_vars_plugins/runme.sh
+++ b/test/integration/targets/old_style_vars_plugins/runme.sh
@@ -12,13 +12,6 @@ export ANSIBLE_VARS_PLUGINS=./vars_plugins
 export ANSIBLE_VARS_ENABLED=require_enabled
 [ "$(ansible-inventory -i localhost, --list --yaml all "$@" | grep -c 'require_enabled')" = "1" ]
 
-# Test deprecated features
-export ANSIBLE_VARS_PLUGINS=./deprecation_warning
-WARNING="The vars plugin v2_vars_plugin .* is relying on the deprecated entrypoints \`get_host_vars\` and \`get_group_vars\`"
-ANSIBLE_DEPRECATION_WARNINGS=True ANSIBLE_NOCOLOR=True ANSIBLE_FORCE_COLOR=False \
-        ansible-inventory -i localhost, --list all "$@" 2> err.txt
-ansible localhost -m debug -a "msg={{ lookup('file', 'err.txt') | regex_replace('\n', '') }}" | grep "$WARNING"
-
 # Test how many times vars plugins are loaded for a simple play containing a task
 # host_group_vars is stateless, so we can load it once and reuse it, every other vars plugin should be instantiated before it runs
 cat << EOF > "test_task_vars.yml"

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -233,5 +233,4 @@ lib/ansible/galaxy/api.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/utils/encrypt.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/utils/ssh_functions.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/vars/manager.py pylint:ansible-deprecated-version-comment  # TODO: 2.20
-lib/ansible/vars/plugins.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/galaxy/role.py pylint:ansible-deprecated-python-version-comment  # TODO: 2.20


### PR DESCRIPTION
##### SUMMARY
Removes the vars plugin `get_host_vars` and `get_group_vars` fallback which was deprecated.

##### ISSUE TYPE
- Feature Pull Request