### PR TITLE
Fix regression in `ansible.builtin.first_found` lookup

### DIFF
--- a/changelogs/fragments/86270-fix-first_found-lookup-regression.yml
+++ b/changelogs/fragments/86270-fix-first_found-lookup-regression.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    first_found - Fix regression introduced with Ansible 2.19 that the lookup does not search the
+    ``files`` paths when used outside of a ``with_first_found:`` block.

--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -242,7 +242,7 @@ class LookupModule(LookupBase):
         else:
             terms = _recurse_terms(terms, omit_undefined=False)  # undefined values are only omitted when invoked using `with`
 
-            subdir = None
+            subdir = 'files'  # generic fallback for lookups
 
         self.set_options(var_options=variables, direct=kwargs)
 


### PR DESCRIPTION
##### SUMMARY

When used not by with_first_found, but with the…

      vars:
        _item: "{{ lookup('ansible.builtin.first_found', _files) }}"

… syntax, the search paths were off:

```
roles/ROLE/files/FILE        ≠ roles/ROLE/None/FILE
roles/ROLE/FILE              = roles/ROLE/FILE
roles/ROLE/tasks/files/FILE  ≠ roles/ROLE/tasks/None/FILE
roles/ROLE/tasks/FILE        = roles/ROLE/tasks/FILE
playbooks/hosts/files/FILE   ≠ playbooks/hosts/None/FILE
playbooks/hosts/FILE         = playbooks/hosts/FILE
playbooks/hosts/files/FILE   ≠ playbooks/hosts/None/FILE
playbooks/hosts/FILE         = playbooks/hosts/FILE
```

This changed in commit 35750ed3218e7bce68b21f473cecb0a3b9d60321 (contained in 2.19+), almost certainly not deliberately, because the `subdir` variable is passed to `find_file_in_search_path()` which just stringifies it, so `None` is not even useful.

This commit reinstates the former behaviour, so older playbooks do not suddenly misbehave (and thus should be backported to the affected releases).

Fixes: https://forum.ansible.com/t/first-found-lookup-not-searching-the-expected-paths/44896

##### ISSUE TYPE

- Bugfix Pull Request
