### PR TITLE
apt: Fix the autoremove or purge parameters not working in certain cases

### DIFF
--- a/changelogs/fragments/86245-apt-autoremove-purge-fix.yaml
+++ b/changelogs/fragments/86245-apt-autoremove-purge-fix.yaml
@@ -1,0 +1,6 @@
+bugfixes:
+  - apt - Fix autoremove not working when redundant package changes are requested (https://github.com/ansible/ansible/pull/86245)
+  - apt - Fix purge option with state=present (https://github.com/ansible/ansible/pull/86245)
+  - apt - Fix autoremove and purge during upgrades (https://github.com/ansible/ansible/pull/86245)
+minor_changes:
+  - apt - The autoremove option takes precedence over the autoclean option. The autoclean option only works if no other options are specified. (https://github.com/ansible/ansible/pull/86245)

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -761,7 +761,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             pkg_list.append("'%s=%s'" % (name, version))
     packages = ' '.join(pkg_list)
 
-    if packages:
+    if packages or autoremove:
         if force:
             force_yes = '--force-yes'
         else:
@@ -825,9 +825,11 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             diff = {}
         status = True
 
-        changed = True
+        changed = len(packages) > 0
         if build_dep:
             changed = APT_GET_ZERO not in out
+        if CLEAN_OP_CHANGED_STR["autoremove"] in out:
+            changed = True
 
         data = dict(changed=changed, stdout=out, stderr=err, diff=diff)
         if rc:
@@ -969,7 +971,7 @@ def remove(m, pkgspec, cache, purge=False, force=False,
             pkg_list.append("'%s'" % package)
     packages = ' '.join(pkg_list)
 
-    if not packages:
+    if not packages and not autoremove:
         m.exit_json(changed=False)
     else:
         if force:
@@ -1017,7 +1019,10 @@ def remove(m, pkgspec, cache, purge=False, force=False,
             diff = {}
         if rc:
             m.fail_json(msg="'apt-get remove %s' failed: %s" % (packages, err), stdout=out, stderr=err, rc=rc)
-        m.exit_json(changed=True, stdout=out, stderr=err, diff=diff)
+
+        changed = len(packages) > 0 or CLEAN_OP_CHANGED_STR["autoremove"] in out
+
+        m.exit_json(changed=changed, stdout=out, stderr=err, diff=diff)
 
 
 def cleanup(m, purge=False, force=False, operation=None,
@@ -1354,7 +1359,8 @@ def main():
         aptclean_stdout, aptclean_stderr, aptclean_diff = aptclean(module)
         # If there is nothing else to do exit. This will set state as
         #  changed based on if the cache was updated.
-        if not p['package'] and p['upgrade'] == 'no' and not p['deb']:
+        # Note: 'autoclean' is no longer needed at this point, because it's a subset of 'clean'.
+        if not p['package'] and p['upgrade'] == 'no' and not p['deb'] and not p['autoremove']:
             module.exit_json(
                 changed=True,
                 msg=aptclean_stdout,

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -156,6 +156,7 @@ options:
   autoclean:
     description:
       - If V(true), cleans the local repository of retrieved package files that can no longer be downloaded.
+      - 'O(autoclean) cannot be used in combination with other parameters.'
     type: bool
     default: 'no'
     version_added: "2.4"
@@ -1517,10 +1518,10 @@ def main():
                         module.fail_json(msg="invalid package spec: %s" % package)
 
             if not packages:
-                if autoclean:
-                    cleanup(module, p['purge'], force=force_yes, operation='autoclean', dpkg_options=dpkg_options)
                 if autoremove:
                     cleanup(module, p['purge'], force=force_yes, operation='autoremove', dpkg_options=dpkg_options)
+                if autoclean:
+                    cleanup(module, p['purge'], force=force_yes, operation='autoclean', dpkg_options=dpkg_options)
 
             if p['state'] in ('latest', 'present', 'build-dep', 'fixed'):
                 state_upgrade = False

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1080,7 +1080,7 @@ def aptclean(m):
     return (clean_out, clean_err, clean_diff)
 
 
-def upgrade(m, mode="yes", force=False, default_release=None,
+def upgrade(m, mode="yes", purge=False, force=False, default_release=None,
             use_apt_get=False,
             dpkg_options=expand_dpkg_options(DPKG_OPTIONS), autoremove=False, fail_on_autoremove=False,
             allow_unauthenticated=False,
@@ -1089,8 +1089,17 @@ def upgrade(m, mode="yes", force=False, default_release=None,
 
     if autoremove:
         autoremove = '--auto-remove'
+        autoremove_aptitude = '-o Aptitude::Delete-Unused=1'
     else:
         autoremove = ''
+        autoremove_aptitude = '-o Aptitude::Delete-Unused=0'
+
+    if purge:
+        purge = '--purge'
+        purge_aptitude = '-o Aptitude::Purge-Unused=1'
+    else:
+        purge = ''
+        purge_aptitude = '-o Aptitude::Purge-Unused=0'
 
     if m.check_mode:
         check_arg = '--simulate'
@@ -1102,19 +1111,19 @@ def upgrade(m, mode="yes", force=False, default_release=None,
     if mode == "dist" or (mode == "full" and use_apt_get):
         # apt-get dist-upgrade
         apt_cmd = APT_GET_CMD
-        upgrade_command = "dist-upgrade %s" % (autoremove)
+        upgrade_command = "dist-upgrade %s %s" % (autoremove, purge)
     elif mode == "full" and not use_apt_get:
         # aptitude full-upgrade
         apt_cmd = APTITUDE_CMD
-        upgrade_command = "full-upgrade"
+        upgrade_command = "full-upgrade %s %s" % (autoremove_aptitude, purge_aptitude)
     else:
         if use_apt_get:
             apt_cmd = APT_GET_CMD
-            upgrade_command = "upgrade --with-new-pkgs %s" % (autoremove)
+            upgrade_command = "upgrade --with-new-pkgs %s %s" % (autoremove, purge)
         else:
             # aptitude safe-upgrade # mode=yes # default
             apt_cmd = APTITUDE_CMD
-            upgrade_command = "safe-upgrade"
+            upgrade_command = "safe-upgrade %s %s" % (autoremove_aptitude, purge_aptitude)
             prompt_regex = r"(^Do you want to ignore this warning and proceed anyway\?|^\*\*\*.*\[default=.*\])"
 
     if force:
@@ -1469,15 +1478,16 @@ def main():
             if p['upgrade']:
                 upgrade(
                     module,
-                    p['upgrade'],
-                    force_yes,
-                    p['default_release'],
-                    use_apt_get,
-                    dpkg_options,
-                    autoremove,
-                    fail_on_autoremove,
-                    allow_unauthenticated,
-                    allow_downgrade
+                    mode=p['upgrade'],
+                    purge=p['purge'],
+                    force=force_yes,
+                    default_release=p['default_release'],
+                    use_apt_get=use_apt_get,
+                    dpkg_options=dpkg_options,
+                    autoremove=autoremove,
+                    fail_on_autoremove=fail_on_autoremove,
+                    allow_unauthenticated=allow_unauthenticated,
+                    allow_downgrade=allow_downgrade
                 )
 
             if p['deb']:
@@ -1506,15 +1516,16 @@ def main():
                     module.fail_json(msg='unable to install additional packages when upgrading all installed packages')
                 upgrade(
                     module,
-                    'yes',
-                    force_yes,
-                    p['default_release'],
-                    use_apt_get,
-                    dpkg_options,
-                    autoremove,
-                    fail_on_autoremove,
-                    allow_unauthenticated,
-                    allow_downgrade
+                    mode='yes',
+                    purge=p['purge'],
+                    force=force_yes,
+                    default_release=p['default_release'],
+                    use_apt_get=use_apt_get,
+                    dpkg_options=dpkg_options,
+                    autoremove=autoremove,
+                    fail_on_autoremove=fail_on_autoremove,
+                    allow_unauthenticated=allow_unauthenticated,
+                    allow_downgrade=allow_downgrade
                 )
 
             if packages:

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -717,7 +717,7 @@ def mark_installed(m: AnsibleModule, packages: list[str], manual: bool) -> None:
 
 
 def install(m, pkgspec, cache, upgrade=False, default_release=None,
-            install_recommends=None, force=False,
+            install_recommends=None, purge=True, force=False,
             dpkg_options=expand_dpkg_options(DPKG_OPTIONS),
             build_dep=False, fixed=False, autoremove=False, fail_on_autoremove=False, only_upgrade=False,
             allow_unauthenticated=False, allow_downgrade=False, allow_change_held_packages=False):
@@ -768,6 +768,11 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         else:
             force_yes = ''
 
+        if purge:
+            purge = '--purge'
+        else:
+            purge = ''
+
         if m.check_mode:
             check_arg = '--simulate'
         else:
@@ -796,8 +801,8 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         if build_dep:
             cmd = "%s -y %s %s %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, fail_on_autoremove, check_arg, packages)
         else:
-            cmd = "%s -y %s %s %s %s %s %s %s install %s" % \
-                  (APT_GET_CMD, dpkg_options, only_upgrade, fixed, force_yes, autoremove, fail_on_autoremove, check_arg, packages)
+            cmd = "%s -y %s %s %s %s %s %s %s %s install %s" % \
+                  (APT_GET_CMD, dpkg_options, only_upgrade, fixed, purge, force_yes, autoremove, fail_on_autoremove, check_arg, packages)
 
         if default_release:
             cmd += " -t '%s'" % (default_release,)
@@ -1541,6 +1546,7 @@ def main():
                     upgrade=state_upgrade,
                     default_release=p['default_release'],
                     install_recommends=install_recommends,
+                    purge=p['purge'],
                     force=force_yes,
                     dpkg_options=dpkg_options,
                     build_dep=state_builddep,

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -763,3 +763,67 @@
       - not srcpkgcache_bin.stat.exists
     fail_msg: "apt cache files still exist."
     success_msg: "apt cache files are cleaned."
+
+# Test that 'autoremove' works when redundant package changes are requested
+- name: Install the hello package and mark it as automatically installed
+  shell: "apt-get -y install hello && apt-mark auto hello"
+
+- name: Autoremove while requesting an already installed package to be present
+  apt:
+    name: apt
+    state: present
+    autoremove: true
+  register: autoremove_1
+
+- name: Nothing to autoremove
+  apt:
+    autoremove: true
+  register: autoremove_2
+
+- name: Verify that the first autoremove worked
+  assert:
+    that:
+      - autoremove_1 is changed
+      - autoremove_2 is not changed
+
+- name: Install the hello package and mark it as automatically installed
+  shell: "apt-get -y install hello && apt-mark auto hello"
+
+- name: Autoremove while requesting an already absent package to be absent
+  apt:
+    name: hello-traditional
+    state: absent
+    autoremove: true
+  register: autoremove_1
+
+- name: Nothing to autoremove
+  apt:
+    autoremove: true
+  register: autoremove_2
+
+- name: Verify that the first autoremove worked
+  assert:
+    that:
+      - autoremove_1 is changed
+      - autoremove_2 is not changed
+
+# Test that 'autoremove' works with 'clean'
+- name: Install the hello package and mark it as automatically installed
+  shell: "apt-get -y install hello && apt-mark auto hello"
+
+- name: Autoremove while cleaning
+  apt:
+    clean: true
+    autoremove: true
+  register: autoremove_1
+
+- name: Nothing to autoremove
+  apt:
+    autoremove: true
+  register: autoremove_2
+
+- name: Verify that the first autoremove worked
+  assert:
+    that:
+      - autoremove_1 is changed
+      - autoremove_2 is not changed

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -909,3 +909,83 @@
     that:
       - purge_test is changed
       - "'nano*' not in config_check.stdout"
+
+# Test the purge and autoremove options during upgrades
+- name: Install the nano package and mark it as automatically installed
+  shell: "apt-get -y install nano && apt-mark auto nano"
+
+- name: Full upgrade
+  apt:
+    upgrade: full
+    autoremove: true
+    purge: true
+  register: autoremove_1
+
+- name: Autoremove for a second time
+  apt:
+    autoremove: true
+  register: autoremove_2
+
+- name: Check if the configuration files have been removed
+  shell: "apt-get --dry-run purge ?config-files"
+  register: config_check
+
+- name: Verify that the first autoremove worked
+  assert:
+    that:
+      - autoremove_1 is changed
+      - autoremove_2 is not changed
+      - "'nano*' not in config_check.stdout"
+
+- name: Install the nano package and mark it as automatically installed
+  shell: "apt-get -y install nano && apt-mark auto nano"
+
+- name: Safe upgrade
+  apt:
+    upgrade: safe
+    autoremove: true
+    purge: true
+  register: autoremove_1
+
+- name: Autoremove for a second time
+  apt:
+    autoremove: true
+  register: autoremove_2
+
+- name: Check if the configuration files have been removed
+  shell: "apt-get --dry-run purge ?config-files"
+  register: config_check
+
+- name: Verify that the first autoremove worked
+  assert:
+    that:
+      - autoremove_1 is changed
+      - autoremove_2 is not changed
+      - "'nano*' not in config_check.stdout"
+
+- name: Install the nano package and mark it as automatically installed
+  shell: "apt-get -y install nano && apt-mark auto nano"
+
+- name: Safe upgrade with apt-get
+  apt:
+    upgrade: safe
+    force_apt_get: true
+    autoremove: true
+    purge: true
+  register: autoremove_1
+
+- name: Autoremove for a second time
+  apt:
+    autoremove: true
+  register: autoremove_2
+
+- name: Check if the configuration files have been removed
+  shell: "apt-get --dry-run purge ?config-files"
+  register: config_check
+
+- name: Verify that the first autoremove worked
+  assert:
+    that:
+      - autoremove_1 is changed
+      - autoremove_2 is not changed
+      - "'nano*' not in config_check.stdout"

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -827,3 +827,85 @@
     that:
       - autoremove_1 is changed
       - autoremove_2 is not changed
+
+# Test that the purge option works
+- name: Install the nano package
+  shell: "apt-get -y install nano"
+
+- name: Remove and purge it
+  apt:
+    name: nano
+    state: absent
+    purge: true
+  register: purge_test
+
+- name: Check if the configuration files have been removed
+  shell: "apt-get --dry-run purge ?config-files"
+  register: config_check
+
+- name: Verify that purge worked
+  assert:
+    that:
+      - purge_test is changed
+      - "'nano*' not in config_check.stdout"
+
+- name: Install the nano package and mark it as automatically installed
+  shell: "apt-get -y install nano && apt-mark auto nano"
+
+- name: Autoremove and purge
+  apt:
+    autoremove: true
+    purge: true
+  register: purge_test
+
+- name: Check if the configuration files have been removed
+  shell: "apt-get --dry-run purge ?config-files"
+  register: config_check
+
+- name: Verify that purge worked
+  assert:
+    that:
+      - purge_test is changed
+      - "'nano*' not in config_check.stdout"
+
+- name: Install the nano package and mark it as automatically installed
+  shell: "apt-get -y install nano && apt-mark auto nano"
+
+- name: Autoremove and purge while installing hello
+  apt:
+    name: hello
+    state: present
+    autoremove: true
+    purge: true
+  register: purge_test
+
+- name: Check if the configuration files have been removed
+  shell: "apt-get --dry-run purge ?config-files"
+  register: config_check
+
+- name: Verify that purge worked
+  assert:
+    that:
+      - purge_test is changed
+      - "'nano*' not in config_check.stdout"
+
+- name: Install the nano package and mark it as automatically installed
+  shell: "apt-get -y install nano && apt-mark auto nano"
+
+- name: Autoremove and purge while removing hello
+  apt:
+    name: hello
+    state: absent
+    autoremove: true
+    purge: true
+  register: purge_test
+
+- name: Check if the configuration files have been removed
+  shell: "apt-get --dry-run purge ?config-files"
+  register: config_check
+
+- name: Verify that purge worked
+  assert:
+    that:
+      - purge_test is changed
+      - "'nano*' not in config_check.stdout"


### PR DESCRIPTION
##### SUMMARY

This PR fixes some bugs in the `apt` module that cause the `autoremove` or `purge` parameters to be ignored.

More specifically:

1. 26fe86cd3dd4d9ee65f225d6c85129cd2590ee84 fixes an issue where `autoremove` is ignored if redundant package changes are requested:

       - shell: "apt-get -y install hello && apt-mark auto hello"
  
       - apt:
           name: apt              # Note: the apt package is already installed
           state: present
           autoremove: true       # BUG: autoremove of "hello" is not performed

2. In the `apt-get` package manager, there is no `--autoclean` flag that can be added to another action. This is why performing an `autoclean` together with another action is unsupported in the Ansible `apt` module too. 

    Fixing this would require significant changes, which I find hard to justify (increased complexity & risk of bugs). This is why a5fc24989658b295a6d455f3cbb4fb16b611d93e just adds this limitation to the documentation for now.

    Also, a5fc24989658b295a6d455f3cbb4fb16b611d93e makes the `autoremove` option take precedence over `autoclean`. This concentrates all limitations on the `autoclean` option (like in `apt-get`), while the `autoremove` option works without limitations.

3. 38c38304b88e245b1c91625d8d0d6ad1205c8836 fixes an issue where `purge` is ignored if `state: present` is used. Also, some missing integration tests for the `purge` option are added.

4. bb4d0e0f48199e1077b00ac0023e3aeb4b996ee5 fixes an issue where `autoremove` and `purge` would be ignored if the `upgrade` option was used.

These changes partially address #38791 (`autoremove` is fixed, and the limitations of `autoclean` are documented).

##### ISSUE TYPE

- Bugfix Pull Request