### PR TITLE
known_hosts: return rc and stderr in fail_json

### DIFF
--- a/changelogs/fragments/known_hosts.yml
+++ b/changelogs/fragments/known_hosts.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - known_hosts - return rc and stderr when ssh-keygen command fails for further debugging (https://github.com/ansible/ansible/issues/85850).

--- a/lib/ansible/modules/known_hosts.py
+++ b/lib/ansible/modules/known_hosts.py
@@ -225,7 +225,13 @@ def sanity_check(module, host, key, sshkeygen):
         rc, stdout, stderr = module.run_command(sshkeygen_command)
 
     if stdout == '':  # host not found
-        module.fail_json(msg="Host parameter does not match hashed host field in supplied key")
+        results = {
+            "msg": "Host parameter does not match hashed host field in supplied key",
+            "rc": rc,
+        }
+        if stderr:
+            results["stderr"] = stderr
+        module.fail_json(**results)
 
 
 def search_for_host_key(module, host, key, path, sshkeygen):

--- a/test/integration/targets/known_hosts/tasks/main.yml
+++ b/test/integration/targets/known_hosts/tasks/main.yml
@@ -507,3 +507,4 @@
     that:
       - result is failed
       - result.msg == 'Host parameter does not match hashed host field in supplied key'
+      - result.rc is defined


### PR DESCRIPTION
##### SUMMARY

* When ssh-keygen fails, return rc and stderr in fail_json
  in order to help debugging.

Fixes: #85850

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/known_hosts.yml
lib/ansible/modules/known_hosts.py
test/integration/targets/known_hosts/tasks/main.yml


