### PR TITLE
Fix psrp - ReadTimeout exceptions now mark host as unreachable

### DIFF
--- a/changelogs/fragments/85966-psrp-readtimeout.yml
+++ b/changelogs/fragments/85966-psrp-readtimeout.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - psrp - ReadTimeout exceptions now mark host as unreachable instead of fatal (https://github.com/ansible/ansible/issues/85966)

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -331,7 +331,7 @@ try:
     from pypsrp.host import PSHost, PSHostUserInterface
     from pypsrp.powershell import PowerShell, RunspacePool
     from pypsrp.wsman import WSMan
-    from requests.exceptions import ConnectionError, ConnectTimeout
+    from requests.exceptions import ConnectionError, ConnectTimeout, ReadTimeout
 except ImportError as err:
     HAS_PYPSRP = False
     PYPSRP_IMP_ERR = err
@@ -405,6 +405,11 @@ class Connection(ConnectionBase):
             except (ConnectionError, ConnectTimeout) as e:
                 raise AnsibleConnectionFailure(
                     "Failed to connect to the host via PSRP: %s"
+                    % to_native(e)
+                )
+            except ReadTimeout as e:
+                raise AnsibleConnectionFailure(
+                    "Failed to read from the host via PSRP: %s"
                     % to_native(e)
                 )
 

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -480,11 +480,11 @@ class Connection(ConnectionBase):
             display.vvv(u"PSRP: EXEC %s" % script, host=self._psrp_host)
 
         try:
-          rc, stdout, stderr = self._exec_psrp_script(
-              script=script,
-              input_data=pwsh_in_data.splitlines() if pwsh_in_data else None,
-              arguments=script_args,
-          )
+            rc, stdout, stderr = self._exec_psrp_script(
+                script=script,
+                input_data=pwsh_in_data.splitlines() if pwsh_in_data else None,
+                arguments=script_args,
+            )
         except ReadTimeout as e:
             raise AnsibleConnectionFailure(
                 "Failed to read from the host via PSRP: %s"

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -487,9 +487,8 @@ class Connection(ConnectionBase):
             )
         except ReadTimeout as e:
             raise AnsibleConnectionFailure(
-                "Failed to read from the host via PSRP: %s"
-                % to_native(e)
-            )
+                "HTTP read timeout during PSRP script execution"
+            ) from e
         return rc, stdout, stderr
 
     def put_file(self, in_path: str, out_path: str) -> None:

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -407,11 +407,6 @@ class Connection(ConnectionBase):
                     "Failed to connect to the host via PSRP: %s"
                     % to_native(e)
                 )
-            except ReadTimeout as e:
-                raise AnsibleConnectionFailure(
-                    "Failed to read from the host via PSRP: %s"
-                    % to_native(e)
-                )
 
             self._connected = True
             self._last_pipeline = None
@@ -484,11 +479,17 @@ class Connection(ConnectionBase):
             pwsh_in_data = in_data
             display.vvv(u"PSRP: EXEC %s" % script, host=self._psrp_host)
 
-        rc, stdout, stderr = self._exec_psrp_script(
-            script=script,
-            input_data=pwsh_in_data.splitlines() if pwsh_in_data else None,
-            arguments=script_args,
-        )
+        try:
+          rc, stdout, stderr = self._exec_psrp_script(
+              script=script,
+              input_data=pwsh_in_data.splitlines() if pwsh_in_data else None,
+              arguments=script_args,
+          )
+        except ReadTimeout as e:
+            raise AnsibleConnectionFailure(
+                "Failed to read from the host via PSRP: %s"
+                % to_native(e)
+            )
         return rc, stdout, stderr
 
     def put_file(self, in_path: str, out_path: str) -> None:


### PR DESCRIPTION
##### SUMMARY
ReadTimeout exceptions now mark host as unreachable instead of fatal

Added try to _exec_psrp_script to capture ReadTimeout and raise AnsibleConnectionFailure


Fixes #85966 
##### ISSUE TYPE

- Bugfix Pull Request

