### PR TITLE
[stable-2.19] Remove AddType warning for cleanup (#86029)

### DIFF
--- a/changelogs/fragments/add-type-warning.yml
+++ b/changelogs/fragments/add-type-warning.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    Windows - ignore temporary file cleanup warning when using AnsibleModule to
+    compile C# utils. This should reduce the number of warnings that can safely
+    be ignored when running PowerShell modules - https://github.com/ansible/ansible/issues/85976

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.AddType.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.AddType.psm1
@@ -278,10 +278,16 @@ Function Add-CSharpType {
         if ($PSCmdlet.ParameterSetName -eq "Module") {
             $temp_path = $AnsibleModule.Tmpdir
             $include_debug = $AnsibleModule.Verbosity -ge 3
+
+            # AnsibleModule will handle the cleanup after module execution
+            # which should be enough time for AVs or other processes to release
+            # any locks on the temp files.
+            $tmpdir_clean_is_error = $false
         }
         else {
             $temp_path = [System.IO.Path]::GetTempPath()
             $include_debug = $IncludeDebugInfo.IsPresent
+            $tmpdir_clean_is_error = $true
         }
         $temp_path = Join-Path -Path $temp_path -ChildPath ([Guid]::NewGuid().Guid)
 
@@ -388,17 +394,13 @@ Function Add-CSharpType {
             }
             finally {
                 # Try to delete the temp path, if this fails and we are running
-                # with a module object write a warning instead of failing.
+                # with a module object, ignore and let it cleanup later.
                 try {
                     [System.IO.Directory]::Delete($temp_path, $true)
                 }
                 catch {
-                    $msg = "Failed to cleanup temporary directory '$temp_path' used for compiling C# code."
-                    if ($AnsibleModule) {
-                        $AnsibleModule.Warn("$msg Files may still be present after the task is complete. Error: $_")
-                    }
-                    else {
-                        throw "$msg Error: $_"
+                    if ($tmpdir_clean_is_error) {
+                        throw "Failed to cleanup temporary directory '$temp_path' used for compiling C# code. Error: $_"
                     }
                 }
             }

--- a/test/integration/targets/win_exec_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_exec_wrapper/tasks/main.yml
@@ -268,14 +268,6 @@
       <<: *become_vars
       ansible_remote_tmp: C:\Windows\TEMP\test-dir
 
-  - name: assert warning about tmpdir deletion is present
-    assert:
-      that:
-      - temp_deletion_warning.warnings | count == 1
-      - >-
-        temp_deletion_warning.warnings[0] is
-        regex("(?i).*Failed to cleanup temporary directory 'C:\\\\Windows\\\\TEMP\\\\test-dir\\\\.*' used for compiling C# code\\. Files may still be present after the task is complete\\..*")
-
   always:
   - name: ensure test user is deleted
     win_user:


### PR DESCRIPTION
##### SUMMARY
Removes the warning emitted when using Add-Type and the cleanup of temp files fails due to a file still being in use. The cleanup should be handled by AnsibleModule on exit giving it more time to wait for any open file handles to close. The exception is still present if calling `Add-CSharpType` without an `AnsibleModule` object.

(cherry picked from commit 99bb587906e20742c1e009e3247022073be83ae7)

Backport of https://github.com/ansible/ansible/pull/86029

##### ISSUE TYPE
- Bugfix Pull Request