### PR TITLE
package_facts: Use apk query instead of apk info to gather facts

### DIFF
--- a/changelogs/fragments/package_facts_apk.yml
+++ b/changelogs/fragments/package_facts_apk.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - package_facts - use apk query instead of apk info for gathering package facts in Alpine (https://github.com/ansible/ansible/issues/86579).

--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -423,8 +423,8 @@ class APK(CLIMgr):
         return json.loads(out)
 
     def get_package_details(self, package):
-      version, release = package.get('version', '').rsplit("-", 1)
-      return {'name': package.get('name', ''), 'version': version, 'release': release}
+        version, release = package.get('version', '').rsplit("-", 1)
+        return {'name': package.get('name', ''), 'version': version, 'release': release}
 
 
 class PKG_INFO(CLIMgr):

--- a/lib/ansible/modules/package_facts.py
+++ b/lib/ansible/modules/package_facts.py
@@ -251,6 +251,7 @@ ansible_facts:
 """
 
 import re
+import json
 
 from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.module_utils.basic import AnsibleModule
@@ -415,22 +416,15 @@ class APK(CLIMgr):
     CLI = 'apk'
 
     def list_installed(self):
-        rc, out, err = module.run_command([self._cli, 'info', '-v'])
+        cmd = [self._cli, 'query', '--installed', '--fields', 'name,version', '--format', 'json', '*']
+        rc, out, err = module.run_command(cmd)
         if rc != 0:
-            raise Exception("Unable to list packages rc=%s : %s" % (rc, err))
-        return out.splitlines()
+            raise Exception(f"Unable to list packages rc={rc} : {err}")
+        return json.loads(out)
 
     def get_package_details(self, package):
-        raw_pkg_details = {'name': package, 'version': '', 'release': ''}
-        nvr = package.rsplit('-', 2)
-        try:
-            return {
-                'name': nvr[0],
-                'version': nvr[1],
-                'release': nvr[2],
-            }
-        except IndexError:
-            return raw_pkg_details
+      version, release = package.get('version', '').rsplit("-", 1)
+      return {'name': package.get('name', ''), 'version': version, 'release': release}
 
 
 class PKG_INFO(CLIMgr):

--- a/test/integration/targets/package_facts/tasks/main.yml
+++ b/test/integration/targets/package_facts/tasks/main.yml
@@ -127,3 +127,16 @@
         - name: restore previous flags for the selected package
           command: 'pkg set --yes -v 0 -A 0 {{ pkg_name }}'
   when: ansible_os_family == "FreeBSD"
+
+- name: Run package_fact tests - Alpine
+  block:
+    - name: Gather package facts
+      package_facts:
+        manager: apk
+
+    - name: check for ansible_facts.packages exists
+      assert:
+        that:
+          - ansible_facts.packages is defined
+          - (ansible_facts.packages | length) >= 1
+  when: ansible_distribution == "Alpine"


### PR DESCRIPTION
##### SUMMARY

* ``apk query`` gives more options to gather facts than ``apk info``

Fixes: #86579

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/package_facts_apk.yml
lib/ansible/modules/package_facts.py
test/integration/targets/package_facts/tasks/main.yml


