### PR TITLE
adhoc - fix traceback for meta end_play tasks

### DIFF
--- a/changelogs/fragments/fix-adhoc-meta-end_play.yml
+++ b/changelogs/fragments/fix-adhoc-meta-end_play.yml
@@ -1,3 +1,3 @@
 bugfixes:
 - >-
-  adhoc - fix executing ``- meta: end_play`` tasks.
+  ``ansible``, ``ansible-console`` - fix executing ``- meta: end_play`` tasks.

--- a/changelogs/fragments/fix-adhoc-meta-end_play.yml
+++ b/changelogs/fragments/fix-adhoc-meta-end_play.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- >-
+  adhoc - fix executing ``- meta: end_play`` tasks.

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -14,7 +14,7 @@ from ansible import constants as C
 from ansible import context
 from ansible.cli.arguments import option_helpers as opt_help
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
-from ansible.executor.task_queue_manager import TaskQueueManager
+from ansible.executor.task_queue_manager import AnsibleEndPlay, TaskQueueManager
 from ansible.module_utils.common.text.converters import to_text
 from ansible.parsing.splitter import parse_kv
 from ansible.playbook import Playbook
@@ -198,6 +198,8 @@ class AdHocCLI(CLI):
             result = self._tqm.run(play)
 
             self._tqm.send_callback('v2_playbook_on_stats', self._tqm._stats)
+        except AnsibleEndPlay as e:
+            result = e.result
         finally:
             if self._tqm:
                 self._tqm.cleanup()

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -20,7 +20,7 @@ import sys
 from ansible import constants as C
 from ansible import context
 from ansible.cli.arguments import option_helpers as opt_help
-from ansible.executor.task_queue_manager import TaskQueueManager
+from ansible.executor.task_queue_manager import AnsibleEndPlay, TaskQueueManager
 from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.parsing.splitter import parse_kv
@@ -230,6 +230,8 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
                 result = self._tqm.run(play)
                 display.debug(result)
+            except AnsibleEndPlay as e:
+                result = e.result
             finally:
                 if self._tqm:
                     self._tqm.cleanup()

--- a/test/integration/targets/adhoc/roles/end_play/tasks/main.yml
+++ b/test/integration/targets/adhoc/roles/end_play/tasks/main.yml
@@ -1,0 +1,1 @@
+- meta: end_play

--- a/test/integration/targets/adhoc/runme.sh
+++ b/test/integration/targets/adhoc/runme.sh
@@ -26,3 +26,5 @@ ansible localhost -m setup > /dev/null
 ansible localhost -m assert -a '{"that": "ansible_facts.distribution is defined"}'
 # test flushing the fact cache
 ansible --flush-cache localhost -m debug -a "msg={{ ansible_facts }}" | grep '"msg": {}'
+# test meta end_play
+ansible localhost -m include_role -a name=end_play

--- a/test/integration/targets/ansible-console/roles/end_play/tasks/main.yml
+++ b/test/integration/targets/ansible-console/roles/end_play/tasks/main.yml
@@ -1,0 +1,1 @@
+- meta: end_play

--- a/test/integration/targets/ansible-console/runme.sh
+++ b/test/integration/targets/ansible-console/runme.sh
@@ -8,3 +8,9 @@ set -eux
 unset ANSIBLE_HOST_PATTERN_MISMATCH
 
 echo debug var=inventory_hostname | ansible-console '{{"localhost"}}'
+
+echo include_role name=end_play | ansible-console localhost 2>&1 | tee err.txt
+if grep -q "ERROR" err.txt; then
+  echo "Failed to execute end_play"
+  exit 1
+fi


### PR DESCRIPTION
##### SUMMARY

Traceback shared here: https://forum.ansible.com/t/executing-meta-end-play-triggers-ansibleerror/44889

Prior to https://github.com/ansible/ansible/commit/e201b542be23bccd2418eab661cdf5454af3bea8, adhoc could execute `- meta: end_play` tasks successfully, and could be useful if adhoc is used to execute a tasks file or role.

##### ISSUE TYPE

- Bugfix Pull Request
