### PR TITLE
Improve `to_uuid` documentation

### DIFF
--- a/lib/ansible/plugins/filter/to_uuid.yml
+++ b/lib/ansible/plugins/filter/to_uuid.yml
@@ -3,7 +3,7 @@ DOCUMENTATION:
   version_added: "2.9"
   short_description: namespaced UUID generator
   description:
-    - Use to generate namespaced Universal Unique ID.
+    - Use to generate namespaced Universal Unique ID (UUIDv5).
   positional: _input, namespace
   options:
     _input:
@@ -17,7 +17,7 @@ DOCUMENTATION:
 
 EXAMPLES: |
 
-  # To create a namespaced UUIDv5
+  # To create a namespaced UUIDv5 using the namespace '11111111-2222-3333-4444-555555555555'
   uuid: "{{ string | to_uuid(namespace='11111111-2222-3333-4444-555555555555') }}"
 
 


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
One has to look into the examples to realize the generaed UUID is a UUIDv5.

As of today, [`to_uuid` returns a UUIDv5](https://github.com/ansible/ansible/blob/f2357cdc53c99b7444f09deea398f0b80f0cb66f/lib/ansible/plugins/filter/core.py#L338-L346) Document it.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Docs Pull Request
