### PR TITLE
Only set become_ options on PlayContext if the task uses become

### DIFF
--- a/changelogs/fragments/template-become-options-lazily.yml
+++ b/changelogs/fragments/template-become-options-lazily.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Tasks that don't use a become plugin can now leave common become variables undefined.

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -245,6 +245,8 @@ class PlayContext(Base):
 
         attrs_considered = []
         for (attr, variable_names) in C.MAGIC_VARIABLE_MAPPING.items():
+            if attr.startswith("become_") and not self._become_plugin:
+                continue
             for variable_name in variable_names:
                 if attr in attrs_considered:
                     continue

--- a/test/integration/targets/become/tasks/main.yml
+++ b/test/integration/targets/become/tasks/main.yml
@@ -18,3 +18,9 @@
   loop_control:
     loop_var: become_test_config
     label: "{{ become_test }}"
+
+- name: Test ansible_become_password is templated lazily
+  vars:
+    ansible_become_password: "{{ not_defined_anywhere }}"
+    ansible_become: no  # override variable set by ansible-test
+  ping:


### PR DESCRIPTION
##### SUMMARY

In https://forum.ansible.com/t/using-a-variable-from-one-play-across-other-plays, the variable `ansible_become_pass` is set on the play, so it's inherited by play-level gather facts and set on PlayContext. When the PlayContext is templated by the TE, it gives an error since it is not defined.

The error makes sense if [DEFAULT_BECOME](https://docs.ansible.com/projects/ansible/latest/reference_appendices/config.html#default-become) or the variable `ansible_become` is `True`, but if the task isn't using a become plugin it doesn't seem like it should give an error. This fixes that.

##### ISSUE TYPE

- Bugfix Pull Request
