### PR TITLE
ansible-test: add logic for checking invalid imports

### DIFF
--- a/changelogs/fragments/ansible_test_os_system.yml
+++ b/changelogs/fragments/ansible_test_os_system.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - ansible-test - add a rule for os.system call (https://github.com/ansible/ansible/issues/86250).

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/constants.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/constants.py
@@ -60,6 +60,7 @@ REJECTLIST_IMPORTS = {
 }
 SUBPROCESS_REGEX = re.compile(r'subprocess\.Po.*')
 OS_CALL_REGEX = re.compile(r'os\.call.*')
+OS_SYSTEM_REGEX = re.compile(r'os\.system.*')
 
 
 PLUGINS_WITH_RETURN_VALUES = ('module', )

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/constants.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/constants.py
@@ -58,9 +58,6 @@ REJECTLIST_IMPORTS = {
         }
     },
 }
-SUBPROCESS_REGEX = re.compile(r'subprocess\.Po.*')
-OS_CALL_REGEX = re.compile(r'os\.call.*')
-OS_SYSTEM_REGEX = re.compile(r'os\.system.*')
 
 
 PLUGINS_WITH_RETURN_VALUES = ('module', )

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -325,10 +325,20 @@ class InvalidImportChecker(ast.NodeVisitor):
             if isinstance(node.func.value, ast.Name):
                 if node.func.value.id == 'os':
                     if node.func.attr in self.os_methods:
-                        self.system_calls.append((node.lineno, node.col_offset, self.os_methods.get(node.func.attr), f"use-run-command-not-os-{node.func.attr}"))
+                        self.system_calls.append(
+                            (
+                                node.lineno, node.col_offset, self.os_methods.get(node.func.attr),
+                                f"use-run-command-not-os-{node.func.attr}"
+                            )
+                        )
                 elif node.func.value.id == 'subprocess':
                     if node.func.attr in self.subprocess_methods:
