### PR TITLE
Fix jsonfile cache on WSL

### DIFF
--- a/changelogs/fragments/85816-wsl-cache-files.yml
+++ b/changelogs/fragments/85816-wsl-cache-files.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cache plugins - close temp cache file before moving it to fix error on WSL. (https://github.com/ansible/ansible/pull/85816)

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -162,6 +162,7 @@ class BaseFileCacheModule(BaseCacheModule):
             except OSError as ex:
                 display.error_as_warning(f"Error in {self.plugin_name!r} cache plugin while trying to write to {tmpfile_path!r}.", exception=ex)
             try:
+                os.close(tmpfile_handle) # os.rename fails if handle is still open in WSL2
                 os.rename(tmpfile_path, cachefile)
                 os.chmod(cachefile, mode=S_IRWU_RG_RO)
             except OSError as ex:

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -162,7 +162,7 @@ class BaseFileCacheModule(BaseCacheModule):
             except OSError as ex:
                 display.error_as_warning(f"Error in {self.plugin_name!r} cache plugin while trying to write to {tmpfile_path!r}.", exception=ex)
             try:
-                os.close(tmpfile_handle) # os.rename fails if handle is still open in WSL2
+                os.close(tmpfile_handle)  # os.rename fails if handle is still open in WSL
                 os.rename(tmpfile_path, cachefile)
                 os.chmod(cachefile, mode=S_IRWU_RG_RO)
             except OSError as ex:


### PR DESCRIPTION


##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
On WSL, `os.rename` can't correctly move a file while a handle to that file is still open. It remains half-moved where neither the source or destination seem to exist (according to `os.path.exists`). However the move seems to complete correctly when the open handle is closed.

In `BaseFileCacheModule`, when writing a cache file, a temporary file is created with `mkstemp` that returns an open file descriptor and a filename. Once the cache is written to that file, it is renamed to the correct file name with `os.rename` and then its permissions set with `os.chmod`. On WSL the `os.chmod` fails because it doesn't think the file exists yet because the file descriptor returned by `mkstemp` is still open. This PR fixes this by closing that file descriptor before renaming.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->
To reproduce the original issue, on WSL, run:
`ANSIBLE_CACHE_PLUGIN=jsonfile ANSIBLE_CACHE_PLUGIN_CONNECTION=.fact_cache ansible localhost -m setup`

##### ISSUE TYPE

- Bugfix Pull Request
