### PR TITLE
Remove deprecation marker that has been actioned

### DIFF
--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -49,7 +49,6 @@ if t.TYPE_CHECKING:
 
 display = Display()
 
-# deprecated: description='enable top-level facts deprecation' core_version='2.20'
 _DEPRECATE_TOP_LEVEL_FACT_TAG = _tags.Deprecated(
     msg='INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change.',
     version='2.24',
@@ -70,7 +69,6 @@ def _deprecate_top_level_fact(value: t.Any) -> t.Any:
     The inner values are shared to aid in message de-duplication across hosts/values, and reduce intra-process memory usage.
     Unique tag instances are required to achieve the correct de-duplication within a top-level templating operation.
     """
-    # deprecated: description='enable top-level facts deprecation' core_version='2.20'
     return _DEPRECATE_TOP_LEVEL_FACT_TAG.tag(value)
 
 

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -230,4 +230,3 @@ test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:a
 test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:ansible-deprecated-unnecessary-collection-name  # required to verify plugin against core
 test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:ansible-deprecated-collection-name-not-permitted  # required to verify plugin against core
 lib/ansible/galaxy/api.py pylint:ansible-deprecated-version  # TODO: 2.20
-lib/ansible/vars/manager.py pylint:ansible-deprecated-version-comment  # TODO: 2.20


### PR DESCRIPTION
##### SUMMARY
The marker is no longer needed as it was actioned in https://github.com/ansible/ansible/commit/931c923e0e901a64db1b19d04782a9e4b325ac21.

##### ISSUE TYPE
- Feature Pull Request
