### PR TITLE
apt_repository: Deprecate module

### DIFF
--- a/changelogs/fragments/apt_repository_deprecate.yml
+++ b/changelogs/fragments/apt_repository_deprecate.yml
@@ -1,0 +1,4 @@
+---
+deprecated_features:
+    - apt_repository - deprecate in favor of deb822_repository.
+    - apt_key - deprecate in favor of deb822_repository.

--- a/lib/ansible/modules/_apt_key.py
+++ b/lib/ansible/modules/_apt_key.py
@@ -18,6 +18,10 @@ short_description: Add or remove an apt key
 description:
     - Add or remove an I(apt) key, optionally downloading it.
 extends_documentation_fragment: action_common_attributes
+deprecated:
+    alternative: ansible.builtin.deb822_repository
+    why: The M(ansible.builtin.apt_key) module is deprecated in favor of the M(ansible.builtin.deb822_repository) module.
+    removed_in: "2.25"
 attributes:
     check_mode:
         support: full

--- a/lib/ansible/modules/_apt_repository.py
+++ b/lib/ansible/modules/_apt_repository.py
@@ -16,6 +16,10 @@ short_description: Add and remove APT repositories
 description:
     - Add or remove an APT repositories in Ubuntu and Debian.
 extends_documentation_fragment: action_common_attributes
+deprecated:
+    alternative: ansible.builtin.deb822_repository
+    why: The M(ansible.builtin.apt_repository) module is deprecated in favor of the M(ansible.builtin.deb822_repository) module.
+    removed_in: "2.25"
 attributes:
     check_mode:
         support: full

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -1,19 +1,5 @@
-# (c) 2014, James Tanner <tanner.jc@gmail.com>
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright (c) 2014, James Tanner <tanner.jc@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: skip test on unsupported platforms
   meta: end_play

--- a/test/integration/targets/setup_deb_repo/tasks/main.yml
+++ b/test/integration/targets/setup_deb_repo/tasks/main.yml
@@ -6,6 +6,7 @@
       - dpkg-dev
       - equivs
       - libfile-fcntllock-perl  # to silence warning by equivs-build
+      - python3-debian
 
   - set_fact:
       repodir: /tmp/repo/
@@ -52,10 +53,15 @@
       - [stable, {}]
       - [testing, {NotAutomatic: "yes", ButAutomaticUpgrades: "yes"}]
 
-  - name: Install the repo
-    apt_repository:
-      repo: deb [trusted=yes arch=all] file:{{ repodir }} {{ item }} main
-      update_cache: false # interferes with task 'Test update_cache 1'
+  - name: Add local filesystem repository using deb822 format
+    deb822_repository:
+      name: "local_repo_{{ item }}"
+      uris: "file://{{ repodir }}"
+      suites: "{{ item }}"
+      components: "main"
+      state: present
+      architectures: all
+      trusted: true
     loop:
       - stable
       - testing

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -783,10 +783,9 @@ def deprecation_schema(for_collection):
         Required('why'): doc_string,
         'alternative': doc_string,
         'alternatives': doc_string,
+        Required('removed_from_collection'): collection_name,
+        'removed': Any(True),
     }
-
-    if for_collection:
-        main_fields.update({Required('removed_from_collection'): collection_name, 'removed': Any(True)})
 
     date_schema = {
         Required('removed_at_date'): date(),

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -4,7 +4,7 @@ lib/ansible/_internal/_wrapt.py black!skip  # vendored code
 lib/ansible/config/base.yml no-unwanted-files
 lib/ansible/keyword_desc.yml no-unwanted-files
 lib/ansible/modules/apt.py validate-modules:parameter-invalid
-lib/ansible/modules/apt_repository.py validate-modules:parameter-invalid
+lib/ansible/modules/_apt_repository.py validate-modules:parameter-invalid
 lib/ansible/modules/async_status.py validate-modules!skip
 lib/ansible/modules/async_wrapper.py ansible-doc!skip  # not an actual module
 lib/ansible/modules/async_wrapper.py pylint:ansible-bad-function # ignore, required

--- a/test/units/modules/test_apt_key.py
+++ b/test/units/modules/test_apt_key.py
@@ -5,7 +5,7 @@ import os
 from unittest.mock import patch, Mock
 import unittest
 
-from ansible.modules import apt_key
+from ansible.modules import _apt_key
 
 
 def returnc(x):
@@ -14,13 +14,13 @@ def returnc(x):
 
 class AptKeyTestCase(unittest.TestCase):
 
-    @patch.object(apt_key, 'apt_key_bin', '/usr/bin/apt-key')
-    @patch.object(apt_key, 'lang_env', returnc)
+    @patch.object(_apt_key, 'apt_key_bin', '/usr/bin/apt-key')
+    @patch.object(_apt_key, 'lang_env', returnc)
     @patch.dict(os.environ, {'HTTP_PROXY': 'proxy.example.com'})
     def test_import_key_with_http_proxy(self):
         m_mock = Mock()
         m_mock.run_command.return_value = (0, '', '')
-        apt_key.import_key(
+        _apt_key.import_key(
             m_mock, keyring=None, keyserver='keyserver.example.com',
             key_id='0xDEADBEEF')
         self.assertEqual(


### PR DESCRIPTION
##### SUMMARY

* Deprecate apt_repository in favor of deb822_repository

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/apt_repository_deprecate.yml
lib/ansible/modules/apt_repository.py

