### PR TITLE
Removed deprecated func passlib_or_crypt

### DIFF
--- a/changelogs/fragments/passlib_or_crypt-removal.yml
+++ b/changelogs/fragments/passlib_or_crypt-removal.yml
@@ -1,0 +1,3 @@
+removed_features:
+  - >-
+    Removed the deprecated function ``passlib_or_crypt``, use ``do_encrypt`` instead.

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -176,11 +176,6 @@ class PasslibHash(BaseHash):
         return to_text(result, errors='strict')
 
 
-def passlib_or_crypt(secret, algorithm, salt=None, salt_size=None, rounds=None, ident=None):
-    display.deprecated("passlib_or_crypt API is deprecated in favor of do_encrypt", version='2.20')
-    return do_encrypt(secret, algorithm, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)
-
-
 def do_encrypt(result, encrypt, salt_size=None, salt=None, ident=None, rounds=None):
     if PASSLIB_AVAILABLE:
         return PasslibHash(encrypt).hash(result, salt=salt, salt_size=salt_size, rounds=rounds, ident=ident)

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -230,6 +230,5 @@ test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:a
 test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:ansible-deprecated-unnecessary-collection-name  # required to verify plugin against core
 test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:ansible-deprecated-collection-name-not-permitted  # required to verify plugin against core
 lib/ansible/galaxy/api.py pylint:ansible-deprecated-version  # TODO: 2.20
-lib/ansible/utils/encrypt.py pylint:ansible-deprecated-version  # TODO: 2.20
 lib/ansible/vars/manager.py pylint:ansible-deprecated-version-comment  # TODO: 2.20
 lib/ansible/galaxy/role.py pylint:ansible-deprecated-python-version-comment  # TODO: 2.20

--- a/test/units/utils/test_encrypt.py
+++ b/test/units/utils/test_encrypt.py
@@ -21,7 +21,7 @@ def assert_hash(expected, secret, algorithm, **settings):
 @pytest.mark.skipif(not encrypt.PASSLIB_AVAILABLE, reason='passlib must be installed to run this test')
 def test_passlib():
     expected = "$5$12345678$uAZsE3BenI2G.nA8DpTl.9Dc8JiqacI53pEqRr5ppT7"
-    assert encrypt.passlib_or_crypt("123", "sha256_crypt", salt="12345678", rounds=5000) == expected
+    assert encrypt.do_encrypt("123", "sha256_crypt", salt="12345678", rounds=5000) == expected
 
 
 @pytest.mark.skipif(not encrypt.PASSLIB_AVAILABLE, reason='passlib must be installed to run this test')


### PR DESCRIPTION
##### SUMMARY
This function is deprecated and was marked for removal in 2.20.

##### ISSUE TYPE
- Feature Pull Request