### PR TITLE
Prevent IO capture hang/loss in `basic.run_command`

### DIFF
--- a/changelogs/fragments/run_command_output_selector.yml
+++ b/changelogs/fragments/run_command_output_selector.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - run_command - Fixed premature selector unregistration on empty read from stdout/stderr that caused truncated output or hangs in rare situations.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2093,7 +2093,7 @@ class AnsibleModule(object):
                 stdout_changed = False
                 for key, event in events:
                     b_chunk = key.fileobj.read(32768)
-                    if not b_chunk:
+                    if not b_chunk and b_chunk is not None:
                         selector.unregister(key.fileobj)
                     elif key.fileobj == cmd.stdout:
                         stdout += b_chunk


### PR DESCRIPTION
##### SUMMARY

Fixes #30411 Ansible's handling of `fileobj.read()` needs to disambiguate `None` vs. `b''`

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

# Ansible Background

From Ansible v2.16.4 [basic.py](https://github.com/ansible/ansible/blob/9f6649cadcb255ed4cdfa9adf67da4abd7ba5e83/lib/ansible/module_utils/basic.py#L2053)
. `AnsiballZ_command.py` eventually calls this code and this is the main loop that runs, on the managed node and monitors the module/command being ran. In our case, it's monitor `migrate_service_data`. Below is a snippet of the main run loop.


```
            while True:
                events = selector.select(1)
                stdout_changed = False
                for key, event in events:
                    b_chunk = key.fileobj.read(32768)
                    if not b_chunk:
                        selector.unregister(key.fileobj)
```

The selector is monitoring two file descriptors; the read end of two pipes (stdout and stderr from `migrate_service_data`).

The pipes are removed form the selector when:
* select ie. (`select`, `ppoll`, etc) reports data is ready to read
* `key.fileobj.read(...)` returns something not truthy i.e. `None`, `b''`

# Problem

I am able to strace `AnsiballZ_command.py` [1] and the forked `migrate_service_data` _before_ the deadlock.

`migrate_service_data` is blocked on a write to the shared pipe. I used `lsof` to verify and trace that the other end of the pipe is the `AnsiballZ_command.py` process.

```
# A bunch of syscalls before this
...
write(1, "Gave permission: username: aap24"..., 8278 <detached ...>  # <-- hung here
```

`AnsiballZ_command.py` strace correlated to the code loop above.


Common path through the code loop.
```
# events = selector.select(1)
ppoll([{fd=4, events=POLLIN}, {fd=6, events=POLLIN}], 2, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=114726251})

# b_chunk = key.fileobj.read(32768)
read(6, "2025-09-15 20:23:39,837 INFO    "..., 32768) = 170
read(6, 0xaaaaefc7e77a, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
```

Deviation from the common code path in the loop.
```
# events = selector.select(1)
ppoll([{fd=4, events=POLLIN}, {fd=6, events=POLLIN}], 2, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=4, revents=POLLIN}], left {tv_sec=0, tv_nsec=593004480})

# b_chunk = key.fileobj.read(32768)
read(4, 0xaaaaefbae610, 32768)          = -1 EAGAIN (Resource temporarily unavailable)

# if not b_chunk:
#    selector.unregister(key.fileobj)
```

Next iteration of the loop, back to the common code path BUT `fd=4` is not in the `ppoll` list now.

```
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=275806828})
```

# Solution

Ansible's handling of `fileobj.read()` needs to disambiguate `None` vs. `b''`

Example python code to show `fileobj.read()` behavior.
```python
import os

r, w = os.pipe()
os.set_blocking(r, False)

fileobj = os.fdopen(r, "rb", buffering=0)

data = fileobj.read(10)
print("1. read(10) ->", data)

if not data:
    print("\tfirst read not truthy")

os.close(w)

data = fileobj.read(10)
print("2. read(10) ->", data)

if not data:
    print("\tsecond read not truthy")
```

| example return value | reason |
| - | - |
| `b'example data'` | The data read from the pipe |
| `b''` | Write side of the pipe closed.  |
| `None` | No data in the pipe to read. |


# References

[1] `AnsiballZ_command.py` strace

```
ppoll([{fd=4, events=POLLIN}, {fd=6, events=POLLIN}], 2, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=741716830})
read(6, "2025-09-15 20:23:37,749 INFO    "..., 32768) = 170
read(6, 0xaaaaefc7e77a, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=4, events=POLLIN}, {fd=6, events=POLLIN}], 2, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=34046284})
read(6, "2025-09-15 20:23:38,715 INFO    "..., 32768) = 170
read(6, 0xaaaaefbae6ba, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=4, events=POLLIN}, {fd=6, events=POLLIN}], 2, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=4, revents=POLLIN}], left {tv_sec=0, tv_nsec=767117975})
read(4, "Gave permission: username: aap24"..., 32768) = 8283
read(4, 0xaaaaefbb074b, 20480)          = -1 EAGAIN (Resource temporarily unavailable)
mmap(NULL, 27004928, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0xffff9023f000
munmap(0xffff8cec9000, 26996736)        = 0
ppoll([{fd=4, events=POLLIN}, {fd=6, events=POLLIN}], 2, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=114726251})
read(6, "2025-09-15 20:23:39,837 INFO    "..., 32768) = 170
read(6, 0xaaaaefc7e77a, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=4, events=POLLIN}, {fd=6, events=POLLIN}], 2, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=4, revents=POLLIN}], left {tv_sec=0, tv_nsec=593004480})
read(4, 0xaaaaefbae610, 32768)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=275806828})
read(6, "2025-09-15 20:23:40,969 INFO    "..., 32768) = 170
read(6, 0xaaaaefbae6ba, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 0 (Timeout)
wait4(3005094, 0xffffcdde57f4, WNOHANG, NULL) = 0
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=988243025})
read(6, "2025-09-15 20:23:41,982 INFO    "..., 32768) = 170
read(6, 0xaaaaefbae79a, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 0 (Timeout)
wait4(3005094, 0xffffcdde57f4, WNOHANG, NULL) = 0
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=874003905})
read(6, "2025-09-15 20:23:43,109 INFO    "..., 32768) = 170
read(6, 0xaaaaefbae87a, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 0 (Timeout)
wait4(3005094, 0xffffcdde57f4, WNOHANG, NULL) = 0
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=868225660})
read(6, "2025-09-15 20:23:44,243 INFO    "..., 32768) = 170
read(6, 0xaaaaefbae95a, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=13950865})
read(6, "2025-09-15 20:23:45,229 INFO    "..., 32768) = 170
read(6, 0xaaaaefbaea3a, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 0 (Timeout)
wait4(3005094, 0xffffcdde57f4, WNOHANG, NULL) = 0
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=877761060})
read(6, "2025-09-15 20:23:46,352 INFO    "..., 32768) = 170
read(6, 0xaaaaefbaeb1a, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 0 (Timeout)
wait4(3005094, 0xffffcdde57f4, WNOHANG, NULL) = 0
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=794575324})
read(6, "2025-09-15 20:23:47,559 INFO    "..., 32768) = 170
read(6, 0xaaaaefbaebfa, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 0 (Timeout)
wait4(3005094, 0xffffcdde57f4, WNOHANG, NULL) = 0
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=968477675})
read(6, "2025-09-15 20:23:48,592 INFO    "..., 32768) = 170
read(6, 0xaaaaefbaecda, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 0 (Timeout)
wait4(3005094, 0xffffcdde57f4, WNOHANG, NULL) = 0
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=839890014})
read(6, "2025-09-15 20:23:49,754 INFO    "..., 32768) = 170
read(6, 0xaaaaefbaedba, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 0 (Timeout)
wait4(3005094, 0xffffcdde57f4, WNOHANG, NULL) = 0
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=844214390})
read(6, "2025-09-15 20:23:50,912 INFO    "..., 32768) = 170
read(6, 0xaaaaefbaee9a, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 1 ([{fd=6, revents=POLLIN}], left {tv_sec=0, tv_nsec=3097815})
read(6, "2025-09-15 20:23:51,909 INFO    "..., 32768) = 170
read(6, 0xaaaaefbaef7a, 28672)          = -1 EAGAIN (Resource temporarily unavailable)
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 0 (Timeout)
wait4(3005094, 0xffffcdde57f4, WNOHANG, NULL) = 0
ppoll([{fd=6, events=POLLIN}], 1, {tv_sec=1, tv_nsec=0}, NULL, 0) = 0 (Timeout)
wait4(3005094, 0xffffcdde57f4, WNOHANG, NULL) = 0
```
