### PR TITLE
ansible-playbook - refactor task processing to remove duplicated loading logic

### DIFF
--- a/changelogs/fragments/86603-consolidated-block-loading-code.yml
+++ b/changelogs/fragments/86603-consolidated-block-loading-code.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-playbook - consolidated block and task loading code to remove duplicated logic (https://github.com/ansible/ansible/pull/86603).

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from ansible.errors import AnsibleParserError
 from ansible.module_utils.common.sentinel import Sentinel
-from ansible.playbook.attribute import NonInheritableFieldAttribute
+from ansible.playbook.attribute import Attribute, NonInheritableFieldAttribute
 from ansible.playbook.base import Base
 from ansible.playbook.conditional import Conditional
 from ansible.playbook.collectionsearch import CollectionSearch
@@ -111,7 +111,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
 
         return super(Block, self).preprocess_data(ds)
 
-    def _load(self, attr, ds, type):
+    def _load(self, attr: Attribute, ds: list, keyword: str = "tasks"):
         try:
             return load_list_of_tasks(
                 ds,
@@ -124,7 +124,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
                 use_handlers=self._use_handlers,
             )
         except AssertionError as ex:
-            raise AnsibleParserError(f"A malformed block was encountered while loading {type}", obj=self._ds) from ex
+            raise AnsibleParserError(f"A malformed block was encountered while loading {keyword}", obj=self._ds) from ex
 
     def _load_block(self, attr, ds):
         return self._load(attr, ds, 'block')

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -111,9 +111,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
 
         return super(Block, self).preprocess_data(ds)
 
-    # FIXME: these do nothing but augment the exception message; DRY and nuke
-
-    def _load_block(self, attr, ds):
+    def _load(self, attr, ds, type):
         try:
             return load_list_of_tasks(
                 ds,
@@ -126,37 +124,16 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
                 use_handlers=self._use_handlers,
             )
         except AssertionError as ex:
-            raise AnsibleParserError("A malformed block was encountered while loading a block", obj=self._ds) from ex
+            raise AnsibleParserError(f"A malformed block was encountered while loading {type}", obj=self._ds) from ex
+        
+    def _load_block(self, attr, ds):
+        return self._load(attr, ds, 'block')
 
     def _load_rescue(self, attr, ds):
-        try:
-            return load_list_of_tasks(
-                ds,
-                play=self._play,
-                block=self,
-                role=self._role,
-                task_include=None,
-                variable_manager=self._variable_manager,
-                loader=self._loader,
-                use_handlers=self._use_handlers,
-            )
-        except AssertionError as ex:
-            raise AnsibleParserError("A malformed block was encountered while loading rescue.", obj=self._ds) from ex
+        return self._load(attr, ds, 'rescue')
 
     def _load_always(self, attr, ds):
-        try:
-            return load_list_of_tasks(
-                ds,
-                play=self._play,
-                block=self,
-                role=self._role,
-                task_include=None,
-                variable_manager=self._variable_manager,
-                loader=self._loader,
-                use_handlers=self._use_handlers,
-            )
-        except AssertionError as ex:
-            raise AnsibleParserError("A malformed block was encountered while loading always", obj=self._ds) from ex
+        return self._load(attr, ds, 'always')
 
     def _validate_always(self, attr, name, value):
         if value and not self.block:

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from ansible.errors import AnsibleParserError
 from ansible.module_utils.common.sentinel import Sentinel
-from ansible.playbook.attribute import Attribute, NonInheritableFieldAttribute
+from ansible.playbook.attribute import NonInheritableFieldAttribute
 from ansible.playbook.base import Base
 from ansible.playbook.conditional import Conditional
 from ansible.playbook.collectionsearch import CollectionSearch
@@ -111,7 +111,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
 
         return super(Block, self).preprocess_data(ds)
 
-    def _load(self, attr: Attribute, ds: list, keyword: str = "tasks"):
+    def _load(self, attr: str, ds: object) -> list:
         try:
             return load_list_of_tasks(
                 ds,
@@ -124,16 +124,16 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
                 use_handlers=self._use_handlers,
             )
         except AssertionError as ex:
-            raise AnsibleParserError(f"A malformed block was encountered while loading {keyword}", obj=self._ds) from ex
+            raise AnsibleParserError(f"A malformed block was encountered while loading {attr}.", obj=self._ds) from ex
 
     def _load_block(self, attr, ds):
-        return self._load(attr, ds, 'block')
+        return self._load(attr, ds)
 
     def _load_rescue(self, attr, ds):
-        return self._load(attr, ds, 'rescue')
+        return self._load(attr, ds)
 
     def _load_always(self, attr, ds):
-        return self._load(attr, ds, 'always')
+        return self._load(attr, ds)
 
     def _validate_always(self, attr, name, value):
         if value and not self.block:

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -125,7 +125,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
             )
         except AssertionError as ex:
             raise AnsibleParserError(f"A malformed block was encountered while loading {type}", obj=self._ds) from ex
-        
+
     def _load_block(self, attr, ds):
         return self._load(attr, ds, 'block')
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -26,7 +26,7 @@ from ansible.errors import AnsibleError
 from ansible.errors import AnsibleParserError, AnsibleAssertionError, AnsibleValueOmittedError
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.common.yaml import yaml_dump
-from ansible.playbook.attribute import Attribute, NonInheritableFieldAttribute
+from ansible.playbook.attribute import NonInheritableFieldAttribute
 from ansible.playbook.base import Base
 from ansible.playbook.block import Block
 from ansible.playbook.collectionsearch import CollectionSearch
