### PR TITLE
Use `dict` in the local implementation of `unique`

### DIFF
--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -71,10 +71,7 @@ def unique(environment, a, case_sensitive=None, attribute=None):
             raise AnsibleError("Ansible's unique filter does not support case_sensitive=False nor attribute parameters, "
                                "you need a newer version of Jinja2 that provides their version of the filter.")
 
-        c = []
-        for x in a:
-            if x not in c:
-                c.append(x)
+        c = list(dict.fromkeys(a))
 
     return c
 


### PR DESCRIPTION
##### SUMMARY

Hello maintainers,

I am new to Ansible; I would like to understand its internals. Your feedback is much appreciated.

When the host does not have jinja2 packages, `unique` relies on a for-loop filter. Its execution time grows linearly with the data size:

    # python -m cProfile -s tottime uniq.py
             100005 function calls in 45.853 seconds

       Ordered by: internal time

       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
            1   45.838   45.838   45.851   45.851 uniq.py:1(uniq)
       100000    0.013    0.000    0.013    0.000 {method 'append' of 'list' objects}
            1    0.002    0.002   45.853   45.853 uniq.py:1(<module>)
            1    0.001    0.001    0.001    0.001 {method 'extend' of 'list' objects}
            1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
            1    0.000    0.000   45.853   45.853 {built-in method builtins.exec}

Use a `dict` instead, its execution time is almost constant.

    # python -m cProfile -s tottime uniq.py
             6 function calls in 0.008 seconds

       Ordered by: internal time

       ncalls  tottime  percall  cumtime  percall filename:lineno(function)
            1    0.005    0.005    0.005    0.005 {built-in method fromkeys}
            1    0.001    0.001    0.008    0.008 uniq.py:1(<module>)
            1    0.001    0.001    0.006    0.006 uniq.py:8(uniq2)
            1    0.000    0.000    0.000    0.000 {method 'extend' of 'list' objects}
            1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
            1    0.000    0.000    0.008    0.008 {built-in method builtins.exec}

Since [Python 3.7](https://docs.python.org/3/whatsnew/3.7.html#what-s-new-in-python-3-7), `dict` preserves insertion order. #63417 will not be hit; it is the reason why the for-loop was introduced.

Tested with,

     1  def uniq(a):
     2      c = []
     3      for x in a:
     4          if x not in c:
     5              c.append(x)
     6      return c
     7
     8  def uniq2(a):
     9      return list(dict.fromkeys(a))
    10
    11  init = list(range(100_000))
    12  init.extend(init)
    13
    14  uniq2(init)

##### ISSUE TYPE

- Feature Pull Request