### PR TITLE
Handle malformed AZP API responses gracefully

### DIFF
--- a/test/lib/ansible_test/_internal/ci/azp.py
+++ b/test/lib/ansible_test/_internal/ci/azp.py
@@ -243,7 +243,15 @@ class AzurePipelinesChanges:
             display.warning('Unable to find project. Cannot determine changes. All tests will be executed.')
             return set()
 
-        commits = set(build['sourceVersion'] for build in result['value'])
+        try:
+            commits = set(build['sourceVersion'] for build in result['value'])
+        except KeyError as key_err:
+            # most likely due to internal AZP issues it may return malformed objects w/o `sourceVersion`
+            display.warning(
+                'Unable to find recently successful merge commits due to a malformed AZP missing '
+                f'a key {key_err!s}. Cannot determine changes. All tests will be executed.',
+            )
+            return set()
 
         return commits
 


### PR DESCRIPTION
##### SUMMARY

This patch lets `ansible-test` keep running post receiving an unexpectedly-shaped response from the AZP API with a successful HTTP response code.

An example of this happening [[1]] looks as follows:

```python-traceback
Traceback (most recent call last):
  File "/__w/2/ansible/bin/ansible-test", line 46, in <module>
    main()
  File "/__w/2/ansible/bin/ansible-test", line 37, in main
    cli_main(args)
  File "/__w/2/ansible/test/lib/ansible_test/_internal/__init__.py", line 70, in main
    main_internal(cli_args)
  File "/__w/2/ansible/test/lib/ansible_test/_internal/__init__.py", line 97, in main_internal
    args.func(config)
  File "/__w/2/ansible/test/lib/ansible_test/_internal/commands/integration/posix.py", line 44, in command_posix_integration
    host_state, internal_targets = command_integration_filter(args, all_targets)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/2/ansible/test/lib/ansible_test/_internal/commands/integration/__init__.py", line 917, in command_integration_filter
    changes = get_changes_filter(args)
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/2/ansible/test/lib/ansible_test/_internal/executor.py", line 39, in get_changes_filter
    paths = detect_changes(args)
            ^^^^^^^^^^^^^^^^^^^^
  File "/__w/2/ansible/test/lib/ansible_test/_internal/executor.py", line 64, in detect_changes
    paths = get_ci_provider().detect_changes(args)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/2/ansible/test/lib/ansible_test/_internal/ci/azp.py", line 92, in detect_changes
    result = self._get_changes(args)
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/2/ansible/test/lib/ansible_test/_internal/ci/azp.py", line 86, in _get_changes
    self._changes = AzurePipelinesChanges(args)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/2/ansible/test/lib/ansible_test/_internal/ci/azp.py", line 200, in __init__
    commits = self.get_successful_merge_run_commits()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/__w/2/ansible/test/lib/ansible_test/_internal/ci/azp.py", line 246, in get_successful_merge_run_commits
    commits = set(build['sourceVersion'] for build in result['value'])
                                                      ~~~~~~^^^^^^^^^
KeyError: 'value'
```

[1]: https://dev.azure.com/ansible/ansible/_build/results?buildId=163224&view=logs&j=2dc8d72b-188c-5a60-cbae-e15a799e7fa2&t=d83aedb7-f8c2-5094-ecbd-98bff0f21af5&l=142

##### ISSUE TYPE

- Test Pull Request
