### PR TITLE
user - Warn when an invalid shell is specified on BusyBox systems

### DIFF
--- a/changelogs/fragments/86243-user-busybox-shell-warn.yml
+++ b/changelogs/fragments/86243-user-busybox-shell-warn.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - On BusyBox systems, warn when an invalid shell is specified (https://github.com/ansible/ansible/pull/86342)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3133,6 +3133,24 @@ class BusyBox(User):
         - remove_user()
         - modify_user()
     """
+    def _validate_shell(self):
+        if not self.shell:
+            return
+
+        try:
+            with open("/etc/shells", "r") as f:
+                shells = [
+                    shell
+                    for shell in (line.strip() for line in f)
+                    if shell
+                    and not shell.startswith("#")
+                ]
+        except FileNotFoundError:
+            return
+
+        if self.shell not in shells:
+            self.module.warn(f"'{self.shell}' is not listed as a valid shell on the remote host.")
+
     def _build_password_string(self, current_password=None):
         """
         Build the appropriate password string based on the current password and
@@ -3165,6 +3183,8 @@ class BusyBox(User):
 
     def create_user(self):
         cmd = [self.module.get_bin_path('adduser', True)]
+
+        self._validate_shell()
 
         cmd.append('-D')
 
@@ -3274,6 +3294,8 @@ class BusyBox(User):
 
         add_cmd_bin = self.module.get_bin_path('adduser', True)
         remove_cmd_bin = self.module.get_bin_path('delgroup', True)
+
+        self._validate_shell()
 
         # Manage group membership
         if self.groups:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -37,3 +37,4 @@
 - import_tasks: test_seuser_warning.yml
 - import_tasks: ssh_keygen.yml
 - include_tasks: test_modify_user_home.yml
+- include_tasks: test_invalid_shell.yml

--- a/test/integration/targets/user/tasks/test_invalid_shell.yml
+++ b/test/integration/targets/user/tasks/test_invalid_shell.yml
@@ -1,0 +1,26 @@
+---
+- name: Run test for Alpine Linux only
+  meta: end_host
+  when: ansible_distribution != 'Alpine'
+
+- name: Move user home directory
+  block:
+    - name: Create user with invalid shell
+      user:
+        name: ansibulluser
+        shell: /tmp/ansibulluser
+        state: present
+      register: user_output
+      ignore_errors: true
+
+    - name: Check if user output contains error
+      assert:
+        that:
+          - user_output.warnings is defined
+          - user_output.warnings is search("'/tmp/ansibulluser' is not listed as a valid shell on the remote host")
+
+  always:
+    - name: Remove user
+      user:
+        name: ansibulluser
+        state: absent


### PR DESCRIPTION
##### SUMMARY

Only for BusyBox since that was the context where this initally came up. It may make sense to add this warning more broadly.

`chsh` on Alpine warns but does not error when changing to an invalid shell. Other distros error with an invalid shell.

Depends on #86143.

Example output
```
> ansible-playbook playbook.yml

PLAY [all] ***************************************************************************************************

TASK [Gathering Facts] ***************************************************************************************
ok: [alpine]

TASK [user] **************************************************************************************************
[WARNING]: '/usr/bin/nope' is not listed as a valid shell on the remote host.
ok: [alpine]

PLAY RECAP ***************************************************************************************************
alpine                     : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
