### PR TITLE
ansible-test - Replace Alpine 3.22 with 3.23

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -119,8 +119,8 @@ stages:
       - template: templates/matrix.yml  # context/controller (ansible-test container management)
         parameters:
           targets:
-            - name: Alpine 3.22
-              test: alpine/3.22
+            - name: Alpine 3.23
+              test: alpine/3.23
             - name: Fedora 42
               test: fedora/42
             - name: RHEL 9.7
@@ -138,8 +138,8 @@ stages:
         parameters:
           testFormat: linux/{0}
           targets:
-            - name: Alpine 3.22
-              test: alpine322
+            - name: Alpine 3.23
+              test: alpine323
             - name: Fedora 42
               test: fedora42
             - name: Ubuntu 22.04
@@ -153,8 +153,8 @@ stages:
         parameters:
           testFormat: linux/{0}
           targets:
-            - name: Alpine 3.22
-              test: alpine322
+            - name: Alpine 3.23
+              test: alpine323
             - name: Fedora 42
               test: fedora42
             - name: Ubuntu 24.04

--- a/changelogs/fragments/ansible-test-alpine.yml
+++ b/changelogs/fragments/ansible-test-alpine.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Replace Alpine 3.22 container and remote with 3.23.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,7 +1,7 @@
 base image=quay.io/ansible/base-test-container:v2.21-0 python=3.14,3.9,3.10,3.11,3.12,3.13
 default image=quay.io/ansible/default-test-container:v2.21-0 python=3.14,3.9,3.10,3.11,3.12,3.13 context=collection
 default image=quay.io/ansible/ansible-core-test-container:v2.21-0 python=3.14,3.9,3.10,3.11,3.12,3.13 context=ansible-core
-alpine322 image=quay.io/ansible/alpine-test-container:3.22-v2.20-1 python=3.12 cgroup=none audit=none
+alpine323 image=quay.io/ansible/alpine-test-container:3.23-v2.21-1 python=3.12 cgroup=none audit=none
 fedora42 image=quay.io/ansible/fedora-test-container:42-v2.20-1 python=3.13 cgroup=v2-only
 ubuntu2204 image=quay.io/ansible/ubuntu-test-container:22.04-v2.20-1 python=3.10
 ubuntu2404 image=quay.io/ansible/ubuntu-test-container:24.04-v2.20-1 python=3.12

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -1,4 +1,4 @@
-alpine/3.22 python=3.12 become=doas_sudo provider=aws arch=x86_64
+alpine/3.23 python=3.12 become=doas_sudo provider=aws arch=x86_64
 alpine become=doas_sudo provider=aws arch=x86_64
 fedora/42 python=3.13 become=sudo provider=aws arch=x86_64
 fedora become=sudo provider=aws arch=x86_64


### PR DESCRIPTION
##### SUMMARY

ansible-test - Replace Alpine 3.22 with 3.23.

##### ISSUE TYPE

Feature Pull Request
