### PR TITLE
ssh - fix tty dependency with become

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1129,6 +1129,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         if not self._is_pipelining_enabled("new", wrap_async) and tmpdir is None:
             self._make_tmp_path()
             tmpdir = self._connection._shell.tmpdir
+            display.vvv("Pipelining is enabled.")
 
         if task_vars is None:
             task_vars = dict()

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -360,8 +360,10 @@ DOCUMENTATION = """
               version_added: '2.12'
       use_tty:
         version_added: '2.5'
-        default: true
-        description: add -tt to ssh commands to force tty allocation.
+        description:
+          - When set to C(True), add -tt to ssh commands to force tty allocation.  This disables pipelining.
+          - When set to C(False), -tt will not be added to ssh commands.
+          - Default is C(False) unless the become plugin requires a tty.
         env: [{name: ANSIBLE_SSH_USETTY}]
         ini:
         - {key: usetty, section: ssh_connection}
@@ -786,6 +788,12 @@ class Connection(ConnectionBase):
 
         return self._populated_agent
 
+    def _use_tty(self) -> bool:
+        use_tty = self.get_option('use_tty')
+        if use_tty is None:
+            use_tty = self.become and self.become.require_tty
+        return use_tty
+
     def _build_command(self, binary: str, subsystem: str, *other_args: bytes | str) -> list[bytes]:
         """
         Takes an executable (ssh, scp, sftp or wrapper) and optional extra arguments and returns the remote command
@@ -884,6 +892,11 @@ class Connection(ConnectionBase):
             (b"-o", b"ConnectTimeout=" + to_bytes(timeout, errors='surrogate_or_strict', nonstring='simplerepr')),
             u"ANSIBLE_TIMEOUT/timeout set"
         )
+
+        # -tt can cause various issues in some environments so allow the user
+        # to disable it as a troubleshooting method.
+        if self._use_tty():
+            self._add_args(b_command, (b'-tt',), u'opt use_tty')
 
         # Add in any common or binary-specific arguments from the PlayContext
         # (i.e. inventory or task settings or overrides on the command line).
@@ -1502,17 +1515,7 @@ class Connection(ConnectionBase):
 
         ssh_executable = self.get_option('ssh_executable')
 
-        # -tt can cause various issues in some environments so allow the user
-        # to disable it as a troubleshooting method.
-        use_tty = self.get_option('use_tty')
-
-        args: tuple[str, ...]
-        if not in_data and sudoable and use_tty:
-            args = ('-tt', self.host, cmd)
-        else:
-            args = (self.host, cmd)
-
-        cmd = self._build_command(ssh_executable, 'ssh', *args)
+        cmd = self._build_command(ssh_executable, 'ssh', self.host, cmd)
         (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable)
 
         # When running on Windows, stderr may contain CLIXML encoded output
@@ -1580,15 +1583,8 @@ class Connection(ConnectionBase):
         return self._is_tty_requested()
 
     def _is_tty_requested(self):
-
-        # check if we require tty (only from our args, cannot see options in configuration files)
-        opts = []
-        for opt in ('ssh_args', 'ssh_common_args', 'ssh_extra_args'):
-            attr = self.get_option(opt)
-            if attr is not None:
-                opts.extend(self._split_ssh_args(attr))
-
-        args, dummy = self._tty_parser.parse_known_args(opts)
+        cmd = self._build_command(self.get_option('ssh_executable'), 'ssh')
+        args, dummy = self._tty_parser.parse_known_args(list(map(bytes.decode, cmd)))
 
         if args.t:
             return True

--- a/test/integration/targets/connection_ssh/become_plugins/noop.py
+++ b/test/integration/targets/connection_ssh/become_plugins/noop.py
@@ -1,0 +1,34 @@
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+DOCUMENTATION = """
+    name: noop
+    short_description: Test become plugin attributes.
+    description: Test become plugin attributes that modulate pipelining.
+    options:
+      become_pass:
+        description: Password option required by BecomeBase.
+        default: pass
+"""
+
+import os
+
+from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.plugins.become import BecomeBase
+
+
+class BecomeModule(BecomeBase):
+    name = 'noop'
+    prompt = 'testing become plugin attributes via ansible-test'
+
+    require_tty = boolean(os.environ.get("ANSIBLE_TEST_BECOME_REQUIRE_TTY", BecomeBase.require_tty))
+    pipelining = boolean(os.environ.get("ANSIBLE_TEST_BECOME_PIPELINING", BecomeBase.pipelining))
+
+    def build_become_command(self, cmd, shell):
+        super(BecomeModule, self).build_become_command(cmd, shell)
+
+        if not cmd:
+            return cmd
+
+        return f'echo "{self.prompt}"; read PASS; echo {self.success}; exec {cmd}'

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -96,4 +96,7 @@ ANSIBLE_SSH_VERBOSITY=1 ansible ssh -m raw -a whoami -i test_connection.inventor
 # enable SSH client verbosity level 3 via var; ensure debug3 lines
 ansible ssh -m raw -a whoami -i test_connection.inventory -vvvvv -e ansible_ssh_verbosity=3 2>&1 | grep 'debug3:'
 
