### PR TITLE
deb822_repository: Support for importing multiple keys for a single repository (#85700)

### DIFF
--- a/changelogs/fragments/85700-deb822-repository-signed-by-multiple-keys.yml
+++ b/changelogs/fragments/85700-deb822-repository-signed-by-multiple-keys.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- deb822_repository - The ``signed_by`` parameter now supports a list of keys. Added ``key_filenames`` return value containing the list of key file paths (https://github.com/ansible/ansible/issues/85700).

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -113,11 +113,14 @@ options:
         type: bool
     signed_by:
         description:
-        - Either a URL to a GPG key, absolute path to a keyring file, one or
-          more fingerprints of keys either in the C(trusted.gpg) keyring or in
-          the keyrings in the C(trusted.gpg.d/) directory, or an ASCII armored
-          GPG public key block.
-        type: str
+        - A string or list of strings that can be one of the below.
+            - a URL to a GPG key
+            - the absolute path to a keyring file
+            - one or more fingerprints of keys either in the C(trusted.gpg) keyring or in
+              the keyrings in the C(trusted.gpg.d/) directory
+            - An ASCII armored GPG public key block.
+        type: list
+        elements: str
     suites:
         description:
         - >-
@@ -216,6 +219,18 @@ EXAMPLES = """
     components: stable
     architectures: amd64
     signed_by: https://download.example.com/linux/ubuntu/gpg
+
+- name: Add repo using multiple keys
+  deb822_repository:
+    name: example
+    types: deb
+    uris: https://download.example.com/linux/ubuntu
+    suites: '{{ ansible_distribution_release }}'
+    components: stable
+    architectures: amd64
+    signed_by:
+      - https://download.example.com/linux/ubuntu/gpg
+      - https://download.example-two.com/linux/ubuntu/gpg
 """
 
 RETURN = """
@@ -247,10 +262,18 @@ dest:
   sample: /etc/apt/sources.list.d/focal-archive.sources
 
 key_filename:
-  description: Path to the signed_by key file
+  description: Space delimited string of the Path(s) to the signed_by key file(s)
   returned: always
   type: str
-  sample: /etc/apt/keyrings/debian.gpg
+  sample: "/etc/apt/keyrings/debian.gpg"
+
+key_filenames:
+  description: List of strings of the Path(s) to the signed_by key file(s)
+  returned: state == present
+  type: list
+  elements: str
+  sample: ["/etc/apt/keyrings/debian.gpg", "/etc/apt/keyrings/ansible-test.gpg"]
+  version_added: '2.22'
 """
 
 import os
@@ -338,51 +361,153 @@ def format_field_name(v):
     return v.replace('_', '-').title()
 
 
-def is_armored(b_data):
+FINGERPRINT_RE = re.compile(r'^[A-Fa-f0-9]{4}(\s?[A-Fa-f0-9]{4}){9}!?$')
+
+
+def is_fingerprint(value: str) -> bool:
+    """
+    Check if a value is a GPG key fingerprint.
+
+    Fingerprints are 40 hex characters, optionally separated by spaces,
+    and optionally ending with '!' to indicate exact key matching.
+    Examples:
+        - "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2"
+        - "A1B2 C3D4 E5F6 A1B2 C3D4 E5F6 A1B2 C3D4 E5F6 A1B2"
+        - "A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2!"
+    """
+    return bool(FINGERPRINT_RE.match(value.strip()))
+
+
+def is_armored(b_data: bytes) -> bool:
+    """
+    Checks if the PGP Header is in the binary data.
+    If so, it is an ASCII-armored PGP public key.
+    """
     return b'-----BEGIN PGP PUBLIC KEY BLOCK-----' in b_data
 
 
-def write_signed_by_key(module, v, slug):
-    changed = False
-    if os.path.isfile(v):
-        return changed, v, None
+PGP_BLOCK_ONLY_RE = re.compile(
+    r"""
+    \A
+    -----BEGIN\ PGP\ PUBLIC\ KEY\ BLOCK-----\n
+    (?:[A-Za-z0-9+/= ]*\n)*   # base64 and armor headers
+    -----END\ PGP\ PUBLIC\ KEY\ BLOCK-----\n?
+    \Z
+    """,
+    re.VERBOSE,)
 
-    b_data = None
 
-    parts = generic_urlparse(urlparse(v))
+def is_inline_key(value: str) -> bool:
+    """
+    Check if value is an ASCII-armored PGP public key.
+    """
+    value = value.strip("\n")
+    return bool(PGP_BLOCK_ONLY_RE.match(value))
+
+
+def dearmor_key(module, b_data):
+    """
+    Convert ASCII-armored key to binary format.
+    Returns binary key data.
+    """
+    gpg_path = module.get_bin_path('gpg', required=True)
+    rc, so, se = module.run_command(
+        [gpg_path, '--batch', '--yes', '--dearmor'],
+        data=b_data,
+        binary_data=True,
+        encoding=None,
+        check_rc=True,)
+    return so
+
+
+def fetch_key_data(module, key):
+    """
+    Fetch key data from URL or return raw PGP data.
+    Returns bytes.
+    """
+
+    # Check if it's a URL
+    parts = generic_urlparse(urlparse(key))
     if parts.scheme:
         try:
-            r = open_url(v, http_agent=get_user_agent())
+            r = open_url(key, http_agent=get_user_agent())
+            return r.read()
         except Exception as exc:
             raise RuntimeError('Could not fetch signed_by key.') from exc
+
+    # Must be raw PGP data
+    return to_bytes(key)
+
+
+def write_signed_by_key(module, v, slug):
+    """
+    Process signing keys from a list.
+    v: list of keys (URLs, file paths, fingerprints, or armored PGP public key)
+    Returns: (changed, signed_by_filename, signed_by_data, fingerprints)
+    """
+    changed = False
+
+    # Separate the signed_by values into lists by type
+    fingerprints = []
+    filepaths = []
+    urls = []
+    inline_keys = []
+    for key in v:
+        key = key.strip()
+        if is_fingerprint(key):
+            key = key.replace(" ", "")  # Remove whitespace from fingerprints
+            fingerprints.append(key)
+        elif os.path.isfile(key):
+            filepaths.append(key)
+        elif key.startswith("http"):
+            urls.append(key)
+        elif is_inline_key(key):
+            inline_keys.append(key)
         else:
-            b_data = r.read()
-    else:
-        # Not a file, nor a URL, just pass it through
-        return changed, None, v
+            module.fail_json(msg=f"Signed-by value {key} is not valid")
 
-    if not b_data:
-        return changed, v, None
+    # If only a single inline PGP key, return it directly
+    if len(inline_keys) == 1 and not (fingerprints or filepaths or urls):
+        return changed, None, inline_keys[0], []
+    # If only fingerprints, return them directly
+    if fingerprints and not (filepaths or urls or inline_keys):
+        return changed, None, None, fingerprints
+    # If only filepaths and fingerprints, return them directly
+    if filepaths and not (urls or inline_keys):
+        return changed, filepaths, None, fingerprints
 
-    tmpfd, tmpfile = tempfile.mkstemp(dir=module.tmpdir)
-    with os.fdopen(tmpfd, 'wb') as f:
-        f.write(b_data)
+    # Write URLS and inline keys to a file
+    if urls or inline_keys:
+        all_key_data = []
+        for key in urls + inline_keys:
+            key_data = fetch_key_data(module, key)
+            # Convert armored keys to binary for consistent format
+            if is_armored(key_data):
+                key_data = dearmor_key(module, key_data)
+            all_key_data.append(key_data)
+        combined_data = b''.join(all_key_data)
 
-    ext = 'asc' if is_armored(b_data) else 'gpg'
-    filename = make_signed_by_filename(slug, ext)
+        tmpfd, tmpfile = tempfile.mkstemp(dir=module.tmpdir)
+        with os.fdopen(tmpfd, 'wb') as f:
+            f.write(combined_data)
 
-    src_chksum = module.sha256(tmpfile)
-    dest_chksum = module.sha256(filename)
+        ext = 'gpg'  # Keys are always saved as binary .gpg file
+        filename = make_signed_by_filename(slug, ext)
 
-    if src_chksum != dest_chksum:
-        changed |= ensure_keyrings_dir(module)
-        if not module.check_mode:
-            module.atomic_move(tmpfile, filename)
-        changed |= True
+        src_chksum = module.sha256(tmpfile)
+        dest_chksum = module.sha256(filename)
 
-    changed |= module.set_mode_if_different(filename, S_IRWU_RG_RO, False)
+        if src_chksum != dest_chksum:
+            changed |= ensure_keyrings_dir(module)
+            if not module.check_mode:
+                module.atomic_move(tmpfile, filename)
+            changed = True
 
-    return changed, filename, None
+        changed |= module.set_mode_if_different(filename, S_IRWU_RG_RO, False)
+
+        if filename not in filepaths:
+            filepaths.append(filename)
+        return changed, filepaths, None, fingerprints
 
 
 def install_python_debian(module, deb_pkg_name):
@@ -462,7 +587,8 @@ def main():
                 'type': 'bool',
             },
             'signed_by': {
-                'type': 'str',
+                'type': 'list',
+                'elements': 'str',
             },
             'suites': {
                 'elements': 'str',
@@ -607,7 +733,8 @@ def main():
         )
 
     deb822 = Deb822()
-    signed_by_filename = None
+    output_key_filenames = None
+    output_key_filenames_list = None
     for key, value in sorted(params.items()):
         if value is None:
             continue
@@ -616,12 +743,28 @@ def main():
             value = format_bool(value)
         elif isinstance(value, int):
             value = to_native(value)
+        elif key == 'signed_by':
+            key_changed, signed_by_filename, signed_by_data, fingerprints = write_signed_by_key(module, value, slug)
+            changed |= key_changed
+
+            # Build the Signed-By value
+            if signed_by_data:
+                # Single inline PGP key (no fingerprints in this case)
+                value = signed_by_data
+            else:
+                # Combine keyring file path with fingerprints
+                signed_by_parts = []
+                if signed_by_filename:
+                    signed_by_parts.extend(signed_by_filename)
+                    output_key_filenames = ' '.join(signed_by_filename)
+                    output_key_filenames_list = signed_by_filename
+                signed_by_parts.extend(fingerprints)
+                value = ' '.join(signed_by_parts) if signed_by_parts else None
+
+            if value is None:
+                continue
         elif is_sequence(value):
             value = format_list(value)
-        elif key == 'signed_by':
-            key_changed, signed_by_filename, signed_by_data = write_signed_by_key(module, value, slug)
-            value = signed_by_filename or signed_by_data
-            changed |= key_changed
 
         if value.count('\n') > 0:
             value = format_multiline(value)
@@ -649,7 +792,8 @@ def main():
         repo=repo,
         changed=changed,
         dest=sources_filename,
-        key_filename=signed_by_filename,
+        key_filename=output_key_filenames,
+        key_filenames=output_key_filenames_list,
     )
 
 

