### PR TITLE
Clarify ansible-galaxy changelog fragment

### DIFF
--- a/changelogs/fragments/install-ansible-core-compatible-collections.yml
+++ b/changelogs/fragments/install-ansible-core-compatible-collections.yml
@@ -1,4 +1,4 @@
-bugfixes:
+major_changes:
 - >-
   ``ansible-galaxy install`` and ``ansible-galaxy collection install|download`` -
   collections that declare a ``requires_ansible`` version that is not compatible with the running ansible-core version are now excluded from installation and download by default. In previous versions, ansible-galaxy would install such collections even if doing so resulted in an error at load time. To restore the previous behavior, set ``COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH`` to ``ignore`` in your configuration.

--- a/changelogs/fragments/install-ansible-core-compatible-collections.yml
+++ b/changelogs/fragments/install-ansible-core-compatible-collections.yml
@@ -1,7 +1,5 @@
 bugfixes:
 - >-
   ``ansible-galaxy install`` and ``ansible-galaxy collection install|download`` -
-  no longer install or download collections which don't support the currently
-  executing version of ansible-core. The previous behavior can be restored by setting the
-  ``COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH`` configuration to ``ignore``.
+  collections that declare a ``requires_ansible`` version that is not compatible with the running ansible-core version are now excluded from installation and download by default. In previous versions, ansible-galaxy would install such collections even if doing so resulted in an error at load time. To restore the previous behavior, set ``COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH`` to ``ignore`` in your configuration.
   (https://github.com/ansible/ansible/issues/78539)

--- a/changelogs/fragments/install-ansible-core-compatible-collections.yml
+++ b/changelogs/fragments/install-ansible-core-compatible-collections.yml
@@ -1,6 +1,7 @@
 bugfixes:
 - >-
-  ``ansible-galaxy install`` and ``ansible-galaxy collection install|download`` - now consider
-  the ``COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH`` configuration.
-  Collections which will cause a warning/error at load time are no longer installed/downloaded.
+  ``ansible-galaxy install`` and ``ansible-galaxy collection install|download`` -
+  no longer install or download collections which don't support the currently
+  executing version of ansible-core. The previous behavior can be restored by setting the
+  ``COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH`` configuration to ``ignore``.
   (https://github.com/ansible/ansible/issues/78539)


### PR DESCRIPTION
##### SUMMARY

Revise changelog added in #86183

Please see the discussion here https://github.com/ansible/ansible/pull/86183#discussion_r2892070446.

I've tried to rephrase this to make it clearer that collections which don't support the currently executing version of ansible-core are no longer installed by default.

##### ISSUE TYPE

- Docs Pull Request
