### PR TITLE
Added handling of path names on Windows targets

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import json
 import os
 import os.path
+import ntpath
 import stat
 import tempfile
 
@@ -294,7 +295,11 @@ class ActionModule(ActionBase):
             tmp_src = self._connection._shell.join_path(self._connection._shell.tmpdir, '.source')
 
             # ensure we keep suffix for validate
-            suffix = os.path.splitext(dest_file)[1]
+            if getattr(self._connection._shell, "_IS_WINDOWS", False):
+                suffix = ntpath.splitext(dest_file)[1]
+            else:
+                suffix = os.path.splitext(dest_file)[1]
+
             if suffix:
                 tmp_src += suffix
 


### PR DESCRIPTION
When using sftp/scp against a Windows host, the ansible.builtin.copy module failed to correctly calculate the file suffix if the directory name starts (or contains) a dot (for example: (".a/b")

##### SUMMARY

Even though the official documentation of `ansible.builtin.copy` states "for Windows targets, use the ansible.windows.win_copy module instead", WinRM is incredibly slow, so I'm using SSH instead and it seems to be working fine (?). The only issue I've noticed is that, when copying directories containing a dot, like (`b/.b/b`), the command was failing like this:
```
[ERROR]: Task failed: failed to transfer file to /tmp/tmp.ygKmxV2WSX/ansible-tests/tools-to-install/b/.b/b /C:/Users/Administrator/AppData/Local/Temp/ansible-tmp-1773560138.7718484-8900-39598762715548/.source.b/b:

scp: dest open "/C:/Users/Administrator/AppData/Local/Temp/ansible-tmp-1773560138.7718484-8900-39598762715548/.source.b/b": No such file or directory
scp: failed to upload file /tmp/tmp.ygKmxV2WSX/ansible-tests/tools-to-install/b/.b/b to /C:/Users/Administrator/AppData/Local/Temp/ansible-tmp-1773560138.7718484-8900-39598762715548/.source.b/b
Origin: /tmp/tmp.ygKmxV2WSX/ansible-tests/playbook.yaml:4:5

2   hosts: targets
3   tasks:
4   - name: Copy tools
      ^ column 5

fatal: [192.168.0.66]: FAILED! => {
    "changed": false,
    "msg": "Task failed: failed to transfer file to /tmp/tmp.ygKmxV2WSX/ansible-tests/tools-to-install/b/.b/b /C:/Users/Administrator/AppData/Local/Temp/ansible-tmp-1773560138.7718484-8900-39598762715548/.source.b/b:\n\nscp: dest open \"/C:/Users/Administrator/AppData/Local/Temp/ansible-tmp-1773560138.7718484-8900-39598762715548/.source.b/b\": No such file or directory\r\nscp: failed to upload file /tmp/tmp.ygKmxV2WSX/ansible-tests/tools-to-install/b/.b/b to /C:/Users/Administrator/AppData/Local/Temp/ansible-tmp-1773560138.7718484-8900-39598762715548/.source.b/b"
}
```

This PR fixes the issue.

##### ISSUE TYPE

- Bugfix Pull Request