### PR TITLE
🧪 Set timeouts for CI jobs and steps

### DIFF
--- a/.azure-pipelines/templates/coverage.yml
+++ b/.azure-pipelines/templates/coverage.yml
@@ -7,23 +7,29 @@ jobs:
   - job: Coverage
     displayName: Code Coverage
     container: $[ variables.defaultContainer ]
+    timeoutInMinutes: 13  # 8 + 5
     workspace:
       clean: all
     steps:
       - checkout: self
         fetchDepth: $(fetchDepth)
         path: $(checkoutPath)
+        timeoutInMinutes: 1
       - task: DownloadPipelineArtifact@2
         displayName: Download Coverage Data
         inputs:
           path: coverage/
           patterns: "Coverage */*=coverage.combined"
+        timeoutInMinutes: 2
       - bash: .azure-pipelines/scripts/combine-coverage.py coverage/
         displayName: Combine Coverage Data
+        timeoutInMinutes: 1
       - bash: .azure-pipelines/scripts/report-coverage.sh
         displayName: Generate Coverage Report
         condition: gt(variables.coverageFileCount, 0)
+        timeoutInMinutes: 3
       - bash: .azure-pipelines/scripts/publish-codecov.py "$(outputPath)"
         displayName: Publish to codecov.io
         condition: gt(variables.coverageFileCount, 0)
         continueOnError: true
+        timeoutInMinutes: 1

--- a/.azure-pipelines/templates/test.yml
+++ b/.azure-pipelines/templates/test.yml
@@ -12,34 +12,45 @@ jobs:
     - job: test_${{ replace(replace(replace(replace(job.test, '/', '_'), '.', '_'), '-', '_'), '@', '_') }}
       displayName: ${{ job.name }}
       container: $[ variables.defaultContainer ]
+      timeoutInMinutes: 90  # 85 + 5
       workspace:
         clean: all
       steps:
         - checkout: self
           fetchDepth: $(fetchDepth)
           path: $(checkoutPath)
+          timeoutInMinutes: 1
         - bash: .azure-pipelines/scripts/run-tests.sh "$(entryPoint)" "${{ job.test }}" "$(coverageBranches)"
           displayName: Run Tests
+          timeoutInMinutes: 65  # 60 + 5
         - bash: .azure-pipelines/scripts/process-results.sh
           condition: succeededOrFailed()
           displayName: Process Results
+          timeoutInMinutes: 1
         - bash: .azure-pipelines/scripts/aggregate-coverage.sh "$(Agent.TempDirectory)"
           condition: eq(variables.haveCoverageData, 'true')
           displayName: Aggregate Coverage Data
+          # integration: < 4m
+          # units: < 14m 30s
+          # sanity: < 15s
+          timeoutInMinutes: 15
         - task: PublishTestResults@2
           condition: eq(variables.haveTestResults, 'true')
           inputs:
             testResultsFiles: "$(outputPath)/junit/*.xml"
           displayName: Publish Test Results
+          timeoutInMinutes: 1
         - task: PublishPipelineArtifact@1
           condition: eq(variables.haveBotResults, 'true')
           displayName: Publish Bot Results
           inputs:
             targetPath: "$(outputPath)/bot/"
             artifactName: "Bot $(System.JobAttempt) $(System.StageDisplayName) $(System.JobDisplayName)"
+          timeoutInMinutes: 1
         - task: PublishPipelineArtifact@1
           condition: eq(variables.haveCoverageData, 'true')
           displayName: Publish Coverage Data
           inputs:
             targetPath: "$(Agent.TempDirectory)/coverage/"
             artifactName: "Coverage $(System.JobAttempt) $(System.StageDisplayName) $(System.JobDisplayName)"
+          timeoutInMinutes: 1


### PR DESCRIPTION
Sometimes, AZP would mark steps in jobs as cancelled when they've actually exited successfully but on the boundary of the default 60-minute timeout. Such logs might be difficult to reason about.

Additionally, `entry-point.sh` sets a 60-minute timeout for the main test invocation but it would never trigger earlier that AZP would kill such a job as the job-global timeout was 60 minutes already and it'd always be hit earlier than the test runner one.

The patch sets maximum observable step timeouts with extra 5 minutes for the main testing step and additional 5 minutes for the job.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Maintenance Pull Request
- Test Pull Request

###### Context

Here's examples of jobs affected by this:
* https://dev.azure.com/ansible/ansible/_build/results?buildId=160297&view=logs&j=eaa379d5-0da8-5407-13ea-aa86f12b6d38&s=1c49865c-024e-57b4-5346-ccc3d8dcd362
* https://dev.azure.com/ansible/ansible/_build/results?buildId=160766&view=logs&j=eaa379d5-0da8-5407-13ea-aa86f12b6d38
* https://dev.azure.com/ansible/ansible/_build/results?buildId=160877&view=logs&j=26a6818c-7a55-5301-191d-87f9382f47e1
* https://dev.azure.com/ansible/ansible/_build/results?buildId=160983&view=logs&j=26a6818c-7a55-5301-191d-87f9382f47e1
* https://dev.azure.com/ansible/ansible/_build/results?buildId=161110&view=logs&j=4dd7ae1b-9dd6-5dd8-2bd1-792daf6fe143
* https://dev.azure.com/ansible/ansible/_build/results?buildId=161207&view=logs&j=be97a381-5ab6-5e8e-40e3-1cba663cfcaf
* https://dev.azure.com/ansible/ansible/_build/results?buildId=161207&view=logs&j=eaa379d5-0da8-5407-13ea-aa86f12b6d38
* https://dev.azure.com/ansible/ansible/_build/results?buildId=161207&view=logs&j=a35fe918-df14-5b9d-e19b-d15faeb6b74b

Alternative to and closes #86073.