### PR TITLE
vars_prompt: add choices support for input validation

### DIFF
--- a/changelogs/fragments/vars_prompt_choices_support.yml
+++ b/changelogs/fragments/vars_prompt_choices_support.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - vars_prompt now supports a `choices` key for input validation. If choices are defined, users must pick one of the provided options. Values supplied via `--extra-vars` are also validated against the choices list.

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -139,13 +139,48 @@ class PlaybookExecutor:
                             salt = var.get("salt", None)
                             unsafe = boolean(var.get("unsafe", False))
 
-                            if vname not in self._variable_manager.extra_vars:
-                                if self._tqm:
-                                    self._tqm.send_callback('v2_playbook_on_vars_prompt', vname, private, prompt, encrypt, confirm, salt_size, salt,
-                                                            default, unsafe)
-                                    play.vars[vname] = display.do_var_prompt(vname, private, prompt, encrypt, confirm, salt_size, salt, default, unsafe)
-                                else:  # we are either in --list-<option> or syntax check
-                                    play.vars[vname] = default
+                            # 🔹 New: support for choices
+                            choices = var.get("choices")
+
+                            if self._tqm:
+                                self._tqm.send_callback(
+                                    'v2_playbook_on_vars_prompt',
+                                    vname, private, prompt, encrypt, confirm,
+                                    salt_size, salt, default, unsafe
+                                )
+
+                                # Skip prompt if provided via --extra-vars
+                                if vname in self._variable_manager.extra_vars:
+                                    play.vars[vname] = self._variable_manager.extra_vars[vname]
+
+                                    # If choices are defined, validate extra-vars value too
+                                    if choices and play.vars[vname] not in choices:
+                                        raise ValueError(
+                                            f"Invalid value for '{vname}': "
+                                            f"'{play.vars[vname]}' not in allowed choices {choices}"
+                                        )
+                                    continue
+
+                                answer = display.do_var_prompt(
+                                    vname, private, prompt, encrypt, confirm,
+                                    salt_size, salt, default, unsafe
+                                )
+
+                                # 🔹 Check choices for interactive input
+                                if choices:
+                                    while answer not in choices:
+                                        display.display(
+                                            f"Invalid choice. Must be one of: {choices}",
+                                            color='red'
+                                        )
+                                        answer = display.do_var_prompt(
+                                            vname, private, prompt, encrypt, confirm,
+                                            salt_size, salt, default, unsafe
+                                        )
+
+                                play.vars[vname] = answer
+                            else:
+                                play.vars[vname] = default
 
                     # Post validate so any play level variables are templated
                     all_vars = self._variable_manager.get_vars(play=play)

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -255,7 +255,7 @@ class Play(Base, Taggable, CollectionSearch):
                 if 'name' not in prompt_data:
                     raise AnsibleParserError("Invalid vars_prompt data structure, missing 'name' key", obj=ds)
                 for key in prompt_data:
-                    if key not in ('name', 'prompt', 'default', 'private', 'confirm', 'encrypt', 'salt_size', 'salt', 'unsafe'):
+                    if key not in ('name', 'prompt', 'default', 'private', 'confirm', 'encrypt', 'salt_size', 'salt', 'unsafe', 'choices'):
                         raise AnsibleParserError("Invalid vars_prompt data structure, found unsupported key '%s'" % key, obj=ds)
                 vars_prompts.append(prompt_data)
         return vars_prompts

--- a/test/integration/targets/vars_prompt_choices/aliases
+++ b/test/integration/targets/vars_prompt_choices/aliases
@@ -1,2 +1,2 @@
-shippable/posix/group1
+shippable/posix/group3
 context/controller

--- a/test/integration/targets/vars_prompt_choices/aliases
+++ b/test/integration/targets/vars_prompt_choices/aliases
@@ -1,0 +1,1 @@
+context/controller

--- a/test/integration/targets/vars_prompt_choices/aliases
+++ b/test/integration/targets/vars_prompt_choices/aliases
@@ -1,1 +1,2 @@
+shippable/posix/group1
 context/controller

--- a/test/integration/targets/vars_prompt_choices/main.yml
+++ b/test/integration/targets/vars_prompt_choices/main.yml
@@ -1,0 +1,11 @@
+- hosts: localhost
+  gather_facts: no
+  vars_prompt:
+    - name: color
+      prompt: "Choose a color"
+      choices:
+        - red
+        - green
+  tasks:
+    - debug:
+        var: color

