### PR TITLE
Raise min setuptools and remove wheel from build

### DIFF
--- a/changelogs/fragments/ansible-minimum-setuptools.yml
+++ b/changelogs/fragments/ansible-minimum-setuptools.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - The minimum required ``setuptools`` version is now ``77.0.3``, as it is needed for the new PEP 636 license format

--- a/changelogs/fragments/ansible-minimum-setuptools.yml
+++ b/changelogs/fragments/ansible-minimum-setuptools.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - The minimum required ``setuptools`` version is now ``77.0.3``, as it is needed for the new PEP 636 license format
+  - The minimum required ``setuptools`` version is now ``77.0.3``, as it is needed for the new PEP 639 license format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 70.1, <= 80.3.1"]  # lower bound to support controller Python versions, upper bound for latest version tested at release
+requires = ["setuptools >= 77.0.3, <= 80.3.1"]  # lower bound to support license/license-files (PEP 636), upper bound for latest version tested at release
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -10,13 +10,17 @@ authors = [
 ]
 description = "Radically simple IT automation"
 readme = "README.md"
+license = "GPL-3.0-or-later"
+license-files = [
+    "COPYING",
+    "licenses/*.txt",
+]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Natural Language :: English",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
@@ -44,10 +48,6 @@ dependencies = {file = "requirements.txt"}
 
 [tool.setuptools]
 include-package-data = false
-license-files = [
-    "COPYING",
-    "licenses/*.txt",
-]
 
 [tool.setuptools.packages.find]
 where = ["lib", "test/lib"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 77.0.3, <= 80.3.1"]  # lower bound to support license/license-files (PEP 636), upper bound for latest version tested at release
+requires = ["setuptools >= 77.0.3, <= 80.3.1"]  # lower bound to support license/license-files (PEP 639), upper bound for latest version tested at release
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
##### SUMMARY
Raises the minimum setuptools version used for our build requirements to support the new license identifiers. This removes a deprecation warning emitted by setuptools and will avoid breaking the build when the old format is eventually removed.

This also removes the wheel requirement from the build as it is no longer required.

Fixes: https://github.com/ansible/ansible/issues/86036

##### ISSUE TYPE
- Feature Pull Request