### PR TITLE
uri: add server_hostname for SNI validation

### DIFF
--- a/changelogs/fragments/86293-uri-server-hostname.yml
+++ b/changelogs/fragments/86293-uri-server-hostname.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible.builtin.uri - add ``server_hostname`` to set TLS SNI and certificate hostname validation when connecting by IP (https://github.com/ansible/ansible/issues/86293)

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -470,8 +470,28 @@ class HTTPRedirectHandler(urllib.request.HTTPRedirectHandler):
         )
 
 
+class ServerHostnameSSLContextProxy:
+    def __init__(self, context, server_hostname):
+        self._context = context
+        self.server_hostname = server_hostname
+
+    def wrap_socket(self, sock, server_hostname=None, *args, **kwargs):
+        if self.server_hostname:
+            server_hostname = self.server_hostname
+        return self._context.wrap_socket(sock, server_hostname=server_hostname, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._context, name)
+
+    def __setattr__(self, name, value):
+        if name in ("_context", "server_hostname"):
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._context, name, value)
+
+
 def make_context(cafile=None, cadata=None, capath=None, ciphers=None, validate_certs=True, client_cert=None,
-                 client_key=None):
+                 client_key=None, server_hostname=None):
     if ciphers is None:
         ciphers = []
 
@@ -479,6 +499,8 @@ def make_context(cafile=None, cadata=None, capath=None, ciphers=None, validate_c
         raise TypeError('Ciphers must be a list. Got %s.' % ciphers.__class__.__name__)
 
     context = ssl.create_default_context(cafile=cafile)
+    if server_hostname:
+        context = ServerHostnameSSLContextProxy(context, server_hostname)
 
     if not validate_certs:
         context.options |= ssl.OP_NO_SSLv3
@@ -707,7 +729,7 @@ class Request:
                  url_username=None, url_password=None, http_agent=None, force_basic_auth=False,
                  follow_redirects='urllib2', client_cert=None, client_key=None, cookies=None, unix_socket=None,
                  ca_path=None, unredirected_headers=None, decompress=True, ciphers=None, use_netrc=True,
-                 context=None):
+                 context=None, server_hostname=None):
         """This class works somewhat similarly to the ``Session`` class of from requests
         by defining a cookiejar that can be used across requests as well as cascaded defaults that
         can apply to repeated requests
@@ -747,6 +769,7 @@ class Request:
         self.ciphers = ciphers
         self.use_netrc = use_netrc
         self.context = context
+        self.server_hostname = server_hostname
         if isinstance(cookies, cookiejar.CookieJar):
             self.cookies = cookies
         else:
@@ -763,7 +786,7 @@ class Request:
              force_basic_auth=None, follow_redirects=None,
              client_cert=None, client_key=None, cookies=None, use_gssapi=False,
              unix_socket=None, ca_path=None, unredirected_headers=None, decompress=None,
-             ciphers=None, use_netrc=None, context=None):
+             ciphers=None, use_netrc=None, context=None, server_hostname=None):
         """
         Sends a request via HTTP(S) or FTP using urllib (Python3)
 
@@ -807,6 +830,7 @@ class Request:
         :kwarg use_netrc: (optional) Boolean determining whether to use credentials from ~/.netrc file
         :kwarg context: (optional) ssl.Context object for SSL validation. When provided, all other SSL related
             arguments are ignored. See make_context.
+        :kwarg server_hostname: (optional) String to use for TLS SNI and certificate hostname verification.
         :returns: HTTPResponse. Added in Ansible 2.9
         """
 
@@ -835,6 +859,7 @@ class Request:
         ciphers = self._fallback(ciphers, self.ciphers)
         use_netrc = self._fallback(use_netrc, self.use_netrc)
         context = self._fallback(context, self.context)
+        server_hostname = self._fallback(server_hostname, self.server_hostname)
 
         handlers = []
 
@@ -856,6 +881,7 @@ class Request:
                 validate_certs=validate_certs,
                 client_cert=client_cert,
                 client_key=client_key,
+                server_hostname=server_hostname,
             )
         if unix_socket:
             ssl_handler = UnixHTTPSHandler(unix_socket=unix_socket, context=context)
@@ -986,7 +1012,8 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
              force_basic_auth=False, follow_redirects='urllib2',
              client_cert=None, client_key=None, cookies=None,
              use_gssapi=False, unix_socket=None, ca_path=None,
-             unredirected_headers=None, decompress=True, ciphers=None, use_netrc=True):
+             unredirected_headers=None, decompress=True, ciphers=None, use_netrc=True,
+             server_hostname=None):
     """
     Sends a request via HTTP(S) or FTP using urllib (Python3)
 
@@ -999,7 +1026,8 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
                           force_basic_auth=force_basic_auth, follow_redirects=follow_redirects,
                           client_cert=client_cert, client_key=client_key, cookies=cookies,
                           use_gssapi=use_gssapi, unix_socket=unix_socket, ca_path=ca_path,
