### PR TITLE
[stable-2.20] ansible-galaxy - install/download collections which support ansible-core by default

### DIFF
--- a/changelogs/fragments/install-ansible-core-compatible-collections.yml
+++ b/changelogs/fragments/install-ansible-core-compatible-collections.yml
@@ -1,0 +1,6 @@
+bugfixes:
+- >-
+  ``ansible-galaxy install`` and ``ansible-galaxy collection install|download`` - now consider
+  the ``COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH`` configuration.
+  Collections which will cause a warning/error at load time are no longer installed/downloaded.
+  (https://github.com/ansible/ansible/issues/78539)

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -288,6 +288,8 @@ class GalaxyAPI:
         if not no_cache:
             self._cache = _load_cache(self._b_cache_path)
 
+        self.requires_ansible = collections.defaultdict(dict)
+
         display.debug('Validate TLS certificates for %s: %s' % (self.api_server, self.validate_certs))
 
     def __str__(self):
@@ -772,6 +774,11 @@ class GalaxyAPI:
 
         signatures = data.get('signatures') or []
 
+        # NOTE: Galaxy and Hub already populated the cache when listing versions.
+        # NOTE: Allow 3rd party servers to provide version-specific metadata lazily.
+        if (requires_ansible := data.get('requires_ansible')):
+            self.requires_ansible[f"{namespace}.{name}"][version] = requires_ansible
+
         download_url_info = urlparse(data['download_url'])
         if not download_url_info.scheme and not download_url_info.path.startswith('/'):
             # galaxy does a lot of redirects, with much more complex pathing than we use
@@ -844,7 +851,10 @@ class GalaxyAPI:
 
         versions = []
         while True:
-            versions += [v['version'] for v in data[results_key]]
+            for v in data[results_key]:
+                versions.append(v["version"])
+                # requires_ansible is new in galaxy_ng 4.3.0
+                self.requires_ansible[f"{namespace}.{name}"][v["version"]] = v.get("requires_ansible")
 
             next_link = data
             for path in pagination_path:

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -550,6 +550,8 @@ def download_collections(
             format(path=output_path),
     ):
         for fqcn, concrete_coll_pin in dep_map.copy().items():  # FIXME: move into the provider
+            if concrete_coll_pin.type == "requires_ansible":
+                continue
             if concrete_coll_pin.is_virtual:
                 display.display(
                     '{coll!s} is not downloadable'.
@@ -734,6 +736,8 @@ def install_collections(
     keyring_exists = artifacts_manager.keyring is not None
     with _display_progress("Starting collection install process"):
         for fqcn, concrete_coll_pin in dependency_map.items():
+            if concrete_coll_pin.type == "requires_ansible":
+                continue
             if concrete_coll_pin.is_virtual:
                 display.vvvv(
                     "Encountered {coll!s}, skipping.".
@@ -1827,6 +1831,10 @@ def _resolve_depenency_map(
         'installed by default unless a specific version is requested. '
         'To enable pre-releases globally, use --pre.'
     )
+    requires_ansible_hint = '' if C.COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH == 'ignore' else (
+        'Hint: To disregard whether the collection supports the current version of '
+        'ansible-core, configure COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH as "ignore".'
+    )
 
     collection_dep_resolver = build_collection_dependency_resolver(
         galaxy_apis=galaxy_apis,
@@ -1847,16 +1855,27 @@ def _resolve_depenency_map(
             ).mapping,
         )
     except CollectionDependencyResolutionImpossible as dep_exc:
-        conflict_causes = (
-            '* {req.fqcn!s}:{req.ver!s} ({dep_origin!s})'.format(
-                req=req_inf.requirement,
-                dep_origin='direct request'
-                if req_inf.parent is None
-                else 'dependency of {parent!s}'.
-                format(parent=req_inf.parent),
-            )
-            for req_inf in dep_exc.causes
-        )
+        conflict_causes = []
+        for req_inf in dep_exc.causes:
+            if req_inf.requirement.type == "requires_ansible":
+                if req_inf.requirement.has_candidate:
+                    continue
+                collection = str(req_inf.parent)
+                parents = [str(r._parent) for r in req_inf.parent._requirements if r._parent is not None]
+                if not parents:
+                    dep_origin = 'direct request'
+                else:
+                    dep_origin = f'dependency of {", ".join(parents)}'
+            else:
+                collection = str(req_inf.requirement)
+                dep_origin = 'direct request' if req_inf.parent is None else f'dependency of {req_inf.parent!s}'
+
+            cause = f"* {collection} ({dep_origin})"
+            if req_inf.requirement.type == "requires_ansible":
+                cause += f" requires {req_inf.requirement.fqcn!s} {req_inf.requirement.ver!s}"
+
+            conflict_causes.append(cause)
+
         error_msg_lines = list(chain(
             (
                 'Failed to resolve the requested '
@@ -1865,6 +1884,9 @@ def _resolve_depenency_map(
             ),
             conflict_causes,
         ))
+        if any(req_inf.requirement.type == "requires_ansible" for req_inf in dep_exc.causes):
+            dep_exc = None
+            error_msg_lines.append(requires_ansible_hint)
         error_msg_lines.append(pre_release_hint)
         raise AnsibleError('\n'.join(error_msg_lines)) from dep_exc
     except CollectionDependencyInconsistentCandidate as dep_exc:

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -12,8 +12,11 @@ import subprocess
 import typing as t
 import yaml
 
-from contextlib import contextmanager
+from collections.abc import Mapping
+from contextlib import contextmanager, suppress
+from functools import cache
 from hashlib import sha256
+from pathlib import Path
 from urllib.error import URLError
 from urllib.parse import urldefrag
 from shutil import rmtree
@@ -337,6 +340,33 @@ class ConcreteArtifactsManager:
 
         self._artifact_meta_cache[collection.src] = collection_meta
         return collection_meta
+
+    def get_direct_requires_ansible(self, collection: Candidate) -> str | None:
+        """Extract requires_ansible from the on-disk collection artifact."""
+        if collection.is_concrete_artifact:
+            b_artifact_path = self.get_artifact_path(collection)
+        else:
+            b_artifact_path = self.get_galaxy_artifact_path(collection)
+
+        if collection.is_url or collection.is_file or collection.is_online_index_pointer:
+            runtime = _get_runtime_from_tar(b_artifact_path) or {}
+        elif collection.is_dir:
+            runtime = _get_runtime_from_dir(b_artifact_path) or {}
+        elif collection.is_virtual:
+            runtime = {}
+
+        if not isinstance(runtime, Mapping):
+            raise AnsibleError(
+                f"The collection {collection} (type {collection.type}) (from {collection.src}) "
+                "has an invalid meta/runtime.yml metadata. This file must contain a YAML dictionary."
+            )
+        if "requires_ansible" in runtime and not isinstance(runtime["requires_ansible"], str):
+            raise AnsibleError(
+                f"The collection {collection} (type {collection.type}) from {collection.src}) "
+                "has invalid meta/runtime.yml metadata. The value for requires_ansible must be a string."
+            )
+        # NOTE: Using None as a sentinel since it's not a valid value otherwise.
+        return runtime.get("requires_ansible")
 
     def save_collection_source(self, collection, url, sha256_hash, token, signatures_url, signatures):
         # type: (Candidate, str, str, GalaxyToken, str, list[dict[str, str]]) -> None
@@ -756,3 +786,21 @@ def _tarfile_extract(
     finally:
         if tar_obj is not None:
             tar_obj.close()
+
+
+@cache
+def _get_runtime_from_dir(b_path: bytes) -> object:
+    """Load the meta/runtime.yml from a collection directory."""
+    runtime_path = Path(b_path.decode()) / "meta" / "runtime.yml"
+    with suppress(OSError):
+        return yaml_load(runtime_path.read_text())
+
+
+@cache
+def _get_runtime_from_tar(b_path: bytes) -> object:
+    """Load the meta/runtime.yml from a collection artifact."""
+    with suppress(tarfile.TarError, KeyError):
+        with tarfile.open(b_path, mode='r') as collection_tar:
+            runtime = collection_tar.getmember("meta/runtime.yml")
+            with _tarfile_extract(collection_tar, runtime) as (_member, member_obj):
+                return yaml_load(member_obj)

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -26,11 +26,14 @@ if t.TYPE_CHECKING:
         '_ComputedReqKindsMixin',
     )
 
+from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.collection import HAS_PACKAGING, PkgReq
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.common.arg_spec import ArgumentSpecValidator
+from ansible.plugins.loader import _does_collection_support_ansible_version
+from ansible.release import __version__
 from ansible.utils.collection_loader import AnsibleCollectionRef
 from ansible.utils.display import Display
 
@@ -543,7 +546,7 @@ class _ComputedReqKindsMixin:
 
     @property
     def canonical_package_id(self) -> str:
-        if not self.is_virtual:
+        if not self.is_virtual or self.type == "requires_ansible":
             return to_native(self.fqcn)
 
         return (
@@ -633,6 +636,13 @@ class Requirement(
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         super(Requirement, self).__init__()
+        # NOTE: Hack to display the origin of impossible collection requirements when requires_ansible is incompatible
+        # e.g. Requirement ns.col -> ns.col:$ver -> Requirement ns.dep -> ns.dep:$ver -> Requirement ansible-core<2.19
+        #   - ResolutionImpossible.causes[0].requirement is Requirement ansible-core<2.19
+        #   - ResolutionImpossible.causes[0].parent is Candidate ns.dep:$ver
+        #   - ResolutionImpossible.causes[0].parent._requirements[0] is Requirement ns.dep
+        #   - ResolutionImpossible.causes[0].parent._requirements[0]._parent is Candidate ns.col:$ver
+        self._parent: Candidate | None = None
 
 
 class Candidate(
@@ -647,6 +657,8 @@ class Candidate(
 
     def __init__(self, *args: object, **kwargs: object) -> None:
         super(Candidate, self).__init__()
+        # NOTE: Hack to display the origin of impossible collection requirements when requires_ansible is incompatible
+        self._requirements: list[Requirement] = []
 
     def with_signatures_repopulated(self) -> Candidate:
         """Populate a new Candidate instance with Galaxy signatures.
@@ -657,3 +669,43 @@ class Candidate(
 
         signatures = self.src.get_collection_signatures(self.namespace, self.name, self.ver)
         return self.__class__(self.fqcn, self.ver, self.src, self.type, frozenset([*self.signatures, *signatures]))
+
+
+class AnsibleRequirement(Requirement):
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super(AnsibleRequirement, self).__init__()
+
+        self.has_candidate: None | Candidate
+        if _does_collection_support_ansible_version(self.ver, __version__):
+            self.has_candidate = Candidate("ansible-core", __version__, None, "requires_ansible", None)
+        else:
+            self.has_candidate = None
+
+    @classmethod
+    def from_collection(cls, concrete_art_mgr: ConcreteArtifactsManager, candidate: Candidate) -> None | t.Self:
+        """
+        Create a Requirement from a collection Candidate's requires_ansible metadata.
+        """
+        if (
+            C.COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH == "ignore"
+            or candidate.is_virtual
+            or candidate.type == "requires_ansible"
+        ):
+            return None
+
+        if candidate.type == 'galaxy':
+            requires_ansible = (candidate.src.requires_ansible.get(candidate.fqcn) or {}).get(candidate.ver)
+        else:
+            requires_ansible = concrete_art_mgr.get_direct_requires_ansible(candidate)
+
+        if requires_ansible is None:
+            display.warning(f"{candidate!s} does not have requires_ansible metadata.")
+            return None
+
+        # Passing the "fqcn" attribute so __unicode__ doesn't need to be overridden.
+        res = cls("ansible-core", requires_ansible, None, "requires_ansible", None)
+        res._parent = candidate
+        return res
+
+    def is_satisfied_by(self, candidate: Candidate) -> bool:
+        return self.has_candidate == candidate

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -22,6 +22,7 @@ from ansible.galaxy.collection.gpg import get_signature_from_source
 from ansible.galaxy.dependency_resolution.dataclasses import (
     Candidate,
     Requirement,
+    AnsibleRequirement,
 )
 from ansible.galaxy.dependency_resolution.versioning import (
     is_pre_release,
@@ -86,6 +87,10 @@ class CollectionDependencyProvider(AbstractProvider):
         self._make_req_from_dict = functools.partial(
             Requirement.from_requirement_dict,
             art_mgr=concrete_artifacts_manager,
+        )
+        self._make_ansible_requirement = functools.partial(
+            AnsibleRequirement.from_collection,
+            concrete_artifacts_manager,
         )
         self._preferred_candidates = set(preferred_candidates or ())
         self._with_deps = with_deps
@@ -188,10 +193,14 @@ class CollectionDependencyProvider(AbstractProvider):
         to find concrete candidates for this requirement. If there's a
         pre-installed candidate, it's prepended in front of others.
         """
-        return [
-            match for match in self._find_matches(list(requirements[identifier]))
-            if not any(match.ver == incompat.ver for incompat in incompatibilities[identifier])
-        ]
+        results = []
+        for match in self._find_matches(list(requirements[identifier])):
+            if any(match.ver == incompat.ver for incompat in incompatibilities[identifier]):
+                continue
+
+            match._requirements = list(requirements[identifier])
+            results.append(match)
+        return results
 
     def _find_matches(self, requirements: list[Requirement]) -> list[Candidate]:
         # FIXME: The first requirement may be a Git repo followed by
@@ -203,6 +212,12 @@ class CollectionDependencyProvider(AbstractProvider):
         # The fqcn is guaranteed to be the same
         version_req = "A SemVer-compliant version or '*' is required. See https://semver.org to learn how to compose it correctly. "
         version_req += "This is an issue with the collection."
+
+        if first_req.type == "requires_ansible":
+            for r in requirements:
+                if r.has_candidate is None:
+                    return []
+            return [first_req.has_candidate]
 
         # If we're upgrading collections, we can't calculate preinstalled_candidates until the latest matches are found.
         # Otherwise, we can potentially avoid a Galaxy API call by doing this first.
@@ -390,17 +405,23 @@ class CollectionDependencyProvider(AbstractProvider):
         ):
             return True
 
+        if requirement.type == 'requires_ansible':
+            return requirement.is_satisfied_by(candidate)
+
         return meets_requirements(
             version=candidate.ver,
             requirements=requirement.ver,
         )
 
-    def get_dependencies(self, candidate: Candidate) -> list[Requirement]:
+    def get_dependencies(self, candidate: Candidate) -> t.Iterator[Requirement]:
         r"""Get direct dependencies of a candidate.
 
         :returns: A collection of requirements that `candidate` \
                   specifies as its dependencies.
         """
+        if candidate.type == "requires_ansible":
+            return
+
         # FIXME: If there's several galaxy servers set, there may be a
         # FIXME: situation when the metadata of the same collection
         # FIXME: differs. So how do we resolve this case? Priority?
@@ -408,6 +429,10 @@ class CollectionDependencyProvider(AbstractProvider):
         # FIXME: any differences?
         # NOTE: The underlying implementation currently uses first found
         req_map = self._api_proxy.get_collection_dependencies(candidate)
+
+        if (requires_ansible := self._make_ansible_requirement(candidate)):
+            requires_ansible._parent = candidate
+            yield requires_ansible
 
         # NOTE: This guard expression MUST perform an early exit only
         # NOTE: after the `get_collection_dependencies()` call because
@@ -419,10 +444,9 @@ class CollectionDependencyProvider(AbstractProvider):
         #
         # NOTE: Virtual candidates should always return dependencies
         # NOTE: because they are ephemeral and non-installable.
-        if not self._with_deps and not candidate.is_virtual:
-            return []
-
-        return [
-            self._make_req_from_dict({'name': dep_name, 'version': dep_req})
-            for dep_name, dep_req in req_map.items()
-        ]
+        for dep_name, dep_req in req_map.items():
+            if not (self._with_deps or candidate.is_virtual):
+                continue
+            dependency = self._make_req_from_dict({'name': dep_name, 'version': dep_req})
+            dependency._parent = candidate
+            yield dependency

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/download.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/download.yml
@@ -12,11 +12,16 @@
   args:
     chdir: '{{ galaxy_dir }}/download'
   register: download_collection
+  # TODO: remove external dependencies and define requires_ansible based on the current version
+  environment:
+    ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
 
 - name: check that the amazon.aws collection was downloaded
   stat:
     path: '{{ galaxy_dir }}/download/collections/amazon-aws-1.0.0.tar.gz'
   register: download_collection_amazon_actual
+  environment:
+    ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
 
 - name: check that the awx.awx collection was downloaded
   stat:
@@ -34,6 +39,8 @@
   command: 'ansible-galaxy collection install -r requirements.yml --no-deps'
   args:
     chdir: '{{ galaxy_dir }}/download/collections/'
+  environment:
+    ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
 
 - name: list installed collections
   command: 'ansible-galaxy collection list'

--- a/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
+++ b/test/integration/targets/ansible-galaxy-collection/library/setup_collections.py
@@ -55,6 +55,16 @@ options:
         - The dependencies of the collection.
         type: dict
         default: '{}'
+      use_symlink:
+        description:
+        - Create a symlink in the collection.
+        type: bool
+        default: False
+      runtime:
+        description:
+        - File content for meta/runtime.yml.
+        type: str
+        default: 'requires_ansible: ">=2.9"'
 author:
 - Jordan Borean (@jborean93)
 """
@@ -100,6 +110,7 @@ def publish_collection(module, collection):
     version = collection['version']
     dependencies = collection['dependencies']
     use_symlink = collection['use_symlink']
+    runtime = collection['runtime']
 
     result = {}
     collection_dir = os.path.join(module.tmpdir, "%s-%s-%s" % (namespace, name, version))
@@ -123,7 +134,7 @@ def publish_collection(module, collection):
     with open(os.path.join(b_collection_dir, b'galaxy.yml'), mode='wb') as fd:
         fd.write(to_bytes(yaml.safe_dump(galaxy_meta), errors='surrogate_or_strict'))
     with open(os.path.join(b_collection_dir, b'meta/runtime.yml'), mode='wb') as fd:
-        fd.write(b'requires_ansible: ">=1.0.0"')
+        fd.write(to_bytes(runtime))
 
     with tempfile.NamedTemporaryFile(mode='wb') as temp_fd:
         temp_fd.write(b"data")
@@ -238,6 +249,7 @@ def run_module():
                 version=dict(type='str', default='1.0.0'),
                 dependencies=dict(type='dict', default={}),
                 use_symlink=dict(type='bool', default=False),
+                runtime=dict(type='str', default='requires_ansible: ">=2.9"'),
             ),
         ),
         signature_dir=dict(type='path', default=None),

--- a/test/integration/targets/ansible-galaxy-collection/tasks/check_requires_ansible.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/check_requires_ansible.yml
@@ -1,0 +1,138 @@
+- environment:
+    ANSIBLE_NOCOLOR: True
+    ANSIBLE_FORCE_COLOR: false
+  vars:
+    test_base_dir: "{{ [remote_tmp_dir, 'requires_ansible_' ~ subcommand] | path_join }}"
+    temp1: "{{ [test_base_dir, 'collections'] | path_join }}"
+    temp2: "{{ [test_base_dir, 'other_collections'] | path_join }}"
+    install_or_download: "ansible-galaxy collection {{ subcommand }}{{ (subcommand == 'install') | ternary(' --force-with-deps', '')}}"
+    failed_error: |
+        \[ERROR\]: Failed to resolve the requested dependencies map\. Could not satisfy the following requirements:
+        \* ns_requires_ansible\.name_requires_ansible:1\.0\.0 \(direct request\) requires ansible-core <1\.1
+    hint: >-
+        Hint: To disregard whether the collection supports the current version
+        of ansible-core, configure COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH as "ignore"
+    undocumented_warning: >-
+      \[WARNING\]: ns_requires_ansible\.name_requires_ansible:.* does not have requires_ansible metadata.
+  block:
+  - name: "{{ subcommand }} incompatible collection"
+    command: "{{ install_or_download }} -p {{ temp1 }} ns_requires_ansible.name_requires_ansible"
+    register: expected_fail
+    failed_when: expected_fail is success
+
+  - assert:
+      that:
+        - expected_fail.stderr is search(failed_error, multiline=True)
+        - expected_fail.stderr is search(hint)
+
+  - name: "{{ subcommand }} specific version of incompatible collection"
+    command: "{{ install_or_download }} -p {{ temp1 }} 'ns_requires_ansible.name_requires_ansible:1.0.0'"
+    register: expected_fail
+    failed_when: expected_fail is success
+
+  - assert:
+      that:
+        - expected_fail.stderr is search(failed_error, multiline=True)
+        - expected_fail.stderr is search(hint)
+
+  - name: Download incompatible tarfile for tarfile tests
+    command: ansible-galaxy collection download -p {{ temp1 }} ns_requires_ansible.name_requires_ansible
+    environment:
+      ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
+
+  - name: "{{ subcommand }} incompatible tarfile"
+    command: "{{ install_or_download }} -p {{ temp2 }} {{ temp1 }}/ns_requires_ansible-name_requires_ansible-1.0.0.tar.gz"
+    register: expected_fail
+    failed_when: expected_fail is success
+
+  - assert:
+      that:
+        - expected_fail.stderr is search(failed_error, multiline=True)
+        - expected_fail.stderr is search(hint)
+
+  - name: "{{ subcommand }} tarfile and allow mismatched version"
+    command: "{{ install_or_download }} -p {{ temp2 }} {{ temp1 }}/ns_requires_ansible-name_requires_ansible-1.0.0.tar.gz"
+    environment:
+      ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
+
+  - name: setup - {{ subcommand }} build directory
+    block:
+      - name: setup - init collection build directory
+        command: ansible-galaxy collection init ns_requires_ansible.name_requires_ansible --init-path {{ temp2 }}/ansible_collections
+
+      - name: setup - add  requires_ansible in the runtime file
+        shell: >-
+          echo 'requires_ansible: "<1.1"' > {{ temp2 }}/ansible_collections/ns_requires_ansible/name_requires_ansible/meta/runtime.yml
+    when: subcommand == 'download'
+
+  - name: "{{ subcommand }} incompatible directory"
+    command: "{{ install_or_download }} -p {{ temp1 }} {{ temp2 }}/ansible_collections/ns_requires_ansible/name_requires_ansible"
+    register: expected_fail
+    failed_when: expected_fail is success
+
+  - assert:
+      that:
+        - expected_fail.stderr is search(failed_error, multiline=True)
+        - expected_fail.stderr is search(hint)
+
+  - name: "{{ subcommand }} directory and allow mismatched version"
+    command: "{{ install_or_download }} -p {{ temp1 }} {{ temp2 }}/ansible_collections/ns_requires_ansible/name_requires_ansible"
+    environment:
+      ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH: ignore
+
+  - name: setup - {{ subcommand }} remove requires_ansible metadata
+    file:
+      path: "{{ temp2 }}/ansible_collections/ns_requires_ansible/name_requires_ansible/meta/runtime.yml"
+      state: absent
+
+  - name: "{{ subcommand }} directory with undocumented, optional requires_ansible metadata"
+    command: "{{ install_or_download }} -p {{ temp1 }} {{ temp2 }}/ansible_collections/ns_requires_ansible/name_requires_ansible"
+    register: expected_success
+
+  - assert:
+      that:
+        - expected_success.stderr is search(undocumented_warning)
+
+  - name: "{{ subcommand }} collection with incompatible dependency"
+    command: "{{ install_or_download }} -p {{ temp1 }} 'ns_requires_ansible.dependency:2.0.0'"
+    register: expected_error
+    failed_when: expected_error is not failed
+
+  - assert:
+      that:
+        - expected_error.stderr is search(expected_message, multiline=True)
+    vars:
+      expected_message: |
+        \[ERROR\]: Failed to resolve the requested dependencies map\. Could not satisfy the following requirements:
+        \* ns_requires_ansible\.name_requires_ansible:1\.0\.0 \(dependency of ns_requires_ansible\.dependency:2\.0\.0\) requires ansible-core <1\.1
+
+  - name: "{{ subcommand }} collection version without incompatible dependency"
+    command: "{{ install_or_download }} -p {{ temp1 }} ns_requires_ansible.dependency"
+    register: expected_success
+
+  - assert:
+      that:
+        - expected_success.stdout is search(expected_message)
+    vars:
+      expected_message: >-
+        '?ns_requires_ansible\.dependency:1\.0\.0'? was {{ subcommand }}ed successfully
+
+  - name: "{{ subcommand }} collection with unsuccessful backtracking"
+    command: "{{ install_or_download }} ns_requires_ansible.backtracking_error"
+    register: expected_fail
+    failed_when: expected_fail is success
+
+  - assert:
+      that:
+        - expected_fail.stderr is search(expected_message, multiline=True)
+        - expected_fail.stderr is search(hint)
+    vars:
+      expected_message: |
+        \[ERROR\]: Failed to resolve the requested dependencies map\. Could not satisfy the following requirements:
+        \* ns_requires_ansible\.name_requires_ansible:1\.0\.0 \(dependency of ns_requires_ansible\.dependency_incompat:1\.0\.0\) requires ansible-core <1\.1
+
+  always:
+  - name: Clean up test dir
+    file:
+      path: "{{ test_base_dir }}"
+      state: absent

--- a/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/main.yml
@@ -210,9 +210,15 @@
 - name: run ansible-galaxy collection list tests
   include_tasks: list.yml
 
-- include_tasks: upgrade.yml
-  args:
-    apply:
-      environment:
-        ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
-        ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
+- environment:
+    ANSIBLE_CONFIG: '{{ galaxy_dir }}/ansible.cfg'
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}'
+  block:
+  - include_tasks: upgrade.yml
+
+  - include_tasks: check_requires_ansible.yml
+    loop:
+      - install
+      - download
+    loop_control:
+      loop_var: subcommand

--- a/test/integration/targets/ansible-galaxy-collection/vars/main.yml
+++ b/test/integration/targets/ansible-galaxy-collection/vars/main.yml
@@ -201,3 +201,43 @@ collection_list:
     version: 4.5.6
     dependencies:
       ns_with_wildcard_dep.name_with_wildcard_dep: 5.6.7-beta.3
+
+  - namespace: ns_requires_ansible
+    name: name_requires_ansible
+    version: 1.0.0
+    runtime: |-
+      requires_ansible: "<1.1"
+
+  - namespace: ns_requires_ansible
+    name: dependency
+    version: 1.0.0
+
+  - namespace: ns_requires_ansible
+    name: dependency
+    version: 2.0.0
+    dependencies:
+      ns_requires_ansible.name_requires_ansible: 1.0.0
+
+  - namespace: ns_requires_ansible
+    name: dependency_incompat
+    version: 1.0.0
+    dependencies:
+      ns_requires_ansible.name_requires_ansible: 1.0.0
+
+  - namespace: ns_requires_ansible
+    name: dependency_incompat
+    version: 2.0.0
+    dependencies:
+      ns_requires_ansible.dependency: 2.0.0  # pinned incompatible version
+
+  - namespace: ns_requires_ansible
+    name: dependency_incompat
+    version: 3.0.0
+    dependencies:
+      ns_requires_ansible.name_requires_ansible: 1.0.0
+
+  - namespace: ns_requires_ansible
+    name: backtracking_error
+    version: 1.0.0
+    dependencies:
+      ns_requires_ansible.dependency_incompat: "*"

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -897,10 +897,11 @@ def test_install_collections_from_tar(collection_artifact, monkeypatch):
 
     # Filter out the progress cursor display calls.
     display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2] and len(m[1]) == 1]
-    assert len(display_msgs) == 4
+    assert len(display_msgs) == 5
     assert display_msgs[0] == "Process install dependency map"
-    assert display_msgs[1] == "Starting collection install process"
-    assert display_msgs[2] == "Installing 'ansible_namespace.collection:0.1.0' to '%s'" % to_text(collection_path)
+    assert display_msgs[1] == "[WARNING]: ansible_namespace.collection:0.1.0 does not have requires_ansible metadata.\n"
+    assert display_msgs[2] == "Starting collection install process"
+    assert display_msgs[3] == "Installing 'ansible_namespace.collection:0.1.0' to '%s'" % to_text(collection_path)
 
 
 # Makes sure we don't get stuck in some recursive loop
@@ -937,11 +938,12 @@ def test_install_collection_with_circular_dependency(collection_artifact, monkey
 
     # Filter out the progress cursor display calls.
     display_msgs = [m[1][0] for m in mock_display.mock_calls if 'newline' not in m[2] and len(m[1]) == 1]
-    assert len(display_msgs) == 4
+    assert len(display_msgs) == 5
     assert display_msgs[0] == "Process install dependency map"
-    assert display_msgs[1] == "Starting collection install process"
-    assert display_msgs[2] == "Installing 'ansible_namespace.collection:0.1.0' to '%s'" % to_text(collection_path)
-    assert display_msgs[3] == "ansible_namespace.collection:0.1.0 was installed successfully"
+    assert display_msgs[1] == "[WARNING]: ansible_namespace.collection:0.1.0 does not have requires_ansible metadata.\n"
+    assert display_msgs[2] == "Starting collection install process"
+    assert display_msgs[3] == "Installing 'ansible_namespace.collection:0.1.0' to '%s'" % to_text(collection_path)
+    assert display_msgs[4] == "ansible_namespace.collection:0.1.0 was installed successfully"
 
 
 @pytest.mark.parametrize('collection_artifact', [


### PR DESCRIPTION
##### SUMMARY

Waiting on #86626. The changelog revision needs to be cherry-picked onto this branch.

Backport for #86183

ansible-galaxy now respects the requires_ansible metadata unless https://docs.ansible.com/projects/ansible/latest/reference_appendices/config.html#collections-on-ansible-version-mismatch is set to 'ignore'.

(cherry picked from commit b1323f3ab1df54f86015a7ec11814e17b2b44896)

##### ISSUE TYPE

- Bugfix Pull Request
