### PR TITLE
ansible-test - Improve git submodule error handling

### DIFF
--- a/changelogs/fragments/ansible-test-missing-submodule.yml
+++ b/changelogs/fragments/ansible-test-missing-submodule.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test - Missing git submodules in the source tree now result in a warning instead of an error.
+  - ansible-test - When using the ``env --list-files`` option, non-filename output is now sent to stderr.

--- a/test/integration/targets/ansible-test-git/collection-tests/git-common.bash
+++ b/test/integration/targets/ansible-test-git/collection-tests/git-common.bash
@@ -37,6 +37,9 @@ git config user.email 'ansible-test@ansible.com'
 git add "README.md"
 git commit -m "Initial commit."
 
+# copy sub project
+cp -a "${WORK_DIR}/sub" "${WORK_DIR}/sub-copy"
+
 # init super project
 rm -rf "${WORK_DIR}/super" # needed when re-creating in place
 mkdir "${WORK_DIR}/super"
@@ -47,9 +50,15 @@ git init
 # add submodule
 git -c protocol.file.allow=always submodule add "${WORK_DIR}/sub" "${SUBMODULE_DST}"
 
+# add a second submodule and then remove the directory to verify the error is handled gracefully
+git -c protocol.file.allow=always submodule add "${WORK_DIR}/sub-copy" "${SUBMODULE_DST}-copy"
+rm -rf "${SUBMODULE_DST}-copy"
+
 # prepare for tests
 expected="${WORK_DIR}/expected.txt"
 actual="${WORK_DIR}/actual.txt"
+expected_warnings="${TEST_DIR}/expected-warnings.txt"
+actual_warnings="${WORK_DIR}/actual-warnings.txt"
 cd "${WORK_DIR}/super/ansible_collections/ns/col"
 mkdir tests/.git
 touch tests/.git/keep.txt  # make sure ansible-test correctly ignores version control within collection subdirectories
@@ -57,9 +66,11 @@ find . -type f ! -path '*/.git/*' ! -name .git | sed 's|^\./||' | sort >"${expec
 set -x
 
 # test at the collection base
-ansible-test env --list-files | sort >"${actual}"
+ansible-test env --list-files 2>"${actual_warnings}" | sort >"${actual}"
 diff --unified "${expected}" "${actual}"
+diff --unified "${expected_warnings}" "${actual_warnings}"
 
 # test at the submodule base
-(cd sub && ansible-test env --list-files | sort >"${actual}")
+(cd sub && ansible-test env --list-files 2>"${actual_warnings}" | sort >"${actual}")
 diff --unified "${expected}" "${actual}"
+diff --unified "${expected_warnings}" "${actual_warnings}"

--- a/test/integration/targets/ansible-test-git/expected-warnings.txt
+++ b/test/integration/targets/ansible-test-git/expected-warnings.txt
@@ -1,0 +1,3 @@
+WARNING: Missing submodule: sub-copy
+WARNING: Reviewing previous 1 warning(s):
+WARNING: Missing submodule: sub-copy

--- a/test/lib/ansible_test/_internal/commands/env/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/env/__init__.py
@@ -63,6 +63,9 @@ class EnvConfig(CommonConfig):
             # default to --show if no options were given
             self.show = True
 
+        if self.list_files:
+            self.display_stderr = True
+
 
 def command_env(args: EnvConfig) -> None:
     """Entry point for the `env` command."""
@@ -122,7 +125,7 @@ def list_files_env(args: EnvConfig) -> None:
         return
 
     for path in data_context().content.all_files():
-        display.info(path)
+        print(path)  # display goes to stderr, this should be on stdout
 
 
 def set_timeout(args: EnvConfig) -> None:

--- a/test/lib/ansible_test/_internal/provider/source/git.py
+++ b/test/lib/ansible_test/_internal/provider/source/git.py
@@ -14,6 +14,7 @@ from ...encoding import (
 
 from ...util import (
     SubprocessError,
+    display,
 )
 
 from . import (
@@ -50,7 +51,13 @@ class GitSource(SourceProvider):
             submodule_paths = [os.path.relpath(p, rel_path) for p in submodule_paths if p.startswith(rel_path)]
 
         for submodule_path in submodule_paths:
-            paths.extend(os.path.join(submodule_path, p) for p in self.__get_paths(os.path.join(path, submodule_path)))
+            submodule_full_path = os.path.join(path, submodule_path)
+
+            if not os.path.exists(submodule_full_path):
+                display.warning(f"Missing submodule: {submodule_path}")
+                continue
+
+            paths.extend(os.path.join(submodule_path, p) for p in self.__get_paths(submodule_full_path))
 
         # git reports submodule directories as regular files
         paths = [p for p in paths if p not in submodule_paths]


### PR DESCRIPTION
##### SUMMARY

Also fix `env --list-files` to ensure non-filename output is sent to stderr.

##### ISSUE TYPE

Bugfix Pull Request
