### PR TITLE
[stable-2.19] Fix network module failures on tagged RPC responses (#86601)

### DIFF
--- a/changelogs/fragments/86601-untag-jsonrpc-responses.yml
+++ b/changelogs/fragments/86601-untag-jsonrpc-responses.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-connection - Prevent unpickling failures in module contexts by ensuring that AnsibleTaggedObjects in pickled responses are converted to plain types in ``JsonRpcServer``.

--- a/lib/ansible/utils/jsonrpc.py
+++ b/lib/ansible/utils/jsonrpc.py
@@ -11,6 +11,7 @@ from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.connection import ConnectionError
 from ansible.module_utils.six import binary_type, text_type
 from ansible.utils.display import Display
+from ansible.utils.vars import transform_to_native_types
 
 display = Display()
 
@@ -83,7 +84,8 @@ class JsonRpcServer(object):
             result = to_text(result)
         if not isinstance(result, text_type):
             response["result_type"] = "pickle"
-            result = to_text(pickle.dumps(result), errors='surrogateescape')
+            # typically consumed in a module context; transform custom types (e.g. tagged/vaulted values) to native to prevent unpickling failures
+            result = to_text(pickle.dumps(transform_to_native_types(result, redact=False)))
         response['result'] = result
         return response
 

--- a/test/units/utils/test_jsonrpc.py
+++ b/test/units/utils/test_jsonrpc.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+import pickle
+
+from ansible._internal._datatag._tags import Origin
+from ansible.utils.jsonrpc import JsonRpcServer
+
+
+def test_response_type_cleansing() -> None:
+    """Avoid unpickling errors in module contexts by ensuring that non-scalar JsonRpc responses are not pickled with tags."""
+
+    class RPCTest:
+        def returns_list_with_tagged_str(self) -> list:
+            return [Origin(description="blar").tag("taggedstr")]
+
+    s = JsonRpcServer()
+    s.register(RPCTest())
+    req = dict(method="returns_list_with_tagged_str", id=1, params=(tuple(), {}))
+    jsonrpc_res = s.handle_request(json.dumps(req))
+
+    deserialized_res = json.loads(jsonrpc_res)
+
+    pickled_res = deserialized_res.get("result")
+
+    assert pickled_res is not None
+
+    res = pickle.loads(pickled_res.encode(errors="surrogateescape"))
+
+    assert res == ["taggedstr"]
+    assert not Origin.is_tagged_on(res[0])


### PR DESCRIPTION
##### SUMMARY
Fix network module failures on tagged RPC responses

* Zap tags in networking JsonRpcServer before pickling responses.
* Verify with unit test - suboptimal, but avoids a fake network connection plugin.

(cherry picked from commit a2873891249264732b29ec9db10b0fd64e54dd9a)

##### ISSUE TYPE
- Bugfix Pull Request