-                          unredirected_headers=unredirected_headers, decompress=decompress, ciphers=ciphers, use_netrc=use_netrc)
+                          unredirected_headers=unredirected_headers, decompress=decompress, ciphers=ciphers,
+                          use_netrc=use_netrc, server_hostname=server_hostname)
 
 
 # deprecated: description='TypedDict Required/NotRequired' python_version='3.11'
@@ -1349,6 +1377,7 @@ def url_argument_spec():
         http_agent=dict(type='str', default='ansible-httpget'),
         use_proxy=dict(type='bool', default=True),
         validate_certs=dict(type='bool', default=True),
+        server_hostname=dict(type='str'),
         url_username=dict(type='str'),
         url_password=dict(type='str', no_log=True),
         force_basic_auth=dict(type='bool', default=False),
@@ -1371,7 +1400,7 @@ def url_redirect_argument_spec():
 def fetch_url(module, url, data=None, headers=None, method=None,
               use_proxy=None, force=False, last_mod_time=None, timeout=10,
               use_gssapi=False, unix_socket=None, ca_path=None, cookies=None, unredirected_headers=None,
-              decompress=True, ciphers=None, use_netrc=True):
+              decompress=True, ciphers=None, use_netrc=True, server_hostname=None):
     """Sends a request via HTTP(S) or FTP (needs the module as parameter)
 
     :arg module: The AnsibleModule (used to get username, password etc. (s.b.).
@@ -1393,6 +1422,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     :kwarg decompress: (optional) Whether to attempt to decompress gzip content-encoded responses
     :kwarg cipher: (optional) List of ciphers to use
     :kwarg boolean use_netrc: (optional) If False: Ignores login and password in ~/.netrc file (Default: True)
+    :kwarg server_hostname: (optional) String to use for TLS SNI and certificate hostname verification
 
     :returns: A tuple of (**response**, **info**). Use ``response.read()`` to read the data.
         The **info** contains the 'status' and other meta data. When a HttpError (status >= 400)
@@ -1435,6 +1465,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     client_cert = module.params.get('client_cert')
     client_key = module.params.get('client_key')
     use_gssapi = module.params.get('use_gssapi', use_gssapi)
+    server_hostname = module.params.get('server_hostname', server_hostname)
 
     if not isinstance(cookies, cookiejar.CookieJar):
         cookies = cookiejar.CookieJar()
@@ -1449,7 +1480,8 @@ def fetch_url(module, url, data=None, headers=None, method=None,
                      follow_redirects=follow_redirects, client_cert=client_cert,
                      client_key=client_key, cookies=cookies, use_gssapi=use_gssapi,
                      unix_socket=unix_socket, ca_path=ca_path, unredirected_headers=unredirected_headers,
-                     decompress=decompress, ciphers=ciphers, use_netrc=use_netrc)
+                     decompress=decompress, ciphers=ciphers, use_netrc=use_netrc,
+                     server_hostname=server_hostname)
         # Lowercase keys, to conform to py2 behavior
         info.update({k.lower(): v for k, v in r.info().items()})
 

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -474,8 +474,8 @@ class HTTPRedirectHandler(urllib.request.HTTPRedirectHandler):
 
 class ServerHostnameSSLContextProxy:
     def __init__(self, context, server_hostname):
-        object.__setattr__(self, "_context", context)
-        object.__setattr__(self, "server_hostname", server_hostname)
+        self._context = context
+        self.server_hostname = server_hostname
 
     def wrap_socket(self, sock, server_hostname=None, *args, **kwargs):
         if self.server_hostname:

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -472,8 +472,28 @@ class HTTPRedirectHandler(urllib.request.HTTPRedirectHandler):
         )
 
 
+class ServerHostnameSSLContextProxy:
+    def __init__(self, context, server_hostname):
+        object.__setattr__(self, "_context", context)
+        object.__setattr__(self, "server_hostname", server_hostname)
+
+    def wrap_socket(self, sock, server_hostname=None, *args, **kwargs):
+        if self.server_hostname:
+            server_hostname = self.server_hostname
+        return self._context.wrap_socket(sock, server_hostname=server_hostname, *args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._context, name)
+
+    def __setattr__(self, name, value):
+        if name in ("_context", "server_hostname"):
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._context, name, value)
+
+
 def make_context(cafile=None, cadata=None, capath=None, ciphers=None, validate_certs=True, client_cert=None,
-                 client_key=None):
+                 client_key=None, server_hostname=None):
     if ciphers is None:
         ciphers = []
 
@@ -481,6 +501,8 @@ def make_context(cafile=None, cadata=None, capath=None, ciphers=None, validate_c
         raise TypeError('Ciphers must be a list. Got %s.' % ciphers.__class__.__name__)
 
     context = ssl.create_default_context(cafile=cafile)
+    if server_hostname:
+        context = ServerHostnameSSLContextProxy(context, server_hostname)
 
     if not validate_certs:
         context.options |= ssl.OP_NO_SSLv3
@@ -710,7 +732,7 @@ class Request:
                  url_username=None, url_password=None, http_agent=None, force_basic_auth=False,
                  follow_redirects='urllib2', client_cert=None, client_key=None, cookies=None, unix_socket=None,
                  ca_path=None, unredirected_headers=None, decompress=True, ciphers=None, use_netrc=True,
-                 context=None):
+                 context=None, server_hostname=None):
         """This class works somewhat similarly to the ``Session`` class of from requests
         by defining a cookiejar that can be used across requests as well as cascaded defaults that
         can apply to repeated requests
