### PR TITLE
rpm_key: Faillback to sequoia-sq for RHEL 10

### DIFF
--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -123,6 +123,7 @@ class RpmKey(object):
         self.gpg = self.module.get_bin_path('gpg')
         if not self.gpg:
             self.gpg = self.module.get_bin_path('gpg2', required=True)
+        self.sq = self.module.get_bin_path('sq')
 
         if '://' in key:
             keyfile = self.fetch_key(key)
@@ -237,11 +238,22 @@ class RpmKey(object):
         rc, stdout, stderr = self.module.run_command(cmd)
         if rc != 0:  # No key is installed on system
             return False
-        cmd += ' --qf "%{description}" | ' + self.gpg + ' --no-tty --batch --with-colons --fixed-list-mode -'
-        stdout, stderr = self.execute_command(cmd)
-        for line in stdout.splitlines():
-            if keyid in line.split(':')[4]:
-                return True
+
+        cmd = self.rpm + ' -q  gpg-pubkey --qf "%{description}" | ' + self.gpg + ' --no-tty --batch --with-colons --fixed-list-mode -'
+        rc, stdout, stderr = self.module.run_command(cmd)
+        if rc == 0:
+            for line in stdout.splitlines():
+                if keyid in line.split(':')[4]:
+                    return True
+
+        if self.sq:
+            cmd = self.rpm + ' -q  gpg-pubkey --qf "%{description}" | ' + self.sq + ' keyring list'
+            rc, stdout, stderr = self.module.run_command(cmd)
+            if rc == 0:
+                for line in stdout.splitlines():
+                    if keyid in line.split(' ')[2]:
+                        return True
+
         return False
 
     def import_key(self, keyfile):


### PR DESCRIPTION
##### SUMMARY

Refer to https://access.redhat.com/solutions/7133967:

- This is an expected behavior. The new PQC(post Quantum Cryptography) key is added to the file "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release" by recently released "redhat-release-10.1-17.el10.x86_64". Red Hat will start signing the RPMs with the new key. This key is in the OpenPGP version 6 packet format, which GnuPG does not support at all.
- A workaround is to use /usr/bin/sq from the sequoia-sq package shipped with Red Hat 10 to access these keys. rpmkeys internally uses Sequoia-PGP.

This PR will faillback with sequoia-sq, in case gnupg/gnupg2 couldn't read the installed keys correctly.

Fixes https://github.com/ansible/ansible/issues/86246

##### ISSUE TYPE

- Bugfix Pull Request
