### PR TITLE
ansible-galaxy: handle an error when invalid regex specified

### DIFF
--- a/changelogs/fragments/collection_skeleton_ignore.yml
+++ b/changelogs/fragments/collection_skeleton_ignore.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - ansible-galaxy - raise an error when wrong regex value specified in collection_skeleton_ignore.

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1138,18 +1138,17 @@ class GalaxyCLI(CLI):
             skeleton_ignore_expressions = ['^.*/.git_keep$']
 
         obj_skeleton = os.path.expanduser(obj_skeleton)
-        failed_re_expressions = {}
+        failed_re_expressions = ""
         skeleton_ignore_re = []
         for x in skeleton_ignore_expressions:
             try:
                 skeleton_ignore_re.append(re.compile(x))
             except re.error as e:
-                failed_re_expressions[x] = str(e)
+                failed_re_expressions += f"- {x}: {str(e)}\n"
                 continue
         if failed_re_expressions:
             raise AnsibleError(
-                "Failed to compile regular expressions for "
-                f"skeleton ignore: {', '.join([f'{k}: {v}' for k, v in failed_re_expressions.items()])}"
+                f"Failed to compile regular expressions for skeleton ignore: \n{failed_re_expressions}"
             )
 
         if not os.path.exists(obj_skeleton):

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -1138,7 +1138,19 @@ class GalaxyCLI(CLI):
             skeleton_ignore_expressions = ['^.*/.git_keep$']
 
         obj_skeleton = os.path.expanduser(obj_skeleton)
-        skeleton_ignore_re = [re.compile(x) for x in skeleton_ignore_expressions]
+        failed_re_expressions = {}
+        skeleton_ignore_re = []
+        for x in skeleton_ignore_expressions:
+            try:
+                skeleton_ignore_re.append(re.compile(x))
+            except re.error as e:
+                failed_re_expressions[x] = str(e)
+                continue
+        if failed_re_expressions:
+            raise AnsibleError(
+                "Failed to compile regular expressions for "
+                f"skeleton ignore: {', '.join([f'{k}: {v}' for k, v in failed_re_expressions.items()])}"
+            )
 
         if not os.path.exists(obj_skeleton):
             raise AnsibleError("- the skeleton path '{0}' does not exist, cannot init {1}".format(

--- a/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/init.yml
@@ -170,11 +170,43 @@
     - assert:
         that:
           - not validate_readme_content.changed
+
+    - name: create a skeleton directory
+      file:
+        path: "{{ galaxy_dir }}/scratch/{{ item }}"
+        state: directory
+      loop:
+        - "invalid_skeleton"
+        - "invalid_skeleton/custom_skeleton"
+
+    - name: create an invalid skeleton ignore expression in ansible.cfg
+      copy:
+        content: |
+          [galaxy]
+          collection_skeleton_ignore=[^.*/.git_keep$
+        dest: "{{ galaxy_dir }}/scratch/invalid_skeleton/ansible.cfg"
+
+    - name: create a collection using the invalid skeleton
+      command: ansible-galaxy collection init ansible_test.my_collection --init-path {{ galaxy_dir }}/scratch/invalid_skeleton --collection-skeleton {{ galaxy_dir }}/scratch/invalid_skeleton/custom_skeleton
+      register: init_invalid_ignore_expression
+      environment:
+        ANSIBLE_CONFIG: "{{ galaxy_dir }}/scratch/invalid_skeleton/ansible.cfg"
+      ignore_errors: true
+
+    - name: assert create collection with invalid skeleton ignore expression
+      assert:
+        that:
+          - "init_invalid_ignore_expression.failed"
+          - "'Failed to compile regular expressions for skeleton ignore' in init_invalid_ignore_expression.stderr"
+
   always:
     - name: cleanup
       file:
-        path: "{{ galaxy_dir }}/scratch/skeleton"
+        path: "{{ galaxy_dir }}/scratch/{{ item }}"
         state: absent
+      loop:
+        - "skeleton"
+        - "invalid_skeleton"
 
 - name: create collection for ignored files and folders
   command: ansible-galaxy collection init ansible_test.ignore


### PR DESCRIPTION
##### SUMMARY

* Handle exception when invalid regex specified in collection_skeleton_ignore

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/collection_skeleton_ignore.yml
lib/ansible/cli/galaxy.py
test/integration/targets/ansible-galaxy-collection/tasks/init.yml


