### PR TITLE
copy: add create_parent option for file destinations

### DIFF
--- a/changelogs/fragments/85795-copy-create-parent.yml
+++ b/changelogs/fragments/85795-copy-create-parent.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible.builtin.copy - add ``create_parent`` option to create the parent directory of ``dest`` when copying a file.

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -56,7 +56,7 @@ options:
     - Behavior is unchanged when O(dest) ends with a trailing C(/).
     type: bool
     default: no
-    version_added: 'X.Y'
+    version_added: '2.21'
   backup:
     description:
     - Create a backup file including the timestamp information so you can get the original file back if you somehow clobbered it incorrectly.

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -49,6 +49,14 @@ options:
     - If O(src) and O(dest) are files, the parent directory of O(dest) is not created and the task fails if it does not already exist.
     type: path
     required: yes
+  create_parent:
+    description:
+    - Create the parent directory of O(dest) if it does not exist.
+    - This option only applies when O(dest) is a file path.
+    - Behavior is unchanged when O(dest) ends with a trailing C(/).
+    type: bool
+    default: no
+    version_added: 'X.Y'
   backup:
     description:
     - Create a backup file including the timestamp information so you can get the original file back if you somehow clobbered it incorrectly.
@@ -478,6 +486,7 @@ def main():
             local_follow=dict(type='bool'),
             checksum=dict(type='str'),
             follow=dict(type='bool', default=False),
+            create_parent=dict(type='bool', default=False),
         ),
         add_file_common_args=True,
         supports_check_mode=True,
@@ -492,6 +501,7 @@ def main():
     b_dest = to_bytes(dest, errors='surrogate_or_strict')
     backup = module.params['backup']
     force = module.params['force']
+    create_parent = module.params['create_parent']
     _original_basename = module.params.get('_original_basename', None)
     validate = module.params.get('validate', None)
     follow = module.params['follow']
@@ -581,6 +591,7 @@ def main():
         if os.access(b_dest, os.R_OK) and os.path.isfile(b_dest):
             checksum_dest = module.sha1(dest)
     else:
+        parent_dir = os.path.dirname(b_dest)
         if not os.path.exists(os.path.dirname(b_dest)):
             try:
                 # os.path.exists() can return false in some
@@ -591,10 +602,23 @@ def main():
             except OSError as e:
                 if "permission denied" in to_native(e).lower():
                     module.fail_json(msg="Destination directory %s is not accessible" % (os.path.dirname(dest)))
-            module.fail_json(msg="Destination directory %s does not exist" % (os.path.dirname(dest)))
 
-    if not os.access(os.path.dirname(b_dest), os.W_OK) and not module.params['unsafe_writes']:
-        module.fail_json(msg="Destination %s not writable" % (os.path.dirname(dest)))
+            if create_parent:
+                if not module.check_mode:
+                    try:
+                        os.makedirs(parent_dir, exist_ok=True)
+                    except OSError as e:
+                        module.fail_json(
+                            msg="Failed to create destination directory %s: %s" % (to_native(parent_dir), to_native(e))
+                        )
+                changed = True
+            else:
+                module.fail_json(
+                    msg="Destination directory %s does not exist" % (os.path.dirname(dest))
+                )
+
+        if not os.access(os.path.dirname(b_dest), os.W_OK) and not module.params['unsafe_writes']:
+            module.fail_json(msg="Destination %s not writable" % (os.path.dirname(dest)))
 
     backup_file = None
     if checksum_src != checksum_dest or os.path.islink(b_dest):

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -16,14 +16,15 @@ short_description: Template a file out to a target host
 options:
   follow:
     description:
-    - Determine whether symbolic links should be followed.
-    - When set to V(true) symbolic links will be followed, if they exist.
-    - When set to V(false) symbolic links will not be followed.
-    - Previous to Ansible 2.4, this was hardcoded as V(true).
+      - Determine whether symbolic links should be followed.
+      - When set to V(true) symbolic links will be followed, if they exist.
+      - When set to V(false) symbolic links will not be followed.
+      - Previous to Ansible 2.4, this was hardcoded as V(true).
     type: bool
     default: no
     version_added: '2.4'
