### PR TITLE
Update DataLoader.get_basedir to be an abspath

### DIFF
--- a/changelogs/fragments/data-loader-basedir-abspath.yml
+++ b/changelogs/fragments/data-loader-basedir-abspath.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- DataLoader - Update ``DataLoader.get_basedir`` to be an abspath

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -54,7 +54,7 @@ class DataLoader:
 
     def __init__(self) -> None:
 
-        self._basedir: str = '.'
+        self._basedir: str = os.path.abspath('.')
 
         # NOTE: not effective with forks as the main copy does not get updated.
         # avoids rereading files
@@ -227,7 +227,7 @@ class DataLoader:
 
     def set_basedir(self, basedir: str) -> None:
         """ sets the base directory, used to find files when a relative path is given """
-        self._basedir = basedir
+        self._basedir = os.path.abspath(basedir)
 
     def path_dwim(self, given: str) -> str:
         """

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-import os
 import sys
 import typing as t
 
@@ -447,7 +446,7 @@ class VariableManager:
         """
 
         variables = {}
-        variables['playbook_dir'] = os.path.abspath(self._loader.get_basedir())
+        variables['playbook_dir'] = self._loader.get_basedir()
         variables['ansible_playbook_python'] = sys.executable
         variables['ansible_config_file'] = C.CONFIG_FILE
 

--- a/test/units/parsing/test_dataloader.py
+++ b/test/units/parsing/test_dataloader.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import collections
 import os
 import pathlib
 import tempfile
@@ -109,9 +110,9 @@ class TestDataLoader(unittest.TestCase):
             self.assertIn('/tmp/roles/testrole/tasks/included2.yml', called_args)
             self.assertIn('/tmp/roles/testrole/tasks/tasks/included2.yml', called_args)
 
-            # relative directories below are taken in account too:
-            self.assertIn('tasks/included2.yml', called_args)
-            self.assertIn('included2.yml', called_args)
+            c = collections.Counter(called_args)
+            assert c['/tmp/roles/testrole/tasks/included2.yml'] == 1
+            assert c['/tmp/roles/testrole/tasks/tasks/included2.yml'] == 2
 
     def test_path_dwim_root(self):
         self.assertEqual(self._loader.path_dwim('/'), '/')
@@ -167,7 +168,7 @@ class TestPathDwimRelativeStackDataLoader(unittest.TestCase):
         self.assertRaisesRegex(AnsibleFileNotFound, 'on the Ansible Controller', self._loader.path_dwim_relative_stack, None, None, None)
 
     def test_empty_strings(self):
-        self.assertEqual(self._loader.path_dwim_relative_stack('', '', ''), './')
+        self.assertEqual(self._loader.path_dwim_relative_stack('', '', ''), os.path.abspath('./') + '/')
 
     def test_empty_lists(self):
         self.assertEqual(self._loader.path_dwim_relative_stack([], '', '~/'), os.path.expanduser('~'))


### PR DESCRIPTION
##### SUMMARY

This PR aims to address a performance issue in that `VariableManager.get_vars` causes a `os.path.abspath` for every host for every task.

This is mediated in this PR by always storing the abspath for the `_basedir`, and no longer calculating it on access.

##### ISSUE TYPE

- Bugfix Pull Request
