### PR TITLE
Fix module_defaults templating for gather_facts, service, and package actions

### DIFF
--- a/changelogs/fragments/module_defaults-action-plugin-templating.yml
+++ b/changelogs/fragments/module_defaults-action-plugin-templating.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - package, service, gather_facts - fix templating module_defaults for modules executed by these action plugins. (https://github.com/ansible/ansible/issues/85848)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1387,10 +1387,10 @@ def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine, t
                 tmp_args.update(templar.resolve_to_container(module_defaults.get(f'group/{group_name}', {})))
 
     # handle specific action defaults
-    if not template_fully:
-        tmp_args.update(templar.resolve_to_container(module_defaults.get(action, {})))
-    else:
+    if template_fully:
         tmp_args.update(templar.template(module_defaults.get(action, {})))
+    else:
+        tmp_args.update(templar.resolve_to_container(module_defaults.get(action, {})))
 
     return tmp_args
 

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1359,8 +1359,6 @@ def modify_module(
 def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine) -> dict[str, t.Any]:
     """
     Get module_defaults that match or contain a fully qualified action/module name.
-
-    The return value is not finalized by default because it occurs in TaskArgsFinalizer.
     """
     action_groups = task._parent._play._action_groups
     defaults = task.module_defaults

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1384,7 +1384,10 @@ def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine, t
         if default.startswith('group/'):
             group_name = default.split('group/')[-1]
             if group_name in group_names:
-                tmp_args.update(templar.resolve_to_container(module_defaults.get(f'group/{group_name}', {})))
+                if template_fully:
+                    tmp_args.update(templar.template(module_defaults.get(f'group/{group_name}', {})))
+                else:
+                    tmp_args.update(templar.resolve_to_container(module_defaults.get(f'group/{group_name}', {})))
 
     # handle specific action defaults
     if template_fully:

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1405,7 +1405,7 @@ def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine, f
 
 def _apply_action_arg_defaults(action: str, task: Task, action_args: dict[str, t.Any], templar: Templar) -> dict[str, t.Any]:
     """
-    Finalized arguments from module_defaults and update with action_args.
+    Finalize arguments from module_defaults and update with action_args.
 
     This is used by action plugins like gather_facts, package, and service,
     which select modules to execute after normal task argument finalization.

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1356,7 +1356,11 @@ def modify_module(
     )
 
 
-def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine, template_fully: bool = False) -> dict[str, t.Any]:
+def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine, finalize: bool = False) -> dict[str, t.Any]:
+    """Get module_defaults that match or contain a fully qualified action/module name.
+
+    The return value is not finalized by default because it occurs in TaskArgsFinalizer.
+    """
     action_groups = task._parent._play._action_groups
     defaults = task.module_defaults
 
@@ -1384,13 +1388,13 @@ def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine, t
         if default.startswith('group/'):
             group_name = default.split('group/')[-1]
             if group_name in group_names:
-                if template_fully:
+                if finalize:
                     tmp_args.update(templar.template(module_defaults.get(f'group/{group_name}', {})))
                 else:
                     tmp_args.update(templar.resolve_to_container(module_defaults.get(f'group/{group_name}', {})))
 
     # handle specific action defaults
-    if template_fully:
+    if finalize:
         tmp_args.update(templar.template(module_defaults.get(action, {})))
     else:
         tmp_args.update(templar.resolve_to_container(module_defaults.get(action, {})))
@@ -1399,7 +1403,12 @@ def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine, t
 
 
 def _apply_action_arg_defaults(action: str, task: Task, action_args: dict[str, t.Any], templar: Templar) -> dict[str, t.Any]:
-    args = _get_action_arg_defaults(action, task, templar._engine, template_fully=True)
+    """Finalized arguments from module_defaults and update with action_args.
+
+    This is used by action plugins like gather_facts, package, and service,
+    which select modules to execute after normal task argument finalization.
+    """
+    args = _get_action_arg_defaults(action, task, templar._engine, finalize=True)
     args.update(action_args)
 
     return args

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1393,7 +1393,7 @@ def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine) -
 
 
 def _apply_action_arg_defaults(action: str, task: Task, action_args: dict[str, t.Any], templar: Templar) -> dict[str, t.Any]:
-    args = _get_action_arg_defaults(action, task, templar._engine)
+    args = templar.template(_get_action_arg_defaults(action, task, templar._engine))
     args.update(action_args)
 
     return args

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1357,7 +1357,8 @@ def modify_module(
 
 
 def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine, finalize: bool = False) -> dict[str, t.Any]:
-    """Get module_defaults that match or contain a fully qualified action/module name.
+    """
+    Get module_defaults that match or contain a fully qualified action/module name.
 
     The return value is not finalized by default because it occurs in TaskArgsFinalizer.
     """
@@ -1403,7 +1404,8 @@ def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine, f
 
 
 def _apply_action_arg_defaults(action: str, task: Task, action_args: dict[str, t.Any], templar: Templar) -> dict[str, t.Any]:
-    """Finalized arguments from module_defaults and update with action_args.
+    """
+    Finalized arguments from module_defaults and update with action_args.
 
     This is used by action plugins like gather_facts, package, and service,
     which select modules to execute after normal task argument finalization.

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1356,7 +1356,7 @@ def modify_module(
     )
 
 
-def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine) -> dict[str, t.Any]:
+def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine, template_fully: bool = False) -> dict[str, t.Any]:
     action_groups = task._parent._play._action_groups
     defaults = task.module_defaults
 
