### PR TITLE
Fix user module to remove SELinux mappings on deletion

### DIFF
--- a/changelogs/fragments/86230-userdel-selinux-mappings-removal.yaml
+++ b/changelogs/fragments/86230-userdel-selinux-mappings-removal.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user module - add selinux_user option to allow removal of SELinux mappings when a user is deleted (https://github.com/ansible/ansible/issues/86218)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -147,6 +147,12 @@ options:
             - The behavior is the same as C(userdel --remove), check the man page for details and support.
         type: bool
         default: no
+    selinux_user:
+        description:
+            - This only affects O(state=absent), it removes any SELinux user mapping for the user.
+            - The behavior is the same as C(userdel --selinux-user), check the man page for details and support.
+        type: bool
+        default: no
     login_class:
         description:
             - Optionally sets the user's login class, a feature of most BSD OSs.
@@ -610,6 +616,7 @@ class User(object):
         self.shell = module.params['shell']
         self.password = module.params['password']
         self.force = module.params['force']
+        self.selinux_user = module.params['selinux_user']
         self.remove = module.params['remove']
         self.create_home = module.params['create_home']
         self.move_home = module.params['move_home']
@@ -720,6 +727,8 @@ class User(object):
             command_name = 'userdel'
 
         cmd = [self.module.get_bin_path(command_name, True)]
+        if self.selinux_user and not self.local:
+            cmd.append('-Z')
         if self.force and not self.local:
             cmd.append('-f')
         if self.remove:
@@ -3429,6 +3438,7 @@ def main():
             # following options are specific to userdel
             force=dict(type='bool', default=False),
             remove=dict(type='bool', default=False),
+            selinux_user=dict(type='bool', default=False),
             # following options are specific to useradd
             create_home=dict(type='bool', default=True, aliases=['createhome']),
             skeleton=dict(type='str'),

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -149,6 +149,7 @@ options:
         default: no
     selinux_user:
         description:
+            - This option is applicable for SELinux-enabled systems.
             - This only affects O(state=absent), it removes any SELinux user mapping for the user.
             - The behavior is the same as C(userdel --selinux-user), check the man page for details and support.
         type: bool

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -153,6 +153,7 @@ options:
             - The behavior is the same as C(userdel --selinux-user), check the man page for details and support.
         type: bool
         default: no
+        version_added: "2.21"
     login_class:
         description:
             - Optionally sets the user's login class, a feature of most BSD OSs.

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -154,7 +154,7 @@ options:
             - The behavior is the same as C(userdel --selinux-user), check the man page for details and support.
         type: bool
         default: no
-        version_added: "2.21"
+        version_added: "2.22"
     login_class:
         description:
             - Optionally sets the user's login class, a feature of most BSD OSs.

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -1,6 +1,15 @@
 # Test code for the user module.
 # Copyright: (c) 2017, James Tanner <tanner.jc@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- name: determine if selinux is installed
+  shell: which getenforce || exit 0
+  register: selinux_installed
+
+- name: determine if selinux is enabled
+  shell: getenforce
+  register: selinux_enabled
+  when: selinux_installed.stdout != ""
+  ignore_errors: true
 
 - import_tasks: test_create_user.yml
 - import_tasks: test_create_system_user.yml
@@ -38,3 +47,5 @@
 - import_tasks: ssh_keygen.yml
 - include_tasks: test_modify_user_home.yml
 - include_tasks: test_invalid_shell.yml
+- include_tasks: test_selinux_enabled.yml
+  when: selinux_installed is defined and selinux_installed.stdout != "" and selinux_enabled.stdout != "Disabled"

--- a/test/integration/targets/user/tasks/test_selinux_enabled.yml
+++ b/test/integration/targets/user/tasks/test_selinux_enabled.yml
@@ -1,0 +1,26 @@
+- name: Test selinux user deletion
+  vars:
+    username: selinux_ansibull
+  block:
+
+  - name: Add {{ username }} user
+    user:
+      name: "{{ username }}"
+      state: present
+      seuser: unconfined_u
+
+  - name: Remove {{ username }} user
+    user:
+      name: "{{ username }}"
+      state: absent
+      force: true
+      selinux_user: true
+
+  - name: Check for residual {{ username }} data
+    shell: grep -r {{ username }} /etc/selinux 2> /dev/null | wc -l
+    register: residual_count
+
+  - name: Assert full removal of {{ username }}
+    assert:
+      that:
+        - 0 == "{{ residual_count.stdout | int }}"

--- a/test/integration/targets/user/tasks/test_selinux_enabled.yml
+++ b/test/integration/targets/user/tasks/test_selinux_enabled.yml
@@ -24,3 +24,30 @@
     assert:
       that:
         - 0 == "{{ residual_count.stdout | int }}"
+
+- name: Test selinux user deletion without -Z
+  vars:
+    username: selinux_ansibull_nosel
+  block:
+
+  - name: Add {{ username }} user
+    user:
+      name: "{{ username }}"
+      state: present
+      seuser: unconfined_u
+
+  - name: Remove {{ username }} user WITHOUT -Z behavior
+    user:
+      name: "{{ username }}"
+      state: absent
+      force: true
+      selinux_user: false
+
+  - name: Check for residual {{ username }} data
+    shell: grep -r {{ username }} /etc/selinux 2> /dev/null | wc -l
+    register: residual_count
+
+  - name: Assert SELinux data still exists since removal was done without selinux_user
+    assert:
+      that:
+        - 0 != "{{ residual_count.stdout | int }}"


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->
This PR adds a new option `selinux_user` to the Ansible `user` module to support removal of SELinux user mappings.

Fixes #86218

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
