### PR TITLE
user: Guard Linux-only -K options on FreeBSD (fixes #86252)

### DIFF
--- a/changelogs/fragments/freebsd-user-ignore-uidmin.yml
+++ b/changelogs/fragments/freebsd-user-ignore-uidmin.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - "user module: FreeBSD backend now correctly ignores uid_min, uid_max, and umask,
-    instead of passing unsupported '-K' options to pw(8). (fixes #86252)"
+  - "user: FreeBSD backend now correctly ignores uid_min, uid_max, and umask,
+    instead of passing unsupported '-K' options to pw(8) (https://github.com/ansible/ansible/issues/86252)."

--- a/changelogs/fragments/freebsd-user-ignore-uidmin.yml
+++ b/changelogs/fragments/freebsd-user-ignore-uidmin.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "user module: FreeBSD backend now correctly ignores uid_min, uid_max, and umask,
+    instead of passing unsupported '-K' options to pw(8). (fixes #86252)"

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1507,6 +1507,7 @@ class FreeBsdUser(User):
                 cmd.append('-k')
                 cmd.append(self.skeleton)
 
+            # Only use -K with useradd (Linux). FreeBSD's pw(8) does not support -K.
             if self.module.get_bin_path('useradd', required=False):
                 if self.umask is not None:
                     cmd.append('-K')
@@ -1527,6 +1528,7 @@ class FreeBsdUser(User):
             else:
                 cmd.append(str(calendar.timegm(self.expires)))
 
+        # Only use -K with useradd (Linux). FreeBSD's pw(8) does not support -K.
         if self.module.get_bin_path('useradd', required=False):
             if self.uid_min is not None:
                 cmd.append('-K')

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1507,9 +1507,10 @@ class FreeBsdUser(User):
                 cmd.append('-k')
                 cmd.append(self.skeleton)
 
-            if self.umask is not None:
-                cmd.append('-K')
-                cmd.append('UMASK=' + self.umask)
+            if self.module.get_bin_path('useradd', required=False):
+                if self.umask is not None:
+                    cmd.append('-K')
+                    cmd.append('UMASK=' + self.umask)
 
         if self.shell is not None:
             cmd.append('-s')
@@ -1526,13 +1527,14 @@ class FreeBsdUser(User):
             else:
                 cmd.append(str(calendar.timegm(self.expires)))
 
-        if self.uid_min is not None:
-            cmd.append('-K')
-            cmd.append('UID_MIN=' + str(self.uid_min))
+        if self.module.get_bin_path('useradd', required=False):
+            if self.uid_min is not None:
+                cmd.append('-K')
+                cmd.append('UID_MIN=' + str(self.uid_min))
 
-        if self.uid_max is not None:
-            cmd.append('-K')
-            cmd.append('UID_MAX=' + str(self.uid_max))
+            if self.uid_max is not None:
+                cmd.append('-K')
+                cmd.append('UID_MAX=' + str(self.uid_max))
 
         # system cannot be handled currently - should we error if its requested?
         # create the user

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -35,3 +35,4 @@
     - ansible_distribution != 'Alpine'
 - import_tasks: ssh_keygen.yml
 - import_tasks: uidmin_linux_behavior.yml
+  when: ansible_facts.system == 'FreeBSD'

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -34,3 +34,4 @@
     - ansible_facts.system == 'Linux'
     - ansible_distribution != 'Alpine'
 - import_tasks: ssh_keygen.yml
+- import_tasks: uidmin_linux_behavior.yml

--- a/test/integration/targets/user/tasks/uidmin_linux_behavior.yml
+++ b/test/integration/targets/user/tasks/uidmin_linux_behavior.yml
@@ -1,32 +1,52 @@
 ---
-- name: Verify uid_min, uid_max, and umask still work on Linux
+# Test that uid_min, uid_max, and umask are ignored on FreeBSD
+# FreeBSD's pw command doesn't support -K option (Linux-only)
+
+- name: Create user with uid_min and uid_max set to impossible constraints
   ansible.builtin.user:
-    name: testuser_integ
-    uid_min: 1500
-    uid_max: 2000
-    umask: "022"
-    state: present
-  register: user_result
+    name: uidtest
+    uid_min: 99999 # Set to impossible high value
+    uid_max: 99999 # Same impossible value
+    umask: "077"
+    create_home: yes
   become: true
+  register: user_create_result
+  when: ansible_os_family == "FreeBSD"
 
-- name: Ensure module did not fail
+- name: Get uid of created user
+  ansible.builtin.command: id -u uidtest
+  register: user_uid
+  become: true
+  when: ansible_os_family == "FreeBSD"
+
+- name: Verify user was created despite impossible uid_min/uid_max constraints
   ansible.builtin.assert:
     that:
-      - user_result is not failed
+      - user_create_result is not failed
+      - user_uid.stdout|int < 99999 # UID should be normal (not the impossible constraint)
+    msg: |
+      On FreeBSD, uid_min/uid_max constraints should be ignored.
+      User should be created with normal UID (not 99999).
+  when: ansible_os_family == "FreeBSD"
 
-- name: Check that user was created
-  ansible.builtin.getent:
-    database: passwd
-    key: testuser_integ
-  register: passwd_entry
+- name: Stat home directory
+  ansible.builtin.stat:
+    path: /home/uidtest
+  register: homestat
+  become: true
+  when: ansible_os_family == "FreeBSD"
 
-- name: Assert user exists
+- name: Verify umask was ignored (home dir has default permissions)
   ansible.builtin.assert:
     that:
-      - passwd_entry is not failed
+      - homestat.stat.mode != "0700" # If umask=077 was applied, dir would be 0700
+    msg: "On FreeBSD, umask should be ignored (home dir should have default permissions)"
+  when: ansible_os_family == "FreeBSD"
 
 - name: Cleanup test user
   ansible.builtin.user:
-    name: testuser_integ
+    name: uidtest
     state: absent
+    remove: yes
   become: true
+  when: ansible_os_family == "FreeBSD"

--- a/test/integration/targets/user/tasks/uidmin_linux_behavior.yml
+++ b/test/integration/targets/user/tasks/uidmin_linux_behavior.yml
@@ -1,0 +1,32 @@
+---
+- name: Verify uid_min, uid_max, and umask still work on Linux
+  ansible.builtin.user:
+    name: testuser_integ
+    uid_min: 1500
+    uid_max: 2000
+    umask: "022"
+    state: present
+  register: user_result
+  become: true
+
+- name: Ensure module did not fail
+  ansible.builtin.assert:
+    that:
+      - user_result is not failed
+
+- name: Check that user was created
+  ansible.builtin.getent:
+    database: passwd
+    key: testuser_integ
+  register: passwd_entry
+
+- name: Assert user exists
+  ansible.builtin.assert:
+    that:
+      - passwd_entry is not failed
+
+- name: Cleanup test user
+  ansible.builtin.user:
+    name: testuser_integ
+    state: absent
+  become: true

--- a/test/integration/targets/user/tasks/uidmin_linux_behavior.yml
+++ b/test/integration/targets/user/tasks/uidmin_linux_behavior.yml
@@ -11,13 +11,11 @@
     create_home: yes
   become: true
   register: user_create_result
-  when: ansible_os_family == "FreeBSD"
 
 - name: Get uid of created user
   ansible.builtin.command: id -u uidtest
   register: user_uid
   become: true
-  when: ansible_os_family == "FreeBSD"
 
 - name: Verify user was created despite impossible uid_min/uid_max constraints
   ansible.builtin.assert:
@@ -27,21 +25,18 @@
     msg: |
       On FreeBSD, uid_min/uid_max constraints should be ignored.
       User should be created with normal UID (not 99999).
-  when: ansible_os_family == "FreeBSD"
 
 - name: Stat home directory
   ansible.builtin.stat:
     path: /home/uidtest
   register: homestat
   become: true
-  when: ansible_os_family == "FreeBSD"
 
 - name: Verify umask was ignored (home dir has default permissions)
   ansible.builtin.assert:
     that:
       - homestat.stat.mode != "0700" # If umask=077 was applied, dir would be 0700
     msg: "On FreeBSD, umask should be ignored (home dir should have default permissions)"
-  when: ansible_os_family == "FreeBSD"
 
 - name: Cleanup test user
   ansible.builtin.user:
@@ -49,4 +44,3 @@
     state: absent
     remove: yes
   become: true
-  when: ansible_os_family == "FreeBSD"


### PR DESCRIPTION
SUMMARY
Fix handling of `uid_min`, `uid_max`, and `umask` options in `ansible.builtin.user` on FreeBSD.
FreeBSD’s `pw useradd` command does not support the Linux-specific `-K` option, causing failures when these parameters are set.
This change ensures these options are only applied when `useradd` is available (Linux), matching documentation stating they are ignored on non-Linux platforms.

Fixes: #86252

Signed-off-by: Jason Hall <jason.kei.hall@gmail.com>

ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
lib/ansible/modules/user.py