### PR TITLE
Soft deprecate ansible.module_utils.six

### DIFF
--- a/changelogs/fragments/soft-deprecate-six.yml
+++ b/changelogs/fragments/soft-deprecate-six.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+- >
+  ``ansible.module_utils.six`` - The ``six`` compatibility library provided at ``ansible.module_utils.six`` is deprecated, and planned for removal in ansible-core 2.24

--- a/lib/ansible/module_utils/six/__init__.py
+++ b/lib/ansible/module_utils/six/__init__.py
@@ -33,6 +33,8 @@ import operator
 import sys
 import types
 
+# deprecated: description="Replace with ansible.module_utils.common.warnings.deprecate for 2.24" core_version="2.22"
+
 # The following makes it easier for us to script updates of the bundled code. It is not part of
 # upstream six
 _BUNDLED_METADATA = {"pypi_name": "six", "version": "1.17.0"}

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/unwanted.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/unwanted.py
@@ -110,6 +110,10 @@ class AnsibleUnwantedChecker(BaseChecker):
                 'Iterator',
             )
         ),
+
+        'ansible.module_utils.six': UnwantedEntry(
+            'the Python standard library equivalent'
+        ),
     }
 
     unwanted_functions = {
@@ -133,14 +137,6 @@ class AnsibleUnwantedChecker(BaseChecker):
                                         ),
                                         modules_only=True),
     }
-
-    def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
-        # ansible.module_utils.six is deprecated and collections can still use it until it is removed
-        if self.is_ansible_core:
-            self.unwanted_imports['ansible.module_utils.six'] = UnwantedEntry(
-                'the Python standard library equivalent'
-            )
 
     @functools.cached_property
     def is_ansible_core(self) -> bool:


### PR DESCRIPTION
##### SUMMARY

Soft deprecate ansible.module_utils.six

This will enable the sanity test for collection maintainers, but not a user facing warning yet.

In 2.22 a user facing deprecation warning will be added.

This doesn't slow down the deprecation clock, it will start with 2.21 and be set for removal in 2.24.

##### ISSUE TYPE

- Feature Pull Request

