### PR TITLE
Add integration test for role_skeleton_ignore with custom skeleton #86524

### DIFF
--- a/changelogs/fragments/role_skeleton_ignore_test.yml
+++ b/changelogs/fragments/role_skeleton_ignore_test.yml
@@ -1,0 +1,2 @@
+trivial:
+  - Add integration coverage for role_skeleton_ignore with custom role skeleton.

--- a/changelogs/fragments/role_skeleton_ignore_test.yml
+++ b/changelogs/fragments/role_skeleton_ignore_test.yml
@@ -1,2 +1,0 @@
-trivial:
-  - Add integration coverage for role_skeleton_ignore with custom role skeleton.

--- a/test/integration/targets/ansible-galaxy-role/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/main.yml
@@ -70,3 +70,4 @@
 
 - import_tasks: dir-traversal.yml
 - import_tasks: valid-role-symlinks.yml
+- import_tasks: test_role_skeleton_ignore.yml

--- a/test/integration/targets/ansible-galaxy-role/tasks/test_role_skeleton_ignore.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/test_role_skeleton_ignore.yml
@@ -1,0 +1,53 @@
+---
+- name: Test role_skeleton_ignore with custom role skeleton
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    home_dir: "{{ lookup('env', 'HOME') }}"
+    skeleton_dir: "{{ home_dir }}/.ansible/role-skeleton"
+    role_name: testrole_ignore
+
+  tasks:
+    - name: Ensure clean skeleton directory
+      ansible.builtin.file:
+        path: "{{ skeleton_dir }}"
+        state: absent
+
+    - name: Create custom role skeleton directory
+      ansible.builtin.file:
+        path: "{{ skeleton_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: Add file to custom skeleton that should be ignored
+      ansible.builtin.copy:
+        dest: "{{ skeleton_dir }}/CLAUDE.md"
+        content: "This file should be ignored"
+
+    - name: Write ansible.cfg with role_skeleton_ignore
+      ansible.builtin.copy:
+        dest: "{{ home_dir }}/.ansible.cfg"
+        content: |
+          [galaxy]
+          role_skeleton = {{ skeleton_dir }}
+          role_skeleton_ignore = ^\./CLAUDE\.md$
+
+    - name: Remove role directory if it exists
+      ansible.builtin.file:
+        path: "{{ role_name }}"
+        state: absent
+
+    - name: Initialize role using ansible-galaxy
+      ansible.builtin.command:
+        cmd: ansible-galaxy role init {{ role_name }}
+
+    - name: Check that ignored file was not copied
+      ansible.builtin.stat:
+        path: "{{ role_name }}/CLAUDE.md"
+      register: ignored_file
+
+    - name: Assert ignored file is absent
+      ansible.builtin.assert:
+        that:
+          - not ignored_file.stat.exists

--- a/test/integration/targets/ansible-galaxy-role/tasks/test_role_skeleton_ignore.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/test_role_skeleton_ignore.yml
@@ -1,53 +1,43 @@
 ---
-- name: Test role_skeleton_ignore with custom role skeleton
-  hosts: localhost
-  gather_facts: false
+- name: Ensure clean skeleton directory
+  ansible.builtin.file:
+    path: "{{ lookup('env', 'HOME') }}/.ansible/role-skeleton"
+    state: absent
 
-  vars:
-    home_dir: "{{ lookup('env', 'HOME') }}"
-    skeleton_dir: "{{ home_dir }}/.ansible/role-skeleton"
-    role_name: testrole_ignore
+- name: Create custom role skeleton directory
+  ansible.builtin.file:
+    path: "{{ lookup('env', 'HOME') }}/.ansible/role-skeleton"
+    state: directory
+    mode: "0755"
 
-  tasks:
-    - name: Ensure clean skeleton directory
-      ansible.builtin.file:
-        path: "{{ skeleton_dir }}"
-        state: absent
+- name: Add file to custom skeleton that should be ignored
+  ansible.builtin.copy:
+    dest: "{{ lookup('env', 'HOME') }}/.ansible/role-skeleton/CLAUDE.md"
+    content: "This file should be ignored"
 
-    - name: Create custom role skeleton directory
-      ansible.builtin.file:
-        path: "{{ skeleton_dir }}"
-        state: directory
-        mode: "0755"
+- name: Write ansible.cfg with role_skeleton_ignore
+  ansible.builtin.copy:
+    dest: "{{ lookup('env', 'HOME') }}/.ansible.cfg"
+    content: |
+      [galaxy]
+      role_skeleton = {{ lookup('env', 'HOME') }}/.ansible/role-skeleton
+      role_skeleton_ignore = ^\./CLAUDE\.md$
 
-    - name: Add file to custom skeleton that should be ignored
-      ansible.builtin.copy:
-        dest: "{{ skeleton_dir }}/CLAUDE.md"
-        content: "This file should be ignored"
+- name: Remove role directory if it exists
+  ansible.builtin.file:
+    path: testrole_ignore
+    state: absent
 
-    - name: Write ansible.cfg with role_skeleton_ignore
-      ansible.builtin.copy:
-        dest: "{{ home_dir }}/.ansible.cfg"
-        content: |
-          [galaxy]
-          role_skeleton = {{ skeleton_dir }}
-          role_skeleton_ignore = ^\./CLAUDE\.md$
+- name: Initialize role using ansible-galaxy
+  ansible.builtin.command:
+    cmd: ansible-galaxy role init testrole_ignore
 
-    - name: Remove role directory if it exists
-      ansible.builtin.file:
-        path: "{{ role_name }}"
-        state: absent
+- name: Check that ignored file was not copied
+  ansible.builtin.stat:
+    path: testrole_ignore/CLAUDE.md
+  register: ignored_file
 
-    - name: Initialize role using ansible-galaxy
-      ansible.builtin.command:
-        cmd: ansible-galaxy role init {{ role_name }}
-
-    - name: Check that ignored file was not copied
-      ansible.builtin.stat:
-        path: "{{ role_name }}/CLAUDE.md"
-      register: ignored_file
-
-    - name: Assert ignored file is absent
-      ansible.builtin.assert:
-        that:
-          - not ignored_file.stat.exists
+- name: Assert ignored file is absent
+  ansible.builtin.assert:
+    that:
+      - not ignored_file.stat.exists


### PR DESCRIPTION
Thanks for the feedback. The test file was previously written as a play.
I’ve converted it to a task-only file so it can be executed by the
integration test harness and verified it via
`ansible-test integration ansible-galaxy-role`.

Related Issue
Fixes : #86481