### PR TITLE
Replace relative links in the issue templates with absolute links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
       [communication]:
       https://docs.ansible.com/ansible/devel/community/communication.html
 
-      [issue search]: ../search?q=is%3Aissue&type=issues
+      [issue search]: https://github.com/ansible/ansible/search?q=is%3Aissue&type=issues
 
       [XKCD 1172]: https://xkcd.com/1172/
 

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -31,7 +31,7 @@ body:
       [communication]:
       https://docs.ansible.com/ansible/devel/community/communication.html
 
-      [issue search]: ../search?q=is%3Aissue&type=issues
+      [issue search]: https://github.com/ansible/ansible/search?q=is%3Aissue&type=issues
 
       [submit a pull request]:
       https://docs.ansible.com/ansible-core/devel/community/documentation_contributions.html

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -55,12 +55,12 @@ body:
       [communication]:
       https://docs.ansible.com/ansible/devel/community/communication.html
 
-      [issue search]: ../search?q=is%3Aissue&type=issues
+      [issue search]: https://github.com/ansible/ansible/search?q=is%3Aissue&type=issues
 
       [forum help]:
       https://forum.ansible.com/c/help/6
 
-      [new proposal]: ../../proposals/issues/new
+      [new proposal]: https://github.com/ansible/proposals/issues/new
 
 
 - type: textarea
@@ -90,7 +90,7 @@ body:
       instead outlining your research and implementation considerations.
 
 
-      [new proposal]: ../../proposals/issues/new
+      [new proposal]: https://github.com/ansible/proposals/issues/new
     placeholder: >-
       I am trying to do X with ansible-core from the devel branch on GitHub and
       I think that implementing a feature Y would be very helpful for me and


### PR DESCRIPTION
##### SUMMARY

Fixes #86552

The relative links don't work when accessed from the `New Issue` option in https://github.com/ansible/ansible/issues.

##### ISSUE TYPE

- Bugfix Pull Request
