### PR TITLE
assemble: make example less dangerous

### DIFF
--- a/lib/ansible/modules/assemble.py
+++ b/lib/ansible/modules/assemble.py
@@ -120,6 +120,7 @@ EXAMPLES = r"""
   ansible.builtin.assemble:
     src: /etc/ssh/conf.d/
     dest: /etc/ssh/sshd_config
+    delimiter: Match all # close any open Match blocks
     validate: /usr/sbin/sshd -t -f %s
 """
 


### PR DESCRIPTION
##### SUMMARY

I don't think it's a good idea to suggest concatenating SSH config files, because unexpected results may occur. If a restriction block exists in a file it ends when the file ends, but if the files are concatenated, that restriction block would suddenly run on to whatever config comes after it, which could result in a lock-out or unintended access.

From the [sshd_config manual page](http://linux.die.net/man/5/sshd_config):

> If all of the criteria on the Match line are satisfied, the keywords on the following lines override those set in the global section of the config file, **until either another Match line or the end of the file.**

A safe way to concat SSH config files is to add `Match all` between each file, which will close any open restriction blocks and otherwise have no effect.

##### ISSUE TYPE

- Docs Pull Request
