### PR TITLE
Remove unused CLI.init_parser usage parameter

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -372,7 +372,7 @@ class CLI(ABC):
         return op
 
     @abstractmethod
-    def init_parser(self, usage="", desc=None, epilog=None):
+    def init_parser(self, desc=None, epilog=None):
         """
         Create an options parser for most ansible scripts
 
@@ -382,11 +382,11 @@ class CLI(ABC):
         An implementation will look something like this::
 
             def init_parser(self):
-                super(MyCLI, self).init_parser(usage="My Ansible CLI", inventory_opts=True)
+                super(MyCLI, self).init_parser(desc='The purpose of the program is...')
                 ansible.arguments.option_helpers.add_runas_options(self.parser)
                 self.parser.add_option('--my-option', dest='my_option', action='store')
         """
-        self.parser = opt_help.create_base_parser(self.name, usage=usage, desc=desc, epilog=epilog)
+        self.parser = opt_help.create_base_parser(self.name, desc=desc, epilog=epilog)
 
     @abstractmethod
     def post_process_args(self, options):

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -37,8 +37,7 @@ class AdHocCLI(CLI):
 
     def init_parser(self):
         """ create an options parser for bin/ansible """
-        super(AdHocCLI, self).init_parser(usage='%prog <host-pattern> [options]',
-                                          desc="Define and run a single task 'playbook' against a set of hosts",
+        super(AdHocCLI, self).init_parser(desc="Define and run a single task 'playbook' against a set of hosts",
                                           epilog="Some actions do not make sense in Ad-Hoc (include, meta, etc)")
 
         opt_help.add_runas_options(self.parser)

--- a/lib/ansible/cli/arguments/option_helpers.py
+++ b/lib/ansible/cli/arguments/option_helpers.py
@@ -322,7 +322,7 @@ def version(prog=None):
 # Functions to add pre-canned options to an OptionParser
 #
 
-def create_base_parser(prog, usage="", desc=None, epilog=None):
+def create_base_parser(prog, desc=None, epilog=None):
     """
     Create an options parser for all ansible scripts
     """

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -44,7 +44,6 @@ class InventoryCLI(CLI):
 
     def init_parser(self):
         super(InventoryCLI, self).init_parser(
-            usage='usage: %prog [options] [group]',
             desc='Show Ansible inventory information, by default it uses the inventory script JSON format')
 
         opt_help.add_inventory_options(self.parser)

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -40,7 +40,6 @@ class PlaybookCLI(CLI):
 
         # create parser for CLI options
         super(PlaybookCLI, self).init_parser(
-            usage="%prog [options] playbook.yml [playbook2 ...]",
             desc="Runs Ansible playbooks, executing the defined tasks on the targeted hosts.")
 
         opt_help.add_connect_options(self.parser)

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -108,7 +108,6 @@ class PullCLI(CLI):
 
         # signature is different from parent as caller should not need to add usage/desc
         super(PullCLI, self).init_parser(
-            usage='%prog -U <repository> [options] [<playbook.yml>]',
             desc="pulls playbooks from a VCS repo and executes them on target host")
 
         # Do not add check_options as there's a conflict with --checkout/-C


### PR DESCRIPTION
##### SUMMARY

Fixes #85787

Removed unused parameter from ansible-pull, ansible-playbook, ansible-inventory, ansible

Since neither `CLI.init_parser` and `ansible.cli.arguments.option_helpers.create_base_parser` are public API, I removed the parameter from both without any deprecation.

##### ISSUE TYPE

- Bugfix Pull Request
