### PR TITLE
ssh: respect ANSIBLE_HOME for control_path_dir default

### DIFF
--- a/changelogs/fragments/79737-ssh-control-path-dir-ansible-home.yml
+++ b/changelogs/fragments/79737-ssh-control-path-dir-ansible-home.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - SSH connection plugin - The default ``control_path_dir`` now respects
+    the ``ANSIBLE_HOME`` configuration setting, using ``ANSIBLE_HOME/cp``
+    instead of the previously hardcoded ``~/.ansible/cp``
+    (https://github.com/ansible/ansible/issues/79737).

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -315,7 +315,7 @@ DOCUMENTATION = """
           - name: ansible_control_path
             version_added: '2.7'
       control_path_dir:
-        default: ~/.ansible/cp
+        default: '{{ ANSIBLE_HOME ~ "/cp" }}'
         description:
           - This sets the directory to use for ssh control path if the control path setting is null.
           - Also, provides the ``%(directory)s`` variable for the control path setting.
@@ -671,6 +671,14 @@ class Connection(ConnectionBase):
         self._tty_parser.add_argument('-o', action='append')
 
         self._populated_agent: pathlib.Path | None = None
+
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+        # Inject ANSIBLE_HOME into template variables so plugin defaults
+        # like '{{ ANSIBLE_HOME ~ "/cp" }}' resolve correctly.
+        if var_options is None:
+            var_options = {}
+        var_options.setdefault('ANSIBLE_HOME', C.config.get_config_value('ANSIBLE_HOME'))
+        super().set_options(task_keys=task_keys, var_options=var_options, direct=direct)
 
     # The connection is created by running ssh/scp/sftp from the exec_command,
     # put_file, and fetch_file methods, so we don't need to do any connection

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -96,4 +96,11 @@ ANSIBLE_SSH_VERBOSITY=1 ansible ssh -m raw -a whoami -i test_connection.inventor
 # enable SSH client verbosity level 3 via var; ensure debug3 lines
 ansible ssh -m raw -a whoami -i test_connection.inventory -vvvvv -e ansible_ssh_verbosity=3 2>&1 | grep 'debug3:'
 
+# test that control_path_dir respects ANSIBLE_HOME
+CUSTOM_HOME="$(mktemp -d)"
+ANSIBLE_HOME="$CUSTOM_HOME" ansible-playbook test_ssh_control_path_dir.yml "$@" -i test_connection.inventory
+# verify the cp directory was created under custom ANSIBLE_HOME, not ~/.ansible
+test -d "$CUSTOM_HOME/cp"
+rm -rf "$CUSTOM_HOME"
+
 echo PASS

--- a/test/integration/targets/connection_ssh/test_ssh_control_path_dir.yml
+++ b/test/integration/targets/connection_ssh/test_ssh_control_path_dir.yml
@@ -1,0 +1,20 @@
+- hosts: ssh
+  gather_facts: false
+  vars:
+    ansible_connection: ssh
+  tasks:
+    - name: run a command to trigger SSH connection and control path creation
+      raw: echo ok
+
+    - name: check that control path directory was created under ANSIBLE_HOME
+      stat:
+        path: "{{ lookup('env', 'ANSIBLE_HOME') }}/cp"
+      register: cpdir_stat
+      delegate_to: localhost
+
+    - name: assert control path directory exists
+      assert:
+        that:
+          - cpdir_stat.stat.exists
+          - cpdir_stat.stat.isdir
+        fail_msg: "Control path directory '{{ lookup('env', 'ANSIBLE_HOME') }}/cp' was not created"


### PR DESCRIPTION
##### SUMMARY

The SSH connection plugin's `control_path_dir` option has a hardcoded default of `~/.ansible/cp`, which ignores the `ANSIBLE_HOME` configuration setting entirely. When a user configures `ANSIBLE_HOME` to a custom path (e.g. `~/.cache/ansible`), the control path directory still gets created under `~/.ansible/cp`.

This removes the hardcoded default and adds a runtime fallback to `$ANSIBLE_HOME/cp` when no explicit `control_path_dir` is configured. This is consistent with how other path defaults in the codebase reference `ANSIBLE_HOME`.

An earlier PR (#82026) addressed this but was closed with a reference to #76114, which only added the `ANSIBLE_HOME` config option itself without updating the SSH plugin's default. Confirmed still broken on 2.17.4 per the issue thread.

Fixes #79737

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ssh connection plugin

##### ADDITIONAL INFORMATION

Tested by verifying:
- When `ANSIBLE_HOME` is set to a custom path, `control_path_dir` now defaults to `$ANSIBLE_HOME/cp`
- When `control_path_dir` is explicitly configured, the explicit value is still used
- Added unit test covering the fallback behavior