### PR TITLE
🧪 Set timeouts for CI jobs

### DIFF
--- a/.azure-pipelines/templates/coverage.yml
+++ b/.azure-pipelines/templates/coverage.yml
@@ -7,7 +7,7 @@ jobs:
   - job: Coverage
     displayName: Code Coverage
     container: $[ variables.defaultContainer ]
-    timeoutInMinutes: 13  # 8 + 5
+    timeoutInMinutes: 10
     workspace:
       clean: all
     steps:

--- a/.azure-pipelines/templates/coverage.yml
+++ b/.azure-pipelines/templates/coverage.yml
@@ -7,6 +7,7 @@ jobs:
   - job: Coverage
     displayName: Code Coverage
     container: $[ variables.defaultContainer ]
+    timeoutInMinutes: 13  # 8 + 5
     workspace:
       clean: all
     steps:

--- a/.azure-pipelines/templates/test.yml
+++ b/.azure-pipelines/templates/test.yml
@@ -12,7 +12,7 @@ jobs:
     - job: test_${{ replace(replace(replace(replace(job.test, '/', '_'), '.', '_'), '-', '_'), '@', '_') }}
       displayName: ${{ job.name }}
       container: $[ variables.defaultContainer ]
-      timeoutInMinutes: 90  # 85 + 5
+      timeoutInMinutes: 65
       workspace:
         clean: all
       steps:

--- a/.azure-pipelines/templates/test.yml
+++ b/.azure-pipelines/templates/test.yml
@@ -12,6 +12,7 @@ jobs:
     - job: test_${{ replace(replace(replace(replace(job.test, '/', '_'), '.', '_'), '-', '_'), '@', '_') }}
       displayName: ${{ job.name }}
       container: $[ variables.defaultContainer ]
+      timeoutInMinutes: 90  # 85 + 5
       workspace:
         clean: all
       steps:


### PR DESCRIPTION
Sometimes, AZP would mark steps in jobs as cancelled when they've actually exited successfully but on the boundary of the default 60-minute timeout. Such logs might be difficult to reason about.

Additionally, `entry-point.sh` sets a 60-minute timeout for the main test invocation but it would never trigger earlier that AZP would kill such a job as the job-global timeout was 60 minutes already and it'd always be hit earlier than the test runner one.

The patch sets maximum observable job timeouts with extra buffer to account for flakiness.

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" if there is a corresponding issue -->

##### ISSUE TYPE

- Maintenance Pull Request
- Test Pull Request

###### Context

Here's examples of jobs affected by this:
* https://dev.azure.com/ansible/ansible/_build/results?buildId=160297&view=logs&j=eaa379d5-0da8-5407-13ea-aa86f12b6d38&s=1c49865c-024e-57b4-5346-ccc3d8dcd362
* https://dev.azure.com/ansible/ansible/_build/results?buildId=160766&view=logs&j=eaa379d5-0da8-5407-13ea-aa86f12b6d38
* https://dev.azure.com/ansible/ansible/_build/results?buildId=160877&view=logs&j=26a6818c-7a55-5301-191d-87f9382f47e1
* https://dev.azure.com/ansible/ansible/_build/results?buildId=160983&view=logs&j=26a6818c-7a55-5301-191d-87f9382f47e1
* https://dev.azure.com/ansible/ansible/_build/results?buildId=161110&view=logs&j=4dd7ae1b-9dd6-5dd8-2bd1-792daf6fe143
* https://dev.azure.com/ansible/ansible/_build/results?buildId=161207&view=logs&j=be97a381-5ab6-5e8e-40e3-1cba663cfcaf
* https://dev.azure.com/ansible/ansible/_build/results?buildId=161207&view=logs&j=eaa379d5-0da8-5407-13ea-aa86f12b6d38
* https://dev.azure.com/ansible/ansible/_build/results?buildId=161207&view=logs&j=a35fe918-df14-5b9d-e19b-d15faeb6b74b

Alternative to and closes #86026.