### PR TITLE
[stable-2.17] Remove scheduled runs

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -12,15 +12,6 @@ pr:
       - devel
       - stable-*
 
-schedules:
-  - cron: 0 7 * * *
-    displayName: Nightly
-    always: true
-    branches:
-      include:
-        - devel
-        - stable-*
-
 variables:
   - name: checkoutPath
     value: ansible


### PR DESCRIPTION
##### SUMMARY

Scheduled runs are no longer needed now that ansible-core 2.17 is EOL.

##### ISSUE TYPE

Test Pull Request
