### PR TITLE
dnf: Return error message from RPM installation

### DIFF
--- a/changelogs/fragments/dnf_install.yml
+++ b/changelogs/fragments/dnf_install.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+   - dnf5 - return failure message which occured while running RPM scriptlet (https://github.com/ansible/ansible/issues/86117).

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -1178,7 +1178,7 @@ class DnfModule(YumDnf):
                     if tid is not None:
                         transaction = self.base.history.old([tid])[0]
                         if transaction.return_code:
-                            failure_response['failures'].append(transaction.output())
+                            failure_response['failures'].extend(transaction.output())
 
                 if failure_response['failures']:
                     failure_response['msg'] = 'Failed to install some of the specified packages'

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -808,6 +808,7 @@ class Dnf5Module(YumDnf):
                         try:
                             failures = transaction.get_rpm_messages()
                         except AttributeError:
+                            # get_rpm_messages is not available in dnf5 < 5.2.7.0
                             pass
                     if not failures:
                         failures = ["{}: {}".format(transaction.transaction_result_to_string(result), log) for log in transaction.get_transaction_problems()]

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -803,9 +803,13 @@ class Dnf5Module(YumDnf):
                         rc=1,
                     )
                 elif result != libdnf5.base.Transaction.TransactionRunResult_SUCCESS:
+                    failures = []
                     if result == libdnf5.base.Transaction.TransactionRunResult_ERROR_RPM_RUN:
-                        failures = [transaction.get_rpm_messages()]
-                    else:
+                        try:
+                            failures = transaction.get_rpm_messages()
+                        except AttributeError:
+                            pass
+                    if not failures:
                         failures = ["{}: {}".format(transaction.transaction_result_to_string(result), log) for log in transaction.get_transaction_problems()]
 
                     self.module.fail_json(

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -802,16 +802,15 @@ class Dnf5Module(YumDnf):
                         failures=[],
                         rc=1,
                     )
-                elif result == libdnf5.base.Transaction.TransactionRunResult_ERROR_RPM_RUN:
-                    self.module.fail_json(
-                        msg=f"Failed to install RPM: {','.join(transaction.get_rpm_messages())}",
-                        failures=[],
-                        rc=1,
-                    )
                 elif result != libdnf5.base.Transaction.TransactionRunResult_SUCCESS:
+                    if result == libdnf5.base.Transaction.TransactionRunResult_ERROR_RPM_RUN:
+                        failures = [transaction.get_rpm_messages()]
+                    else:
+                        failures = ["{}: {}".format(transaction.transaction_result_to_string(result), log) for log in transaction.get_transaction_problems()]
+
                     self.module.fail_json(
                         msg="Failed to install some of the specified packages",
-                        failures=["{}: {}".format(transaction.transaction_result_to_string(result), log) for log in transaction.get_transaction_problems()],
+                        failures=failures,
                         rc=1,
                     )
 

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -806,7 +806,7 @@ class Dnf5Module(YumDnf):
                     failures = []
                     if result == libdnf5.base.Transaction.TransactionRunResult_ERROR_RPM_RUN:
                         try:
-                            failures = transaction.get_rpm_messages()
+                            failures = list(transaction.get_rpm_messages())
                         except AttributeError:
                             # get_rpm_messages is not available in dnf5 < 5.2.7.0
                             pass

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -810,8 +810,8 @@ class Dnf5Module(YumDnf):
                         except AttributeError:
                             # get_rpm_messages is not available in dnf5 < 5.2.7.0
                             pass
-                    if not failures:
-                        failures = ["{}: {}".format(transaction.transaction_result_to_string(result), log) for log in transaction.get_transaction_problems()]
+                    # Add the transaction problems to the failures
+                    failures.extend(["{}: {}".format(transaction.transaction_result_to_string(result), log) for log in transaction.get_transaction_problems()])
 
                     self.module.fail_json(
                         msg="Failed to install some of the specified packages",

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -802,6 +802,12 @@ class Dnf5Module(YumDnf):
                         failures=[],
                         rc=1,
                     )
