### PR TITLE
apt_repository: preserve whitespace in source lines

### DIFF
--- a/changelogs/fragments/apt_repository-preserve-whitespace.yml
+++ b/changelogs/fragments/apt_repository-preserve-whitespace.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - >-
+    apt_repository - Preserve original whitespace in source lines instead of
+    collapsing multiple spaces to one, which broke cdrom entries with significant
+    spaces inside brackets
+    (https://github.com/ansible/ansible/issues/86024).

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -299,14 +299,14 @@ class SourcesList(object):
             comment = line[i + 1:].strip()
             line = line[:i]
 
-        # Split a source into substring to make sure that it is source spec.
-        # Duplicated whitespaces in a valid source spec will be removed.
+        # Validate that the line starts with a known source type keyword.
+        # Preserve original whitespace so entries like cdrom lines with
+        # significant spaces inside brackets are not mangled.
         source = line.strip()
         if source:
-            chunks = source.split()
-            if chunks[0] in VALID_SOURCE_TYPES:
+            first_word = source.split(None, 1)[0]
+            if first_word in VALID_SOURCE_TYPES:
                 valid = True
-                source = ' '.join(chunks)
 
         if raise_if_invalid_or_disabled and (not valid or not enabled):
             raise InvalidSource(line)

--- a/test/units/modules/test_apt_repository_whitespace.py
+++ b/test/units/modules/test_apt_repository_whitespace.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from ansible.modules.apt_repository import SourcesList
+
+
+class TestParsePreservesWhitespace:
+    """Verify that _parse does not collapse significant whitespace."""
+
+    def test_cdrom_double_space_preserved(self):
+        """Spaces inside cdrom bracket notation must survive round-trip."""
+        src = SourcesList.__new__(SourcesList)
+        line = 'deb cdrom:[OS Astra Linux 1.8.1.6  DVD]/ 1.8_x86-64 contrib main'
+        valid, enabled, source, comment = src._parse(line)
+        assert valid is True
+        assert enabled is True
+        assert '1.8.1.6  DVD' in source, "double space inside brackets was collapsed"
+
+    def test_normal_source_unchanged(self):
+        src = SourcesList.__new__(SourcesList)
+        line = 'deb http://archive.ubuntu.com/ubuntu noble main restricted'
+        valid, enabled, source, comment = src._parse(line)
+        assert valid is True
+        assert source == 'deb http://archive.ubuntu.com/ubuntu noble main restricted'
+
+    def test_disabled_source(self):
+        src = SourcesList.__new__(SourcesList)
+        line = '# deb http://archive.ubuntu.com/ubuntu noble main'
+        valid, enabled, source, comment = src._parse(line)
+        assert valid is True
+        assert enabled is False
+
+    def test_source_with_comment(self):
+        src = SourcesList.__new__(SourcesList)
+        line = 'deb http://example.com/repo stable main # my repo'
+        valid, enabled, source, comment = src._parse(line)
+        assert valid is True
+        assert comment == 'my repo'
+        assert source == 'deb http://example.com/repo stable main'


### PR DESCRIPTION
##### SUMMARY
The `_parse` method collapsed multiple consecutive spaces to one via `split()`/`join()`, which broke cdrom entries where spaces inside brackets are significant:

```
deb cdrom:[OS Astra Linux 1.8.1.6  DVD]/ 1.8_x86-64 contrib main
```

became:

```
deb cdrom:[OS Astra Linux 1.8.1.6 DVD]/ 1.8_x86-64 contrib main
```

This broke the repository because apt expects the exact string to match the disc label.

The fix checks only the first word against `VALID_SOURCE_TYPES` for validation, without reconstructing the entire line. Original whitespace is preserved.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt_repository

##### ADDITIONAL INFORMATION
Fixes #86024

Unit tests cover: cdrom double-space preserved, normal source, disabled source, source with comment.