### PR TITLE
ansible-test - Honor integration_config.yml for integration tests scr…

### DIFF
--- a/changelogs/fragments/ansible-test-script-target-issue.yml
+++ b/changelogs/fragments/ansible-test-script-target-issue.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ansible-test - add vars file into command line when running integration script target (https://github.com/ansible/ansible/pull/86198).

--- a/test/lib/ansible_test/_internal/commands/integration/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/integration/__init__.py
@@ -616,6 +616,10 @@ def command_integration_script(
         env = integration_environment(args, target, test_dir, test_env.inventory_path, test_env.ansible_config, env_config, test_env, host_state)
         cwd = os.path.join(test_env.targets_dir, target.relative_path)
 
+        if os.path.exists(test_env.vars_file):
+            vars_file_relative_path = os.path.relpath(test_env.vars_file, cwd)
+            cmd += ['-e', '@%s' % vars_file_relative_path]
+
         env.update(
             # support use of adhoc ansible commands in collections without specifying the fully qualified collection name
             ANSIBLE_PLAYBOOK_DIR=cwd,


### PR DESCRIPTION
##### SUMMARY
While running `ansible-test` for script target (containing `runme.sh`) the `tests/integration/integration_config.yml` containing additional variables is not add in the command line. This PR aims to fix that
<!--- Describe the change below, including rationale and design decisions -->

Before this PR, the `ansible-test` generated command is:

```
./runme.sh
```
With this PR it will be 

```
./runme.sh -e @../../integration_config.yml
```

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
