### PR TITLE
uri: Fixed is_uri to correctly reject strings without a URI scheme.

### DIFF
--- a/lib/ansible/plugins/test/uri.py
+++ b/lib/ansible/plugins/test/uri.py
@@ -9,7 +9,8 @@ def is_uri(value, schemes=None):
     """ Will verify that the string passed is a valid 'URI', if given a list of valid schemes it will match those """
     try:
         x = urlparse(value)
-        isit = all([x.scheme is not None, x.path is not None, not schemes or x.scheme in schemes])
+        # urlparse returns empty string for scheme when not present, not None
+        isit = all([x.scheme, x.path is not None, not schemes or x.scheme in schemes])
     except Exception as e:
         isit = False
     return isit


### PR DESCRIPTION
##### SUMMARY
Fixed the `is_uri` test plugin to reject strings without a URI scheme. The func was checking x.scheme is not None, but urlparse() returns an empty string ''(not None) when no scheme is present. Now would work for URIs like `"not-a-uri"`, `"just-text"`, `"/path/to/file"`, & even empty strings.




##### ISSUE TYPE
- Bugfix Pull Request
