### PR TITLE
[stable-2.20] Avoid the ssh-agent exiting before tests end (#85979)

### DIFF
--- a/test/integration/targets/ssh_agent/tasks/tests.yml
+++ b/test/integration/targets/ssh_agent/tasks/tests.yml
@@ -29,15 +29,17 @@
   vars:
     pid: '{{ auto.stdout|regex_findall("ssh-agent\[(\d+)\]")|first }}'
 
-- command: ssh-agent -D -s -a '{{ output_dir }}/agent.sock'
-  async: 30
-  poll: 0
+- shell: ssh-agent -D -s -a '{{ output_dir }}/agent.sock' &
+  register: ssh_agent_result
 
-- command: ansible-playbook -i {{ ansible_inventory_sources|first|quote }} -vvv {{ role_path }}/auto.yml
-  environment:
-    ANSIBLE_CALLBACK_RESULT_FORMAT: yaml
-    ANSIBLE_SSH_AGENT: '{{ output_dir }}/agent.sock'
-  register: existing
+- block:
+  - command: ansible-playbook -i {{ ansible_inventory_sources|first|quote }} -vvv {{ role_path }}/auto.yml
+    environment:
+      ANSIBLE_CALLBACK_RESULT_FORMAT: yaml
+      ANSIBLE_SSH_AGENT: '{{ output_dir }}/agent.sock'
+    register: existing
+  always:
+    - command: "kill {{ ssh_agent_result.stdout | regex_search('Agent pid ([0-9]+)', '\\1') | first }}"
 
 - assert:
     that:


### PR DESCRIPTION
##### SUMMARY
Backport of #85979

(cherry picked from commit 05d5b0f168513922166a7f2190695a1acd0f1b33)
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Test Pull Request

