### PR TITLE
Removed deprecated DEFAULT_TRANSPORT smart option

### DIFF
--- a/changelogs/fragments/smart-transport-removal.yml
+++ b/changelogs/fragments/smart-transport-removal.yml
@@ -1,0 +1,4 @@
+removed_features:
+  - >-
+    Removed the option to set the ``DEFAULT_TRANSPORT`` configuration to ``smart`` that selects the default transport
+    as either ``ssh`` or ``paramiko`` based on the underlying platform configuraton.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1215,7 +1215,6 @@ DEFAULT_TRANSPORT:
   default: ssh
   description:
     - Can be any connection plugin available to your ansible installation.
-    - There is also a (DEPRECATED) special 'smart' option, that will toggle between 'ssh' and 'paramiko' depending on controller OS and ssh versions.
   env: [{name: ANSIBLE_TRANSPORT}]
   ini:
   - {key: transport, section: defaults}

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -31,7 +31,6 @@ from ansible.utils.helpers import pct_to_int
 from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.collection_loader._collection_finder import _get_collection_name_from_path, _get_collection_playbook_path
 from ansible.utils.path import makedirs_safe
-from ansible.utils.ssh_functions import set_default_transport
 from ansible.utils.display import Display
 
 
@@ -64,14 +63,6 @@ class PlaybookExecutor:
                 passwords=self.passwords,
                 forks=context.CLIARGS.get('forks'),
             )
-
-        # Note: We run this here to cache whether the default ansible ssh
-        # executable supports control persist.  Sometime in the future we may
-        # need to enhance this to check that ansible_ssh_executable specified
-        # in inventory is also cached.  We can't do this caching at the point
-        # where it is used (in task_executor) because that is post-fork and
-        # therefore would be discarded after every task.
-        set_default_transport()
 
     def run(self):
         """

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -967,9 +967,6 @@ class TaskExecutor:
 
         self._play_context.connection = current_connection
 
-        # TODO: play context has logic to update the connection for 'smart'
-        # (default value, will chose between ssh and paramiko) and 'persistent'
-        # (really paramiko), eventually this should move to task object itself.
         conn_type = self._play_context.connection
 
         connection, plugin_load_context = self._shared_loader_obj.connection_loader.get_with_context(

--- a/lib/ansible/utils/ssh_functions.py
+++ b/lib/ansible/utils/ssh_functions.py
@@ -50,20 +50,3 @@ def check_for_controlpersist(ssh_executable):
 
     _HAS_CONTROLPERSIST[ssh_executable] = has_cp
     return has_cp
-
-
-def set_default_transport():
-
-    # deal with 'smart' connection .. one time ..
-    if C.DEFAULT_TRANSPORT == 'smart':
-        display.deprecated(
-            msg="The `smart` option for connections is deprecated.",
-            version="2.20",
-            help_text="Set the connection plugin directly instead.",
-        )
-
-        # see if SSH can support ControlPersist if not use paramiko
-        if not check_for_controlpersist('ssh') and paramiko is not None:
-            C.DEFAULT_TRANSPORT = "paramiko"
-        else:
-            C.DEFAULT_TRANSPORT = "ssh"

--- a/lib/ansible/utils/ssh_functions.py
+++ b/lib/ansible/utils/ssh_functions.py
@@ -20,9 +20,7 @@ from __future__ import annotations
 
 import subprocess
 
-from ansible import constants as C
 from ansible.module_utils.common.text.converters import to_bytes
-from ansible.module_utils.compat.paramiko import _paramiko as paramiko
 from ansible.utils.display import Display
 
 display = Display()

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -231,7 +231,6 @@ test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:a
 test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:ansible-deprecated-collection-name-not-permitted  # required to verify plugin against core
 lib/ansible/galaxy/api.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/utils/encrypt.py pylint:ansible-deprecated-version  # TODO: 2.20
-lib/ansible/utils/ssh_functions.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/vars/manager.py pylint:ansible-deprecated-version-comment  # TODO: 2.20
 lib/ansible/vars/plugins.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/galaxy/role.py pylint:ansible-deprecated-python-version-comment  # TODO: 2.20


### PR DESCRIPTION
##### SUMMARY
Removes the logic for handling `DEFAULT_TRANSPORT` set to `smart`.

##### ISSUE TYPE
- Feature Pull Request