### PR TITLE
core: Add filter to convert PPA uri to URL

### DIFF
--- a/changelogs/fragments/ppa_2_url.yml
+++ b/changelogs/fragments/ppa_2_url.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - core - Add filter to convert PPA uri to URL.

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -13,6 +13,9 @@ module: deb822_repository
 notes:
 - This module will not automatically update caches, call the M(ansible.builtin.apt) module based
   on the changed state.
+seealso:
+    - plugin_type: filter
+      plugin: ansible.builtin.ppa_to_url
 options:
     allow_downgrade_to_insecure:
         description:
@@ -216,6 +219,17 @@ EXAMPLES = """
     components: stable
     architectures: amd64
     signed_by: https://download.example.com/linux/ubuntu/gpg
+
+- name: Add repo using PPA
+  deb822_repository:
+    name: example
+    types: deb
+    uris: "{{ 'ppa:user/ppa-name' | ppa_to_url }}"
+    suites: '{{ ansible_distribution_release }}'
+    components: stable
+    architectures: amd64
+    signed_by: "{{ 'ppa:user/ppa-name' | ppa_to_url }}/gpg"
+
 """
 
 RETURN = """

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -21,6 +21,7 @@ import typing as t
 from collections.abc import Mapping
 from functools import partial
 from random import Random, SystemRandom, shuffle
+from urllib.parse import urlparse
 
 from jinja2.filters import do_map, do_select, do_selectattr, do_reject, do_rejectattr, pass_environment, sync_do_groupby
 from jinja2.environment import Environment
@@ -729,6 +730,53 @@ def type_debug(obj: object) -> str:
     return native_type_name(obj)
 
 
+def ppa_to_url(url: str) -> str:
+    expected_format_msg = f"Invalid PPA format: {url}. Expected format: ppa:user/ppa-name, user/ppa-name, or user"
+    if ":" not in url:
+        # Handle user/ppa-name and user formats
+        url = f"ppa:{url}"
+
+    (prefix, dummy, ppa_path) = url.rpartition(':')
+    if not prefix == 'ppa':
+        raise ValueError(expected_format_msg) from None
+
+    (user, dummy, ppa_name) = ppa_path.partition('/')
+    user = user.lstrip('~')
+    if '/' in ppa_name:
+        ubuntu_version, dummy, ppa_name = ppa_name.partition('/')
+        if ubuntu_version != 'ubuntu' or '/' in ppa_name:
+            raise ValueError(expected_format_msg) from None
+    ppa_name = ppa_name or 'ppa'
+    return f"https://ppa.launchpad.net/{user}/{ppa_name}/ubuntu"
+
+
+def url_to_ppa(url: str) -> str:
+    expected_format_msg = (
+        f"Invalid URL format: {url}. "
+        "Expected format: https://launchpad.net/~user/+archive/ubuntu/package "
+        "or https://ppa.launchpad.net/user/package/ubuntu"
+    )
+    if "://" not in url:
+        url = f"https://{url}"
+
+    parsed_url = urlparse(url)
+    if parsed_url.netloc == 'launchpad.net':
+        path = parsed_url.path.split('/')
+        if len(path) != 5:
+            raise ValueError(expected_format_msg) from None
+        user = path[1].replace('~', '')
+        ppa_name = path[-1]
+        return f"ppa:{user}/{ppa_name}"
+    elif parsed_url.netloc == 'ppa.launchpad.net':
+        path = parsed_url.path.split('/')
+        if len(path) != 4:
+            raise ValueError(expected_format_msg) from None
+        user = path[1].replace('~', '')
+        ppa_name = path[2]
+        return f"ppa:{user}/{ppa_name}"
+    raise ValueError(expected_format_msg) from None
+
+
 class FilterModule(object):
     """ Ansible core jinja2 filters """
 
@@ -832,4 +880,7 @@ class FilterModule(object):
             'selectattr': wrapped_selectattr,
             'reject': wrapped_reject,
             'rejectattr': wrapped_rejectattr,
+
+            'ppa_to_url': ppa_to_url,
+            'url_to_ppa': url_to_ppa,
         }

--- a/lib/ansible/plugins/filter/ppa_to_url.yml
+++ b/lib/ansible/plugins/filter/ppa_to_url.yml
@@ -1,0 +1,38 @@
+DOCUMENTATION:
+  name: ppa_to_url
+  author: ansible core team
+  version_added: "2.21"
+  short_description: convert a PPA URI to a URL
+  description:
+    - Converts a PPA URI to a URL.
+    - This can be used with conjunction with the M(ansible.builtin.deb822_repository) module
+      to add a PPA repository to the system.
+  positional: _input
+  options:
+    _input:
+      description:
+        - A PPA URI to convert to a URL.
+        - The input can be in the format of ppa:user/ppa-name, user/ppa-name, or user.
+      type: string
+      required: true
+  seealso:
+    - plugin_type: module
+      plugin: ansible.builtin.deb822_repository
+EXAMPLES: |
+
+  # => https://ppa.launchpad.net/user/ppa-name/ubuntu
+  {{ 'ppa:user/ppa-name' | ppa_to_url }}
+
+  # => https://ppa.launchpad.net/user/ppa-name/ubuntu
+  {{ 'user/ppa-name' | ppa_to_url }}
+
+  # => https://ppa.launchpad.net/user/ppa/ubuntu
+  {{ 'user' | ppa_to_url }}
+
+  # => https://ppa.launchpad.net/~user/ppa-name/ubuntu
+  {{ 'ppa:~user/ppa-name' | ppa_to_url }}
+
+RETURN:
+  _value:
+    description: The URL of the PPA URI.
+    type: string

--- a/lib/ansible/plugins/filter/url_to_ppa.yml
+++ b/lib/ansible/plugins/filter/url_to_ppa.yml
@@ -1,0 +1,32 @@
+DOCUMENTATION:
+  name: url_to_ppa
+  author: ansible core team
+  version_added: "2.21"
+  short_description: convert a URL to a PPA URI
+  description:
+    - Converts a URL to a PPA URI.
+  positional: _input
+  options:
+    _input:
+      description:
+        - A URL to convert to a PPA URI.
+        - The input can be in the format of https://launchpad.net/~user/+archive/ubuntu/package
+          or https://ppa.launchpad.net/user/package/ubuntu.
+        - The tilde (~) in the user name is optional in the input.
+      type: string
+      required: true
+  seealso:
+    - plugin_type: module
+      plugin: ansible.builtin.deb822_repository
+EXAMPLES: |
+
+  # => ppa:user/package
+  {{ 'https://launchpad.net/~user/+archive/ubuntu/package' | url_to_ppa }}
+
+  # => ppa:user/package
+  {{ 'https://ppa.launchpad.net/user/package/ubuntu' | url_to_ppa }}
+
+RETURN:
+  _value:
+    description: The PPA URI.
+    type: string

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -863,3 +863,7 @@
       - "'|commonpath expects' in commonpath_02.msg"
 
 - include_tasks: password_hash.yml
+
+- include_tasks: ppa_to_url.yml
+
+- include_tasks: url_to_ppa.yml

--- a/test/integration/targets/filter_core/tasks/ppa_to_url.yml
+++ b/test/integration/targets/filter_core/tasks/ppa_to_url.yml
@@ -1,0 +1,47 @@
+- name: Test ppa_to_url filter
+  set_fact:
+    ppa_url: 'ppa:user/ppa-name'
+    ppa_without_prefix: 'user/ppa-name'
+    ppa_without_ppaname: 'user'
+    ppa_with_tilde: 'ppa:~user/ppa-name'
+    invalid_ppa: 'ppa:user/ppa-name/invalid'
+    ppa_with_ubuntu_version: 'ppa:user/ubuntu/ppa-name'
+    invalid_ppa_with_no_ubuntu_version: 'ppa:user/ppa-name/sample'
+    expected_url: 'https://ppa.launchpad.net/user/ppa-name/ubuntu'
+    expected_url_without_prefix: 'https://ppa.launchpad.net/user/ppa-name/ubuntu'
+    expected_url_without_ppaname: 'https://ppa.launchpad.net/user/ppa/ubuntu'
+    expected_url_with_tilde: 'https://ppa.launchpad.net/user/ppa-name/ubuntu'
+    expected_url_ppa_with_ubuntu_version: 'https://ppa.launchpad.net/user/ppa-name/ubuntu'
+
+- name: Verify ppa_to_url filter
+  assert:
+    that:
+      - ppa_url | ppa_to_url == expected_url
+      - ppa_without_prefix | ppa_to_url == expected_url_without_prefix
+      - ppa_without_ppaname | ppa_to_url == expected_url_without_ppaname
+      - ppa_with_tilde | ppa_to_url == expected_url_with_tilde
+      - ppa_with_ubuntu_version | ppa_to_url == expected_url_ppa_with_ubuntu_version
+
+- name: Test ppa_to_url filter with invalid format
+  set_fact:
+    foo: '{{ invalid_ppa | ppa_to_url }}'
+  ignore_errors: yes
+  register: ppa_to_url_invalid_ppa
+
+- name: Verify ppa_to_url filter with invalid format
+  assert:
+    that:
+      - ppa_to_url_invalid_ppa is failed
+      - "'Invalid PPA format' in ppa_to_url_invalid_ppa.msg"
+
+- name: Test ppa_to_url filter with invalid format
+  set_fact:
+    foo: '{{ invalid_ppa_with_no_ubuntu_version | ppa_to_url }}'
+  ignore_errors: yes
+  register: ppa_to_url_invalid_ppa_with_no_ubuntu_version
+
+- name: Verify ppa_to_url filter with invalid format
+  assert:
+    that:
+      - ppa_to_url_invalid_ppa_with_no_ubuntu_version is failed
+      - "'Invalid PPA format' in ppa_to_url_invalid_ppa_with_no_ubuntu_version.msg"

--- a/test/integration/targets/filter_core/tasks/url_to_ppa.yml
+++ b/test/integration/targets/filter_core/tasks/url_to_ppa.yml
@@ -1,0 +1,25 @@
+- name: Test url_to_ppa filter
+  set_fact:
+    launchpad_url: 'https://launchpad.net/~user/+archive/ubuntu/package'
+    ppa_url: 'https://ppa.launchpad.net/user/package/ubuntu'
+    expected_ppa: 'ppa:user/package'
+    invalid_url: 'https://launchpad.net/~user/+archive/ubuntu/package/invalid'
+    invalid_netloc: 'https://invalid.launchpad.net/~user/+archive/ubuntu/package/ubuntu'
+
+- set_fact:
+    foo: '{{ invalid_url | url_to_ppa }}'
+  ignore_errors: yes
+  register: url_to_ppa_invalid_url
+
+- set_fact:
+    foo: '{{ invalid_netloc | url_to_ppa }}'
+  ignore_errors: yes
+  register: url_to_ppa_invalid_netloc
+
+- name: Verify url_to_ppa filter
+  assert:
+    that:
+      - url_to_ppa_invalid_url is failed
+      - "'Invalid URL format' in url_to_ppa_invalid_url.msg"
+      - url_to_ppa_invalid_netloc is failed
+      - "'Invalid URL format' in url_to_ppa_invalid_netloc.msg"


### PR DESCRIPTION
##### SUMMARY

* Add support for converting PPA uri to URL
  for deb822_repository and other usage

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/ppa_2_url.yml
lib/ansible/modules/deb822_repository.py
lib/ansible/plugins/filter/core.py
lib/ansible/plugins/filter/ppa_to_url.yml
test/integration/targets/filter_core/tasks/main.yml


