### PR TITLE
ansible-test - Fix traceback on missing tmp dir

### DIFF
--- a/changelogs/fragments/ansible-test-missing-dir-fix.yml
+++ b/changelogs/fragments/ansible-test-missing-dir-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Fix a traceback that can occur when using delegation before the ansible-test temp directory is created.

--- a/test/lib/ansible_test/_internal/delegation.py
+++ b/test/lib/ansible_test/_internal/delegation.py
@@ -124,6 +124,8 @@ def delegate(args: CommonConfig, host_state: HostState, exclude: list[str], requ
 @contextlib.contextmanager
 def metadata_context(args: EnvironmentConfig) -> t.Generator[None]:
     """A context manager which exports delegation metadata."""
+    os.makedirs(ResultType.TMP.path, exist_ok=True)
+
     with tempfile.NamedTemporaryFile(prefix='metadata-', suffix='.json', dir=ResultType.TMP.path) as metadata_fd:
         args.metadata_path = os.path.join(ResultType.TMP.relative_path, os.path.basename(metadata_fd.name))
         args.metadata.to_file(args.metadata_path)


### PR DESCRIPTION
##### SUMMARY

Fix a traceback that can occur when using delegation before the ansible-test temp directory is created.

##### ISSUE TYPE

Bugfix Pull Request
