### PR TITLE
ansible-vault - fixed formatting of 'not vault encrypted' message

### DIFF
--- a/changelogs/fragments/85977-vault-view-follows-symlinks.yml
+++ b/changelogs/fragments/85977-vault-view-follows-symlinks.yml
@@ -1,0 +1,10 @@
+minor_changes:
+  - ansible-vault - improved error messages for better clarity and context when
+    vault operations fail, helping users diagnose configuration or file access
+    issues more easily (https://github.com/ansible/ansible/pull/85977).
+
+bugfixes:
+  - ansible-vault - previously, the ``view`` command did not follow symbolic links,
+    causing it to fail when the provided vault file path was a symlink. The command
+    now correctly follows symlinks when viewing encrypted files
+    (https://github.com/ansible/ansible/pull/85977).

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -890,7 +890,7 @@ class VaultEditor:
         try:
             plaintext = self.vault.decrypt(ciphertext)
         except AnsibleError as e:
-            raise AnsibleError("%s for %s" % (to_native(e), to_native(filename)))
+            raise AnsibleError(f"Failed to decrypt {filename}.") from e
         self.write_data(plaintext, output_file or filename, shred=False)
 
     def create_file(self, filename, secret, vault_id=None):
@@ -949,7 +949,7 @@ class VaultEditor:
             plaintext = self.vault.decrypt(vaulttext)
             return plaintext
         except AnsibleError as e:
-            raise AnsibleVaultError("%s for %s" % (to_native(e), to_native(filename)))
+            raise AnsibleError(f"Failed to view {filename}.") from e
 
     # FIXME/TODO: make this use VaultSecret
     def rekey_file(self, filename, new_vault_secret, new_vault_id=None):
@@ -966,8 +966,7 @@ class VaultEditor:
         try:
             plaintext, vault_id_used, _dummy = self.vault.decrypt_and_get_vault_id(vaulttext)
         except AnsibleError as e:
-            raise AnsibleError("%s for %s" % (to_native(e), to_native(filename)))
-
+            raise AnsibleError(f"Failed to rekey {filename}.") from e
         # This is more or less an assert, see #18247
         if new_vault_secret is None:
             raise AnsibleError('The value for the new_password to rekey %s with is not valid' % filename)

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -659,7 +659,7 @@ class VaultLib:
             raise AnsibleVaultError("A vault password must be specified to decrypt data.", obj=vaulttext)
 
         if not is_encrypted(b_vaulttext):
-            raise AnsibleVaultError("Input is not vault encrypted data", obj=vaulttext)
+            raise AnsibleVaultError("Input is not vault encrypted data.", obj=vaulttext)
 
         b_vaulttext, dummy, cipher_name, vault_id = parse_vaulttext_envelope(b_vaulttext)
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -659,7 +659,7 @@ class VaultLib:
             raise AnsibleVaultError("A vault password must be specified to decrypt data.", obj=vaulttext)
 
         if not is_encrypted(b_vaulttext):
-            raise AnsibleVaultError("Input is not vault encrypted data.", obj=vaulttext)
+            raise AnsibleVaultError("Input is not vault encrypted data", obj=vaulttext)
 
         b_vaulttext, dummy, cipher_name, vault_id = parse_vaulttext_envelope(b_vaulttext)
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -942,6 +942,9 @@ class VaultEditor:
 
     def plaintext(self, filename):
 
+        # follow the symlink
+        filename = self._real_path(filename)
+
         b_vaulttext = self.read_data(filename)
         vaulttext = to_text(b_vaulttext)
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -656,10 +656,10 @@ class VaultLib:
         b_vaulttext = to_bytes(vaulttext, nonstring='error')  # enforce vaulttext is str/bytes, keep type check if removing type conversion
 
         if self.secrets is None:
-            raise AnsibleVaultError("A vault password must be specified to decrypt data.")
+            raise AnsibleVaultError("A vault password must be specified to decrypt data.", obj=vaulttext)
 
         if not is_encrypted(b_vaulttext):
-            raise AnsibleVaultError("Input is not vault encrypted data.")
+            raise AnsibleVaultError("Input is not vault encrypted data.", obj=vaulttext)
 
         b_vaulttext, dummy, cipher_name, vault_id = parse_vaulttext_envelope(b_vaulttext)
 
@@ -668,10 +668,10 @@ class VaultLib:
         if cipher_name in CIPHER_ALLOWLIST:
             this_cipher = CIPHER_MAPPING[cipher_name]()
         else:
-            raise AnsibleVaultError(f"Cipher {cipher_name!r} could not be found.")
+            raise AnsibleVaultError(f"Cipher {cipher_name!r} could not be found.", obj=vaulttext)
 
         if not self.secrets:
-            raise AnsibleVaultError('Attempting to decrypt but no vault secrets found.')
+            raise AnsibleVaultError('Attempting to decrypt but no vault secrets found.', obj=vaulttext)
 
         # WARNING: Currently, the vault id is not required to match the vault id in the vault blob to
         #          decrypt a vault properly. The vault id in the vault blob is not part of the encrypted
@@ -729,7 +729,7 @@ class VaultLib:
                              (to_text(vault_secret_id), to_text(origin), e))
                 continue
         else:
-            raise AnsibleVaultError("Decryption failed (no vault secrets were found that could decrypt).")
+            raise AnsibleVaultError("Decryption failed (no vault secrets were found that could decrypt).", obj=vaulttext)
 
         return b_plaintext, vault_id_used, vault_secret_used
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -656,10 +656,10 @@ class VaultLib:
         b_vaulttext = to_bytes(vaulttext, nonstring='error')  # enforce vaulttext is str/bytes, keep type check if removing type conversion
 
         if self.secrets is None:
-            raise AnsibleVaultError("A vault password must be specified to decrypt data.", obj=vaulttext)
+            raise AnsibleVaultError("A vault password must be specified to decrypt data.")
 
         if not is_encrypted(b_vaulttext):
-            raise AnsibleVaultError("Input is not vault encrypted data.", obj=vaulttext)
+            raise AnsibleVaultError("Input is not vault encrypted data.")
 
         b_vaulttext, dummy, cipher_name, vault_id = parse_vaulttext_envelope(b_vaulttext)
 
@@ -668,10 +668,10 @@ class VaultLib:
         if cipher_name in CIPHER_ALLOWLIST:
             this_cipher = CIPHER_MAPPING[cipher_name]()
         else:
-            raise AnsibleVaultError(f"Cipher {cipher_name!r} could not be found.", obj=vaulttext)
+            raise AnsibleVaultError(f"Cipher {cipher_name!r} could not be found.")
 
         if not self.secrets:
-            raise AnsibleVaultError('Attempting to decrypt but no vault secrets found.', obj=vaulttext)
+            raise AnsibleVaultError('Attempting to decrypt but no vault secrets found.')
 
         # WARNING: Currently, the vault id is not required to match the vault id in the vault blob to
         #          decrypt a vault properly. The vault id in the vault blob is not part of the encrypted
@@ -729,7 +729,7 @@ class VaultLib:
                              (to_text(vault_secret_id), to_text(origin), e))
                 continue
         else:
