### PR TITLE
Fix: handle ValueError in run_command when parsing invalid args(shlex.split)

### DIFF
--- a/changelogs/fragments/basic_shlex_split.yml
+++ b/changelogs/fragments/basic_shlex_split.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - basic - handle exception raised while shlex.split (https://github.com/ansible/ansible/issues/85719).
+  - basic - fail in controlled manner when ``run_command()`` attempts to parse a command with broken syntax passed in as a string (https://github.com/ansible/ansible/issues/85719).

--- a/changelogs/fragments/basic_shlex_split.yml
+++ b/changelogs/fragments/basic_shlex_split.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - basic - handle exception raised while shlex.split (https://github.com/ansible/ansible/issues/85719).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1974,7 +1974,10 @@ class AnsibleModule(object):
         else:
             # ensure args are a list
             if isinstance(args, (bytes, str)):
-                args = shlex.split(to_text(args, errors='surrogateescape'))
+                try:
+                    args = shlex.split(to_text(args, errors='surrogateescape'))
+                except ValueError as e:
+                    self.fail_json(msg=f"Invalid command syntax in run_command: {e}")
 
             # expand ``~`` in paths, and all environment vars
             if expand_user_and_vars:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1977,7 +1977,7 @@ class AnsibleModule(object):
                 try:
                     args = shlex.split(to_text(args, errors='surrogateescape'))
                 except ValueError as e:
-                    self.fail_json(msg=f"Invalid command syntax in run_command", exception=e)
+                    self.fail_json(msg="Invalid command syntax in run_command", exception=e)
 
             # expand ``~`` in paths, and all environment vars
             if expand_user_and_vars:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1977,7 +1977,7 @@ class AnsibleModule(object):
                 try:
                     args = shlex.split(to_text(args, errors='surrogateescape'))
                 except ValueError as e:
-                    self.fail_json(msg=f"Invalid command syntax in run_command: {e}")
+                    self.fail_json(msg=f"Invalid command syntax in run_command", exception=e)
 
             # expand ``~`` in paths, and all environment vars
             if expand_user_and_vars:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1977,7 +1977,7 @@ class AnsibleModule(object):
                 try:
                     args = shlex.split(to_text(args, errors='surrogateescape'))
                 except ValueError as e:
-                    self.fail_json(msg="Invalid command syntax in run_command", exception=e)
+                    self.fail_json(msg=f"Invalid command syntax in run_command: {e}", exception=e)
 
             # expand ``~`` in paths, and all environment vars
             if expand_user_and_vars:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1977,7 +1977,7 @@ class AnsibleModule(object):
                 try:
                     args = shlex.split(to_text(args, errors='surrogateescape'))
                 except ValueError as e:
-                    self.fail_json(msg=f"Invalid command syntax in run_command: {e}", exception=e)
+                    self.fail_json(msg="Invalid command syntax in run_command", exception=e)
 
             # expand ``~`` in paths, and all environment vars
             if expand_user_and_vars:

--- a/test/integration/targets/assemble/tasks/main.yml
+++ b/test/integration/targets/assemble/tasks/main.yml
@@ -198,3 +198,22 @@
       - result.diff.after is defined
       - result.diff.before is defined
       - "result.state == 'file'"
+
+- name: Setup for validate test
+  ansible.builtin.file:
+    path: "{{ remote_tmp_dir }}/src_val_syntax"
+    state: directory
+
+- name: assemble with invalid validation command
+  ansible.builtin.assemble:
+    src: "{{ remote_tmp_dir }}/src_val_syntax"
+    dest: "{{ remote_tmp_dir }}/dest_val_syntax"
+    validate: "echo 'missing %s"
+  register: assemble_syntax_error
+  ignore_errors: yes
+
+- name: assert assemble failed with ignore_errors
+  assert:
+    that:
+      - assemble_syntax_error.failed
+      - "'Invalid command syntax' in assemble_syntax_error.msg"


### PR DESCRIPTION
SUMMARY  
Handle `ValueError` raised while splitting args using `shlex.split` in `run_command`.  
Fixes: #85719  

Signed-off-by: Jason Hall <jason.kei.hall@gmail.com>  

ISSUE TYPE  
Bugfix Pull Request  

COMPONENT NAME  
changelogs/fragments/basic_shlex_split.yml  
lib/ansible/module_utils/basic.py  
test/integration/targets/assemble/tasks/main.yml  