@@ -750,6 +772,7 @@ class Request:
         self.ciphers = ciphers
         self.use_netrc = use_netrc
         self.context = context
+        self.server_hostname = server_hostname
         if isinstance(cookies, cookiejar.CookieJar):
             self.cookies = cookies
         else:
@@ -766,7 +789,7 @@ class Request:
              force_basic_auth=None, follow_redirects=None,
              client_cert=None, client_key=None, cookies=None, use_gssapi=False,
              unix_socket=None, ca_path=None, unredirected_headers=None, decompress=None,
-             ciphers=None, use_netrc=None, context=None):
+             ciphers=None, use_netrc=None, context=None, server_hostname=None):
         """
         Sends a request via HTTP(S) or FTP using urllib (Python3)
 
@@ -810,6 +833,7 @@ class Request:
         :kwarg use_netrc: (optional) Boolean determining whether to use credentials from ~/.netrc file
         :kwarg context: (optional) ssl.Context object for SSL validation. When provided, all other SSL related
             arguments are ignored. See make_context.
+        :kwarg server_hostname: (optional) String to use for TLS SNI and certificate hostname verification.
         :returns: HTTPResponse. Added in Ansible 2.9
         """
 
@@ -838,6 +862,7 @@ class Request:
         ciphers = self._fallback(ciphers, self.ciphers)
         use_netrc = self._fallback(use_netrc, self.use_netrc)
         context = self._fallback(context, self.context)
+        server_hostname = self._fallback(server_hostname, self.server_hostname)
 
         handlers = []
 
@@ -859,6 +884,7 @@ class Request:
                 validate_certs=validate_certs,
                 client_cert=client_cert,
                 client_key=client_key,
+                server_hostname=server_hostname,
             )
         if unix_socket:
             ssl_handler = UnixHTTPSHandler(unix_socket=unix_socket, context=context)
@@ -989,7 +1015,8 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
              force_basic_auth=False, follow_redirects='urllib2',
              client_cert=None, client_key=None, cookies=None,
              use_gssapi=False, unix_socket=None, ca_path=None,
-             unredirected_headers=None, decompress=True, ciphers=None, use_netrc=True):
+             unredirected_headers=None, decompress=True, ciphers=None, use_netrc=True,
+             server_hostname=None):
     """
     Sends a request via HTTP(S) or FTP using urllib (Python3)
 
@@ -1002,7 +1029,8 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
                           force_basic_auth=force_basic_auth, follow_redirects=follow_redirects,
                           client_cert=client_cert, client_key=client_key, cookies=cookies,
                           use_gssapi=use_gssapi, unix_socket=unix_socket, ca_path=ca_path,
-                          unredirected_headers=unredirected_headers, decompress=decompress, ciphers=ciphers, use_netrc=use_netrc)
+                          unredirected_headers=unredirected_headers, decompress=decompress, ciphers=ciphers,
+                          use_netrc=use_netrc, server_hostname=server_hostname)
 
 
 def prepare_multipart(fields):
@@ -1144,6 +1172,7 @@ def url_argument_spec():
         http_agent=dict(type='str', default='ansible-httpget'),
         use_proxy=dict(type='bool', default=True),
         validate_certs=dict(type='bool', default=True),
+        server_hostname=dict(type='str'),
         url_username=dict(type='str'),
         url_password=dict(type='str', no_log=True),
         force_basic_auth=dict(type='bool', default=False),
@@ -1166,7 +1195,7 @@ def url_redirect_argument_spec():
 def fetch_url(module, url, data=None, headers=None, method=None,
               use_proxy=None, force=False, last_mod_time=None, timeout=10,
               use_gssapi=False, unix_socket=None, ca_path=None, cookies=None, unredirected_headers=None,
-              decompress=True, ciphers=None, use_netrc=True):
+              decompress=True, ciphers=None, use_netrc=True, server_hostname=None):
     """Sends a request via HTTP(S) or FTP (needs the module as parameter)
 
     :arg module: The AnsibleModule (used to get username, password etc. (s.b.).
@@ -1188,6 +1217,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     :kwarg decompress: (optional) Whether to attempt to decompress gzip content-encoded responses
     :kwarg cipher: (optional) List of ciphers to use
     :kwarg boolean use_netrc: (optional) If False: Ignores login and password in ~/.netrc file (Default: True)
+    :kwarg server_hostname: (optional) String to use for TLS SNI and certificate hostname verification
 
     :returns: A tuple of (**response**, **info**). Use ``response.read()`` to read the data.
         The **info** contains the 'status' and other meta data. When a HttpError (status >= 400)
@@ -1230,6 +1260,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     client_cert = module.params.get('client_cert')
     client_key = module.params.get('client_key')
     use_gssapi = module.params.get('use_gssapi', use_gssapi)
+    server_hostname = module.params.get('server_hostname', server_hostname)
 
     if not isinstance(cookies, cookiejar.CookieJar):
         cookies = cookiejar.CookieJar()
@@ -1244,7 +1275,8 @@ def fetch_url(module, url, data=None, headers=None, method=None,
                      follow_redirects=follow_redirects, client_cert=client_cert,
                      client_key=client_key, cookies=cookies, use_gssapi=use_gssapi,
                      unix_socket=unix_socket, ca_path=ca_path, unredirected_headers=unredirected_headers,
-                     decompress=decompress, ciphers=ciphers, use_netrc=use_netrc)
+                     decompress=decompress, ciphers=ciphers, use_netrc=use_netrc,
+                     server_hostname=server_hostname)
         # Lowercase keys, to conform to py2 behavior
         info.update({k.lower(): v for k, v in r.info().items()})
 

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -116,6 +116,12 @@ options:
       - This should only be used on personally controlled sites using self-signed certificates.
     type: bool
     default: yes
