### PR TITLE
Add codespell sanity test for core

### DIFF
--- a/test/sanity/code-smell/codespell.json
+++ b/test/sanity/code-smell/codespell.json
@@ -1,0 +1,5 @@
+{
+    "text": true,
+    "error_code": "ansible-test",
+    "output": "path-line-column-code-message"
+}

--- a/test/sanity/code-smell/codespell.py
+++ b/test/sanity/code-smell/codespell.py
@@ -1,0 +1,109 @@
+"""Check for common misspelled words using codespell."""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+import typing as t
+
+
+def main() -> None:
+    paths = sys.argv[1:] or sys.stdin.read().splitlines()
+
+    ignore_words_lines = (pathlib.Path(__file__).parent / 'codespell' / 'ignore-words.txt').read_text().splitlines()
+    ignore_words = [re.split(r'\s*#', line, maxsplit=1)[0] for line in ignore_words_lines]
+
+    quiet_level = (
+        32  # don't print configuration file
+        + 16  # don't print the list of fixed files
+        + 4  # omit warnings about automatic fixes that were disabled in the dictionary
+        + 2  # disable warnings about binary files
+        + 1  # disable warnings about wrong encoding
+    )
+
+    paths = [path for path in paths if path != 'test/sanity/ignore.txt']
+
+    with tempfile.NamedTemporaryFile(mode='wt') as ignore_words_temp_file:
+        ignore_words_temp_file.write('\n'.join(ignore_words))
+        ignore_words_temp_file.flush()
+
+        cmd = [
+            sys.executable,
+            '-m',
+            'codespell_lib',
+            '--disable-colors',
+            '--builtin',
+            'clear',  # minimize false positives
+            '--quiet-level',
+            str(quiet_level),
+            '--ignore-words',
+            ignore_words_temp_file.name,
+        ] + paths
+
+        process = subprocess.run(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+    if process.stderr:
+        print(process.stderr.strip(), file=sys.stderr)
+        sys.exit(1)
+
+    if not (stdout := process.stdout.strip()):
+        return
+
+    if process.returncode not in (0, 65):
+        print(f'Unexpected return code: {process.returncode}')
+        sys.exit(1)
+
+    pattern = re.compile(r'^(?P<path>[^:]*):(?P<line>[0-9]+): (?P<left>.*) ==> (?P<right>.*)$')
+    matches = parse_to_list_of_dict(pattern, stdout)
+    results: list[str] = []
+
+    for match in matches:
+        path, line_num_str, left, right = match['path'], match['line'], match['left'], match['right']
+        line_num = int(line_num_str)
+
+        try:
+            line = pathlib.Path(path).read_text().splitlines()[line_num - 1]
+            col_num = line.index(left) + 1
+        except UnicodeDecodeError:
+            col_num = 0
+
+        if len(left) <= 3 and pathlib.Path(path).suffix == '.py':
+            continue  # ignore short words in Python files, as they're likely just short variable names
+
+        code = re.sub('[^a-zA-Z]', '_', left)
+
+        results.append(f"{path}:{line_num}:{col_num}: {code}: {left} ==> {right}")
+
+    print('\n'.join(results))
+
+
+def parse_to_list_of_dict(pattern: re.Pattern, value: str) -> list[dict[str, t.Any]]:
+    matched = []
+    unmatched = []
+
+    for line in value.splitlines():
+        match = re.search(pattern, line)
+
+        if match:
+            matched.append(match.groupdict())
+        else:
+            unmatched.append(line)
+
+    if unmatched:
+        raise Exception(f'Pattern {pattern!r} did not match values:\n' + '\n'.join(unmatched))
+
+    return matched
+
+
+if __name__ == '__main__':
+    main()

--- a/test/sanity/code-smell/codespell.requirements.in
+++ b/test/sanity/code-smell/codespell.requirements.in
@@ -1,0 +1,1 @@
+codespell

--- a/test/sanity/code-smell/codespell.requirements.txt
+++ b/test/sanity/code-smell/codespell.requirements.txt
@@ -1,0 +1,2 @@
+# edit "codespell.requirements.in" and generate with: hacking/update-sanity-requirements.py --test codespell
+codespell==2.4.1

--- a/test/sanity/code-smell/codespell/ignore-words.txt
+++ b/test/sanity/code-smell/codespell/ignore-words.txt
@@ -1,0 +1,2 @@
+afile  # commonly used variable name for "a file"
+astroid  # pylint's astroid

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -156,6 +156,34 @@ lib/ansible/module_utils/facts/hardware/aix.py pylint:used-before-assignment
 lib/ansible/modules/rpm_key.py pylint:used-before-assignment
 lib/ansible/modules/service.py pylint:used-before-assignment
 lib/ansible/modules/user.py pylint:used-before-assignment
+lib/ansible/_internal/_wrapt.py codespell!skip  # vendored code
+lib/ansible/config/ansible_builtin_runtime.yml codespell:aci  # network collection name
+lib/ansible/galaxy/token.py codespell:chouse  # contributor's name
+lib/ansible/modules/assemble.py codespell:Fromm  # contributor's name
+lib/ansible/modules/group.py codespell:Fromm  # contributor's name
+lib/ansible/modules/stat.py codespell:woth  # write-other
+lib/ansible/modules/uri.py codespell:aNULL  # cipher name
+lib/ansible/modules/user.py codespell:Fromm  # contributor's name
+lib/ansible/plugins/action/assemble.py codespell:Fromm  # contributor's name
+test/integration/targets/ansible_log/runme.sh codespell:ALOG  # variable name
+test/integration/targets/apt/tasks/apt.yml codespell:hel  # test data
+test/integration/targets/filter_mathstuff/tasks/main.yml codespell:fo  # expected test output
+test/integration/targets/lineinfile/tasks/test_string01.yml codespell:Thi  # test data
+test/integration/targets/lineinfile/tasks/test_string01.yml codespell:ine  # test data
+test/integration/targets/lookup_ini/lookup-8859-15.ini codespell:indien  # French
+test/integration/targets/lookup_ini/lookup.ini codespell:indien  # French
+test/integration/targets/lookup_ini/lookup.properties codespell:indien  # French
+test/integration/targets/lookup_ini/test_lookup_properties.yml codespell:indien  # French
+test/integration/targets/module_utils_Ansible.Process/library/ansible_process_tests.ps1 codespell:caf  # expected test output
+test/lib/ansible_test/config/inventory.networking.template codespell:aci  # network collection name
+test/units/errors/fixtures/outputs/short_file_left_marker.txt codespell!skip  # intentionally truncated test data
+test/units/errors/fixtures/outputs/short_file_long_line_truncated_past_target.txt codespell!skip  # intentionally truncated test data
+test/units/errors/fixtures/outputs/short_file_no_column.txt codespell!skip  # intentionally truncated test data
+test/units/errors/fixtures/outputs/short_file_truncated_target.txt codespell!skip  # intentionally truncated test data
+test/units/errors/fixtures/outputs/short_file_truncated_target_last_displayed_char.txt codespell!skip  # intentionally truncated test data
+test/units/module_utils/facts/fixtures/cpuinfo/s390x-z13-2cpu-cpuinfo codespell!skip  # test data
+test/units/module_utils/facts/fixtures/cpuinfo/s390x-z14-64cpu-cpuinfo codespell!skip  # test data
+test/units/module_utils/facts/system/distribution/fixtures/univention_corporate_server_5.2.json codespell!skip  # test data
 lib/ansible/plugins/action/copy.py pylint:undefined-variable
 test/integration/targets/module_utils/library/test_optional.py pylint:used-before-assignment
 test/support/windows-integration/plugins/action/win_copy.py pylint:undefined-variable


### PR DESCRIPTION
##### SUMMARY

Add codespell sanity test for core.

This tool was chosen due to its relatively low false positive rate within source code, compared to alternatives.

##### ISSUE TYPE

Feature Pull Request
