### PR TITLE
Fix directory path construction and return result in copy action

### DIFF
--- a/changelogs/fragments/85834-fix-copy-in-single-file-directory.yml
+++ b/changelogs/fragments/85834-fix-copy-in-single-file-directory.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "copy - when a single-file directory was specified as the source, ``changed`` used to be ``false`` even when the source was actually copied. It now makes sure ``changed`` is ``true`` in this case. The return value is now consistent with the other directory copy cases. (https://github.com/ansible/ansible/issues/85833)"
+  - "copy - when a single-file directory was specified as the source, ``changed`` used to be ``false`` even when the source was actually copied. It now makes sure ``changed`` is ``true`` in this case. (https://github.com/ansible/ansible/issues/85833)"

--- a/changelogs/fragments/85834-fix-copy-in-single-file-directory.yml
+++ b/changelogs/fragments/85834-fix-copy-in-single-file-directory.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "copy - when a single-file directory was specified as the source, ``changed`` used to be ``false`` even when the source was actually copied. It now makes sure ``changed`` is ``true`` in this case. (https://github.com/ansible/ansible/issues/85833)"
+  - "copy - when a single-file local directory was specified as the source, ``changed`` used to be ``false`` even when the source was actually copied. It now makes sure ``changed`` is ``true`` in this case. (https://github.com/ansible/ansible/issues/85833)"

--- a/changelogs/fragments/85834-fix-copy-in-single-file-directory.yml
+++ b/changelogs/fragments/85834-fix-copy-in-single-file-directory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "copy - when a single-file directories was specified as the source, ``changed`` was false even when the source was actually copied. Fix now makes sure ``changed`` is true in this case. Fix also changes the return value to be consistent with other directory copy cases. (https://github.com/ansible/ansible/issues/85833)"

--- a/changelogs/fragments/85834-fix-copy-in-single-file-directory.yml
+++ b/changelogs/fragments/85834-fix-copy-in-single-file-directory.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "copy - when a single-file directories was specified as the source, ``changed`` was false even when the source was actually copied. Fix now makes sure ``changed`` is true in this case. Fix also changes the return value to be consistent with other directory copy cases. (https://github.com/ansible/ansible/issues/85833)"
+  - "copy - when a single-file directory was specified as the source, ``changed`` used to be ``false`` even when the source was actually copied. It now makes sure ``changed`` is ``true`` in this case. The return value is now consistent with the other directory copy cases. (https://github.com/ansible/ansible/issues/85833)"

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -532,7 +532,7 @@ class ActionModule(ActionBase):
             paths = os.path.split(source_rel)
             dir_path = ''
             for dir_component in paths:
-                os.path.join(dir_path, dir_component)
+                dir_path = os.path.join(dir_path, dir_component)
                 implicit_directories.add(dir_path)
             if 'diff' in result and not result['diff']:
                 del result['diff']

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -529,10 +529,8 @@ class ActionModule(ActionBase):
                 result.update(module_return)
                 return self._ensure_invocation(result)
 
-            source_rel_parent = os.path.dirname(source_rel)
-            while source_rel_parent != '':
-                implicit_directories.add(source_rel_parent)
-                source_rel_parent = os.path.dirname(source_rel_parent)
+            while (source_rel := os.path.dirname(source_rel)) != '':
+                implicit_directories.add(source_rel)
 
             if 'diff' in result and not result['diff']:
                 del result['diff']

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -529,11 +529,11 @@ class ActionModule(ActionBase):
                 result.update(module_return)
                 return self._ensure_invocation(result)
 
-            paths = os.path.split(source_rel)
-            dir_path = ''
-            for dir_component in paths:
-                dir_path = os.path.join(dir_path, dir_component)
-                implicit_directories.add(dir_path)
+            source_rel_parent = os.path.dirname(source_rel)
+            while source_rel_parent != '':
+                implicit_directories.add(source_rel_parent)
+                source_rel_parent = os.path.dirname(source_rel_parent)
+
             if 'diff' in result and not result['diff']:
                 del result['diff']
             module_executed = True

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -484,10 +484,8 @@ class ActionModule(ActionBase):
         # A list of source file tuples (full_path, relative_path) which will try to copy to the destination
         source_files = {'files': [], 'directories': [], 'symlinks': []}
 
-        source_is_dir = os.path.isdir(to_bytes(source, errors='surrogate_or_strict'))
-
         # If source is a directory populate our list else source is a file and translate it to a tuple.