--- a/test/integration/targets/deb822_repository/tasks/test.yml
+++ b/test/integration/targets/deb822_repository/tasks/test.yml
@@ -146,7 +146,8 @@
       - remove_repos_1 is changed
       - remove_stats.results|map(attribute='stat')|selectattr('exists') == []
 
-- name: Add repo with signed_by
+
+- name: Add repo with signed_by as - single inline key block
   deb822_repository:
     name: ansible-test
     types: deb
@@ -168,27 +169,10 @@
       -----END PGP PUBLIC KEY BLOCK-----
   register: signed_by_inline
 
-- name: Change signed_by to URL
-  deb822_repository:
-    name: ansible-test
-    types: deb
-    uris: https://deb.debian.org
-    suites: stable
-    components:
-      - main
-      - contrib
-      - non-free
-    signed_by: https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
-  register: signed_by_url
-
 - assert:
     that:
       - signed_by_inline.key_filename is none
       - signed_by_inline.repo|trim == signed_by_inline_expected
-      - signed_by_url is changed
-      - signed_by_url.key_filename == '/etc/apt/keyrings/ansible-test.gpg'
-      - >
-        'BEGIN' not in signed_by_url.repo
   vars:
     signed_by_inline_expected: |-
       Components: main contrib non-free
@@ -206,6 +190,621 @@
       Suites: stable
       Types: deb
       URIs: https://deb.debian.org
