### PR TITLE
sivel's amazing debugging wonders

### DIFF
--- a/lib/ansible/__init__.py
+++ b/lib/ansible/__init__.py
@@ -16,6 +16,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import annotations
+import sys as _sys
 
 # make vendored top-level modules accessible EARLY
 import ansible._vendor
@@ -27,3 +28,9 @@ import ansible._vendor
 # This is for backwards compat.  Code should be ported to get these from
 # ansible.release instead of from here.
 from ansible.release import __version__, __author__
+
+try:
+    import ansible._d
+    _sys.modules['_d'] = ansible._d
+except ImportError:
+    pass

--- a/lib/ansible/_d.py
+++ b/lib/ansible/_d.py
@@ -1,0 +1,15 @@
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+from os import environ as _e
+
+if 'ANSIBLE_DEV_DEBUG' not in _e and 'ANSIBLE_TEST_ANSIBLE_LIB_ROOT' not in _e:
+    raise ImportError('_d')
+
+
+from ansible.utils.display import Display as _Display
+
+_d = _Display()
+_p = _d.display


### PR DESCRIPTION
##### SUMMARY

I made my life harder when I effectively disallowed printing directly from workers. This means that I either deal with the truncated warning output from things printed from the worker, or I do:

```python
from ansible.utils.display import Display
display = Display()
display.display('my awesome debugging')
```

That is just unacceptable.

This PR adds some fancy debugging wonders, that when either `ANSIBLE_DEV_DEBUG` or `ANSIBLE_TEST_ANSIBLE_LIB_ROOT` exist as env vars, regardless of their values we'll get access to:

```python
import _d
_d._p('much better and awesomer debugging')
```

##### ISSUE TYPE

- Feature Pull Request
- Test Pull Request