+  server_hostname:
+    description:
+      - Explicit TLS server hostname (SNI) to use for certificate validation.
+      - Useful when connecting to an HTTPS service by IP address.
+    type: str
+    version_added: '2.22'
   timeout:
     description:
       - Timeout in seconds for URL request.

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -116,6 +116,12 @@ options:
       - This should only be used on personally controlled sites using self-signed certificates.
     type: bool
     default: yes
+  server_hostname:
+    description:
+      - Explicit TLS server hostname (SNI) to use for certificate validation.
+      - Useful when connecting to an HTTPS service by IP address.
+    type: str
+    version_added: '2.21'
   timeout:
     description:
       - Timeout in seconds for URL request.

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -141,6 +141,12 @@ options:
     type: bool
     default: true
     version_added: '1.9.2'
+  server_hostname:
+    description:
+      - Explicit TLS server hostname (SNI) to use for certificate validation.
+      - Useful when connecting to an HTTPS service by IP address.
+    type: str
+    version_added: '2.22'
   client_cert:
     description:
       - PEM formatted certificate chain file to be used for SSL client authentication.
@@ -235,6 +241,7 @@ notes:
   - The dependency on httplib2 was removed in Ansible 2.1.
   - The module returns all the HTTP headers in lower-case.
   - For Windows targets, use the M(ansible.windows.win_uri) module instead.
+  - When using O(server_hostname) with an IP address URL, you may need to set the C(Host) header explicitly.
 seealso:
 - module: ansible.builtin.get_url
 - module: ansible.windows.win_uri
@@ -264,6 +271,14 @@ EXAMPLES = r"""
     force_basic_auth: true
     status_code: 201
     body_format: json
+
+- name: Connect by IP with explicit SNI hostname
+  ansible.builtin.uri:
+    url: https://192.0.2.10/api/health
+    server_hostname: example.com
+    headers:
+      Host: example.com
+    validate_certs: true
 
 - name: Login to a form based webpage, then use the returned cookie to access the app in later tasks
   ansible.builtin.uri:
@@ -566,7 +581,8 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout, c
                            method=method, timeout=socket_timeout, unix_socket=module.params['unix_socket'],
                            ca_path=ca_path, unredirected_headers=unredirected_headers,
                            use_proxy=module.params['use_proxy'], decompress=decompress,
-                           ciphers=ciphers, use_netrc=use_netrc, force=module.params['force'], **kwargs)
+                           ciphers=ciphers, use_netrc=use_netrc, force=module.params['force'],
+                           server_hostname=module.params.get('server_hostname'), **kwargs)
 
     if src:
         # Try to close the open file handle
@@ -604,6 +620,7 @@ def main():
         decompress=dict(type='bool', default=True),
         ciphers=dict(type='list', elements='str'),
         use_netrc=dict(type='bool', default=True),
+        server_hostname=dict(type='str'),
     )
 
     module = AnsibleModule(

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -141,6 +141,12 @@ options:
     type: bool
     default: true
     version_added: '1.9.2'
+  server_hostname:
+    description:
+      - Explicit TLS server hostname (SNI) to use for certificate validation.
+      - Useful when connecting to an HTTPS service by IP address.
+    type: str
+    version_added: '2.21'
   client_cert:
     description:
       - PEM formatted certificate chain file to be used for SSL client authentication.
@@ -235,6 +241,7 @@ notes:
   - The dependency on httplib2 was removed in Ansible 2.1.
   - The module returns all the HTTP headers in lower-case.
   - For Windows targets, use the M(ansible.windows.win_uri) module instead.
+  - When using O(server_hostname) with an IP address URL, you may need to set the C(Host) header explicitly.
 seealso:
 - module: ansible.builtin.get_url
 - module: ansible.windows.win_uri
@@ -264,6 +271,14 @@ EXAMPLES = r"""
     force_basic_auth: true
     status_code: 201
     body_format: json
