### PR TITLE
Avoid the ssh-agent exiting before tests end

### DIFF
--- a/test/integration/targets/ssh_agent/tasks/tests.yml
+++ b/test/integration/targets/ssh_agent/tasks/tests.yml
@@ -29,15 +29,17 @@
   vars:
     pid: '{{ auto.stdout|regex_findall("ssh-agent\[(\d+)\]")|first }}'
 
-- command: ssh-agent -D -s -a '{{ output_dir }}/agent.sock'
-  async: 30
-  poll: 0
+- shell: ssh-agent -D -s -a '{{ output_dir }}/agent.sock' &
+  register: ssh_agent_result
 
-- command: ansible-playbook -i {{ ansible_inventory_sources|first|quote }} -vvv {{ role_path }}/auto.yml
-  environment:
-    ANSIBLE_CALLBACK_RESULT_FORMAT: yaml
-    ANSIBLE_SSH_AGENT: '{{ output_dir }}/agent.sock'
-  register: existing
+- block:
+  - command: ansible-playbook -i {{ ansible_inventory_sources|first|quote }} -vvv {{ role_path }}/auto.yml
+    environment:
+      ANSIBLE_CALLBACK_RESULT_FORMAT: yaml
+      ANSIBLE_SSH_AGENT: '{{ output_dir }}/agent.sock'
+    register: existing
+  always:
+    - command: "kill {{ ssh_agent_result.stdout | regex_search('Agent pid ([0-9]+)', '\\1') | first }}"
 
 - assert:
     that:


### PR DESCRIPTION
##### SUMMARY
There were couple of occurrences where the hard 30 seconds limit on running ssh-agent was not enough for the test to run and the ssh-agent was killed resulting in the test failing with "Connection refused". This change just lets the agent run in the background and kills it manually after the tests finish.
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Test Pull Request
