### PR TITLE
Add serial_continue_on_batch_failure play keyword for independent host processing in serial execution

### DIFF
--- a/changelogs/fragments/86148-serial-continue-on-batch-failure.yml
+++ b/changelogs/fragments/86148-serial-continue-on-batch-failure.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "playbook - Add ``serial_continue_on_batch_failure`` play keyword to allow continuing serial execution even when entire batch fails. This enables independent processing of hosts when using serial execution (https://github.com/ansible/ansible/issues/86148)."

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1950,6 +1950,20 @@ RETRY_FILES_SAVE_PATH:
   ini:
   - {key: retry_files_save_path, section: defaults}
   type: path
+SERIAL_CONTINUE_ON_BATCH_FAILURE:
+  name: Default serial continue on batch failure
+  default: False
+  description:
+    - Sets the default value for the serial_continue_on_batch_failure play keyword.
+    - When True, serial execution will continue to the next batch even if all hosts in the current batch failed.
+    - This allows independent processing of hosts when using serial execution.
+    - Can be overridden at the play level.
+  env:
+    - name: ANSIBLE_SERIAL_CONTINUE_ON_BATCH_FAILURE
+  ini:
+    - section: defaults
+      key: serial_continue_on_batch_failure
+  type: boolean
 RUN_VARS_PLUGINS:
   name: When should vars plugins run relative to inventory
   default: demand

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -191,8 +191,14 @@ class PlaybookExecutor:
                                 (previously_failed + previously_unreachable)
 
                             if len(batch) == failed_hosts_count:
-                                break_play = True
-                                break
+                                if play.serial_continue_on_batch_failure and not break_play:
+                                    display.debug(
+                                        "All hosts in batch failed, but continuing to next batch due to "
+                                        "serial_continue_on_batch_failure setting"
+                                    )
+                                else:
+                                    break_play = True
+                                    break
 
                             # update the previous counts so they don't accumulate incorrectly
                             # over multiple serial batches

--- a/lib/ansible/keyword_desc.yml
+++ b/lib/ansible/keyword_desc.yml
@@ -55,6 +55,7 @@ retries: "Number of retries before giving up in a :term:`until` loop. This setti
 roles: List of roles to be imported into the play
 run_once: Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterward apply any results and facts to all active hosts in the same batch.
 serial: Explicitly define how Ansible batches the execution of the current play on the play's target. See :ref:`rolling_update_batch_size`.
+serial_continue_on_batch_failure: When set to True and using serial execution, continue to the next batch even if all hosts in the current batch failed. This allows independent processing of hosts when using serial execution. By default (False), if all hosts in a batch fail, the play stops immediately.
 strategy: Allows you to choose the strategy plugin to use for the play. See :ref:`strategy_plugins`.
 tags: Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line.
 tasks: Main list of tasks to execute in the play, they run after :term:`roles` and before :term:`post_tasks`.

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -85,6 +85,7 @@ class Play(Base, Taggable, CollectionSearch):
     force_handlers = NonInheritableFieldAttribute(isa='bool', default=context.cliargs_deferred_get('force_handlers'), always_post_validate=True)
     max_fail_percentage = NonInheritableFieldAttribute(isa='percent', always_post_validate=True)
     serial = NonInheritableFieldAttribute(isa='list', default=list, always_post_validate=True)
+    serial_continue_on_batch_failure = NonInheritableFieldAttribute(isa='bool', default=C.SERIAL_CONTINUE_ON_BATCH_FAILURE, always_post_validate=True)
     strategy = NonInheritableFieldAttribute(isa='string', default=C.DEFAULT_STRATEGY, always_post_validate=True)
     order = NonInheritableFieldAttribute(isa='string', always_post_validate=True)
 

--- a/test/integration/targets/serial_batch_failure/aliases
+++ b/test/integration/targets/serial_batch_failure/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group3
+context/controller

--- a/test/integration/targets/serial_batch_failure/inventory
+++ b/test/integration/targets/serial_batch_failure/inventory
@@ -1,0 +1,5 @@
+[test_hosts]
+host1 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
+host2 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
+host3 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
+host4 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/serial_batch_failure/runme.sh
+++ b/test/integration/targets/serial_batch_failure/runme.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Test default behavior - playbook should stop after first batch fails
+ansible-playbook test_default_behavior.yml -i inventory -e "test_name=default_behavior" "$@" 2>&1 | tee /tmp/serial_test_default.out
+grep -q "host3 should not execute" /tmp/serial_test_default.out && exit 1 || echo "✓ Default behavior: execution stopped as expected"
+
+# Test continue on batch failure - playbook should continue to all hosts
+ansible-playbook test_continue_enabled.yml -i inventory -e "test_name=continue_enabled" "$@" 2>&1 | tee /tmp/serial_test_continue.out
+grep -q "host3 executed" /tmp/serial_test_continue.out || (echo "✗ Continue enabled: host3 should have executed" && exit 1)
+echo "✓ Continue enabled: all hosts executed"
+
+# Test with rescue blocks
+ansible-playbook test_with_rescue.yml -i inventory "$@"
+echo "✓ Rescue blocks work correctly"
+
+# Test with max_fail_percentage - playbook should fail but we verify behavior
+ansible-playbook test_max_fail_percentage.yml -i inventory "$@" 2>&1 | tee /tmp/serial_test_max_fail.out || true
+# Verify the second play did NOT execute (should stop when max_fail_percentage reached)
+grep -q "max_fail_percentage test completed" /tmp/serial_test_max_fail.out && exit 1 || echo "✓ max_fail_percentage interaction works"
+
+echo "All integration tests passed!"

