### PR TITLE
Fix escaping issue in ansiballz wrapper for sitecustomize

### DIFF
--- a/changelogs/fragments/ansiballz-wrapper-sitecustomize.yml
+++ b/changelogs/fragments/ansiballz-wrapper-sitecustomize.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- modules - fix AnsiballZ wrapper code escaping of sitecustomize

--- a/lib/ansible/_internal/_ansiballz/_wrapper.py
+++ b/lib/ansible/_internal/_ansiballz/_wrapper.py
@@ -121,7 +121,7 @@ def _ansiballz_main(
         z = zipfile.ZipFile(modlib_path, mode='a')
 
         # py3: modlib_path will be text, py2: it's bytes.  Need bytes at the end
-        sitecustomize = u'import sys\\nsys.path.insert(0,"%s")\\n' % modlib_path
+        sitecustomize = 'import sys\nsys.path.insert(0, "%s")\n' % modlib_path
         sitecustomize = sitecustomize.encode('utf-8')
         # Use a ZipInfo to work around zipfile limitation on hosts with
         # clocks set to a pre-1980 year (for instance, Raspberry Pi)


### PR DESCRIPTION
##### SUMMARY

Fix escaping issue in ansiballz wrapper for sitecustomize

I found this while looking at tracebacks for another issue:

```
Error in sitecustomize; set PYTHONVERBOSE for traceback:
SyntaxError: unexpected character after line continuation character (sitecustomize.py, line 1)
```

Seems when we moved this out of `module_common` the extra escapes weren't removed.

##### ISSUE TYPE

- Bugfix Pull Request