### PR TITLE
fix load_params when a very long option string is passed

### DIFF
--- a/lib/ansible/module_utils/_internal/_debugging.py
+++ b/lib/ansible/module_utils/_internal/_debugging.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import pathlib
 import sys
 
@@ -17,7 +18,14 @@ def load_params() -> tuple[bytes, str]:
     profile: str = parsed_args.profile
 
     if args:
-        if (args_path := pathlib.Path(args)).is_file():
+        args_path = pathlib.Path(args)
+        try:
+            is_file = args_path.is_file()
+        except OSError as e:
+            if e.errno != errno.ENAMETOOLONG:
+                raise
+            is_file = False
+        if is_file:
             buffer = args_path.read_bytes()
         else:
             buffer = args.encode(errors='surrogateescape')


### PR DESCRIPTION
##### SUMMARY

I am currently seeing issues like this one in ansible-lint, imo even while private `load_params` should not error out:
```
WARNING  Ignored exception from ArgsRule.matchtasks while processing roles/mysql_cluster/tasks/main.yml (tasks): [Errno 36] File name too long: '{"ANSIBLE_MODULE_ARGS": ...}}'
DEBUG    Ignored exception details
Traceback (most recent call last):
  File "/home/florian/.local/share/pipx/venvs/ansible/lib/python3.13/site-packages/ansiblelint/_internal/rules.py", line 105, in getmatches
    matches.extend(method(file))
                   ~~~~~~^^^^^^
  File "/home/florian/.local/share/pipx/venvs/ansible/lib/python3.13/site-packages/ansiblelint/rules/__init__.py", line 188, in matchtasks
    result = self.matchtask(task, file=file)
  File "/home/florian/.local/share/pipx/venvs/ansible/lib/python3.13/site-packages/ansiblelint/rules/args.py", line 210, in matchtask
    module.main()
    ~~~~~~~~~~~^^
  File "/home/florian/.local/share/pipx/venvs/ansible/lib/python3.13/site-packages/ansible_collections/community/mysql/plugins/modules/mysql_user.py", line 492, in main
    module = AnsibleModule(
        argument_spec=argument_spec,
        supports_check_mode=True,
        mutually_exclusive=(('append_privs', 'subtract_privs'),)
    )
  File "/home/florian/.local/share/pipx/venvs/ansible/lib/python3.13/site-packages/ansiblelint/rules/args.py", line 83, in __init__
    super().__init__(*args, **kwargs)  # type: ignore[no-untyped-call]
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/florian/.local/share/pipx/venvs/ansible/lib/python3.13/site-packages/ansible/module_utils/basic.py", line 421, in __init__
    self._load_params()
    ~~~~~~~~~~~~~~~~~^^
  File "/home/florian/.local/share/pipx/venvs/ansible/lib/python3.13/site-packages/ansible/module_utils/basic.py", line 1255, in _load_params
    self.params = _load_params()
                  ~~~~~~~~~~~~^^
  File "/home/florian/.local/share/pipx/venvs/ansible/lib/python3.13/site-packages/ansible/module_utils/basic.py", line 328, in _load_params
    _ANSIBLE_ARGS, _ANSIBLE_PROFILE = _debugging.load_params()
                                      ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/florian/.local/share/pipx/venvs/ansible/lib/python3.13/site-packages/ansible/module_utils/_internal/_debugging.py", line 20, in load_params
    if (args_path := pathlib.Path(args)).is_file():
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib64/python3.13/pathlib/_abc.py", line 482, in is_file
    return S_ISREG(self.stat(follow_symlinks=follow_symlinks).st_mode)
                   ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/pathlib/_local.py", line 515, in stat
    return os.stat(self, follow_symlinks=follow_symlinks)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: [Errno 36] File name too long: '{"ANSIBLE_MODULE_ARGS": ....}}'
```

I am not sure where to add tests, any recommendations?

##### ISSUE TYPE

- Bugfix Pull Request
