### PR TITLE
Added unit tests for path_dwim_relative_stack with None values

### DIFF
--- a/changelogs/fragments/86056-dataloader-none-tests.yml
+++ b/changelogs/fragments/86056-dataloader-none-tests.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add unit test coverage for DataLoader.path_dwim_relative_stack to ensure safety when dirname or source are None (https://github.com/ansible/ansible/issues/86056).

--- a/test/units/parsing/test_dataloader.py
+++ b/test/units/parsing/test_dataloader.py
@@ -188,6 +188,15 @@ class TestPathDwimRelativeStackDataLoader(unittest.TestCase):
     def test_path_endswith_role_source_main_yml_source_in_dirname(self):
         self.assertRaises(AnsibleFileNotFound, self._loader.path_dwim_relative_stack, 'foo/bar/tasks/', 'tasks', 'tasks/main.yml')
 
+    def test_source_none_valid_paths(self):
+        self.assertRaisesRegex(AnsibleFileNotFound, 'on the Ansible Controller', self._loader.path_dwim_relative_stack, ['/tmp'], 'files', None)
+
+    def test_dirname_none_valid_source(self):
+        self.assertRaises(AnsibleFileNotFound, self._loader.path_dwim_relative_stack, ['/tmp'], None, 'foo.yml')
+
+    def test_dirname_and_source_none(self):
+        self.assertRaisesRegex(AnsibleFileNotFound, 'on the Ansible Controller', self._loader.path_dwim_relative_stack, ['/tmp'], None, None)
+
 
 class TestDataLoaderWithVault(unittest.TestCase):
 


### PR DESCRIPTION
SUMMARY
Added unit test coverate for `DataLoader.path_dwim_relative_stack` to ensure safety when `dirname` or `source` are passed as None.

Fixes #86056
signed-off by: Jason Hall jason.kei.hall@gmail.com

ISSUE TYPE
Test Pull Request

COMPONENT NAME
test/units/parsing/test_dataloader.py
