### PR TITLE
apt_repository: use UBUNTU_CODENAME for PPA on derivative distros

### DIFF
--- a/changelogs/fragments/apt_repository-derivative-codename.yml
+++ b/changelogs/fragments/apt_repository-derivative-codename.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - >-
+    apt_repository - Use ``UBUNTU_CODENAME`` from ``os-release`` when available so that
+    PPA URLs on Ubuntu derivatives (Linux Mint, Pop!_OS, etc.) resolve to the correct
+    Ubuntu codename instead of the derivative's own codename
+    (https://github.com/ansible/ansible/issues/86610).

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -445,9 +445,27 @@ class UbuntuSourcesList(SourcesList):
     LP_API = 'https://api.launchpad.net/1.0/~%s/+archive/%s'
     PPA_URI = 'https://ppa.launchpadcontent.net'
 
+    _OS_RELEASE_PATHS = ('/etc/os-release', '/usr/lib/os-release')
+
+    @classmethod
+    def _ubuntu_codename(cls):
+        """Read UBUNTU_CODENAME from os-release for derivative distros (Mint, Pop!_OS, etc.)."""
+        for path in cls._OS_RELEASE_PATHS:
+            try:
+                with open(path) as f:
+                    for line in f:
+                        k, _sep, v = line.partition('=')
+                        if k.strip() == 'UBUNTU_CODENAME':
+                            v = v.strip().strip('"')
+                            if v:
+                                return v
+            except FileNotFoundError:
+                continue
+        return None
+
     def __init__(self, module):
         self.module = module
-        self.codename = module.params['codename'] or distro.codename
+        self.codename = module.params['codename'] or self._ubuntu_codename() or distro.codename
         super(UbuntuSourcesList, self).__init__(module)
 
         self.apt_key_bin = self.module.get_bin_path('apt-key', required=False)

--- a/test/units/modules/test_apt_repository.py
+++ b/test/units/modules/test_apt_repository.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from ansible.modules.apt_repository import UbuntuSourcesList
+
+
+class TestUbuntuCodename:
+    """Test _ubuntu_codename() reads UBUNTU_CODENAME from os-release."""
+
+    def _write_os_release(self, tmp_path, content):
+        p = tmp_path / "os-release"
+        p.write_text(content)
+        return str(p)
+
+    def test_derivative_returns_ubuntu_codename(self, tmp_path, monkeypatch):
+        path = self._write_os_release(tmp_path, (
+            'ID=linuxmint\n'
+            'VERSION_CODENAME=zara\n'
+            'UBUNTU_CODENAME=noble\n'
+        ))
+        monkeypatch.setattr(UbuntuSourcesList, '_OS_RELEASE_PATHS', (path,))
+        assert UbuntuSourcesList._ubuntu_codename() == 'noble'
+
+    def test_plain_ubuntu(self, tmp_path, monkeypatch):
+        path = self._write_os_release(tmp_path, (
+            'ID=ubuntu\n'
+            'VERSION_CODENAME=noble\n'
+            'UBUNTU_CODENAME=noble\n'
+        ))
+        monkeypatch.setattr(UbuntuSourcesList, '_OS_RELEASE_PATHS', (path,))
+        assert UbuntuSourcesList._ubuntu_codename() == 'noble'
+
+    def test_debian_returns_none(self, tmp_path, monkeypatch):
+        path = self._write_os_release(tmp_path, (
+            'ID=debian\n'
+            'VERSION_CODENAME=bookworm\n'
+        ))
+        monkeypatch.setattr(UbuntuSourcesList, '_OS_RELEASE_PATHS', (path,))
+        assert UbuntuSourcesList._ubuntu_codename() is None
+
+    def test_missing_file_returns_none(self, monkeypatch):
+        monkeypatch.setattr(UbuntuSourcesList, '_OS_RELEASE_PATHS', ('/nonexistent/path',))
+        assert UbuntuSourcesList._ubuntu_codename() is None
+
+    def test_empty_value_skipped(self, tmp_path, monkeypatch):
+        path = self._write_os_release(tmp_path, (
+            'UBUNTU_CODENAME=\n'
+        ))
+        monkeypatch.setattr(UbuntuSourcesList, '_OS_RELEASE_PATHS', (path,))
+        assert UbuntuSourcesList._ubuntu_codename() is None
+
+    def test_quoted_value(self, tmp_path, monkeypatch):
+        path = self._write_os_release(tmp_path, (
+            'UBUNTU_CODENAME="noble"\n'
+        ))
+        monkeypatch.setattr(UbuntuSourcesList, '_OS_RELEASE_PATHS', (path,))
+        assert UbuntuSourcesList._ubuntu_codename() == 'noble'


### PR DESCRIPTION
##### SUMMARY
On Ubuntu derivatives (Linux Mint, Pop!\_OS, etc.) `aptsources.distro.get_distro().codename` returns the derivative's own codename (e.g. `zara` on Mint) instead of the Ubuntu base codename (`noble`). Since PPA URLs always target Ubuntu, the wrong codename produces a 404 from Launchpad.

This reads `UBUNTU_CODENAME` from `/etc/os-release` before falling back to `distro.codename`. The explicit `codename` module parameter still takes precedence.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt_repository

##### ADDITIONAL INFORMATION
Fixes #86610

Priority order:
1. `codename` parameter (user override)
2. `UBUNTU_CODENAME` from os-release (derivative distros set this to the Ubuntu base)
3. `distro.codename` (existing fallback)

Unit tests cover: derivative distro, plain Ubuntu, Debian (returns None), missing file, empty value, and quoted value.