### PR TITLE
[stable-2.19] runtime-metadata sanity test: ignore pre-release and build identifier

### DIFF
--- a/changelogs/fragments/85193-runtime-metadata.yml
+++ b/changelogs/fragments/85193-runtime-metadata.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - The runtime-metadata sanity test now ignores pre-release and build identifiers in collection versions. This prevents errors if a tombstone version is ``X.0.0``, while the collection's version is ``X.0.0-prerelease`` (https://github.com/ansible/ansible/issues/85193)."

--- a/test/integration/targets/ansible-test-sanity-runtime-metadata/ansible_collections/ns/prerelease/galaxy.yml
+++ b/test/integration/targets/ansible-test-sanity-runtime-metadata/ansible_collections/ns/prerelease/galaxy.yml
@@ -1,0 +1,5 @@
+namespace: ns
+name: prerelease
+version: 3.0.0-prerelease
+authors:
+  - Ansible

--- a/test/integration/targets/ansible-test-sanity-runtime-metadata/ansible_collections/ns/prerelease/meta/runtime.yml
+++ b/test/integration/targets/ansible-test-sanity-runtime-metadata/ansible_collections/ns/prerelease/meta/runtime.yml
@@ -1,0 +1,25 @@
+plugin_routing:
+  modules:
+    deprecated_module:
+      deprecation:
+        removal_version: 4.0.0
+        warning_text: Will no longer be there.
+    tombstoned_module:
+      tombstone:
+        removal_version: 3.0.0
+        warning_text: Is no longer there.
+    tombstoned_module_with_prerelease_version:
+      tombstone:
+        removal_version: 3.0.0-a1
+        warning_text: Is no longer there.
+    tombstoned_module_with_prerelease_and_build_meta_version:
+      tombstone:
+        removal_version: 3.0.0-a1+bla.test.1234567
+        warning_text: Is no longer there.
+    tombstoned_module_with_build_meta_version:
+      tombstone:
+        removal_version: 3.0.0+bla.test.1234567
+        warning_text: Is no longer there.
+    module_with_invalid_removal_version:
+      tombstone:
+        removal_version: 4.0.0

--- a/test/integration/targets/ansible-test-sanity-runtime-metadata/expected-prerelease.txt
+++ b/test/integration/targets/ansible-test-sanity-runtime-metadata/expected-prerelease.txt
@@ -1,0 +1,1 @@
+meta/runtime.yml:0:0: The tombstone removal_version ('4.0.0') must not be after the current version (SemanticVersion('3.0.0')) for dictionary value @ data['plugin_routing']['modules']['module_with_invalid_removal_version']['tombstone']['removal_version']. Got '4.0.0'

--- a/test/integration/targets/ansible-test-sanity-runtime-metadata/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-runtime-metadata/runme.sh
@@ -13,3 +13,8 @@ cd ../no_version
 ansible-test sanity --test runtime-metadata --color --truncate 0 --failure-ok --lint "${@}" 1> actual-stdout.txt 2> actual-stderr.txt
 diff -u "${TEST_DIR}/expected-no_version.txt" actual-stdout.txt
 grep -F -f "${TEST_DIR}/expected-no_version.txt" actual-stderr.txt
+
+cd ../prerelease
+ansible-test sanity --test runtime-metadata --color --truncate 0 --failure-ok --lint "${@}" 1> actual-stdout.txt 2> actual-stderr.txt
+diff -u "${TEST_DIR}/expected-prerelease.txt" actual-stdout.txt
+grep -F -f "${TEST_DIR}/expected-prerelease.txt" actual-stderr.txt

--- a/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
+++ b/test/lib/ansible_test/_util/controller/sanity/code-smell/runtime-metadata.py
@@ -135,7 +135,7 @@ def get_collection_version():
     try:
         result = collection_detail.read_manifest_json('.') or collection_detail.read_galaxy_yml('.')
         version = SemanticVersion()
-        version.parse(result['version'])
+        version.parse(result['version'].split('-', 1)[0].split('+', 1)[0])
         return version
     except Exception:  # pylint: disable=broad-except
         # We do not care why it fails, in case we cannot get the version


### PR DESCRIPTION
##### SUMMARY
Backport of #85198 to stable-2.19.

##### ISSUE TYPE
- Bugfix Pull Request
