### PR TITLE
service_facts: report correct status for failed services

### DIFF
--- a/changelogs/fragments/service_facts.yml
+++ b/changelogs/fragments/service_facts.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - service_facts - report correct status when service is in failed state under systemd (https://github.com/ansible/ansible/issues/81115).

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -296,41 +296,63 @@ class SystemctlScanService(BaseService):
                     status_val = fields[2]
 
                 service_name = fields[0]
-                if fields[3] == "running":
-                    state_val = "running"
+                if fields[3] in ["running", "failed"]:
+                    state_val = fields[3]
 
                 services[service_name] = {"name": service_name, "state": state_val, "status": status_val, "source": "systemd"}
 
     def _list_from_unit_files(self, systemctl_path, services):
 
         # now try unit files for complete picture and final 'status'
-        rc, stdout, stderr = self.module.run_command("%s list-unit-files --no-pager --type service --all" % systemctl_path, use_unsafe_shell=True)
+        rc, stdout, stderr = self.module.run_command(f"{systemctl_path} list-unit-files --no-pager --type service --all", use_unsafe_shell=True)
         if rc != 0:
-            self.module.warn("Could not get unit files data from systemd: %s" % stderr)
-        else:
-            for line in [svc_line for svc_line in stdout.split('\n') if '.service' in svc_line]:
-                # there is one more column (VENDOR PRESET) from `systemctl list-unit-files` for systemd >= 245
-                try:
-                    service_name, status_val = line.split()[:2]
-                except IndexError:
-                    self.module.fail_json(msg="Malformed output discovered from systemd list-unit-files: {0}".format(line))
-                if service_name not in services:
-                    rc, stdout, stderr = self.module.run_command("%s show %s --property=ActiveState" % (systemctl_path, service_name), use_unsafe_shell=True)
-                    state = 'unknown'
-                    if not rc and stdout != '':
-                        state = stdout.replace('ActiveState=', '').rstrip()
-                    services[service_name] = {"name": service_name, "state": state, "status": status_val, "source": "systemd"}
-                elif services[service_name]["status"] not in self.BAD_STATES:
-                    services[service_name]["status"] = status_val
+            self.module.warn(f"Could not get unit files data from systemd: {stderr}")
+            return
+
+        for line in [svc_line for svc_line in stdout.split('\n') if '.service' in svc_line]:
+            # there is one more column (VENDOR PRESET) from `systemctl list-unit-files` for systemd >= 245
+            try:
+                service_name, status_val = line.split()[:2]
+            except IndexError:
+                self.module.fail_json(msg=f"Malformed output discovered from systemd list-unit-files: {line}")
+
+            # Gather properties such as unitfilestate and activestate from the service
+            prop_dict = {
+                "UnitFileState": status_val,
+                "ActiveState": "unknown"
+            }
+            property_string = " ".join(f"--property={p}" for p in prop_dict)
+            rc, stdout, dummy = self.module.run_command(f"{systemctl_path} show {service_name} {property_string}", use_unsafe_shell=True)
+            if not rc and stdout != '':
+                for line in stdout.splitlines():
+                    if "=" in line:
+                        key, value = line.split("=", 1)
+                        if key in prop_dict:
+                            prop_dict[key] = value.rstrip()
+
+            if service_name not in services:
+                # Add the service to the services
+                services[service_name] = {
+                    "name": service_name,
+                    "state": prop_dict["ActiveState"],
+                    "status": prop_dict["UnitFileState"],
+                    "source": "systemd"
+                }
+            else:
+                # Update the status if the service is found in the unit files
+                # because it might be different from the status in the units list
+                services[service_name]["status"] = prop_dict["UnitFileState"]
 
     def gather_services(self):
 
         services = {}
-        if self.systemd_enabled():
-            systemctl_path = self.module.get_bin_path("systemctl", opt_dirs=["/usr/bin", "/usr/local/bin"])
-            if systemctl_path:
-                self._list_from_units(systemctl_path, services)
-                self._list_from_unit_files(systemctl_path, services)
+        if not self.systemd_enabled():
+            return services
+
+        systemctl_path = self.module.get_bin_path("systemctl", opt_dirs=["/usr/bin", "/usr/local/bin"])
+        if systemctl_path:
+            self._list_from_units(systemctl_path, services)
+            self._list_from_unit_files(systemctl_path, services)
 
         return services
 

--- a/test/integration/targets/service_facts/files/failed_service.systemd
+++ b/test/integration/targets/service_facts/files/failed_service.systemd
@@ -1,0 +1,10 @@
+[Unit]
+Description=Ansible Test Service which fails
+After=local-fs.target
+
+[Service]
+Type=simple
+ExecStart=/bin/false
+
+[Install]
+WantedBy=multi-user.target

--- a/test/integration/targets/service_facts/tasks/failed_enabled_service.yml
+++ b/test/integration/targets/service_facts/tasks/failed_enabled_service.yml
@@ -1,0 +1,44 @@
+- name: install the systemd unit file
+  copy:
+    src: failed_service.systemd
+    dest: /etc/systemd/system/ansible_failed_service.service
+    mode: '0644'
+  register: install_systemd_result
+
+- name: assert that the systemd unit file was installed
+  assert:
+    that:
+      - "install_systemd_result.dest == '/etc/systemd/system/ansible_failed_service.service'"
+      - "install_systemd_result.state == 'file'"
+      - "install_systemd_result.mode == '0644'"
+
+- name: start the ansible test service
+  service:
+    name: ansible_failed_service
+    enabled: yes
+    state: started
+  register: start_result
+
+- name: assert that the service was enabled and changes reported
+  assert:
+    that:
+      - "start_result.state == 'started'"
+      - "start_result is changed"
+
+- name: make sure systemd is reloaded
+  shell: systemctl daemon-reload
+
+- name: Populate service facts
+  service_facts:
+
+- name: Check if the service status is correct
+  assert:
+    that:
+      - "services['ansible_failed_service.service'].state == 'failed'"
+      - "services['ansible_failed_service.service'].status == 'enabled'"
+
+- name: remove the systemd unit file
+  file:
+    path: /etc/systemd/system/ansible_failed_service.service
+    state: absent
+  register: remove_systemd_result

--- a/test/integration/targets/service_facts/tasks/main.yml
+++ b/test/integration/targets/service_facts/tasks/main.yml
@@ -25,3 +25,12 @@
   when:
     - ansible_service_mgr == "systemd"
     - ansible_distribution != 'Alpine'
+
+- name: Test enabled failed service facts
+  block:
+    - name: test failed service facts
+      include_tasks: 'failed_enabled_service.yml'
+
+  when:
+    - ansible_service_mgr == "systemd"
+    - ansible_distribution != 'Alpine'


### PR DESCRIPTION
##### SUMMARY

* Report correct status for the failed services under systemd

Fixes: #81115

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/service_facts.yml
lib/ansible/modules/service_facts.py
test/integration/targets/service_facts/files/failed_service.systemd
test/integration/targets/service_facts/tasks/failed_enabled_service.yml
test/integration/targets/service_facts/tasks/main.yml


