### PR TITLE
ssh_askpass: use SSH_ASKPASS_PROMPT env var for reliable prompt detec…

### DIFF
--- a/changelogs/fragments/86319-ssh_askpass_prompt.yml
+++ b/changelogs/fragments/86319-ssh_askpass_prompt.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "ssh_askpass - Use SSH_ASKPASS_PROMPT environment variable for more reliable prompt type detection (https://github.com/ansible/ansible/issues/86319)"

--- a/lib/ansible/cli/_ssh_askpass.py
+++ b/lib/ansible/cli/_ssh_askpass.py
@@ -27,6 +27,19 @@ def handle_prompt(prompt: str) -> bool:
         sys.stdout.flush()
         return True
 
+    ssh_askpass_prompt = os.environ.get('SSH_ASKPASS_PROMPT')
+
+    prompt_response_map = {
+        'none': '',
+        'confirm': 'yes',
+    }
+
+    if ssh_askpass_prompt in prompt_response_map:
+        # We write the mapped value and immediately flush it
+        sys.stdout.write(prompt_response_map[ssh_askpass_prompt])
+        sys.stdout.flush()
+        return True
+
     # deprecated: description='Python 3.13 and later support track' python_version='3.12'
     can_track = sys.version_info[:2] >= (3, 13)
     kwargs = dict(track=False) if can_track else {}

--- a/test/integration/targets/connection_ssh/test_ssh_askpass.yml
+++ b/test/integration/targets/connection_ssh/test_ssh_askpass.yml
@@ -90,3 +90,31 @@
           - '"EXEC ssh " in askpass_out.stdout'
           - '"sshpass" not in askpass_out.stdout'
           - askpass_out.stdout is search('uid=\d+\(' ~ test_user_name ~ '\)')
+
+    - name: Test handle_prompt logic directly
+      shell: |
+        {{ ansible_playbook_python }} -c "
+        import os, sys;
+        sys.path.insert(0, '/root/ansible/lib');
+        os.environ['SSH_ASKPASS_PROMPT'] = 'confirm';
+        from ansible.cli._ssh_askpass import handle_prompt;
+        handle_prompt('Any Message');
+        "
+      register: test_confirm
+
+    - name: Test handle_prompt logic with none
+      shell: |
+        {{ ansible_playbook_python }} -c "
+        import os, sys;
+        sys.path.insert(0, '/root/ansible/lib');
+        os.environ['SSH_ASKPASS_PROMPT'] = 'none';
+        from ansible.cli._ssh_askpass import handle_prompt;
+        handle_prompt('Any Message');
+        "
+      register: test_none
+
+    - name: Verify responses
+      assert:
+        that:
+          - test_confirm.stdout | trim == "yes"
+          - test_none.stdout | trim == ""


### PR DESCRIPTION
##### SUMMARY

Inspect SSH_ASKPASS_PROMPT environment variable for reliable prompt type detection in SSH_ASKPASS script. OpenSSH sets this variable to indicate prompt types: 'confirm' for yes/no questions, 'none' for information only, and default/empty for password input. This provides more reliable detection than relying solely on regex patterns.

Fixes: #86319

Signed-off-by: Jason Hall jason.kei.hall@gmail.com

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lib/ansible/cli/_ssh_askpass.py
