### PR TITLE
Implement get_file_bcontents() method

### DIFF
--- a/changelogs/fragments/85861-implement-get_file_bcontents-method.yaml
+++ b/changelogs/fragments/85861-implement-get_file_bcontents-method.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - dataloader - add ``get_file_bcomponents()`` method to return raw byte contents of a file, preserving ``Origin`` and ``SourceWasEncrypted``
+    tags without decoding (https://github.com/ansible/ansible/issues/85852).

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -200,7 +200,7 @@ class DataLoader:
         if not source_was_plaintext:
             bytes_content = SourceWasEncrypted().tag(bytes_content)
 
-        return AnsibleTagHelper.tag_copy(bytes_content, bytes_content)
+        return bytes_content
 
     def _get_file_contents(self, file_name: str) -> tuple[bytes, bool]:
         """

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -191,9 +191,10 @@ class DataLoader:
 
         return AnsibleTagHelper.tag_copy(bytes_content, str_content)
 
-    def get_text_file_bcomponents(self, file_name: str) -> bytes:
+    def get_file_bcomponents(self, file_name: str) -> bytes:
         """
-        Returns the raw byte contents of the specified (DWIM-expanded for relative) file path.
+        Returns an `Origin` tagged bytes object with the content of the specified
+        (DWIM-expanded for relative) file path, decrypting if necessary, but without decoding.
         """
         bytes_content, source_was_plaintext = self._get_file_contents(file_name)
         if not source_was_plaintext:

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -191,6 +191,16 @@ class DataLoader:
 
         return AnsibleTagHelper.tag_copy(bytes_content, str_content)
 
+    def get_text_file_bcomponents(self, file_name: str) -> bytes:
+        """
+        Returns the raw byte contents of the specified (DWIM-expanded for relative) file path.
+        """
+        bytes_content, source_was_plaintext = self._get_file_contents(file_name)
+        if not source_was_plaintext:
+            bytes_content = SourceWasEncrypted().tag(bytes_content)
+
+        return AnsibleTagHelper.tag_copy(bytes_content, bytes_content)
+
     def _get_file_contents(self, file_name: str) -> tuple[bytes, bool]:
         """
         Reads the file contents from the given file name

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -191,7 +191,7 @@ class DataLoader:
 
         return AnsibleTagHelper.tag_copy(bytes_content, str_content)
 
-    def get_file_bcomponents(self, file_name: str) -> bytes:
+    def get_file_bcontents(self, file_name: str) -> bytes:
         """
         Returns an `Origin` tagged bytes object with the content of the specified
         (DWIM-expanded for relative) file path, decrypting if necessary, but without decoding.


### PR DESCRIPTION
Add method to retrieve raw byte contents of a file in reference to the feature requested by issue #85852

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Added a new method that mirrors the DataLoader.get_text_file_contents() method named DataLoader.get_text_file_bcontents() that returns a tagged copy of the raw bytes of a file, as requested by a user in the aforementioned issue, in order to improve the API user experience.
<!--- Add "Fixes #1234" if there is a corresponding issue -->

##### ISSUE TYPE

- Feature Pull Request
