### PR TITLE
[stable-2.14] Install `xt_comment` kernel mod @ `iptables` test (#86187)

### DIFF
--- a/test/integration/targets/iptables/tasks/main.yml
+++ b/test/integration/targets/iptables/tasks/main.yml
@@ -33,4 +33,14 @@
     name: iptables
     state: present
 
+- name: install xt_comment for iptables `-m comment` tests on RHEL 10
+  dnf:
+    name:
+    - kernel-modules-extra-{{ ansible_facts.kernel }}
+    state: present
+    exclude:
+    # prevent attempts to upgrade the kernel and install kernel modules for a non-running kernel version
+    - kernel-core
+  when: ansible_distribution == 'RedHat'
+
 - import_tasks: chain_management.yml


### PR DESCRIPTION
This patch fixes integration test jobs running under RHEL 10.0 that don't have this extension pre-installed.



ci_complete
ci_coverage
(cherry picked from commit 69c9fbed26543bb3a998c2b0d0a76db05358febf)

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" if there is a corresponding issue -->

##### ISSUE TYPE

- Test Pull Request