+
+
+- name: Test Checkmode for adding repo with signed_by as - single inline key block
+  deb822_repository:
+    name: ansible-test-inline
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by: |-
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      
+      mDMEYCQjIxYJKwYBBAHaRw8BAQdAD/P5Nvvnvk66SxBBHDbhRml9ORg1WV5CvzKY
+      CuMfoIS0BmFiY2RlZoiQBBMWCgA4FiEErCIG1VhKWMWo2yfAREZd5NfO31cFAmAk
+      IyMCGyMFCwkIBwMFFQoJCAsFFgIDAQACHgECF4AACgkQREZd5NfO31fbOwD6ArzS
+      dM0Dkd5h2Ujy1b6KcAaVW9FOa5UNfJ9FFBtjLQEBAJ7UyWD3dZzhvlaAwunsk7DG
+      3bHcln8DMpIJVXht78sL
+      =IE0r
+      -----END PGP PUBLIC KEY BLOCK-----
+  register: signed_by_inline_checkmode
+  check_mode: yes
+
+- name: Verify repo file does not exist for checkmode with - single inline key
+  stat:                                                                                                 
+    path: /etc/apt/sources.list.d/ansible-test-inline.sources                                                      
+  register: verify_checkmode_inline
+
+- assert:
+    that:
+      - signed_by_inline_checkmode is changed
+      - not verify_checkmode_inline.stat.exists
+
+
+- name: Add repo with signed_by as - URL
+  deb822_repository:
+    name: ansible-test
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by: https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
+  register: signed_by_url
+
+- assert:
+    that:
+      - signed_by_url is changed
+      - signed_by_url.key_filename == '/etc/apt/keyrings/ansible-test.gpg'
+      - >
+        'BEGIN' not in signed_by_url.repo
+      - signed_by_url.repo|trim == signed_by_url_expected
+  vars:
+    signed_by_url_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test
+      Signed-By: /etc/apt/keyrings/ansible-test.gpg
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+
+- name: Test Checkmode for adding repo with signed_by as - URL
+  deb822_repository:
+    name: ansible-test-url
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
+  register: signed_by_url_checkmode
+  check_mode: true
+
+- name: Verify repo file does not exist for checkmode with - url
+  stat:
+    path: /etc/apt/sources.list.d/ansible-test-url.sources
+  register: verify_checkmode_url
+
+- assert:
+    that:
+      - signed_by_url_checkmode is changed
+      - not verify_checkmode_url.stat.exists
+
+
+- name: Add repo with signed_by as - filepath
+  deb822_repository:
+    name: ansible-test
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - /etc/apt/keyrings/ansible-test.gpg
+  register: signed_by_filepath
+
+- assert:
+    that:
+      - signed_by_filepath.key_filename == '/etc/apt/keyrings/ansible-test.gpg'
+      - signed_by_filepath.key_filenames == ['/etc/apt/keyrings/ansible-test.gpg']
+
+- name: Test Checkmode for adding repo with signed_by as - filepath
+  deb822_repository:
+    name: ansible-test-filepath
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - /etc/apt/keyrings/ansible-test.gpg
+  register: signed_by_filepath_checkmode
+  check_mode: true
+
+- name: Verify repo file does not exist for checkmode with - filepath
+  stat:
+    path: /etc/apt/sources.list.d/ansible-test-filepath.sources
+  register: verify_checkmode_filepath
+
+- assert:
+    that:
+      - signed_by_filepath_checkmode is changed
+      - not verify_checkmode_filepath.stat.exists
+
+
+- name: Add repo with signed_by as - fingerprint
+  deb822_repository:
+    name: ansible-test
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - F8B5 C3D4 E5F6 A1B2 C3D4 E5F6 A1B2 C3D4 E5F6 C37C
+  register: signed_by_fingerprint
+  check_mode: true
+
+- assert:
+    that:
+      - signed_by_fingerprint is changed
+      - signed_by_fingerprint.repo|trim == signed_by_fingerprint_expected
+  vars:
+    signed_by_fingerprint_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test
+      Signed-By: F8B5C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6C37C
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+
+- name: Test Checkmode for adding repo with signed_by as - fingerprint
+  deb822_repository:
+    name: ansible-test-fingerprint
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - F8B5 C3D4 E5F6 A1B2 C3D4 E5F6 A1B2 C3D4 E5F6 C37C
+  register: signed_by_fingerprint_checkmode
+  check_mode: yes
+
+- name: Verify repo file does not exist for checkmode with - fingerprint
+  stat:
+    path: /etc/apt/sources.list.d/ansible-test-fingerprint.sources
+  register: verify_checkmode_fingerprint
+
+- assert:
+    that:
+      - signed_by_fingerprint_checkmode is changed
+      - not verify_checkmode_fingerprint.stat.exists
+
+
+- name: Add repo with signed_by as - URLs and fingerprint
+  deb822_repository:
+    name: ansible-test
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
+      - https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
+      - F8B5 C3D4 E5F6 A1B2 C3D4 E5F6 A1B2 C3D4 E5F6 C37C
+  register: signed_by_urls_fingerprint
+
+- assert:
+    that:
+      - signed_by_urls_fingerprint is changed
+      - signed_by_urls_fingerprint.key_filename == '/etc/apt/keyrings/ansible-test.gpg'
+      - signed_by_urls_fingerprint.key_filenames == ['/etc/apt/keyrings/ansible-test.gpg']
+      - signed_by_urls_fingerprint.repo|trim == signed_by_urls_fingerprint_expected
+  vars:
+    signed_by_urls_fingerprint_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test
+      Signed-By: /etc/apt/keyrings/ansible-test.gpg F8B5C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6C37C
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+
+- name: Test Checkmode for adding a repo with signed_by as - URLs and fingerprint
+  deb822_repository:
+    name: ansible-test-multiple-url
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
+      - https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
+      - F8B5 C3D4 E5F6 A1B2 C3D4 E5F6 A1B2 C3D4 E5F6 C37C
+  register: signed_by_urls_fingerprint_checkmode
+  check_mode: yes
+
+- name: Verify repo file does not exist for checkmode with - URLs and fingerprint
+  stat:
+    path: /etc/apt/sources.list.d/ansible-test-multiple-url.sources
+  register: verify_checkmode_urls_fingerprint
+
+- assert:
+    that:
+      - signed_by_urls_fingerprint_checkmode is changed
+      - not verify_checkmode_urls_fingerprint.stat.exists
+      - signed_by_urls_fingerprint_checkmode.key_filename == '/etc/apt/keyrings/ansible-test-multiple-url.gpg'
+      - signed_by_urls_fingerprint_checkmode.key_filenames == ['/etc/apt/keyrings/ansible-test-multiple-url.gpg']
+      - signed_by_urls_fingerprint_checkmode.repo|trim == signed_by_urls_fingerprint_checkmode_expected
+  vars:
+    signed_by_urls_fingerprint_checkmode_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test-multiple-url
+      Signed-By: /etc/apt/keyrings/ansible-test-multiple-url.gpg F8B5C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6C37C
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+
+- name: Add repo with signed_by as - filepath, fingerprint
+  deb822_repository:
+    name: ansible-test
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - /etc/apt/keyrings/ansible-test.gpg
+      - ffffDDDDeeee44449999aaaa2222dddd4444bbbb
+  register: signed_by_filepath_fingerprint
+
+- assert:
+    that:
+      - signed_by_filepath_fingerprint is changed
+      - signed_by_filepath_fingerprint.key_filename == '/etc/apt/keyrings/ansible-test.gpg'
+      - signed_by_filepath_fingerprint.key_filenames == ['/etc/apt/keyrings/ansible-test.gpg']
+      - signed_by_filepath_fingerprint.repo|trim == signed_by_filepath_fingerprint_expected
+  vars:
+    signed_by_filepath_fingerprint_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test
+      Signed-By: /etc/apt/keyrings/ansible-test.gpg ffffDDDDeeee44449999aaaa2222dddd4444bbbb
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+
+- name: Test checkmode for add repo with signed_by as - filepath, fingerprint
+  deb822_repository:
+    name: ansible-test-multiple
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - /etc/apt/keyrings/ansible-test.gpg
+      - ffffDDDDeeee44449999aaaa2222dddd4444bbbb
+  register: signed_by_filepath_fingerprint_checkmode
+  check_mode: yes
+
+- name: Verify repo file does not exist for checkmode with - filepath, fingerprint
+  stat:
+    path: /etc/apt/sources.list.d/ansible-test-multiple.sources
+  register: verify_checkmode_filepath_fingerprint
+
+- assert:
+    that:
+      - signed_by_filepath_fingerprint_checkmode is changed
+      - not verify_checkmode_filepath_fingerprint.stat.exists
+      - signed_by_filepath_fingerprint_checkmode.key_filename == '/etc/apt/keyrings/ansible-test.gpg'
+      - signed_by_filepath_fingerprint_checkmode.key_filenames == ['/etc/apt/keyrings/ansible-test.gpg']
+      - signed_by_filepath_fingerprint_checkmode.repo|trim == signed_by_filepath_fingerprint_checkmode_expected
+  vars:
+    signed_by_filepath_fingerprint_checkmode_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test-multiple
+      Signed-By: /etc/apt/keyrings/ansible-test.gpg ffffDDDDeeee44449999aaaa2222dddd4444bbbb
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+
+- name: Add repo with signed_by as - fingerprints
+  deb822_repository:
+    name: ansible-test
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - "A1B2 C3D4 E5F6 A1B2 C3D4 E5F6 A1B2 C3D4 E5F6 A1B2"
+      - "F8A5C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6987B"
+  register: signed_by_fingerprints
+
+- assert:
+    that:
+      - signed_by_fingerprints is changed
+      - signed_by_fingerprints.key_filename is none
+      - signed_by_fingerprints.key_filenames is none
+      - signed_by_fingerprints.repo|trim == signed_by_fingerprints_expected
+  vars:
+    signed_by_fingerprints_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test
+      Signed-By: A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2 F8A5C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6987B
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+
+- name: Add repo with signed_by as - key blocks
+  deb822_repository:
+    name: ansible-test
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+        mDMEYCQjIxYJKwYBBAHaRw8BAQdAD/P5Nvvnvk66SxBBHDbhRml9ORg1WV5CvzKY
+        CuMfoIS0BmFiY2RlZoiQBBMWCgA4FiEErCIG1VhKWMWo2yfAREZd5NfO31cFAmAk
+        IyMCGyMFCwkIBwMFFQoJCAsFFgIDAQACHgECF4AACgkQREZd5NfO31fbOwD6ArzS
+        dM0Dkd5h2Ujy1b6KcAaVW9FOa5UNfJ9FFBtjLQEBAJ7UyWD3dZzhvlaAwunsk7DG
+        3bHcln8DMpIJVXht78sL
+        =IE0r
+        -----END PGP PUBLIC KEY BLOCK-----
+      - |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+        mDMEYCQjIxYJKwYBBAHaRw8BAQdAD/P5Nvvnvk66SxBBHDbhRml9ORg1WV5CvzKY
+        CuMfoIS0BmFiY2RlZoiQBBMWCgA4FiEErCIG1VhKWMWo2yfAREZd5NfO31cFAmAk
+        IyMCGyMFCwkIBwMFFQoJCAsFFgIDAQACHgECF4AACgkQREZd5NfO31fbOwD6ArzS
+        dM0Dkd5h2Ujy1b6KcAaVW9FOa5UNfJ9FFBtjLQEBAJ7UyWD3dZzhvlaAwunsk7DG
+        3bHcln8DMpIJVXht78sL
+        =IE0r
+        -----END PGP PUBLIC KEY BLOCK-----
+  register: signed_by_key_blocks
+
+- assert:
+    that:
+      - signed_by_key_blocks is changed
+      - signed_by_key_blocks.key_filename == '/etc/apt/keyrings/ansible-test.gpg'
+      - signed_by_key_blocks.key_filenames == ['/etc/apt/keyrings/ansible-test.gpg']
+      - signed_by_key_blocks.repo|trim == signed_by_keyblocks_expected
+  vars:
+    signed_by_keyblocks_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test
+      Signed-By: /etc/apt/keyrings/ansible-test.gpg
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+
+- name: Add repo with signed_by as - keyblock and url
+  deb822_repository:
+    name: ansible-test
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - |
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+
+        mDMEYCQjIxYJKwYBBAHaRw8BAQdAD/P5Nvvnvk66SxBBHDbhRml9ORg1WV5CvzKY
+        CuMfoIS0BmFiY2RlZoiQBBMWCgA4FiEErCIG1VhKWMWo2yfAREZd5NfO31cFAmAk
+        IyMCGyMFCwkIBwMFFQoJCAsFFgIDAQACHgECF4AACgkQREZd5NfO31fbOwD6ArzS
+        dM0Dkd5h2Ujy1b6KcAaVW9FOa5UNfJ9FFBtjLQEBAJ7UyWD3dZzhvlaAwunsk7DG
+        3bHcln8DMpIJVXht78sL
+        =IE0r
+        -----END PGP PUBLIC KEY BLOCK-----
+      - https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
+  register: signed_by_keyblock_url
+
+- assert:
+    that:
+      - signed_by_keyblock_url is changed
+      - signed_by_keyblock_url.key_filename == '/etc/apt/keyrings/ansible-test.gpg'
+      - signed_by_keyblock_url.key_filenames == ['/etc/apt/keyrings/ansible-test.gpg']
+      - signed_by_keyblock_url.repo|trim == signed_by_keyblock_url_expected
+  vars:
+    signed_by_keyblock_url_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test
+      Signed-By: /etc/apt/keyrings/ansible-test.gpg
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+- name: Add repo with signed_by as - filepath, url, fingerprint
+  deb822_repository:
+    name: ansible-test
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - /etc/apt/keyrings/ansible-test.gpg
+      - https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
+      - ffffDDDDeeee44449999aaaa2222dddd4444bbbb
+  register: signed_by_filepath_url_fingerprint
+
+- assert:
+    that:
+      - signed_by_filepath_url_fingerprint is changed
+      - signed_by_filepath_url_fingerprint.key_filename == '/etc/apt/keyrings/ansible-test.gpg'
+      - signed_by_filepath_url_fingerprint.key_filenames == ['/etc/apt/keyrings/ansible-test.gpg']
+      - signed_by_filepath_url_fingerprint.repo|trim == signed_by_filepath_url_fingerprint_expected
+  vars:
+    signed_by_filepath_url_fingerprint_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test
+      Signed-By: /etc/apt/keyrings/ansible-test.gpg ffffDDDDeeee44449999aaaa2222dddd4444bbbb
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+
+- name: Checkmode for adding repo with signed_by as - filepath, url, fingerprint
+  deb822_repository:
+    name: ansible-test-final
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - /etc/apt/keyrings/ansible-test.gpg
+      - https://ci-files.testing.ansible.com/test/integration/targets/apt_key/apt-key-example-binary.gpg
+      - ffffDDDDeeee44449999aaaa2222dddd4444bbbb
+  register: signed_by_filepath_url_fingerprint_checkmode
+  check_mode: yes
+
+
+- name: Verify repo file does not exist for checkmode with - url, filepath, fingerprint
+  stat:
+    path: /etc/apt/sources.list.d/ansible-test-final.sources
+  register: verify_checkmode_filepath_url_fingerprint
+
+- assert:
+    that:
+      - signed_by_filepath_url_fingerprint_checkmode is changed
+      - not verify_checkmode_filepath_url_fingerprint.stat.exists
+      - signed_by_filepath_url_fingerprint_checkmode.key_filename == '/etc/apt/keyrings/ansible-test.gpg /etc/apt/keyrings/ansible-test-final.gpg'
+      - signed_by_filepath_url_fingerprint_checkmode.key_filenames == ['/etc/apt/keyrings/ansible-test.gpg', '/etc/apt/keyrings/ansible-test-final.gpg']
+      - signed_by_filepath_url_fingerprint_checkmode.repo|trim == signed_by_filepath_url_fingerprint_checkmode_expected
+  vars:
+    signed_by_filepath_url_fingerprint_checkmode_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test-final
+      Signed-By: /etc/apt/keyrings/ansible-test.gpg /etc/apt/keyrings/ansible-test-final.gpg ffffDDDDeeee44449999aaaa2222dddd4444bbbb
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+
+- name: Add repo with signed_by as - fingerprint with trailing '!'
+  deb822_repository:
+    name: ansible-test
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - "A1B2 C3D4 E5F6 A1B2 C3D4 E5F6 A1B2 C3D4 E5F6 A1B2!"
+  register: signed_by_fingerprint_exact
+
+- assert:
+    that:
+      - signed_by_fingerprint_exact is changed
+      - signed_by_fingerprint_exact.key_filename is none
+      - signed_by_fingerprint_exact.key_filenames is none
+      - signed_by_fingerprint_exact.repo|trim == signed_by_fingerprint_exact_expected
+  vars:
+    signed_by_fingerprint_exact_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test
+      Signed-By: A1B2C3D4E5F6A1B2C3D4E5F6A1B2C3D4E5F6A1B2!
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+
+- name: Test Idempotency and Changed - Add repo with signed_by as - filepath, fingerprint
+  deb822_repository:
+    name: ansible-test
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - /etc/apt/keyrings/ansible-test.gpg
+      - ffffDDDDeeee44449999aaaa2222dddd4444bbbb
+  register: signed_by_idempotent_changed
+
+- assert:
+    that:
+      - signed_by_idempotent_changed is changed
+      - signed_by_idempotent_changed.key_filename == '/etc/apt/keyrings/ansible-test.gpg'
+      - signed_by_idempotent_changed.key_filenames == ['/etc/apt/keyrings/ansible-test.gpg']
+      - signed_by_idempotent_changed.repo|trim == signed_by_idempotent_changed_expected
+  vars:
+    signed_by_idempotent_changed_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test
+      Signed-By: /etc/apt/keyrings/ansible-test.gpg ffffDDDDeeee44449999aaaa2222dddd4444bbbb
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
+
+- name: Test Idempotency and Not Changed - Add repo with signed_by as - fingerprint, filepath
+  deb822_repository:
+    name: ansible-test
+    types: deb
+    uris: https://deb.debian.org
+    suites: stable
+    components:
+      - main
+      - contrib
+      - non-free
+    signed_by:
+      - ffffDDDDeeee44449999aaaa2222dddd4444bbbb
+      - /etc/apt/keyrings/ansible-test.gpg
+  register: signed_by_idempotent_not_changed
+
+- assert:
+    that:
+      - signed_by_idempotent_not_changed is not changed
+      - signed_by_idempotent_not_changed.key_filename == '/etc/apt/keyrings/ansible-test.gpg'
+      - signed_by_idempotent_not_changed.key_filenames == ['/etc/apt/keyrings/ansible-test.gpg']
+      - signed_by_idempotent_not_changed.repo|trim == signed_by_idempotent_not_changed_expected
+  vars:
+    signed_by_idempotent_not_changed_expected: |-
+      Components: main contrib non-free
+      X-Repolib-Name: ansible-test
+      Signed-By: /etc/apt/keyrings/ansible-test.gpg ffffDDDDeeee44449999aaaa2222dddd4444bbbb
+      Suites: stable
+      Types: deb
+      URIs: https://deb.debian.org
+
 
 - name: remove ansible-test repo
   deb822_repository:
