### PR TITLE
Deprecate `ansible.module_utils.six`

### DIFF
--- a/changelogs/fragments/deprecate-six.yml
+++ b/changelogs/fragments/deprecate-six.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - Deprecate the ``ansible.module_utils.six`` module. Use the Python standard library equivalent instead.

--- a/lib/ansible/module_utils/six/__init__.py
+++ b/lib/ansible/module_utils/six/__init__.py
@@ -33,6 +33,14 @@ import operator
 import sys
 import types
 
+from ansible.module_utils.common import warnings as _warnings
+
+_warnings.deprecate(
+    msg="The `ansible.module_utils.six` module is deprecated.",
+    help_text="Use the Python standard library equivalent instead.",
+    version="2.24",
+)
+
 # The following makes it easier for us to script updates of the bundled code. It is not part of
 # upstream six
 _BUNDLED_METADATA = {"pypi_name": "six", "version": "1.17.0"}

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/unwanted.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/unwanted.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import os
 import typing as t
 
@@ -108,10 +109,6 @@ class AnsibleUnwantedChecker(BaseChecker):
                 'Iterator',
             )
         ),
-
-        'ansible.module_utils.six': UnwantedEntry(
-            'the Python standard library equivalent'
-        ),
     }
 
     unwanted_functions = {
@@ -135,6 +132,18 @@ class AnsibleUnwantedChecker(BaseChecker):
                                         ),
                                         modules_only=True),
     }
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if self.is_ansible_core:
+            self.unwanted_imports['ansible.module_utils.six'] = UnwantedEntry(
+                'the Python standard library equivalent'
+            )
+
+    @functools.cached_property
+    def is_ansible_core(self) -> bool:
+        """True if ansible-core is being tested."""
+        return not self.linter.config.collection_name
 
     def visit_import(self, node):  # type: (astroid.node_classes.Import) -> None
         """Visit an import node."""

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/unwanted.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/unwanted.py
@@ -135,6 +135,7 @@ class AnsibleUnwantedChecker(BaseChecker):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        # ansible.module_utils.six is deprecated and collections can still use it until it is removed
         if self.is_ansible_core:
             self.unwanted_imports['ansible.module_utils.six'] = UnwantedEntry(
                 'the Python standard library equivalent'


### PR DESCRIPTION
##### SUMMARY
Fixes #85920
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
