### PR TITLE
Fix RHEL iptables integration test

### DIFF
--- a/test/integration/targets/iptables/tasks/main.yml
+++ b/test/integration/targets/iptables/tasks/main.yml
@@ -43,7 +43,7 @@
     exclude:
     # prevent attempts to upgrade the kernel and install kernel modules for a non-running kernel version
     - kernel-core
-  when: ansible_distribution == 'RedHat'
+  when: ansible_distribution == 'RedHat' and ansible_facts['distribution_version'] is version('10.0', '>=')
 
 - name: Use iptables with unnecessary extension match
   iptables:

--- a/test/lib/ansible_test/_internal/host_profiles.py
+++ b/test/lib/ansible_test/_internal/host_profiles.py
@@ -63,6 +63,7 @@ from .util import (
     ANSIBLE_SOURCE_ROOT,
     ANSIBLE_LIB_ROOT,
     ANSIBLE_TEST_ROOT,
+    OutputStream,
 )
 
 from .util_common import (
@@ -1462,6 +1463,8 @@ class PosixRemoteProfile(ControllerHostProfile[PosixRemoteConfig], RemoteProfile
 
         ssh = self.get_origin_controller_connection()
         ssh.run([shell], data=setup_sh, capture=False)
+        if self.config.platform == 'rhel' and self.config.version == '10.0':
+            ssh.run(["reboot"], capture=False, interactive=False, output_stream=OutputStream.ORIGINAL)
 
     def get_ssh_connection(self) -> SshConnection:
         """Return an SSH connection for accessing the host."""

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -298,12 +298,27 @@ bootstrap_remote_rhel_9()
 
 bootstrap_remote_rhel_10()
 {
+    # the iptables integration test relies on kernel-modules-extra
+    kernel_list="$(dnf list --showduplicates kernel | awk '/kernel.x86_64/ {print $2}')"
+    modules_list="$(dnf list --showduplicates kernel-modules-extra | awk '/kernel-modules-extra.x86_64/ {print $2}')"
+
+    kernel_tmp=$(mktemp)
+    modules_tmp=$(mktemp)
+
+    printf "%s\n" "$kernel_list" | sort -u > "$kernel_tmp"
+    printf "%s\n" "$modules_list" | sort -u > "$modules_tmp"
+
+    kernel_version="$(comm -12 $kernel_tmp $modules_tmp | head -n1)"
+
+    rm -f "$kernel_tmp" "$modules_tmp"
+
     py_pkg_prefix="python3"
 
     packages="
         gcc
         ${py_pkg_prefix}-devel
         ${py_pkg_prefix}-pip
+        kernel-${kernel_version}
         "
 
     if [ "${controller}" ]; then
@@ -314,6 +329,7 @@ bootstrap_remote_rhel_10()
             ${py_pkg_prefix}-packaging
             ${py_pkg_prefix}-pyyaml
             ${py_pkg_prefix}-resolvelib
+            kernel-${kernel_version}
             "
     fi
 


### PR DESCRIPTION
##### SUMMARY

The iptables integration test is failing on RHEL 9.6 and 10.0 because kernel-modules-extra package cannot be found: https://dev.azure.com/ansible/ansible/_build/results?buildId=166488&view=logs&j=a8db40fc-acf7-5b40-e96d-20345000ff7f&t=72c8f12a-cf68-5b7b-5fb0-3674e2311370&l=11376

Since this package is necessary for RHEL 10, the bootstrap script installs a kernel version with the corresponding kernel-modules-extra package, and ansible-test reboots the instance before using it.

Older RHEL versions no longer unnecessarily attempt to install kernel-modules-extra.

##### ISSUE TYPE

- Test Pull Request
