### PR TITLE
[duplicate] Silence detached HEAD advice during SCM checkouts

### DIFF
--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -443,7 +443,7 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
             format(repo_url=to_native(git_url)),
         ) from proc_err
 
-    git_switch_cmd = git_executable, 'checkout', to_text(version)
+    git_switch_cmd = git_executable, '-c', 'advice.detachedHead=false', 'checkout', to_text(version)
     try:
         subprocess.check_call(git_switch_cmd, cwd=b_checkout_path)
     except subprocess.CalledProcessError as proc_err:

--- a/lib/ansible/utils/galaxy.py
+++ b/lib/ansible/utils/galaxy.py
@@ -77,7 +77,7 @@ def scm_archive_resource(src, scm='git', name=None, version='HEAD', keep_scm_met
     run_scm_cmd(clone_cmd, tempdir)
 
     if scm == 'git' and version:
-        checkout_cmd = [scm_path, 'checkout', to_text(version)]
+        checkout_cmd = [scm_path, '-c', 'advice.detachedHead=false', 'checkout', to_text(version)]
         run_scm_cmd(checkout_cmd, os.path.join(tempdir, name))
 
     temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.tar', dir=C.DEFAULT_LOCAL_TMP)

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -147,7 +147,7 @@ def test_concrete_artifact_manager_scm_cmd(url, version, trailing_slash, monkeyp
     clone_cmd = [git_executable, 'clone', repo, '']
 
     assert mock_subprocess_check_call.call_args_list[0].args[0] == clone_cmd
-    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, 'checkout', 'commitish')
+    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, '-c', 'advice.detachedHead=false', 'checkout', 'commitish')
 
 
 @pytest.mark.parametrize(
@@ -178,7 +178,7 @@ def test_concrete_artifact_manager_scm_cmd_shallow(url, version, trailing_slash,
     shallow_clone_cmd = [git_executable, 'clone', '--depth=1', repo, '']
 
     assert mock_subprocess_check_call.call_args_list[0].args[0] == shallow_clone_cmd
-    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, 'checkout', 'HEAD')
+    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, '-c', 'advice.detachedHead=false', 'checkout', 'HEAD')
 
 
 @pytest.mark.parametrize(
@@ -210,7 +210,7 @@ def test_concrete_artifact_manager_scm_cmd_validate_certs(ignore_certs_cli, igno
         clone_cmd.extend(['-c', 'http.sslVerify=false'])
 
     assert mock_subprocess_check_call.call_args_list[0].args[0] == clone_cmd
-    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, 'checkout', 'HEAD')
+    assert mock_subprocess_check_call.call_args_list[1].args[0] == (git_executable, '-c', 'advice.detachedHead=false', 'checkout', 'HEAD')
 
 
 def test_build_requirement_from_path(collection_artifact):


### PR DESCRIPTION
This PR silences the 'detached HEAD' advice during SCM checkouts (e.g., when installing collections from tags).

### Rationale
When Ansible checkouts a specific tag or commit, Git displays a long advice message about being in a 'detached HEAD' state. While informative for human users, this is often 'noise' in automated environments and script outputs.

### Technical Approach
I've added `-c advice.detachedHead=false` to the `git checkout` commands in:
- `lib/ansible/galaxy/collection/concrete_artifact_manager.py`
- `lib/ansible/utils/galaxy.py`

This is the standard and surgical way to suppress this specific advice for a single command. Unit tests have been updated to reflect this change.

*Note: The name 'magnificat' that appeared in some earlier test logs was simply a local configuration name used for testing purposes and has no relation to the fix itself.*