### PR TITLE
service: Add compatibility with GNU Hurd

### DIFF
--- a/changelogs/fragments/hurd-service-support.yml
+++ b/changelogs/fragments/hurd-service-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - service - add support for GNU Hurd systems, which use SysV init scripts (https://github.com/ansible/ansible/pull/86622).

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -986,6 +986,16 @@ class LinuxService(Service):
         return (rc_state, stdout, stderr)
 
 
+class HurdService(LinuxService):
+    """
+    This is the GNU Hurd Service manipulation class - it uses SysV init scripts
+    and should be broadly compatible with the Linux Service manipulation class.
+    """
+
+    platform = 'GNU'
+    distribution = None
+
+
 class FreeBsdService(Service):
     """
     This is the FreeBSD Service manipulation class - it uses the /etc/rc.conf


### PR DESCRIPTION
##### SUMMARY

Trying to use the `service` module on GNU/Hurd (Debian) fails with:

```
fatal: [cfarm432]: FAILED! => {"changed": false, "msg": "get_service_tools not implemented on target platform"}
```

It uses standard SysV init scripts, so let's just use the same service class implementation as Linux.

##### ISSUE TYPE

- Bugfix Pull Request
