### PR TITLE
Fix powershell method on non-pipelined conns

### DIFF
--- a/changelogs/fragments/86397-windows-no-pipelining.yml
+++ b/changelogs/fragments/86397-windows-no-pipelining.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    Fix up ``powershell`` shell commands when using a connection plugin that does not support stdin/pipeline input -
+    https://github.com/ansible/ansible/issues/86397

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -392,7 +392,15 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         """
         Determines if we are required and can do pipelining, only 'new' style modules can support pipelining
         """
-        return bool(module_style == 'new' and self._connection.is_pipelining_enabled(wrap_async))
+        # FUTURE: Move async checks from connection.is_pipelining_enabled here
+        # as async and pipelining is a property on the execution layer and not
+        # the capabilities of the connection itself.
+        conditions = [
+            module_style == 'new',
+            not C.DEFAULT_KEEP_REMOTE_FILES,                     # user doesn't want to keep remote files
+            self._connection.is_pipelining_enabled(wrap_async),  # connection/become supports pipelining and is enabled
+        ]
+        return all(conditions)
 
     def _get_admin_users(self):
         """
@@ -465,8 +473,16 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
 
         become_unprivileged = self._is_become_unprivileged()
         basefile = self._connection._shell._generate_temp_dir_name()
-        cmd = self._connection._shell._mkdtemp2(basefile=basefile, system=become_unprivileged, tmpdir=tmpdir)
-        result = self._low_level_execute_command(cmd.command, in_data=cmd.input_data, sudoable=False)
+
+        cmd = None
+        in_data = None
+        if self._connection.is_pipelining_enabled(wrap_async=False):
+            cmd_details = self._connection._shell._mkdtemp2(basefile=basefile, system=become_unprivileged, tmpdir=tmpdir)
+            cmd = cmd_details.command
+            in_data = cmd_details.input_data
+        else:
+            cmd = self._connection._shell.mkdtemp(basefile=basefile, system=become_unprivileged, tmpdir=tmpdir)
+        result = self._low_level_execute_command(cmd, in_data=in_data, sudoable=False)
 
         # error handling on this seems a little aggressive?
         if result['rc'] != 0:
@@ -486,7 +502,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
                 output = ('Failed to create temporary directory. '
                           'In some cases, you may have been able to authenticate and did not have permissions on the target directory. '
                           'Consider changing the remote tmp path in ansible.cfg to a path rooted in "/tmp", for more error information use -vvv. '
-                          'Failed command was: %s, exited with result %d' % (cmd.command, result['rc']))
+                          'Failed command was: %s, exited with result %d' % (cmd, result['rc']))
             if 'stdout' in result and result['stdout'] != u'':
                 output = output + u", stdout output: %s" % result['stdout']
             if display.verbosity > 3 and 'stderr' in result and result['stderr'] != u'':
@@ -907,8 +923,15 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
                 expand_path = '~%s' % (self._get_remote_user() or '')
 
         # use shell to construct appropriate command and execute
-        cmd = self._connection._shell._expand_user2(expand_path)
-        data = self._low_level_execute_command(cmd.command, in_data=cmd.input_data, sudoable=False)
+        cmd = None
+        in_data = None
+        if self._connection.is_pipelining_enabled(wrap_async=False):
+            cmd_details = self._connection._shell._expand_user2(expand_path)
+            cmd = cmd_details.command
+            in_data = cmd_details.input_data
+        else:
+            cmd = self._connection._shell.expand_user(expand_path)
+        data = self._low_level_execute_command(cmd, in_data=in_data, sudoable=False)
 
         try:
             initial_fragment = data['stdout'].strip().splitlines()[-1]

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -311,7 +311,6 @@ class ConnectionBase(AnsiblePlugin):
         # TODO: deprecate always_pipeline_modules and has_native_async in favor for each plugin overriding this function
         conditions = [
             is_enabled or self.always_pipeline_modules,       # enabled via config or forced via connection (eg winrm)
-            not C.DEFAULT_KEEP_REMOTE_FILES,                  # user wants remote files
             not wrap_async or self.has_native_async,          # async does not normally support pipelining unless it does (eg winrm)
         ]
         return all(conditions)

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -100,12 +100,11 @@ class ShellModule(ShellBase):
         mode: int = 0o700,
         tmpdir: str | None = None,
     ) -> str:
-        # This is not called in Ansible anymore but it is kept for backwards
-        # compatibility in case other action plugins outside Ansible calls this.
+        # This is used when connection plugins do not support pipelining.
         if not basefile:
             basefile = self.__class__._generate_temp_dir_name()
-        basefile = _script.quote_pwsh_argument(basefile)
-        basetmpdir = _script.quote_pwsh_argument(tmpdir if tmpdir else self.get_option('remote_tmp'))
+        basefile = _script.quote_pwsh_argument(basefile, force_quote=True)
+        basetmpdir = _script.quote_pwsh_argument(tmpdir if tmpdir else self.get_option('remote_tmp'), force_quote=True)
 
         script = f"""
         {self._CONSOLE_ENCODING}
