### PR TITLE
Fix returned groups in the user module

### DIFF
--- a/changelogs/fragments/81164-fix-user-module-groups-output-issue.yml‎
+++ b/changelogs/fragments/81164-fix-user-module-groups-output-issue.yml‎
@@ -1,0 +1,1 @@
+- The ``user`` module now outputs the exhaustive list of groups a user belongs to. Previously, only specified groups to which the user is to be added were displayed (https://github.com/ansible/ansible/issues/80669).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -604,6 +604,7 @@ class User(object):
         self.expires = None
         self.password_lock = module.params['password_lock']
         self.groups = None
+        self.current_groups = []
         self.local = module.params['local']
         self.profile = module.params['profile']
         self.authorization = module.params['authorization']
@@ -902,6 +903,11 @@ class User(object):
         info = self.user_info()
         has_append = self._check_usermod_append()
 
+        current_groups = self.user_group_membership(exclude_primary=False)
+    
+        if self.groups is None or self.append:
+            self.current_groups = current_groups
+
         if self.uid is not None and info[2] != int(self.uid):
             cmd.append('-u')
             cmd.append(self.uid)
@@ -919,7 +925,6 @@ class User(object):
 
         if self.groups is not None:
             # get a list of all groups for the user, including the primary
-            current_groups = self.user_group_membership(exclude_primary=False)
             groups_need_mod = False
             groups = []
 
@@ -3398,8 +3403,12 @@ def main():
         result['comment'] = info[4]
         result['home'] = info[5]
         result['shell'] = info[6]
-        if user.groups is not None:
-            result['groups'] = user.groups
+        
+        groups = set(user.current_groups)
+        if (user.groups is not None):
+            groups.update(user.groups.split(','))
+        
+        result['groups'] = ','.join(list(groups))
 
         # handle missing homedirs
         info = user.user_info()

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -904,7 +904,6 @@ class User(object):
         has_append = self._check_usermod_append()
 
         current_groups = self.user_group_membership(exclude_primary=False)
-    
         if self.groups is None or self.append:
             self.current_groups = current_groups
 
@@ -3402,12 +3401,10 @@ def main():
         result['group'] = info[3]
         result['comment'] = info[4]
         result['home'] = info[5]
-        result['shell'] = info[6]
-        
+        result['shell'] = info[6]       
         groups = set(user.current_groups)
         if (user.groups is not None):
             groups.update(user.groups.split(','))
-        
         result['groups'] = ','.join(list(groups))
 
         # handle missing homedirs

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -18,6 +18,7 @@
 - import_tasks: test_expires_min_max.yml
 - import_tasks: test_expires_warn.yml
 - import_tasks: test_ssh_key_passphrase.yml
+- import_tasks: test_returned_groups.yml
 - include_tasks: test_password_lock.yml
   when: ansible_distribution != 'Alpine'
 - include_tasks: test_password_lock_new_user.yml

--- a/test/integration/targets/user/tasks/test_returned_groups.yml
+++ b/test/integration/targets/user/tasks/test_returned_groups.yml
@@ -1,0 +1,65 @@
+- name: Create user with mutiple groups
+  ansible.builtin.user:
+    name: testuser
+    groups:
+      - www-data
+      - sudo
+    append: false
+    state: present
+  register: __user_create
+
+- name: Ensure that the groups returned match the requested ones
+  ansible.builtin.assert:
+    that:
+      - __user_create.groups.split(',') | length == 2
+      - "'www-data' in __user_create.groups and 'sudo' in __user_create.groups"
+
+- name: Append a group to the user
+  ansible.builtin.user: 
+    name: testuser
+    groups:
+      - man
+    append: true
+    state: present
+  register: __user_append
+
+- name:  Ensure that the groups returned are the current groups for the user 
+  ansible.builtin.assert:
+    that: 
+      - __user_append.groups.split(',') | length == 3
+      - "'www-data' in __user_append.groups and 'sudo' in __user_append.groups and 'man' in __user_append.groups"
+
+- name: Overwrite groups
+  ansible.builtin.user: 
+    name: testuser
+    groups: ['disk']
+    append: false
+  register: __overwrite_state
+
+- name: Ensure that old groups are removed
+  ansible.builtin.assert:
+    that: 
+      - __overwrite_state.groups.split(',') | length == 1
+      - "'disk' in __overwrite_state.groups"
+
+- name: Get user info 
+  ansible.builtin.user:
+    name: testuser 
+    state: present
+  register: __user_info
+
+- name: Ensure that the current groups are returned
+  ansible.builtin.assert:
+    that: 
+      - __user_info.groups.split(',') | length == 1
+      - "'disk' in __user_info.groups"
+
+- name: Delete user 
+  ansible.builtin.user: 
+    name: testuser
+    state: absent
+  register: __remove_user
+
+- name: Ensure groups are not returned 
+  ansible.builtin.assert:
+    that: __remove_user.groups is not defined or __remove_user.groups == ''

--- a/test/integration/targets/user/tasks/test_returned_groups.yml
+++ b/test/integration/targets/user/tasks/test_returned_groups.yml
@@ -1,9 +1,7 @@
-- name: Create user with mutiple groups
+- name: Create user
   ansible.builtin.user:
     name: testuser
-    groups:
-      - www-data
-      - sudo
+    groups: ['www-data']
     append: false
     state: present
   register: __user_create
@@ -11,8 +9,8 @@
 - name: Ensure that the groups returned match the requested ones
   ansible.builtin.assert:
     that:
-      - __user_create.groups.split(',') | length == 2
-      - "'www-data' in __user_create.groups and 'sudo' in __user_create.groups"
+      - __user_create.groups.split(',') | length == 1
+      - "'www-data' in __user_create.groups"
 
 - name: Append a group to the user
   ansible.builtin.user: 
@@ -26,8 +24,8 @@
 - name:  Ensure that the groups returned are the current groups for the user 
   ansible.builtin.assert:
     that: 
-      - __user_append.groups.split(',') | length == 3
-      - "'www-data' in __user_append.groups and 'sudo' in __user_append.groups and 'man' in __user_append.groups"
+      - __user_append.groups.split(',') | length == 2
+      - "'www-data' in __user_append.groups and 'man' in __user_append.groups"
 
 - name: Overwrite groups
   ansible.builtin.user: 


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Get the list of the groups the user belongs to by reusing previsouly calculated values withinthe user_group_membership function. Whenver the user module is invoked the user_group_membership  will be called only one time to return an accurate  result about the current groups to which the user belongs.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->
Fixes #80669

##### ISSUE TYPE

- Bugfix Pull Request

