### PR TITLE
Explicitly notify Codecov about upload completion

### DIFF
--- a/.azure-pipelines/scripts/publish-codecov.py
+++ b/.azure-pipelines/scripts/publish-codecov.py
@@ -118,16 +118,40 @@ def upload_files(codecov_bin: pathlib.Path, config_file: pathlib.Path, files: t.
         run(*cmd)
 
 
+def report_upload_completion(
+    codecov_bin: pathlib.Path,
+    config_file: pathlib.Path,
+    dry_run: bool = False,
+) -> None:
+    """Notify Codecov backend that all reports we wanted are in."""
+    cmd = [
+        codecov_bin,
+        '--disable-telem',
+        f'--codecov-yml-path={config_file}',
+        'send-notifications',
+    ]
+
+    if dry_run:
+        cmd.append('--dry-run')
+
+    run(*cmd)
+
+
 def main() -> None:
     args = parse_args()
 
     with tempfile.TemporaryDirectory(prefix='codecov-') as tmpdir:
         config_file = pathlib.Path(tmpdir) / 'config.yml'
-        config_file.write_text('')
+        # Refs:
+        # * https://docs.codecov.com/docs/codecovyml-reference#codecovnotifymanual_trigger
+        # * https://docs.codecov.com/docs/notifications#preventing-notifications-until-youre-ready-to-send-notifications
+        config_file.write_text('codecov:\n  notify:\n    manual_trigger: true')
 
         codecov_bin = install_codecov(pathlib.Path(tmpdir))
         files = process_files(args.path)
         upload_files(codecov_bin, config_file, files, args.dry_run)
+        # Ref: https://docs.codecov.com/docs/cli-options#send-notifications
+        report_upload_completion(codecov_bin, config_file, args.dry_run)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch add an additional invocation of Codecov CLI that tells the backend that we're done uploading. It is supposed to stop Codecov from guessing whether to wait for more uploads for the CI or start processing them already.

Upstream refs:
* https://docs.codecov.com/docs/cli-options#send-notifications
* https://docs.codecov.com/docs/notifications#preventing-notifications-until-youre-ready-to-send-notifications
* https://docs.codecov.com/docs/codecovyml-reference#codecovnotifymanual_trigger
* https://github.com/codecov/codecov-cli/pull/195 (https://github.com/getsentry/prevent-cli/commit/d634ebd8f21d2880df12f002d83afa499652ea25)
* https://github.com/codecov/codecov-action/issues/1436
* https://github.com/codecov/engineering-team/issues/107
* https://github.com/codecov/roadmap/issues/20
* https://github.com/codecov/feedback/discussions/204#discussioncomment-8796433
* https://github.com/codecov/engineering-team/issues/1245
* https://github.com/codecov/engineering-team/issues/3
* https://github.com/codecov/worker/pull/14 (https://github.com/codecov/umbrella/commit/71626b6368a880d92f1d611917e6ec08598ef26b)

ci_complete
ci_coverage

##### SUMMARY

SSIA.

##### ISSUE TYPE

- Test Pull Request
