### PR TITLE
Pass AnsiballZ module args via stdin instead of embedding in wrapper

### DIFF
--- a/lib/ansible/_internal/_ansiballz/_wrapper.py
+++ b/lib/ansible/_internal/_ansiballz/_wrapper.py
@@ -40,11 +40,11 @@ def _ansiballz_main(
     zip_data: str,
     ansible_module: str,
     module_fqn: str,
-    params: str,
     profile: str,
     date_time: datetime.datetime,
     extensions: dict[str, dict[str, object]],
     rlimit_nofile: int,
+    params: str | None = None,
 ) -> None:
     import os
     import os.path
@@ -238,7 +238,19 @@ def _ansiballz_main(
     # See comments in the debug() method for information on debugging
     #
 
-    encoded_params = params.encode()
+    if params is not None:
+        # Args were passed as a function argument (legacy / debug mode).
+        encoded_params = params.encode()
+    else:
+        # Check if args were prepended as a module-level global (pipelining
+        # mode, where stdin carries the script itself).
+        import __main__
+        pipelined_params = getattr(__main__, '_ANSIBALLZ_PARAMS', None)
+        if pipelined_params is not None:
+            encoded_params = pipelined_params if isinstance(pipelined_params, bytes) else pipelined_params.encode()
+        else:
+            # Non-pipelining: args are passed via stdin.
+            encoded_params = sys.stdin.buffer.read()
 
     # There's a race condition with the controller removing the
     # remote_tmpdir and this module executing under async.  So we cannot

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -988,6 +988,8 @@ class _BuiltModule:
     has_environment: bool = False
     command_lookup: _GetCommandArgs | None = None
     process_result: _ProcessResult | None = None
+    b_module_args_json: bytes | None = None
+    """Serialized module args JSON, passed to the module via stdin instead of embedded in the wrapper."""
 
     def get_command_args(
         self,
@@ -1124,6 +1126,7 @@ def _find_module_utils(
     has_environment = False
     command_lookup: _GetCommandArgs | None = None
     process_result: _ProcessResult | None = None
+    b_module_args_json: bytes | None = None
 
     if module_substyle == 'python':
         date_time = datetime.datetime.now(datetime.timezone.utc)
@@ -1225,12 +1228,14 @@ def _find_module_utils(
         encoder = get_module_encoder(cached_module.metadata.serialization_profile, Direction.CONTROLLER_TO_MODULE)
 
         try:
-            encoded_params = json.dumps(params, cls=encoder)
+            b_module_args_json = to_bytes(json.dumps(params, cls=encoder))
         except TypeError as ex:
             raise AnsibleError(f'Failed to serialize arguments for the {module_name!r} module.') from ex
 
         extension_manager.source_mapping = cached_module.source_mapping
 
+        # Build the wrapper without module args — args are passed via stdin at
+        # execution time, making the wrapper host-independent and cacheable.
         code = _get_ansiballz_code(shebang)
         args = dict(
             ansible_module=module_name,
@@ -1238,7 +1243,6 @@ def _find_module_utils(
             profile=cached_module.metadata.serialization_profile,
             date_time=date_time,
             rlimit_nofile=rlimit_nofile,
-            params=encoded_params,
             extensions=extension_manager.get_extensions(),
             zip_data=to_text(cached_module.zip_data),
         )
@@ -1385,6 +1389,7 @@ if __name__ == "__main__":
         has_environment=has_environment,
         command_lookup=command_lookup,
         process_result=process_result,
+        b_module_args_json=b_module_args_json,
     )
 
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1151,9 +1151,19 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
 
         else:
             if self._is_pipelining_enabled(module_style):
-                in_data = module_data
+                if module_bits.b_module_args_json is not None:
+                    # Pipelining sends the script via stdin, so we can't also
+                    # pass args via stdin.  Prepend args as a global variable
+                    # that the wrapper reads instead.
+                    in_data = b'_ANSIBALLZ_PARAMS = ' + module_bits.b_module_args_json + b'\n' + module_data
+                else:
+                    in_data = module_data
             else:
                 cmd = remote_module_path
+                # For new-style Python modules (AnsiballZ), pass args via stdin
+                # instead of embedding them in the wrapper script.
+                if module_bits.b_module_args_json is not None:
+                    in_data = module_bits.b_module_args_json
 
             cmd = self._connection._shell.build_module_command(environment_string, shebang, cmd, arg_path=args_file_path).strip()
 


### PR DESCRIPTION
## Summary

- Pass module arguments via stdin (non-pipelining) or as a prepended global variable (pipelining) instead of embedding them in the AnsiballZ wrapper script
- Makes the wrapper host-independent, eliminating redundant per-host processing of the 200-500KB base64 zip payload
- Reduces per-host cost from "rebuild 300KB+ wrapper string" to "serialize small args JSON + concatenate with cached wrapper bytes"

Fixes #86629

## Details

The AnsiballZ wrapper embeds module args directly via the `params` key. Since args are host-specific (templated variables), this forces the entire wrapper to be rebuilt per host, redundantly processing the base64-encoded zip through `to_text` -> `repr` -> f-string -> `to_bytes` (~1.2MB of string allocation per host).

This PR separates args from the wrapper:

- **`_wrapper.py`**: `params` argument made optional. Falls back to `_ANSIBALLZ_PARAMS` global (pipelining) then stdin (non-pipelining).
- **`module_common.py`**: New `b_module_args_json` field on `_BuiltModule`. Args serialized separately instead of embedded in wrapper args dict.
- **`action/__init__.py`**: Routes args via stdin or prepends as global variable depending on pipelining mode.

## Test plan

- [x] `test/units/executor/module_common/test_module_common.py` — 39/39 passed
- [x] `test/units/plugins/action/test_action.py` — 17/17 passed
- [ ] Integration testing with multi-host playbooks to verify args delivery via both pipelining and non-pipelining paths
