### PR TITLE
Fix reusing interpreter discovery with delegate_to

### DIFF
--- a/changelogs/fragments/86517-delegate-interpreter-discovery.yml
+++ b/changelogs/fragments/86517-delegate-interpreter-discovery.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Delegate ``discovered_interpreter_*`` facts regardless of ``delegate_facts`` so ``delegate_to`` hosts perform interpreter discovery once. (https://github.com/ansible/ansible/issues/86517)

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -334,17 +334,8 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
 
                 # update the local vars copy for the retry
                 use_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
-
-                # TODO: this condition prevents 'wrong host' from being updated
-                # but in future we would want to be able to update 'delegated host facts'
-                # irrespective of task settings
-                if not self._task.delegate_to or self._task.delegate_facts:
-                    # store in local task_vars facts collection for the retry and any other usages in this worker
-                    task_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
-                    # preserve this so _execute_module can propagate back to controller as a fact
-                    self._discovered_interpreter_key = discovered_key
-                else:
-                    task_vars['ansible_delegated_vars'][self._task.delegate_to]['ansible_facts'][discovered_key] = self._discovered_interpreter
+                # preserve this so _execute_module can propagate back to controller as a fact
+                self._discovered_interpreter_key = discovered_key
 
         return module_bits, module_path
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -442,9 +442,7 @@ class StrategyBase:
                     _add(fact_key)
         if always_keys:
             _pop = facts.pop
-            always_facts = {
-                'ansible_facts': dict((k, _pop(k)) for k in list(facts) if k in always_keys)
-            }
+            always_facts = dict((k, _pop(k)) for k in list(facts) if k in always_keys)
             host_list = self.get_delegated_hosts(result, task)
             _set_host_facts = self._variable_manager.set_host_facts
             for target_host in host_list:

--- a/test/integration/targets/interpreter_discovery_python/reuse_discovery.yml
+++ b/test/integration/targets/interpreter_discovery_python/reuse_discovery.yml
@@ -1,0 +1,23 @@
+- hosts: intra_task
+  gather_facts: no
+  connection: local
+  vars:
+    ansible_python_interpreter: auto
+  tasks:
+    - ping:
+      loop:
+        - 1
+        - 2
+    - assert:
+        that: ansible_facts['discovered_interpreter_python'] is defined
+
+- hosts: inter_task
+  gather_facts: no
+  connection: local
+  vars:
+    ansible_python_interpreter: auto
+  tasks:
+    - ping:
+    - ping:
+    - assert:
+        that: ansible_facts['discovered_interpreter_python'] is defined

--- a/test/integration/targets/interpreter_discovery_python/runme.sh
+++ b/test/integration/targets/interpreter_discovery_python/runme.sh
@@ -8,3 +8,7 @@ ansible-playbook discovery.yml -i ../../inventory "${@}"
 ansible-playbook bad-connection.yml -vvv 2>&1 | tee discovery.txt
 
 grep 'Attempting python interpreter discovery.' discovery.txt
+
+out="$(ansible-playbook -i intra_task,inter_task reuse_discovery.yml -vvv "$@")"
+[ "$(grep -c "<intra_task> Attempting python interpreter discovery." <<< "$out")" -eq 1 ]
+[ "$(grep -c "<inter_task> Attempting python interpreter discovery." <<< "$out")" -eq 1 ]

--- a/test/integration/targets/interpreter_discovery_python_delegate_facts/delegate_facts.yml
+++ b/test/integration/targets/interpreter_discovery_python_delegate_facts/delegate_facts.yml
@@ -4,6 +4,13 @@
     - name: Test python interpreter discovery with delegate_to without delegate_facts
       ping:
       delegate_to: testhost
+
+    - name: Test interpreter discovery fact is delegated regardless of delegate_facts
+      assert:
+        that:
+          - hostvars['testhost']['ansible_facts']['discovered_interpreter_python'] is defined
+          - hostvars['localhost']['ansible_facts']['discovered_interpreter_python'] is undefined
+
     - name: Test python interpreter discovery with delegate_to with delegate_facts
       ping:
       delegate_to: testhost

--- a/test/integration/targets/interpreter_discovery_python_delegate_facts/runme.sh
+++ b/test/integration/targets/interpreter_discovery_python_delegate_facts/runme.sh
@@ -2,4 +2,6 @@
 
 set -eux
 
-ansible-playbook delegate_facts.yml -i inventory "$@"
+out="$(ansible-playbook delegate_facts.yml -vvv -i inventory "$@")"
+
+[ "$(grep -c "Attempting python interpreter discovery" <<< "$out")" -eq 1 ]


### PR DESCRIPTION
##### SUMMARY

Set `discovered_interpreter_*` facts for `delegate_to` hosts even when `delegate_facts` is False. Previously interpreter discovery would occur repeatedly.

This was broken in two places. The action plugin did not return the fact for later tasks, and the strategy set the host facts `{"ansible_facts": value}` instead of the `value` (causing nested facts, i.e. `{"ansible_facts": {"facts": value}}`).

The action plugin also had some redundant logic which I removed.

Fixes #86517

##### ISSUE TYPE

- Bugfix Pull Request
