### PR TITLE
config lookup, fallback to existing constants when needed

### DIFF
--- a/changelogs/fragments/configlookupfix.yml
+++ b/changelogs/fragments/configlookupfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - config lookup now uses preexisting constants for templating when needed.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -2248,3 +2248,14 @@ _Z_TEST_ENTRY_2:
   ini:
     - section: testing
       key: valid2
+_Z_TEST_ENTRY_3:
+  version_added: '2.21'
+  name: testentry
+  description: for tests
+  type: path
+  default: '{{ANSIBLE_HOME}}'
+  env:
+    - name: ANSIBLE_TEST_ENTRY3
+  ini:
+    - section: testing
+      key: valid3

--- a/lib/ansible/plugins/lookup/config.py
+++ b/lib/ansible/plugins/lookup/config.py
@@ -80,6 +80,8 @@ _raw:
   type: raw
 """
 
+from collections import ChainMap
+
 import ansible.plugins.loader as plugin_loader
 
 from ansible import constants as C
@@ -104,6 +106,9 @@ class LookupModule(LookupBase):
 
         ret = []
 
+        # primarily use task vars, but fallback to existing constants when needed
+        var_context = ChainMap(variables, vars(C))
+
         for term in terms:
             if not isinstance(term, str):
                 raise AnsibleError(f'Invalid setting identifier, {term!r} is not a {str}, its a {type(term)}.')
@@ -119,7 +124,7 @@ class LookupModule(LookupBase):
                 if p is None:
                     raise AnsibleError(f"Unable to load {ptype} plugin {pname!r}.")
             try:
-                result, origin = C.config.get_config_value_and_origin(term, plugin_type=ptype, plugin_name=pname, variables=variables)
+                result, origin = C.config.get_config_value_and_origin(term, plugin_type=ptype, plugin_name=pname, variables=var_context)
             except AnsibleUndefinedConfigEntry as e:
                 match missing:
                     case 'error':

--- a/test/integration/targets/lookup_config/tasks/main.yml
+++ b/test/integration/targets/lookup_config/tasks/main.yml
@@ -129,3 +129,8 @@
       - config_origin1[1] == "default"
       - config_origin2[0] == 'yolo'
       - 'config_origin2[1] == "var: _z_test_entry"'
+
+- name: verify interdependent templating
+  assert:
+    that:
+      - lookup('config', 'ANSIBLE_HOME') == lookup('config', '_Z_TEST_ENTRY_3')


### PR DESCRIPTION
fixes #86463

##### ISSUE TYPE

- Bugfix Pull Request


#### ADDITIONAL INFO
pre:
```
localhost | SUCCESS => {
    "msg": [
        [
            "/collections",
            "/usr/share/ansible/collections"
        ]
    ]
}

```

post:
```
localhost | SUCCESS => {
    "msg": [
        [
            "/home/bcoca/.ansible/collections",
            "/usr/share/ansible/collections"
        ]
    ]
}

```