### PR TITLE
Added ansible-galaxy role download command

### DIFF
--- a/changelogs/fragments/86116-galaxy-role-download.yaml
+++ b/changelogs/fragments/86116-galaxy-role-download.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-galaxy - add new 'role download' command to download roles as tarballs for offline installation (https://github.com/ansible/ansible/issues/86116)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -311,6 +311,34 @@ class GalaxyCLI(CLI):
 
         self.add_info_options(role_parser, parents=[common, roles_path, offline])
         self.add_install_options(role_parser, parents=[common, force, roles_path])
+        self.add_download_role_options(role_parser, parents=[common, force, roles_path])
+
+    def add_download_role_options(self, parser, parents=None):
+        download_parser = parser.add_parser(
+            "download",
+            parents=parents,
+            help="Download roles as tarballs for offline installation.",
+        )
+        download_parser.set_defaults(func=self.execute_download_role)
+
+        download_parser.add_argument(
+            "args",
+            metavar="role",
+            nargs="*",
+            help="Role(s) to download (name or name/version)",
+        )
+        download_parser.add_argument(
+            "-r",
+            "--role-file",
+            dest="role_file",
+            help="A file containing a list of roles to be downloaded",
+        )
+        download_parser.add_argument(
+            "--output-path",
+            dest="output_path",
+            default="./",
+            help="The path in which to download the role tarballs",
+        )
 
     def add_download_options(self, parser, parents=None):
         download_parser = parser.add_parser('download', parents=parents,
@@ -1388,6 +1416,60 @@ class GalaxyCLI(CLI):
             self._execute_install_collection(
                 collection_requirements, collection_path,
                 artifacts_manager=artifacts_manager,
+            )
+
+    def execute_download_role(self):
+        """
+        Download roles as tarballs for offline installation.
+        """
+        self._display_role_info = _display_role
+
+        # Use context.CLIARGS to access arguments
+        role_file = context.CLIARGS.get("role_file")
+        role_args = context.CLIARGS.get("args", [])
+        output_path = context.CLIARGS.get("output_path", "./")
+
+        # Parse role requirements
+        roles_to_download = []
+        if role_file:
+            requirements = self._parse_requirements_file(role_file)
+            # _parse_requirements_file returns GalaxyRole objects in the 'roles' key
+            roles_to_download = requirements.get("roles", [])
+        else:
+            # For direct role arguments, create GalaxyRole objects
+            for role_arg in role_args:
+                role_req = RoleRequirement.role_yaml_parse(role_arg.strip())
+                role_obj = GalaxyRole(self.galaxy, self.lazy_role_api, **role_req)
+                roles_to_download.append(role_obj)
+
+        if not roles_to_download:
+            raise AnsibleError("No valid role requirements found to download")
+
+        # Set output path
+        if not os.path.exists(output_path):
+            os.makedirs(output_path)
+
+        display.display("Starting galaxy role download process")
+
+        # Download each role using the GalaxyRole objects
+        for role_obj in roles_to_download:
+            self._execute_download_single_role(role_obj, output_path)
+
+    def _execute_download_single_role(self, role_obj, output_path):
+        """
+        Download a single role as a tarball using a GalaxyRole object.
+        """
+        display.display("Downloading role %s" % role_obj.name)
+
+        # Use the GalaxyRole object directly to download
+        try:
+            tarball_path = role_obj.download(output_path)
+            display.display(
+                "Successfully downloaded role %s to %s" % (role_obj.name, tarball_path)
+            )
+        except Exception as e:
+            raise AnsibleError(
+                "Failed to download role %s: %s" % (role_obj.name, to_native(e))
             )
 
     def _execute_install_collection(

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -240,6 +240,78 @@ class GalaxyRole(object):
 
         return False
 
+    def download(self, output_path="./"):
+        """
+        Download the role as a tarball to the specified output path.
+
+        :param output_path: Path where the tarball should be saved.
+        :return: Path to the downloaded tarball.
+        """
+        # Ensure the API client is available
+        if not self.api:
+            raise AnsibleError(
+                "Cannot download role %s: no API client available" % self.name
+            )
+
+        # Get role information to find download URL
+        role_data = self.api.lookup_role_by_name(self.name)
+        if not role_data:
+            raise AnsibleError("Role %s not found" % self.name)
+
+        # Find the download URL - try different possible locations
+        download_url = None
+
+        # Try different possible locations for the download URL
+        if "download_url" in role_data:
+            download_url = role_data["download_url"]
+        elif "github_repo" in role_data and "github_user" in role_data:
+            # Construct GitHub URL if we have repo info
+            download_url = "https://github.com/%s/%s/archive/%s.tar.gz" % (
+                role_data["github_user"],
+                role_data["github_repo"],
+                self.version or "master",
+            )
+        elif "versions" in role_data and role_data["versions"]:
+            # Try to get from versions
+            for version in role_data["versions"]:
+                if "download_url" in version:
+                    download_url = version["download_url"]
+                    break
+
+        if not download_url:
+            raise AnsibleError("No download URL found for role %s" % self.name)
+
+        # Download the tarball using open_url (like the fetch method does)
+        try:
+            display.display("- downloading role from %s" % download_url)
+
+            # Use open_url to download the file (like the existing fetch method)
+            url_file = open_url(
+                download_url,
+                validate_certs=self._validate_certs,
+                http_agent=user_agent(),
+                timeout=60,
+            )
+
+            # Determine filename
+            filename = "%s-%s.tar.gz" % (self.name, role_data.get("version", "latest"))
+            output_file = os.path.join(output_path, filename)
+
+            # Save the file
+            with open(output_file, "wb") as f:
+                data = url_file.read()
+                while data:
+                    f.write(data)
+                    data = url_file.read()
+
+            return output_file
+
+        except Exception as e:
+            raise AnsibleError(
+                "Failed to download role %s from %s: %s"
+                % (self.name, download_url, to_native(e))
+            )
+
     def install(self):
 
         if self.scm:

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -1358,3 +1358,96 @@ def test_install_collection_with_roles(requirements_file, monkeypatch):
     assert mock_role_install.call_count == 0
 
     assert any(list('contains roles which will be ignored' in mock_call[1][0] for mock_call in mock_display.mock_calls))
+
+
+def test_execute_download_role_single(mocker, tmp_path):
+    mock_galaxy = mocker.Mock()
+    mock_role = mocker.Mock()
+    mock_role.name = "test.role"
+    mock_role.download.return_value = str(tmp_path / "test.role-latest.tar.gz")
+
+    mocker.patch("ansible.cli.galaxy.GalaxyRole", return_value=mock_role)
+    mocker.patch(
+        "ansible.cli.galaxy.RoleRequirement.role_yaml_parse",
+        return_value={"name": "test.role"},
+    )
+
+    galaxy_cli = GalaxyCLI(
+        args=[
+            "ansible-galaxy",
+            "role",
+            "download",
+            "test.role",
+            "--output-path",
+            str(tmp_path),
+        ]
+    )
+    galaxy_cli.parse()
+    galaxy_cli.galaxy = mock_galaxy
+    galaxy_cli.lazy_role_api = mocker.Mock()
+
+    galaxy_cli.execute_download_role()
+
+    mock_role.download.assert_called_once_with(str(tmp_path))
+
+
+def test_execute_download_role_requirements_file(mocker, tmp_path):
+    mock_galaxy = mocker.Mock()
+    mock_role = mocker.Mock()
+    mock_role.name = "test.role"
+    mock_role.download.return_value = str(tmp_path / "test.role-latest.tar.gz")
+
+    mocker.patch(
+        "ansible.cli.galaxy.GalaxyCLI._parse_requirements_file",
+        return_value={"roles": [mock_role]},
+    )
+
+    galaxy_cli = GalaxyCLI(
+        args=[
+            "ansible-galaxy",
+            "role",
+            "download",
+            "-r",
+            "requirements.yml",
+            "--output-path",
+            str(tmp_path),
+        ]
+    )
+    galaxy_cli.parse()
+    galaxy_cli.galaxy = mock_galaxy
+    galaxy_cli.lazy_role_api = mocker.Mock()
+
+    galaxy_cli.execute_download_role()
+
+    mock_role.download.assert_called_once_with(str(tmp_path))
+
+
+def test_execute_download_role_no_requirements(mocker):
+    galaxy_cli = GalaxyCLI(args=["ansible-galaxy", "role", "download"])
+    galaxy_cli.parse()
+    galaxy_cli.galaxy = mocker.Mock()
+
+    with pytest.raises(
+        AnsibleError, match="No valid role requirements found to download"
+    ):
+        galaxy_cli.execute_download_role()
+
+
+def test_role_download_command_parser():
+    galaxy_cli = GalaxyCLI(
+        args=[
+            "ansible-galaxy",
+            "role",
+            "download",
+            "test.role",
+            "--output-path",
+            "/tmp",
+        ]
+    )
+
+    galaxy_cli.init_parser()
+    galaxy_cli.parse()
+
+    assert context.CLIARGS["func"] == galaxy_cli.execute_download_role
+    assert context.CLIARGS["args"] == ("test.role",)  # args is a tuple
+    assert context.CLIARGS["output_path"] == "/tmp"


### PR DESCRIPTION
SUMMARY
Add ansible-galaxy role download command for downloading roles as tarballs.
Fixes: #86116

Signed-off by: Jason Hall <jason.kei.hall@gmail.com>

ISSUE TYPE
Feature Pull Request

COMPONENT NAME
lib/ansible/cli/galaxy.py
lib/ansible/galaxy/role.py
test/units/cli/test_galaxy.py
