### PR TITLE
Remove decrypt arg-docs mismatch

### DIFF
--- a/changelogs/fragments/86128-fix-script-decrypt-docs-mismatch.yml
+++ b/changelogs/fragments/86128-fix-script-decrypt-docs-mismatch.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - script - remove the currently unsupported ``decrypt`` argument from the script module documentation - https://github.com/ansible/ansible/issues/86067

--- a/changelogs/fragments/86128-fix-script-decrypt-docs-mismatch.yml
+++ b/changelogs/fragments/86128-fix-script-decrypt-docs-mismatch.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - script - remove the currently unsupported ``decrypt`` argument from the script module documentation - https://github.com/ansible/ansible/issues/86067
+  - script - remove the currently unsupported ``decrypt`` argument from the module documentation (https://github.com/ansible/ansible/issues/86067).

--- a/lib/ansible/modules/script.py
+++ b/lib/ansible/modules/script.py
@@ -54,7 +54,7 @@ notes:
   - This module is also supported for Windows targets.
   - If the script returns non-UTF-8 data, it must be encoded to avoid issues. One option is to pipe
     the output through C(base64).
-  - This module will automatically unvault the script. 
+  - This module will automatically unvault the script.
 seealso:
   - module: ansible.builtin.shell
   - module: ansible.windows.win_shell

--- a/lib/ansible/modules/script.py
+++ b/lib/ansible/modules/script.py
@@ -64,7 +64,6 @@ extends_documentation_fragment:
     - action_common_attributes
     - action_common_attributes.files
     - action_common_attributes.raw
-    - decrypt
 attributes:
     check_mode:
         support: partial

--- a/lib/ansible/modules/script.py
+++ b/lib/ansible/modules/script.py
@@ -54,6 +54,7 @@ notes:
   - This module is also supported for Windows targets.
   - If the script returns non-UTF-8 data, it must be encoded to avoid issues. One option is to pipe
     the output through C(base64).
+  - This module will automatically unvault the script. 
 seealso:
   - module: ansible.builtin.shell
   - module: ansible.windows.win_shell

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -98,7 +98,7 @@ class ActionModule(ActionBase):
             if executable:
                 executable = to_native(new_module_args['executable'], errors='surrogate_or_strict')
             try:
-                source = self._loader.get_real_file(self._find_needle('files', source), decrypt=self._task.args.get('decrypt', True))
+                source = self._loader.get_real_file(self._find_needle('files', source))
             except AnsibleError as e:
                 raise AnsibleActionFail(to_native(e))
 


### PR DESCRIPTION
##### SUMMARY

Removes the use of the `decrypt` arg in the action plugin
and removes the associated doc fragment.

This parameter should not be added because it makes no
sense to allow the use of a non-decrypted script because 
a script can't be run if it's not decrypted.

I'm marking this as a docs change and not a bugfix
because there is no change in behavior after this pull.
The lack of a `decrypt` parameter in the `argspec` 
prevents a value being passed in for `decrypt` and,
copuled with the `args.get('decrypt', True)` it means that
`decrypt` is always set to True (the default behavior).

^ If this assertion is incorrect just lmk 🤙

Fixes #86067 

##### ISSUE TYPE

- Docs Pull Request
