### PR TITLE
Fix lint syntax error on ./test/integration/targets/unarchive/tasks/test_missing_binaries.yml

### DIFF
--- a/test/integration/targets/unarchive/tasks/test_missing_binaries.yml
+++ b/test/integration/targets/unarchive/tasks/test_missing_binaries.yml
@@ -40,7 +40,7 @@
         PATH: "{{ ENV_PATH }}"
       vars:
         ENV_PATH: "{{ ansible_env['PATH']| regex_replace(re, '') }}"
-        re: "[^A-Za-z](\/usr\/bin:?)"
+        re: '[^A-Za-z](\/usr\/bin:?)'
 
     - name: Ensure tasks worked as expected
       assert:


### PR DESCRIPTION
##### SUMMARY

Fixes #86095


This PR fixes a minor yaml syntax issue on `./test/integration/targets/unarchive/tasks/test_missing_binaries.yml`

Here's explanation from coding agent:
> In YAML, backslash escape sequences are only interpreted in double-quoted strings. The string "[^A-Za-z](\\/usr\\/bin:?)" had \\/ which isn't a valid YAML escape sequence (only sequences like \n, \t, \", \\ are valid).
> In single-quoted YAML strings, backslashes are treated literally, so '[^A-Za-z](/usr/bin:?)' works fine. Since forward slashes don't need escaping in regex patterns anyway, single quotes were the right choice here.

