### PR TITLE
replace random with secrets when generating passwords

### DIFF
--- a/changelogs/fragments/replace-random-with-secrets.yml
+++ b/changelogs/fragments/replace-random-with-secrets.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - replace random.SystemRandom() with secrets.SystemRandom() when
+    generating passwords and issue a warning if a seed is provided

--- a/changelogs/fragments/replace-random-with-secrets.yml
+++ b/changelogs/fragments/replace-random-with-secrets.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - replace random.SystemRandom() with secrets.SystemRandom() when
-    generating passwords and issue a warning if a seed is provided
+  - password lookup plugin - replace random.SystemRandom() with secrets.SystemRandom() when
+    generating passwords and issue a warning if a seed is provided (https://github.com/ansible/ansible/issues/85956, https://github.com/ansible/ansible/pull/85971).

--- a/changelogs/fragments/replace-random-with-secrets.yml
+++ b/changelogs/fragments/replace-random-with-secrets.yml
@@ -1,3 +1,3 @@
 bugfixes:
   - password lookup plugin - replace random.SystemRandom() with secrets.SystemRandom() when
-    generating passwords and issue a warning if a seed is provided (https://github.com/ansible/ansible/issues/85956, https://github.com/ansible/ansible/pull/85971).
+    generating passwords (https://github.com/ansible/ansible/issues/85956, https://github.com/ansible/ansible/pull/85971).

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -128,6 +128,7 @@ _raw:
 
 import contextlib
 import os
+import secrets
 import string
 import time
 import hashlib

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -128,7 +128,6 @@ _raw:
 
 import contextlib
 import os
-import secrets
 import string
 import time
 import hashlib

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -67,10 +67,7 @@ DOCUMENTATION = """
         description:
           - A seed to initialize the random number generator.
           - Identical seeds will yield identical passwords.
-          - B(Note) that this drastically reduces the security of this plugin.
-            First, when O(seed) is provided, a non-cryptographic random number generator is used.
-            Second, if the seed does not contain enough entropy, the generated string is weak.
-            B(Do not use the generated string as a password or a token when using this option!)
+          - B(Note) that a weak seed, one without enough entropy, will not create a sufficiently secure encryption for the password.
         type: str
     notes:
       - If the file already exists, no data will be written to it.

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -67,15 +67,12 @@ DOCUMENTATION = """
         description:
           - A seed to initialize the random number generator.
           - Identical seeds will yield identical passwords.
-          - Use this only for idempotent password generation, which is unsafe and
-            should only be used for testing.
+          - B(Note) that this drastically reduces the security of this plugin.
+            First, when O(seed) is provided, a non-cryptographic random number generator is used.
+            Second, if the seed does not contain enough entropy, the generated string is weak.
+            B(Do not use the generated string as a password or a token when using this option!)
         type: str
     notes:
-      - A great alternative to the password lookup plugin,
-        if you don't need to generate random passwords on a per-host basis,
-        would be to use Vault in playbooks.
-        Read the documentation there and consider using it first,
-        it will be more desirable for most applications.
       - If the file already exists, no data will be written to it.
         If the file has contents, those contents will be read in as the password.
         Empty files cause the password to return as an empty string.

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -112,6 +112,10 @@ EXAMPLES = """
 - name: create lowercase 8 character name for Kubernetes pod name
   ansible.builtin.set_fact:
     random_pod_name: "web-{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_lowercase', 'digits'], length=8) }}"
+
+- name: create idempotent password for use in testing/CI, not recommended for production
+  ansible.builtin.set_fact:
+    password: "{{ lookup('ansible.builtin.password', '/dev/null', seed=inventory_hostname) }}"
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -113,10 +113,6 @@ EXAMPLES = """
 - name: create lowercase 8 character name for Kubernetes pod name
   ansible.builtin.set_fact:
     random_pod_name: "web-{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_lowercase', 'digits'], length=8) }}"
-
-- name: create random but idempotent password
-  ansible.builtin.set_fact:
-    password: "{{ lookup('ansible.builtin.password', '/dev/null', seed=inventory_hostname) }}"
 """
 
 RETURN = """

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -70,6 +70,11 @@ DOCUMENTATION = """
           - B(Note) that a weak seed, one without enough entropy, will not create a sufficiently secure encryption for the password.
         type: str
     notes:
+      - A great alternative to the password lookup plugin,
+        if you don't need to generate random passwords on a per-host basis,
+        would be to use Vault in playbooks.
+        Read the documentation there and consider using it first,
+        it will be more desirable for most applications.
       - If the file already exists, no data will be written to it.
         If the file has contents, those contents will be read in as the password.
         Empty files cause the password to return as an empty string.

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -67,7 +67,8 @@ DOCUMENTATION = """
         description:
           - A seed to initialize the random number generator.
           - Identical seeds will yield identical passwords.
-          - Use this for random-but-idempotent password generation.
+          - Use this only for idempotent password generation, which is unsafe and
+            should only be used for testing.
         type: str
     notes:
       - A great alternative to the password lookup plugin,

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -57,7 +57,7 @@ def random_password(length=DEFAULT_PASSWORD_LENGTH, chars=C.DEFAULT_PASSWORD_CHA
         random_generator = secrets.SystemRandom()
     else:
         random_generator = random.Random(seed)
-        warnings.warn("The use of a seed is not secure and should only be used for testing.")
+        display.warning("The use of a seed is not secure and should only be used for testing.")
 
     return u''.join(random_generator.choice(chars) for dummy in range(length))
 

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -57,7 +57,6 @@ def random_password(length=DEFAULT_PASSWORD_LENGTH, chars=C.DEFAULT_PASSWORD_CHA
         random_generator = secrets.SystemRandom()
     else:
         random_generator = random.Random(seed)
-        display.warning("The use of a seed is not secure and should only be used for testing.")
 
     return u''.join(random_generator.choice(chars) for dummy in range(length))
 

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -57,6 +57,8 @@ def random_password(length=DEFAULT_PASSWORD_LENGTH, chars=C.DEFAULT_PASSWORD_CHA
         random_generator = secrets.SystemRandom()
     else:
         random_generator = random.Random(seed)
+        warnings.warn("The use of a seed is not secure and should only be used for testing.")
+
     return u''.join(random_generator.choice(chars) for dummy in range(length))
 
 

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import random
+import secrets
 import string
 import warnings
 
@@ -53,7 +54,7 @@ def random_password(length=DEFAULT_PASSWORD_LENGTH, chars=C.DEFAULT_PASSWORD_CHA
         raise AnsibleAssertionError(f'{chars=!r} ({type(chars)}) is not a {type(str)}.')
 
     if seed is None:
-        random_generator = random.SystemRandom()
+        random_generator = secrets.SystemRandom()
     else:
         random_generator = random.Random(seed)
     return u''.join(random_generator.choice(chars) for dummy in range(length))

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import random
-import secrets
 import string
 import warnings
 

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import random
+import secrets
 import string
 import warnings
 


### PR DESCRIPTION
##### SUMMARY

This PR:
- replaces `random.SystemRandom()` with `secrets.SystemRandom()` when generating passwords
- adds warning regarding using a seed

Fixes #85956 

##### ISSUE TYPE

- Bugfix Pull Request
