### PR TITLE
ansible-test - Fix expat on Fedora 42 remotes

### DIFF
--- a/changelogs/fragments/ansible-test-fedora42-expat.yml
+++ b/changelogs/fragments/ansible-test-fedora42-expat.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Upgrade ``expat`` during provisioning of Fedora 42 remote instances.

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -163,6 +163,18 @@ bootstrap_remote_fedora()
         && break
         retry_or_fail
     done
+
+    packages="
+        expat
+        "
+
+    retry_init
+    while true; do
+        # shellcheck disable=SC2086
+        dnf update -q -y ${packages} \
+        && break
+        retry_or_fail
+    done
 }
 
 bootstrap_remote_freebsd()


### PR DESCRIPTION
##### SUMMARY

ansible-test - Fix expat on Fedora 42 remotes.

##### ISSUE TYPE

Bugfix Pull Request