@@ -1387,14 +1387,16 @@ def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine) -
                 tmp_args.update(templar.resolve_to_container(module_defaults.get(f'group/{group_name}', {})))
 
     # handle specific action defaults
-    tmp_args.update(templar.resolve_to_container(module_defaults.get(action, {})))
+    if not template_fully:
+        tmp_args.update(templar.resolve_to_container(module_defaults.get(action, {})))
+    else:
+        tmp_args.update(templar.template(module_defaults.get(action, {})))
 
     return tmp_args
 
 
 def _apply_action_arg_defaults(action: str, task: Task, action_args: dict[str, t.Any], templar: Templar) -> dict[str, t.Any]:
-    # Perform templating for action plugins.
-    args = templar.template(_get_action_arg_defaults(action, task, templar._engine))
+    args = _get_action_arg_defaults(action, task, templar._engine, template_fully=True)
     args.update(action_args)
 
     return args

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1356,7 +1356,7 @@ def modify_module(
     )
 
 
-def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine, finalize: bool = False) -> dict[str, t.Any]:
+def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine) -> dict[str, t.Any]:
     """
     Get module_defaults that match or contain a fully qualified action/module name.
 
@@ -1389,16 +1389,10 @@ def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine, f
         if default.startswith('group/'):
             group_name = default.split('group/')[-1]
             if group_name in group_names:
-                if finalize:
-                    tmp_args.update(templar.template(module_defaults.get(f'group/{group_name}', {})))
-                else:
-                    tmp_args.update(templar.resolve_to_container(module_defaults.get(f'group/{group_name}', {})))
+                tmp_args.update(templar.resolve_to_container(module_defaults.get(f'group/{group_name}', {})))
 
     # handle specific action defaults
-    if finalize:
-        tmp_args.update(templar.template(module_defaults.get(action, {})))
-    else:
-        tmp_args.update(templar.resolve_to_container(module_defaults.get(action, {})))
+    tmp_args.update(templar.resolve_to_container(module_defaults.get(action, {})))
 
     return tmp_args
 
@@ -1410,7 +1404,8 @@ def _apply_action_arg_defaults(action: str, task: Task, action_args: dict[str, t
     This is used by action plugins like gather_facts, package, and service,
     which select modules to execute after normal task argument finalization.
     """
-    args = _get_action_arg_defaults(action, task, templar._engine, finalize=True)
+    args = _get_action_arg_defaults(action, task, templar._engine)
+    args = templar.template({k: v for k, v in args.items() if k not in action_args})
     args.update(action_args)
 
     return args

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -1393,6 +1393,7 @@ def _get_action_arg_defaults(action: str, task: Task, templar: TemplateEngine) -
 
 
 def _apply_action_arg_defaults(action: str, task: Task, action_args: dict[str, t.Any], templar: Templar) -> dict[str, t.Any]:
+    # Perform templating for action plugins.
     args = templar.template(_get_action_arg_defaults(action, task, templar._engine))
     args.update(action_args)
 

--- a/test/integration/targets/gathering_facts/runme.sh
+++ b/test/integration/targets/gathering_facts/runme.sh
@@ -26,6 +26,9 @@ ANSIBLE_FACTS_MODULES='ansible.legacy.setup' ansible-playbook test_module_defaul
 
 ansible-playbook test_module_defaults.yml "$@" --tags networking
 
