### PR TITLE
user - Preserve current password when modifying user on BusyBox systems

### DIFF
--- a/changelogs/fragments/user-busybox-preserve-password.yml
+++ b/changelogs/fragments/user-busybox-preserve-password.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - preserve existing password when modifying accounts on BusyBox systems (https://github.com/ansible/ansible/pull/86530)

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3150,11 +3150,11 @@ class BusyBox(User):
         if self.password is not None:
             password = self.password
         elif current_password:
+            password = current_password
             if current_password == LOCK_INDICATOR:
                 # Special handling when the password is only a '!' to avoid
                 # unnecessary changes to the password to values like '!!' or '!*'.
                 lock = ''
-                password = current_password
             elif current_password.startswith(LOCK_INDICATOR):
                 # Preserve the existing password but unlock the account even if
                 # no password hash was provided in the module parameters.

--- a/test/integration/targets/user/tasks/test_create_user_password.yml
+++ b/test/integration/targets/user/tasks/test_create_user_password.yml
@@ -19,13 +19,20 @@
     update_password: on_create
   register: test_user_update_password
 
+- name: Test current password is preserved when not specified
+  user:
+    name: ansibulluser
+    update_password: always
+  register: test_no_changes
+
 - name: Ensure password was not changed
   assert:
     that:
       - test_user_update_password is not changed
+      - test_no_changes is not changed
 
 - name: Verify password hash for Linux
-  when: ansible_facts.os_family in ['RedHat', 'Debian']
+  when: ansible_facts.system == 'Linux'
   block:
     - name: LINUX | Get shadow entry for ansibulluser
       getent:
@@ -35,7 +42,7 @@
     - name: LINUX | Ensure password hash was not removed
       assert:
         that:
-          - getent_shadow['ansibulluser'][1] != '*'
+          - getent_shadow['ansibulluser'][0] != '*'
 
 - name: Test plaintext warning
   when: ansible_facts.system != 'Darwin'


### PR DESCRIPTION
##### SUMMARY

A bug in `_build_password_string` introduced in #86143 incorrectly changes the password hash to `*` if no password is specified in the task.

Update the integration tests to cover this scenario and use the correct index value when comparing data from the shadow database.

##### ISSUE TYPE

- Bugfix Pull Request
