### PR TITLE
[stable-2.20] fix package installation when specifying architecture without version. Fixes #86156 (#86219)

### DIFF
--- a/changelogs/fragments/86156-dnf-multilib-arch.yml
+++ b/changelogs/fragments/86156-dnf-multilib-arch.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "dnf - fix package installation when specifying architecture without version (e.g., ``libgcc.i686``) where a different architecture of the same package is already installed (https://github.com/ansible/ansible/issues/86156)."

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -717,9 +717,16 @@ class DnfModule(YumDnf):
             else:
                 solution = dnf.subject.Subject(pkg_spec).get_best_solution(self.base.sack)
                 q = solution["query"]
-                if not q or not solution['nevra'] or solution['nevra'].has_just_name():
+                nevra = solution['nevra']
+                if not q or not nevra or nevra.has_just_name() or not nevra.version:
                     return False
-                installed = self.base.sack.query().installed().filter(name=solution['nevra'].name)
+
+                # Filter by name and arch (if specified), but NOT by version
+                # since we need to find installed packages to compare versions against
+                filter_kwargs = {'name': nevra.name}
+                if nevra.arch:
+                    filter_kwargs['arch'] = nevra.arch
+                installed = self.base.sack.query().installed().filter(**filter_kwargs)
                 if not installed:
                     return False
                 return installed[0].evr_gt(q[0])

--- a/test/integration/targets/dnf/tasks/multilib.yml
+++ b/test/integration/targets/dnf/tasks/multilib.yml
@@ -57,6 +57,51 @@
             - "not dnf_result.changed"
             - "rpm_result.stdout_lines[0].startswith('multilib-dinginessentail-1.1-1')"
             - "rpm_result.stdout_lines[1].startswith('multilib-dinginessentail-1.1-1')"
+
+    - name: remove multilib-dinginessentail for arch-only test
+      dnf:
+        name: multilib-dinginessentail
+        state: absent
+
+    - name: install x86_64 version first
+      dnf:
+        name: "multilib-dinginessentail-1.0-1.x86_64"
+        state: present
+      register: dnf_result
+
+    - assert:
+        that:
+          - dnf_result is changed
+
+    - name: install i686 version by specifying only arch (no version)
+      dnf:
+        name: "multilib-dinginessentail.i686"
+        state: present
+      register: dnf_result
+
+    - name: check multilib-dinginessentail with rpm
+      shell: rpm -q multilib-dinginessentail
+      register: rpm_result
+
+    - name: verify both architectures are installed
+      assert:
+        that:
+          - dnf_result is changed
+          - rpm_result.stdout_lines | length == 2
+          - rpm_result.stdout_lines | select('match', '.*\\.x86_64$') | list | length == 1
+          - rpm_result.stdout_lines | select('match', '.*\\.i686$') | list | length == 1
+
+    - name: install i686 version again to verify idempotency
+      dnf:
+        name: "multilib-dinginessentail.i686"
+        state: present
+      register: dnf_result
+
+    - name: verify no changes on second install
+      assert:
+        that:
+          - dnf_result is not changed
+
   always:
     - name: Clean up
       dnf:


### PR DESCRIPTION
(cherry picked from commit 8a4b184)

Co-authored-by: sivel / Matt Martz <matt@sivel.net>