### PR TITLE
Update validation logic for parameter checks to allow for None value for `required_if`

### DIFF
--- a/changelogs/fragments/86074-None-value-in-required_if.yml
+++ b/changelogs/fragments/86074-None-value-in-required_if.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "``required_if`` - fix argument validation for value ``None`` when the option is omitted and defaults to `None`."

--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -272,7 +272,7 @@ def check_required_if(requirements, parameters, options_context=None):
         else:
             missing['requires'] = 'all'
 
-        if key in parameters and parameters[key] == val:
+        if (key in parameters and parameters[key] == val) or (val is None and key not in parameters):
             for check in requirements:
                 count = count_terms(check, parameters)
                 if count == 0:

--- a/test/units/module_utils/common/validation/test_check_required_if.py
+++ b/test/units/module_utils/common/validation/test_check_required_if.py
@@ -76,3 +76,14 @@ def test_check_required_if_multiple():
     options_context = ["foo_context"]
     assert check_required_if(arguments_terms, params) == []
     assert check_required_if(arguments_terms, params, options_context) == []
+
+
+def test_check_required_if_None_vallue():
+    arguments_terms = [["state", None, ("path",)]]
+    params = {}
+    expected = "state is None but all of the following are missing: path"
+
+    with pytest.raises(TypeError) as e:
+        check_required_if(arguments_terms, params)
+
+    assert to_native(e.value) == expected


### PR DESCRIPTION
~~_I know changelog/tests aren't updated yet, it'll come asap_~~

##### SUMMARY

User might want to force argument(s) if another is absent.

UseCase: 
My collection offers a `preset` argument that sets the parameters `match_user`, `prefix` and `catchall` for the user.
If the users chooses to not use the `preset`s but instead specify everything themselves I want to require them to specify the 3 parameters.

So, this is valid (no `preset` but all 3 are provided)
```yml
domain_name: "example.com"
target_addresses: ["admin@example.com"]
catchall: true
prefix: true
match_user: "admin"
```
This is also valid as we use the preset
```yml
domain_name: "example.com"
target_addresses: ["admin@example.com"]
preset: "exact
```
But this is invalid as we are missing `preset` or the `match_user`, `prefix` and `catchall` group
```yml
domain_name: "example.com"
target_addresses: ["admin@example.com"]
```
this is also invalid as we are missing `prefix` 
```yml
domain_name: "example.com"
target_addresses: ["admin@example.com"]
catchall: true
match_user: "admin"
```

This changes allows devs to declare
```py
required_if=[
	("preset", None, ["match_user", "prefix", "catchall"], True),
],
```
which triggers an error for the failing cases the following message 
```
preset is None but any of the following are missing: match_user, prefix, catchall found in rules
```

Which seems like a perfect fit

<details>
<summary> module spec </summary>

```python
AnsibleModule(
	argument_spec=dict(
		api_token=dict(type="str", required=True, no_log=True),
		only_specified_rules=dict(type="bool", required=False, default=False),
		rules=dict(
			type="list",
			required=True,
			elements="dict",
			options=dict(
				domain_name=dict(type="str", required=True),
				target_addresses=dict(type="list", elements="str", required=True),
				preset=dict(
					type="str",
					required=False,
					choices=[
						"any_address",
						"catchall_except_valid",
						"prefix_match",
						"exact_match",
					],
				),
				match_user=dict(type="str", required=False),
				prefix=dict(type="bool", required=False),
				catchall=dict(type="bool", required=False),
			),
			required_if=[
				("preset", None, ["match_user", "prefix", "catchall"], True),
				("preset", "prefix_match", ["match_user"], True),
				("preset", "exact_match", ["match_user"], True),
			],
		),
	),
)
```

</details>

##### ISSUE TYPE

- Bugfix Pull Request