+
+- name: Connect by IP with explicit SNI hostname
+  ansible.builtin.uri:
+    url: https://192.0.2.10/api/health
+    server_hostname: example.com
+    headers:
+      Host: example.com
+    validate_certs: true
 
 - name: Login to a form based webpage, then use the returned cookie to access the app in later tasks
   ansible.builtin.uri:
@@ -572,7 +587,8 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout, c
                            method=method, timeout=socket_timeout, unix_socket=module.params['unix_socket'],
                            ca_path=ca_path, unredirected_headers=unredirected_headers,
                            use_proxy=module.params['use_proxy'], decompress=decompress,
-                           ciphers=ciphers, use_netrc=use_netrc, force=module.params['force'], **kwargs)
+                           ciphers=ciphers, use_netrc=use_netrc, force=module.params['force'],
+                           server_hostname=module.params.get('server_hostname'), **kwargs)
 
     if src:
         # Try to close the open file handle
@@ -610,6 +626,7 @@ def main():
         decompress=dict(type='bool', default=True),
         ciphers=dict(type='list', elements='str'),
         use_netrc=dict(type='bool', default=True),
+        server_hostname=dict(type='str'),
     )
 
     module = AnsibleModule(

--- a/lib/ansible/plugins/doc_fragments/url.py
+++ b/lib/ansible/plugins/doc_fragments/url.py
@@ -35,6 +35,12 @@ options:
       - This should only be used on personally controlled sites using self-signed certificates.
     type: bool
     default: yes
+  server_hostname:
+    description:
+      - Explicit TLS server hostname (SNI) to use for certificate validation.
+      - Useful when connecting to an HTTPS service by IP address.
+    type: str
+    version_added: '2.22'
   url_username:
     description:
       - The username for use in HTTP basic authentication.

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -360,6 +360,51 @@
       - 'sni_host in result.content'
   when: ansible_python.has_sslcontext
 
+- name: Resolve SNI hostname to IP
+  command: >-
+    {{ ansible_python.executable }} -c
+    "import socket; print(socket.gethostbyname('{{ sni_host }}'))"
+  register: sni_host_lookup
+  changed_when: false
+  failed_when: sni_host_lookup.rc != 0 or sni_host_lookup.stdout | length == 0
+  when: ansible_python.has_sslcontext
+
+- name: Set SNI IP address
+  set_fact:
+    sni_host_ip: "{{ sni_host_lookup.stdout | trim }}"
+  when: ansible_python.has_sslcontext
+
+- name: Test SNI with IP and explicit server_hostname
+  uri:
+    url: "https://{{ sni_host_ip }}/"
+    server_hostname: "{{ sni_host }}"
+    headers:
+      Host: "{{ sni_host }}"
+    return_content: true
+  register: result_sni_ip
+  when: ansible_python.has_sslcontext
+
+- name: Assert SNI verification succeeds with IP and server_hostname
+  assert:
+    that:
+      - result_sni_ip is successful
+      - 'sni_host in result_sni_ip.content'
+  when: ansible_python.has_sslcontext
+
+- name: Test SNI with IP without server_hostname
+  uri:
+    url: "https://{{ sni_host_ip }}/"
+  register: result_sni_ip_no_hostname
+  ignore_errors: true
+  when: ansible_python.has_sslcontext
+
+- name: Assert SNI verification fails without server_hostname
+  assert:
+    that:
+      - result_sni_ip_no_hostname is failed
+      - "'Hostname mismatch' in result_sni_ip_no_hostname.msg or 'IP address mismatch' in result_sni_ip_no_hostname.msg or (result_sni_ip_no_hostname.msg is match('hostname .* doesn.t match .*'))"
+  when: ansible_python.has_sslcontext
+
 - name: validate the status_codes are correct
   uri:
     url: "https://{{ httpbin_host }}/status/202"

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -402,7 +402,7 @@
   assert:
     that:
       - result_sni_ip_no_hostname is failed
-      - "'Hostname mismatch' in result_sni_ip_no_hostname.msg or (result_sni_ip_no_hostname.msg is match('hostname .* doesn.t match .*'))"
+      - "'Hostname mismatch' in result_sni_ip_no_hostname.msg or 'IP address mismatch' in result_sni_ip_no_hostname.msg or (result_sni_ip_no_hostname.msg is match('hostname .* doesn.t match .*'))"
   when: ansible_python.has_sslcontext
 
 - name: validate the status_codes are correct

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -391,6 +391,20 @@
       - 'sni_host in result_sni_ip.content'
   when: ansible_python.has_sslcontext
 
+- name: Test SNI with IP without server_hostname
+  uri:
+    url: "https://{{ sni_host_ip }}/"
+  register: result_sni_ip_no_hostname
+  ignore_errors: true
+  when: ansible_python.has_sslcontext
+
+- name: Assert SNI verification fails without server_hostname
+  assert:
+    that:
+      - result_sni_ip_no_hostname is failed
+      - "'Hostname mismatch' in result_sni_ip_no_hostname.msg or (result_sni_ip_no_hostname.msg is match('hostname .* doesn.t match .*'))"
+  when: ansible_python.has_sslcontext
+
 - name: validate the status_codes are correct
   uri:
     url: "https://{{ httpbin_host }}/status/202"

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -360,6 +360,35 @@
       - 'sni_host in result.content'
   when: ansible_python.has_sslcontext
 
+- name: Resolve SNI hostname to IP
+  command: "getent hosts {{ sni_host }}"
+  register: sni_host_lookup
+  changed_when: false
+  failed_when: sni_host_lookup.rc != 0 or sni_host_lookup.stdout_lines | length == 0
+  when: ansible_python.has_sslcontext
+
+- name: Set SNI IP address
+  set_fact:
+    sni_host_ip: "{{ (sni_host_lookup.stdout_lines[0].split())[0] }}"
+  when: ansible_python.has_sslcontext
+
+- name: Test SNI with IP and explicit server_hostname
+  uri:
+    url: "https://{{ sni_host_ip }}/"
+    server_hostname: "{{ sni_host }}"
+    headers:
+      Host: "{{ sni_host }}"
+    return_content: true
+  register: result_sni_ip
+  when: ansible_python.has_sslcontext
+
+- name: Assert SNI verification succeeds with IP and server_hostname
+  assert:
+    that:
+      - result_sni_ip is successful
+      - 'sni_host in result_sni_ip.content'
+  when: ansible_python.has_sslcontext
+
 - name: validate the status_codes are correct
   uri:
     url: "https://{{ httpbin_host }}/status/202"

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -361,15 +361,17 @@
   when: ansible_python.has_sslcontext
 
 - name: Resolve SNI hostname to IP
-  command: "getent hosts {{ sni_host }}"
+  command: >-
+    {{ ansible_python.executable }} -c
+    "import socket; print(socket.gethostbyname('{{ sni_host }}'))"
   register: sni_host_lookup
   changed_when: false
-  failed_when: sni_host_lookup.rc != 0 or sni_host_lookup.stdout_lines | length == 0
+  failed_when: sni_host_lookup.rc != 0 or sni_host_lookup.stdout | length == 0
   when: ansible_python.has_sslcontext
 
 - name: Set SNI IP address
   set_fact:
-    sni_host_ip: "{{ (sni_host_lookup.stdout_lines[0].split())[0] }}"
+    sni_host_ip: "{{ sni_host_lookup.stdout | trim }}"
   when: ansible_python.has_sslcontext
 
 - name: Test SNI with IP and explicit server_hostname

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -54,6 +54,7 @@ def test_Request_fallback(urlopen_mock, install_opener_mock, mocker):
         ca_path=pem,
         ciphers=['ECDHE-RSA-AES128-SHA256'],
         use_netrc=True,
+        server_hostname='sni.example.com',
     )
     fallback_mock = mocker.spy(request, '_fallback')
 
