### PR TITLE
Perform shallow (depth=1) git clone when version is HEAD, don't perform unnecessary checkout when version is HEAD

### DIFF
--- a/changelogs/fragments/shallow_git_clone.yml
+++ b/changelogs/fragments/shallow_git_clone.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
   - ansible-galaxy - Perform shallow (depth=1) git clone when version is HEAD
-  - ansible-galaxy - Don't perform unneccessary checkout when version is HEAD
+  - ansible-galaxy - Don't perform unnecessary checkout when version is HEAD

--- a/changelogs/fragments/shallow_git_clone.yml
+++ b/changelogs/fragments/shallow_git_clone.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ansible-galaxy - Perform shallow (depth=1) git clone when version is HEAD

--- a/changelogs/fragments/shallow_git_clone.yml
+++ b/changelogs/fragments/shallow_git_clone.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
   - ansible-galaxy - Perform shallow (depth=1) git clone when version is HEAD
+  - ansible-galaxy - Don't perform unneccessary checkout when version is HEAD

--- a/lib/ansible/utils/galaxy.py
+++ b/lib/ansible/utils/galaxy.py
@@ -80,7 +80,7 @@ def scm_archive_resource(src, scm='git', name=None, version='HEAD', keep_scm_met
 
     run_scm_cmd(clone_cmd, tempdir)
 
-    if scm == 'git' and version:
+    if scm == 'git' and version and version != 'HEAD':
         checkout_cmd = [scm_path, 'checkout', to_text(version)]
         run_scm_cmd(checkout_cmd, os.path.join(tempdir, name))
 

--- a/lib/ansible/utils/galaxy.py
+++ b/lib/ansible/utils/galaxy.py
@@ -63,6 +63,10 @@ def scm_archive_resource(src, scm='git', name=None, version='HEAD', keep_scm_met
     tempdir = tempfile.mkdtemp(dir=C.DEFAULT_LOCAL_TMP)
     clone_cmd = [scm_path, 'clone']
 
+    # Perform a shallow clone if simply cloning HEAD
+    if scm == 'git' and version == 'HEAD':
+        clone_cmd.append('--depth=1')
+
     # Add specific options for ignoring certificates if requested
     ignore_certs = context.CLIARGS['ignore_certs'] or C.GALAXY_IGNORE_CERTS
 


### PR DESCRIPTION
##### SUMMARY

ansible-galaxy - Perform shallow (depth=1) git clone when version is HEAD
ansible-galaxy - Don't perform unnecessary checkout when version is HEAD

##### ISSUE TYPE

Feature Pull Request
