### PR TITLE
Fix win_exec_wrapper integration test to match #86029

### DIFF
--- a/test/integration/targets/win_exec_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_exec_wrapper/tasks/main.yml
@@ -268,13 +268,10 @@
       <<: *become_vars
       ansible_remote_tmp: C:\Windows\TEMP\test-dir
 
-  - name: assert warning about tmpdir deletion is present
+  - name: assert warning about tmpdir deletion is absent
     assert:
       that:
-      - temp_deletion_warning.warnings | count == 1
-      - >-
-        temp_deletion_warning.warnings[0] is
-        regex("(?i).*Failed to cleanup temporary directory 'C:\\\\Windows\\\\TEMP\\\\test-dir\\\\.*' used for compiling C# code\\. Files may still be present after the task is complete\\..*")
+      - temp_deletion_warning.warnings | count == 0
 
   always:
   - name: ensure test user is deleted

--- a/test/integration/targets/win_exec_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_exec_wrapper/tasks/main.yml
@@ -268,11 +268,6 @@
       <<: *become_vars
       ansible_remote_tmp: C:\Windows\TEMP\test-dir
 
-  - name: assert warning about tmpdir deletion is absent
-    assert:
-      that:
-      - temp_deletion_warning.warnings | count == 0
-
   always:
   - name: ensure test user is deleted
     win_user:


### PR DESCRIPTION
##### SUMMARY

Fixes https://dev.azure.com/ansible/ansible/_build/results?buildId=160728&view=logs&j=87d18c77-eb8b-5b70-be2e-cec51ea897fd&t=7342d004-809f-517d-b20b-b4dcfac348f6&l=3952

Follow up to #86029, not sure why CI didn't catch this

##### ISSUE TYPE

- Test Pull Request
