### PR TITLE
Add fail_on_update option for apt (update_cache)

### DIFF
--- a/changelogs/fragments/86061-apt-fail-on-update.yml
+++ b/changelogs/fragments/86061-apt-fail-on-update.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - apt - Added ``fail_on_update`` parameter allow tasks to continue if ``apt-get update`` fails after retries.

--- a/changelogs/fragments/86061-apt-fail-on-update.yml
+++ b/changelogs/fragments/86061-apt-fail-on-update.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - apt - Added ``fail_on_update`` parameter allow tasks to continue if ``apt-get update`` fails after retries.
+  - apt - Added ``fail_on_update`` parameter to allow tasks to continue if ``apt-get update`` fails after retries.

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -183,6 +183,12 @@ options:
     type: bool
     default: 'no'
     version_added: "2.11"
+  fail_on_update:
+    description:
+      - If V(true) and O(update_cache) is enabled, failure to update apt cache within O(update_cache_retries) will fail the task.
+    type: bool
+    default: 'yes'
+    version_added: '2.20'
   force_apt_get:
     description:
       - Force usage of apt-get instead of aptitude.
@@ -1237,6 +1243,7 @@ def main():
             autoremove=dict(type='bool', default=False),
             autoclean=dict(type='bool', default=False),
             fail_on_autoremove=dict(type='bool', default=False),
+            fail_on_update=dict(type='bool', default=True),
             policy_rc_d=dict(type='int', default=None),
             only_upgrade=dict(type='bool', default=False),
             force_apt_get=dict(type='bool', default=False),
@@ -1434,7 +1441,10 @@ def main():
                             f"Failed to update apt cache after {update_cache_retries} retries: "
                             f"{err if err else 'unknown reason'}"
                         )
-                        module.fail_json(msg=msg)
+                        if p['fail_on_update']:
+                            module.fail_json(msg=msg)
+                        else:
+                            module.warn(msg)
 
                     cache.open(progress=None)
                     mtimestamp, post_cache_update_time = get_updated_cache_time()

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -188,7 +188,7 @@ options:
       - If V(true) and O(update_cache) is enabled, failure to update apt cache within O(update_cache_retries) will fail the task.
     type: bool
     default: 'yes'
-    version_added: '2.20'
+    version_added: '2.21'
   force_apt_get:
     description:
       - Force usage of apt-get instead of aptitude.


### PR DESCRIPTION
##### SUMMARY

By default on Debian the following command: `apt-get update -q` would have a RC of 0, despite having "temporary" issues:

```bash
$ sudo apt-get update -q; echo $?
Hit:2 http://deb.debian.org/debian bookworm InRelease
Hit:3 http://deb.debian.org/debian bookworm-updates InRelease
Hit:4 http://deb.debian.org/debian bookworm-backports InRelease
Hit:5 http://security.debian.org/debian-security bookworm-security InRelease
Hit:1 https://rspamd.com/apt-stable bookworm InRelease
Hit:6 http://repo.mysql.com/apt/debian bookworm InRelease
Err:6 http://repo.mysql.com/apt/debian bookworm InRelease
  The following signatures were invalid: EXPKEYSIG B7B3B788A8D3785C MySQL Release Engineering <mysql-build@oss.oracle.com>
Reading package lists...
Building dependency tree...
Reading state information...
1 package can be upgraded. Run 'apt list --upgradable' to see it.
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://repo.mysql.com/apt/debian bookworm InRelease: The following signatures were invalid: EXPKEYSIG B7B3B788A8D3785C MySQL Release Engineering <mysql-build@oss.oracle.com>
W: Failed to fetch http://repo.mysql.com/apt/debian/dists/bookworm/InRelease  The following signatures were invalid: EXPKEYSIG B7B3B788A8D3785C MySQL Release Engineering <mysql-build@oss.oracle.com>
W: Some index files failed to download. They have been ignored, or old ones used instead.
0
```

There is also a way to configure this behavior either directly as arg or apt-conf:

```bash
$ sudo apt-get update -o APT::Update::Error-Mode=any
$ sudo apt-get update --error-on=any; echo $?
Hit:1 http://security.debian.org/debian-security bookworm-security InRelease
Hit:2 http://deb.debian.org/debian bookworm InRelease
Hit:3 http://deb.debian.org/debian bookworm-updates InRelease
Hit:4 http://deb.debian.org/debian bookworm-backports InRelease
Hit:5 http://repo.mysql.com/apt/debian bookworm InRelease
Hit:6 https://rspamd.com/apt-stable bookworm InRelease
Err:5 http://repo.mysql.com/apt/debian bookworm InRelease
  The following signatures were invalid: EXPKEYSIG B7B3B788A8D3785C MySQL Release Engineering <mysql-build@oss.oracle.com>
Reading package lists... Done
W: An error occurred during the signature verification. The repository is not updated and the previous index files will be used. GPG error: http://repo.mysql.com/apt/debian bookworm InRelease: The following signatures were invalid: EXPKEYSIG B7B3B788A8D3785C MySQL Release Engineering <mysql-build@oss.oracle.com>
E: Failed to fetch http://repo.mysql.com/apt/debian/dists/bookworm/InRelease  The following signatures were invalid: EXPKEYSIG B7B3B788A8D3785C MySQL Release Engineering <mysql-build@oss.oracle.com>
E: Some index files failed to download. They have been ignored, or old ones used instead.
100
```

python-apt unfortunately does not support this config option fully, it will always fail unless it is a error of type: `StatTransientNetworkError`
([Source](https://salsa.debian.org/apt-team/apt/-/blob/main/apt-pkg/update.cc?ref_type=heads#L110-116))

and we also unfortunately do not get any more details from the python-apt call: https://salsa.debian.org/apt-team/python-apt/-/blob/main/apt/cache.py?ref_type=heads#L566-571

**So in short:** There is a mismatch in how `apt-get update` fails by default in Debian (soft/warnings), and how it fails in Ansible (hard/errors).

This PR will add an option to not fail after retries. So we will avoid failing too quickly, given that we can not currently see what the error would be - which is also the reason why I did not pass-through `raise_on_error = False` as argument to `cache.update()`.

It is set to `True` by default so it will be backward compatible.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request