@@ -175,7 +175,7 @@ class Play(Base, Taggable, CollectionSearch):
 
         return super(Play, self).preprocess_data(ds)
 
-    def _load(self, attr: Attribute, ds: list, keyword: str = "tasks"):
+    def _load(self, attr: str, ds: object) -> list[Block]:
         """
         Loads a list of blocks from a list which may be mixed tasks/blocks.
         Bare tasks outside of a block are given an implicit block.
@@ -183,16 +183,16 @@ class Play(Base, Taggable, CollectionSearch):
         try:
             return load_list_of_blocks(ds=ds, play=self, variable_manager=self._variable_manager, loader=self._loader)
         except AssertionError as ex:
-            raise AnsibleParserError(f"A malformed block was encountered while loading {keyword}.", obj=self._ds) from ex
+            raise AnsibleParserError(f"A malformed block was encountered while loading {attr}.", obj=self._ds) from ex
 
     def _load_tasks(self, attr, ds):
-        return self._load(attr, ds, 'tasks')
+        return self._load(attr, ds)
 
     def _load_pre_tasks(self, attr, ds):
-        return self._load(attr, ds, keyword='pre_tasks')
+        return self._load(attr, ds)
 
     def _load_post_tasks(self, attr, ds):
-        return self._load(attr, ds, keyword='post_tasks')
+        return self._load(attr, ds)
 
     def _load_handlers(self, attr, ds):
         """

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -26,7 +26,7 @@ from ansible.errors import AnsibleError
 from ansible.errors import AnsibleParserError, AnsibleAssertionError, AnsibleValueOmittedError
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.common.yaml import yaml_dump
-from ansible.playbook.attribute import NonInheritableFieldAttribute
+from ansible.playbook.attribute import Attribute, NonInheritableFieldAttribute
 from ansible.playbook.base import Base
 from ansible.playbook.block import Block
 from ansible.playbook.collectionsearch import CollectionSearch
@@ -175,7 +175,7 @@ class Play(Base, Taggable, CollectionSearch):
 
         return super(Play, self).preprocess_data(ds)
 
-    def _load_tasks(self, attr, ds, stage="tasks"):
+    def _load(self, attr: Attribute, ds: list, keyword: str = "tasks"):
         """
         Loads a list of blocks from a list which may be mixed tasks/blocks.
         Bare tasks outside of a block are given an implicit block.
@@ -183,13 +183,16 @@ class Play(Base, Taggable, CollectionSearch):
         try:
             return load_list_of_blocks(ds=ds, play=self, variable_manager=self._variable_manager, loader=self._loader)
         except AssertionError as ex:
-            raise AnsibleParserError(f"A malformed block was encountered while loading {stage}.", obj=self._ds) from ex
+            raise AnsibleParserError(f"A malformed block was encountered while loading {keyword}.", obj=self._ds) from ex
+
+    def _load_tasks(self, attr, ds):
+        return self._load(attr, ds, 'tasks')
 
     def _load_pre_tasks(self, attr, ds):
-        return self._load_tasks(attr, ds, stage='pre_tasks')
+        return self._load(attr, ds, keyword='pre_tasks')
 
     def _load_post_tasks(self, attr, ds):
-        return self._load_tasks(attr, ds, stage='post_tasks')
+        return self._load(attr, ds, keyword='post_tasks')
 
     def _load_handlers(self, attr, ds):
         """

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -175,9 +175,7 @@ class Play(Base, Taggable, CollectionSearch):
 
         return super(Play, self).preprocess_data(ds)
 
-    # DTFIX-FUTURE: these do nothing but augment the exception message; DRY and nuke
-
-    def _load_tasks(self, attr, ds):
+    def _load_tasks(self, attr, ds, stage="tasks"):
         """
         Loads a list of blocks from a list which may be mixed tasks/blocks.
         Bare tasks outside of a block are given an implicit block.
@@ -185,27 +183,13 @@ class Play(Base, Taggable, CollectionSearch):
         try:
             return load_list_of_blocks(ds=ds, play=self, variable_manager=self._variable_manager, loader=self._loader)
         except AssertionError as ex:
-            raise AnsibleParserError("A malformed block was encountered while loading tasks.", obj=self._ds) from ex
+            raise AnsibleParserError(f"A malformed block was encountered while loading {stage}.", obj=self._ds) from ex
 
     def _load_pre_tasks(self, attr, ds):
-        """
-        Loads a list of blocks from a list which may be mixed tasks/blocks.
-        Bare tasks outside of a block are given an implicit block.
-        """
-        try:
-            return load_list_of_blocks(ds=ds, play=self, variable_manager=self._variable_manager, loader=self._loader)
-        except AssertionError as ex:
-            raise AnsibleParserError("A malformed block was encountered while loading pre_tasks.", obj=self._ds) from ex
+        return self._load_tasks(attr, ds, stage='pre_tasks')
 
     def _load_post_tasks(self, attr, ds):
-        """
-        Loads a list of blocks from a list which may be mixed tasks/blocks.
-        Bare tasks outside of a block are given an implicit block.
-        """
-        try:
-            return load_list_of_blocks(ds=ds, play=self, variable_manager=self._variable_manager, loader=self._loader)
-        except AssertionError as ex:
-            raise AnsibleParserError("A malformed block was encountered while loading post_tasks.", obj=self._ds) from ex
+        return self._load_tasks(attr, ds, stage='post_tasks')
 
     def _load_handlers(self, attr, ds):
         """


### PR DESCRIPTION
##### SUMMARY

Fixes two instances of code duplication inside the playbook module. Rectifies a FIXME and a DTFIX-FUTURE.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request
- (Refactor Pull Request)