-                        self.system_calls.append((node.lineno, node.col_offset, self.subprocess_methods.get(node.func.attr), f"use-run-command-not-subprocess-{node.func.attr}"))
+                        self.system_calls.append(
+                            (
+                                node.lineno, node.col_offset, self.subprocess_methods.get(node.func.attr),
+                                f"use-run-command-not-{node.func.attr.lower()}"
+                            )
+                        )
 
         # Case 2: Checking for function calls
         elif isinstance(node.func, ast.Name):

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -318,7 +318,7 @@ class InvalidImportChecker(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Call(self, node):
-        """Checks for function calls: os.system(...) or system(...) (if imported)."""
+        """Checks for function calls: os.system(...) or system(...) or subprocess.Popen(...) (if imported)."""
 
         # Case 1: Checking imports
         if isinstance(node.func, ast.Attribute):
@@ -336,7 +336,7 @@ class InvalidImportChecker(ast.NodeVisitor):
                         self.system_calls.append(
                             (
                                 node.lineno, node.col_offset, self.subprocess_methods.get(node.func.attr),
-                                f"use-run-command-not-{node.func.attr.lower()}"
+                                f"use-run-command-not-{node.func.attr.lower().replace('_', '-')}"
                             )
                         )
 
@@ -344,7 +344,7 @@ class InvalidImportChecker(ast.NodeVisitor):
         elif isinstance(node.func, ast.Name):
             func_name = node.func.id
             if func_name in self.import_names:
-                self.system_calls.append((node.lineno, node.col_offset, func_name, f"use-run-command-not-{func_name}"))
+                self.system_calls.append((node.lineno, node.col_offset, func_name, "use-run-command-not-native-function"))
 
         self.generic_visit(node)
 

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -32,7 +32,6 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from contextlib import contextmanager
 from fnmatch import fnmatch
-from typing import List, Tuple
 
 from antsibull_docs_parser import dom
 from antsibull_docs_parser.parser import parse, Context
@@ -276,8 +275,8 @@ class InvalidImportChecker(ast.NodeVisitor):
     uses of invalid imports.
     """
     def __init__(self):
-        self.import_names: List[str] = []
-        self.system_calls: List[Tuple[int, int, str, str]] = []
+        self.import_names = []
+        self.system_calls = []
 
     def visit_ImportFrom(self, node):
         """Checks for 'from something import anything' or 'from something import anything as mysys'."""
@@ -296,12 +295,6 @@ class InvalidImportChecker(ast.NodeVisitor):
                 if alias.name == 'Popen':
                     imported_name = alias.asname if alias.asname else 'Popen'
                     self.import_names.append(imported_name)
-                elif alias.name == 'check_call':
-                    imported_name = alias.asname if alias.asname else 'check_call'
-                    self.import_names.append(imported_name)
-                elif alias.name == 'check_output':
-                    imported_name = alias.asname if alias.asname else 'check_output'
-                    self.import_names.append(imported_name)
         self.generic_visit(node)
 
     def visit_Call(self, node):
@@ -317,12 +310,7 @@ class InvalidImportChecker(ast.NodeVisitor):
                         self.system_calls.append((node.lineno, node.col_offset, "os.call", "use-run-command-not-os-call"))
                 elif node.func.value.id == 'subprocess':
                     if node.func.attr == 'Popen':
-                        self.system_calls.append((node.lineno, node.col_offset, "subprocess.Popen", "use-run-command-not-subprocess-popen"))
-                    elif node.func.attr == 'check_call':
-                        self.system_calls.append((node.lineno, node.col_offset, "subprocess.check_call", "use-run-command-not-subprocess-check-call"))
-                    elif node.func.attr == 'check_output':
-                        self.system_calls.append((node.lineno, node.col_offset, "subprocess.check_output", "use-run-command-not-subprocess-check-output"))
-
+                        self.system_calls.append((node.lineno, node.col_offset, "subprocess.Popen", "use-run-command-not-popen"))
         # Case 2: Checking for function calls
         elif isinstance(node.func, ast.Name):
             func_name = node.func.id

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -93,6 +93,7 @@ from .constants import (
     REJECTLIST_IMPORTS,
     SUBPROCESS_REGEX,
     OS_CALL_REGEX,
+    OS_SYSTEM_REGEX,
     PLUGINS_WITH_RETURN_VALUES,
     PLUGINS_WITH_EXAMPLES,
     PLUGINS_WITH_YAML_EXAMPLES,
@@ -481,6 +482,19 @@ class ModuleValidator(Validator):
                         msg=('os.call() call found. Should be module.run_command'),
                         line=(line_no + 1),
                         column=(os_call_match.span()[0] + 1)
+                    )
+
+    def _check_for_os_system(self):
+        if 'os.system' in self.text:
+            for line_no, line in enumerate(self.text.splitlines()):
+                os_system_match = OS_SYSTEM_REGEX.search(line)
+                if os_system_match:
+                    self.reporter.error(
+                        path=self.object_path,
+                        code='use-run-command-not-os-system',
+                        msg=('os.system() call found. Should be module.run_command'),
+                        line=(line_no + 1),
+                        column=(os_system_match.span()[0] + 1)
                     )
 
     def _find_rejectlist_imports(self):
@@ -2448,6 +2462,7 @@ class ModuleValidator(Validator):
             if self.plugin_type == 'module':
                 self._check_for_subprocess()
                 self._check_for_os_call()
+                self._check_for_os_system()
 
         if self._powershell_module():
             self._validate_ps_replacers()

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -32,6 +32,7 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from contextlib import contextmanager
 from fnmatch import fnmatch
+from typing import List, Tuple
 
 from antsibull_docs_parser import dom
 from antsibull_docs_parser.parser import parse, Context
@@ -91,9 +92,6 @@ from .constants import (
     NO_LOG_REGEX,
     FORBIDDEN_DICTIONARY_KEYS,
     REJECTLIST_IMPORTS,
-    SUBPROCESS_REGEX,
-    OS_CALL_REGEX,
-    OS_SYSTEM_REGEX,
     PLUGINS_WITH_RETURN_VALUES,
     PLUGINS_WITH_EXAMPLES,
     PLUGINS_WITH_YAML_EXAMPLES,
@@ -270,6 +268,68 @@ class Validator(metaclass=abc.ABCMeta):
     def validate(self):
         """Run this method to generate the test results"""
         pass
+
+
+class InvalidImportChecker(ast.NodeVisitor):
+    """
+    Analyzes a Python script's Abstract Syntax Tree (AST) to detect
+    uses of invalid imports.
+    """
+    def __init__(self):
+        self.import_names: List[str] = []
+        self.system_calls: List[Tuple[int, int, str, str]] = []
+
+    def visit_ImportFrom(self, node):
+        """Checks for 'from something import anything' or 'from something import anything as mysys'."""
+        if node.module == 'os':
+            for alias in node.names:
+                # If aliased, store the alias name; otherwise, store particular name from import
+                if alias.name == 'system':
+                    imported_name = alias.asname if alias.asname else 'system'
+                    self.import_names.append(imported_name)
+                elif alias.name == 'call':
+                    imported_name = alias.asname if alias.asname else 'call'
+                    self.import_names.append(imported_name)
+        elif node.module == 'subprocess':
+            for alias in node.names:
+                # If aliased, store the alias name; otherwise, store particular name from import
+                if alias.name == 'Popen':
+                    imported_name = alias.asname if alias.asname else 'Popen'
+                    self.import_names.append(imported_name)
+                elif alias.name == 'check_call':
+                    imported_name = alias.asname if alias.asname else 'check_call'
+                    self.import_names.append(imported_name)
+                elif alias.name == 'check_output':
+                    imported_name = alias.asname if alias.asname else 'check_output'
+                    self.import_names.append(imported_name)
+        self.generic_visit(node)
+
+    def visit_Call(self, node):
+        """Checks for function calls: os.system(...) or system(...) (if imported)."""
+
+        # Case 1: Checking imports
+        if isinstance(node.func, ast.Attribute):
+            if isinstance(node.func.value, ast.Name):
+                if node.func.value.id == 'os':
+                    if node.func.attr == 'system':
+                        self.system_calls.append((node.lineno, node.col_offset, "os.system", "use-run-command-not-os-system"))
+                    elif node.func.attr == 'call':
+                        self.system_calls.append((node.lineno, node.col_offset, "os.call", "use-run-command-not-os-call"))
+                elif node.func.value.id == 'subprocess':
+                    if node.func.attr == 'Popen':
+                        self.system_calls.append((node.lineno, node.col_offset, "subprocess.Popen", "use-run-command-not-subprocess-popen"))
+                    elif node.func.attr == 'check_call':
+                        self.system_calls.append((node.lineno, node.col_offset, "subprocess.check_call", "use-run-command-not-subprocess-check-call"))
+                    elif node.func.attr == 'check_output':
+                        self.system_calls.append((node.lineno, node.col_offset, "subprocess.check_output", "use-run-command-not-subprocess-check-output"))
+
+        # Case 2: Checking for function calls
+        elif isinstance(node.func, ast.Name):
+            func_name = node.func.id
+            if func_name in self.import_names:
+                self.system_calls.append((node.lineno, node.col_offset, func_name, f"use-run-command-not-{func_name}"))
+
+        self.generic_visit(node)
 
 
 class ModuleValidator(Validator):
@@ -456,46 +516,18 @@ class ModuleValidator(Validator):
                         'https://docs.ansible.com/ansible-core/devel/dev_guide/developing_modules_documenting.html#copyright'
                 )
 
-    def _check_for_subprocess(self):
-        for child in self.ast.body:
-            if isinstance(child, ast.Import):
-                if child.names[0].name == 'subprocess':
-                    for line_no, line in enumerate(self.text.splitlines()):
-                        sp_match = SUBPROCESS_REGEX.search(line)
-                        if sp_match:
-                            self.reporter.error(
-                                path=self.object_path,
-                                code='use-run-command-not-popen',
-                                msg=('subprocess.Popen call found. Should be module.run_command'),
-                                line=(line_no + 1),
-                                column=(sp_match.span()[0] + 1)
-                            )
-
-    def _check_for_os_call(self):
-        if 'os.call' in self.text:
-            for line_no, line in enumerate(self.text.splitlines()):
-                os_call_match = OS_CALL_REGEX.search(line)
-                if os_call_match:
-                    self.reporter.error(
-                        path=self.object_path,
-                        code='use-run-command-not-os-call',
-                        msg=('os.call() call found. Should be module.run_command'),
-                        line=(line_no + 1),
-                        column=(os_call_match.span()[0] + 1)
-                    )
-
-    def _check_for_os_system(self):
-        if 'os.system' in self.text:
-            for line_no, line in enumerate(self.text.splitlines()):
-                os_system_match = OS_SYSTEM_REGEX.search(line)
-                if os_system_match:
-                    self.reporter.error(
-                        path=self.object_path,
-                        code='use-run-command-not-os-system',
-                        msg=('os.system() call found. Should be module.run_command'),
-                        line=(line_no + 1),
-                        column=(os_system_match.span()[0] + 1)
-                    )
+    def _check_for_invalid_imports(self):
+        checker = InvalidImportChecker()
+        checker.visit(self.ast)
+        if checker.system_calls:
+            for line_no, col_no, caller_name, code in checker.system_calls:
+                self.reporter.error(
+                    path=self.object_path,
+                    code=code,
+                    msg=f'{caller_name}() call found. Should be module.run_command',
+                    line=line_no,
+                    column=col_no
+                )
 
     def _find_rejectlist_imports(self):
         for child in self.ast.body:
@@ -2460,9 +2492,7 @@ class ModuleValidator(Validator):
                 self._ensure_imports_below_docs(doc_info, first_callable)
 
             if self.plugin_type == 'module':
-                self._check_for_subprocess()
-                self._check_for_os_call()
-                self._check_for_os_system()
+                self._check_for_invalid_imports()
 
         if self._powershell_module():
             self._validate_ps_replacers()

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -277,23 +277,43 @@ class InvalidImportChecker(ast.NodeVisitor):
     def __init__(self):
         self.import_names = []
         self.system_calls = []
+        self.os_methods = {
+            'popen': 'os.popen',
+            'posix_spawn': 'os.posix_spawn',
+            'posix_spawnp': 'os.posix_spawnp',
+            'spawnl': 'os.spawnl',
+            'spawnle': 'os.spawnle',
+            'spawnlp': 'os.spawnlp',
+            'spawnlpe': 'os.spawnlpe',
+            'spawnv': 'os.spawnv',
+            'spawnve': 'os.spawnve',
+            'spawnvp': 'os.spawnvp',
+            'spawnvpe': 'os.spawnvpe',
+            'system': 'os.system',
+        }
+        self.subprocess_methods = {
+            'Popen': 'subprocess.Popen',
+            'call': 'subprocess.call',
+            'run': 'subprocess.run',
+            'getstatusoutput': 'subprocess.getstatusoutput',
+            'getoutput': 'subprocess.getoutput',
+            'check_output': 'subprocess.check_output',
+            'check_call': 'subprocess.check_call',
+        }
 
     def visit_ImportFrom(self, node):
         """Checks for 'from something import anything' or 'from something import anything as mysys'."""
         if node.module == 'os':
             for alias in node.names:
                 # If aliased, store the alias name; otherwise, store particular name from import
-                if alias.name == 'system':
-                    imported_name = alias.asname if alias.asname else 'system'
-                    self.import_names.append(imported_name)
-                elif alias.name == 'call':
-                    imported_name = alias.asname if alias.asname else 'call'
+                if alias.name in self.os_methods:
+                    imported_name = alias.asname if alias.asname else alias.name
                     self.import_names.append(imported_name)
         elif node.module == 'subprocess':
             for alias in node.names:
                 # If aliased, store the alias name; otherwise, store particular name from import
-                if alias.name == 'Popen':
-                    imported_name = alias.asname if alias.asname else 'Popen'
+                if alias.name in self.subprocess_methods:
+                    imported_name = alias.asname if alias.asname else alias.name
                     self.import_names.append(imported_name)
         self.generic_visit(node)
 
@@ -304,13 +324,12 @@ class InvalidImportChecker(ast.NodeVisitor):
         if isinstance(node.func, ast.Attribute):
             if isinstance(node.func.value, ast.Name):
                 if node.func.value.id == 'os':
-                    if node.func.attr == 'system':
-                        self.system_calls.append((node.lineno, node.col_offset, "os.system", "use-run-command-not-os-system"))
-                    elif node.func.attr == 'call':
-                        self.system_calls.append((node.lineno, node.col_offset, "os.call", "use-run-command-not-os-call"))
+                    if node.func.attr in self.os_methods:
+                        self.system_calls.append((node.lineno, node.col_offset, self.os_methods.get(node.func.attr), f"use-run-command-not-os-{node.func.attr}"))
                 elif node.func.value.id == 'subprocess':
-                    if node.func.attr == 'Popen':
-                        self.system_calls.append((node.lineno, node.col_offset, "subprocess.Popen", "use-run-command-not-popen"))
+                    if node.func.attr in self.subprocess_methods:
+                        self.system_calls.append((node.lineno, node.col_offset, self.subprocess_methods.get(node.func.attr), f"use-run-command-not-subprocess-{node.func.attr}"))
+
         # Case 2: Checking for function calls
         elif isinstance(node.func, ast.Name):
             func_name = node.func.id

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -328,7 +328,7 @@ class InvalidImportChecker(ast.NodeVisitor):
                         self.system_calls.append(
                             (
                                 node.lineno, node.col_offset, self.os_methods.get(node.func.attr),
-                                f"use-run-command-not-os-{node.func.attr}"
+                                "use-run-command-instead"
                             )
                         )
                 elif node.func.value.id == 'subprocess':
@@ -336,7 +336,7 @@ class InvalidImportChecker(ast.NodeVisitor):
                         self.system_calls.append(
                             (
                                 node.lineno, node.col_offset, self.subprocess_methods.get(node.func.attr),
-                                f"use-run-command-not-{node.func.attr.lower().replace('_', '-')}"
+                                "use-run-command-instead"
                             )
                         )
 
@@ -344,7 +344,7 @@ class InvalidImportChecker(ast.NodeVisitor):
         elif isinstance(node.func, ast.Name):
             func_name = node.func.id
             if func_name in self.import_names:
-                self.system_calls.append((node.lineno, node.col_offset, func_name, "use-run-command-not-native-function"))
+                self.system_calls.append((node.lineno, node.col_offset, func_name, "use-run-command-instead"))
 
         self.generic_visit(node)
 

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -21,6 +21,7 @@ lib/ansible/modules/file.py validate-modules:undocumented-parameter
 lib/ansible/modules/getent.py validate-modules:bad-return-value-key  # used for documentation, not a real key
 lib/ansible/modules/git.py use-argspec-type-path
 lib/ansible/modules/git.py validate-modules:doc-required-mismatch
+lib/ansible/modules/mount_facts.py validate-modules:use-run-command-not-check_output
 lib/ansible/modules/package_facts.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/service.py validate-modules:nonexistent-parameter-documented
 lib/ansible/modules/service.py validate-modules:use-run-command-not-popen

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -21,14 +21,14 @@ lib/ansible/modules/file.py validate-modules:undocumented-parameter
 lib/ansible/modules/getent.py validate-modules:bad-return-value-key  # used for documentation, not a real key
 lib/ansible/modules/git.py use-argspec-type-path
 lib/ansible/modules/git.py validate-modules:doc-required-mismatch
-lib/ansible/modules/mount_facts.py validate-modules:use-run-command-not-check_output
+lib/ansible/modules/mount_facts.py validate-modules:use-run-command-instead
 lib/ansible/modules/package_facts.py validate-modules:doc-choices-do-not-match-spec
 lib/ansible/modules/service.py validate-modules:nonexistent-parameter-documented
-lib/ansible/modules/service.py validate-modules:use-run-command-not-popen
+lib/ansible/modules/service.py validate-modules:use-run-command-instead
 lib/ansible/modules/stat.py validate-modules:parameter-invalid
 lib/ansible/modules/systemd_service.py validate-modules:parameter-invalid
 lib/ansible/modules/user.py validate-modules:doc-default-does-not-match-spec
-lib/ansible/modules/user.py validate-modules:use-run-command-not-popen
+lib/ansible/modules/user.py validate-modules:use-run-command-instead
 lib/ansible/module_utils/basic.py pylint:unused-import  # deferring resolution to allow enabling the rule now
 lib/ansible/module_utils/compat/selinux.py import-3.9!skip # pass/fail depends on presence of libselinux.so
 lib/ansible/module_utils/compat/selinux.py import-3.10!skip # pass/fail depends on presence of libselinux.so


### PR DESCRIPTION
##### SUMMARY

* Recommend module.run_command instead of os.system, os.call, subprocess.Popen, subprocess.check_output, subprocess.check_call

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE



- Test Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/constants.py
test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py


