### PR TITLE
[stable-2.20] copy - fix reporting changed=True when local single-file dir is copied

### DIFF
--- a/changelogs/fragments/85834-fix-copy-in-single-file-directory.yml
+++ b/changelogs/fragments/85834-fix-copy-in-single-file-directory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "copy - when a single-file local directory was specified as the source, ``changed`` used to be ``false`` even when the source was actually copied. It now makes sure ``changed`` is ``true`` in this case. (https://github.com/ansible/ansible/issues/85833)"

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -529,11 +529,9 @@ class ActionModule(ActionBase):
                 result.update(module_return)
                 return self._ensure_invocation(result)
 
-            paths = os.path.split(source_rel)
-            dir_path = ''
-            for dir_component in paths:
-                os.path.join(dir_path, dir_component)
-                implicit_directories.add(dir_path)
+            while (source_rel := os.path.dirname(source_rel)) != '':
+                implicit_directories.add(source_rel)
+
             if 'diff' in result and not result['diff']:
                 del result['diff']
             module_executed = True

--- a/test/integration/targets/copy/tasks/src_directory_contaning_one_single_file.yml
+++ b/test/integration/targets/copy/tasks/src_directory_contaning_one_single_file.yml
@@ -1,0 +1,29 @@
+# Test copying to a source directory that contains only a single file in a deeper structure
+
+- name: Ensure that dest top directory doesn't exist
+  file:
+    path: '{{ remote_dir }}/subdir_with_deep_single_file'
+    state: absent
+
+- name: Copy subdir_with_deep_single_file directory which contains a single file
+  copy:
+    src: subdir_with_deep_single_file
+    dest: '{{ remote_dir }}'
+  register: copy_result
+
+- name: Debug copy result
+  debug:
+    var: copy_result
+    verbosity: 1
+
+- name: Check the transferred file
+  stat:
+    path: '{{ remote_dir }}/subdir_with_deep_single_file/dir/file.txt'
+  register: stat_file
+
+- name: Assert that transferred file exists and copy_result is as expected for deeper structure
+  assert:
+    that:
+      - 'stat_file.stat.exists'
+      - 'copy_result.changed'
+      - 'copy_result.dest == remote_dir + "/subdir_with_deep_single_file/dir/file.txt"'

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -2531,3 +2531,5 @@
         state: absent
       loop:
         - '{{ remote_file }}'
+
+- include_tasks: src_directory_contaning_one_single_file.yml


### PR DESCRIPTION
##### SUMMARY

Backport for #85834

* Fix directory path construction in the action plugin

Fixes #85833

(cherry picked from commit 17fb4af38d3e8aedec91cecf6707da0f6b30bad5)

##### ISSUE TYPE

- Bugfix Pull Request
