### PR TITLE
Fix unarchive file metadata setting 

### DIFF
--- a/changelogs/fragments/85917-fix-unarchive-metadata.yml
+++ b/changelogs/fragments/85917-fix-unarchive-metadata.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    ``ansible.builtin.unarchive`` - Module ``unarchive`` now sets the ``owner`` and ``group`` metadata of ALL created files and directories even if the directory is not explicitly contained in the archive.
+    Previously, certain directories would retain their previous ownership because the archive did not explicitly contain those directories.
+    (https://github.com/ansible/ansible/pull/85815)

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -884,14 +884,12 @@ class TgzArchive(object):
         When listing the files in an archive, archives can include files in directories
         while excluding the containing directory. This property includes those implicitly
         created directories so that their metadata can be properly set.
-        https://github.com/ansible/ansible/issues/35426 <- top level folders
-        https://github.com/ansible/ansible/issues/85815 <- sub level folders
         """
 
         if self._files_created_by_archive:
             return self._files_created_by_archive.keys()
 
-        self._files_created_by_archive = dict()
+        self._files_created_by_archive = dict()  # Use dict as ordered set
         for file in self.files_in_archive:
             filepath = Path(file)
             self._files_created_by_archive[str(filepath)] = None

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -1176,10 +1176,7 @@ def main():
         for filename in handler.files_created_by_archive:
             file_args['path'] = os.path.join(b_dest, to_bytes(filename, errors='surrogate_or_strict'))
 
-            try:
-                res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
-            except OSError as ex:
-                module.fail_json("Unexpected error when accessing exploded file.", exception=ex, **res_args)
+            res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
 
     if module.params['list_files']:
         res_args['files'] = handler.files_in_archive

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -894,8 +894,7 @@ class TgzArchive(object):
             filepath = Path(file)
             self._files_created_by_archive[str(filepath)] = None
             for parent in filepath.parents:
-                if parent not in self._files_created_by_archive:
-                    self._files_created_by_archive[str(parent)] = None
+                self._files_created_by_archive[str(parent)] = None
 
         self._files_created_by_archive.pop('.', None)
         self._files_created_by_archive.pop('..', None)

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -894,7 +894,8 @@ class TgzArchive(object):
             filepath = Path(file)
             self._files_created_by_archive[str(filepath)] = None
             for parent in filepath.parents:
-                self._files_created_by_archive[str(parent)] = None
+                if parent not in self._files_created_by_archive:
+                    self._files_created_by_archive[str(parent)] = None
 
         self._files_created_by_archive.pop('.', None)
         self._files_created_by_archive.pop('..', None)

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -250,9 +250,9 @@ import pwd
 import re
 import stat
 import time
-from collections.abc import KeysView
 from functools import partial
 from pathlib import Path
+from typing import Iterator
 from zipfile import ZipFile
 
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
@@ -878,28 +878,26 @@ class TgzArchive(object):
         return self._files_in_archive
 
     @property
-    def files_created_by_archive(self) -> KeysView[str]:
-        """Return a list of files created implicitly or explicitly by the archive.
+    def files_created_by_archive(self) -> Iterator[str]:
+        """Return an iterator of files created implicitly or explicitly by the archive.
 
         When listing the files in an archive, archives can include files in directories
         while excluding the containing directory. This property includes those implicitly
         created directories so that their metadata can be properly set.
         """
 
-        if self._files_created_by_archive:
-            return self._files_created_by_archive.keys()
+        if not self._files_created_by_archive:
+            self._files_created_by_archive = dict()  # Use dict as ordered set
+            for file in self.files_in_archive:
+                filepath = Path(file)
+                self._files_created_by_archive[str(filepath)] = None
+                for parent in filepath.parents:
+                    self._files_created_by_archive[str(parent)] = None
 
-        self._files_created_by_archive = dict()  # Use dict as ordered set
-        for file in self.files_in_archive:
-            filepath = Path(file)
-            self._files_created_by_archive[str(filepath)] = None
-            for parent in filepath.parents:
-                self._files_created_by_archive[str(parent)] = None
+            self._files_created_by_archive.pop('.', None)
+            self._files_created_by_archive.pop('..', None)
 
-        self._files_created_by_archive.pop('.', None)
-        self._files_created_by_archive.pop('..', None)
-
-        return self._files_created_by_archive.keys()
+        yield from self._files_created_by_archive.keys()
 
     def is_unarchived(self):
         cmd = [self.cmd_path, '--diff', '-C', self.b_dest]

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -252,11 +252,12 @@ import stat
 import time
 from functools import partial
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, cast
 from zipfile import ZipFile
 
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.collections import OrderedSet
 from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.common.locale import get_best_parsable_locale
 from ansible.module_utils.urls import fetch_file
@@ -820,7 +821,7 @@ class TgzArchive(object):
         self.tar_type = None
         self.zipflag = '-z'
         self._files_in_archive = []
-        self._files_created_by_archive = None
+        self._files_created_by_archive: OrderedSet[str] | None = None
 
     def _get_tar_type(self):
         cmd = [self.cmd_path, '--version']
@@ -886,18 +887,19 @@ class TgzArchive(object):
         created directories so that their metadata can be properly set.
         """
 
-        if not self._files_created_by_archive:
-            self._files_created_by_archive = dict()  # Use dict as ordered set
+        if self._files_created_by_archive is None:
+            self._files_created_by_archive = cast(OrderedSet[str], OrderedSet())
+            assert self._files_created_by_archive is not None  # For type hinting
             for file in self.files_in_archive:
                 filepath = Path(file)
-                self._files_created_by_archive[str(filepath)] = None
+                self._files_created_by_archive.add(str(filepath))
                 for parent in filepath.parents:
-                    self._files_created_by_archive[str(parent)] = None
+                    self._files_created_by_archive.add(str(parent))
 
-            self._files_created_by_archive.pop('.', None)
-            self._files_created_by_archive.pop('..', None)
+            self._files_created_by_archive.discard('.')
+            self._files_created_by_archive.discard('..')
 
-        yield from self._files_created_by_archive.keys()
+        yield from self._files_created_by_archive
 
     def is_unarchived(self):
         cmd = [self.cmd_path, '--diff', '-C', self.b_dest]

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -888,11 +888,10 @@ class TgzArchive(object):
         https://github.com/ansible/ansible/issues/85815 <- sub level folders
         """
 
-
         if self._files_created_by_archive:
             return self._files_created_by_archive.keys()
 
-        self._files_created_by_archive: dict[str, None] | None = dict()
+        self._files_created_by_archive = dict()
         for file in self.files_in_archive:
             filepath = Path(file)
             self._files_created_by_archive[str(filepath)] = None

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -250,6 +250,7 @@ import pwd
 import re
 import stat
 import time
+from collections.abc import KeysView
 from functools import partial
 from pathlib import Path
 from zipfile import ZipFile
@@ -424,6 +425,8 @@ class ZipArchive(object):
 
             archive.close()
         return self._files_in_archive
+
+    files_created_by_archive = files_in_archive
 
     def _valid_time_stamp(self, timestamp_str):
         """ Return a valid time object from the given time string """
@@ -817,6 +820,7 @@ class TgzArchive(object):
         self.tar_type = None
         self.zipflag = '-z'
         self._files_in_archive = []
+        self._files_created_by_archive: dict[str, None] | None = None
 
     def _get_tar_type(self):
         cmd = [self.cmd_path, '--version']
@@ -872,6 +876,33 @@ class TgzArchive(object):
                 self._files_in_archive.append(to_native(filename))
 
         return self._files_in_archive
+
+    @property
+    def files_created_by_archive(self) -> KeysView[str]:
+        """Return a list of files created implicitly or explicitly by the archive.
+
+        When listing the files in an archive, archives can include files in directories
+        while excluding the containing directory. This property includes those implicitly
+        created directories so that their metadata can be properly set.
+        https://github.com/ansible/ansible/issues/35426 <- top level folders
+        https://github.com/ansible/ansible/issues/85815 <- sub level folders
+        """
+
+
+        if self._files_created_by_archive:
+            return self._files_created_by_archive.keys()
+
+        self._files_created_by_archive: dict[str, None] | None = dict()
+        for file in self.files_in_archive:
+            filepath = Path(file)
+            self._files_created_by_archive[str(filepath)] = None
+            for parent in filepath.parents:
+                self._files_created_by_archive[str(parent)] = None
+
+        self._files_created_by_archive.pop('.', None)
+        self._files_created_by_archive.pop('..', None)
+
+        return self._files_created_by_archive.keys()
 
     def is_unarchived(self):
         cmd = [self.cmd_path, '--diff', '-C', self.b_dest]
@@ -1145,31 +1176,13 @@ def main():
     # Run only if we found differences (idempotence) or diff was missing
     if res_args.get('diff', True) and not module.check_mode:
         # do we need to change perms?
-        folders = set()
-        for filename in handler.files_in_archive:
+        for filename in handler.files_created_by_archive:
             file_args['path'] = os.path.join(b_dest, to_bytes(filename, errors='surrogate_or_strict'))
 
             try:
                 res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
             except OSError as ex:
                 module.fail_json("Unexpected error when accessing exploded file.", exception=ex, **res_args)
-
-            if '/' in filename:
-                folder_path = Path(filename).parent
-                if folder_path not in folders:
-                    folders.add(folder_path)
-
-        # make sure folders implicitly included in the archive have the right permissions
-        # https://github.com/ansible/ansible/issues/35426 <- top level folders
-        # https://github.com/ansible/ansible/issues/85815 <- sub level folders
-        if folders:
-            absolute_dest = Path(dest)
-            for folder in folders:
-                file_args['path'] = absolute_dest / folder
-                try:
-                    res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
-                except OSError as ex:
-                    module.fail_json("Unexpected error when accessing exploded file.", exception=ex, **res_args)
 
     if module.params['list_files']:
         res_args['files'] = handler.files_in_archive

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -820,7 +820,7 @@ class TgzArchive(object):
         self.tar_type = None
         self.zipflag = '-z'
         self._files_in_archive = []
-        self._files_created_by_archive: dict[str, None] | None = None
+        self._files_created_by_archive = None
 
     def _get_tar_type(self):
         cmd = [self.cmd_path, '--version']

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -821,7 +821,6 @@ class TgzArchive(object):
         self.tar_type = None
         self.zipflag = '-z'
         self._files_in_archive = []
-        self._files_created_by_archive: OrderedSet[str] | None = None
 
     def _get_tar_type(self):
         cmd = [self.cmd_path, '--version']
@@ -886,20 +885,17 @@ class TgzArchive(object):
         while excluding the containing directory. This property includes those implicitly
         created directories so that their metadata can be properly set.
         """
+        files_created = cast(OrderedSet[str], OrderedSet())
+        for file in self.files_in_archive:
+            filepath = Path(file)
+            files_created.add(str(filepath))
+            for parent in filepath.parents:
+                files_created.add(str(parent))
 
-        if self._files_created_by_archive is None:
-            self._files_created_by_archive = cast(OrderedSet[str], OrderedSet())
-            assert self._files_created_by_archive is not None  # For type hinting
-            for file in self.files_in_archive:
-                filepath = Path(file)
-                self._files_created_by_archive.add(str(filepath))
-                for parent in filepath.parents:
-                    self._files_created_by_archive.add(str(parent))
+        files_created.discard('.')
+        files_created.discard('..')
 
-            self._files_created_by_archive.discard('.')
-            self._files_created_by_archive.discard('..')
-
-        yield from self._files_created_by_archive
+        yield from files_created
 
     def is_unarchived(self):
         cmd = [self.cmd_path, '--diff', '-C', self.b_dest]

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -251,6 +251,7 @@ import re
 import stat
 import time
 from functools import partial
+from pathlib import Path
 from zipfile import ZipFile
 
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
@@ -1144,7 +1145,7 @@ def main():
     # Run only if we found differences (idempotence) or diff was missing
     if res_args.get('diff', True) and not module.check_mode:
         # do we need to change perms?
-        top_folders = []
+        folders = set()
         for filename in handler.files_in_archive:
             file_args['path'] = os.path.join(b_dest, to_bytes(filename, errors='surrogate_or_strict'))
 
@@ -1154,15 +1155,17 @@ def main():
                 module.fail_json("Unexpected error when accessing exploded file.", exception=ex, **res_args)
 
             if '/' in filename:
-                top_folder_path = filename.split('/')[0]
-                if top_folder_path not in top_folders:
-                    top_folders.append(top_folder_path)
+                folder_path = Path(filename).parent
+                if folder_path not in folders:
+                    folders.add(folder_path)
 
-        # make sure top folders have the right permissions
-        # https://github.com/ansible/ansible/issues/35426
-        if top_folders:
-            for f in top_folders:
-                file_args['path'] = "%s/%s" % (dest, f)
+        # make sure folders implicitly included in the archive have the right permissions
+        # https://github.com/ansible/ansible/issues/35426 <- top level folders
+        # https://github.com/ansible/ansible/issues/85815 <- sub level folders
+        if folders:
+            absolute_dest = Path(dest)
+            for folder in folders:
+                file_args['path'] = absolute_dest / folder
                 try:
                     res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
                 except OSError as ex:

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -22,5 +22,5 @@
 - import_tasks: test_unprivileged_user.yml
 - import_tasks: test_different_language_var.yml
 - import_tasks: test_invalid_options.yml
-- import_tasks: test_ownership_top_folder.yml
+- import_tasks: test_ownership_implicit_folders.yml
 - import_tasks: test_relative_dest.yml

--- a/test/integration/targets/unarchive/tasks/test_ownership_implicit_folders.yml
+++ b/test/integration/targets/unarchive/tasks/test_ownership_implicit_folders.yml
@@ -1,23 +1,29 @@
-- name: Test unarchiving as root and apply different ownership to top folder
+- name: Test unarchiving as root and apply different ownership to implicitly created folders
   vars:
     ansible_become: yes
     ansible_become_user: root
     ansible_become_password: null
   block:
-    - name: Create top folder owned by root
+    - name: Create directory structure owned by root
       file:
-        path: "{{ test_user.home }}/tarball-top-folder"
+        path: "{{ test_user.home }}/tarball-top-folder/subfolder"
         state: directory
         owner: root
 
-    - name: Add a file owned by root
+    - name: Add a file owned by root to top-folder
       copy:
         src: foo.txt
         dest: "{{ test_user.home }}/tarball-top-folder/foo-unarchive.txt"
         mode: preserve
 
-    - name: Create a tarball as root. This tarball won't list the top folder when doing "tar tvf test-tarball.tar.gz"
-      shell: tar -czf test-tarball.tar.gz tarball-top-folder/foo-unarchive.txt
+    - name: Add a file owned by root to sub-folder
+      copy:
+        src: foo.txt
+        dest: "{{ test_user.home }}/tarball-top-folder/subfolder/bar-unarchive.txt"
+        mode: preserve
+
+    - name: Create a tarball as root. This tarball won't list the top folder or subfolder when doing "tar tvf test-tarball.tar.gz"
+      shell: tar -czf test-tarball.tar.gz tarball-top-folder/foo-unarchive.txt tarball-top-folder/subfolder/bar-unarchive.txt
       args:
         chdir: "{{ test_user.home }}"
         creates: "{{ test_user.home }}/test-tarball.tar.gz"
@@ -29,7 +35,7 @@
         owner: "{{ test_user.name }}"
         group: "{{ test_user.group }}"
 
-    - name: "unarchive the tarball as root. apply ownership for {{ test_user.name }}"
+    - name: Unarchive the tarball as root. apply ownership for {{ test_user.name }}
       unarchive:
         src: "{{ test_user.home }}/test-tarball.tar.gz"
         dest: "{{ test_user.home }}/unarchivetest3-unarchive"
@@ -48,3 +54,14 @@
         that:
           - top_folder_info.stat.pw_name == test_user.name
           - top_folder_info.stat.gid == test_user.group
+
+    - name: Stat the extracted subfolder
+      stat:
+        path: "{{ test_user.home }}/unarchivetest3-unarchive/tarball-top-folder/subfolder"
+      register: sub_folder_info
+
+    - name: "verify that extracted top folder is owned by {{ test_user.name }}"
+      assert:
+        that:
+          - sub_folder_info.stat.pw_name == test_user.name
+          - sub_folder_info.stat.gid == test_user.group


### PR DESCRIPTION
##### SUMMARY

Because archives can contain files without containing their parent directories, module
`unarchive` does not set file metadata for implicitly created folders. This PR expands
the fix in #73024 from fixing just the metadata of top-level files to all created files
or directories.

Fixes #85815 

##### ISSUE TYPE

Bugfix Pull Request
