### PR TITLE
Improve deprecation message for top-level facts by including the fact's name

### DIFF
--- a/changelogs/fragments/86411-facts-deprecation.yml
+++ b/changelogs/fragments/86411-facts-deprecation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Mention the actual fact's name in the ``INJECT_FACTS_AS_VARS`` deprecation message (https://github.com/ansible/ansible/pull/86411)."

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -682,7 +682,7 @@ class TaskExecutor:
                     vars_copy['ansible_facts'] = combine_vars(vars_copy.get('ansible_facts', {}), namespace_facts(af))
                     if _INJECT_FACTS:
                         if _INJECT_FACTS_ORIGIN == 'default':
-                            cleaned_toplevel = {k: _deprecate_top_level_fact(v) for k, v in clean_facts(af).items()}
+                            cleaned_toplevel = {k: _deprecate_top_level_fact(v, k) for k, v in clean_facts(af).items()}
                         else:
                             cleaned_toplevel = clean_facts(af)
                         vars_copy.update(cleaned_toplevel)
@@ -782,7 +782,7 @@ class TaskExecutor:
                     if _INJECT_FACTS_ORIGIN == 'default':
                         # This happens x2 due to loops and being able to use values in subsequent iterations
                         # these copies are later discarded in favor of 'total/final' one on loop end.
-                        cleaned_toplevel = {k: _deprecate_top_level_fact(v) for k, v in clean_facts(af).items()}
+                        cleaned_toplevel = {k: _deprecate_top_level_fact(v, k) for k, v in clean_facts(af).items()}
                     else:
                         cleaned_toplevel = clean_facts(af)
                     variables.update(cleaned_toplevel)

--- a/lib/ansible/vars/clean.py
+++ b/lib/ansible/vars/clean.py
@@ -155,13 +155,17 @@ def clean_facts(facts):
     return strip_internal_keys(data)
 
 
+def namespace_fact_name(fact_name):
+    """ return fact name w/o an ansible_ prefix """
+    if fact_name.startswith('ansible_') and fact_name not in ('ansible_local',):
+        return fact_name[8:]
+    return fact_name
+
+
 def namespace_facts(facts):
     """ return all facts inside 'ansible_facts' w/o an ansible_ prefix """
     deprefixed = {}
     for k in facts:
-        if k.startswith('ansible_') and k not in ('ansible_local',):
-            deprefixed[k[8:]] = module_response_deepcopy(facts[k])
-        else:
-            deprefixed[k] = module_response_deepcopy(facts[k])
+        deprefixed[namespace_fact_name(k)] = module_response_deepcopy(facts[k])
 
     return {'ansible_facts': deprefixed}

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -37,7 +37,7 @@ from ansible._internal._templating._engine import TemplateEngine
 from ansible.plugins.loader import cache_loader
 from ansible.utils.display import Display
 from ansible.utils.vars import combine_vars, load_extra_vars, load_options_vars
-from ansible.vars.clean import namespace_facts, clean_facts
+from ansible.vars.clean import namespace_facts, namespace_fact_name, clean_facts
 from ansible.vars.hostvars import HostVars
 from ansible.vars.plugins import get_vars_from_inventory_sources, get_vars_from_path
 from ansible.vars.reserved import warn_if_reserved
@@ -48,12 +48,6 @@ if t.TYPE_CHECKING:
 
 display = Display()
 
-_DEPRECATE_TOP_LEVEL_FACT_TAG = _tags.Deprecated(
-    msg='INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change.',
-    version='2.24',
-    deprecator=_deprecator.ANSIBLE_CORE_DEPRECATOR,
-    help_text='Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.',
-)
 _DEPRECATE_VARS = _tags.Deprecated(
     msg='The internal "vars" dictionary is deprecated.',
     version='2.24',
@@ -62,13 +56,21 @@ _DEPRECATE_VARS = _tags.Deprecated(
 )
 
 
-def _deprecate_top_level_fact(value: t.Any) -> t.Any:
+def _deprecate_top_level_fact(value: t.Any, key: str) -> t.Any:
     """
     Deprecate the given top-level fact value.
     The inner values are shared to aid in message de-duplication across hosts/values, and reduce intra-process memory usage.
     Unique tag instances are required to achieve the correct de-duplication within a top-level templating operation.
     """
-    return _DEPRECATE_TOP_LEVEL_FACT_TAG.tag(value)
+    stripped_key = namespace_fact_name(key)
+    no_prefix = " (no `ansible_` prefix)" if stripped_key != key else ""
+    tag = _tags.Deprecated(
+        msg='INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change.',
+        version='2.24',
+        deprecator=_deprecator.ANSIBLE_CORE_DEPRECATOR,
+        help_text=f'Use `ansible_facts["{stripped_key}"]`{no_prefix} instead of `{key}`.',
+    )
+    return tag.tag(value)
 
 
 def preprocess_vars(a):
@@ -299,7 +301,7 @@ class VariableManager:
                 # push facts to main namespace
                 if inject:
                     if origin == 'default':
-                        clean_top = {k: (_deprecate_top_level_fact(v) if k != 'ansible_local' else v) for k, v in clean_facts(facts).items()}
+                        clean_top = {k: (_deprecate_top_level_fact(v, k) if k != 'ansible_local' else v) for k, v in clean_facts(facts).items()}
                     else:
                         clean_top = clean_facts(facts)
                     all_vars = _combine_and_track(all_vars, clean_top, "facts")


### PR DESCRIPTION
##### SUMMARY
Right now if a deprecation message is shown for INJECT_FACTS_AS_VARS, the name of the fact is not included. This is particularly confusing if the fact's name does not start with `ansible_`, because the message explicitly hints at the `ansible_` prefix. (https://forum.ansible.com/t/inject-facts-as-vars-is-defaulting-to-false-in-2-24/44886/18)

This PR adjusts the deprecation to include the fact's name:
```
TASK [debug] ***************************************************************************************************************************************************************
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: /path/to/test-facts.yml:12:14

10       vars:
11         foo: "meh {{ bar }}"
12         bar: "asdf {{ ansible_distribution }}"
                ^ column 14

Use `ansible_facts["distribution"]` (no `ansible_` prefix) instead of `ansible_distribution`.

ok: [localhost] => {
    "msg": "meh asdf Archlinux"
}

TASK [debug] ***************************************************************************************************************************************************************
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from ansible-core version 2.24.
Origin: /path/to/test-facts.yml:14:14

12         bar: "asdf {{ ansible_distribution }}"
13     - debug:
14         msg: "{{ baz }}"
                ^ column 14

Use `ansible_facts["baz"]` instead of `baz`.

ok: [localhost] => {
    "msg": "bam"
}
```
(The second case is a cached host fact set with `set_fact` and `cacheable: true`.)

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request