-        if source_is_dir:
+        if os.path.isdir(to_bytes(source, errors='surrogate_or_strict')):
             # Get a list of the files we want to replicate on the remote side
             source_files = _walk_dirs(source, local_follow=local_follow,
                                       trailing_slash_detector=self._connection._shell.path_has_trailing_slash)
@@ -590,7 +588,7 @@ class ActionModule(ActionBase):
 
             changed = changed or module_return.get('changed', False)
 
-        if module_executed and not source_is_dir:
+        if module_executed and len(source_files['files']) == 1:
             result.update(module_return)
 
             # the file module returns the file path as 'path', but

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -484,8 +484,10 @@ class ActionModule(ActionBase):
         # A list of source file tuples (full_path, relative_path) which will try to copy to the destination
         source_files = {'files': [], 'directories': [], 'symlinks': []}
 
+        source_is_dir = os.path.isdir(to_bytes(source, errors='surrogate_or_strict'))
+
         # If source is a directory populate our list else source is a file and translate it to a tuple.
-        if os.path.isdir(to_bytes(source, errors='surrogate_or_strict')):
+        if source_is_dir:
             # Get a list of the files we want to replicate on the remote side
             source_files = _walk_dirs(source, local_follow=local_follow,
                                       trailing_slash_detector=self._connection._shell.path_has_trailing_slash)
@@ -588,7 +590,7 @@ class ActionModule(ActionBase):
 
             changed = changed or module_return.get('changed', False)
 
-        if module_executed and len(source_files['files']) == 1:
+        if module_executed and not source_is_dir:
             result.update(module_return)
 
             # the file module returns the file path as 'path', but

--- a/test/integration/targets/copy/files/subdir_with_single_file/file.txt
+++ b/test/integration/targets/copy/files/subdir_with_single_file/file.txt
@@ -1,1 +1,0 @@
-file.txt

--- a/test/integration/targets/copy/files/subdir_with_single_file/file.txt
+++ b/test/integration/targets/copy/files/subdir_with_single_file/file.txt
@@ -1,0 +1,1 @@
+file.txt

--- a/test/integration/targets/copy/tasks/src_directory_contaning_one_single_file.yml
+++ b/test/integration/targets/copy/tasks/src_directory_contaning_one_single_file.yml
@@ -1,0 +1,27 @@
+- name: Ensure that dest top directory doesn't exist
+  file:
+    path: '{{ remote_dir }}/subdir_with_single_file'
+    state: absent
+
+- name: Copy subdir_with_single_file directory which contains a single file
+  copy:
+    src: subdir_with_single_file
+    dest: '{{ remote_dir }}'
+  register: copy_result
+
+- name: Debug copy result
+  debug:
+    var: copy_result
+    verbosity: 1
+
+- name: Check the transferred file
+  stat:
+    path: '{{ remote_dir }}/subdir_with_single_file/file.txt'
+  register: stat_file
+
+- name: Assert that transferred file exists and copy_result is as expected
+  assert:
+    that:
+      - 'stat_file.stat.exists'
+      - 'copy_result.changed'
+      - 'copy_result.dest == remote_dir'

--- a/test/integration/targets/copy/tasks/src_directory_contaning_one_single_file.yml
+++ b/test/integration/targets/copy/tasks/src_directory_contaning_one_single_file.yml
@@ -24,4 +24,4 @@
     that:
       - 'stat_file.stat.exists'
       - 'copy_result.changed'
-      - 'copy_result.dest == remote_dir + "/"'
+      - 'copy_result.dest == remote_dir + "/subdir_with_single_file/file.txt"'

--- a/test/integration/targets/copy/tasks/src_directory_contaning_one_single_file.yml
+++ b/test/integration/targets/copy/tasks/src_directory_contaning_one_single_file.yml
@@ -1,33 +1,3 @@
-# Test copying a source directory that contains only a single file
-
-- name: Ensure that dest top directory doesn't exist
-  file:
-    path: '{{ remote_dir }}/subdir_with_single_file'
-    state: absent
-
-- name: Copy subdir_with_single_file directory which contains a single file
-  copy:
-    src: subdir_with_single_file
-    dest: '{{ remote_dir }}'
-  register: copy_result
-
-- name: Debug copy result
-  debug:
-    var: copy_result
-    verbosity: 1
-
-- name: Check the transferred file
-  stat:
-    path: '{{ remote_dir }}/subdir_with_single_file/file.txt'
-  register: stat_file
-
-- name: Assert that transferred file exists and copy_result is as expected
-  assert:
-    that:
-      - 'stat_file.stat.exists'
-      - 'copy_result.changed'
-      - 'copy_result.dest == remote_dir + "/subdir_with_single_file/file.txt"'
-
 # Test copying to a source directory that contains only a single file in a deeper structure
 
 - name: Ensure that dest top directory doesn't exist
