### PR TITLE
apt: make clean idempotent by checking for cached files

### DIFF
--- a/changelogs/fragments/84880-apt-clean-idempotency.yml
+++ b/changelogs/fragments/84880-apt-clean-idempotency.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - apt - ensure the `clean` parameter only reports a changed state if there are actually packages or partial downloads to be removed from the cache (https://github.com/ansible/ansible/issues/84880).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -1058,7 +1058,29 @@ def cleanup(m, purge=False, force=False, operation=None,
     m.exit_json(changed=changed, stdout=out, stderr=err, diff=diff)
 
 
+def is_dir_empty(path):
+    if not os.path.exists(path) or not os.path.isdir(path):
+        return True
+    try:
+        return not os.listdir(path)
+    except (FileNotFoundError, PermissionError):
+        return True
+
+
 def aptclean(m):
+    changed = False
+
+    archive_dir = "/var/cache/apt/archives"
+    partial_dir = os.path.join(archive_dir, "partial")
+
+    if not is_dir_empty(partial_dir):
+        changed = True
+    elif os.path.exists(archive_dir):
+        for f in os.listdir(archive_dir):
+            if f.endswith('.deb'):
+                changed = True
+                break
+
     clean_rc, clean_out, clean_err = m.run_command(['apt-get', 'clean'])
     clean_diff = parse_diff(clean_out) if m._diff else {}
 
@@ -1066,7 +1088,7 @@ def aptclean(m):
         m.fail_json(msg="apt-get clean failed", stdout=clean_out, rc=clean_rc)
     if clean_err:
         m.fail_json(msg="apt-get clean failed: %s" % clean_err, stdout=clean_out, rc=clean_rc)
-    return (clean_out, clean_err, clean_diff)
+    return (clean_out, clean_err, clean_diff, changed)
 
 
 def upgrade(m, mode="yes", force=False, default_release=None,
@@ -1351,12 +1373,12 @@ def main():
         )
 
     if p['clean'] is True:
-        aptclean_stdout, aptclean_stderr, aptclean_diff = aptclean(module)
+        aptclean_stdout, aptclean_stderr, aptclean_diff, aptclean_changed = aptclean(module)
         # If there is nothing else to do exit. This will set state as
         #  changed based on if the cache was updated.
         if not p['package'] and p['upgrade'] == 'no' and not p['deb']:
             module.exit_json(
-                changed=True,
+                changed=aptclean_changed,
                 msg=aptclean_stdout,
                 stdout=aptclean_stdout,
                 stderr=aptclean_stderr,

--- a/test/integration/targets/apt/tasks/clean.yml
+++ b/test/integration/targets/apt/tasks/clean.yml
@@ -1,0 +1,26 @@
+---
+- name: Manually create a dummy file in the apt archive dir
+  copy:
+    content: "dummy data"
+    dest: /var/cache/apt/archives/test_idempotency.deb
+    mode: '0644'
+
+- name: Run apt clean (First time - should be changed)
+  apt:
+    clean: yes
+  register: first_clean
+
+- name: Verify first clean reported a change
+  assert:
+    that:
+      - first_clean is changed
+
+- name: Run apt clean (Second time - should NOT be changed)
+  apt:
+    clean: yes
+  register: second_clean
+
+- name: Verify second clean reported NO change (Idempotency)
+  assert:
+    that:
+      - second_clean is not changed

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -22,6 +22,8 @@
 - block:
   - import_tasks: 'apt.yml'
 
+  - import_tasks: 'clean.yml'
+
   - import_tasks: 'apt_deb_depend.yml'
 
   - import_tasks: 'url-with-deps.yml'


### PR DESCRIPTION
SUMMARY
This PR makes the `apt` module's `clean` parameter idempotent by ensuring it only reports a `changed` state when files are actually removed from the cache.

Previously, `apt: clean: yes` always returend `changed: true`. This change implements a filesystem check on `/var/cache/apt/archives/` and its `partial/` subdirectory to detect the presence of `.deb` files or incomplete downloads before executing the clean command.

Fixes #84880
Signed-off-by: Jason Hall jason.kei.hall@gmail.com

ISSUE TYPE
Feature Pull Request

COMPONENT NAME
lib/ansible/modules/apt.py
test/integration/targets/apt/tasks/clean.yml
changelogs/fragments/84880-apt-clean-idempotency.yml




