### PR TITLE
[stable-2.18] Prevent IO capture hang/loss in `basic.run_command` (#85869)

### DIFF
--- a/changelogs/fragments/run_command_output_selector.yml
+++ b/changelogs/fragments/run_command_output_selector.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - run_command - Fixed premature selector unregistration on empty read from stdout/stderr that caused truncated output or hangs in rare situations.

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1972,7 +1972,7 @@ class AnsibleModule(object):
                 stdout_changed = False
                 for key, event in events:
                     b_chunk = key.fileobj.read(32768)
-                    if not b_chunk:
+                    if not b_chunk and b_chunk is not None:
                         selector.unregister(key.fileobj)
                     elif key.fileobj == cmd.stdout:
                         stdout += b_chunk


### PR DESCRIPTION
* Prevent run_command output truncation or hang

In cases when the selector used to monitor stdout/stderr activates without
data ready to read (a rare but normal condition), a read from a non-blocking
FD can return `None`, which was being conflated with an empty read (EOF)
condition. This caused the selector to be unregistered prematurely,
sometimes resulting in truncated output or hangs. `None` read results
are now excluded from EOF conditions.

* add changelog

---------
(cherry picked from commit 79ddee1)

Co-authored-by: Chris Meyers <chrismeyersfsu@users.noreply.github.com>
Co-authored-by: Matt Davis <nitzmahone@redhat.com>