### PR TITLE
Disable detached head warning on collection checkout

### DIFF
--- a/changelogs/fragments/86170-disable-detached-head-warning.yml
+++ b/changelogs/fragments/86170-disable-detached-head-warning.yml
@@ -1,3 +1,5 @@
 bugfixes:
-  - ansible-galaxy install - Dependencies of type git with tag or sha versions have caused detached head warning
-    messages (https://github.com/ansible/ansible/issues/86169).
+  - >-
+    ``ansible-galaxy install``/``ansible-galaxy collection download`` - collections from git repositories
+    with a tag or sha version no longer emit detached head warning messages
+    (https://github.com/ansible/ansible/issues/86169).

--- a/changelogs/fragments/86170-disable-detached-head-warning.yml
+++ b/changelogs/fragments/86170-disable-detached-head-warning.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-galaxy install - Dependencies of type git with tag or sha versions have caused detached head warning
+    messages (https://github.com/ansible/ansible/issues/86169).

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -443,7 +443,12 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
             format(repo_url=to_native(git_url)),
         ) from proc_err
 
-    git_switch_cmd = git_executable, 'checkout', to_text(version)
+    if version == 'HEAD':
+        git_args = ()
+    else:
+        git_args = '-c', 'advice.detachedHead=false'
+
+    git_switch_cmd = git_executable, *git_args, 'checkout', to_text(version)
     try:
         subprocess.check_call(git_switch_cmd, cwd=b_checkout_path)
     except subprocess.CalledProcessError as proc_err:

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -147,7 +147,7 @@ def test_concrete_artifact_manager_scm_cmd(url, version, trailing_slash, monkeyp
     clone_cmd = [git_executable, 'clone', repo, '']
 
     assert mock_subprocess_check_call.call_args_list[0].args[0] == clone_cmd
-    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, 'checkout', 'commitish')
+    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, '-c', 'advice.detachedHead=false', 'checkout', 'commitish')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
##### SUMMARY

Pass `advice.detachedHead=false` to git checkout command to disable detached head warnings when collections are installed from git type dependencies with tag versions.

Fixes https://github.com/ansible/ansible/issues/86169

##### ISSUE TYPE

- Bugfix Pull Request