@@ -79,10 +80,11 @@ def test_Request_fallback(urlopen_mock, install_opener_mock, mocker):
         call(None, ['ECDHE-RSA-AES128-SHA256']),  # ciphers
         call(None, True),  # use_netrc
         call(None, None),  # context
+        call(None, 'sni.example.com'),  # server_hostname
     ]
     fallback_mock.assert_has_calls(calls)
 
-    assert fallback_mock.call_count == 19  # All but headers use fallback
+    assert fallback_mock.call_count == 20  # All but headers use fallback
 
     args = urlopen_mock.call_args[0]
     assert args[1] is None  # data, this is handled in the Request not urlopen
@@ -123,6 +125,16 @@ def test_Request_open(urlopen_mock, install_opener_mock):
             found_handlers.append(handler)
 
     assert len(found_handlers) == len(expected_handlers)
+
+
+def test_Request_open_server_hostname(urlopen_mock, install_opener_mock, mocker):
+    make_context = mocker.patch('ansible.module_utils.urls.make_context')
+    make_context.return_value = ssl.create_default_context()
+
+    Request().open('GET', 'https://ansible.com/', server_hostname='example.com')
+
+    make_context.assert_called_once()
+    assert make_context.call_args.kwargs['server_hostname'] == 'example.com'
 
 
 def test_Request_open_unix_socket(urlopen_mock, install_opener_mock):
