### PR TITLE
ansible-pull verify that file is in repo

### DIFF
--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -83,6 +83,7 @@ class PullCLI(CLI):
     PLAYBOOK_ERRORS = {
         1: 'File does not exist',
         2: 'File is not readable',
+        3: 'File is not in the source repository',
     }
     ARGUMENTS = {'playbook.yml': 'The name of one the YAML format files to run as an Ansible playbook. '
                                  'This can be a relative path within the checkout. By default, Ansible will '
@@ -360,11 +361,13 @@ class PullCLI(CLI):
         return rc
 
     @staticmethod
-    def try_playbook(path):
-        if not os.path.exists(path):
+    def try_playbook(path, book_path):
+        if not os.path.exists(book_path):
             return 1
-        if not os.access(path, os.R_OK):
+        if not os.access(book_path, os.R_OK):
             return 2
+        if not book_path.startswith(path):
+            return 3
         return 0
 
     @staticmethod
@@ -374,8 +377,8 @@ class PullCLI(CLI):
         if context.CLIARGS['args'] and context.CLIARGS['args'][0] is not None:
             playbooks = []
             for book in context.CLIARGS['args']:
-                book_path = os.path.join(path, book)
-                rc = PullCLI.try_playbook(book_path)
+                book_path = os.path.realpath(os.path.join(path, book))
+                rc = PullCLI.try_playbook(path, book_path)
                 if rc != 0:
                     errors.append("%s: %s" % (book_path, PullCLI.PLAYBOOK_ERRORS[rc]))
                     continue
@@ -387,11 +390,11 @@ class PullCLI(CLI):
             return playbook
         else:
             fqdn = socket.getfqdn()
-            hostpb = os.path.join(path, fqdn + '.yml')
-            shorthostpb = os.path.join(path, fqdn.split('.')[0] + '.yml')
-            localpb = os.path.join(path, PullCLI.DEFAULT_PLAYBOOK)
+            hostpb = os.path.realpath(os.path.join(path, fqdn + '.yml'))
+            shorthostpb = os.path.realpath(os.path.join(path, fqdn.split('.')[0] + '.yml'))
+            localpb = os.path.realpath(os.path.join(path, PullCLI.DEFAULT_PLAYBOOK))
             for pb in [hostpb, shorthostpb, localpb]:
-                rc = PullCLI.try_playbook(pb)
+                rc = PullCLI.try_playbook(path, pb)
                 if rc == 0:
                     playbook = pb
                     break

--- a/test/integration/targets/ansible-pull/runme.sh
+++ b/test/integration/targets/ansible-pull/runme.sh
@@ -104,6 +104,19 @@ function pass_tests_file_not_accessible {
 	fi
 }
 
+function pass_tests_file_not_in_repo {
+	if ! grep 'File is not in the source repository' "${temp_log}"; then
+		cat "${temp_log}"
+		echo "Tried to run playbook not in source repository"
+		exit 1
+	fi
+	if grep MAGICKEYWORD "${temp_log}"; then
+		cat "${temp_log}"
+		echo "Managed to run playbook not in source repository"
+		exit 1
+	fi
+}
+
 export ANSIBLE_INVENTORY
 export ANSIBLE_HOST_PATTERN_MISMATCH
 
@@ -173,6 +186,10 @@ cp "${script_location}/pull-integration-test/local.yml" "${unreadable_file}"
 chmod a-r "${unreadable_file}"
 ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" "$@" "${unreadable_file}" 2>&1 | tee "${temp_log}"
 pass_tests_file_not_accessible
+
+pathtrav="$(echo "${PWD}" | sed -E 's|^|..|;s|[^/]+|..|g')"
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" "$@" "${pathtrav}${script_location}/pull-integration-test/local.yml" 2>&1 | tee "${temp_log}"
+pass_tests_file_not_in_repo
 
 set -o pipefail
 

--- a/test/integration/targets/ansible-pull/runme.sh
+++ b/test/integration/targets/ansible-pull/runme.sh
@@ -11,6 +11,8 @@ repo_dir="${temp_dir}/repo"
 pull_dir="${temp_dir}/pull"
 temp_log="${temp_dir}/pull.log"
 
+script_location="${PWD}"
+
 ansible-playbook setup.yml -i ../../inventory
 
 cleanup="$(pwd)/cleanup.yml"
@@ -81,6 +83,27 @@ function pass_tests_multi {
 	fi
 }
 
+function pass_tests_file_exist {
+	if ! grep 'File does not exist' "${temp_log}"; then
+		cat "${temp_log}"
+		echo "Tried to run nonexisting playbook"
+		exit 1
+	fi
+}
+
+function pass_tests_file_not_accessible {
+	if ! grep 'File is not readable' "${temp_log}"; then
+		cat "${temp_log}"
+		echo "Tried to run not accessible playbook"
+		exit 1
+	fi
+	if grep MAGICKEYWORD "${temp_log}"; then
+		cat "${temp_log}"
+		echo "Managed to run not accessible playbook"
+		exit 1
+	fi
+}
+
 export ANSIBLE_INVENTORY
 export ANSIBLE_HOST_PATTERN_MISMATCH
 
@@ -138,6 +161,20 @@ echo 'test run on changes, yaml result format'
 change_repo
 ANSIBLE_CALLBACK_RESULT_FORMAT='yaml' ansible-pull -d "${pull_dir}" -U "${repo_dir}" --only-if-changed "$@" | tee "${temp_log}"
 pass_tests
+
+# run tests for file permissions
+set +o pipefail
+
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" "$@" "nonexistent.yml" 2>&1 | tee "${temp_log}"
+pass_tests_file_exist
+
+unreadable_file="${PWD}/unreadable.txt"
+cp "${script_location}/pull-integration-test/local.yml" "${unreadable_file}"
+chmod a-r "${unreadable_file}"
+ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" "$@" "${unreadable_file}" 2>&1 | tee "${temp_log}"
+pass_tests_file_not_accessible
+
+set -o pipefail
 
 if [ "${ORIG_CONFIG}" != "" ]; then
   export ANSIBLE_CONFIG="${ORIG_CONFIG}"

--- a/test/integration/targets/ansible-pull/runme.sh
+++ b/test/integration/targets/ansible-pull/runme.sh
@@ -183,7 +183,7 @@ pass_tests_file_exist
 
 unreadable_file="${PWD}/unreadable.txt"
 cp "${script_location}/pull-integration-test/local.yml" "${unreadable_file}"
-chmod a-r "${unreadable_file}"
+chmod 000 "${unreadable_file}"
 ANSIBLE_CONFIG='' ansible-pull -d "${pull_dir}" -U "${repo_dir}" "$@" "${unreadable_file}" 2>&1 | tee "${temp_log}"
 pass_tests_file_not_accessible
 


### PR DESCRIPTION
##### SUMMARY

Adding checks to `ansible-pull` to verify that the playbook actually resides in the pulled repository and not in an arbitrary location. If not you can run any playbook with e.g. `ansible-pull -U https://github.com/ansible/ansible.git -i localhost $(pwd)/pull-poc.yml`

Also added unit tests for file not existing or accessible, which is unchanged but related to my changes.

##### ISSUE TYPE

- Bugfix Pull Request
- Test Pull Request
