### PR TITLE
cron: allow env var with cron_file without requiring user (fix #83682)

### DIFF
--- a/changelogs/fragments/83682-cron-env-no-user.yml
+++ b/changelogs/fragments/83682-cron-env-no-user.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "cron module - Fix incorrect validation that required ``user`` when using ``cron_file`` with ``env: true``. Environment variables in cron files no longer require specifying a user. (https://github.com/ansible/ansible/issues/83682)"

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -651,7 +651,7 @@ def main():
         module.fail_json(msg="Solaris does not support special_time=... or @reboot")
 
     if do_install:
-        if cron_file and not user:
+        if cron_file and not user and not env:
             module.fail_json(msg="To use cron_file=... parameter you must specify user=... as well")
 
         if job is None:


### PR DESCRIPTION
SUMMARY
Allow environment variables to be added to cron files (`cron_file=`) without requiring the `user` parameter.
Previously the module incorrectly required `user=` even though cron.d environment variables do not include a user field.
Fixes: #83682

Signed-off-by: Jason Hall jason.kei.hall@gmail.com

ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
lib/ansible/modules/cron.py