### PR TITLE
ansible-test - Remove obsolete remote auth

### DIFF
--- a/changelogs/fragments/ansible-test-auth-cleanup.yml
+++ b/changelogs/fragments/ansible-test-auth-cleanup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Remove support for an obsolete remote authentication method.

--- a/test/lib/ansible_test/_internal/ci/local.py
+++ b/test/lib/ansible_test/_internal/ci/local.py
@@ -260,22 +260,9 @@ class PasswordAuthenticator(Authenticator):
 
     def prepare_auth_request(self, config: dict[str, object], context: AuthContext) -> dict[str, object]:
         parts = self.config_file().read_text().strip().split(maxsplit=1)
-
-        if len(parts) == 1:  # temporary backward compatibility for legacy API keys
-            request = dict(
-                config=config,
-                auth=dict(
-                    remote=dict(
-                        key=parts[0],
-                    ),
-                ),
-            )
-
-            return request
-
         username, password = parts
 
-        request = dict(
+        request: dict[str, object] = dict(
             type="remote:password",
             config=config,
             username=username,


### PR DESCRIPTION
##### SUMMARY

ansible-test - Remove obsolete remote auth.

##### ISSUE TYPE

Feature Pull Request
