### PR TITLE
Inject pickling behavior into singleton object

### DIFF
--- a/lib/ansible/utils/singleton.py
+++ b/lib/ansible/utils/singleton.py
@@ -11,15 +11,12 @@ class Singleton(type):
     functionality.  If an instance of the class exists, it's returned,
     otherwise a single instance is instantiated and returned.
     """
-
     def __init__(cls, name, bases, dct):
         super(Singleton, cls).__init__(name, bases, dct)
         cls.__instance = None
         cls.__rlock = RLock()
-        
         cls.__copy__ = lambda self: self
         cls.__deepcopy__ = lambda self, memo: self
-        
         def __reduce_ex__(self, protocol):
             # Reconstruct by calling the class
             return (cls, ())
@@ -34,5 +31,3 @@ class Singleton(type):
                 cls.__instance = super(Singleton, cls).__call__(*args, **kw)
 
         return cls.__instance
-    
-

--- a/lib/ansible/utils/singleton.py
+++ b/lib/ansible/utils/singleton.py
@@ -17,6 +17,7 @@ class Singleton(type):
         cls.__rlock = RLock()
         cls.__copy__ = lambda self: self
         cls.__deepcopy__ = lambda self, memo: self
+
         def __reduce_ex__(self, protocol):
             # Reconstruct by calling the class
             return (cls, ())

--- a/lib/ansible/utils/singleton.py
+++ b/lib/ansible/utils/singleton.py
@@ -12,11 +12,18 @@ class Singleton(type):
     otherwise a single instance is instantiated and returned.
     """
 
-    # FIXME: object identity/singleton-ness does not appear to survive pickle roundtrip (eg, copy.copy, copy.deepcopy), implement __reduce_ex__ and __copy__?
     def __init__(cls, name, bases, dct):
         super(Singleton, cls).__init__(name, bases, dct)
         cls.__instance = None
         cls.__rlock = RLock()
+        
+        cls.__copy__ = lambda self: self
+        cls.__deepcopy__ = lambda self, memo: self
+        
+        def __reduce_ex__(self, protocol):
+            # Reconstruct by calling the class
+            return (cls, ())
+        cls.__reduce_ex__ = __reduce_ex__
 
     def __call__(cls, *args, **kw):
         if cls.__instance is not None:
@@ -27,3 +34,5 @@ class Singleton(type):
                 cls.__instance = super(Singleton, cls).__call__(*args, **kw)
 
         return cls.__instance
+    
+


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Found an old comment:     
# FIXME: object identity/singleton-ness does not appear to survive pickle roundtrip (eg, copy.copy, copy.deepcopy), implement __reduce_ex__ and __copy__?

Added the methods mentioned above, though I did not test to see if pickling would survive roundtrip. Seems like community.general.pickle is the optimal solution if you want pickling to work .

##### ISSUE TYPE

- Bugfix Pull Request
