### PR TITLE
user: change ssh-keygen existing warning to debug

### DIFF
--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1240,7 +1240,7 @@ class User(object):
                 self.module.warn(f'Overwriting existing ssh key private file "{ssh_key_file}"')
                 overwrite = 'y'
             else:
-                self.module.warn(f'Found existing ssh key private file "{ssh_key_file}", no force, so skipping ssh-keygen generation')
+                self.module.debug(f'Found existing ssh key private file "{ssh_key_file}", no force, so skipping ssh-keygen generation')
                 return (None, 'Key already exists, use "force: yes" to overwrite', '')
 
         if os.path.exists(pub_file):


### PR DESCRIPTION
##### SUMMARY
This PR changes the notification for an existing SSH key from a `warn` to a `debug` message when `force: false`.

**Rationale:**
In accordance with Ansible's idempotency principles, finding a system already in the desired state is a "success," not a condition that requires a warning. Currently, the module produces "yellow" warning noise even when it is performing correctly. Moving this to `module.debug` preserves the information for troubleshooting with `-vvv` while keeping standard playbook runs clean and green.

Fixes #86401

##### COMPONENT NAME
`user` module

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
