### PR TITLE
ansible-galaxy - Change error to warning when no paths exist

### DIFF
--- a/changelogs/fragments/86341-galaxy-list-warn.yml
+++ b/changelogs/fragments/86341-galaxy-list-warn.yml
@@ -1,0 +1,2 @@
+bugfixes:
+   - ansible-galaxy - warn instead of raising an error when no valid role or collections paths exist (https://github.com/ansible/ansible/pull/86341)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1610,8 +1610,8 @@ class GalaxyCLI(CLI):
             display.warning(w)
 
         if not path_found:
-            raise AnsibleOptionsError(
-                "- None of the provided paths were usable. Please specify a valid path with --{0}s-path".format(context.CLIARGS['type'])
+            display.warning(
+                "None of the provided paths were usable. Please specify a valid path with --{0}s-path.".format(context.CLIARGS['type'])
             )
 
         return 0
@@ -1695,8 +1695,8 @@ class GalaxyCLI(CLI):
             display.warning(w)
 
         if not collections and not path_found:
-            raise AnsibleOptionsError(
-                "- None of the provided paths were usable. Please specify a valid path with --{0}s-path".format(context.CLIARGS['type'])
+            display.warning(
+                "None of the provided paths were usable. Please specify a valid path with --{0}s-path.".format(context.CLIARGS['type'])
             )
 
         if output_format == 'json':

--- a/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/list.yml
@@ -152,14 +152,13 @@
 - name: test that no json is emitted when no collection paths are usable
   command: "ansible-galaxy collection list --format json"
   register: list_result_error
-  ignore_errors: True
   environment:
     ANSIBLE_COLLECTIONS_PATH: "i_dont_exist"
 
-- name: Ensure we get the expected error
+- name: Ensure we get the expected warning
   assert:
     that:
-      - "'{}' not in list_result_error.stdout"
+      - "'{}' in list_result_error.stdout"
       - "'None of the provided paths were usable' in list_result_error.stderr"
 
 - name: install an artifact to the second collections path

--- a/test/units/cli/galaxy/test_execute_list_collection.py
+++ b/test/units/cli/galaxy/test_execute_list_collection.py
@@ -11,7 +11,7 @@ import pytest
 from ansible import constants as C
 from ansible import context
 from ansible.cli.galaxy import GalaxyCLI
-from ansible.errors import AnsibleError, AnsibleOptionsError
+from ansible.errors import AnsibleError
 from ansible.galaxy import collection
 from ansible.galaxy.dependency_resolution.dataclasses import Requirement
 from ansible.module_utils.common.text.converters import to_native
@@ -201,12 +201,12 @@ def test_execute_list_collection_no_valid_paths(mocker, capsys, tmp_path_factory
     tmp_path = tmp_path_factory.mktemp('test-ÅÑŚÌβŁÈ Collections')
     concrete_artifact_cm = collection.concrete_artifact_manager.ConcreteArtifactsManager(tmp_path, validate_certs=False)
 
-    with pytest.raises(AnsibleOptionsError, match=r'None of the provided paths were usable.'):
-        gc.execute_list_collection(artifacts_manager=concrete_artifact_cm)
+    gc.execute_list_collection(artifacts_manager=concrete_artifact_cm)
 
     out, err = capsys.readouterr()
 
     assert '[WARNING]: - the configured path' in err
+    assert '[WARNING]: None of the provided paths were usable' in err
     assert 'exists, but it is not a directory.' in err
 
 


### PR DESCRIPTION
##### SUMMARY

When listing collections and roles, a warning is much more appropriate than an error for missing paths.

Fixes #73127.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
