### PR TITLE
file: fix relative path handling for atomic symlink replacement

### DIFF
--- a/changelogs/fragments/file-relative-path-symlink.yml
+++ b/changelogs/fragments/file-relative-path-symlink.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - >-
+    file - Fix atomic replacement of symlinks and hard links when using a
+    relative destination path. ``os.path.dirname`` returns an empty string for
+    bare filenames, causing the temporary file to be created under the
+    filesystem root instead of the working directory
+    (https://github.com/ansible/ansible/issues/86146).

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -775,8 +775,9 @@ def ensure_symlink(path, src, follow, force, timestamps):
     if changed and not module.check_mode:
         if prev_state != 'absent':
             # try to replace atomically
+            b_dir = os.path.dirname(b_path) or b'.'
             b_tmppath = to_bytes(os.path.sep).join(
-                [os.path.dirname(b_path), to_bytes(".%s.%s.tmp" % (os.getpid(), time.time()))]
+                [b_dir, to_bytes(".%s.%s.tmp" % (os.getpid(), time.time()))]
             )
             try:
                 if prev_state == 'directory':
@@ -894,8 +895,9 @@ def ensure_hardlink(path, src, follow, force, timestamps):
     if changed and not module.check_mode:
         if prev_state != 'absent':
             # try to replace atomically
+            b_dir = os.path.dirname(b_path) or b'.'
             b_tmppath = to_bytes(os.path.sep).join(
-                [os.path.dirname(b_path), to_bytes(".%s.%s.tmp" % (os.getpid(), time.time()))]
+                [b_dir, to_bytes(".%s.%s.tmp" % (os.getpid(), time.time()))]
             )
             try:
                 if prev_state == 'directory':

--- a/test/units/modules/test_file_relative_path.py
+++ b/test/units/modules/test_file_relative_path.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import os
+
+
+class TestDirnameOrDot:
+    """Ensure the dirname-or-dot pattern works for relative paths."""
+
+    def test_relative_path_returns_dot(self):
+        assert os.path.dirname(b'my_link') == b''
+        assert (os.path.dirname(b'my_link') or b'.') == b'.'
+
+    def test_absolute_path_returns_dir(self):
+        assert os.path.dirname(b'/tmp/my_link') == b'/tmp'
+        assert (os.path.dirname(b'/tmp/my_link') or b'.') == b'/tmp'
+
+    def test_tmppath_relative(self):
+        """Temp file for a relative path should be in current dir, not root."""
+        b_path = b'my_link'
+        b_dir = os.path.dirname(b_path) or b'.'
+        b_tmppath = os.path.sep.encode().join(
+            [b_dir, b'.12345.67890.tmp']
+        )
+        assert b_tmppath == b'./.12345.67890.tmp'
+        assert not b_tmppath.startswith(b'/.'), "temp file must not be at filesystem root"
+
+    def test_tmppath_absolute(self):
+        b_path = b'/home/user/my_link'
+        b_dir = os.path.dirname(b_path) or b'.'
+        b_tmppath = os.path.sep.encode().join(
+            [b_dir, b'.12345.67890.tmp']
+        )
+        assert b_tmppath == b'/home/user/.12345.67890.tmp'


### PR DESCRIPTION
##### SUMMARY
When the destination path is a bare filename (e.g. `my_link`), `os.path.dirname` returns an empty string. The temp file path then becomes `/.PID.TIME.tmp` (at the filesystem root), causing `Permission denied` errors.

This adds an `or b'.'" fallback so the temp file is created in the current directory instead. Both atomic replacement code paths (symlinks and hard links) are fixed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
file

##### ADDITIONAL INFORMATION
Fixes #86146

Reproducer from the issue:
```yaml
- name: Create a link
  ansible.builtin.file:
    state: link
    src: 'my_folder'
    follow: false
    force: yes
    path: 'my_link'
```

Previous PRs (#86151, #86351) were closed — one for AI attribution issues, one went stale. This is a minimal one-line-per-site fix.