### PR TITLE
Mention pkg name in `package-data` sanity output

### DIFF
--- a/test/sanity/code-smell/package-data.py
+++ b/test/sanity/code-smell/package-data.py
@@ -247,7 +247,7 @@ def check_build(complete_file_list: list[str], use_upper_setuptools_version: boo
             errors.extend(check_files('sdist', expected_sdist_files, actual_sdist_files))
             errors.extend(check_files('wheel', expected_wheel_files, actual_wheel_files))
 
-    errors = [f'{msg} ({setuptools_version})' for msg in errors]
+    errors = [f'{msg} (setuptools=={setuptools_version})' for msg in errors]
 
     return errors
 


### PR DESCRIPTION
The logs were displaying a series of numbers in parens like `(66.1.0)` at the end of each error line. It's unintuitive what that means. I had to look into the source code to confirm my suspicion of it being the version of `setuptools`. This patch spells it out.

##### SUMMARY

SSIA.

##### ISSUE TYPE

- Test Pull Request
