### PR TITLE
ansible-test - Replace Fedora 42 with 43

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -123,8 +123,8 @@ stages:
           targets:
             - name: Alpine 3.23
               test: alpine/3.23
-            - name: Fedora 42
-              test: fedora/42
+            - name: Fedora 43
+              test: fedora/43
             - name: RHEL 9.7
               test: rhel/9.7
             - name: RHEL 10.1
@@ -142,8 +142,8 @@ stages:
           targets:
             - name: Alpine 3.23
               test: alpine323
-            - name: Fedora 42
-              test: fedora42
+            - name: Fedora 43
+              test: fedora43
             - name: Ubuntu 22.04
               test: ubuntu2204
             - name: Ubuntu 24.04
@@ -157,8 +157,8 @@ stages:
           targets:
             - name: Alpine 3.23
               test: alpine323
-            - name: Fedora 42
-              test: fedora42
+            - name: Fedora 43
+              test: fedora43
             - name: Ubuntu 24.04
               test: ubuntu2404
           groups:
@@ -169,8 +169,8 @@ stages:
         parameters:
           testFormat: linux/{0}
           targets:
-            - name: Fedora 42
-              test: fedora42
+            - name: Fedora 43
+              test: fedora43
           groups:
             - 7
   - stage: Galaxy

--- a/changelogs/fragments/ansible-test-platforms.yml
+++ b/changelogs/fragments/ansible-test-platforms.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Replace Fedora 42 with 43.

--- a/test/integration/targets/ansible-test-container/runme.py
+++ b/test/integration/targets/ansible-test-container/runme.py
@@ -192,8 +192,9 @@ def get_test_scenarios() -> list[TestScenario]:
             ]
 
             if engine == 'podman':
-                if os_release.id not in ('ubuntu',):
+                if os_release.id not in ('ubuntu', 'fedora'):
                     # rootfull podman is not supported by all systems
+                    # rootfull podman networking stopped working on Fedora 43 hosts when docker is installed
                     user_scenarios.append(UserScenario(ssh=ROOT_USER))
 
                 # TODO: test podman remote on Alpine and Ubuntu hosts
@@ -201,8 +202,9 @@ def get_test_scenarios() -> list[TestScenario]:
                 if os_release.id not in ('alpine', 'ubuntu'):
                     user_scenarios.append(UserScenario(remote=unprivileged_user))
 
-                if LOGINUID_MISMATCH and os_release.id not in ('ubuntu',):
+                if LOGINUID_MISMATCH and os_release.id not in ('ubuntu', 'fedora'):
                     # rootfull podman is not supported by all systems
+                    # rootfull podman networking stopped working on Fedora 43 hosts when docker is installed
                     user_scenarios.append(UserScenario())
 
             for user_scenario in user_scenarios:

--- a/test/integration/targets/rpm_key/tasks/main.yaml
+++ b/test/integration/targets/rpm_key/tasks/main.yaml
@@ -2,6 +2,10 @@
    meta: end_play
    when: ansible_distribution == "RedHat" and ansible_distribution_version == "10.1"
 
+ - name: Skip Fedora 43 until rpm_key has been updated
+   meta: end_play
+   when: ansible_distribution == "Fedora" and ansible_distribution_version == "43"
+
  - when: ansible_os_family == "RedHat"
    block:
 

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -2,6 +2,6 @@ base image=quay.io/ansible/base-test-container:v2.21-0 python=3.14,3.9,3.10,3.11
 default image=quay.io/ansible/default-test-container:v2.21-0 python=3.14,3.9,3.10,3.11,3.12,3.13 context=collection
 default image=quay.io/ansible/ansible-core-test-container:v2.21-0 python=3.14,3.9,3.10,3.11,3.12,3.13 context=ansible-core
 alpine323 image=quay.io/ansible/alpine-test-container:3.23-v2.21-1 python=3.12 cgroup=none audit=none
-fedora42 image=quay.io/ansible/fedora-test-container:42-v2.20-1 python=3.13 cgroup=v2-only
+fedora43 image=quay.io/ansible/fedora-test-container:43-v2.21-1 python=3.14 cgroup=v2-only
 ubuntu2204 image=quay.io/ansible/ubuntu-test-container:22.04-v2.20-1 python=3.10
 ubuntu2404 image=quay.io/ansible/ubuntu-test-container:24.04-v2.20-1 python=3.12

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -1,6 +1,6 @@
 alpine/3.23 python=3.12 become=doas_sudo provider=aws arch=x86_64
 alpine become=doas_sudo provider=aws arch=x86_64
-fedora/42 python=3.13 become=sudo provider=aws arch=x86_64
+fedora/43 python=3.14 become=sudo provider=aws arch=x86_64
 fedora become=sudo provider=aws arch=x86_64
 freebsd/14.3 python=3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 freebsd/15.0 python=3.12 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64


### PR DESCRIPTION
##### SUMMARY

ansible-test - Replace Fedora 42 with 43.

##### ISSUE TYPE

Feature Pull Request
