### PR TITLE
deb822_repository: add signed_by_target to support embedding keys fro…

### DIFF
--- a/changelogs/fragments/85246-deb822-embed-url-key.yml
+++ b/changelogs/fragments/85246-deb822-embed-url-key.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "deb822_repository: add C(signed_by_target) to allow fetching and embedding ASCII-armored GPG keys from URLs or files directly into the source file (https://github.com/ansible/ansible/issues/85246)."

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -118,6 +118,17 @@ options:
           the keyrings in the C(trusted.gpg.d/) directory, or an ASCII armored
           GPG public key block.
         type: str
+    signed_by_target:
+        description:
+        - Controls whether the GPG key provided in O(signed_by) should be written as a file or embedded directly.
+        - When set to V(file) and O(signed_by) is a URL, the key is downloaded to a file in C(/etc/apt/keyrings/).
+        - When set to V(embed) and O(signed_by) is a URL, the key content is fetched and placed directly into the C(Signed-By) field of the C(.sources) file.
+        type: str
+        choices:
+        - file
+        - embed
+        default: file
+        version_added: '2.21'
     suites:
         description:
         - >-
@@ -342,7 +353,7 @@ def is_armored(b_data):
     return b'-----BEGIN PGP PUBLIC KEY BLOCK-----' in b_data
 
 
-def write_signed_by_key(module, v, slug):
+def write_signed_by_key(module, v, slug, signed_by_target='file'):
     changed = False
     if os.path.isfile(v):
         return changed, v, None
@@ -357,6 +368,11 @@ def write_signed_by_key(module, v, slug):
             raise RuntimeError('Could not fetch signed_by key.') from exc
         else:
             b_data = r.read()
+
+            if signed_by_target == 'embed':
+                if not is_armored(b_data):
+                    module.fail_json(msg="The key fetched from the URL is not ASCII armored. Binary keys cannot be embedded.")
+                return False, None, to_native(b_data)
     else:
         # Not a file, nor a URL, just pass it through
         return changed, None, v
@@ -463,6 +479,11 @@ def main():
             },
             'signed_by': {
                 'type': 'str',
+            },
+            'signed_by_target': {
+                'type': 'str',
+                'choices': ['file', 'embed'],
+                'default': 'file',
             },
             'suites': {
                 'elements': 'str',
@@ -580,6 +601,7 @@ def main():
             name.lower(),
         ),
     )
+    signed_by_target = params.pop('signed_by_target', 'file')
     sources_filename = make_sources_filename(slug)
 
     if state == 'absent':
@@ -613,7 +635,7 @@ def main():
         elif is_sequence(value):
             value = format_list(value)
         elif key == 'signed_by':
-            key_changed, signed_by_filename, signed_by_data = write_signed_by_key(module, value, slug)
+            key_changed, signed_by_filename, signed_by_data = write_signed_by_key(module, value, slug, signed_by_target)
             value = signed_by_filename or signed_by_data
             changed |= key_changed
 

--- a/test/integration/targets/deb822_repository/tasks/test.yml
+++ b/test/integration/targets/deb822_repository/tasks/test.yml
@@ -243,3 +243,85 @@
 - assert:
     that:
       - ansible_test_http_agent is changed
+
+- name: Create the 'fake' downloaded key on the local filesystem
+  copy:
+    dest: "{{ remote_tmp_dir }}/mock_downloaded_key.asc"
+    content: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      mDMEYCQjIxYJKwYBBAHaRw8BAQdAD/P5Nvvnvk66SxBBHDbhRml9ORg1WV5CvzKY
+      CuMfoIS0BmFiY2RlZoiQBBMWCgA4FiEErCIG1VhKWMWo2yfAREZd5NfO31cFAmAk
+      IyMCGyMFCwkIBwMFFQoJCAsFFgIDAQACHgECF4AACgkQREZd5NfO31fbOwD6ArzS
+      dM0Dkd5h2Ujy1b6KcAaVW9FOa5UNfJ9FFBtjLQEBAJ7UyWD3dZzhvlaAwunsk7DG
+      3bHcln8DMpIJVXht78sL
+      =IE0r
+      -----END PGP PUBLIC KEY BLOCK-----
+
+- name: Add repo with embedded key (using fake URL to test download logic)
+  deb822_repository:
+    name: ansible-test-embed-mock
+    types: deb
+    uris: http://example.com/debian
+    suites: stable
+    signed_by: "file://{{ remote_tmp_dir }}/mock_downloaded_key.asc"
+    signed_by_target: embed
+    components:
+      - main
+      - contrib
+      - non-free
+  register: embed_mock_test
+
+- name: Stat for potential leftover key file
+  stat:
+    path: /etc/apt/keyrings/ansible-test-embed-mock.asc
+  register: embed_key_stat
+
+- assert:
+    that:
+      - embed_mock_test is changed
+      - embed_mock_test.key_filename is none
+      - "'BEGIN PGP PUBLIC KEY BLOCK' in embed_mock_test.repo"
+      - not embed_key_stat.stat.exists
+
+- name: Add repo with embedded key from URL (idempotency)
+  deb822_repository:
+    name: ansible-test-embed-mock
+    types: deb
+    uris: http://example.com/debian
+    suites: stable
+    signed_by: "file://{{ remote_tmp_dir }}/mock_downloaded_key.asc"
+    signed_by_target: embed
+    components:
+      - main
+      - contrib
+      - non-free
+  register: embed_url_idem
+
+- assert:
+    that:
+      - embed_url_idem is not changed
+
+- name: Attempt to embed binary key from URL (should fail)
+  deb822_repository:
+    name: ansible-test-embed-fail
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    signed_by: https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
+    signed_by_target: embed
+    components:
+      - main
+      - contrib
+      - non-free
+  ignore_errors: true
+  register: embed_binary_fail
+
+- assert:
+    that:
+      - embed_binary_fail is failed
+      - "'not ASCII armored' in embed_binary_fail.msg"
+
+- name: Remove embed test repo
+  deb822_repository:
+    name: ansible-test-embed-mock
+    state: absent


### PR DESCRIPTION
SUMMARY
Add signed_by_target parameter to deb822_repository to allow embedding keys fetched from URLs. Previously, keys fetched from a URI could only be stored as standalone files. This change allows the module to download an ASCII-armored key and embed it directly into the .sources file when signed_by_target: embed is specified. 

Fixes: #85246 
Signed-off-by: Jason Hall jason.kei.hall@gmail.com

ISSUE TYPE
Feature Pull Request

COMPONENT NAME
lib/ansible/modules/deb822_repository.py 
test/integration/targets/deb822_repository/tasks/test.yml 
changelogs/fragments/85246-deb822-embed-url-key.yml
