### PR TITLE
Fix misc docs

### DIFF
--- a/lib/ansible/_internal/_yaml/_constructor.py
+++ b/lib/ansible/_internal/_yaml/_constructor.py
@@ -74,7 +74,7 @@ class AnsibleInstrumentedConstructor(_BaseConstructor):
                 if self._duplicate_key_mode == 'error':
                     raise AnsibleConstructorError(problem=msg, problem_mark=key_node.start_mark)
 
-                if self._duplicate_key_mode == 'warn':
+                if self._duplicate_key_mode in ['warn', 'warning']:
                     display.warning(msg=msg, obj=key, help_text='Using last defined value only.')
 
             keys.add(key)

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1368,10 +1368,9 @@ DUPLICATE_YAML_DICT_KEY:
   ini:
   - {key: duplicate_dict_key, section: defaults}
   type: string
-  choices: &basic_error2
-    error: issue a 'fatal' error and stop the play
+  choices:
+    <<: *basic_error
     warn: issue a warning but continue
-    ignore: just continue silently
   version_added: "2.9"
 ERROR_ON_MISSING_HANDLER:
   name: Missing handler error
@@ -2071,7 +2070,7 @@ _TEMPLAR_UNTRUSTED_TEMPLATE_BEHAVIOR:
   default: ignore
   description:
     - Action to take when processing of an untrusted template is skipped.
-    - For `ignore` or `warn`, the input template string is returned as-is.
+    - For `ignore` or `warning`, the input template string is returned as-is.
     - This setting has no effect on expressions.
     - Experimental diagnostic feature, subject to change.
   type: choices

--- a/test/integration/targets/yaml_parsing/tasks/main.yml
+++ b/test/integration/targets/yaml_parsing/tasks/main.yml
@@ -4,10 +4,18 @@
     ANSIBLE_DUPLICATE_YAML_DICT_KEY: warn
   register: duplicate_warn
 
+- name: Test ANSIBLE_DUPLICATE_YAML_DICT_KEY=warning
+  command: ansible-playbook {{ verbosity }} {{ role_path }}/playbook.yml
+  environment:
+    ANSIBLE_DUPLICATE_YAML_DICT_KEY: warning
+  register: duplicate_warning
+
 - assert:
     that:
       - duplicate_warn.stderr is contains("Found duplicate mapping key 'foo'")
       - duplicate_warn.rc == 0
+      - duplicate_warning.stderr is contains("Found duplicate mapping key 'foo'")
+      - duplicate_warning.rc == 0
 
 - name: Test ANSIBLE_DUPLICATE_YAML_DICT_KEY=error
   command: ansible-playbook {{ verbosity }} {{ role_path }}/playbook.yml

--- a/test/units/parsing/yaml/test_errors.py
+++ b/test/units/parsing/yaml/test_errors.py
@@ -98,8 +98,9 @@ def test_yaml_parser_error(
         assert error.value._help_text is None
 
 
-def test_yaml_duplicate_key_warning(mocker: pytest_mock.MockerFixture) -> None:
-    set_duplicate_yaml_dict_key_config(mocker, 'warn')
+@pytest.mark.parametrize("mode", ['warn', 'warning'])
+def test_yaml_duplicate_key_warning(mocker: pytest_mock.MockerFixture, mode: str) -> None:
+    set_duplicate_yaml_dict_key_config(mocker, mode)
 
     patched_warning = mocker.patch.object(Display(), 'warning')
 


### PR DESCRIPTION
##### SUMMARY

* Removed unused basic_error2 yaml marker
* Corrected option value for _ANSIBLE_TEMPLAR_UNTRUSTED_TEMPLATE_BEHAVIOR

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE

- Docs Pull Request



##### COMPONENT NAME
lib/ansible/config/base.yml

