### PR TITLE
template module - Report syntax error line number

### DIFF
--- a/changelogs/fragments/jinja-syntax-error-line-numbers.yml
+++ b/changelogs/fragments/jinja-syntax-error-line-numbers.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - template module - Report the line number for Jinja syntax errors in template files.

--- a/lib/ansible/_internal/_templating/_jinja_bits.py
+++ b/lib/ansible/_internal/_templating/_jinja_bits.py
@@ -496,6 +496,14 @@ def create_template_error(ex: Exception, variable: t.Any, is_expression: bool) -
         if isinstance(ex, RecursionError):
             msg = f"Recursive loop detected in {kind}."
         elif isinstance(ex, TemplateSyntaxError):
+            if (origin := Origin.get_tag(variable)) and origin.line_num is None and ex.lineno > 0:
+                # When there is an origin without a line number, use the line number provided by the Jinja syntax error.
+                # This should only occur on templates which represent the entire contents of a file.
+                # Templates loaded from within a file, such as YAML, will use the existing origin.
+                # It's not possible to combine origins here, due to potential layout differences between the original content and the parsed output.
+                # This can happen, for example, with YAML multi-line strings.
+                variable = origin.replace(line_num=ex.lineno, col_num=None).tag(variable)
+
             msg = f"Syntax error in {kind}."
 
             if is_expression and is_possibly_template(variable):

--- a/test/integration/targets/templating-syntax-errors/aliases
+++ b/test/integration/targets/templating-syntax-errors/aliases
@@ -1,0 +1,2 @@
+context/controller
+shippable/posix/group4

--- a/test/integration/targets/templating-syntax-errors/runme.sh
+++ b/test/integration/targets/templating-syntax-errors/runme.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ansible-playbook template-file.yml "${@}" | tee template-file.out
+
+echo "Verifying contents of error reports ..."
+
+# verify the template-file error report is correct
+grep 'template-file.j2:5' template-file.out
+grep '5 {% sorry' template-file.out
+
+echo "PASS"

--- a/test/integration/targets/templating-syntax-errors/template-file.j2
+++ b/test/integration/targets/templating-syntax-errors/template-file.j2
@@ -1,0 +1,5 @@
+line 1
+line 2
+line 3
+line 4
+{% sorry

--- a/test/integration/targets/templating-syntax-errors/template-file.yml
+++ b/test/integration/targets/templating-syntax-errors/template-file.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - template:
+        src: template-file.j2
+        dest: template-file.txt
+      ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY

Report the line number for Jinja syntax errors in template files.

Resolves https://github.com/ansible/ansible/issues/86085

Syntax errors in template files now show the line number provided by Jinja, along with context.

For example, from the integration test added in this PR:

```
Syntax error in template: Encountered unknown tag 'sorry'.
Origin: /Users/mclay/code/mattclay/ansible/test/results/.tmp/integration/templating-syntax-errors-iluc6qeg-ÅÑŚÌβŁÈ/test/integration/targets/templating-syntax-errors/template-file.j2:5

3 line 3
4 line 4
5 {% sorry
  ^^^^^^^^
```

##### ISSUE TYPE

Bugfix Pull Request
