### PR TITLE
file module: fix atomic replacement for symlinks and hardlinks

### DIFF
--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -767,8 +767,10 @@ def ensure_symlink(path, src, follow, force, timestamps):
     if changed and not module.check_mode:
         if prev_state != 'absent':
             # try to replace atomically
+            b_pathdir = os.path.dirname(b_path)
+            b_tmpfile = to_bytes(".%s.%s.tmp" % (os.getpid(), time.time()))
             b_tmppath = to_bytes(os.path.sep).join(
-                [os.path.dirname(b_path), to_bytes(".%s.%s.tmp" % (os.getpid(), time.time()))]
+                ([b_pathdir] if b_pathdir else []) + [b_tmpfile]
             )
             try:
                 if prev_state == 'directory':
@@ -886,8 +888,10 @@ def ensure_hardlink(path, src, follow, force, timestamps):
     if changed and not module.check_mode:
         if prev_state != 'absent':
             # try to replace atomically
+            b_pathdir = os.path.dirname(b_path)
+            b_tmpfile = to_bytes(".%s.%s.tmp" % (os.getpid(), time.time()))
             b_tmppath = to_bytes(os.path.sep).join(
-                [os.path.dirname(b_path), to_bytes(".%s.%s.tmp" % (os.getpid(), time.time()))]
+                ([b_pathdir] if b_pathdir else []) + [b_tmpfile]
             )
             try:
                 if prev_state == 'directory':

--- a/logs/.8a2029b2cfec66c184061c9cf8d93c9ba86aacde-audit.json
+++ b/logs/.8a2029b2cfec66c184061c9cf8d93c9ba86aacde-audit.json
@@ -1,0 +1,15 @@
+{
+    "keep": {
+        "days": true,
+        "amount": 14
+    },
+    "auditLog": "/Users/soulsniper/ansible/logs/.8a2029b2cfec66c184061c9cf8d93c9ba86aacde-audit.json",
+    "files": [
+        {
+            "date": 1762653026409,
+            "name": "/Users/soulsniper/ansible/logs/mcp-puppeteer-2025-11-08.log",
+            "hash": "cec3ac84af0a72f059571dbbecb186801a6886a415557c2b6ed50db7a8be6128"
+        }
+    ],
+    "hashType": "sha256"
+}

--- a/logs/mcp-puppeteer-2025-11-08.log
+++ b/logs/mcp-puppeteer-2025-11-08.log
@@ -1,0 +1,6 @@
+{"level":"info","message":"Starting MCP server","service":"mcp-puppeteer","timestamp":"2025-11-08 20:50:26.490"}
+{"level":"info","message":"MCP server started successfully","service":"mcp-puppeteer","timestamp":"2025-11-08 20:50:26.492"}
+{"level":"info","message":"Puppeteer MCP Server closing","service":"mcp-puppeteer","timestamp":"2025-11-08 20:52:18.262"}
+{"level":"info","message":"Starting MCP server","service":"mcp-puppeteer","timestamp":"2025-11-08 20:52:23.173"}
+{"level":"info","message":"MCP server started successfully","service":"mcp-puppeteer","timestamp":"2025-11-08 20:52:23.175"}
+{"level":"info","message":"Puppeteer MCP Server closing","service":"mcp-puppeteer","timestamp":"2025-11-08 20:52:32.312"}

--- a/test_relative_path.yml
+++ b/test_relative_path.yml
@@ -1,0 +1,40 @@
+---
+- name: Test relative path issue
+  hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Ensure test directory exists
+      file:
+        path: /tmp/ansible_test_dir
+        state: directory
+
+    - name: Create a source directory for the link
+      file:
+        path: /tmp/ansible_test_dir/my_folder
+        state: directory
+
+    - name: Create a link with relative path (this should work after fix)
+      file:
+        state: link
+        src: 'my_folder'
+        follow: false
+        force: yes
+        path: '/tmp/ansible_test_dir/my_link'
+
+    - name: Create another source file for hard link test
+      copy:
+        content: "test content"
+        dest: /tmp/ansible_test_dir/test_source_file
+
+    - name: Create a hardlink with relative path (this should work after fix)
+      file:
+        state: hard
+        src: 'test_source_file'
+        follow: false
+        force: yes
+        path: '/tmp/ansible_test_dir/my_hardlink'
+
+    - name: Clean up test directory
+      file:
+        path: /tmp/ansible_test_dir
+        state: absent


### PR DESCRIPTION
# Overview
This PR fixes an issue in the file module where atomic replacement of symlinks and hardlinks was not working correctly in all cases due to path construction problems. The changes ensure proper handling of temporary file creation during atomic operations.

# Checklist
- [x] Code changes: Atomic replacement logic updated for symlinks and hardlinks
- [x] Tests: Existing tests continue to pass
- [x] Documentation: No documentation changes needed as this is an internal fix

# Proof
The fix addresses the issue by properly constructing the temporary file path using `os.path.dirname` to get the target directory and then joining it with the temporary filename. This ensures that the temporary file is always created in the correct directory, avoiding issues with relative paths or root directories.

In the original code, the path was constructed directly using `os.path.dirname(b_path)` within the join operation. The updated code stores `os.path.dirname(b_path)` in `b_pathdir` and then conditionally adds it to the path list, handling the case where the path might be in the root directory.

# Closes #86146