### PR TITLE
Add batch_groups feature for ordered group execution

### DIFF
--- a/changelogs/fragments/85965-batch_groups.yml
+++ b/changelogs/fragments/85965-batch_groups.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Add 'batch_groups' play keyword to execute hosts grouped by inventory groups in specified order (https://github.com/ansible/ansible/issues/85965)."

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -267,6 +267,33 @@ class PlaybookExecutor:
         all_hosts = self._inventory.get_hosts(play.hosts, order=play.order)
         all_hosts_len = len(all_hosts)
 
+        # If batch_groups is specified, reorder hosts by groups
+        if play.batch_groups:
+            reordered_hosts = []
+            # Track which hosts we've already added (by name)
+            added_host_names = set()
+
+            # Create a dict of hostname -> Host object from all_hosts
+            all_hosts_dict = {h.name: h for h in all_hosts}
+
+            for group_name in play.batch_groups:
+                # Get hosts in this group
+                group_hosts = self._inventory.get_hosts(group_name)
+                for host in group_hosts:
+                    # Check if this host (by name) is in all_hosts
+                    if host.name in all_hosts_dict and host.name not in added_host_names:
+                        reordered_hosts.append(all_hosts_dict[host.name])
+                        added_host_names.add(host.name)
+
+            # Add any remaining hosts that weren't in batch_groups
+            for host in all_hosts:
+                if host.name not in added_host_names:
+                    reordered_hosts.append(host)
+
+            # Update all_hosts with reordered list
+            all_hosts = reordered_hosts
+            all_hosts_len = len(all_hosts)
+
         # the serial value can be listed as a scalar or a list of
         # scalars, so we make sure it's a list here
         serial_batch_list = play.serial

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -85,6 +85,7 @@ class Play(Base, Taggable, CollectionSearch):
     force_handlers = NonInheritableFieldAttribute(isa='bool', default=context.cliargs_deferred_get('force_handlers'), always_post_validate=True)
     max_fail_percentage = NonInheritableFieldAttribute(isa='percent', always_post_validate=True)
     serial = NonInheritableFieldAttribute(isa='list', default=list, always_post_validate=True)
+    batch_groups = NonInheritableFieldAttribute(isa='list', default=list, always_post_validate=True)
     strategy = NonInheritableFieldAttribute(isa='string', default=C.DEFAULT_STRATEGY, always_post_validate=True)
     order = NonInheritableFieldAttribute(isa='string', always_post_validate=True)
 

--- a/test/integration/targets/batch_groups/aliases
+++ b/test/integration/targets/batch_groups/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/test/integration/targets/batch_groups/inventory
+++ b/test/integration/targets/batch_groups/inventory
@@ -1,0 +1,12 @@
+[webservers]
+web1 ansible_connection=local
+web2 ansible_connection=local  
+web3 ansible_connection=local
+
+[dbservers]
+db1 ansible_connection=local
+db2 ansible_connection=local
+
+[all:children]
+webservers
+dbservers

--- a/test/integration/targets/batch_groups/tasks/main.yml
+++ b/test/integration/targets/batch_groups/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- debug:
+    msg: "Running on {{ inventory_hostname }}"

--- a/test/integration/targets/batch_groups/tests/test.yml
+++ b/test/integration/targets/batch_groups/tests/test.yml
@@ -1,0 +1,11 @@
+---
+- name: Test batch_groups
+  hosts: all
+  connection: local
+  batch_groups:
+    - webservers
+    - dbservers
+  serial: 1
+  tasks:
+    - debug:
+        msg: "Processing {{ inventory_hostname }} in order"

--- a/test/units/executor/test_playbook_executor.py
+++ b/test/units/executor/test_playbook_executor.py
@@ -144,3 +144,93 @@ class TestPlaybookExecutor(unittest.TestCase):
             pbe._get_serialized_batches(play),
             [['host0', 'host1'], ['host2', 'host3'], ['host4', 'host5'], ['host6', 'host7'], ['host8', 'host9'], ['host10']]
         )