+                elif result == libdnf5.base.Transaction.TransactionRunResult_ERROR_RPM_RUN:
+                    self.module.fail_json(
+                        msg=f"Failed to install RPM: {','.join(transaction.get_rpm_messages())}",
+                        failures=[],
+                        rc=1,
+                    )
                 elif result != libdnf5.base.Transaction.TransactionRunResult_SUCCESS:
                     self.module.fail_json(
                         msg="Failed to install some of the specified packages",

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -631,7 +631,12 @@
     that:
         - "not dnf_result is changed"
         - "dnf_result is failed"
-        - ansible_facts["pkg_mgr"] == "dnf5" and "'Failed to install RPM:' in dnf_result.msg"
+
+- name: verify that dnf5 failed with the correct message
+  assert:
+    that:
+        - "'Failed to install RPM:' in dnf_result.msg"
+    when: ansible_facts["pkg_mgr"] == "dnf5"
 
 # setup for testing installing an RPM from local file
 

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -631,12 +631,8 @@
     that:
         - "not dnf_result is changed"
         - "dnf_result is failed"
-
-- name: verify that dnf5 failed with the correct message
-  assert:
-    that:
-        - "'Failed to install RPM:' in dnf_result.msg"
-    when: ansible_facts["pkg_mgr"] == "dnf5"
+        - "'Failed to install some' in dnf_results.msg"
+        - dnf_results.failures | length > 0
 
 # setup for testing installing an RPM from local file
 

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -618,6 +618,21 @@
         - "not dnf_result is changed"
         - "dnf_result is failed"
 
+- name: try to install an RPM with error in scriptlet
+  dnf:
+    name: https://github.com/Akasurde/ansible_pull_test_repo/raw/refs/heads/main/broken-scriptlet-test-1.0-1.noarch.rpm
+    state: present
+    disable_gpg_check: true
+  register: dnf_result
+  ignore_errors: True
+
+- name: verify that dnf failed
+  assert:
+    that:
+        - "not dnf_result is changed"
+        - "dnf_result is failed"
+        - ansible_facts["pkg_mgr"] == "dnf5" and "'Failed to install RPM:' in dnf_result.msg"
+
 # setup for testing installing an RPM from local file
 
 - set_fact:

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -631,8 +631,8 @@
     that:
         - "not dnf_result is changed"
         - "dnf_result is failed"
-        - "'Failed to install some' in dnf_results.msg"
-        - dnf_results.failures | length > 0
+        - "'Failed to install some' in dnf_result.msg"
+        - dnf_result.failures | length > 0
 
 # setup for testing installing an RPM from local file
 

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -620,7 +620,7 @@
 
 - name: try to install an RPM with error in scriptlet
   dnf:
-    name: https://github.com/Akasurde/ansible_pull_test_repo/raw/refs/heads/main/broken-scriptlet-test-1.0-1.noarch.rpm
+    name: broken-scriptlet
     state: present
     disable_gpg_check: true
   register: dnf_result
@@ -631,8 +631,8 @@
     that:
         - "not dnf_result is changed"
         - "dnf_result is failed"
-        - "'Failed to install some' in dnf_result.msg"
         - dnf_result.failures | length > 0
+        - '"scriptlet failed, exit status 1" in dnf_result.failures[0]'
 
 # setup for testing installing an RPM from local file
 

--- a/test/integration/targets/setup_rpm_repo/library/create_repo.py
+++ b/test/integration/targets/setup_rpm_repo/library/create_repo.py
@@ -34,6 +34,7 @@ class RPM:
     file: str | None = None
     binary: str | None = None
     provides: list[str] | None = None
+    pre: str | None = None
 
 
 SPECS = [
@@ -66,6 +67,7 @@ SPECS = [
     RPM(name='package-name', version='1.0'),
     RPM(name='provides-package', version='1.0', provides=['provided-package']),
     RPM(name='provided-package', version='1.0'),
+    RPM(name='broken-scriptlet', version='1.0', pre='/bin/false\n'),
 ]
 
 
@@ -91,6 +93,9 @@ def create_repo():
                     spec.file, make_gif()
                 )
             )
+
+        if spec.pre:
+            pkg.add_pre(spec.pre)
 
         if spec.binary:
             pkg.add_simple_compilation(installPath=spec.binary)


### PR DESCRIPTION
##### SUMMARY

* When RPM scriptlet fails, return those error messages
  for further debugging.

Fixes: #86117

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/dnf_install.yml
lib/ansible/modules/dnf5.py
test/integration/targets/dnf/tasks/dnf.yml