--- a/test/integration/targets/vars_prompt_choices/tasks/main.yml
+++ b/test/integration/targets/vars_prompt_choices/tasks/main.yml
@@ -1,9 +1,7 @@
 - name: Run playbook with valid choice
   command: >
-    ansible-playbook test/integration/targets/vars_prompt_choices/main.yml
+    ansible-playbook targets/vars_prompt_choices/main.yml
     --extra-vars "color=red"
-  args:
-    chdir: "{{ lookup('env', 'ANSIBLE_TESTS') | default('/root/devs/ansible', true) }}"
   register: result_valid
   ignore_errors: yes
 
@@ -14,10 +12,8 @@
 
 - name: Run playbook with invalid choice
   command: >
-    ansible-playbook test/integration/targets/vars_prompt_choices/main.yml
+    ansible-playbook targets/vars_prompt_choices/main.yml
     --extra-vars "color=blue"
-  args:
-    chdir: "{{ lookup('env', 'ANSIBLE_TESTS') | default('/root/devs/ansible', true) }}"
   register: result_invalid
   ignore_errors: yes
 

--- a/test/integration/targets/vars_prompt_choices/tasks/main.yml
+++ b/test/integration/targets/vars_prompt_choices/tasks/main.yml
@@ -1,0 +1,27 @@
+- name: Run playbook with valid choice
+  command: >
+    ansible-playbook test/integration/targets/vars_prompt_choices/main.yml
+    --extra-vars "color=red"
+  args:
+    chdir: "{{ lookup('env', 'ANSIBLE_TESTS') | default('/root/devs/ansible', true) }}"
+  register: result_valid
+  ignore_errors: yes
+
+- name: Assert valid choice succeeded
+  assert:
+    that:
+      - result_valid.rc == 0
+
+- name: Run playbook with invalid choice
+  command: >
+    ansible-playbook test/integration/targets/vars_prompt_choices/main.yml
+    --extra-vars "color=blue"
+  args:
+    chdir: "{{ lookup('env', 'ANSIBLE_TESTS') | default('/root/devs/ansible', true) }}"
+  register: result_invalid
+  ignore_errors: yes
+
+- name: Assert invalid choice failed
+  assert:
+    that:
+      - result_invalid.rc != 0


### PR DESCRIPTION
## Summary
This PR adds support for a new `choices` key in `vars_prompt`, allowing list-based input validation directly in playbooks. Users can now restrict input to predefined options, improving playbook usability and preventing invalid data entry.

## Feature
**Example usage:**

```yaml
hosts: localhost
gather_facts: no
vars_prompt:
  - name: color
    prompt: "Choose a color"
    choices:
      - red
      - green
      - blue
    private: no

tasks:
  - debug:
      msg: "You selected: {{ color }}"
````

**Behavior:**

* If the user enters an invalid choice during interactive prompts, they are shown the valid options and prompted again.
* Values provided via `--extra-vars` are also validated against the choices list.
* If an invalid value is passed via `--extra-vars`, a `ValueError` is raised with a clear error message.

**Example with --extra-vars:**

Valid usage:

```bash
ansible-playbook playbook.yml --extra-vars "color=red"
```

Invalid usage (raises error):

```bash
ansible-playbook playbook.yml --extra-vars "color=yellow"
```

Error:

```
Invalid value for 'color': 'yellow' not in allowed choices ['red', 'green', 'blue']
```

## Changes Made

* **`lib/ansible/playbook/play.py`**: Added `'choices'` to the list of allowed keys in `vars_prompt` validation.
* **`lib/ansible/executor/playbook_executor.py`**:

  * Added logic to validate interactive user input against choices list.
  * Added validation for values provided via `--extra-vars`.
  * Implemented re-prompting logic when invalid choices are entered interactively.
  * Added clear error messages showing available options.
* **`changelogs/fragments/vars_prompt_choices_support.yml`**: Added changelog fragment documenting the new feature.

## Notes

* **Backward compatible**: No changes to existing behavior unless `choices` is explicitly used.
* **Enhanced UX**: Clear error messages guide users to valid options.
* **Comprehensive validation**: Both interactive input and `--extra-vars` are validated.
* **Useful for**: Enforcing specific input options (e.g., environments, regions, deployment types).

## ISSUE TYPE

* Feature Pull Request

## Testing

Test interactive prompts with valid/invalid choices:

```bash
ansible-playbook test_choices.yml
```

Test --extra-vars validation with valid choice:

```bash
ansible-playbook test_choices.yml --extra-vars "color=red"
```

Test --extra-vars validation with invalid choice (should raise error):

```bash
ansible-playbook test_choices.yml --extra-vars "color=yellow"
```