@@ -444,4 +456,4 @@ def test_open_url(urlopen_mock, install_opener_mock, mocker):
                                      force_basic_auth=False, follow_redirects='urllib2',
                                      client_cert=None, client_key=None, cookies=None, use_gssapi=False,
                                      unix_socket=None, ca_path=None, unredirected_headers=None, decompress=True,
-                                     ciphers=None, use_netrc=True)
+                                     ciphers=None, use_netrc=True, server_hostname=None)

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -54,6 +54,7 @@ def test_Request_fallback(urlopen_mock, install_opener_mock, mocker):
         ca_path=pem,
         ciphers=['ECDHE-RSA-AES128-SHA256'],
         use_netrc=True,
+        server_hostname='sni.example.com',
     )
     fallback_mock = mocker.spy(request, '_fallback')
 
@@ -79,10 +80,11 @@ def test_Request_fallback(urlopen_mock, install_opener_mock, mocker):
         call(None, ['ECDHE-RSA-AES128-SHA256']),  # ciphers
         call(None, True),  # use_netrc
         call(None, None),  # context
+        call(None, 'sni.example.com'),  # server_hostname
     ]
     fallback_mock.assert_has_calls(calls)
 
-    assert fallback_mock.call_count == 19  # All but headers use fallback
+    assert fallback_mock.call_count == 20  # All but headers use fallback
 
     args = urlopen_mock.call_args[0]
     assert args[1] is None  # data, this is handled in the Request not urlopen
@@ -123,6 +125,16 @@ def test_Request_open(urlopen_mock, install_opener_mock):
             found_handlers.append(handler)
 
     assert len(found_handlers) == len(expected_handlers)
+
+
+def test_Request_open_server_hostname(urlopen_mock, install_opener_mock, mocker):
+    make_context = mocker.patch('ansible.module_utils.urls.make_context')
+    make_context.return_value = ssl.create_default_context()
+
+    Request().open('GET', 'https://ansible.com/', server_hostname='example.com')
+
+    make_context.assert_called_once()
+    assert make_context.call_args.kwargs['server_hostname'] == 'example.com'
 
 
 def test_Request_open_unix_socket(urlopen_mock, install_opener_mock):

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -456,4 +456,4 @@ def test_open_url(urlopen_mock, install_opener_mock, mocker):
                                      force_basic_auth=False, follow_redirects='urllib2',
                                      client_cert=None, client_key=None, cookies=None, use_gssapi=False,
                                      unix_socket=None, ca_path=None, unredirected_headers=None, decompress=True,
-                                     ciphers=None, use_netrc=True)
+                                     ciphers=None, use_netrc=True, server_hostname=None)

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -63,7 +63,7 @@ def test_fetch_url(open_url_mock, fake_ansible_module):
                                           follow_redirects='urllib2', force=False, force_basic_auth='', headers=None,
                                           http_agent='ansible-httpget', last_mod_time=None, method=None, timeout=10, url_password='', url_username='',
                                           use_proxy=True, validate_certs=True, use_gssapi=False, unix_socket=None, ca_path=None, unredirected_headers=None,
-                                          decompress=True, ciphers=None, use_netrc=True)
+                                          decompress=True, ciphers=None, use_netrc=True, server_hostname=None)
 
 
 def test_fetch_url_params(open_url_mock, fake_ansible_module):
@@ -76,6 +76,7 @@ def test_fetch_url_params(open_url_mock, fake_ansible_module):
         'follow_redirects': 'all',
         'client_cert': 'client.pem',
         'client_key': 'client.key',
+        'server_hostname': 'sni.example.com',
     }
 
     r, info = fetch_url(fake_ansible_module, BASE_URL)
@@ -86,7 +87,7 @@ def test_fetch_url_params(open_url_mock, fake_ansible_module):
                                           follow_redirects='all', force=False, force_basic_auth=True, headers=None,
                                           http_agent='ansible-test', last_mod_time=None, method=None, timeout=10, url_password='passwd', url_username='user',
                                           use_proxy=True, validate_certs=False, use_gssapi=False, unix_socket=None, ca_path=None, unredirected_headers=None,
-                                          decompress=True, ciphers=None, use_netrc=True)
+                                          decompress=True, ciphers=None, use_netrc=True, server_hostname='sni.example.com')
 
 
 def test_fetch_url_cookies(mocker, fake_ansible_module):

--- a/test/units/modules/test_uri.py
+++ b/test/units/modules/test_uri.py
@@ -44,3 +44,15 @@ class TestUri:
                 uri.main()
             fetch_url.assert_called_once()
             assert fetch_url.call_args[1].get("force")