@@ -145,16 +144,16 @@ class ShellModule(ShellBase):
         user_home_path: str,
         username: str = '',
     ) -> str:
-        # This is not called in Ansible anymore but it is kept for backwards
-        # compatibility in case other actions plugins outside Ansible called this.
+        # This is used when connection plugins do not support pipelining.
 
         script = self._CONSOLE_ENCODING
         if user_home_path == '~':
             script += "; (Get-Location).Path"
         elif user_home_path.startswith('~\\'):
-            script += f"; ((Get-Location).Path + {_script.quote_pwsh_argument(user_home_path[1:])})"
+            quoted_home = _script.quote_pwsh_argument(user_home_path[1:], force_quote=True)
+            script += f"; ((Get-Location).Path + {quoted_home})"
         else:
-            script += f"; {_script.quote_pwsh_argument(user_home_path)}"
+            script += f"; {_script.quote_pwsh_argument(user_home_path, force_quote=True)}"
 
         return self._encode_pwsh_script_as_command(script)
 

--- a/test/integration/targets/connection_windows_no_pipelining/action_plugins/shell_test.py
+++ b/test/integration/targets/connection_windows_no_pipelining/action_plugins/shell_test.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        result['remote_expand_user'] = self._remote_expand_user("~\\test")
+        result['tmpdir'] = self._make_tmp_path()
+
+        return result

--- a/test/integration/targets/connection_windows_no_pipelining/aliases
+++ b/test/integration/targets/connection_windows_no_pipelining/aliases
@@ -1,0 +1,4 @@
+windows
+shippable/windows/group1
+shippable/windows/smoketest
+needs/target/connection

