### PR TITLE
[stable-2.18] 🧪 Set timeouts for CI jobs

### DIFF
--- a/.azure-pipelines/templates/coverage.yml
+++ b/.azure-pipelines/templates/coverage.yml
@@ -7,6 +7,7 @@ jobs:
   - job: Coverage
     displayName: Code Coverage
     container: $[ variables.defaultContainer ]
+    timeoutInMinutes: 10
     workspace:
       clean: all
     steps:

--- a/.azure-pipelines/templates/test.yml
+++ b/.azure-pipelines/templates/test.yml
@@ -12,6 +12,7 @@ jobs:
     - job: test_${{ replace(replace(replace(replace(job.test, '/', '_'), '.', '_'), '-', '_'), '@', '_') }}
       displayName: ${{ job.name }}
       container: $[ variables.defaultContainer ]
+      timeoutInMinutes: 65
       workspace:
         clean: all
       steps:


### PR DESCRIPTION
Sometimes, AZP would mark steps in jobs as cancelled when they've actually exited successfully but on the boundary of the default 60-minute timeout. Such logs might be difficult to reason about.

Additionally, `entry-point.sh` sets a 60-minute timeout for the main test invocation but it would never trigger earlier that AZP would kill such a job as the job-global timeout was 60 minutes already and it'd always be hit earlier than the test runner one.

The patch sets maximum observable job timeouts with extra buffer to account for flakiness.

PR #86073
(cherry picked from commit 730af32)

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" if there is a corresponding issue -->

##### ISSUE TYPE

- Test Pull Request
