### PR TITLE
Support checksum files that have a single space

### DIFF
--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -487,7 +487,7 @@ def parse_digest_lines(filename, lines):
     """
     checksum_map = []
     BSD_DIGEST_LINE = re.compile(r'^(\w+) ?\((?P<path>.+)\) ?= (?P<digest>[\w.]+)$')
-    GNU_DIGEST_LINE = re.compile(r'^(?P<digest>[\w.]+) ([ *])(?P<path>.+)$')
+    GNU_DIGEST_LINE = re.compile(r'^(?P<digest>[\w.]+)\s+\*?(?P<path>.+)$')
 
     if len(lines) == 1 and len(lines[0].split()) == 1:
         # Only a single line with a single string

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -358,6 +358,15 @@
       30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892  not_target1.txt
       d0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b  not_target2.txt
 
+- name: create sha256 checksum file of src and a single space
+  copy:
+    dest: '{{ files_dir }}/sha256sum.txt'
+    content: |
+      b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006. 27617.txt
+      b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006. 71420.txt
+      30949cc401e30ac494d695ab8764a9f76aae17c5d73c67f65e9b558f47eff892 not_target1.txt
+      d0dbfc1945bc83bf6606b770e442035f2c4e15c886ee0c22fb3901ba19900b5b not_target2.txt
+
 - name: create sha256 checksum file of src with a dot leading path
   copy:
     dest: '{{ files_dir }}/sha256sum_with_dot.txt'


### PR DESCRIPTION
##### SUMMARY

This change re-introduces support for checksum files that have a single space between the checksum and filename.

This is not strictly GNU-compatible, but it worked with Ansible <2.19.0. Some major software projects (like Jenkins) release checksum files with a single space rather than two. In 5b0d170496, the checksum parsing algorithm was changed so that the simple `split(" ")` mechanism was removed and replaced with a regexp.

This commit adds a bit of flexibility to said regexp to support checksum files as described above, and also removes the unused capture group for the `*`.

Related to https://github.com/ansible/ansible/issues/84476
See https://github.com/ansible/ansible/pull/84485

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
