### PR TITLE
Add IncompleteRead diagnostics to collection downloads

### DIFF
--- a/changelogs/fragments/a-g-dl-checksum-mismatch-diag.yml
+++ b/changelogs/fragments/a-g-dl-checksum-mismatch-diag.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ansible-galaxy - Update the error message in regards to collection download checksum mismatch to include the downloaded size,
+  information about incomplete reads if the ``Content-Length`` differs from the downloaded file size.

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -503,9 +503,9 @@ def _download_file(url, b_path, expected_hash, validate_certs, token=None, timeo
             format(actual_hash=actual_hash, expected_hash=expected_hash)
         )
         if expected_hash != actual_hash:
-            msg = 'Mismatch artifact hash with downloaded file'
             st = os.stat(b_file_path)
             cl = int(resp.headers['content-length'])
+            msg = f'Mismatched artifact hash with downloaded file of {st.st_size} bytes.'
             if st.st_size != cl:
                 diff = cl - st.st_size
                 msg += f' Incomplete read, ({resp.length=}, {cl=}, {st.st_size=}) failed to read remaining {diff} bytes.'

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -503,7 +503,13 @@ def _download_file(url, b_path, expected_hash, validate_certs, token=None, timeo
             format(actual_hash=actual_hash, expected_hash=expected_hash)
         )
         if expected_hash != actual_hash:
-            raise AnsibleError('Mismatch artifact hash with downloaded file')
+            msg = 'Mismatch artifact hash with downloaded file'
+            st = os.stat(b_file_path)
+            cl = int(resp.headers['content-length'])
+            if st.st_size != cl:
+                diff = cl - st.st_size
+                msg += f' Incomplete read, ({resp.length=}, {cl=}, {st.st_size=}) failed to read remaining {diff} bytes.'
+            raise AnsibleError(msg)
 
     return b_file_path
 

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -919,10 +919,12 @@ def test_download_file_hash_mismatch(tmp_path_factory, monkeypatch):
     data = b"\x00\x01\x02\x03"
 
     mock_open = MagicMock()
-    mock_open.return_value = BytesIO(data)
+    mock_open.return_value = resp = MagicMock()
+    resp.read = BytesIO(data).read
+    resp.headers = {'content-length': f'{len(data)}'}
     monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
 
-    expected = "Mismatch artifact hash with downloaded file"
+    expected = "Mismatched artifact hash with downloaded file of 4 bytes."
     with pytest.raises(AnsibleError, match=expected):
         collection._download_file('http://google.com/file', temp_dir, 'bad', True)
 


### PR DESCRIPTION
##### SUMMARY

This PR aims to add additional information that may assist in troubleshooting issues where collection downloads result in a checksum mismatch.

I've copied the same concept of the change we made in https://github.com/ansible/ansible/pull/85164 to add additional output if we hit an "IncompleteRead" scenario, to help explain what the source of the corruption may be.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request
