### PR TITLE
ansible-galaxy: fix KeyError on missing 'results' key in collection i…

### DIFF
--- a/changelogs/fragments/86406-galaxy-keyerror.yaml
+++ b/changelogs/fragments/86406-galaxy-keyerror.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - fix KeyError when installing a collection if the server response is missing expected keys.

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -847,8 +847,10 @@ class GalaxyAPI:
             # since v3 pulp_ansible does not, we cannot rely on version
             # to indicate which key to use
             results_key = 'data'
-        else:
+        elif 'results' in data:
             results_key = 'results'
+        else:
+            return []
 
         versions = []
         while True:

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -850,7 +850,8 @@ class GalaxyAPI:
         elif 'results' in data:
             results_key = 'results'
         else:
-            return []
+            raise AnsibleError("Expected 'data' or 'results' in response from %s when getting "
+                               "versions for %s.%s" % (self.api_server, namespace, name))
 
         versions = []
         while True:


### PR DESCRIPTION
##### SUMMARY
Fixes #86406

The `get_collection_versions` method in `lib/ansible/galaxy/api.py` was assuming that if the `data` key is missing in the API response, the `results` key must exist. This caused a `KeyError` when the server response didn't contain either (e.g., on specific API failures or environment issues).

I added a check to raise an AnsibleError if neither data nor results keys are present.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ADDITIONAL INFORMATION
I verified that this change does not break successful collection installations.