### PR TITLE
Fix types @ `galaxy.collection.galaxy_api_proxy`

### DIFF
--- a/lib/ansible/galaxy/collection/galaxy_api_proxy.py
+++ b/lib/ansible/galaxy/collection/galaxy_api_proxy.py
@@ -34,7 +34,7 @@ class MultiGalaxyAPIProxy:
         self._offline = offline  # Prevent all GalaxyAPI calls
 
     @property
-    def is_offline_mode_requested(self):
+    def is_offline_mode_requested(self) -> bool:
         return self._offline
 
     def _assert_that_offline_mode_is_not_requested(self) -> None:
@@ -117,7 +117,7 @@ class MultiGalaxyAPIProxy:
             else self._apis
         )
 
-        last_err: t.Optional[Exception]
+        last_err: Exception
 
         for api in api_lookup_order:
             try:

--- a/test/sanity/code-smell/mypy/ansible-core.ini
+++ b/test/sanity/code-smell/mypy/ansible-core.ini
@@ -23,6 +23,9 @@ ignore_missing_imports = True
 [mypy-ansible_test.*]
 ignore_missing_imports = True
 
+[mypy-ansible.galaxy.collection.galaxy_api_proxy]
+strict_optional = True
+
 [mypy-ansible.galaxy.collection.gpg]
 strict_optional = True
 


### PR DESCRIPTION
##### SUMMARY

This includes enforcing `strict_optional` for the
`ansible.galaxy.collection.galaxy_api_proxy` module in MyPy.

This patch has been extracted from #85961 to reduce its scope.

##### ISSUE TYPE

- Test Pull Request