+# test gather_facts action templates module_defaults for different module name
+ansible-playbook test_module_defaults.yml "$@" --tags templating
+
 # test it works by default
 ANSIBLE_FACTS_MODULES='ansible.legacy.slow' ansible -m gather_facts localhost --playbook-dir ./ "$@"
 

--- a/test/integration/targets/gathering_facts/test_module_defaults.yml
+++ b/test/integration/targets/gathering_facts/test_module_defaults.yml
@@ -128,3 +128,21 @@
     - assert:
         that:
           - "ansible_facts.gather_subset == 'min'"
+
+- name: Test module_defaults templating when the action and module differ
+  hosts: localhost
+  gather_facts: True
+  tags:
+    - templating
+  vars:
+    subset_facts:
+      - "!all"
+      - "!min"
+      - env
+  module_defaults:
+    setup:
+      gather_subset: "{{ subset_facts }}"
+  tasks:
+    - assert:
+        that:
+          - ansible_facts.gather_subset == subset_facts

--- a/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
+++ b/test/integration/targets/module_defaults/collections/ansible_collections/testns/testcoll/meta/runtime.yml
@@ -69,6 +69,8 @@ action_groups:
     - metadata:
         extend_group:
           - testgroup
+  contains_setup:
+    - ansible.builtin.setup
   empty_metadata:
     - metadata: {}
   bad_metadata_format:

--- a/test/integration/targets/module_defaults/test_action_groups.yml
+++ b/test/integration/targets/module_defaults/test_action_groups.yml
@@ -130,3 +130,18 @@
         - metadata:
           collections:
             - testns.testcoll
+
+    - name: Test action plugin templates group defaults
+      vars:
+        setup_subset:
+          - "!all"
+          - "!min"
+          - local
+      module_defaults:
+        group/testns.testcoll.contains_setup:
+          gather_subset: "{{ setup_subset }}"
+      block:
+        - gather_facts:
+        - assert:
+            that:
+              - ansible_facts.gather_subset == setup_subset

--- a/test/integration/targets/package/tasks/main.yml
+++ b/test/integration/targets/package/tasks/main.yml
@@ -69,28 +69,53 @@
 # Verify module_defaults for package and the underlying module are utilized
 # Validates: https://github.com/ansible/ansible/issues/72918
 - block:
-    # 'name' is required
+    # note: dnf module unexpectedly succeeds when no arguments are provided.
+    # Until the requires_one_of (?) bug is fixed, this test asserts changes are made to avoid false positives.
     - name: install apt with package defaults
       package:
       module_defaults:
         package:
           name: apt
           state: present
+      register: result
 
+    - assert:
+        that: result is changed
+
+    - name: uninstall apt between tests
+      dnf5:
+        name: apt
+        state: absent
+
+    # Validate package handles applying templated defaults for dnf
+    # https://github.com/ansible/ansible/issues/85848
     - name: install apt with dnf defaults (auto)
       package:
       module_defaults:
-        dnf:
-          name: apt
+        dnf5:
+          name: "{{ 'apt' }}"
           state: present
+      register: result
 
-    - name: install apt with dnf defaults (use dnf)
+    - assert:
+        that: result is changed
+
+    - name: uninstall apt between tests
+      dnf5:
+        name: apt
+        state: absent
+
+    - name: install apt with dnf defaults (use dnf5)
       package:
-        use: dnf
+        use: dnf5
       module_defaults:
-        dnf:
+        dnf5:
           name: apt
           state: present
+      register: result
+
+    - assert:
+        that: result is changed
   always:
     - name: remove apt
       dnf:

--- a/test/integration/targets/service/tasks/tests.yml
+++ b/test/integration/targets/service/tasks/tests.yml
@@ -32,10 +32,12 @@
   when: "ansible_service_mgr in ['sysvinit', 'systemd']"
   module_defaults:
     sysvinit:
-      name: ansible_test
+      # Test the action plugin templates sysvinit defaults
+      # https://github.com/ansible/ansible/issues/85848
+      name: "{{ 'ansible_test' }}"
       enabled: yes
     systemd:
-      name: ansible_test
+      name: "{{ 'ansible_test' }}"
       enabled: yes
 
 - name: assert that changes reported for check mode run


### PR DESCRIPTION
##### SUMMARY

Action plugins which load module_defaults for other modules now template those arguments.

This can be reproduced by setting module_defaults containing a template for the specific module, and calling the action plugin, e.g.:

```yaml
- gather_facts:
  module_defaults:
    setup:
      gather_subset: "{{ 'all' }}"
```

Fixes #85848

##### ISSUE TYPE

- Bugfix Pull Request
