### PR TITLE
[stable-2.19] Action make_tmp_path fix error (#86505)

### DIFF
--- a/changelogs/fragments/make-tmp-path-msg.yml
+++ b/changelogs/fragments/make-tmp-path-msg.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    Fix up the Action plugin ``_make_tmp_path`` error to only include the command run rather than the shell's dataclass
+    repr from ``mkdtemp``.

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -456,7 +456,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         become_user = self.get_become_option('become_user')
         return bool(become_user and become_user not in admin_users + [remote_user])
 
-    def _make_tmp_path(self, remote_user=None):
+    def _make_tmp_path(self, remote_user: str | None = None) -> str:
         """
         Create and return a temporary path on a remote box.
         """
@@ -494,7 +494,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
                 output = ('Failed to create temporary directory. '
                           'In some cases, you may have been able to authenticate and did not have permissions on the target directory. '
                           'Consider changing the remote tmp path in ansible.cfg to a path rooted in "/tmp", for more error information use -vvv. '
-                          'Failed command was: %s, exited with result %d' % (cmd, result['rc']))
+                          'Failed command was: %s, exited with result %d' % (cmd.command, result['rc']))
             if 'stdout' in result and result['stdout'] != u'':
                 output = output + u", stdout output: %s" % result['stdout']
             if display.verbosity > 3 and 'stderr' in result and result['stderr'] != u'':


### PR DESCRIPTION
##### SUMMARY
Fixes the error to only include the command rather than the dataclass repr. This goes back to how it worked in the past before `_mkdtemp2` was added.

(cherry picked from commit 2c1fdfe0eba4505251c50a0a7f3596641e966007)

Backport of https://github.com/ansible/ansible/pull/86505

##### ISSUE TYPE
- Bugfix Pull Request