+
+    def test_main_server_hostname(self):
+        """The "server_hostname" parameter to fetch_url() must be passed when provided."""
+        resp = MagicMock()
+        resp.headers.get_content_type.return_value = "text/html"
+        info = {"url": "https://192.0.2.10/", "status": 200}
+        with patch.object(uri, "fetch_url", return_value=(resp, info)) as fetch_url, \
+             patch_module_args({"url": "https://192.0.2.10/", "server_hostname": "example.com"}):
+            with pytest.raises(SystemExit):
+                uri.main()
+            fetch_url.assert_called_once()
+            assert fetch_url.call_args[1].get("server_hostname") == "example.com"

--- a/test/units/modules/test_uri.py
+++ b/test/units/modules/test_uri.py
@@ -44,4 +44,3 @@ class TestUri:
                 uri.main()
             fetch_url.assert_called_once()
             assert fetch_url.call_args[1].get("force")
-

--- a/test/units/modules/test_uri.py
+++ b/test/units/modules/test_uri.py
@@ -45,14 +45,3 @@ class TestUri:
             fetch_url.assert_called_once()
             assert fetch_url.call_args[1].get("force")
 
-    def test_main_server_hostname(self):
-        """The "server_hostname" parameter to fetch_url() must be passed when provided."""
-        resp = MagicMock()
-        resp.headers.get_content_type.return_value = "text/html"
-        info = {"url": "https://192.0.2.10/", "status": 200}
-        with patch.object(uri, "fetch_url", return_value=(resp, info)) as fetch_url, \
-             patch_module_args({"url": "https://192.0.2.10/", "server_hostname": "example.com"}):
-            with pytest.raises(SystemExit):
-                uri.main()
-            fetch_url.assert_called_once()
-            assert fetch_url.call_args[1].get("server_hostname") == "example.com"


### PR DESCRIPTION
## Summary

Add support for **`server_hostname`** in **`ansible.builtin.uri`** so users can connect to an IP address while still performing TLS hostname verification against a specified name.
This passes the explicit hostname into the TLS handshake (SNI) and uses it for certificate validation.


## Problem

When `uri` is used with an IP address and `validate_certs: true`, hostname verification fails because the TLS layer only sees the IP address.
Setting the `Host` header alone is not enough to fix this.


## What Changed

* Added `server_hostname` parameter to the `uri` module (and updated `module_utils/urls` arg spec)
* Passed `server_hostname` through `fetch_url` / `open_url` into `Request`
* Wrapped `SSLContext` in `make_context` to force SNI + hostname verification
* Added **unit tests** + **integration test** for IP + `server_hostname`
* Updated documentation + changelog


## Verification

### Unit tests

**Command**

```bash
HOME="/home/shrbhosa/ansible" ./bin/ansible-test units -v --venv \
  test/units/module_utils/urls/test_Request.py \
  test/units/module_utils/urls/test_fetch_url.py \
  test/units/modules/test_uri.py
```

**Result**

```
test/units/modules/test_uri.py: 4 passed
test/units/module_utils/urls/test_fetch_url.py: 9 passed
```

Note: Python 3.9–3.13 were skipped because they were not available in the environment.


### Integration tests

**Command**

```bash
./bin/ansible-test integration -v --docker ubuntu2404 uri
```

**Result**

```
exit_code: 0
elapsed_ms: 149478
ended_at: 2026-01-29T08:03:57.006Z
```


### Manual verification (SNI + server_hostname + IP)

**Start test container**

```bash
podman run -d --name http-test -p 8443:443 -p 8080:80 --env KRB5_PASSWORD=changeme \
  quay.io/ansible/http-test-container:3.5.0
```

**Fetch test CA**

```bash
curl -fsSL http://127.0.0.1:8080/cacert.pem -o /home/shrbhosa/ansible/.tmp-cacert.pem
```

**Run uri against IP with explicit SNI**

```bash
ANSIBLE_LIBRARY="/home/shrbhosa/ansible/lib/ansible/modules" \
PYTHONPATH="/home/shrbhosa/ansible/lib" \
/home/shrbhosa/ansible/.pyuserbase/bin/ansible localhost -c local \
  -m ansible.builtin.uri \
  -a "url=https://127.0.0.1:8443/ \
      server_hostname=sni1.ansible.http.tests \
      headers={'Host':'sni1.ansible.http.tests'} \
      ca_path=/home/shrbhosa/ansible/.tmp-cacert.pem \
      return_content=yes"
```

**Result**

```
status 200
content: sni1.ansible.http.tests
no SSL errors
```


## Changelog

```
changelogs/fragments/86293-uri-server-hostname.yml
```


## Notes

This change only affects `uri` when `server_hostname` is explicitly set.
Normal behavior is unchanged, and CA trust is still required for verification.
Fixes #86293