### PR TITLE
playbook: add regression test for rejecting fractional floats on int attributes

### DIFF
--- a/test/units/playbook/test_base.py
+++ b/test/units/playbook/test_base.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import unittest
 
-from ansible.errors import AnsibleParserError, AnsibleFieldAttributeError
+from ansible.errors import AnsibleError, AnsibleParserError, AnsibleFieldAttributeError
 from ansible._internal._datatag._tags import TrustedAsTemplate
 from ansible.playbook.attribute import FieldAttribute, NonInheritableFieldAttribute
 from ansible._internal._templating._engine import TemplateEngine
@@ -532,3 +532,18 @@ class TestBaseSubClass(TestBase):
         result = bsc.get_validated_value('foo', attribute, value, templar)
         assert TrustedAsTemplate.is_tagged_on(result)
         assert result == 'bar'
+
+    def test_get_validated_value_int_rejects_fractional_float(self):
+        attribute = FieldAttribute(isa='int')
+        templar = TemplateEngine(None)
+        bsc = self.ClassUnderTest()
+
+        self.assertRaisesRegex(
+            AnsibleError,
+            r"The value 0\.9999 could not be converted to 'int'\.",
+            bsc.get_validated_value,
+            'foo',
+            attribute,
+            0.9999,
+            templar,
+        )


### PR DESCRIPTION
### SUMMARY

Adds a regression unit test ensuring that fractional floats (e.g. `0.9999`) are rejected for 'FieldAttribute(isa='int')'.

This verifies the current behavior in 'get_validated_value()', where float-to-int conversions that would truncate raise an error instead of silently truncating.

This protects against regressions related to #83863.

### ISSUE TYPE

- Test Pull Request