### PR TITLE
executor: Remove RETURN_VARS

### DIFF
--- a/changelogs/fragments/ansible-executor-remove-return-vars.yml
+++ b/changelogs/fragments/ansible-executor-remove-return-vars.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - executor - remove unused RETURN_VARS

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -49,7 +49,6 @@ if t.TYPE_CHECKING:
 display = Display()
 
 
-RETURN_VARS = [x for x in C.MAGIC_VARIABLE_MAPPING.items() if 'become' not in x and '_pass' not in x]
 _INJECT_FACTS, _INJECT_FACTS_ORIGIN = C.config.get_config_value_and_origin('INJECT_FACTS_AS_VARS')
 
 __all__ = ['TaskExecutor']


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
`RETURN_VARS` was introduced for #70331, and last used in #70853.

    # git grep RETURN_VARS | wc -l
    1

Remove it.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
