### PR TITLE
find: add locale encoding in err msg when none is given

### DIFF
--- a/changelogs/fragments/find-default-encoding.yml
+++ b/changelogs/fragments/find-default-encoding.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - find - add locale encoding in err msg when none is given

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -152,6 +152,7 @@ options:
     encoding:
         description:
             - When doing a O(contains) search, determine the encoding of the files to be searched.
+            - When no value is provided, the Python default encoding is used.
         type: str
         version_added: "2.17"
     limit:
@@ -283,6 +284,7 @@ skipped_paths:
 import errno
 import fnmatch
 import grp
+import locale
 import os
 import pwd
 import re
@@ -388,8 +390,13 @@ def contentfilter(fsname, pattern, encoding, read_whole_file=False):
         raise e
     except UnicodeDecodeError as e:
         if encoding is None:
-            encoding = 'None (default determined by the Python built-in function "open")'
-        msg = f'Failed to read the file {fsname} due to an encoding error. current encoding: {encoding}'
+            # Get the default encoding for the current locale
+            # This is the same encoding that the open() function uses by default
+            # when no encoding is specified. This value is platform dependent.
+            #
+            # https://docs.python.org/3/library/functions.html#open
+            encoding = f"{locale.getpreferredencoding(False).lower()} (Python default)"
+        msg = f'Failed to decode the file {fsname!r} with encoding: {encoding}'
         raise Exception(msg) from e
     except Exception:
         pass

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -211,7 +211,23 @@
           - fail_to_read_wrong_encoding_file.msg == 'Not all paths examined, check warnings for details'
           - >-
               fail_to_read_wrong_encoding_file.skipped_paths[remote_tmp_dir_test] ==
-              ("Failed to read the file %s/hello_world.gbk due to an encoding error. current encoding: utf-8" % (remote_tmp_dir_test))
+              ("Failed to decode the file '%s/hello_world.gbk' with encoding: utf-8" % (remote_tmp_dir_test))
+
+- name: read a gbk file with no encoding specified (uses locale default)
+  find:
+    paths: "{{ remote_tmp_dir_test }}"
+    patterns: "*.gbk"
+    contains: "你好世界"
+  register: fail_to_read_default_encoding
+
+- name: Verify error message shows locale encoding name
+  vars:
+    error_pattern: 'Failed to decode the file .+ with encoding: .+ \(Python default\)'
+  assert:
+    that:
+      - fail_to_read_default_encoding.msg == 'Not all paths examined, check warnings for details'
+      - fail_to_read_default_encoding.skipped_paths[remote_tmp_dir_test] is search("^" + error_pattern + "$")
+      - fail_to_read_default_encoding.warnings | select('search', error_pattern) | list | length >= 1
 
 - name: read a gbk file by gbk
   find:


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
When the search fails, as expected, the following error is printed out:

    [...] Failed to read the file FILENAME due to an encoding error. current encoding: None (default determined by the Python built-in function "open")

Add [locale encoding](https://docs.python.org/3/library/locale.html#locale.getencoding) in error messages when none is given.

As well, this case is hit for [decoding exceptions](https://github.com/ansible/ansible/blob/895481957b6613ad7e0e511c98914c4ebec111cc/lib/ansible/modules/find.py#L389), not encoding ones.

Change the error message.

Add the corresponding tests, update documentation.

The tests were AI-generated, they pass locally:

```shell
# bin/ansible-test units --venv
[...]
Unit test controller with Python 3.12
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/a-otilibili/src/ansible
configfile: test/lib/ansible_test/_data/pytest/config/default.ini
plugins: xdist-3.8.0, mock-3.15.1
created: 14/14 workers
14 workers [4302 items]
[...]
========== 4275 passed, 2 skipped, 25 xfailed, 67 warnings in 16.73s ===========
```

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
