### PR TITLE
Use strict_optional @ ansible.galaxy.dependency_resolution

### DIFF
--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -51,7 +51,7 @@ class CollectionDependencyProvider(AbstractProvider):
     def __init__(
             self,
             apis: MultiGalaxyAPIProxy,
-            concrete_artifacts_manager: ConcreteArtifactsManager | None = None,
+            concrete_artifacts_manager: ConcreteArtifactsManager,
             preferred_candidates: _c.Iterable[Candidate] | None = None,
             with_deps: bool = True,
             with_pre_releases: bool = False,

--- a/test/sanity/code-smell/mypy/ansible-core.ini
+++ b/test/sanity/code-smell/mypy/ansible-core.ini
@@ -23,6 +23,9 @@ ignore_missing_imports = True
 [mypy-ansible_test.*]
 ignore_missing_imports = True
 
+[mypy-ansible.galaxy.dependency_resolution.*]
+strict_optional = True
+
 [mypy-ansible.module_utils.six.moves.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
This patch drops unnecessary default for
`CollectionDependencyProvider`'s `concrete_artifacts_manager` argument as it is always passed, in every place across the code base where the provider is constructed.

It was also causing MyPy violations on calls to
`_ComputedReqKindsMixin.from_requirement_dict()` in the "strict optional" mode which is now enforced for $sbj, while remaining disabled globally.

It is a #85545 follow-up.

##### SUMMARY

SSIA.

##### ISSUE TYPE

- Test Pull Request
