### PR TITLE
Fix LIB env var incorrectly set to "System.Collections.DictionaryEntry"

### DIFF
--- a/changelogs/fragments/fix-windows-lib-env-corruption.yml
+++ b/changelogs/fragments/fix-windows-lib-env-corruption.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "Fix Windows LIB env var corruption (https://github.com/ansible-collections/ansible.windows/issues/297)."

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.AddType.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.AddType.psm1
@@ -378,7 +378,7 @@ Function Add-CSharpType {
         $originalEnv = @{}
         try {
             'LIB' | ForEach-Object -Process {
-                $value = Get-Item -LiteralPath "Env:\$_" -ErrorAction SilentlyContinue
+                $value = (Get-Item -LiteralPath "Env:\$_" -ErrorAction SilentlyContinue).Value
                 if ($value) {
                     $originalEnv[$_] = $value
                     Remove-Item -LiteralPath "Env:\$_"

--- a/test/integration/targets/module_utils_Ansible.ModuleUtils.AddType/library/add_type_test.ps1
+++ b/test/integration/targets/module_utils_Ansible.ModuleUtils.AddType/library/add_type_test.ps1
@@ -322,6 +322,7 @@ namespace Namespace12
 $env:LIB = "C:\fake\folder\path"
 try {
     Add-CSharpType -Reference $lib_set
+    Assert-Equal -actual $env:LIB -expected "C:\fake\folder\path"
 }
 finally {
     Remove-Item -LiteralPath env:\LIB


### PR DESCRIPTION
##### SUMMARY
This is a fix for a common issue where Ansible is setting the LIB env var to the data type (System.Collections.DictionaryEntry) and not the actual value.

It unfortunately causes downstream issues if you run PowerShell scripts that are affected by the LIB variable not being a search path, but an incorrect string. It causes Add-Type to fail on even the simples call (like `Add-Type "using System;"`

This fixes ansible-collections/ansible.windows#297 in the correct way.
This fixes diyan/pywinrm#354.

##### ISSUE TYPE
- Bugfix Pull Request