-            raise AnsibleVaultError("Decryption failed (no vault secrets were found that could decrypt).", obj=vaulttext)
+            raise AnsibleVaultError("Decryption failed (no vault secrets were found that could decrypt).")
 
         return b_plaintext, vault_id_used, vault_secret_used
 
@@ -924,7 +924,7 @@ class VaultEditor:
             # TODO: return the vault_id that worked?
             plaintext, vault_id_used, vault_secret_used = self.vault.decrypt_and_get_vault_id(vaulttext)
         except AnsibleError as e:
-            raise AnsibleError("%s for %s" % (to_native(e), to_native(filename)))
+            raise AnsibleError(f"Failed to edit {filename}.") from e
 
         # Figure out the vault id from the file, to select the right secret to re-encrypt it
         # (duplicates parts of decrypt, but alas...)

--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -579,6 +579,19 @@ ansible-playbook realpath.yml "$@" --vault-password-file script/vault-secret.sh
 # using symlink
 ansible-playbook symlink.yml "$@" --vault-password-file symlink/get-password-symlink
 
+# test that ansible-vault view follows symlinks (https://github.com/ansible/ansible/pull/85977)
+SYMLINK_FILE="${MYTMPDIR}/symlinked_vault_file"
+REAL_FILE="${MYTMPDIR}/real_vault_file"
+
+echo "secret content" > "${REAL_FILE}"
+ansible-vault encrypt "$@" --vault-password-file vault-password "${REAL_FILE}"
+
+ln -s "${REAL_FILE}" "${SYMLINK_FILE}"
+
+# view via symlink
+OUTPUT=$(ansible-vault view "$@" --vault-password-file vault-password "${SYMLINK_FILE}")
+echo "${OUTPUT}" | grep "secret content"
+
 ### NEGATIVE TESTS
 
 ER='Attempting to decrypt but no vault secrets found'


### PR DESCRIPTION
##### SUMMARY

Currently, when attempting to decrypt/edit a file with ansible vault that is not encrypted, the error message displayed is badly formatted with a full stop in the middle of the error. This PR removes that full stop and makes the error messages easier to understand. 

Steps to reproduce issue:
1. Run `ansible-vault edit test.txt` with test.txt being a blank text file
2. The output is `ERROR! input is not vault encrypted data.  for /full/path/test.txt`

Message after this fix:
`[ERROR]: Input is not vault encrypted data for /full/path/test.txt`

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