@@ -48,7 +18,7 @@
 
 - name: Check the transferred file
   stat:
-    path: '{{ remote_dir }}/subdir_with_deep_single_file/dir2/file.txt'
+    path: '{{ remote_dir }}/subdir_with_deep_single_file/dir/file.txt'
   register: stat_file
 
 - name: Assert that transferred file exists and copy_result is as expected for deeper structure
@@ -56,4 +26,4 @@
     that:
       - 'stat_file.stat.exists'
       - 'copy_result.changed'
-      - 'copy_result.dest == remote_dir + "/subdir_with_deep_single_file/dir2/file.txt"'
+      - 'copy_result.dest == remote_dir + "/subdir_with_deep_single_file/dir/file.txt"'

--- a/test/integration/targets/copy/tasks/src_directory_contaning_one_single_file.yml
+++ b/test/integration/targets/copy/tasks/src_directory_contaning_one_single_file.yml
@@ -1,3 +1,5 @@
+# Test copying a source directory that contains only a single file
+
 - name: Ensure that dest top directory doesn't exist
   file:
     path: '{{ remote_dir }}/subdir_with_single_file'
@@ -25,3 +27,33 @@
       - 'stat_file.stat.exists'
       - 'copy_result.changed'
       - 'copy_result.dest == remote_dir + "/subdir_with_single_file/file.txt"'
+
+# Test copying to a source directory that contains only a single file in a deeper structure
+
+- name: Ensure that dest top directory doesn't exist
+  file:
+    path: '{{ remote_dir }}/subdir_with_deep_single_file'
+    state: absent
+
+- name: Copy subdir_with_deep_single_file directory which contains a single file
+  copy:
+    src: subdir_with_deep_single_file
+    dest: '{{ remote_dir }}'
+  register: copy_result
+
+- name: Debug copy result
+  debug:
+    var: copy_result
+    verbosity: 1
+
+- name: Check the transferred file
+  stat:
+    path: '{{ remote_dir }}/subdir_with_deep_single_file/dir2/file.txt'
+  register: stat_file
+
+- name: Assert that transferred file exists and copy_result is as expected for deeper structure
+  assert:
+    that:
+      - 'stat_file.stat.exists'
+      - 'copy_result.changed'
+      - 'copy_result.dest == remote_dir + "/subdir_with_deep_single_file/dir2/file.txt"'

--- a/test/integration/targets/copy/tasks/src_directory_contaning_one_single_file.yml
+++ b/test/integration/targets/copy/tasks/src_directory_contaning_one_single_file.yml
@@ -24,4 +24,4 @@
     that:
       - 'stat_file.stat.exists'
       - 'copy_result.changed'
-      - 'copy_result.dest == remote_dir'
+      - 'copy_result.dest == remote_dir + "/"'

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -2531,3 +2531,5 @@
         state: absent
       loop:
         - '{{ remote_file }}'
+
+- include_tasks: src_directory_contaning_one_single_file.yml


### PR DESCRIPTION
##### SUMMARY

fixes #85833

First of all, the original Line 535 doesn't do anything.

I believe this is the root cause of issue #85833. If I understand the implementation correctly, the intention is to
1. (Line 484-501) Generate the list of source files, and organize them into `files`, `directories` and `symlinks`.
2. (Line 513-540) Copy files (including creating intermediate directories)
3. (Line 542-563) Copy directories (but exclude the directories that are already created in 2)
4. (Line 565-587) Copy symlinks
5. (Line 591-597) If the copy has happened and the source is a single file, include the last module return result in the action result. (Line 598-599) Otherwise, update the action return result.

The exclusion of directories in Step 2 didn't work because of the original Line 535. That's the cause of #85833 -- the intermediate directory was copied in Step 2 (it wasn't excluded properly), but since the directory was already created in Step 1, the last module return result was no change. As a result Step 5, returned the result of the directory copy, which was no change. After I fixed Line 535, I could verify #85833 is fixed.

In addition, if I understand it correctly, the intention to include the last module return result in Step 5 is only valid when the source is specified to be a file. Currently, when a directory that contains only one file is specified, the return result would be that file, which is strange. I've fixed this issue as well.

##### ISSUE TYPE

- Bugfix Pull Request
