### PR TITLE
interpreter_discovery: removed auto_silent* option

### DIFF
--- a/changelogs/fragments/auto_legacy.yml
+++ b/changelogs/fragments/auto_legacy.yml
@@ -1,0 +1,3 @@
+---
+removed_features:
+    - interpreter_discovery - removed auto_legacy and auto_legacy_slient options (https://github.com/ansible/ansible/issues/85995).

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1678,11 +1678,11 @@ INTERPRETER_PYTHON:
   version_added: "2.8"
   description:
   - Path to the Python interpreter to be used for module execution on remote targets, or an automatic discovery mode.
-    Supported discovery modes are ``auto`` (the default), ``auto_silent``, ``auto_legacy``, and ``auto_legacy_silent``.
+    Supported discovery modes are ``auto`` (the default), and ``auto_silent``.
     All discovery modes match against an ordered list of well-known Python interpreter locations. 
     The fallback behavior will issue a warning that the interpreter should be set explicitly (since interpreters
     installed later may change which one is used). This warning behavior can be disabled by setting ``auto_silent``.
-    The ``auto_legacy`` modes are deprecated and behave the same as their respective ``auto`` modes.
+    The ``auto_legacy*`` modes are removed.
     They exist for backward-compatibility with older Ansible releases that always defaulted to ``/usr/bin/python3``,
     which will use that interpreter if present.
 INTERPRETER_PYTHON_FALLBACK:

--- a/lib/ansible/executor/interpreter_discovery.py
+++ b/lib/ansible/executor/interpreter_discovery.py
@@ -30,11 +30,6 @@ def discover_interpreter(action, interpreter_name, discovery_mode, task_vars):
     found_interpreters = [_FALLBACK_INTERPRETER]  # fallback value
     is_silent = discovery_mode.endswith('_silent')
 
-    if discovery_mode.startswith('auto_legacy'):
-        display.deprecated(
-            msg=f"The '{discovery_mode}' option for 'INTERPRETER_PYTHON' now has the same effect as 'auto'.",
-            version='2.21',
-        )
 
     try:
         bootstrap_python_list = C.config.get_config_value('INTERPRETER_PYTHON_FALLBACK', variables=task_vars)

--- a/lib/ansible/executor/interpreter_discovery.py
+++ b/lib/ansible/executor/interpreter_discovery.py
@@ -30,7 +30,6 @@ def discover_interpreter(action, interpreter_name, discovery_mode, task_vars):
     found_interpreters = [_FALLBACK_INTERPRETER]  # fallback value
     is_silent = discovery_mode.endswith('_silent')
 
-
     try:
         bootstrap_python_list = C.config.get_config_value('INTERPRETER_PYTHON_FALLBACK', variables=task_vars)
 

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -345,7 +345,7 @@ def _get_shebang(interpreter, task_vars, templar: _template.Templar, args=tuple(
                                                        options=TemplateOptions(value_for_omit=C.config.get_config_default(interpreter_config_key)))
 
             # handle interpreter discovery if requested or empty interpreter was provided
-            if not interpreter_out or interpreter_out in ['auto', 'auto_legacy', 'auto_silent', 'auto_legacy_silent']:
+            if not interpreter_out or interpreter_out in ['auto', 'auto_silent']:
 
                 discovered_interpreter_config = u'discovered_interpreter_%s' % interpreter_name
                 facts_from_task_vars = task_vars.get('ansible_facts', {})

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -356,7 +356,7 @@ def _get_shebang(interpreter, task_vars, templar: _template.Templar, args=tuple(
                 else:
                     interpreter_out = facts_from_task_vars[discovered_interpreter_config]
         else:
-            raise InterpreterDiscoveryRequiredError("interpreter discovery required", interpreter_name=interpreter_name, discovery_mode='auto_legacy')
+            raise InterpreterDiscoveryRequiredError("interpreter discovery required", interpreter_name=interpreter_name, discovery_mode='auto')
 
     elif interpreter_config in task_vars:
         # for non python we consult vars for a possible direct override

--- a/test/integration/targets/interpreter_discovery_python/tasks/main.yml
+++ b/test/integration/targets/interpreter_discovery_python/tasks/main.yml
@@ -68,24 +68,6 @@
       - echoout_with_facts.ansible_facts is defined
       - echoout_with_facts.running_python_interpreter == normalized_discovered_interpreter
 
-- name: test that auto_legacy gives a deprecation warning
-  block:
-  - name: clear facts to force interpreter discovery to run
-    meta: clear_facts
-
-  - name: trigger discovery with auto_legacy
-    vars:
-      ansible_python_interpreter: auto_legacy
-      ansible_deprecation_warnings: true
-    ping:
-    register: legacy
-
-  - name: check for warning
-    assert:
-      that:
-      - legacy.deprecations | length == 1
-      - legacy.deprecations[0].msg is contains "The 'auto_legacy' option for 'INTERPRETER_PYTHON' now has the same effect as 'auto'."
-
 - name: test no interpreter found behavior
   block:
   - name: clear facts to force interpreter discovery to run
@@ -190,22 +172,6 @@
       that:
       - auto_silent_out.warnings is not defined
       - auto_silent_out.ansible_facts.discovered_interpreter_python == auto_out.ansible_facts.discovered_interpreter_python
-
-- name: test that auto_legacy_silent never warns and got the same answer as auto_legacy
-  block:
-  - name: clear facts to force interpreter discovery to run
-    meta: clear_facts
-
-  - name: trigger discovery with auto_legacy_silent
-    vars:
-      ansible_python_interpreter: auto_legacy_silent
-    ping:
-    register: legacy_silent
-
-  - assert:
-      that:
-        - legacy_silent.warnings is not defined
-        - legacy_silent.ansible_facts.discovered_interpreter_python == legacy.ansible_facts.discovered_interpreter_python
 
 - name: ensure modules can't set discovered_interpreter_X or ansible_X_interpreter
   block:

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -233,7 +233,6 @@ test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:a
 test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:ansible-deprecated-date-not-permitted  # required to verify plugin against core
 test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:ansible-deprecated-unnecessary-collection-name  # required to verify plugin against core
 test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:ansible-deprecated-collection-name-not-permitted  # required to verify plugin against core
-lib/ansible/executor/interpreter_discovery.py pylint:ansible-deprecated-version  # TODO: 2.21
 lib/ansible/module_utils/basic.py pylint:ansible-deprecated-version  # TODO: 2.21
 lib/ansible/module_utils/basic.py pylint:ansible-deprecated-version-comment  # TODO: 2.21
 lib/ansible/module_utils/common/process.py pylint:ansible-deprecated-version  # TODO: 2.21


### PR DESCRIPTION
##### SUMMARY

* Removed deprecated auto_silent* option from interpreter_discovery_python

Fixes: #85995

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE

- Docs Pull Request



##### COMPONENT NAME
changelogs/fragments/auto_legacy.yml
lib/ansible/config/base.yml
lib/ansible/executor/interpreter_discovery.py
lib/ansible/executor/module_common.py
test/integration/targets/interpreter_discovery_python/tasks/main.yml

