### PR TITLE
Fix windows blocking io error

### DIFF
--- a/changelogs/fragments/fix-windows-blocking-io-error.yml
+++ b/changelogs/fragments/fix-windows-blocking-io-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cli - fixed ``OSError`` on Windows by adding platform check before calling ``os.get_blocking()``, now shows helpful error message directing users to WSL instead of cryptic error

--- a/changelogs/fragments/fix-windows-blocking-io-error.yml
+++ b/changelogs/fragments/fix-windows-blocking-io-error.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - cli - fixed ``OSError`` on Windows by adding platform check before calling ``os.get_blocking()``, now shows helpful error message directing users to WSL instead of cryptic error
+  - cli - windows users now get a clear error about needing wsl instead of crashing with oserror

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -34,6 +34,15 @@ if sys.version_info < _PY_MIN:
 
 def check_blocking_io():
     """Check stdin/stdout/stderr to make sure they are using blocking IO."""
+    # Skip blocking IO check on Windows as os.get_blocking() is not supported
+    # Ansible requires a POSIX OS; on Windows, use WSL (Windows Subsystem for Linux)
+    if sys.platform == 'win32':
+        raise SystemExit(
+            'ERROR: Ansible requires a POSIX operating system (Linux, macOS, BSD, etc.). '
+            'On Windows, please use WSL (Windows Subsystem for Linux) to run Ansible. '
+            'See: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html'
+        )
+
     handles = []
 
     for handle in (sys.stdin, sys.stdout, sys.stderr):


### PR DESCRIPTION
##### SUMMARY

windows users were getting a cryptic `OSError: [WinError 1] Incorrect function` when trying to run ansible because `os.get_blocking()` doesn't work on windows. added a simple platform check to catch this early and show a helpful message about using wsl instead.

##### ISSUE TYPE

- Bugfix Pull Request
