### PR TITLE
ansible-test: pytest: Fix ANSIBLE_COLLECTIONS_PATH imports when given list of multiple paths

### DIFF
--- a/test/lib/ansible_test/_util/target/pytest/plugins/ansible_pytest_collections.py
+++ b/test/lib/ansible_test/_util/target/pytest/plugins/ansible_pytest_collections.py
@@ -16,8 +16,9 @@ ANSIBLE_CONTROLLER_MIN_PYTHON_VERSION = tuple(int(x) for x in os.environ['ANSIBL
 def collection_resolve_package_path(path):
     """Configure the Python package path so that pytest can find our collections."""
     for parent in path.parents:
-        if str(parent) == ANSIBLE_COLLECTIONS_PATH:
-            return parent
+        for collections_path in ANSIBLE_COLLECTIONS_PATH.split(os.pathsep):
+            if str(parent) == collections_path:
+                return parent
 
     raise Exception('File "%s" not found in collection path "%s".' % (path, ANSIBLE_COLLECTIONS_PATH))
 
@@ -89,7 +90,7 @@ def pytest_configure():
     # allow unit tests to import code from collections
 
     # noinspection PyProtectedMember
-    _AnsibleCollectionFinder(paths=[os.path.dirname(ANSIBLE_COLLECTIONS_PATH)])._install()  # pylint: disable=protected-access
+    _AnsibleCollectionFinder(paths=ANSIBLE_COLLECTIONS_PATH.split(os.pathsep))._install()  # pylint: disable=protected-access
 
     try:
         # noinspection PyProtectedMember


### PR DESCRIPTION
This fixes `ansible-test unit` when given a colon-separated list of collections paths via `ANSIBLE_COLLECTIONS_PATH`.

Solves the following error / edge cases:

<details><summary>When <code>ANSIBLE_COLLECTION_PATHS</code> contains multiple <b>valid</b> collections paths</summary>
<p>

Example unit test `import` errors without this fix:

```console
export ANSIBLE_COLLECTIONS_PATH=/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections ;
export ANSIBLE_DEBUG=1 ANSIBLE_ENABLE_TASK_DEBUGGER=1 ANSIBLE_LOG_PATH=$HOME/src/pub/ansible/lyraphase-ansible-playbooks/tmp/ansible.log ;
export ANSIBLE_CALLBACK_PLUGINS=1 ANSIBLE_LOAD_CALLBACK_PLUGINS=1 ANSIBLE_STDOUT_CALLBACK=ansible.posix.debug ANSIBLE_PERSISTENT_LOG_MESSAGES=1 ANSIBLE_NETWORK_IMPORT_MODULES=0 ;
export _ANSIBLE_ANSIBALLZ_DEBUGPY_CONFIG='{"host": "0.0.0.0", "port": 5678}' ;
export ANSIBLE_USER=exampleuser;
export ANSIBLE_CONFIG=~/src/pub/ansible/lyraphase-ansible-playbooks/ansible.cfg ;

ansible-test units -vvvv --debug
Configured locale: en_US.UTF-8
RLIMIT_NOFILE: (1024, 524288)
Loaded configuration: tests/config.yml
Creating container database.
>>> Container Database
{}

WARNING: Skipping unit tests on Python 3.14 because it could not be found.
Unit test module_utils with Python 3.12
Initializing "/tmp/ansible-test-f3ydsujg-injector" as the temporary injector directory.
Injecting "/tmp/python-yt430u7k-ansible/python" as a execv wrapper for the "/usr/bin/python3.12" interpreter.
Stream command: pytest -r a -n auto --color yes -p no:cacheprovider -c /usr/local/lib/python3.12/site-packages/ansible_test/_data/pytest/config/default.ini --junit-xml /home/exampleuser/src/pub/ansible/lyrapha ...
Working directory: /home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense
Program found: /tmp/ansible-test-f3ydsujg-injector/pytest
ANSIBLE_COLLECTIONS_PATH=/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections
ANSIBLE_CONFIG=/usr/local/lib/python3.12/site-packages/ansible_test/_data/ansible.cfg
ANSIBLE_CONTROLLER_MIN_PYTHON_VERSION=3.12
ANSIBLE_DEBUG=true
ANSIBLE_DEPRECATION_WARNINGS=false
ANSIBLE_DEVEL_WARNING=false
ANSIBLE_DISPLAY_TRACEBACK=never
ANSIBLE_FORCE_COLOR=true
ANSIBLE_FORCE_HANDLERS=true
ANSIBLE_HOST_KEY_CHECKING=false
ANSIBLE_HOST_PATTERN_MISMATCH=error
ANSIBLE_INVENTORY=/dev/null
ANSIBLE_LIBRARY=/dev/null
ANSIBLE_LOG_PATH=/tmp/ansible/debug.log
ANSIBLE_PYTHON_MODULE_RLIMIT_NOFILE=1024
ANSIBLE_RETRY_FILES_ENABLED=false
ANSIBLE_TEST_ANSIBLE_LIB_ROOT=/usr/local/lib/python3.12/site-packages/ansible
ANSIBLE_TEST_PYTHON_INTERPRETER=/usr/bin/python3.12
ANSIBLE_TEST_PYTHON_VERSION=3.12
ANSIBLE_WORKER_SHUTDOWN_POLL_COUNT=100
ANSIBLE_WORKER_SHUTDOWN_POLL_DELAY=0.1
HOME=/home/exampleuser
LC_ALL=en_US.UTF-8
PAGER=/bin/cat
PATH=/tmp/ansible-test-f3ydsujg-injector:/tmp/python-yt430u7k-ansible:/tmp/ansible-test-hlg_w7hb-bin:/home/exampleuser/.local/bin:/home/exampleuser/.qlty/bin:/home/exampleuser/.local/lib/npm/bin:/home/exampleuser/.cargo/bin:/home/exampleuser/src/pub/go/bin:/home/exampleuser/.config/oh-my-zsh/custom/plugins/zsh-sweep/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
PYTEST_PLUGINS=ansible_pytest_collections,ansible_forked
PYTHONPATH=/tmp/ansible-test-u5zdjr2r:/usr/local/lib/python3.12/site-packages/ansible_test/_util/target/pytest/plugins
SSH_AUTH_SOCK=/ssh-agent/S.gpg-agent.ssh
============================= test session starts ==============================
platform linux -- Python 3.12.11, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3.12
rootdir: /home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense
configfile: ../../../../../../../../../../usr/local/lib/python3.12/site-packages/ansible_test/_data/pytest/config/default.ini
plugins: plus-0.8.1, xdist-3.8.0, cov-7.0.0, sugar-1.1.1, ansible-25.11.1, anyio-4.11.0
created: 8/8 workers
8 workers [0 items]

scheduling tests via LoadScheduling

==================================== ERRORS ====================================
_ ERROR collecting tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py _
/usr/local/lib/python3.12/site-packages/ansible_test/_util/target/pytest/plugins/ansible_pytest_collections.py:22: in collection_resolve_package_path
    raise Exception('File "%s" not found in collection path "%s".' % (path, ANSIBLE_COLLECTIONS_PATH))
E   Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
_ ERROR collecting tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py _
/usr/local/lib/python3.12/site-packages/ansible_test/_util/target/pytest/plugins/ansible_pytest_collections.py:22: in collection_resolve_package_path
    raise Exception('File "%s" not found in collection path "%s".' % (path, ANSIBLE_COLLECTIONS_PATH))
E   Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
_ ERROR collecting tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py _
/usr/local/lib/python3.12/site-packages/ansible_test/_util/target/pytest/plugins/ansible_pytest_collections.py:22: in collection_resolve_package_path
    raise Exception('File "%s" not found in collection path "%s".' % (path, ANSIBLE_COLLECTIONS_PATH))
E   Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
_ ERROR collecting tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py _
/usr/local/lib/python3.12/site-packages/ansible_test/_util/target/pytest/plugins/ansible_pytest_collections.py:22: in collection_resolve_package_path
    raise Exception('File "%s" not found in collection path "%s".' % (path, ANSIBLE_COLLECTIONS_PATH))
E   Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
_ ERROR collecting tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py _
/usr/local/lib/python3.12/site-packages/ansible_test/_util/target/pytest/plugins/ansible_pytest_collections.py:22: in collection_resolve_package_path
    raise Exception('File "%s" not found in collection path "%s".' % (path, ANSIBLE_COLLECTIONS_PATH))
E   Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
_ ERROR collecting tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py _
/usr/local/lib/python3.12/site-packages/ansible_test/_util/target/pytest/plugins/ansible_pytest_collections.py:22: in collection_resolve_package_path
    raise Exception('File "%s" not found in collection path "%s".' % (path, ANSIBLE_COLLECTIONS_PATH))
E   Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
_ ERROR collecting tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py _
/usr/local/lib/python3.12/site-packages/ansible_test/_util/target/pytest/plugins/ansible_pytest_collections.py:22: in collection_resolve_package_path
    raise Exception('File "%s" not found in collection path "%s".' % (path, ANSIBLE_COLLECTIONS_PATH))
E   Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
_ ERROR collecting tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py _
/usr/local/lib/python3.12/site-packages/ansible_test/_util/target/pytest/plugins/ansible_pytest_collections.py:22: in collection_resolve_package_path
    raise Exception('File "%s" not found in collection path "%s".' % (path, ANSIBLE_COLLECTIONS_PATH))
E   Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
- generated xml file: /home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/output/junit/python3.12-module_utils-units.xml -
=========================== short test summary info ============================
ERROR tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py - Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
ERROR tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py - Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
ERROR tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py - Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
ERROR tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py - Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
ERROR tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py - Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
ERROR tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py - Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
ERROR tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py - Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
ERROR tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py - Exception: File "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" not found in collection path "/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections/ansible_collections".
============================== 8 errors in 1.16s ===============================
Command exited with status 1 after 1.6523163318634033 seconds.
FATAL: Command "pytest -r a -n auto --color yes -p no:cacheprovider -c /usr/local/lib/python3.12/site-packages/ansible_test/_data/pytest/config/default.ini --junit-xml /home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/output/junit/python3.12-module_utils-units.xml --strict-markers --rootdir /home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense --confcutdir /home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense -vvvv tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" returned exit status 1.
Cleaning up temporary python directory: /tmp/python-yt430u7k-ansible
```

</p>
</details>

<details><summary>When <code>ANSIBLE_COLLECTION_PATHS</code> contains multiple <i>some</i> <b>invalid</b> collections paths</summary>
<p>

Example unit test `import` errors without this fix:

```console
$ export ANSIBLE_COLLECTIONS_PATH=/tmp/foo:/blork:/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections ;
$ export ANSIBLE_DEBUG=1 ANSIBLE_ENABLE_TASK_DEBUGGER=1 ANSIBLE_LOG_PATH=$HOME/src/pub/ansible/lyraphase-ansible-playbooks/tmp/ansible.log ;
$ export ANSIBLE_CALLBACK_PLUGINS=1  ANSIBLE_LOAD_CALLBACK_PLUGINS=1 ANSIBLE_STDOUT_CALLBACK=ansible.posix.debug ANSIBLE_PERSISTENT_LOG_MESSAGES=1 ANSIBLE_NETWORK_IMPORT_MODULES=0 ;
$ export _ANSIBLE_ANSIBALLZ_DEBUGPY_CONFIG='{"host": "0.0.0.0", "port": 5678}' ;
$ export ANSIBLE_USER=exampleuser;
$ export ANSIBLE_CONFIG=~/src/pub/ansible/lyraphase-ansible-playbooks/ansible.cfg ;

$ ansible-test units -vvvv --debug

Configured locale: en_US.UTF-8
RLIMIT_NOFILE: (1024, 524288)
Loaded configuration: tests/config.yml
Creating container database.
>>> Container Database
{}

WARNING: Skipping unit tests on Python 3.14 because it could not be found.
Unit test module_utils with Python 3.12
Initializing "/tmp/ansible-test-i5eh5c0e-injector" as the temporary injector directory.
Injecting "/tmp/python-lu_djfap-ansible/python" as a execv wrapper for the "/usr/bin/python3.12" interpreter.
Stream command: pytest -r a -n auto --color yes -p no:cacheprovider -c /usr/local/lib/python3.12/site-packages/ansible_test/_data/pytest/config/default.ini --junit-xml /home/exampleuser/src/pub/ansible/lyrapha ...
Working directory: /home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense
Program found: /tmp/ansible-test-i5eh5c0e-injector/pytest
ANSIBLE_COLLECTIONS_PATH=/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections:/usr/share/ansible/collections
ANSIBLE_CONFIG=/usr/local/lib/python3.12/site-packages/ansible_test/_data/ansible.cfg
ANSIBLE_CONTROLLER_MIN_PYTHON_VERSION=3.12
ANSIBLE_DEBUG=true
ANSIBLE_DEPRECATION_WARNINGS=false
ANSIBLE_DEVEL_WARNING=false
ANSIBLE_DISPLAY_TRACEBACK=never
ANSIBLE_FORCE_COLOR=true
ANSIBLE_FORCE_HANDLERS=true
ANSIBLE_HOST_KEY_CHECKING=false
ANSIBLE_HOST_PATTERN_MISMATCH=error
ANSIBLE_INVENTORY=/dev/null
ANSIBLE_LIBRARY=/dev/null
ANSIBLE_LOG_PATH=/tmp/ansible/debug.log
ANSIBLE_PYTHON_MODULE_RLIMIT_NOFILE=1024
ANSIBLE_RETRY_FILES_ENABLED=false
ANSIBLE_TEST_ANSIBLE_LIB_ROOT=/usr/local/lib/python3.12/site-packages/ansible
ANSIBLE_TEST_PYTHON_INTERPRETER=/usr/bin/python3.12
ANSIBLE_TEST_PYTHON_VERSION=3.12
ANSIBLE_WORKER_SHUTDOWN_POLL_COUNT=100
ANSIBLE_WORKER_SHUTDOWN_POLL_DELAY=0.1
HOME=/home/exampleuser
LC_ALL=en_US.UTF-8
PAGER=/bin/cat
PATH=/tmp/ansible-test-i5eh5c0e-injector:/tmp/python-lu_djfap-ansible:/tmp/ansible-test-6yijxa52-bin:/home/exampleuser/.local/bin:/home/exampleuser/.qlty/bin:/home/exampleuser/.local/lib/npm/bin:/home/exampleuser/.cargo/bin:/home/exampleuser/src/pub/go/bin:/home/exampleuser/.config/oh-my-zsh/custom/plugins/zsh-sweep/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
PYTEST_PLUGINS=ansible_pytest_collections,ansible_forked
PYTHONPATH=/tmp/ansible-test-lqf2_y4_:/usr/local/lib/python3.12/site-packages/ansible_test/_util/target/pytest/plugins
SSH_AUTH_SOCK=/ssh-agent/S.gpg-agent.ssh
============================= test session starts ==============================
platform linux -- Python 3.12.11, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3.12
rootdir: /home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense
configfile: ../../../../../../../../../../usr/local/lib/python3.12/site-packages/ansible_test/_data/pytest/config/default.ini
plugins: plus-0.8.1, xdist-3.8.0, cov-7.0.0, sugar-1.1.1, ansible-25.11.1, anyio-4.11.0
created: 8/8 workers
8 workers [0 items]

scheduling tests via LoadScheduling

==================================== ERRORS ====================================
_ ERROR collecting tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py _
ImportError while importing test module '/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/lib/python3.12/site-packages/_pytest/python.py:507: in importtestmodule
    mod = import_path(
/usr/local/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
    importlib.import_module(module_name)
/usr/lib64/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1324: in _find_and_load_unlocked
    ???
E   ModuleNotFoundError: No module named 'collections.ansible_collections'
- generated xml file: /home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/output/junit/python3.12-module_utils-units.xml -
=========================== short test summary info ============================
ERROR tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py - ImportError while importing test module '/home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/local/lib/python3.12/site-packages/_pytest/python.py:507: in importtestmodule
    mod = import_path(
/usr/local/lib/python3.12/site-packages/_pytest/pathlib.py:587: in import_path
    importlib.import_module(module_name)
/usr/lib64/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1310: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:488: in _call_with_frames_removed
    ???
<frozen importlib._bootstrap>:1387: in _gcd_import
    ???
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1324: in _find_and_load_unlocked
    ???
E   ModuleNotFoundError: No module named 'collections.ansible_collections'
=============================== 1 error in 1.17s ===============================
Command exited with status 1 after 1.6575922966003418 seconds.
FATAL: Command "pytest -r a -n auto --color yes -p no:cacheprovider -c /usr/local/lib/python3.12/site-packages/ansible_test/_data/pytest/config/default.ini --junit-xml /home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense/tests/output/junit/python3.12-module_utils-units.xml --strict-markers --rootdir /home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense --confcutdir /home/exampleuser/src/pub/ansible/lyraphase-ansible-playbooks/collections/ansible_collections/lyraphase/opnsense -vvvv tests/unit/plugins/module_utils/network/opnsense/test_opnsense_facts.py" returned exit status 1.
Cleaning up temporary python directory: /tmp/python-lu_djfap-ansible
```

</p>
</details>

- When `ANSIBLE_COLLECTION_PATHS` contains a single collection path, but an imported dependency collection (e.g. `collections.ansible_collections` / `ansible.netcommon`) could not be found due to existing in _another_ path
  - Error messages similar to above, just with the dependency collection name failing to be found
  - Without this fix, a user is unable to pass the correct multiple collections paths to unit tests
