### PR TITLE
Align AddType debug info with DISPLAY_TRACEBACKS

### DIFF
--- a/changelogs/fragments/add-type-debug-info.yml
+++ b/changelogs/fragments/add-type-debug-info.yml
@@ -1,5 +1,5 @@
 minor_changes:
   - >-
-    PowerShell AddType Util - Will only include the debug information when ``DISPLAY_TRACEBACK`` contains ``errorr`` or
+    PowerShell AddType Util - Will only include the debug information when ``DISPLAY_TRACEBACK`` contains ``error`` or
     ``always``. In the past the debug information would have been included if ``-vvv`` or higher was used but this new
     behavior aligns the logic with the new option added in Ansible 2.19.

--- a/changelogs/fragments/add-type-debug-info.yml
+++ b/changelogs/fragments/add-type-debug-info.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - >-
+    PowerShell AddType Util - Will only include the debug information when ``DISPLAY_TRACEBACK`` contains ``errorr`` or
+    ``always``. In the past the debug information would have been included if ``-vvv`` or higher was used but this new
+    behavior aligns the logic with the new option added in Ansible 2.19.

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -61,6 +61,7 @@ namespace Ansible.Basic
         private List<string> warnings = new List<string>();
         private List<Dictionary<string, string>> deprecations = new List<Dictionary<string, string>>();
         private List<string> cleanupFiles = new List<string>();
+        private string[] _tracebacksFor = new string[0];
 
         private Dictionary<string, string> passVars = new Dictionary<string, string>()
         {
@@ -78,14 +79,15 @@ namespace Ansible.Basic
             { "shell_executable", null },
             { "socket", null },
             { "syslog_facility", null },
-            { "target_log_info", "TargetLogInfo"},
-            { "tracebacks_for", null},
+            { "target_log_info", "TargetLogInfo" },
+            { "tracebacks_for", "_tracebacksFor" },
             { "tmpdir", "tmpdir" },
             { "verbosity", "Verbosity" },
             { "version", "AnsibleVersion" },
         };
         private List<string> passBools = new List<string>() { "check_mode", "debug", "diff", "keep_remote_files", "ignore_unknown_opts", "no_log" };
         private List<string> passInts = new List<string>() { "verbosity" };
+        private string[] passStringArrays = new string[] { "tracebacks_for" };
         private Dictionary<string, List<object>> specDefaults = new Dictionary<string, List<object>>()
         {
             // key - (default, type) - null is freeform
@@ -136,6 +138,7 @@ namespace Ansible.Basic
         public string TargetLogInfo { get; private set; }
         public int Verbosity { get; private set; }
         public string AnsibleVersion { get; private set; }
+        public string[] TracebacksFor { get { return _tracebacksFor; } }
 
         public string Tmpdir
         {
@@ -1049,6 +1052,10 @@ namespace Ansible.Basic
                         value = ParseBool(value);
                     else if (passInts.Contains(key))
                         value = ParseInt(value);
+                    else if (passStringArrays.Contains(key))
+                    {
+                        value = Array.ConvertAll((object[])value, ParseStr);
+                    }
 
                     string propertyName = passVars[key];
                     PropertyInfo property = typeof(AnsibleModule).GetProperty(propertyName);

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.AddType.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.AddType.psm1
@@ -277,7 +277,7 @@ Function Add-CSharpType {
         # configure compile options based on input
         if ($PSCmdlet.ParameterSetName -eq "Module") {
             $temp_path = $AnsibleModule.Tmpdir
-            $include_debug = $AnsibleModule.Verbosity -ge 3
+            $include_debug = $AnsibleModule.TracebacksFor -contains "error" -or $AnsibleModule.TracebacksFor -contains "always"
 
             # AnsibleModule will handle the cleanup after module execution
             # which should be enough time for AVs or other processes to release


### PR DESCRIPTION
##### SUMMARY
Changes the logic used by `Ansible.ModuleUtils.AddType` to only include the debug information when `DISPLAY_TRACEBACKS` is set to `error` or `always`. This aligns with the new logic that no longer uses the verbosity level to include extra traceback information with higher verbosities.

##### ISSUE TYPE
- Feature Pull Request