### PR TITLE
Docs: Clarify user module behavior for invalid password hashes

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -92,6 +92,11 @@ options:
             - B(Linux/Unix/POSIX:) Enter the hashed password as the value.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate the hash of a password.
+            - |
+              !!! Warning
+
+                  If the value does not match a valid hash format, it is written directly to C(/etc/shadow).
+                  This typically breaks authentication but can be used intentionally to lock an account.
             - To create an account with a locked/disabled password on Linux systems, set this to V('!') or V('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to V('*************').
             - B(OS X/macOS:) Enter the cleartext password as the value. Be sure to take relevant security precautions.

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -92,7 +92,7 @@ options:
             - B(Linux/Unix/POSIX:) Enter the hashed password as the value.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate the hash of a password.
-            - "WARNING: If the value does not match a valid hash format, it is written directly to C(/etc/shadow). 
+            - "WARNING: If the value does not match a valid hash format, it is written directly to C(/etc/shadow).
               The module has no way to verify/validate the value.
               This typically breaks authentication, but can be used intentionally to lock an account."
             - To create an account with a locked/disabled password on Linux systems, set this to V('!') or V('*').

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -92,9 +92,8 @@ options:
             - B(Linux/Unix/POSIX:) Enter the hashed password as the value.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate the hash of a password.
-            - "WARNING: If the value does not match a valid hash format, it is written directly to C(/etc/shadow).
-              The module has no way to verify/validate the value.
-              This typically breaks authentication, but can be used intentionally to lock an account."
+            - The value is written directly to C(/etc/shadow) without any validation. The module has no way to verify/validate the value.
+              This typically breaks authentication, but can be used intentionally to lock an account.
             - To create an account with a locked/disabled password on Linux systems, set this to V('!') or V('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to V('*************').
             - B(OS X/macOS:) Enter the cleartext password as the value. Be sure to take relevant security precautions.

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -92,8 +92,9 @@ options:
             - B(Linux/Unix/POSIX:) Enter the hashed password as the value.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate the hash of a password.
-            - The value is written directly to C(/etc/shadow) without any validation. The module has no way to verify/validate the value.
-              This typically breaks authentication, but can be used intentionally to lock an account.
+            - The module writes the value directly to C(/etc/shadow) without any validation. Because the module cannot verify the user input,
+              providing an invalid value will likely result in authentication failure.
+              However, this behaviour can be utilized intentionally to lock a user account.
             - To create an account with a locked/disabled password on Linux systems, set this to V('!') or V('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to V('*************').
             - B(OS X/macOS:) Enter the cleartext password as the value. Be sure to take relevant security precautions.

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -92,8 +92,9 @@ options:
             - B(Linux/Unix/POSIX:) Enter the hashed password as the value.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate the hash of a password.
-            - WARNING: If the value does not match a valid hash format, it is written directly to C(/etc/shadow). The module has no way to verify/validate the value.
-              This typically breaks authentication, but can be used intentionally to lock an account.
+            - "WARNING: If the value does not match a valid hash format, it is written directly to C(/etc/shadow). 
+              The module has no way to verify/validate the value.
+              This typically breaks authentication, but can be used intentionally to lock an account."
             - To create an account with a locked/disabled password on Linux systems, set this to V('!') or V('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to V('*************').
             - B(OS X/macOS:) Enter the cleartext password as the value. Be sure to take relevant security precautions.

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -92,11 +92,8 @@ options:
             - B(Linux/Unix/POSIX:) Enter the hashed password as the value.
             - See L(FAQ entry,https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module)
               for details on various ways to generate the hash of a password.
-            - |
-              !!! Warning
-
-                  If the value does not match a valid hash format, it is written directly to C(/etc/shadow).
-                  This typically breaks authentication but can be used intentionally to lock an account.
+            - WARNING: If the value does not match a valid hash format, it is written directly to C(/etc/shadow). The module has no way to verify/validate the value.
+              This typically breaks authentication, but can be used intentionally to lock an account.
             - To create an account with a locked/disabled password on Linux systems, set this to V('!') or V('*').
             - To create an account with a locked/disabled password on OpenBSD, set this to V('*************').
             - B(OS X/macOS:) Enter the cleartext password as the value. Be sure to take relevant security precautions.


### PR DESCRIPTION
### SUMMARY

Adds a warning to the `password` parameter documentation for the `ansible.builtin.user` module to explicitly state that invalid password hashes are written directly to the shadow file without further validation.

Fixes #85757

### ISSUE TYPE

- Docs Pull Request

---

### WHAT THIS PR DOES

- Adds a clear warning note in the `password` parameter description
- Explains that invalid hashes are written as-is to `/etc/shadow`
- Mentions that this can break authentication but has valid use cases for account locking
- Prevents users from accidentally locking themselves out of accounts due to shell variable expansion issues or other mistakes

### WHY THIS IS NEEDED

As reported in #85757, when an invalid hash is provided (e.g., due to shell variable expansion where `$6` gets interpreted), the module writes the invalid value directly to the shadow file without validation. This PR documents this behavior to set proper user expectations.