-create_parent:
+
+  create_parent:
     description:
       - Create the parent directory of O(dest) if it does not exist.
       - This option only applies when O(dest) is a file path.

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -23,6 +23,14 @@ options:
     type: bool
     default: no
     version_added: '2.4'
+create_parent:
+    description:
+      - Create the parent directory of O(dest) if it does not exist.
+      - This option only applies when O(dest) is a file path.
+      - Behavior is unchanged when O(dest) ends with a trailing C(/).
+    type: bool
+    default: no
+    version_added: '2.21'
 notes:
 - For Windows you can use M(ansible.windows.win_template) which uses V(\\r\\n) as O(newline_sequence) by default.
 - The C(jinja2_native) setting has no effect. Native types are never used in the M(ansible.builtin.template) module

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -57,6 +57,7 @@ class ActionModule(ActionBase):
             follow = boolean(self._task.args.get('follow', False), strict=False)
             trim_blocks = boolean(self._task.args.get('trim_blocks', True), strict=False)
             lstrip_blocks = boolean(self._task.args.get('lstrip_blocks', False), strict=False)
+            create_parent = boolean(self._task.args.get('create_parent', False), strict=False)
         except TypeError as e:
             raise AnsibleActionFail(to_native(e))
 
@@ -162,6 +163,7 @@ class ActionModule(ActionBase):
                         src=result_file,
                         dest=dest,
                         follow=follow,
+                        create_parent=create_parent,
                     ),
                 )
                 # call with ansible.legacy prefix to eliminate collisions with collections while still allowing local override

--- a/test/integration/targets/copy/tasks/dest_file_create_parent.yml
+++ b/test/integration/targets/copy/tasks/dest_file_create_parent.yml
@@ -1,0 +1,34 @@
+# Test create_parent option for file destinations
+
+- name: Copy file to non-existent directory with create_parent
+  ansible.builtin.copy:
+    src: foo.txt
+    dest: "{{ remote_tmp_dir }}/create_parent_test/foo.txt"
+    create_parent: true
+  register: copy_with_create_parent
+
+- name: Stat created file
+  ansible.builtin.stat:
+    path: "{{ remote_tmp_dir }}/create_parent_test/foo.txt"
+  register: created_file
+
+- name: Verify copy succeeded and file exists
+  assert:
+    that:
+      - copy_with_create_parent is changed
+      - created_file.stat.exists
+
+# ---- old behavior ----
+
+- name: Copy file to non-existent directory without create_parent (should fail)
+  ansible.builtin.copy:
+    src: foo.txt
+    dest: "{{ remote_tmp_dir }}/no_create_parent_test/foo.txt"
+  register: copy_without_create_parent
+  ignore_errors: true
+
+- name: Verify copy failed due to missing destination directory
+  assert:
+    that:
+      - copy_without_create_parent is failed
+      - "'does not exist' in copy_without_create_parent.msg"

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -1,13 +1,12 @@
 - block:
-
     - name: Create a local temporary directory
       shell: mktemp -d /tmp/ansible_test.XXXXXXXXX
       register: tempfile_result
       delegate_to: localhost
 
     - set_fact:
-        local_temp_dir: '{{ tempfile_result.stdout }}'
-        remote_dir: '{{ remote_tmp_dir }}/copy'
+        local_temp_dir: "{{ tempfile_result.stdout }}"
+        remote_dir: "{{ remote_tmp_dir }}/copy"
         symlinks:
           ansible-test-abs-link: /tmp/ansible-test-abs-link
           ansible-test-abs-link-dir: /tmp/ansible-test-abs-link-dir
@@ -25,19 +24,19 @@
     - name: Create symbolic link
       command: "ln -s '{{ item.value }}' '{{ item.key }}'"
       args:
