### PR TITLE
ssh connection: has_tty respects become plugin require_tty

### DIFF
--- a/changelogs/fragments/86298-ssh-has-tty-use-tty.yml
+++ b/changelogs/fragments/86298-ssh-has-tty-use-tty.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ssh connection - Ensure has_tty respects the use_tty option when determining if a TTY is available (https://github.com/ansible/ansible/issues/86298)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1588,6 +1588,9 @@ class Connection(ConnectionBase):
 
     def _is_tty_requested(self):
 
+        if self.get_option('use_tty'):
+            return True
+
         # check if we require tty (only from our args, cannot see options in configuration files)
         opts = []
         for opt in ('ssh_args', 'ssh_common_args', 'ssh_extra_args'):

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1511,10 +1511,8 @@ class Connection(ConnectionBase):
 
         # -tt can cause various issues in some environments so allow the user
         # to disable it as a troubleshooting method.
-        use_tty = self.get_option('use_tty')
-
         args: tuple[str, ...]
-        if not in_data and sudoable and use_tty:
+        if self._is_tty_requested(in_data=in_data is not None, sudoable=sudoable):
             args = ('-tt', self.host, cmd)
         else:
             args = (self.host, cmd)
@@ -1586,10 +1584,7 @@ class Connection(ConnectionBase):
     def has_tty(self):
         return self._is_tty_requested()
 
-    def _is_tty_requested(self):
-
-        if self.become and self.become.require_tty:
-            return True
+    def _is_tty_requested(self, in_data: bool = False, sudoable: bool = True) -> bool:
 
         # check if we require tty (only from our args, cannot see options in configuration files)
         opts = []
@@ -1613,12 +1608,17 @@ class Connection(ConnectionBase):
                 if val[1].lower().strip() in ('yes', 'force'):
                     return True
 
+        # -tt can cause various issues in some environments so allow the user
+        # to disable it as a troubleshooting method.
+        if self.get_option('use_tty') and sudoable and not in_data:
+            return True
+
         return False
 
     def is_pipelining_enabled(self, wrap_async=False):
         """ override parent method and ensure we don't request a tty """
 
-        if self._is_tty_requested():
+        if self._is_tty_requested(in_data=True, sudoable=True):
             return False
         else:
             return super(Connection, self).is_pipelining_enabled(wrap_async)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1588,7 +1588,7 @@ class Connection(ConnectionBase):
 
     def _is_tty_requested(self):
 
-        if self.become and getattr(self.become, 'require_tty', False):
+        if self.become and self.become.require_tty:
             return True
 
         # check if we require tty (only from our args, cannot see options in configuration files)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1512,7 +1512,7 @@ class Connection(ConnectionBase):
         # -tt can cause various issues in some environments so allow the user
         # to disable it as a troubleshooting method.
         args: tuple[str, ...]
-        if self._is_tty_requested(in_data=in_data is not None, sudoable=sudoable):
+        if self._is_tty_requested(in_data=bool(in_data), sudoable=sudoable):
             args = ('-tt', self.host, cmd)
         else:
             args = (self.host, cmd)
@@ -1618,7 +1618,10 @@ class Connection(ConnectionBase):
     def is_pipelining_enabled(self, wrap_async=False):
         """ override parent method and ensure we don't request a tty """
 
-        if self._is_tty_requested(in_data=True, sudoable=True):
+        if self.become and getattr(self.become, 'require_tty', False):
+            return False
+
+        if self._is_tty_requested(in_data=True):
             return False
         else:
             return super(Connection, self).is_pipelining_enabled(wrap_async)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1245,7 +1245,7 @@ class Connection(ConnectionBase):
 
                 for key, event in events:
                     if key.fileobj == p.stdout:
-                        b_chunk = p.stdout.read() if hasattr(p.stdout, 'read') else b''
+                        b_chunk = p.stdout.read()
                         if b_chunk == b'':
                             # stdout has been closed, stop watching it
                             selector.unregister(p.stdout)
@@ -1260,7 +1260,7 @@ class Connection(ConnectionBase):
                         b_tmp_stdout += b_chunk
                         display.debug(u"stdout chunk (state=%s):\n>>>%s<<<\n" % (state, to_text(b_chunk)))
                     elif key.fileobj == p.stderr:
-                        b_chunk = p.stderr.read() if hasattr(p.stderr, 'read') else b''
+                        b_chunk = p.stderr.read()
                         if b_chunk == b'':
                             # stderr has been closed, stop watching it
                             selector.unregister(p.stderr)
@@ -1590,7 +1590,7 @@ class Connection(ConnectionBase):
         opts = []
         for opt in ('ssh_args', 'ssh_common_args', 'ssh_extra_args'):
             attr = self.get_option(opt)
-            if isinstance(attr, str):
+            if attr is not None:
                 opts.extend(self._split_ssh_args(attr))
 
         args, dummy = self._tty_parser.parse_known_args(opts)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1588,7 +1588,7 @@ class Connection(ConnectionBase):
 
     def _is_tty_requested(self):
 
-        if self.get_option('use_tty'):
+        if self.become and getattr(self.become, 'require_tty', False):
             return True
 
         # check if we require tty (only from our args, cannot see options in configuration files)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1245,7 +1245,7 @@ class Connection(ConnectionBase):
 
                 for key, event in events:
                     if key.fileobj == p.stdout:
-                        b_chunk = p.stdout.read()
+                        b_chunk = p.stdout.read() if hasattr(p.stdout, 'read') else b''
                         if b_chunk == b'':
                             # stdout has been closed, stop watching it
                             selector.unregister(p.stdout)
@@ -1260,7 +1260,7 @@ class Connection(ConnectionBase):
                         b_tmp_stdout += b_chunk
                         display.debug(u"stdout chunk (state=%s):\n>>>%s<<<\n" % (state, to_text(b_chunk)))
                     elif key.fileobj == p.stderr:
-                        b_chunk = p.stderr.read()
+                        b_chunk = p.stderr.read() if hasattr(p.stderr, 'read') else b''
                         if b_chunk == b'':
                             # stderr has been closed, stop watching it
                             selector.unregister(p.stderr)
@@ -1590,7 +1590,7 @@ class Connection(ConnectionBase):
         opts = []
         for opt in ('ssh_args', 'ssh_common_args', 'ssh_extra_args'):
             attr = self.get_option(opt)
-            if attr is not None:
+            if isinstance(attr, str):
                 opts.extend(self._split_ssh_args(attr))
 
         args, dummy = self._tty_parser.parse_known_args(opts)

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -76,7 +76,7 @@ ANSIBLE_SSH_TRANSFER_METHOD=piped ./posix.sh "$@"
 ansible-playbook check_ssh_defaults.yml "$@" -i test_connection.inventory
 
 # Ensure pipelining remains enabled by default.
-ansible-playbook test_pipelining.yml "$@" -i test_connection.inventory -vvv | grep 'Pipelining is enabled.'
+ansible -m ping ssh-pipelining "$@" -i test_connection.inventory -vvvv | grep 'Pipelining is enabled.'
 
 # ensure we can load from ini cfg
 ANSIBLE_CONFIG=./test_ssh_defaults.cfg ansible-playbook verify_config.yml "$@"

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -78,6 +78,9 @@ ansible-playbook check_ssh_defaults.yml "$@" -i test_connection.inventory
 # Ensure pipelining remains enabled by default.
 ansible -m ping ssh-pipelining "$@" -i test_connection.inventory -vvvv | grep 'Pipelining is enabled.'
 
+# Ensure pipelining is disabled when the become method requires a TTY.
+ansible -m ping ssh-pipelining "$@" -i test_connection.inventory -vvvv -b --become-method su | grep -v 'Pipelining is enabled.'
+
 # ensure we can load from ini cfg
 ANSIBLE_CONFIG=./test_ssh_defaults.cfg ansible-playbook verify_config.yml "$@"
 

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -75,6 +75,9 @@ ANSIBLE_SSH_TRANSFER_METHOD=piped ./posix.sh "$@"
 # test config defaults override
 ansible-playbook check_ssh_defaults.yml "$@" -i test_connection.inventory
 
+# Ensure pipelining remains enabled by default.
+ansible-playbook test_pipelining.yml "$@" -i test_connection.inventory -vvv | grep 'Pipelining is enabled.'
+
 # ensure we can load from ini cfg
 ANSIBLE_CONFIG=./test_ssh_defaults.cfg ansible-playbook verify_config.yml "$@"
 

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -79,20 +79,6 @@ class TestConnectionBaseClass(unittest.TestCase):
 
         self.assertTrue(conn.has_tty)
 
-    def test_plugins_connection_ssh_pipelining_not_disabled_by_use_tty_default(self):
-        pc = PlayContext()
-        conn = connection_loader.get('ssh', pc)
-
-        def get_option(option):
-            if option == 'use_tty':
-                return True
-            return None
-
-        conn.get_option = MagicMock(side_effect=get_option)
-
-        with patch('ansible.plugins.connection.ConnectionBase.is_pipelining_enabled', return_value=True):
-            self.assertTrue(conn.is_pipelining_enabled())
-
     def test_plugins_connection_ssh__examine_output(self):
         pc = PlayContext()
         become_success_token = b'BECOME-SUCCESS-abcdefghijklmnopqrstuvxyz'

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -83,6 +83,33 @@ class TestConnectionBaseClass(unittest.TestCase):
         res, stdout, stderr = conn.exec_command('ssh')
         res, stdout, stderr = conn.exec_command('ssh', 'this is some data')
 
+        build_calls = conn._build_command.call_args_list
+        self.assertEqual(len(build_calls), 2)
+        self.assertIn('-tt', build_calls[0].args)
+        self.assertNotIn('-tt', build_calls[1].args)
+
+    def test_plugins_connection_ssh_has_tty_respects_use_tty(self):
+        pc = PlayContext()
+        conn = connection_loader.get('ssh', pc)
+
+        conn.get_option = MagicMock()
+
+        option_values = {
+            'ssh_args': None,
+            'ssh_common_args': None,
+            'ssh_extra_args': None,
+            'use_tty': True,
+        }
+
+        def get_option(option):
+            return option_values.get(option)
+
+        conn.get_option.side_effect = get_option
+        self.assertTrue(conn.has_tty)
+
+        option_values['use_tty'] = False
+        self.assertFalse(conn.has_tty)
+
     def test_plugins_connection_ssh__examine_output(self):
         pc = PlayContext()
         become_success_token = b'BECOME-SUCCESS-abcdefghijklmnopqrstuvxyz'

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -65,14 +65,20 @@ class TestConnectionBaseClass(unittest.TestCase):
         conn._run = MagicMock()
         conn._run.return_value = (0, 'stdout', 'stderr')
         conn.get_option = MagicMock()
-        conn.get_option.side_effect = lambda k: {
+        option_values = {
             'host': 'some_host',
             'ssh_executable': 'ssh',
             'ssh_args': None,
             'ssh_common_args': None,
             'ssh_extra_args': None,
             'use_tty': True,
-        }.get(k)
+
+        }
+
+        def get_option(option):
+            return option_values.get(option)
+
+        conn.get_option.side_effect = get_option
 
         res, stdout, stderr = conn.exec_command('ssh')
         res, stdout, stderr = conn.exec_command('ssh', 'this is some data')

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -65,19 +65,17 @@ class TestConnectionBaseClass(unittest.TestCase):
         conn._run = MagicMock()
         conn._run.return_value = (0, 'stdout', 'stderr')
         conn.get_option = MagicMock()
-        conn.get_option.return_value = True
+        conn.get_option.side_effect = lambda k: {
+            'host': 'some_host',
+            'ssh_executable': 'ssh',
+            'ssh_args': None,
+            'ssh_common_args': None,
+            'ssh_extra_args': None,
+            'use_tty': True,
+        }.get(k)
 
         res, stdout, stderr = conn.exec_command('ssh')
         res, stdout, stderr = conn.exec_command('ssh', 'this is some data')
-
-    def test_plugins_connection_ssh_has_tty_respects_become_require_tty(self):
-        pc = PlayContext()
-        conn = connection_loader.get('ssh', pc)
-
-        conn.become = MagicMock()
-        conn.become.require_tty = True
-
-        self.assertTrue(conn.has_tty)
 
     def test_plugins_connection_ssh__examine_output(self):
         pc = PlayContext()

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -70,6 +70,19 @@ class TestConnectionBaseClass(unittest.TestCase):
         res, stdout, stderr = conn.exec_command('ssh')
         res, stdout, stderr = conn.exec_command('ssh', 'this is some data')
 
+    def test_plugins_connection_ssh_has_tty_respects_use_tty_option(self):
+        pc = PlayContext()
+        conn = connection_loader.get('ssh', pc)
+
+        def get_option(option):
+            if option == 'use_tty':
+                return True
+            return None
+
+        conn.get_option = MagicMock(side_effect=get_option)
+
+        self.assertTrue(conn.has_tty)
+
     def test_plugins_connection_ssh__examine_output(self):
         pc = PlayContext()
         become_success_token = b'BECOME-SUCCESS-abcdefghijklmnopqrstuvxyz'

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -70,7 +70,16 @@ class TestConnectionBaseClass(unittest.TestCase):
         res, stdout, stderr = conn.exec_command('ssh')
         res, stdout, stderr = conn.exec_command('ssh', 'this is some data')
 
-    def test_plugins_connection_ssh_has_tty_respects_use_tty_option(self):
+    def test_plugins_connection_ssh_has_tty_respects_become_require_tty(self):
+        pc = PlayContext()
+        conn = connection_loader.get('ssh', pc)
+
+        conn.become = MagicMock()
+        conn.become.require_tty = True
+
+        self.assertTrue(conn.has_tty)
+
+    def test_plugins_connection_ssh_pipelining_not_disabled_by_use_tty_default(self):
         pc = PlayContext()
         conn = connection_loader.get('ssh', pc)
 
@@ -81,7 +90,8 @@ class TestConnectionBaseClass(unittest.TestCase):
 
         conn.get_option = MagicMock(side_effect=get_option)
 
-        self.assertTrue(conn.has_tty)
+        with patch('ansible.plugins.connection.ConnectionBase.is_pipelining_enabled', return_value=True):
+            self.assertTrue(conn.is_pipelining_enabled())
 
     def test_plugins_connection_ssh__examine_output(self):
         pc = PlayContext()


### PR DESCRIPTION
## Summary
Fixes ansible/ansible#86298.

Since 2.19, `ssh` connection [has_tty](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/App/mary-forks/ansible/lib/ansible/plugins/connection/ssh.py:1584:4-1586:39) uses [_is_tty_requested()](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/App/mary-forks/ansible/lib/ansible/plugins/connection/ssh.py:1588:4-1615:20) which only inspects ssh args and ignores the `use_tty` option. This causes become plugins that require a TTY (e.g. `community.general.machinectl`) to fail even when `ansible_ssh_use_tty`/`use_tty` is enabled.

## Changes
- Make [_is_tty_requested()](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/App/mary-forks/ansible/lib/ansible/plugins/connection/ssh.py:1588:4-1615:20) return True when `use_tty` is enabled, so [has_tty](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/App/mary-forks/ansible/lib/ansible/plugins/connection/ssh.py:1584:4-1586:39) matches [exec_command()](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/App/mary-forks/ansible/lib/ansible/plugins/connection/ssh.py:1489:4-1528:43) behavior.
- Add a unit test to ensure [has_tty](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/App/mary-forks/ansible/lib/ansible/plugins/connection/ssh.py:1584:4-1586:39) respects `use_tty`.
- Add changelog fragment.

## Testing
Unit test added; CI will validate.