### PR TITLE
Fix mount_facts module for collecting AIX mounts with no options

### DIFF
--- a/changelogs/fragments/fix-mount_facts-AIX-mounts.yml
+++ b/changelogs/fragments/fix-mount_facts-AIX-mounts.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mount_facts - Fix listing AIX mounts with no options.

--- a/lib/ansible/modules/mount_facts.py
+++ b/lib/ansible/modules/mount_facts.py
@@ -216,7 +216,7 @@ LINUX_MOUNT_RE = re.compile(r"^(?P<device>\S+) on (?P<mount>\S+) type (?P<fstype
 # Pattern for other BSD including FreeBSD, DragonFlyBSD, and MacOS
 BSD_MOUNT_RE = re.compile(r"^(?P<device>\S+) on (?P<mount>\S+) \((?P<fstype>.+)\)$")
 # Pattern for AIX, example in https://www.ibm.com/docs/en/aix/7.2?topic=m-mount-command
-AIX_MOUNT_RE = re.compile(r"^(?P<node>\S*)\s+(?P<mounted>\S+)\s+(?P<mount>\S+)\s+(?P<fstype>\S+)\s+(?P<time>\S+\s+\d+\s+\d+:\d+)\s+(?P<options>.*)$")
+AIX_MOUNT_RE = re.compile(r"^(?P<node>\S*)\s+(?P<mounted>\S+)\s+(?P<mount>\S+)\s+(?P<fstype>\S+)\s+(?P<time>\S+\s+\d+\s+\d+:\d+)(?:\s+(?P<options>.*))?$")
 
 
 @dataclass

--- a/lib/ansible/modules/mount_facts.py
+++ b/lib/ansible/modules/mount_facts.py
@@ -216,7 +216,13 @@ LINUX_MOUNT_RE = re.compile(r"^(?P<device>\S+) on (?P<mount>\S+) type (?P<fstype
 # Pattern for other BSD including FreeBSD, DragonFlyBSD, and MacOS
 BSD_MOUNT_RE = re.compile(r"^(?P<device>\S+) on (?P<mount>\S+) \((?P<fstype>.+)\)$")
 # Pattern for AIX, example in https://www.ibm.com/docs/en/aix/7.2?topic=m-mount-command
-AIX_MOUNT_RE = re.compile(r"^(?P<node>\S*)\s+(?P<mounted>\S+)\s+(?P<mount>\S+)\s+(?P<fstype>\S+)\s+(?P<time>\S+\s+\d+\s+\d+:\d+)(?:\s+(?P<options>.*))?$")
+AIX_MOUNT_RE = re.compile(
+    r"^(?P<node>\S*)"
+    r"\s+(?P<mounted>\S+)"
+    r"\s+(?P<mount>\S+)"
+    r"\s+(?P<fstype>\S+)"
+    r"\s+(?P<time>\S+\s+\d+\s+\d+:\d+)"
+    r"(?:\s+(?P<options>.*))?$")
 
 
 @dataclass

--- a/test/units/modules/mount_facts_data.py
+++ b/test/units/modules/mount_facts_data.py
@@ -372,7 +372,8 @@ aix_mount = """node   mounted          mounted over  vfs    date              op
 ----   -------          ------------ ---  ------------   -------------------
        /dev/hd0         /            jfs   Dec 17 08:04   rw, log  =/dev/hd8
        /dev/hd2         /usr         jfs   Dec 17 08:06   rw, log  =/dev/hd8
-sue    /home/local/src  /usr/code    nfs   Dec 17 08:06   ro, log  =/dev/hd8"""
+sue    /home/local/src  /usr/code    nfs   Dec 17 08:06   ro, log  =/dev/hd8
+       /foo/bar         /baz         poolfs Aug 07 21:46"""
 
 aix_mount_parsed = [
     (
@@ -411,6 +412,18 @@ aix_mount_parsed = [
             "options": "ro, log  =/dev/hd8",
         },
     ),
+    (
+        "mount",
+        "/baz",
+        "       /foo/bar         /baz         poolfs Aug 07 21:46",
+        {
+            "mount": "/baz",
+            "device": "/foo/bar",
+            "fstype": "poolfs",
+            "time": "Aug 07 21:46",
+            "options": None,
+        },
+    )
 ]
 
 aix7_2 = AIXData(aix_filesystems, aix_filesystems_parsed, aix_mount, aix_mount_parsed)


### PR DESCRIPTION
##### SUMMARY

This issue was reported for the setup module, but applies to mount_facts too (I think - I'll confirm before merging this).

If the date and time are at the end of the line from the mount command (i.e. no options), the mount is ignored. This fixes the regex so instead of requiring whitespace after the date and time, whitespace is only required if the line contains options.

##### ISSUE TYPE

- Bugfix Pull Request