@@ -241,3 +840,8 @@
 - assert:
     that:
       - ansible_test_http_agent is changed
+
+- name: Cleanup - remove ansible-test repo
+  deb822_repository:
+    name: ansible-test
+    state: absent


### PR DESCRIPTION
This Pull Request was originally #86424. Created this new Pull Request because #86424 was mistakenly created on the 'devel' branch instead of a feature branch.

SUMMARY

This updates the deb822_repository module to allow multiple 'signed_by' keys. It changes the parameter from a string, to a list of strings, however this is still backwards compatible with allowing a string input.

Most of the original code is still in place in the 'write_signed_by_key' function, but changed to allow for multiple keys. The signed_by field allows any combination of filepaths, fingerprints, urls, and inline PGP public keys. Filepaths and fingerprints are returned as is. URLs are downloaded and stored in a new sources file. A single PGP public key is returned as is. A PGP Public key included with any other values is stored in a file.

Since PGP public keys are stored in a file if there is more than one, a de-armor function was added. This function utilizes the 'gpg' package on the target machine to de-armor the key.

The main() function was updated to handle updated return values from the 'write_signed_by_key' function. The module output 'key_filename' has been changed to 'key_filenames' because now multiple filenames can be returned.

Integration tests were added to test the updated functionality.

If there are any changes I could make to improve this submission, please let me know.

Fixes https://github.com/ansible/ansible/issues/85700
ISSUE TYPE

Feature Pull Request

#####COMPONENT NAME

lib/ansible/modules/deb822_repository.py
test/integration/targets/deb822_repository/tasks/test.yml
changelogs/fragments/85700-deb822-repository-signed-by-multiple-keys.yml
