### PR TITLE
user: warn when seuser is set on systems without SELinux

### DIFF
--- a/changelogs/fragments/85542-user-seuser-warning.yml
+++ b/changelogs/fragments/85542-user-seuser-warning.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - user - emit a warning when the ``seuser`` parameter is set on a system where
+    SELinux is not enabled, instead of silently ignoring it
+    (https://github.com/ansible/ansible/issues/85542).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -745,7 +745,7 @@ class User(object):
             if self.non_unique:
                 cmd.append('-o')
 
-        if self.seuser is not None:
+        if self.seuser is not None and self.module.selinux_enabled():
             cmd.append('-Z')
             cmd.append(self.seuser)
         if self.group is not None:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -45,6 +45,8 @@ options:
     seuser:
         description:
             - Optionally sets the C(seuser) type C(user_u) on SELinux enabled systems.
+            - This parameter is silently ignored on systems where SELinux is not enabled.
+              A warning will be emitted in this case.
         type: str
         version_added: "2.1"
     group:
@@ -3424,6 +3426,12 @@ def main():
 
     user = User(module)
     user.check_password_encrypted()
+
+    if user.seuser is not None and not module.selinux_enabled():
+        module.warn(
+            f"'seuser' is set to '{user.seuser}' but SELinux is not enabled on "
+            f"this system. The 'seuser' parameter will be ignored."
+        )
 
     module.debug('User instantiated - platform %s' % user.platform)
     if user.distribution:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -34,4 +34,5 @@
     - ansible_distribution != 'Alpine'
 - include_tasks: test_freebsd_nonexistent.yml
   when: ansible_facts.system == 'FreeBSD'
+- import_tasks: test_seuser_warning.yml
 - import_tasks: ssh_keygen.yml

--- a/test/integration/targets/user/tasks/test_seuser_warning.yml
+++ b/test/integration/targets/user/tasks/test_seuser_warning.yml
@@ -1,0 +1,24 @@
+- name: test seuser parameter emits warning when SELinux is not enabled
+  when: not ansible_facts.selinux.status is defined or ansible_facts.selinux.status != 'enabled'
+  block:
+    - name: create user with seuser on non-SELinux system
+      user:
+        name: ansibulluser_seuser
+        state: present
+        seuser: user_u
+      register: user_seuser_result
+
+    - name: validate warning is emitted for seuser on non-SELinux system
+      assert:
+        that:
+          - user_seuser_result.warnings is defined
+          - user_seuser_result.warnings | length > 0
+          - "'seuser' in user_seuser_result.warnings[0]"
+          - "'SELinux' in user_seuser_result.warnings[0]"
+          - "'ignored' in user_seuser_result.warnings[0]"
+
+  always:
+    - name: remove test user
+      user:
+        name: ansibulluser_seuser
+        state: absent


### PR DESCRIPTION
##### SUMMARY

When the `seuser` parameter is provided but SELinux is not enabled on the target system, the module silently ignores it and reports `changed: true`, misleading users into thinking SELinux user mappings were applied.

This PR adds a runtime check using `module.selinux_enabled()` and emits a warning when `seuser` is set on a system without SELinux. It also skips passing `-Z` to `useradd` to prevent the command from failing on non-SELinux systems.

This approach checks SELinux availability at runtime rather than relying on platform type, as [recommended by @samdoran](https://github.com/ansible/ansible/pull/85649#discussion_r1792917697) in the previous PR.

Supersedes #86662, which was closed due to unsigned commits.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

user

##### ADDITIONAL INFORMATION

**Changes:**
- `lib/ansible/modules/user.py`: Add SELinux check after user instantiation, emit warning via `module.warn()` when `seuser` is set but SELinux is not enabled. Skip passing `-Z` to `useradd` when SELinux is disabled. Updated parameter documentation.
- `test/integration/targets/user/tasks/test_seuser_warning.yml`: Integration test validating the warning is emitted on non-SELinux systems.
- `changelogs/fragments/85542-user-seuser-warning.yml`: Changelog fragment.

Fixes #85542