### PR TITLE
Add new psrp options and change service default

### DIFF
--- a/changelogs/fragments/psrp-options.yml
+++ b/changelogs/fragments/psrp-options.yml
@@ -1,0 +1,17 @@
+minor_changes:
+  - >-
+    psrp - Added the ``no_profile`` option through the variable ``ansible_psrp_no_profile`` that can stop the remote
+    Windows host from loading the user profile on the Ansible tasks. This option requires ``pypsrp>=0.9.0`` to be
+    installed in the Ansible environment.
+  - >-
+    psrp - Added the ``certificate_key_password`` option through the variable ``ansible_psrp_certificate_key_password``
+    that can be used to decrypt the key specified by ``certificate_key_pem``. This option requires ``pypsrp>=0.9.0`` to
+    be installed in the Ansible environment.
+
+breaking_changes:
+  - >-
+    psrp - Changed the default of ``negotiate_service`` used to build the Kerberos Service Principal Name from
+    ``WSMAN`` to ``host``. This aligns the defaults to how the native PowerShell PSRemoting client works on Windows
+    and ensures that Kerberos can be used by more Windows targets by default. No deprecation period is used for this
+    change as ``host`` is a builtin SPN to Windows and should improve compatibility out of the box. To go back to the
+    old behaviour for any reason, set ``ansible_psrp_negotiate_service=WSMAN`` in the host vars.

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -193,6 +193,7 @@ options:
   certificate_key_pem:
     description:
     - The local path to an X509 certificate key to use with certificate auth.
+    - If the certificate key is encrypted then O(certificate_key_password) must also be set.
     type: path
     vars:
     - name: ansible_psrp_certificate_key_pem
@@ -202,6 +203,14 @@ options:
     type: path
     vars:
     - name: ansible_psrp_certificate_pem
+  certificate_key_password:
+    description:
+    - The password for the O(certificate_key_pem) key file if it is encrypted.
+    - This option requires pypsrp >= 0.9.0 to be installed.
+    type: str
+    vars:
+    - name: ansible_psrp_certificate_key_password
+    version_added: '2.21'
   credssp_auth_mechanism:
     description:
     - The sub authentication mechanism to use with CredSSP auth.
@@ -271,7 +280,9 @@ options:
     - Only valid when Kerberos was the negotiated auth or was explicitly set as
       the authentication.
     - Ignored when NTLM was the negotiated auth.
-    default: WSMAN
+    - Before Ansible 2.21 this had a default value of V(WSMAN) which failed to
+      work on some hosts. Since Ansible 2.21 the default value is V(host).
+    default: host
     type: str
     vars:
     - name: ansible_psrp_negotiate_service
@@ -302,6 +313,15 @@ options:
     vars:
     - name: ansible_psrp_configuration_name
     default: Microsoft.PowerShell
+  no_profile:
+    description:
+    - Do not load the user's PowerShell profile when connecting.
+    - This option requires pypsrp >= 0.9.0 to be installed.
+    type: bool
+    default: false
+    vars:
+    - name: ansible_psrp_no_profile
+    version_added: '2.21'
 """
 
 import base64
@@ -396,11 +416,11 @@ class Connection(ConnectionBase):
 
             self.runspace = RunspacePool(
                 connection, host=self.host,
-                configuration_name=self._psrp_configuration_name
+                **self._psrp_runspace_kwargs,
             )
             display.vvvvv(
                 "PSRP OPEN RUNSPACE: auth=%s configuration=%s endpoint=%s" %
-                (self._psrp_auth, self._psrp_configuration_name,
+                (self._psrp_auth, self._psrp_runspace_kwargs.get('configuration_name', 'Unknown'),
                  connection.transport.endpoint), host=self._psrp_host
             )
             try:
@@ -601,7 +621,12 @@ class Connection(ConnectionBase):
 
         self._psrp_port = int(port)
         self._psrp_auth = self.get_option('auth')
-        self._psrp_configuration_name = self.get_option('configuration_name')
+
+        self._psrp_runspace_kwargs = dict(
+            configuration_name=self.get_option('configuration_name'),
+        )
+        if no_profile := self.get_option('no_profile'):
+            self._psrp_runspace_kwargs['no_profile'] = no_profile
 
         # cert validation can either be a bool or a path to the cert
         cert_validation = self.get_option('cert_validation')
@@ -641,6 +666,12 @@ class Connection(ConnectionBase):
             negotiate_hostname_override=self.get_option('negotiate_hostname_override'),
             negotiate_service=self.get_option('negotiate_service'),
         )
+
+        # We don't always set this in case we are working with an older pypsrp
+        # version that doesn't support this option.
+        certificate_key_password = self.get_option('certificate_key_password')
+        if certificate_key_password:
+            self._psrp_conn_kwargs['certificate_key_password'] = certificate_key_password
 
     def _exec_psrp_script(
         self,

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -280,8 +280,8 @@ options:
     - Only valid when Kerberos was the negotiated auth or was explicitly set as
       the authentication.
     - Ignored when NTLM was the negotiated auth.
-    - Before Ansible 2.21 this had a default value of V(WSMAN) which failed to
-      work on some hosts. Since Ansible 2.21 the default value is V(host).
+    - Before ansible-core 2.21, this had a default value of V(WSMAN) which failed to
+      work on some hosts. Since ansible-core 2.21 the default value is V(host).
     default: host
     type: str
     vars:

--- a/test/units/plugins/connection/test_psrp.py
+++ b/test/units/plugins/connection/test_psrp.py
@@ -52,7 +52,9 @@ class TestConnectionPSRP(object):
             {},
             {
                 '_psrp_auth': 'negotiate',
-                '_psrp_configuration_name': 'Microsoft.PowerShell',
+                '_psrp_runspace_kwargs': {
+                    'configuration_name': 'Microsoft.PowerShell',
+                },
                 '_psrp_host': 'inventory_hostname',
                 '_psrp_conn_kwargs': {
                     'server': 'inventory_hostname',
@@ -77,7 +79,7 @@ class TestConnectionPSRP(object):
                     'negotiate_delegate': None,
                     'negotiate_hostname_override': None,
                     'negotiate_send_cbt': True,
-                    'negotiate_service': 'WSMAN',
+                    'negotiate_service': 'host',
                     'read_timeout': 30,
                     'reconnection_backoff': 2.0,
                     'reconnection_retries': 0,
@@ -145,7 +147,7 @@ class TestConnectionPSRP(object):
                     'negotiate_delegate': None,
                     'negotiate_hostname_override': None,
                     'negotiate_send_cbt': True,
-                    'negotiate_service': 'WSMAN',
+                    'negotiate_service': 'host',
                     'read_timeout': 30,
                     'reconnection_backoff': 2.0,
                     'reconnection_retries': 0,


### PR DESCRIPTION
##### SUMMARY
Add new options to the `psrp` connection plugin to specify the profile loading behaviour and a password to use for decrypting the certificate authentication private key.

This also changes the `negotiate_service` default from `WSMAN` to `host` to improve compatibility with Windows targets that may not have the `WSMAN` SPN registered like domain controllers and align with the defaults the native PowerShell PSRemoting client uses.

##### ISSUE TYPE
- Feature Pull Request