### PR TITLE
Add integration test for role_skeleton_ignore with custom skeleton

### DIFF
--- a/test/integration/targets/ansible-galaxy-role/tasks/test_role_skeleton_ignore.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/test_role_skeleton_ignore.yml
@@ -1,0 +1,53 @@
+---
+- name: Test role_skeleton_ignore with custom role skeleton
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    home_dir: "{{ lookup('env', 'HOME') }}"
+    skeleton_dir: "{{ home_dir }}/.ansible/role-skeleton"
+    role_name: testrole_ignore
+
+  tasks:
+    - name: Ensure clean skeleton directory
+      ansible.builtin.file:
+        path: "{{ skeleton_dir }}"
+        state: absent
+
+    - name: Create custom role skeleton directory
+      ansible.builtin.file:
+        path: "{{ skeleton_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Add file to custom skeleton that should be ignored
+      ansible.builtin.copy:
+        dest: "{{ skeleton_dir }}/CLAUDE.md"
+        content: "This file should be ignored"
+
+    - name: Write ansible.cfg with role_skeleton_ignore
+      ansible.builtin.copy:
+        dest: "{{ home_dir }}/.ansible.cfg"
+        content: |
+          [galaxy]
+          role_skeleton = {{ skeleton_dir }}
+          role_skeleton_ignore = ^\./CLAUDE\.md$
+
+    - name: Remove role directory if it exists
+      ansible.builtin.file:
+        path: "{{ role_name }}"
+        state: absent
+
+    - name: Initialize role using ansible-galaxy
+      ansible.builtin.command:
+        cmd: ansible-galaxy role init {{ role_name }}
+
+    - name: Check that ignored file was not copied
+      ansible.builtin.stat:
+        path: "{{ role_name }}/CLAUDE.md"
+      register: ignored_file
+
+    - name: Assert ignored file is absent
+      ansible.builtin.assert:
+        that:
+          - not ignored_file.stat.exists


### PR DESCRIPTION
### Summary
Adds an integration test covering `role_skeleton_ignore` behavior when using
a custom role skeleton.

### Details
The test validates that ignore patterns are matched against relative paths
(e.g. `./CLAUDE.md`), which aligns with the current implementation and explains
the behavior observed in the reported issue.

### Changelog
No changelog fragment added. This PR does not change runtime behavior and only
adds test coverage to document existing behavior.

### Related Issue
Fixes #86481
