### PR TITLE
[stable-2.20] Update win_exec_wrapper integration test to match #86029 (#86052)

### DIFF
--- a/test/integration/targets/win_exec_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_exec_wrapper/tasks/main.yml
@@ -268,14 +268,6 @@
       <<: *become_vars
       ansible_remote_tmp: C:\Windows\TEMP\test-dir
 
-  - name: assert warning about tmpdir deletion is present
-    assert:
-      that:
-      - temp_deletion_warning.warnings | count == 1
-      - >-
-        temp_deletion_warning.warnings[0] is
-        regex("(?i).*Failed to cleanup temporary directory 'C:\\\\Windows\\\\TEMP\\\\test-dir\\\\.*' used for compiling C# code\\. Files may still be present after the task is complete\\..*")
-
   always:
   - name: ensure test user is deleted
     win_user:


### PR DESCRIPTION
##### SUMMARY

Update test following #86039

* Remove assertion now that there is no warning

(cherry picked from commit df34bf9e70115f8f67bb2cb712f05a3c21be4121)

##### ISSUE TYPE

- Test Pull Request
