### PR TITLE
respawn: Allow to check for multiple python modules

### DIFF
--- a/changelogs/fragments/probe_interpreters.yml
+++ b/changelogs/fragments/probe_interpreters.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - common.respawn module utils - Accepts a variable number of module names in ``probe_interpreters_for_module`` API (https://github.com/ansible/ansible/issues/85037).

--- a/lib/ansible/module_utils/common/respawn.py
+++ b/lib/ansible/module_utils/common/respawn.py
@@ -12,6 +12,7 @@ import typing as t
 from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils._internal._ansiballz import _respawn
 
+
 _ANSIBLE_PARENT_PATH = pathlib.Path(__file__).parents[3]
 
 
@@ -48,7 +49,7 @@ def respawn_module(interpreter_path) -> t.NoReturn:
     sys.exit(rc)  # pylint: disable=ansible-bad-function
 
 
-def probe_interpreters_for_module(interpreter_paths, module_name):
+def probe_interpreters_for_module(interpreter_paths: list[str], *module_name: str, **kwargs) -> str | None:
     """
     Probes a supplied list of Python interpreters, returning the first one capable of
     importing the named module. This is useful when attempting to locate a "system
@@ -66,6 +67,15 @@ def probe_interpreters_for_module(interpreter_paths, module_name):
         'PYTHONPATH': f'{_ANSIBLE_PARENT_PATH}:{PYTHONPATH}'.rstrip(': ')
     })
 
+    import_modules = ['ansible.module_utils.basic']
+
+    if not module_name:
+        return None
+
+    import_modules.extend(module_name)
+
+    import_string = f"import {', '.join(import_modules)}"
+
     for interpreter_path in interpreter_paths:
         if not os.path.exists(interpreter_path):
             continue
@@ -74,7 +84,7 @@ def probe_interpreters_for_module(interpreter_paths, module_name):
                 [
                     interpreter_path,
                     '-c',
-                    f'import {module_name}, ansible.module_utils.basic',
+                    import_string,
                 ],
                 env=env,
             )

--- a/test/integration/targets/module_utils/library/test_respawn.py
+++ b/test/integration/targets/module_utils/library/test_respawn.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+
+from __future__ import annotations
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.respawn import has_respawned, probe_interpreters_for_module, respawn_module
+
+HAS_SAMPLEPROJECTPY2 = True
+
+try:
+    import sample  # pylint: disable=unused-import
+except ImportError:
+    HAS_SAMPLEPROJECTPY2 = False
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            'test_multiple_modules': {
+                'type': 'bool',
+                'default': False,
+            },
+        }
+    )
+    system_interpreters = ['/usr/bin/python3', '/usr/bin/python', '/usr/local/bin/python3.12', '/usr/local/bin/python3.11']
+    test_multiple_modules = module.params['test_multiple_modules']
+
+    if not HAS_SAMPLEPROJECTPY2:
+        interpreter = probe_interpreters_for_module(system_interpreters, 'sample')
+        if not interpreter or has_respawned():
+            module.fail_json(f'unable to find sample; tried {system_interpreters}')
+        respawn_module(interpreter)
+
+    if test_multiple_modules:
+        # Check that multiple module names are supported by probe_interpreters_for_module
+        interpreter = probe_interpreters_for_module(system_interpreters, 'os', 're')
+        if not interpreter:
+            module.fail_json(f'unable to find yaml or json; tried {system_interpreters}')
+
+    module.exit_json(changed=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/integration/targets/module_utils/module_utils_respawn.yml
+++ b/test/integration/targets/module_utils/module_utils_respawn.yml
@@ -1,0 +1,41 @@
+- hosts: testhost
+  tasks:
+  - name: Uninstall sampleprojectpy2
+    pip:
+      name: sampleprojectpy2
+      state: absent
+
+  - name: Use a specially crafted module
+    test_respawn:
+    register: result
+    ignore_errors: true
+
+  - name: Check that the Python module is not installed and fails module
+    assert:
+      that:
+        - result is failed
+        - "'unable to find sample;' in result.msg"
+
+  - name: Install sampleprojectpy2
+    pip:
+      name: sampleprojectpy2
+      state: present
+
+  - name: Use a specially crafted module to see if things were imported correctly
+    test_respawn:
+    register: result
+
+  - name: Check that the Python module imported
+    assert:
+      that:
+        - result.changed
+
+  - name: Use a specially crafted module to see if multiple module names are supported
+    test_respawn:
+      test_multiple_modules: true
+    register: result
+
+  - name: Check that the Python modules were imported correctly
+    assert:
+      that:
+        - result.changed

--- a/test/integration/targets/module_utils/runme.sh
+++ b/test/integration/targets/module_utils/runme.sh
@@ -17,3 +17,5 @@ ANSIBLE_MODULE_UTILS=other_mu_dir ansible-playbook module_utils_envvar.yml -i ..
 ansible-playbook module_utils_common_dict_transformation.yml -i ../../inventory "$@"
 
 ansible-playbook module_utils_common_network.yml -i ../../inventory "$@"
+
+ansible-playbook module_utils_respawn.yml -i ../../inventory "$@"


### PR DESCRIPTION
##### SUMMARY

* Allow to check for multiple Python modules

Fixes: #85037

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/probe_interpreters.yml
lib/ansible/module_utils/common/respawn.py
lib/ansible/module_utils/facts/packages.py
lib/ansible/modules/apt.py
lib/ansible/modules/apt_repository.py
lib/ansible/modules/deb822_repository.py
lib/ansible/modules/dnf.py
lib/ansible/modules/dnf5.py
test/integration/targets/module_utils/library/test_respawn.py
test/integration/targets/module_utils/module_utils_respawn.yml
test/integration/targets/module_utils/runme.sh
test/integration/targets/setup_rpm_repo/library/create_repo.py


