### PR TITLE
docs: clarify dict2items usage pattern in group module loops (#85897 …

### DIFF
--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -1,0 +1,32 @@
+.. _dict2items-example-with-group:
+
+Using ``dict2items`` in Loops with the ``group`` Module
+-------------------------------------------------------
+
+When looping over dictionaries that contain structured data (for example, group names and GIDs),
+you can use the ``dict2items`` filter to convert the dictionary into a list of key–value pairs.
+
+Each loop item will then have two attributes: ``item.key`` and ``item.value``.
+If ``item.value`` itself is a dictionary, access its fields using dot notation.
+
+**Example:**
+
+.. code-block:: yaml
+
+    - name: Add groups using dict2items
+      hosts: all
+      tasks:
+        - name: Create groups from a dictionary
+          ansible.builtin.group:
+            name: "{{ item.key }}"
+            gid: "{{ item.value.gid }}"
+            state: present
+          loop: "{{ global_groups | dict2items }}"
+
+**Incorrect usage (common mistake):**
+
+.. code-block:: yaml
+
+    gid: "{{ item.gid }}"   # ❌ This fails because item.gid does not exist
+
+This clarification follows feedback from issue #85897.

--- a/examples/playbooks/loops/dict2items_group.yml
+++ b/examples/playbooks/loops/dict2items_group.yml
@@ -1,0 +1,19 @@
+---
+# Example: Correct use of dict2items for group management
+
+- name: Create groups from dictionary data
+  hosts: all
+  gather_facts: false
+  vars:
+    global_groups:
+      devops:
+        gid: 1001
+      qa:
+        gid: 1002
+  tasks:
+    - name: Add groups using dict2items
+      ansible.builtin.group:
+        name: "{{ item.key }}"
+        gid: "{{ item.value.gid }}"
+        state: present
+      loop: "{{ global_groups | dict2items }}"


### PR DESCRIPTION
### Summary
This PR improves documentation for `dict2items` usage in playbook loops,
highlighting a common mistake when accessing nested dictionary values in tasks
like `ansible.builtin.group`.

### Motivation
Following confusion in issue [#85897](https://github.com/ansible/ansible/issues/85897),
this update adds a clear example showing correct syntax using `item.value.gid`
instead of `item.gid`.

### Changes
- Added a new section to `docs/docsite/rst/playbooks_loops.rst`
- Added an illustrative example playbook under `examples/playbooks/loops/`

### Verification
Example tested on RHEL systems running Ansible 2.15.3

### Related Issues
Follow-up documentation enhancement for #85897.