-        chdir: '{{role_path}}/files/subdir/subdir1'
+        chdir: "{{role_path}}/files/subdir/subdir1"
       with_dict: "{{ symlinks }}"
       delegate_to: localhost
 
     - name: Create group for remote unprivileged user
       group:
-        name: '{{ remote_unprivileged_user_group }}'
+        name: "{{ remote_unprivileged_user_group }}"
       register: group
 
     - name: Create remote unprivileged remote user
       user:
-        name: '{{ remote_unprivileged_user }}'
-        group: '{{ remote_unprivileged_user_group }}'
+        name: "{{ remote_unprivileged_user }}"
+        group: "{{ remote_unprivileged_user_group }}"
       register: user
 
     - name: Check sudoers dir
@@ -56,27 +55,27 @@
 
     - file:
         path: "{{ user.home }}/.ssh"
-        owner: '{{ remote_unprivileged_user }}'
+        owner: "{{ remote_unprivileged_user }}"
         state: directory
         mode: 0700
 
     - name: Duplicate authorized_keys
       copy:
         src: $HOME/.ssh/authorized_keys
-        dest: '{{ user.home }}/.ssh/authorized_keys'
-        owner: '{{ remote_unprivileged_user }}'
+        dest: "{{ user.home }}/.ssh/authorized_keys"
+        owner: "{{ remote_unprivileged_user }}"
         mode: 0600
         remote_src: yes
 
     - file:
         path: "{{ remote_dir }}"
         state: directory
-      remote_user: '{{ remote_unprivileged_user }}'
+      remote_user: "{{ remote_unprivileged_user }}"
 
     # execute tests tasks using an unprivileged user, this is useful to avoid
     # local/remote ambiguity when controller and managed hosts are identical.
     - import_tasks: tests.yml
-      remote_user: '{{ remote_unprivileged_user }}'
+      remote_user: "{{ remote_unprivileged_user }}"
 
     - import_tasks: acls.yml
       when: ansible_system == 'Linux'
@@ -90,6 +89,8 @@
       delegate_to: localhost
 
     - import_tasks: check_mode.yml
+
+    - import_tasks: dest_file_create_parent.yml
 
     # https://github.com/ansible/ansible/issues/57618
     # https://github.com/ansible/ansible/issues/79749
@@ -111,8 +112,8 @@
 
     - name: Test internal options
       copy:
-        content: 'irrelevant'
-        dest: '{{ local_temp_dir}}/file.txt'
+        content: "irrelevant"
+        dest: "{{ local_temp_dir}}/file.txt"
         _diff_peek: true
       register: peek
       ignore_errors: true
@@ -126,27 +127,27 @@
   always:
     - name: Cleaning
       file:
-        path: '{{ local_temp_dir }}'
+        path: "{{ local_temp_dir }}"
         state: absent
       delegate_to: localhost
 
     - name: Remove symbolic link
       file:
-        path: '{{ role_path }}/files/subdir/subdir1/{{ item.key }}'
+        path: "{{ role_path }}/files/subdir/subdir1/{{ item.key }}"
         state: absent
       delegate_to: localhost
       with_dict: "{{ symlinks }}"
 
     - name: Remote unprivileged remote user
       user:
-        name: '{{ remote_unprivileged_user }}'
+        name: "{{ remote_unprivileged_user }}"
         state: absent
         remove: yes
         force: yes
 
     - name: Remove group for remote unprivileged user
       group:
-        name: '{{ remote_unprivileged_user_group }}'
+        name: "{{ remote_unprivileged_user_group }}"
         state: absent
 
     - name: Remove sudoers.d file


### PR DESCRIPTION
SUMMARY
Add create_parent option to ansible.builtin.copy and ansible.builtin.template to explicitly create the parent directory of a file destination when it does not exist.
This makes existing implicit behavior explicit and controllable without changing default behavior.

Fixes: #85795

Signed-off-by: Jason Hall <jason.kei.hall@gmail.com>

ISSUE TYPE
Feature Pull Request

COMPONENT NAME
lib/ansible/modules/copy.py
lib/ansible/modules/template.py
lib/ansible/plugins/action/template.py