+# test factors that impact pipelining
+ansible-playbook test_pipelining.yml "$@"
+
 echo PASS

--- a/test/integration/targets/connection_ssh/test_pipelining.yml
+++ b/test/integration/targets/connection_ssh/test_pipelining.yml
@@ -60,11 +60,11 @@
 
     # FIXME
     # https://github.com/ansible/ansible/issues/86298
-    # - name: Test become plugin requiring TTY
-    #   command: "{{ run_test }} -b --become-method noop"
-    #   environment:
-    #     ANSIBLE_BECOME_PLUGINS: ./become_plugins
-    #     ANSIBLE_TEST_BECOME_REQUIRE_TTY: True
-    #   register: no_pipelining
-    #   failed_when: *validate_become
-    # - assert: *test_no_pipelining
+    - name: Test become plugin requiring TTY
+      command: "{{ run_test }} -b --become-method noop"
+      environment:
+        ANSIBLE_BECOME_PLUGINS: ./become_plugins
+        ANSIBLE_TEST_BECOME_REQUIRE_TTY: True
+      register: no_pipelining
+      failed_when: *validate_become
+    - assert: *test_no_pipelining

--- a/test/integration/targets/connection_ssh/test_pipelining.yml
+++ b/test/integration/targets/connection_ssh/test_pipelining.yml
@@ -1,0 +1,70 @@
+- hosts: localhost
+  gather_facts: no
+  timeout: 4
+  vars:
+    run_test: ansible ssh-pipelining -i test_connection.inventory -m ping -vvvv
+    pipelining_msg: Pipelining is enabled
+    become_msg: Escalation succeeded
+  tasks:
+    - name: Test pipelining
+      command: "{{ run_test }}"
+      register: pipelining_enabled
+    - assert: &test_pipelining
+        that:
+          - "{{ pipelining_enabled.stdout | regex_findall(pipelining_msg) | length == 1 }}"
+          - "{{ pipelining_enabled.stdout | regex_findall('PUT') | length == 0 }}"
+
+    - name: Test pipelining in conjunction with become
+      command: "{{ run_test }} -b"
+      register: pipelining_enabled
+      failed_when:
+        - pipelining_enabled is failed or (pipelining_enabled.stdout | regex_findall(become_msg) | length != 1)
+    - assert: *test_pipelining
+
+    - name: Test pipelining is not used is ssh_extra_args requests TTY
+      command: >-
+        {{ run_test }} -e "ansible_ssh_extra_args='-o RequestTTY=force'"
+      register: no_pipelining
+    - assert: &test_no_pipelining
+        that:
+          - "{{ no_pipelining.stdout | regex_findall(pipelining_msg) | length == 0 }}"
+          - "{{ no_pipelining.stdout | regex_findall('PUT') | length == 1 }}"
+
+    - name: Test pipelining is not used if ssh_common_args requests TTY
+      command: >-
+        {{ run_test }} -e "ansible_ssh_common_args='-o RequestTTY=yes'"
+      register: no_pipelining
+    - assert: *test_no_pipelining
+
+    - name: Test pipelining is not used if ssh_args requests TTY
+      command: >-
+        {{ run_test }} -e "ansible_ssh_args='-o RequestTTY=yes'"
+      register: no_pipelining
+    - assert: *test_no_pipelining
+
+    - name: Test become plugin implicitly requires a TTY
+      command: "{{ run_test }} -b --become-method su"
+      register: no_pipelining
+      failed_when: &validate_become
+        - no_pipelining is failed or (no_pipelining.stdout | regex_findall(become_msg) | length != 1)
+    - assert: *test_no_pipelining
+
+    - name: Test become plugin can disallow pipelining
+      command: "{{ run_test }} -b --become-method noop"
+      environment:
+        ANSIBLE_BECOME_PLUGINS: ./become_plugins
+        ANSIBLE_TEST_BECOME_PIPELINING: False
+      register: no_pipelining
+      failed_when: *validate_become
+    - assert: *test_no_pipelining
+
+    # FIXME
+    # https://github.com/ansible/ansible/issues/86298
+    # - name: Test become plugin requiring TTY
+    #   command: "{{ run_test }} -b --become-method noop"
+    #   environment:
+    #     ANSIBLE_BECOME_PLUGINS: ./become_plugins
+    #     ANSIBLE_TEST_BECOME_REQUIRE_TTY: True
+    #   register: no_pipelining
+    #   failed_when: *validate_become
+    # - assert: *test_no_pipelining


### PR DESCRIPTION
Change use_tty to default true only if the become plugin requires a tty.  Refactor so the test for presence of tty flags depends on the arguments that will actually be passed for execution.

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

Fixes #86298

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
