### PR TITLE
Check if pipelining is enabled and call appropriate function

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -464,8 +464,12 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
 
         become_unprivileged = self._is_become_unprivileged()
         basefile = self._connection._shell._generate_temp_dir_name()
-        cmd = self._connection._shell._mkdtemp2(basefile=basefile, system=become_unprivileged, tmpdir=tmpdir)
-        result = self._low_level_execute_command(cmd.command, in_data=cmd.input_data, sudoable=False)
+        if self._is_pipelining_enabled("new"):
+            cmd = self._connection._shell._mkdtemp2(basefile=basefile, system=become_unprivileged, tmpdir=tmpdir)
+            result = self._low_level_execute_command(cmd.command, in_data=cmd.input_data, sudoable=False)
+        else:
+            cmd = self._connection._shell.mkdtemp(basefile=basefile, system=become_unprivileged, tmpdir=tmpdir)
+            result = self._low_level_execute_command(cmd, in_data=None, sudoable=False)
 
         # error handling on this seems a little aggressive?
         if result['rc'] != 0:

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -235,8 +235,6 @@ class ShellModule(ShellBase):
         mode: int = 0o700,
         tmpdir: str | None = None,
     ) -> str:
-        # This is not called in Ansible anymore but it is kept for backwards
-        # compatibility in case other action plugins outside Ansible calls this.
         if not basefile:
             basefile = self.__class__._generate_temp_dir_name()
         basetmpdir = self._escape(tmpdir if tmpdir else self.get_option('remote_tmp'))


### PR DESCRIPTION
Fixes 86397

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Use "old" mkdtemp function to create temp directory if pipelining is not enabled. This makes sure ansible still works with connection plugins which do not support pipelining.
<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->
Fixes #86397

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

