### PR TITLE
[stable-2.20] Remove `Install-Python-Debian` from the output of deb822_repository

### DIFF
--- a/changelogs/fragments/86403-fix-deb822-repository-output.yml
+++ b/changelogs/fragments/86403-fix-deb822-repository-output.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - deb822_repository - Remove ``Install-Python-Debian`` from files outputed by the ``deb822_repository`` module (https://github.com/ansible/ansible/issues/86395)

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -542,6 +542,7 @@ def main():
     # popped non-deb822 args
     mode = params.pop('mode')
     state = params.pop('state')
+    params.pop('install_python_debian')
 
     name = params['name']
     slug = re.sub(

--- a/test/integration/targets/deb822_repository/tasks/test.yml
+++ b/test/integration/targets/deb822_repository/tasks/test.yml
@@ -119,7 +119,6 @@
     focal_archive_expected: |-
       Components: main restricted
       Date-Max-Future: 10
-      Install-Python-Debian: no
       X-Repolib-Name: ansible-test focal archive
       Suites: focal focal-updates
       Types: deb
@@ -193,7 +192,6 @@
   vars:
     signed_by_inline_expected: |-
       Components: main contrib non-free
-      Install-Python-Debian: no
       X-Repolib-Name: ansible-test
       Signed-By:
           -----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
Fixes: #86395

(cherry picked from commit 28927a7)

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
