### PR TITLE
chore(docs): specify delimiter for ANSIBLE_DEFAULT_VAULT_LIST

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1275,7 +1275,7 @@ DEFAULT_VAULT_ENCRYPT_IDENTITY:
 DEFAULT_VAULT_IDENTITY_LIST:
   name: Default vault ids
   default: []
-  description: 'A list of vault-ids to use by default. Equivalent to multiple ``--vault-id`` args. Vault-ids are tried in order.'
+  description: 'Comma-separated list of vault-ids to use by default. Equivalent to multiple ``--vault-id`` args. Vault-ids are tried in order.'
   env: [{name: ANSIBLE_VAULT_IDENTITY_LIST}]
   ini:
   - {key: vault_identity_list, section: defaults}


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale -->
Clarifies what type of delimiter is expected for use in the `ANSIBLE_VAULT_IDENTITY_LIST` variable.

Modifies sentence structure to align with other list-type config options' documentation.

<!--- Add "Fixes #1234" if there is a corresponding issue -->
Fixes #85818

##### ISSUE TYPE

- Docs Pull Request
