### PR TITLE
dnf: catch ConfigError when conf_file has invalid syntax

### DIFF
--- a/changelogs/fragments/dnf_conf_error.yml
+++ b/changelogs/fragments/dnf_conf_error.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - dnf - raise an error when dnf configuration file is incorrect (https://github.com/ansible/ansible/issues/85681).

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -525,7 +525,7 @@ class DnfModule(YumDnf):
             conf.read()
         except dnf.exceptions.ConfigError as e:
             self.module.fail_json(
-                msg=f"Failed to parse configuration file '{conf.config_file_path}'",
+                msg=f"Error in configuration file '{conf.config_file_path}'",
                 exception=e,
                 results=[],
                 rc=1

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -521,7 +521,14 @@ class DnfModule(YumDnf):
                 conf.config_file_path = conf_file
 
         # Read the configuration file
-        conf.read()
+       try:
+       conf.read()
+       except dnf.exceptions.ConfigError as e:
+        self.module.fail_json(
+        msg=f"Failed to parse configuration file '{conf.config_file_path}': {to_native(e)}",
+        results=[],
+        rc=1
+       )
 
         # Turn off debug messages in the output
         conf.debuglevel = 0

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -521,14 +521,16 @@ class DnfModule(YumDnf):
                 conf.config_file_path = conf_file
 
         # Read the configuration file
-       try:
-       conf.read()
-       except dnf.exceptions.ConfigError as e:
+          # Read the configuration file
+    try:
+        conf.read()
+    except dnf.exceptions.ConfigError as e:
         self.module.fail_json(
-        msg=f"Failed to parse configuration file '{conf.config_file_path}': {to_native(e)}",
-        results=[],
-        rc=1
-       )
+            msg=f"Failed to parse configuration file '{conf.config_file_path}': {to_native(e)}",
+            results=[],
+            rc=1
+        )
+
 
         # Turn off debug messages in the output
         conf.debuglevel = 0

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -531,8 +531,6 @@ class DnfModule(YumDnf):
                 rc=1
             )
 
-
-
         # Turn off debug messages in the output
         conf.debuglevel = 0
 

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -521,16 +521,14 @@ class DnfModule(YumDnf):
                 conf.config_file_path = conf_file
 
         # Read the configuration file
-          # Read the configuration file
-    try:
-        conf.read()
-    except dnf.exceptions.ConfigError as e:
-        self.module.fail_json(
-            msg=f"Failed to parse configuration file '{conf.config_file_path}': {to_native(e)}",
-            results=[],
-            rc=1
-        )
-
+        try:
+            conf.read()
+        except dnf.exceptions.ConfigError as e:
+            self.module.fail_json(
+                msg=f"Failed to parse configuration file '{conf.config_file_path}': {to_native(e)}",
+                results=[],
+                rc=1
+            )
 
         # Turn off debug messages in the output
         conf.debuglevel = 0

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -532,6 +532,7 @@ class DnfModule(YumDnf):
             )
 
 
+
         # Turn off debug messages in the output
         conf.debuglevel = 0
 

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -526,7 +526,7 @@ class DnfModule(YumDnf):
         except dnf.exceptions.ConfigError as e:
             self.module.fail_json(
                 msg=f"Failed to parse configuration file '{conf.config_file_path}'",
-                exception=to_native(e),
+                exception=e,
                 results=[],
                 rc=1
             )

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -525,10 +525,12 @@ class DnfModule(YumDnf):
             conf.read()
         except dnf.exceptions.ConfigError as e:
             self.module.fail_json(
-                msg=f"Failed to parse configuration file '{conf.config_file_path}': {to_native(e)}",
+                msg=f"Failed to parse configuration file '{conf.config_file_path}'",
+                exception=to_native(e),
                 results=[],
                 rc=1
             )
+
 
         # Turn off debug messages in the output
         conf.debuglevel = 0

--- a/test/integration/targets/dnf/tasks/conf_error.yml
+++ b/test/integration/targets/dnf/tasks/conf_error.yml
@@ -1,0 +1,19 @@
+- name: create conf file that excludes lsof
+  copy:
+    content: '[broken_section\nname=value'
+    dest: '{{ remote_tmp_dir }}/broken.conf'
+  register: broken_conf
+
+- name: Use broken conf file
+  dnf:
+    name: bash
+    state: present
+    conf_file: '{{ broken_conf.dest }}'
+  register: dnf_bash_result
+  ignore_errors: True
+
+- name: verify that broken conf raises an error
+  assert:
+    that:
+      - "dnf_bash_result is failed"
+      - "'Error in configuration file' in dnf_bash_result.msg"

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -43,6 +43,7 @@
     - include_tasks: logging.yml
     - include_tasks: cacheonly.yml
     - include_tasks: multilib.yml
+    - include_tasks: conf_error.yml
 
 # Attempting to install a different RHEL release in a tmpdir doesn't work (rhel8 beta)
 - include_tasks: dnfreleasever.yml


### PR DESCRIPTION
When the ansible.builtin.dnf module is run with a configuration file (conf_file) that contains invalid INI syntax, the module crashes with an uncaught dnf.exceptions.ConfigError. This prevents Ansible from receiving valid JSON output and causes a "MODULE FAILURE: No start of json char found" error.

This change wraps the conf.read() call in a try/except block to gracefully handle ConfigError and fail cleanly with a readable error message.

Fixes: ansible/ansible#85681

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

- Bugfix Pull Request
