### PR TITLE
Default pipelining to true for local connections

### DIFF
--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -12,6 +12,23 @@ DOCUMENTATION = """
     author: ansible (@core)
     version_added: historical
     options:
+        pipelining:
+            default: true
+            description:
+                - Pipelining reduces the number of file operations required to execute a module on the controller,
+                  by piping the module data directly to the Python interpreter instead of writing to a temporary file.
+                - For local connections this defaults to C(true) since there is no remote host and no C(requiretty)
+                  concern. This avoids unnecessary temporary file creation and cleanup on the controller.
+            env:
+                - name: ANSIBLE_PIPELINING
+            ini:
+                - section: defaults
+                  key: pipelining
+                - section: connection
+                  key: pipelining
+            type: boolean
+            vars:
+                - name: ansible_pipelining
         become_success_timeout:
             version_added: '2.19'
             type: int
@@ -29,8 +46,6 @@ DOCUMENTATION = """
                 - Strip internal become output preceding command execution. Disable for additional diagnostics.
             vars:
                 - name: ansible_local_become_strip_preamble
-    extends_documentation_fragment:
-        - connection_pipelining
     notes:
         - The remote user is ignored, the user with which the ansible CLI was executed is used instead.
 """


### PR DESCRIPTION
## Summary

- Default `pipelining: true` for the local connection plugin instead of inheriting the global `false` default
- Eliminates unnecessary temp file write/copy/execute/cleanup cycle for local task execution
- The local connection already declares `has_pipelining = True` — pipelining was only off due to the inherited global default

Fixes #86630

## Details

The global pipelining default is `false` because of `requiretty` in sudoers on remote hosts — `sudo` with pipelining conflicts with become when a TTY is required. For local connections this does not apply:

- The controller already has a TTY
- `local.py` creates a PTY when `become.expect_prompt()` is true
- Users who hit issues can still set `ansible_pipelining: false` per host/group

Without pipelining, even local tasks write the AnsiballZ wrapper to a temp file, `shutil.copyfile()` it to a "remote" path (which is also local), execute it, then clean up — all unnecessary I/O.

## Test plan

- [x] `test/units/plugins/action/test_action.py` — 17/17 passed
- [ ] Integration testing with local connection + become scenarios
