### PR TITLE
Do not apply import/include conditionals to imported handlers

### DIFF
--- a/changelogs/fragments/86349-imported-handlers-when.yml
+++ b/changelogs/fragments/86349-imported-handlers-when.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- handlers - Do not apply import/include task conditionals to imported handlers (https://github.com/ansible/ansible/issues/86349)

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -256,7 +256,9 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
             if _parent and (value is Sentinel or extend):
                 try:
                     if getattr(_parent, 'statically_loaded', True):
-                        if hasattr(_parent, '_get_parent_attribute'):
+                        if attr == 'when' and self._use_handlers and not isinstance(_parent, Block):
+                            parent_value = Sentinel
+                        elif hasattr(_parent, '_get_parent_attribute'):
                             parent_value = _parent._get_parent_attribute(attr)
                         else:
                             parent_value = getattr(_parent, f'_{attr}', Sentinel)
@@ -266,7 +268,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
                             value = parent_value
                 except AttributeError:
                     pass
-            if self._role and (value is Sentinel or extend):
+            if self._role and (value is Sentinel or extend) and not (attr == 'when' and self._use_handlers):
                 try:
                     parent_value = getattr(self._role, f'_{attr}', Sentinel)
                     if extend:
@@ -288,7 +290,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
                                 break
                 except AttributeError:
                     pass
-            if self._play and (value is Sentinel or extend):
+            if self._play and (value is Sentinel or extend) and not (attr == 'when' and self._use_handlers):
                 try:
                     play_value = getattr(self._play, f'_{attr}', Sentinel)
                     if play_value is not Sentinel:

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -22,6 +22,7 @@ import unittest
 
 from ansible.playbook.block import Block
 from ansible.playbook.task import Task
+from ansible.playbook.task_include import TaskInclude
 
 
 @pytest.mark.usefixtures('collection_loader')
@@ -70,3 +71,19 @@ class TestBlock(unittest.TestCase):
         b = Block.load(ds)
         self.assertEqual(len(b.block), 1)
         self.assertIsInstance(b.block[0], Task)
+
+    def test_handler_blocks_do_not_inherit_when_from_task_include(self):
+        parent = TaskInclude()
+        parent.when = ['inventory_hostname != "localhost"']
+
+        handler_block = Block(play=None, task_include=parent, use_handlers=True)
+
+        self.assertEqual(handler_block.when, [])
+
+    def test_handler_blocks_still_inherit_when_from_parent_block(self):
+        parent_block = Block(play=None, use_handlers=True)
+        parent_block.when = ['inventory_hostname != "localhost"']
+
+        handler_block = Block(play=None, parent_block=parent_block, use_handlers=True)
+
+        self.assertEqual(handler_block.when, ['inventory_hostname != "localhost"'])


### PR DESCRIPTION
Fixes #86349

## Summary
When a role is imported (directly or via role dependencies) with an additional `when:` conditional, Ansible currently propagates that conditional onto imported handler tasks. Since handlers are global and only executed when notified, they should not have import/include task conditionals appended to their `when`.

This change prevents `when` inheritance onto handler blocks from non-block parents (such as include/import tasks), while preserving normal `when` inheritance from actual parent blocks.

## Changes
- Prevent handler blocks from inheriting `when` from include/import task parents.
- Add unit tests covering:
  - handler blocks do **not** inherit `when` from a `TaskInclude` parent
  - handler blocks **do** inherit `when` from a parent [Block](cci:2://file:///c:/Users/brass/OneDrive/Desktop/Work/App/mary-forks/ansible/lib/ansible/playbook/block.py:31:0-381:19)

## Testing
Not run locally on Windows (Ansible imports require POSIX-only modules like `grp`).
Relying on upstream CI for Linux-based unit test coverage.