### PR TITLE
Remove urllib2 pylint check

### DIFF
--- a/changelogs/fragments/ansible-test-pylint-urllib2.yml
+++ b/changelogs/fragments/ansible-test-pylint-urllib2.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Remove pylint check for ``urllib2`` usage.

--- a/test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/integration/targets/hello/files/bad.py
+++ b/test/integration/targets/ansible-test-sanity/ansible_collections/ns/col/tests/integration/targets/hello/files/bad.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import tempfile
 
 try:
-    import urllib2  # intentionally trigger pylint ansible-bad-import error  # pylint: disable=unused-import
+    import ansible.module_utils.six  # intentionally trigger pylint ansible-bad-import error  # pylint: disable=unused-import
 except ImportError:
-    urllib2 = None
+    pass
 
 try:
-    from urllib2 import Request  # intentionally trigger pylint ansible-bad-import-from error  # pylint: disable=unused-import
+    from ansible.module_utils.six import PY3  # intentionally trigger pylint ansible-bad-import-from error  # pylint: disable=unused-import
 except ImportError:
-    Request = None
+    pass
 
 tempfile.mktemp()  # intentionally trigger pylint ansible-bad-function error

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/unwanted.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/unwanted.py
@@ -83,15 +83,8 @@ class AnsibleUnwantedChecker(BaseChecker):
     )
 
     unwanted_imports = {
-        # see https://docs.python.org/2/library/urllib2.html
-        'urllib2': UnwantedEntry(
-            'ansible.module_utils.urls',
-            ignore_paths=(
-                '/lib/ansible/module_utils/urls.py',
-            )
-        ),
-
         # see https://docs.python.org/3/library/collections.abc.html
+        # deprecated: description='remove collections check now that Python 3.9 is no longer supported' core_version='2.23'
         'collections': UnwantedEntry(
             'collections.abc',
             names=(

--- a/test/sanity/code-smell/mypy/ansible-core.ini
+++ b/test/sanity/code-smell/mypy/ansible-core.ini
@@ -116,9 +116,6 @@ ignore_missing_imports = True
 [mypy-selinux.*]
 ignore_missing_imports = True
 
-[mypy-urllib2.*]
-ignore_missing_imports = True
-
 [mypy-httplib.*]
 ignore_missing_imports = True
 


### PR DESCRIPTION
##### SUMMARY

No supported Python version provides urllib2.

Resolves https://github.com/ansible/ansible/issues/85942

##### ISSUE TYPE

Feature Pull Request