--- a/test/integration/targets/serial_batch_failure/test_continue_enabled.yml
+++ b/test/integration/targets/serial_batch_failure/test_continue_enabled.yml
@@ -1,0 +1,31 @@
+---
+# Test that serial_continue_on_batch_failure=True allows execution to continue
+# even when an entire batch fails
+
+- name: Test serial continue on batch failure enabled
+  hosts: test_hosts
+  gather_facts: false
+  serial: 1
+  serial_continue_on_batch_failure: true
+  tasks:
+    - name: Task that fails on host2
+      ansible.builtin.command: /bin/false
+      when: inventory_hostname == 'host2'
+
+    - name: Task that should run on all hosts including host3
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} executed successfully"
+      register: execution_result
+
+    - name: Mark host3 execution for verification
+      ansible.builtin.set_fact:
+        host3_executed: true
+      when: inventory_hostname == 'host3'
+
+- name: Verify all hosts executed
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check that host3 executed
+      ansible.builtin.debug:
+        msg: "host3 executed"  # This will be grepped in runme.sh

--- a/test/integration/targets/serial_batch_failure/test_default_behavior.yml
+++ b/test/integration/targets/serial_batch_failure/test_default_behavior.yml
@@ -1,0 +1,26 @@
+---
+# Test that default behavior (serial_continue_on_batch_failure=False) stops execution
+# when an entire batch fails
+
+- name: Test default serial batch failure behavior
+  hosts: test_hosts
+  gather_facts: false
+  serial: 1
+  # serial_continue_on_batch_failure defaults to False
+  tasks:
+    - name: Task that fails on host2
+      ansible.builtin.command: /bin/false
+      when: inventory_hostname == 'host2'
+
+    - name: Task that should not run on host3 and host4
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} should not execute this in default mode"
+      failed_when: inventory_hostname in ['host3', 'host4']
+
+- name: Verify execution stopped
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check results
+      ansible.builtin.debug:
+        msg: "If default behavior works, host3 and host4 never executed"

--- a/test/integration/targets/serial_batch_failure/test_max_fail_percentage.yml
+++ b/test/integration/targets/serial_batch_failure/test_max_fail_percentage.yml
@@ -1,0 +1,25 @@
+---
+# Test that max_fail_percentage still works correctly with serial_continue_on_batch_failure
+
+- name: Test serial continue with max_fail_percentage
+  hosts: test_hosts
+  gather_facts: false
+  serial: 1
+  serial_continue_on_batch_failure: true
+  max_fail_percentage: 50
+  tasks:
+    - name: Task that fails on host2 and host3
+      ansible.builtin.command: /bin/false
+      when: inventory_hostname in ['host2', 'host3']
+
+    - name: This should run but play should stop when threshold reached
+      ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} executed"
+
+- name: This play should not execute if max_fail_percentage stopped previous play
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Verification task
+      ansible.builtin.debug:
+        msg: "max_fail_percentage test completed"

--- a/test/integration/targets/serial_batch_failure/test_with_rescue.yml
+++ b/test/integration/targets/serial_batch_failure/test_with_rescue.yml
@@ -1,0 +1,37 @@
+---
+# Test that rescue blocks work correctly with serial_continue_on_batch_failure
+
+- name: Test serial continue with rescue blocks
+  hosts: test_hosts
+  gather_facts: false
+  serial: 1
+  serial_continue_on_batch_failure: true
+  tasks:
+    - name: Block with potential failure
+      block:
+        - name: Task that fails on host2
+          ansible.builtin.command: /bin/false
+          when: inventory_hostname == 'host2'
+
+        - name: This should run on non-failing hosts
+          ansible.builtin.debug:
+            msg: "{{ inventory_hostname }} - main task executed"
+
+      rescue:
+        - name: Rescue task
+          ansible.builtin.debug:
+            msg: "{{ inventory_hostname }} - rescue executed"
+          when: inventory_hostname == 'host2'
+
+      always:
+        - name: Always runs
+          ansible.builtin.debug:
+            msg: "{{ inventory_hostname }} - always executed"
+
+- name: Verify test completed
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Test passed
+      ansible.builtin.debug:
+        msg: "Rescue block test completed successfully"


### PR DESCRIPTION
  Adds serial_continue_on_batch_failure play keyword to allow serial execution to continue to subsequent batches when an entire batch fails. This enables independent host processing in rolling deployments.

  Closes #86148

  **Motivation and Context**

  When using serial execution mode, Ansible currently stops the entire play if all hosts in a batch fail. This prevents processing remaining hosts even when their operations are independent of previous batches.

  This PR introduces an opt-in mechanism to continue serial execution past failed batches, enabling truly independent host processing.

  **Implementation Details**

  Modified Files

  Core Logic (4 files):
  - lib/ansible/playbook/play.py - Added play attribute with NonInheritableFieldAttribute
  - lib/ansible/executor/playbook_executor.py - Modified batch failure check (respects max_fail_percentage)
  - lib/ansible/config/base.yml - Added global configuration option
  - lib/ansible/keyword_desc.yml - Added keyword documentation

  Documentation:
  - changelogs/fragments/86148-serial-continue-on-batch-failure.yml - Changelog entry

  Tests (7 new files):
  - test/integration/targets/serial_batch_failure/ - Comprehensive integration test suite

 Change is fully backward compatible. The new keyword defaults to False, maintaining existing behaviour. No changes required to existing playbooks.

  **Testing Performed**

  Static Analysis:
  - ansible-test sanity --test pep8 - PASSED
  - ansible-test sanity --test pylint - PASSED
  - ansible-test sanity --test yamllint - PASSED

  Integration Tests:
  - All 4 integration test scenarios passed
  - Interaction with rescue blocks validated
  - Interaction with max_fail_percentage verified

