### PR TITLE
Add seealso section to apt module documentation

### DIFF
--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -13,6 +13,8 @@ DOCUMENTATION = """
 ---
 module: apt
 short_description: Manages apt-packages
+seealso:
+  - module: ansible.builtin.apt_repository
 description:
   - Manages I(apt) packages (such as for Debian/Ubuntu).
 version_added: "0.0.2"

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -14,7 +14,7 @@ DOCUMENTATION = """
 module: apt
 short_description: Manages apt-packages
 seealso:
-  - module: ansible.builtin.apt_repository
+  - module: ansible.builtin.deb822_repository
 description:
   - Manages I(apt) packages (such as for Debian/Ubuntu).
 version_added: "0.0.2"


### PR DESCRIPTION
##### SUMMARY

Added seealso section for apt module documentation to improve discovery of apt_repository module.

##### ISSUE TYPE

- Docs Pull Request
