### PR TITLE
Move apt sources lists aside more comprehensively

### DIFF
--- a/test/integration/targets/apt/tasks/downgrade.yml
+++ b/test/integration/targets/apt/tasks/downgrade.yml
@@ -1,6 +1,10 @@
 - block:
   - name: Disable ubuntu repos so system packages are not upgraded and do not change testing env
-    command: mv /etc/apt/sources.list /etc/apt/sources.list.backup
+    shell: |
+      find /etc/apt/sources.list* \
+        \( -name \*.list -or -name \*.sources \) \
+        -and -not -name file_tmp_repo.list \
+        | xargs -I{} mv {} {}.backup
 
   - name: install latest foo
     apt:
@@ -74,4 +78,7 @@
         autoclean: yes
 
     - name: Restore ubuntu repos
-      command: mv /etc/apt/sources.list.backup /etc/apt/sources.list
+      shell: |
+        find /etc/apt/sources.list* -name \*.backup \
+          | sed 's/\.backup$//' \
+          | xargs -I{} mv {}.backup {}

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -195,7 +195,11 @@
 # https://github.com/ansible/ansible/issues/35900
 - block:
   - name: Disable ubuntu repos so system packages are not upgraded and do not change testing env
-    command: mv /etc/apt/sources.list /etc/apt/sources.list.backup
+    shell: |
+      find /etc/apt/sources.list* \
+        \( -name \*.list -or -name \*.sources \) \
+        -and -not -name file_tmp_repo.list \
+        | xargs -I{} mv {} {}.backup
 
   - name: Install foobar, installs foo as a dependency
     apt:
@@ -262,13 +266,20 @@
         autoclean: yes
 
     - name: Restore ubuntu repos
-      command: mv /etc/apt/sources.list.backup /etc/apt/sources.list
+      shell: |
+        find /etc/apt/sources.list* -name \*.backup \
+          | sed 's/\.backup$//' \
+          | xargs -I{} mv {}.backup {}
 
 
 # https://github.com/ansible/ansible/issues/26298
 - block:
   - name: Disable ubuntu repos so system packages are not upgraded and do not change testing env
-    command: mv /etc/apt/sources.list /etc/apt/sources.list.backup
+    shell: |
+      find /etc/apt/sources.list* \
+        \( -name \*.list -or -name \*.sources \) \
+        -and -not -name file_tmp_repo.list \
+        | xargs -I{} mv {} {}.backup
 
   - name: Install foobar, installs foo as a dependency
     apt:
@@ -349,7 +360,10 @@
         autoclean: yes
 
     - name: Restore ubuntu repos
-      command: mv /etc/apt/sources.list.backup /etc/apt/sources.list
+      shell: |
+        find /etc/apt/sources.list* -name \*.backup \
+          | sed 's/\.backup$//' \
+          | xargs -I{} mv {}.backup {}
 
 - name: Downgrades
   import_tasks: "downgrade.yml"

--- a/test/integration/targets/apt/tasks/upgrade.yml
+++ b/test/integration/targets/apt/tasks/upgrade.yml
@@ -1,6 +1,10 @@
 - block:
   - name: Disable ubuntu repos so system packages are not upgraded and do not change testing env
-    command: mv /etc/apt/sources.list /etc/apt/sources.list.backup
+    shell: |
+      find /etc/apt/sources.list* \
+        \( -name \*.list -or -name \*.sources \) \
+        -and -not -name file_tmp_repo.list \
+        | xargs -I{} mv {} {}.backup
 
   - name: install foo-1.0.0
     apt:
@@ -61,4 +65,7 @@
         autoclean: yes
 
     - name: Restore ubuntu repos
-      command: mv /etc/apt/sources.list.backup /etc/apt/sources.list
+      shell: |
+        find /etc/apt/sources.list* -name \*.backup \
+          | sed 's/\.backup$//' \
+          | xargs -I{} mv {}.backup {}


### PR DESCRIPTION
##### SUMMARY

apt sources may be defined in any of `/etc/apt/sources.list`, `/etc/apt/sources.list.d/*.list`, or `/etc/apt/sources.list.d/*.sources`.  When disabling system repositories, move all of these aside rather than only `/etc/apt/sources.list`.

This fixes integration test failures in certain corner cases in Debian's CI environment: when testing reverse-dependencies, we use a testbed with most packages from the testing suite but some packages pinned from unstable.  The latter are currently set up using `/etc/apt/sources.list.d/*.list`, and as a result the `apt` integration tests accidentally upgraded the testbed to unstable in the middle of the test run, causing confusion in later tests.

##### ISSUE TYPE

- Test Pull Request