### PR TITLE
Remove `sleep 0` Linux kernel bug work-around

### DIFF
--- a/changelogs/fragments/no-sleep-0.yml
+++ b/changelogs/fragments/no-sleep-0.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - >
+    core - The ``ActionBase._low_level_execute_command`` method no longer adds ``&& sleep 0`` to commands.
+    This was a work-around for a 10+ year old Linux kernel bug affecting OpenSSH.
+    By August of 2016 the fix had been included in kernel versions 4.1.26, 4.4.12, 4.5.6, 4.6.1 and 4.7.
+    Linux kernel bug report: https://lore.kernel.org/lkml/alpine.LNX.2.00.1512091358290.9574@fanir.tuyoix.net/
+    OpenSSH bug report: https://bugzilla.mindrot.org/show_bug.cgi?id=2492

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1307,9 +1307,6 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         if self._connection.allow_executable:
             if executable is None:
                 executable = self._play_context.executable
-                # mitigation for SSH race which can drop stdout (https://github.com/ansible/ansible/issues/13876)
-                # only applied for the default executable to avoid interfering with the raw action
-                cmd = self._connection._shell.append_command(cmd, 'sleep 0')
             if executable:
                 cmd = executable + ' -c ' + shlex.quote(cmd)
 


### PR DESCRIPTION
##### SUMMARY

The ``ActionBase._low_level_execute_command`` method no longer adds ``&& sleep 0`` to commands. This was a work-around for a 10+ year old Linux kernel bug affecting OpenSSH. By August of 2016 the fix had been included in kernel versions 4.1.26, 4.4.12, 4.5.6, 4.6.1 and 4.7.

Linux kernel bug report: https://lore.kernel.org/lkml/alpine.LNX.2.00.1512091358290.9574@fanir.tuyoix.net/
OpenSSH bug report: https://bugzilla.mindrot.org/show_bug.cgi?id=2492

##### ISSUE TYPE

Feature Pull Request
