### PR TITLE
[stable-2.18] Fix direct S3 link in integration tests (#86464)

### DIFF
--- a/test/sanity/code-smell/no-s3.json
+++ b/test/sanity/code-smell/no-s3.json
@@ -1,0 +1,4 @@
+{
+    "text": true,
+    "output": "path-line-column-message"
+}

--- a/test/sanity/code-smell/no-s3.py
+++ b/test/sanity/code-smell/no-s3.py
@@ -1,0 +1,27 @@
+"""
+Disallow direct linking to S3 buckets.
+S3 buckets should be accessed through a CloudFront distribution.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+
+def main():
+    """Main entry point."""
+    for path in sys.argv[1:] or sys.stdin.read().splitlines():
+        with open(path, 'rb') as path_fd:
+            for line, b_text in enumerate(path_fd.readlines()):
+                try:
+                    text = b_text.decode()
+                except UnicodeDecodeError:
+                    continue
+
+                if match := re.search(r'(http.*?s3\..*?amazonaws\.com)', text):
+                    print(f'{path}:{line + 1}:{match.start(1) + 1}: use a CloudFront distribution instead of an S3 bucket: {match.group(1)}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/86464

(cherry picked from commit b1bc1e2513f0fe28e9fbe7e71b88d9017ff6e535)

This branch had no direct links, but the test is still useful.

##### ISSUE TYPE

Test Pull Request
