### PR TITLE
inventory: increase cache prefix length to 12 to prevent collisions

### DIFF
--- a/changelogs/fragments/86532-inventory-cache-collision.yaml
+++ b/changelogs/fragments/86532-inventory-cache-collision.yaml
@@ -1,3 +1,2 @@
 bugfixes:
-
-inventory - increase cache prefix length from 6 to 12 characters to prevent hash collisions in large environments (#86504).
+  - "inventory - increase cache prefix length from 6 to 12 characters to prevent hash collisions in large environments (#86504)."

--- a/changelogs/fragments/86532-inventory-cache-collision.yaml
+++ b/changelogs/fragments/86532-inventory-cache-collision.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+
+inventory - increase cache prefix length from 6 to 12 characters to prevent hash collisions in large environments (#86504).

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -333,7 +333,7 @@ class Cacheable(_plugin_info.HasPluginInfo, _ConfigurablePlugin):
 
     def _get_cache_prefix(self, path: str) -> str:
         """Return a predictable unique key based on the given path."""
-        return 'k' + hashlib.sha256(f'{self.ansible_name}{path}'.encode(), usedforsecurity=False).hexdigest()[:6]
+        return 'k' + hashlib.sha256(f'{self.ansible_name}{path}'.encode(), usedforsecurity=False).hexdigest()[:12]
 
     def clear_cache(self) -> None:
         self._cache.clear()


### PR DESCRIPTION
### Summary
Fixes #86504

This PR increases the inventory cache prefix hash length from 6 to 12 characters. The original 6-character length led to a ~7.3% collision probability for inventories with ~1,600 devices (Birthday Paradox). Increasing to 12 characters provides $16^{12}$ possibilities, making collisions statistically negligible.

### Issue Type
Bugfix Pull Request

### Component Name
inventory

### Ansible Version
Verified on ansible-core 2.16.x and higher.