### PR TITLE
Fixes Parsing for ClearLinux exposed by Gentoo changing os-release Qu…

### DIFF
--- a/changelogs/fragments/clearlinux-gentoo-parsing.yml
+++ b/changelogs/fragments/clearlinux-gentoo-parsing.yml
@@ -1,3 +1,2 @@
 bugfixes:
   - 'ansible_facts[os_*] - Contained wrong information, if ClearLinux parsing was tried before falling back to general os-release parsing'
-

--- a/changelogs/fragments/clearlinux-gentoo-parsing.yml
+++ b/changelogs/fragments/clearlinux-gentoo-parsing.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - 'ansible_facts[os_*] - Contained wrong information, if ClearLinux parsing was tried before falling back to general os-release parsing'
+

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -438,10 +438,10 @@ class DistributionFiles:
         for line in data.splitlines():
             distribution = re.search("^NAME=(.*)", line)
             if distribution and name == 'NA':
-                na_facts['distribution'] = distribution.group(1).strip('"')
+                na_facts['distribution'] = distribution.group(1).strip('"').strip("'")
             version = re.search("^VERSION=(.*)", line)
             if version and collected_facts['distribution_version'] == 'NA':
-                na_facts['distribution_version'] = version.group(1).strip('"')
+                na_facts['distribution_version'] = version.group(1).strip('"').strip("'")
         return True, na_facts
 
     def parse_distribution_file_Coreos(self, name, data, path, collected_facts):
@@ -489,6 +489,8 @@ class DistributionFiles:
             if 'Clear Linux' not in pname.groups()[0]:
                 return False, clear_facts
             clear_facts['distribution'] = pname.groups()[0]
+        else:
+            return False, clear_facts
         version = re.search('VERSION_ID=(.*)', data)
         if version:
             clear_facts['distribution_major_version'] = version.groups()[0]

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -438,10 +438,10 @@ class DistributionFiles:
         for line in data.splitlines():
             distribution = re.search("^NAME=(.*)", line)
             if distribution and name == 'NA':
-                na_facts['distribution'] = distribution.group(1).strip('"').strip("'")
+                na_facts['distribution'] = distribution.group(1).strip(DistributionFiles.STRIP_QUOTES)
             version = re.search("^VERSION=(.*)", line)
             if version and collected_facts['distribution_version'] == 'NA':
-                na_facts['distribution_version'] = version.group(1).strip('"').strip("'")
+                na_facts['distribution_version'] = version.group(1).strip(DistributionFiles.STRIP_QUOTES)
         return True, na_facts
 
     def parse_distribution_file_Coreos(self, name, data, path, collected_facts):

--- a/test/units/module_utils/facts/system/distribution/fixtures/gentoo.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/gentoo.json
@@ -1,0 +1,47 @@
+{
+    "name": "Gentoo 2.18",
+    "distro": {
+        "codename": "n/a",
+        "id": "gentoo",
+        "name": "Gentoo",
+        "version": "2.18",
+        "version_best": "2.18",
+        "lsb_release_info": {
+            "lsb_version": "n/a",
+            "distributor_id": "Gentoo",
+            "description": "Gentoo Linux",
+            "release": "2.18",
+            "codename": "n/a"
+        },
+        "os_release_info": {
+            "name": "Gentoo",
+            "id": "gentoo",
+            "pretty_name": "Gentoo Linux",
+            "version": "2.18",
+            "version_id": "2.18",
+            "home_url": "https://www.gentoo.org/",
+            "support_url": "https://www.gentoo.org/support/",
+            "bug_report_url": "https://bugs.gentoo.org/",
+            "ansi_color": "1;32"
+        }
+    },
+    "input": {
+        "/etc/os-release": "NAME='Gentoo'\nID='gentoo'\nPRETTY_NAME='Gentoo Linux'\nVERSION='2.18'\nVERSION_ID='2.18'\nHOME_URL='https://www.gentoo.org/'\nSUPPORT_URL='https://www.gentoo.org/support/'\nBUG_REPORT_URL='https://bugs.gentoo.org/'\nANSI_COLOR='1;32'\n",
+        "/etc/gentoo-release": "Gentoo Base System release 2.18\n",
+        "/etc/lsb-release": "DISTRIB_ID=\"Gentoo\"\n",
+        "/usr/lib/os-release": "NAME='Gentoo'\nID='gentoo'\nPRETTY_NAME='Gentoo Linux'\nVERSION='2.18'\nVERSION_ID='2.18'\nHOME_URL='https://www.gentoo.org/'\nSUPPORT_URL='https://www.gentoo.org/support/'\nBUG_REPORT_URL='https://bugs.gentoo.org/'\nANSI_COLOR='1;32'\n"
+    },
+    "platform.dist": [
+        "gentoo",
+        "2.18",
+        "n/a"
+    ],
+    "result": {
+        "distribution": "Gentoo",
+        "distribution_version": "2.18",
+        "distribution_release": "n/a",
+        "distribution_major_version": "2",
+        "os_family": "Gentoo"
+    },
+    "platform.release": "6.18.2-p1-gentoo-dist"
+}


### PR DESCRIPTION
##### SUMMARY

Gentoo has changed the Quoting in os-release from " to ', which is in the spec for the file. After that ansible detected Gentoo as ClearLinux.

This PR fixes the ClearLinux code, so it won't do a partial parsing and returning the partial data.

(Was not sure if it would be better to change the pname regex to include all 3 Variants ", ' and no quotes, or doing the Else)

Also the Output of the Variables were changed, since only " got stripped, i changed this only for the Fallback NA parser in this PR.

##### ISSUE TYPE

- Bugfix Pull Request
