### PR TITLE
Symlink deprecated modules

### DIFF
--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -1,0 +1,1 @@
+_apt_key.py

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -1,0 +1,1 @@
+_apt_repository.py


### PR DESCRIPTION
##### SUMMARY

* Allow normal name resolution of deprecated modules by
  creating symlinks.
  apt_key -> _apt_key
  apt_repository -> _apt_repository

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
lib/ansible/modules/apt_key.py
lib/ansible/modules/apt_repository.py


