### PR TITLE
Fix Python 3.6 compatibility issue in async_wrapper.py

### DIFF
--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -163,12 +163,11 @@ def _run_module(wrapped_cmd, jid):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             shell=False,
-            text=True,
-            encoding="utf-8",
-            errors="surrogateescape",
         )
 
         (outdata, stderr) = script.communicate()
+        outdata = to_text(outdata, errors='surrogateescape')
+        stderr = to_text(stderr, errors='surrogateescape')
 
         (filtered_outdata, json_warnings) = _filter_non_json_lines(outdata)
 


### PR DESCRIPTION
Description

This PR fixes a Python compatibility issue reported by Semgrep.

Details:

Rule ID: python36-compatibility-Popen1

Issue: The errors argument in subprocess.Popen is only supported in Python 3.6+

File: lib/ansible/modules/async_wrapper.py

Line: 160

What changed:

Updated the Popen invocation to ensure compatibility with Python versions below 3.6.

No functional behavior change beyond improved backward compatibility.

Reference:

Semgrep finding: “the errors argument to Popen is only available on Python 3.6+”