### PR TITLE
Fix argument spec for v1 source info schema validation

### DIFF
--- a/changelogs/fragments/86320-schema-validation.yml
+++ b/changelogs/fragments/86320-schema-validation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix source metadata validation (https://github.com/ansible/ansible/pull/86320)."

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -90,8 +90,9 @@ def _validate_v1_source_info_schema(
         version_url=dict(),
         server=dict(),
         signatures=dict(
-            type=list,
-            suboptions=dict(
+            type="list",
+            elements="dict",
+            options=dict(
                 signature=dict(),
                 pubkey_fingerprint=dict(),
                 signing_service=dict(),

--- a/test/units/galaxy/test_collection_dataclasses.py
+++ b/test/units/galaxy/test_collection_dataclasses.py
@@ -6,9 +6,12 @@
 
 from __future__ import annotations
 
+import typing as t
+
 import pytest
 
-from ansible.galaxy.dependency_resolution.dataclasses import Requirement
+from ansible.errors import AnsibleError
+from ansible.galaxy.dependency_resolution.dataclasses import Requirement, _validate_v1_source_info_schema
 
 
 NO_LEADING_WHITESPACES = pytest.mark.xfail(
@@ -62,3 +65,175 @@ def test_requirement_is_pinned_logic(
         'namespace.collection', collection_version_spec,
         None, None, None,
     ).is_pinned is expected_is_pinned_outcome
+
+
+@pytest.mark.parametrize(
+    ("namespace", "name", "version", "provided_arguments", "expected_errors"),
+    [
+        (
+            # Empty data
+            "foo",
+            "bar",
+            "1.2.3",
+            {},
+            [],
+        ),
+        (
+            # Correct data
+            "foo",
+            "bar",
+            "1.2.3",
+            {
+                "format_version": "1.0.0",
+                "download_url": "asdf",
+                "version_url": "asdf",
+                "server": "asdf",
+                "signatures": [
+                    {
+                        "signature": "asdf",
+                        "pubkey_fingerprint": "asdf",
+                        "signing_service": "asdf",
+                        "pulp_created": "asdf",
+                    },
+                ],
+                "name": "bar",
+                "namespace": "foo",
+                "version": "1.2.3",
+            },
+            [],
+        ),
+        (
+            # Random data that is convertible to string, but not a string
+            "foo",
+            "bar",
+            "1.2.3",
+            {
+                "format_version": "1.0.0",
+                "download_url": 123,
+                "version_url": 1.23,
+                "server": True,
+                "signatures": [
+                    {
+                        "signature": [],
+                        "pubkey_fingerprint": {},
+                        "signing_service": None,
+                        "pulp_created": 42,
+                    },
+                ],
+                "name": "bar",
+                "namespace": "foo",
+                "version": "1.2.3",
+            },
+            [],
+        ),
+        (
+            # Invalid data 1
+            "foo",
+            "bar",
+            "1.2.3",
+            {
+                "format_version": 123,
+                "signatures": "a,b,c",
+                "name": "asdf",
+                "namespace": "fdsa",
+                "version": "asdffdsa",
+            },
+            [
+                'dictionary requested, could not parse JSON or key=value',
+                "Elements value for option 'signatures' is of type str and we were unable to convert "
+                "to dict: dictionary requested, could not parse JSON or key=value",
+                "Elements value for option 'signatures' is of type str and we were unable to convert "
+                "to dict: dictionary requested, could not parse JSON or key=value",
+                "Elements value for option 'signatures' is of type str and we were unable to convert "
+                "to dict: dictionary requested, could not parse JSON or key=value",
+                'value of format_version must be one of: 1.0.0, got: 123',
+                'value of name must be one of: bar, got: asdf',
+                'value of namespace must be one of: foo, got: fdsa',
+                'value of version must be one of: 1.2.3, got: asdffdsa',
+            ],
+        ),
+        (
+            # Invalid data 2
+            "foo",
+            "bar",
+            "1.2.3",
+            {
+                "format_version": 123,
+                "signatures": {},
+                "name": "asdf",
+                "namespace": "fdsa",
+                "version": "asdffdsa",
+            },
+            [
+                "argument 'signatures' is of type dict and we were unable to convert to list: <class 'dict'> cannot be converted to a list",
+                'value of format_version must be one of: 1.0.0, got: 123',
+                'value of name must be one of: bar, got: asdf',
+                'value of namespace must be one of: foo, got: fdsa',
+                'value of version must be one of: 1.2.3, got: asdffdsa',
+            ],
+        ),
+        (
+            # Invalid data 3
+            "foo",
+            "bar",
+            "1.2.3",
+            {
+                "signatures": [
+                    {
+                        "foo": 1,
+                    },
+                    {
+                        "signature": None,
+                    },
+                    True,
+                ],
+            },
+            [
+                "Value 'True' in the sub parameter field 'signatures' must be a list, not 'bool'",
+                "Elements value for option 'signatures' is of type bool and we were unable "
+                "to convert to dict: <class 'bool'> cannot be converted to a dict",
+                'signatures.foo. Supported parameters include: pubkey_fingerprint, pulp_created, signature, signing_service.',
+            ],
+        ),
+        (
+            # Unknown parameters
+            "foo",
+            "bar",
+            "1.2.3",
+            {
+                "asdf": 123,
+                "meh": {},
+                "a": [],
+            },
+            [
+                'a, asdf, meh. Supported parameters include: download_url, format_version, '
+                'name, namespace, server, signatures, version, version_url.',
+            ],
+        ),
+    ],
+)
+def test__validate_v1_source_info_schema(
+    namespace: str,
+    name: str,
+    version: str,
+    provided_arguments: dict[str, object],
+    expected_errors: list[str],
+) -> None:
+    result = _validate_v1_source_info_schema(namespace, name, version, provided_arguments)
+    assert result == expected_errors
+
+
+@pytest.mark.parametrize(
+    ("provided_arguments",),
+    [
+        (None,),
+        ("asdf",),
+        (123,),
+        (1.2,),
+        (True,),
+        ([],),
+    ],
+)
+def test__validate_v1_source_info_schema_fail(provided_arguments: t.Any) -> None:
+    with pytest.raises(AnsibleError, match="^Invalid offline source info for foo.bar:1.2.3, expected a dict and got "):
+        _validate_v1_source_info_schema("foo", "bar", "1.2.3", provided_arguments)


### PR DESCRIPTION
##### SUMMARY
While working on types for argument specs, I noticed that the argument spec used for validating v1 source info schemas has two problems:
1. It uses `suboptions` instead of `options`.
2. It does not supply `elements` (so `options` isn't used anyway if 1. would be fixed).
3. It uses `type=list` instead of `type="list"`, which a) disables regular list validation, and b) has unexpected behaviors, for example if a string is there instead of a list. The string will be converted to a list of one-element strings since `list("foo") == ["f", "o", "o"]`.

##### ISSUE TYPE
- Bugfix Pull Request
