### PR TITLE
ansible-vault - improved formatting of ansible-vault error messages

### DIFF
--- a/changelogs/fragments/86602-ansible-vault-improved-formatting-of-error-messages.yml
+++ b/changelogs/fragments/86602-ansible-vault-improved-formatting-of-error-messages.yml
@@ -1,3 +1,4 @@
----
 minor_changes:
-  - ansible-vault - improved formatting of error messages (https://github.com/ansible/ansible/pull/86602).
+  - ansible-vault - improved error messages for better clarity and context when
+    vault operations fail, helping users diagnose configuration or file access
+    issues more easily (https://github.com/ansible/ansible/pull/86602).

--- a/changelogs/fragments/86602-ansible-vault-improved-formatting-of-error-messages.yml
+++ b/changelogs/fragments/86602-ansible-vault-improved-formatting-of-error-messages.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ansible-vault - improved formatting of error messages (https://github.com/ansible/ansible/pull/86602).

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -890,7 +890,7 @@ class VaultEditor:
         try:
             plaintext = self.vault.decrypt(ciphertext)
         except AnsibleError as e:
-            raise AnsibleError("%s for %s" % (to_native(e), to_native(filename)))
+            raise AnsibleError(f"Failed to decrypt {filename}.") from e
         self.write_data(plaintext, output_file or filename, shred=False)
 
     def create_file(self, filename, secret, vault_id=None):
@@ -916,15 +916,12 @@ class VaultEditor:
 
         b_vaulttext = self.read_data(filename)
 
-        # vault or yaml files are always utf8
-        vaulttext = to_text(b_vaulttext)
-
         try:
             # vaulttext gets converted back to bytes, but alas
             # TODO: return the vault_id that worked?
-            plaintext, vault_id_used, vault_secret_used = self.vault.decrypt_and_get_vault_id(vaulttext)
+            plaintext, vault_id_used, vault_secret_used = self.vault.decrypt_and_get_vault_id(b_vaulttext)
         except AnsibleError as e:
-            raise AnsibleError("%s for %s" % (to_native(e), to_native(filename)))
+            raise AnsibleError(f"Failed to edit {filename}.") from e
 
         # Figure out the vault id from the file, to select the right secret to re-encrypt it
         # (duplicates parts of decrypt, but alas...)
@@ -943,13 +940,12 @@ class VaultEditor:
     def plaintext(self, filename):
 
         b_vaulttext = self.read_data(filename)
-        vaulttext = to_text(b_vaulttext)
 
         try:
-            plaintext = self.vault.decrypt(vaulttext)
+            plaintext = self.vault.decrypt(b_vaulttext)
             return plaintext
         except AnsibleError as e:
-            raise AnsibleVaultError("%s for %s" % (to_native(e), to_native(filename)))
+            raise AnsibleError(f"Failed to view {filename}.") from e
 
     # FIXME/TODO: make this use VaultSecret
     def rekey_file(self, filename, new_vault_secret, new_vault_id=None):
@@ -959,15 +955,13 @@ class VaultEditor:
 
         prev = os.stat(filename)
         b_vaulttext = self.read_data(filename)
-        vaulttext = to_text(b_vaulttext)
 
         display.vvvvv(u'Rekeying file "%s" to with new vault-id "%s" and vault secret %s' %
                       (to_text(filename), to_text(new_vault_id), to_text(new_vault_secret)))
         try:
-            plaintext, vault_id_used, _dummy = self.vault.decrypt_and_get_vault_id(vaulttext)
+            plaintext, vault_id_used, _dummy = self.vault.decrypt_and_get_vault_id(b_vaulttext)
         except AnsibleError as e:
-            raise AnsibleError("%s for %s" % (to_native(e), to_native(filename)))
-
+            raise AnsibleError(f"Failed to rekey {filename}.") from e
         # This is more or less an assert, see #18247
         if new_vault_secret is None:
             raise AnsibleError('The value for the new_password to rekey %s with is not valid' % filename)

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -890,7 +890,7 @@ class VaultEditor:
         try:
             plaintext = self.vault.decrypt(ciphertext)
         except AnsibleError as e:
-            raise AnsibleError(f"Failed to decrypt {filename}.") from e
+            raise AnsibleError(f"Failed to decrypt {filename!r}.") from e
         self.write_data(plaintext, output_file or filename, shred=False)
 
     def create_file(self, filename, secret, vault_id=None):
@@ -921,7 +921,7 @@ class VaultEditor:
             # TODO: return the vault_id that worked?
             plaintext, vault_id_used, vault_secret_used = self.vault.decrypt_and_get_vault_id(b_vaulttext)
         except AnsibleError as e:
-            raise AnsibleError(f"Failed to edit {filename}.") from e
+            raise AnsibleError(f"Failed to edit {filename!r}.") from e
 
         # Figure out the vault id from the file, to select the right secret to re-encrypt it
         # (duplicates parts of decrypt, but alas...)
@@ -945,7 +945,7 @@ class VaultEditor:
             plaintext = self.vault.decrypt(b_vaulttext)
             return plaintext
         except AnsibleError as e:
-            raise AnsibleError(f"Failed to view {filename}.") from e
+            raise AnsibleError(f"Failed to view {filename!r}.") from e
 
     # FIXME/TODO: make this use VaultSecret
     def rekey_file(self, filename, new_vault_secret, new_vault_id=None):
@@ -961,7 +961,7 @@ class VaultEditor:
         try:
             plaintext, vault_id_used, _dummy = self.vault.decrypt_and_get_vault_id(b_vaulttext)
         except AnsibleError as e:
-            raise AnsibleError(f"Failed to rekey {filename}.") from e
+            raise AnsibleError(f"Failed to rekey {filename!r}.") from e
         # This is more or less an assert, see #18247
         if new_vault_secret is None:
             raise AnsibleError('The value for the new_password to rekey %s with is not valid' % filename)


### PR DESCRIPTION
## SUMMARY

Currently, when using ansible-vault, the error messages are formatted incorrectly and may be confusing.

This PR ensures that exceptions are correctly chained to surface the error message in a clear and consistent manner to the user.

### EXAMPLES
#### `ansible-vault edit test.txt` (not encrypted test.txt)
###### BEFORE
`[ERROR]: Input is not vault encrypted data. for /full/path/test.txt`
###### AFTER
```
[ERROR]: Failed to edit /full/path/test.txt: Input is not vault encrypted data.

Failed to edit /full/path/test.txt.

<<< caused by >>>

Input is not vault encrypted data.
Origin: /full/path/test.txt
```
#### `ansible-vault view test.txt` (incorrect password for test.txt)
###### BEFORE
`[ERROR]: Decryption failed (no vault secrets were found that could decrypt). for /full/path/test.txt`
###### AFTER
```
[ERROR]: Failed to view /full/path/test.txt: Decryption failed (no vault secrets were found that could decrypt).

Failed to view /full/path/test.txt.

<<< caused by >>>

Decryption failed (no vault secrets were found that could decrypt).
Origin: /full/path/test.txt
```
#### `ansible-vault decrypt test.txt` (incorrect password for test.txt)
###### BEFORE
`[ERROR]: Decryption failed (no vault secrets were found that could decrypt). for /full/path/test.txt`
###### AFTER
```
[ERROR]: Failed to decrypt /full/path/test.txt: Decryption failed (no vault secrets were found that could decrypt).

Failed to decrypt /full/path/test.txt.

<<< caused by >>>

Decryption failed (no vault secrets were found that could decrypt).
Origin: /full/path/test.txt
```

##### ISSUE TYPE

- Bugfix Pull Request