--- a/test/integration/targets/connection_windows_no_pipelining/connection_plugins/winrm_no_pipelining.py
+++ b/test/integration/targets/connection_windows_no_pipelining/connection_plugins/winrm_no_pipelining.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+author: Ansible Core Team
+name: winrm_no_pipelining
+short_description: Testing Windows over non pipelined connection plugin
+description:
+- Used for testing only
+options:
+  remote_addr:
+    description:
+    - Address of the windows machine
+    vars:
+    - name: ansible_host
+    type: str
+  remote_user:
+    description:
+    - The user to log in as to the Windows machine
+    vars:
+    - name: ansible_user
+    type: str
+  remote_password:
+    description: Authentication password.
+    vars:
+    - name: ansible_password
+    type: str
+  port:
+    description:
+    - WinRM port.
+    vars:
+    - name: ansible_port
+    default: 5986
+    type: integer
+  transport:
+    description:
+    - WinRM transport to use.
+    vars:
+    - name: ansible_winrm_transport
+    type: list
+    elements: str
+  server_cert_validation:
+    description:
+    - WinRM server certificate validation mode to use.
+    vars:
+    - name: ansible_winrm_server_cert_validation
+    type: str
+"""
+
+
+from ansible.plugins.connection.winrm import Connection as WinRMBase
+
+
+class Connection(WinRMBase):
+
+    transport = 'winrm_no_pipelining'
+
+    def _build_winrm_kwargs(self) -> None:
+        # Stub out just enough of what the base class needs from known input options.
+        self._winrm_host = self.get_option('remote_addr')
+        self._winrm_user = self.get_option('remote_user')
+        self._winrm_pass = self.get_option('remote_password')
+        self._winrm_port = self.get_option('port')
+        self._winrm_transport = self.get_option('transport')
+
+        self._winrm_scheme = 'http' if self._winrm_port == 5985 else 'https'
+        self._winrm_path = '/wsman'
+        self._winrm_connection_timeout = None
+
+        self._winrm_kwargs = {
+            'username': self._winrm_user,
+            'password': self._winrm_pass,
+            'server_cert_validation': self.get_option('server_cert_validation'),
+        }
+
+    def exec_command(self, cmd, in_data=None, sudoable=False):
+        if in_data:
+            raise Exception(f"Pipelining should be disabled but in_data was provided for {cmd}")
+
+        return super().exec_command(cmd, in_data=in_data, sudoable=sudoable)
+
+    def is_pipelining_enabled(self, wrap_async: bool = False) -> bool:
+        return False

--- a/test/integration/targets/connection_windows_no_pipelining/runme.sh
+++ b/test/integration/targets/connection_windows_no_pipelining/runme.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -eux
+
+export ANSIBLE_CONNECTION_PLUGINS="${PWD}/connection_plugins"
+
+# make sure hosts are using our custom winrm connection that disables pipelining
+ansible -i ../../inventory.winrm localhost \
+    -m template \
+    -a "src=test_connection.inventory.j2 dest=${OUTPUT_DIR}/test_connection.inventory" \
+    "$@"
+
+TEST_PLAYBOOK="${PWD}/tests.yml"
+
+cd ../connection
+
+INVENTORY="${OUTPUT_DIR}/test_connection.inventory" ./test.sh \
+    -e target_hosts=windows \
+    -e action_prefix=win_ \
+    -e local_tmp=/tmp/ansible-local \
+    -e remote_tmp=c:/windows/temp/ansible-remote \
+    "$@"
+
+cd ../connection_windows_no_pipelining
+
+ansible-playbook -i "${OUTPUT_DIR}/test_connection.inventory" "${TEST_PLAYBOOK}" \
+    "$@"

--- a/test/integration/targets/connection_windows_no_pipelining/test_connection.inventory.j2
+++ b/test/integration/targets/connection_windows_no_pipelining/test_connection.inventory.j2
@@ -1,0 +1,10 @@
+[windows]
+{% for host in vars.groups.windows %}
+{{ host }}  ansible_host={{ hostvars[host]['ansible_host'] }}{% if hostvars[host]['ansible_connection'] != 'ssh' %} ansible_port={{ hostvars[host]['ansible_port'] }}{% endif %} ansible_user={{ hostvars[host]['ansible_user'] }} ansible_password={{ hostvars[host]['ansible_password'] | default(hostvars[host]['ansible_test_connection_password']) }}
+{% endfor %}
+
+[windows:vars]
+ansible_connection=winrm_no_pipelining
+# we don't know if we're using an encrypted connection or not, so we'll use message encryption
+ansible_winrm_transport=ntlm
+ansible_winrm_server_cert_validation=ignore

--- a/test/integration/targets/connection_windows_no_pipelining/tests.yml
+++ b/test/integration/targets/connection_windows_no_pipelining/tests.yml
@@ -1,0 +1,24 @@
+---
+- name: test out Windows No Pipelining specific tests
+  hosts: windows
+  force_handlers: yes
+  serial: 1
+  gather_facts: no
+
+  tasks:
+  - name: get remote information for shell method tests
+    ansible.windows.win_powershell:
+      script: |
+        (Resolve-Path ~\).Path + "\test"
+        (Get-Item $env:TEMP).FullName + "\ansible-tmp-"
+    register: remote_info
+
+  - name: test shell methods with pipelining disabled
+    shell_test:
+    register: shell_res
+
+  - name: assert shell test results
+    assert:
+      that:
+        - shell_res.remote_expand_user == remote_info.output[0]
+        - shell_res.tmpdir.startswith(remote_info.output[1])


### PR DESCRIPTION
##### SUMMARY
Fixes the action plugin mkdtemp and expand_user calls to fallback to the original non-pipelined variants when a connection plugin does not support pipelining. For example a 3rd party Windows connection plugin may not support pipelining and thus cannot use the user _mkdtemp2 and _expand_user2 variants exposed by the `powershell` shell plugin as they require data to be sent over stdin.

Fixes: https://github.com/ansible/ansible/issues/86397

##### ISSUE TYPE
- Bugfix Pull Request