### PR TITLE
Use bcrypt < 5 for unit tests

### DIFF
--- a/test/units/requirements.txt
+++ b/test/units/requirements.txt
@@ -1,4 +1,4 @@
-bcrypt ; python_version >= '3.12'  # controller only
+bcrypt < 5 ; python_version >= '3.12'  # controller only, bcrypt 5+ not compatible with passlib
 passlib ; python_version >= '3.12'  # controller only
 pexpect ; python_version >= '3.12'  # controller only
 pywinrm ; python_version >= '3.12'  # controller only


### PR DESCRIPTION
##### SUMMARY

Use bcrypt < 5 for unit tests.

##### ISSUE TYPE

Test Pull Request
