### PR TITLE
ansible-test: add a rule for Popen call

### DIFF
--- a/changelogs/fragments/ansible_test_popen.yml
+++ b/changelogs/fragments/ansible_test_popen.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - ansible-test - add a rule for Popen call (https://github.com/ansible/ansible/issues/86249). 

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/constants.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/constants.py
@@ -58,7 +58,7 @@ REJECTLIST_IMPORTS = {
         }
     },
 }
-SUBPROCESS_REGEX = re.compile(r'subprocess\.Po.*')
+SUBPROCESS_REGEX = re.compile(r'(?:subprocess\.)?Popen\(.*')
 OS_CALL_REGEX = re.compile(r'os\.call.*')
 
 

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -456,19 +456,24 @@ class ModuleValidator(Validator):
                 )
 
     def _check_for_subprocess(self):
+        def _report_error():
+            for line_no, line in enumerate(self.text.splitlines()):
+                sp_match = SUBPROCESS_REGEX.search(line)
+                if sp_match:
+                    self.reporter.error(
+                        path=self.object_path,
+                        code='use-run-command-not-popen',
+                        msg=('subprocess.Popen call found. Should be module.run_command'),
+                        line=(line_no + 1),
+                        column=(sp_match.span()[0] + 1)
+                    )
         for child in self.ast.body:
             if isinstance(child, ast.Import):
                 if child.names[0].name == 'subprocess':
-                    for line_no, line in enumerate(self.text.splitlines()):
-                        sp_match = SUBPROCESS_REGEX.search(line)
-                        if sp_match:
-                            self.reporter.error(
-                                path=self.object_path,
-                                code='use-run-command-not-popen',
-                                msg=('subprocess.Popen call found. Should be module.run_command'),
-                                line=(line_no + 1),
-                                column=(sp_match.span()[0] + 1)
-                            )
+                    _report_error()
+            elif isinstance(child, ast.ImportFrom):
+                if child.module == 'subprocess':
+                    _report_error()
 
     def _check_for_os_call(self):
         if 'os.call' in self.text:


### PR DESCRIPTION
##### SUMMARY

* Recommend module.run_command instead of Popen

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE



- Test Pull Request

##### COMPONENT NAME
test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/constants.py
test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py


