### PR TITLE
ansible-test - Fix misleading program-not-found for missing cwd

### DIFF
--- a/changelogs/fragments/86571-ansible-test-fix-misleading-program-not-found-for-missing-cwd.yml
+++ b/changelogs/fragments/86571-ansible-test-fix-misleading-program-not-found-for-missing-cwd.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "ansible-test - fix misleading ``Required program not found`` error when the working directory does not exist. (https://github.com/ansible/ansible/pull/86571)"

--- a/test/lib/ansible_test/_internal/util.py
+++ b/test/lib/ansible_test/_internal/util.py
@@ -530,7 +530,10 @@ def raw_command(
         try:
             process = subprocess.Popen(cmd, env=env, stdin=stdin, stdout=stdout, stderr=stderr, cwd=cwd)  # pylint: disable=consider-using-with
         except FileNotFoundError as ex:
-            raise ApplicationError('Required program "%s" not found.' % cmd[0]) from ex
+            missing = getattr(ex, 'filename', None)
+            if missing is not None and os.path.normpath(missing) == os.path.normpath(cmd[0]):
+                raise ApplicationError('Required program "%s" not found.' % cmd[0]) from ex
+            raise ApplicationError('File not found: "%s".' % (missing or 'unknown')) from ex
 
         if communicate:
             data_bytes = to_optional_bytes(data)

--- a/test/units/ansible_test/_internal/test_util.py
+++ b/test/units/ansible_test/_internal/test_util.py
@@ -36,6 +36,24 @@ def test_failed_interactive_command() -> None:
     assert error.value.stderr is None
 
 
+def test_missing_program() -> None:
+    """Verify that a missing program raises an ``ApplicationError`` with an appropriate message."""
+    from ansible_test._internal.util import raw_command, ApplicationError
+
+    with pytest.raises(ApplicationError, match='Required program ".+" not found\\.'):
+        raw_command(['/does/not/exist/program'], True)
+
+
+def test_missing_cwd() -> None:
+    """Verify that a missing cwd raises an ``ApplicationError`` with an appropriate message, not a misleading program-not-found error."""
+    from ansible_test._internal.util import raw_command, ApplicationError
+
+    with pytest.raises(ApplicationError, match='File not found: ".+"\\.') as error:
+        raw_command(['ls'], True, cwd='/does/not/exist/cwd')
+
+    assert 'Required program' not in str(error.value)
+
+
 @pytest.mark.parametrize("args,filters,expected", (
     (
         # args after a known option must be separated from existing args


### PR DESCRIPTION
##### SUMMARY

When a collection has an uninitialized git submodule, `ansible-test` reports `FATAL: Required program "git" not found.` even when `git` is installed. The real failure is that the submodule directory does not exist.

`provider/source/git.py`’s `get_paths()` calls __get_paths() for each submodule with cwd set to the submodule path. That leads to `git.py`’s `run_git()` → `util.raw_command(..., cwd=submodule_path)`. If that directory is missing, `Popen(..., cwd=cwd)` raises `FileNotFoundError` with `filename` set to the path. The handler treated every `FileNotFoundError` as “\
executable not found, so the message was wrong.

The fix: only report “Required program … not found” when the missing path is `cmd[0]`. Otherwise report `File not found: "<path>"`, so users see the real cause.

##### ISSUE TYPE

- Bugfix Pull Request
