### PR TITLE
deb822_repository: avoid over-normalizing repository names

### DIFF
--- a/changelogs/fragments/86243.bugfix.yml
+++ b/changelogs/fragments/86243.bugfix.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - deb822_repository no longer over-normalizes repository names when generating
+    sources list filenames, preventing collisions for names that differ by case,
+    underscores, or dots (https://github.com/ansible/ansible/issues/86243)

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -254,7 +254,6 @@ key_filename:
 """
 
 import os
-import re
 import sys
 import tempfile
 import textwrap
@@ -571,15 +570,7 @@ def main():
     state = params.pop('state')
 
     name = params['name']
-    slug = re.sub(
-        r'[^a-z0-9-]+',
-        '',
-        re.sub(
-            r'[_\s]+',
-            '-',
-            name.lower(),
-        ),
-    )
+    slug = name.replace(' ', '-')
     sources_filename = make_sources_filename(slug)
 
     if state == 'absent':

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -254,6 +254,7 @@ key_filename:
 """
 
 import os
+import re
 import sys
 import tempfile
 import textwrap
@@ -570,7 +571,22 @@ def main():
     state = params.pop('state')
 
     name = params['name']
-    slug = name.replace(' ', '-')
+
+    legacy_slug = re.sub(
+        r'[^a-z0-9-]+',
+        '',
+        re.sub(r'[_\s]+', '-', name.lower()),
+    )
+
+    new_slug = name.replace(' ', '-')
+
+    legacy_sources = make_sources_filename(legacy_slug)
+
+    if os.path.exists(legacy_sources):
+        slug = legacy_slug
+    else:
+        slug = new_slug
+
     sources_filename = make_sources_filename(slug)
 
     if state == 'absent':

--- a/test/integration/targets/deb822_repository/tasks/main.yml
+++ b/test/integration/targets/deb822_repository/tasks/main.yml
@@ -183,7 +183,7 @@
             state: absent
 
     - import_tasks: test.yml
-
+    - import_tasks: name_handling.yml
     - import_tasks: install.yml
   always:
     - name: uninstall python3-debian

--- a/test/integration/targets/deb822_repository/tasks/name_handling.yml
+++ b/test/integration/targets/deb822_repository/tasks/name_handling.yml
@@ -1,0 +1,62 @@
+---
+- name: Add repositories with distinct valid names
+  ansible.builtin.deb822_repository:
+    state: present
+    name: "{{ item }}"
+    types: [deb]
+    uris: ["http://example.invalid/repo"]
+    suites: ["stable"]
+    components: [main]
+  loop:
+    - foo-1.2.3
+    - foo_123
+    - FOO_1.23
+
+- name: Verify each sources file exists
+  stat:
+    path: "/etc/apt/sources.list.d/{{ item }}.sources"
+  loop:
+    - foo-1.2.3
+    - foo_123
+    - FOO_1.23
+  register: repo_files
+
+- name: Assert all sources files exist
+  assert:
+    that:
+      - repo_files.results | map(attribute='stat.exists') | min
+
+- name: Add repository with space in name
+  ansible.builtin.deb822_repository:
+    state: present
+    name: "foo 12.3"
+    types: [deb]
+    uris: ["http://example.invalid/repo"]
+    suites: ["stable"]
+    components: [main]
+  register: spaced_name_result
+
+- name: Assert repo creation succeeded
+  assert:
+    that:
+      - spaced_name_result is changed
+
+- name: Verify sources file normalized with dash
+  stat:
+    path: /etc/apt/sources.list.d/foo-12.3.sources
+  register: spaced_name_stat
+
+- name: Assert normalized sources file exists
+  assert:
+    that:
+      - spaced_name_stat.stat.exists
+
+- name: Clean up test repositories
+  ansible.builtin.deb822_repository:
+    name: "{{ item }}"
+    state: absent
+  loop:
+    - foo-1.2.3
+    - foo_123
+    - FOO_1.23
+    - foo 12.3


### PR DESCRIPTION
SUMMARY
Prevent deb822_repository from over-normalizing repository names when generating .sources filenames. This avoids filename collisions for distinct repository names and ensures valid characters are preserved.

Fixes: #86243

Signed-off-by: Jason Hall jason.kei.hall@gmail.com

ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
lib/ansible/modules/deb822_repository.py