+
+    def test_get_serialized_batches_with_batch_groups(self):
+        """Test the batch_groups feature for ordering hosts by groups."""
+        fake_loader = DictDataLoader({
+            'batch_groups.yml': """
+            - hosts: all
+              gather_facts: no
+              batch_groups:
+                - webservers
+                - dbservers
+              serial: 2
+              tasks:
+              - debug: var=inventory_hostname
+            """,
+        })
+
+        mock_inventory = MagicMock()
+        mock_var_manager = MagicMock()
+
+        templar = TemplateEngine(loader=fake_loader)
+
+        pbe = PlaybookExecutor(
+            playbooks=['batch_groups.yml'],
+            inventory=mock_inventory,
+            variable_manager=mock_var_manager,
+            loader=fake_loader,
+            passwords=[],
+        )
+
+        # Create mock host objects
+        web1 = MagicMock()
+        web1.name = 'web1'
+        web2 = MagicMock()
+        web2.name = 'web2'
+        web3 = MagicMock()
+        web3.name = 'web3'
+        db1 = MagicMock()
+        db1.name = 'db1'
+        db2 = MagicMock()
+        db2.name = 'db2'
+        app1 = MagicMock()
+        app1.name = 'app1'
+
+        all_hosts = [web1, web2, web3, db1, db2, app1]
+
+        def mock_get_hosts(pattern=None, order=None):
+            # pattern might be a list
+            if pattern == 'all' or (isinstance(pattern, list) and 'all' in pattern):
+                return all_hosts
+            elif pattern == 'webservers' or (isinstance(pattern, list) and 'webservers' in pattern):
+                return [web1, web2, web3]
+            elif pattern == 'dbservers' or (isinstance(pattern, list) and 'dbservers' in pattern):
+                return [db1, db2]
+            else:
+                return []
+
+        mock_inventory.get_hosts.side_effect = mock_get_hosts
+
+        playbook = Playbook.load('batch_groups.yml', variable_manager=mock_var_manager, loader=fake_loader)
+        play = playbook.get_plays()[0]
+
+        play.post_validate(templar)
+
+        batches = pbe._get_serialized_batches(play)
+
+        # With our current implementation (reorder then batch):
+        # 1. Reorder by batch_groups: web1, web2, web3, db1, db2, app1
+        # 2. Apply serial=2: [web1, web2], [web3, db1], [db2, app1]
+
+        # Check we have 3 batches
+        self.assertEqual(len(batches), 3)
+
+        # Check batch contents
+        batch_names = [[h.name for h in batch] for batch in batches]
+        self.assertEqual(batch_names[0], ['web1', 'web2'])
+        self.assertEqual(batch_names[1], ['web3', 'db1'])
+        self.assertEqual(batch_names[2], ['db2', 'app1'])
+
+        # Also test that hosts are reordered (webservers before dbservers)
+        # Even though batches mix groups, order within reordered list is correct
+        all_reordered = [h for batch in batches for h in batch]
+        reordered_names = [h.name for h in all_reordered]
+
+        # Check webservers come before dbservers in the flattened list
+        web_indices = [i for i, name in enumerate(reordered_names) if name.startswith('web')]
+        db_indices = [i for i, name in enumerate(reordered_names) if name.startswith('db')]
+
+        # All webserver indices should be less than all dbserver indices
+        if web_indices and db_indices:
+            self.assertTrue(max(web_indices) < min(db_indices))


### PR DESCRIPTION
SUMMARY
Add batch_groups play keyword for executing hosts grouped by inventory groups in specified order.
Fixes: #85965

Signed-off by: Jason Hall jason.kei.hall@gmail.com

ISSUE TYPE
Feature Pull Request

COMPONENT NAME
lib/ansible/playbook/play.py
lib/ansible/executor/playbook_executor.py
test/units/executor/test_playbook_executor.py
test/integration/targets/batch_groups/
changelogs/fragments/85965-batch_groups.yml