### PR TITLE
file module, fix relative path symlink

### DIFF
--- a/changelogs/fragments/86146-file-relative-symlink-rewrite.yml
+++ b/changelogs/fragments/86146-file-relative-symlink-rewrite.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ansible.builtin.file: Fix atomic replacement of symlinks when using relative destination paths, which could previously fail with a permission error (https://github.com/ansible/ansible/issues/86146)."

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -767,9 +767,13 @@ def ensure_symlink(path, src, follow, force, timestamps):
     if changed and not module.check_mode:
         if prev_state != 'absent':
             # try to replace atomically
-            b_tmppath = to_bytes(os.path.sep).join(
-                [os.path.dirname(b_path), to_bytes(".%s.%s.tmp" % (os.getpid(), time.time()))]
-            )
+            b_pathdir = os.path.dirname(b_path)
+            b_tmpfile = to_bytes(".%s.%s.tmp" % (os.getpid(), time.time()))
+
+            if b_pathdir:
+                b_tmppath = to_bytes(os.path.sep).join([b_pathdir, b_tmpfile])
+            else:
+                b_tmppath = b_tmpfile
             try:
                 if prev_state == 'directory':
                     os.rmdir(b_path)
@@ -886,9 +890,13 @@ def ensure_hardlink(path, src, follow, force, timestamps):
     if changed and not module.check_mode:
         if prev_state != 'absent':
             # try to replace atomically
-            b_tmppath = to_bytes(os.path.sep).join(
-                [os.path.dirname(b_path), to_bytes(".%s.%s.tmp" % (os.getpid(), time.time()))]
-            )
+            b_pathdir = os.path.dirname(b_path)
+            b_tmpfile = to_bytes(".%s.%s.tmp" % (os.getpid(), time.time()))
+
+            if b_pathdir:
+                b_tmppath = to_bytes(os.path.sep).join([b_pathdir, b_tmpfile])
+            else:
+                b_tmppath = b_tmpfile
             try:
                 if prev_state == 'directory':
                     if os.path.exists(b_path):

--- a/test/integration/targets/file/tasks/link_rewrite.yml
+++ b/test/integration/targets/file/tasks/link_rewrite.yml
@@ -45,3 +45,41 @@
     that:
     - "file.stat.mode == '0644'"
     - "link.stat.lnk_target == 'somefile'"
+
+- name: create temporary build directory for relative link rewrite
+  tempfile:
+    state: directory
+    suffix: ansible_test_relative_link_rewrite
+  register: rewrite_tempdir
+
+- name: create target directories
+  file:
+    path: "{{ rewrite_tempdir.path }}/{{ item }}"
+    state: directory
+  loop:
+    - src_a
+    - src_b
+
+- name: create initial symlink with relative destination path
+  file:
+    state: link
+    src: src_a
+    dest: "{{ rewrite_tempdir.path }}/somelink"
+
+- name: rewrite symlink target using relative destination path
+  file:
+    state: link
+    src: src_b
+    dest: "{{ rewrite_tempdir.path }}/somelink"
+    force: yes
+
+- name: stat rewritten symlink
+  stat:
+    path: "{{ rewrite_tempdir.path }}/somelink"
+    follow: false
+  register: rewritten_link
+
+- assert:
+    that:
+      - rewritten_link.stat.islnk
+      - rewritten_link.stat.lnk_target == 'src_b'


### PR DESCRIPTION
SUMMARY

Fix atomic replacement of symlinks when using relative destination paths in ansible.builtin.file.
Previously, rewriting an existing symlink with a relative destination path could fail with a permission error due to incorrect temporary path construction during atomic replacement.

Fixes: #86146
Signed-off-by: Jason Hall jason.kei.hall@gmail.com

ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
lib/ansible/modules/file.py
test/integration/targets/file/tasks/link_rewrite.yml
changelogs/fragments/86146-file-relative-symlink-rewrite.yml