### PR TITLE
Redirect paramiko to collection

### DIFF
--- a/changelogs/fragments/paramiko_redirects.yml
+++ b/changelogs/fragments/paramiko_redirects.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Redirect connection plugin ansible.builtin.paramiko_ssh to community.general.paramiko_ssh.

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -5,6 +5,10 @@ plugin_routing:
     # test entries
     redirected_local:
       redirect: ansible.builtin.local
+    paramiko:
+      redirect: community.general.paramiko_ssh
+    paramiko_ssh:
+      redirect: community.general.paramiko_ssh
     buildah:
       redirect: containers.podman.buildah
     podman:


### PR DESCRIPTION
##### SUMMARY

When triaging #86244, we discussed adding a redirect for this plugin instead of just removing it at the end of the deprecation cycle since we think it is still useful. I've opened this pull request to get more feedback on whether or not this is something we should do. The corresponding community.general pull request is https://github.com/ansible-collections/community.general/pull/11293.

Note: the redirects have no effect when using the name `paramiko` or `paramiko_ssh` until the plugin is removed (pull request working on that: #86059).

##### ISSUE TYPE

- Feature Pull Request
