### PR TITLE
display action

### DIFF
--- a/lib/ansible/modules/display.py
+++ b/lib/ansible/modules/display.py
@@ -19,7 +19,7 @@ options:
     required: yes
   channel:
     description:
-    - How to display the message, it llows you to use existing display channels in Ansible core.
+    - How to display the message, it allows you to use existing display channels in Ansible core.
       This will format and color and prefix the messages as Ansible itself would.
     choices:
         display: normal text

--- a/lib/ansible/modules/display.py
+++ b/lib/ansible/modules/display.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+DOCUMENTATION = r'''
+module: display
+short_description: Display a message
+description:
+  - This action displays messages during execution either using normal callback semantics or bypassing them
+    and printing directly to the terminal.
+version_added: '2.21'
+options:
+  msg:
+    description:
+    - The message to display.
+    type: str
+    required: yes
+  channel:
+    description:
+    - How to display the message, it llows you to use existing display channels in Ansible core.
+      This will format and color and prefix the messages as Ansible itself would.
+    choices:
+        display: normal text
+        error: Show an error message
+        warning: Emit a warning
+        deprecation: Present a deprecation message
+        verbose: Emulate C(-v) output
+        callback: normal task output via the callback framework
+        log: send message to the ansible log, if it is enabled
+    default: callback
+extends_documentation_fragment:
+  - action_common_attributes
+  - action_common_attributes.conn
+  - action_common_attributes.flow
+attributes:
+    action:
+        support: full
+    async:
+        support: none
+    bypass_host_loop:
+        support: none
+    become:
+        support: none
+    check_mode:
+        support: full
+    diff_mode:
+        support: none
+    connection:
+        support: none
+    delegation:
+        details: Aside from C(register) and/or in combination with C(delegate_facts), it has little effect.
+        support:  partial
+    platform:
+        support: full
+        platforms: all
+seealso:
+  - module: ansible.builtin.assert
+  - module: ansible.builtin.fail
+author:
+  - Ansible Core Team
+'''
+
+EXAMPLES = r'''
+- name: Print the gateway for each host when defined
+  ansible.builtin.display:
+    msg: System {{ inventory_hostname }} has gateway {{ ansible_default_ipv4.gateway }}
+  when: ansible_default_ipv4.gateway is defined
+
+- name: Get uptime information
+  ansible.builtin.shell: /usr/bin/uptime
+  register: result
+
+- name: Print return information from the previous task, if very verbose
+  ansible.builtin.display:
+    msg: '{{result}}'
+  when: ansible_verbosity >= 2
+
+- name: Display all variables/facts known for a host, if very very very verbose
+  ansible.builtin.display:
+    msg: '{{hostvars[inventory_hostname]}}'
+  when: ansible_verbosity >= 4
+
+- name: Assert a value is what we expect
+  ansible.builtin.display:
+      msg: "'X': {{x|default('UNDEFINED')}}.  'X' is {{(x|default(None) in [1,2,3])|ternary('','not')}} in the array"
+  failed_when:
+    - x is not defined or x not in [1,2,3]
+'''

--- a/lib/ansible/plugins/action/display.py
+++ b/lib/ansible/plugins/action/display.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
+
+display = Display()
+
+
+class ActionModule(ActionBase):
+    """ Print statements during execution """
+
+    TRANSFERS_FILES = False
+    _VALID_ARGS = frozenset(('msg', 'channel'))
+    _VALID_CHANNELS = frozenset(('deprecated', 'warning', 'display', 'verbose', 'error', 'callback', 'log'))
+
+    def run(self, tmp=None, task_vars=None):
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        result['failed'] = True
+
+        try:
+            msg = self._task.args['msg']
+        except KeyError:
+            result['msg'] = "The required field 'msg' is missing"
+            return result
+
+        channel = self._task.args.get('channel', 'callback')
+
+        if channel not in self._VALID_CHANNELS:
+            result['msg'] = f"Invalid channel '{channel}', valid values are: {','.join(self._VALID_CHANNELS)}"
+            return result
+
+        if channel == 'callback':
+            result['msg'] = msg
+            result['_ansible_verbose_override'] = True
+            result['_ansible_always_verbose'] = True
+        else:
+            call = getattr(display, channel)
+            try:
+                call(str(msg, errors='strict'))
+            except UnicodeError as e:
+                result['msg'] = f"Could not convert msg to unicode: {e!r}"
+                return result
+
+        result['failed'] = False
+        return result


### PR DESCRIPTION
  New display action that play authors can use to 'display' a message,
  by default it uses the standard callback channel, but can be used to
  bypass callbacks and use the core display facilities

fixes #86547

##### ISSUE TYPE

- Feature Pull Request
