### PR TITLE
facts: Handle mount facts for AIX VIO servers

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/aix.py
+++ b/lib/ansible/module_utils/facts/hardware/aix.py
@@ -236,6 +236,9 @@ class AIXHardware(Hardware):
                     fields = line.split()
                     if len(fields) != 0 and fields[0] != 'node' and fields[0][0] != '-' and re.match('^/.*|^[a-zA-Z].*|^[0-9].*', fields[0]):
                         if re.match('^/', fields[0]):
+                            # AIX VIO SSP mounts match above regexes, but show only 6 fields. we fix this by adding one empty field
+                            if len(fields) < 7:
+                                fields.append("")
                             # normal mount
                             mount = fields[1]
                             mount_info = {'mount': mount,

--- a/lib/ansible/module_utils/facts/system/loadavg.py
+++ b/lib/ansible/module_utils/facts/system/loadavg.py
@@ -23,7 +23,7 @@ class LoadAvgFactCollector(BaseFactCollector):
                 '5m': loadavg[1],
                 '15m': loadavg[2]
             }
-        except OSError:
+        except (OSError, AttributeError):
             pass
 
         return facts


### PR DESCRIPTION
##### SUMMARY
Issue #86179 Setup module does not return hw-info on AIX VIO servers

Fix code failing with indexerr as number of fields is lower as expected
Also fix another issue (not on github) where exception from os module is not catched.
Fixes #86179 

##### ISSUE TYPE

- Bugfix Pull Request
