### PR TITLE
user: clean up systemd lingering when deleting users

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3260,6 +3260,43 @@ class Buildroot(BusyBox):
     platform = 'Linux'
     distribution = 'Buildroot'
 
+def _cleanup_systemd_lingering(module, username):
+    """
+    Best-effort cleanup of systemd lingering for a user.
+
+    If /var/lib/systemd/linger/<username> exists, try to disable lingering
+    via loginctl; if that fails, fall back to removing the lingering file
+    directly. Any errors during cleanup are ignored so that user deletion
+    itself is not blocked.
+    """
+    linger_dir = "/var/lib/systemd/linger"
+    linger_file = os.path.join(linger_dir, username)
+
+    # If there is no lingering file, there is nothing to do
+    if not os.path.exists(linger_file):
+        return
+
+    # Try to use loginctl if available
+    loginctl = module.get_bin_path("loginctl", required=False)
+    if loginctl:
+        rc, out, err = module.run_command(
+            [loginctl, "disable-linger", username],
+            check_rc=False,
+        )
+        # If loginctl worked and the file is gone, we are done
+        if rc == 0 and not os.path.exists(linger_file):
+            return
+
+    # Fallback: try to remove the lingering file directly
+    try:
+        os.remove(linger_file)
+    except OSError:
+        # Do not fail the whole task just because lingering cleanup failed
+        try:
+            module.warn("Failed to clean systemd lingering file for user %s" % username)
+        except AttributeError:
+            # warn() may not exist in very old Ansible versions; ignore silently
+            pass
 
 def main():
     ssh_defaults = dict(
@@ -3337,6 +3374,10 @@ def main():
         if user.user_exists():
             if module.check_mode:
                 module.exit_json(changed=True)
+                
+            # Best-effort cleanup of systemd lingering before deleting the user
+            _cleanup_systemd_lingering(module, user.name)
+
             (rc, out, err) = user.remove_user()
             if rc != 0:
                 module.fail_json(name=user.name, msg=err, rc=rc)


### PR DESCRIPTION

# SUMMARY

This pull request fixes a bug in the `user` module where deleting a user does not remove the systemd lingering configuration associated with that account.

If a user has lingering enabled using:

```

loginctl enable-linger <username>

```

the lingering file remains under:

```

/var/lib/systemd/linger/<username>

````

even after the account is deleted through the `user` module.  
This leaves stale system configuration behind.

This patch adds a best-effort cleanup step before user deletion:
- Attempts `loginctl disable-linger <username>` if available  
- If that fails, removes the lingering file directly  
- Does not fail the task when lingering cleanup cannot be performed

**Fixes #86199**

---

# ISSUE TYPE

- Bugfix Pull Request

---

# RATIONALE AND DESIGN DECISIONS

- The Ansible `user` module aims to fully remove user accounts when `state=absent`.
- systemd lingering represents per-user state and should not persist after user removal.
- Without cleanup, lingering can cause unexpected behavior and system inconsistencies.
- The solution adds a helper function `_cleanup_systemd_lingering()` which:
  - Detects the lingering file
  - Runs `loginctl disable-linger` when possible
  - Falls back to manual file deletion
  - Ignores cleanup errors to avoid breaking existing workflows

The change is minimal, safe, and improves correctness for systemd-based systems.

---

# STEPS TO REPRODUCE (Before Fix)

1. Create a user via the `user` module:
```
   - name: create user
     user:
       name: testuser
````

2. Enable lingering:

   ```
   loginctl enable-linger testuser
   ```

3. Confirm lingering file exists:

   ```
   ls /var/lib/systemd/linger/
   ```

4. Delete the user using:

   ```yaml
   - name: delete user
     user:
       name: testuser
       state: absent
       force: true
   ```

5. Check lingering directory again:

   ```
   ls /var/lib/systemd/linger/
   ```

   ➝ `testuser` file still exists (bug)

---

# VERIFICATION (After Fix)

1. Create the user again
2. Re-enable lingering
3. Run the same deletion playbook
4. Check the lingering directory:

   ```
   ls /var/lib/systemd/linger/
   ```

   ➝ lingering file is removed successfully

Tested on **Ubuntu (WSL 22.04)** on the current devel branch.

---

# ADDITIONAL INFORMATION

* The patch does not change existing behavior for systems without systemd.
* Cleanup happens only when `state=absent` and the user exists.
* Errors during cleanup are intentionally ignored to maintain compatibility.



