### PR TITLE
user: return actual system groups instead of input parameter

### DIFF
--- a/changelogs/fragments/80669-user-return-actual-groups.yml
+++ b/changelogs/fragments/80669-user-return-actual-groups.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - user - return the actual system groups the user belongs to instead of only the
+    groups specified in the module input (https://github.com/ansible/ansible/issues/80669).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -419,10 +419,10 @@ group:
   type: int
   sample: 1001
 groups:
-  description: List of groups of which the user is a member.
-  returned: When O(groups) is not empty and O(state) is V(present)
+  description: Comma-separated list of groups of which the user is a member, sorted alphabetically.
+  returned: When user exists and O(state) is V(present)
   type: str
-  sample: 'chrony,apache'
+  sample: 'apache,chrony'
 home:
   description: "Path to user's home directory."
   returned: When O(state) is V(present)
@@ -3499,8 +3499,7 @@ def main():
         result['comment'] = info[4]
         result['home'] = info[5]
         result['shell'] = info[6]
-        if user.groups is not None:
-            result['groups'] = user.groups
+        result['groups'] = ','.join(sorted(user.user_group_membership()))
 
         # handle missing homedirs
         info = user.user_info()

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -422,10 +422,10 @@ group:
   type: int
   sample: 1001
 groups:
-  description: Comma-separated list of groups of which the user is a member, sorted alphabetically.
+  description: Comma-separated list of groups of which the user is a member.
   returned: When user exists and O(state) is V(present)
   type: str
-  sample: 'apache,chrony'
+  sample: 'chrony,apache'
 home:
   description: "Path to user's home directory."
   returned: When O(state) is V(present)
@@ -3502,7 +3502,7 @@ def main():
         result['comment'] = info[4]
         result['home'] = info[5]
         result['shell'] = info[6]
-        result['groups'] = ','.join(sorted(user.user_group_membership()))
+        result['groups'] = ','.join(user.user_group_membership())
 
         # handle missing homedirs
         info = user.user_info()

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -18,6 +18,7 @@
 - import_tasks: test_expires_min_max.yml
 - import_tasks: test_expires_warn.yml
 - import_tasks: test_ssh_key_passphrase.yml
+- import_tasks: test_returned_groups.yml
 - include_tasks: test_password_lock.yml
 - include_tasks: test_password_lock_new_user.yml
 - include_tasks: test_local.yml

--- a/test/integration/targets/user/tasks/test_returned_groups.yml
+++ b/test/integration/targets/user/tasks/test_returned_groups.yml
@@ -1,0 +1,57 @@
+# Test that the user module returns the actual groups a user belongs to
+# See: https://github.com/ansible/ansible/issues/80669
+
+- name: remove test user for groups return test
+  user:
+    name: ansibulluser_groups
+    state: absent
+
+- name: create test user with initial groups
+  user:
+    name: ansibulluser_groups
+    groups:
+      - daemon
+      - bin
+    state: present
+  register: user_groups_create
+
+- name: validate groups on initial creation
+  assert:
+    that:
+      - "'bin' in user_groups_create.groups"
+      - "'daemon' in user_groups_create.groups"
+
+- name: append a group to the test user
+  user:
+    name: ansibulluser_groups
+    groups:
+      - sys
+    append: true
+    state: present
+  register: user_groups_append
+
+- name: validate groups after append includes all groups
+  assert:
+    that:
+      - "'bin' in user_groups_append.groups"
+      - "'daemon' in user_groups_append.groups"
+      - "'sys' in user_groups_append.groups"
+
+- name: run user module with no groups param
+  user:
+    name: ansibulluser_groups
+    state: present
+  register: user_groups_noarg
+
+- name: validate groups returned even when groups param is not set
+  assert:
+    that:
+      - user_groups_noarg.groups is defined
+      - "'bin' in user_groups_noarg.groups"
+      - "'daemon' in user_groups_noarg.groups"
+      - "'sys' in user_groups_noarg.groups"
+
+- name: clean up test user
+  user:
+    name: ansibulluser_groups
+    state: absent


### PR DESCRIPTION
##### SUMMARY

The `groups` return value from the `user` module was returning whatever was passed in via the `groups` input parameter rather than the user's actual group membership on the system. This means when using `append: true`, the return value only showed the newly appended groups, not the full list the user belongs to.

Fixed by querying the system for the user's real group membership after modification using `user_group_membership()`, which is what the docs describe: "List of groups of which the user is a member."

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

user

##### ADDITIONAL INFORMATION

Reproduction case from the issue - the second task with `append: true` would only return `man` instead of `www-data,sudo,man`:

```yaml
- name: Create user
  user:
    name: "testuser"
    groups: [www-data, sudo]
    append: false
    state: present

- name: Append a group to the user
  user:
    name: "testuser"
    groups: [man]
    append: true
    state: present
  register: result
# result.groups was "man", now correctly returns "man,sudo,www-data"
```

Also updated the RETURN docs to note that groups are now always returned when the user exists (not only when the `groups` parameter is specified), and that the list is sorted alphabetically.

Fixes #80669