### PR TITLE
[stable-2.18] Install `xt_comment` kernel mod @ `iptables` test (#86187)

### DIFF
--- a/test/integration/targets/iptables/tasks/main.yml
+++ b/test/integration/targets/iptables/tasks/main.yml
@@ -35,4 +35,14 @@
     # prevent attempts to upgrade the kernel and install kernel modules for a non-running kernel version
     exclude: "{{ 'kernel-core' if ansible_distribution == 'RedHat' else omit }}"
 
+- name: install xt_comment for iptables `-m comment` tests on RHEL 10
+  dnf:
+    name:
+    - kernel-modules-extra-{{ ansible_facts.kernel }}
+    state: present
+    exclude:
+    # prevent attempts to upgrade the kernel and install kernel modules for a non-running kernel version
+    - kernel-core
+  when: ansible_distribution == 'RedHat'
+
 - import_tasks: chain_management.yml

--- a/test/integration/targets/iptables/tasks/main.yml
+++ b/test/integration/targets/iptables/tasks/main.yml
@@ -43,6 +43,9 @@
     exclude:
     # prevent attempts to upgrade the kernel and install kernel modules for a non-running kernel version
     - kernel-core
-  when: ansible_distribution == 'RedHat'
+  when:
+  - ansible_distribution == 'RedHat'
+  - >-
+    ansible_distribution_major_version | int >= 10
 
 - import_tasks: chain_management.yml


### PR DESCRIPTION
This patch fixes integration test jobs running under RHEL 10.0 that don't have this extension pre-installed.



ci_complete
ci_coverage
(cherry picked from commit 69c9fbed26543bb3a998c2b0d0a76db05358febf)

The backport additionally skips installing `kernel-modules-extra` on RHEL 10+.

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" if there is a corresponding issue -->

##### ISSUE TYPE

- Test Pull Request
