### PR TITLE
Consult deprecation metadata for non-collection builtins

### DIFF
--- a/changelogs/fragments/builtin_deprecation_metadata.yml
+++ b/changelogs/fragments/builtin_deprecation_metadata.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pluginloader - Fixed non-collection load path for builtin non-Jinja plugins to consult deprecation metadata.

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -5,6 +5,10 @@ plugin_routing:
     # test entries
     redirected_local:
       redirect: ansible.builtin.local
+    deprecated_core_connection:
+      deprecation:
+        removal_version: "2.999"
+        warning_text: test connection deprecation warning text
     buildah:
       redirect: containers.podman.buildah
     podman:
@@ -56,6 +60,11 @@ plugin_routing:
     # test entry
     uses_redirected_action:
       redirect: ansible.builtin.ping
+    # test entry
+    deprecated_core_module:
+      deprecation:
+        removal_version: '2.999'
+        warning_text: test module deprecation warning text
     podman_container_info:
       redirect: containers.podman.podman_container_info
     podman_image_info:

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -547,7 +547,6 @@ class PluginLoader:
         except ImportError:
             return None
 
-
         # FIXME: shouldn't need this...
         try:
             # force any type-specific metadata postprocessing to occur

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -135,7 +135,7 @@ class PluginPathContext(object):
 
 
 class PluginLoadContext(object):
-    def __init__(self, plugin_type: str, legacy_package_name: str) -> None:
+    def __init__(self, plugin_type: str, legacy_package_name: str, *, ignore_deprecated: bool = False) -> None:
         self.original_name: str | None = None
         self.redirect_list: list[str] = []
         self.raw_error_list: list[Exception] = []
@@ -168,6 +168,8 @@ class PluginLoadContext(object):
         The fully qualified Python module name for the plugin (accessible via `sys.modules`).
         For non-collection non-core plugins, this may include a non-existent synthetic package element with a hash of the file path to avoid collisions.
         """
+        self.ignore_deprecated: bool = ignore_deprecated
+        """When true, the load context should not record deprecation warnings."""
 
     @property
     def resolved_fqcn(self) -> str | None:
@@ -185,7 +187,7 @@ class PluginLoadContext(object):
         return self._resolved_fqcn
 
     def record_deprecation(self, name: str, deprecation: dict[str, t.Any] | None, collection_name: str) -> t.Self:
-        if not deprecation:
+        if self.ignore_deprecated or not deprecation:
             return self
 
         # The `or ''` instead of using `.get(..., '')` makes sure that even if the user explicitly
@@ -203,6 +205,7 @@ class PluginLoadContext(object):
             date=removal_date,
             version=removal_version,
             deprecator=deprecator_from_collection_name(collection_name),
+            obj=name,
         )
 
         self.deprecated = True
@@ -538,9 +541,12 @@ class PluginLoader:
                 display.debug('Added %s to loader search path' % (directory))
 
     def _query_collection_routing_meta(self, acr, plugin_type, extension=None):
-        collection_pkg = import_module(acr.n_python_collection_package_name)
-        if not collection_pkg:
+        try:
+            if not (collection_pkg := import_module(acr.n_python_collection_package_name)):
+                return None
+        except ImportError:
             return None
+
 
         # FIXME: shouldn't need this...
         try:
@@ -562,7 +568,7 @@ class PluginLoader:
             subdir_qualified_resource = '.'.join([acr.subdirs, acr.resource])
         else:
             subdir_qualified_resource = acr.resource
-        entry = collection_meta.get('plugin_routing', {}).get(plugin_type, {}).get(subdir_qualified_resource + extension, None)
+        entry = collection_meta.get('plugin_routing', {}).get(plugin_type, {}).get(subdir_qualified_resource + (extension or ''), None)
         if not entry:
             # try for extension-agnostic entry
             entry = collection_meta.get('plugin_routing', {}).get(plugin_type, {}).get(subdir_qualified_resource, None)
@@ -573,7 +579,6 @@ class PluginLoader:
         fq_name: str,
         extension: str | None,
         plugin_load_context: PluginLoadContext,
-        ignore_deprecated: bool = False,
     ) -> PluginLoadContext:
         """Search builtin paths to find a plugin. No external paths are searched,
         meaning plugins inside roles inside collections will be ignored.
@@ -594,8 +599,7 @@ class PluginLoader:
             deprecation = routing_metadata.get('deprecation', None)
 
             # this will no-op if there's no deprecation metadata for this plugin
-            if not ignore_deprecated:
-                plugin_load_context.record_deprecation(fq_name, deprecation, acr.collection)
+            plugin_load_context.record_deprecation(fq_name, deprecation, acr.collection)
 
             tombstone = routing_metadata.get('tombstone', None)
 
@@ -705,10 +709,10 @@ class PluginLoader:
         collection_list: list[str] | None = None,
     ) -> PluginLoadContext:
         """ Find a plugin named name, returning contextual info about the load, recursively resolving redirection """
-        plugin_load_context = PluginLoadContext(self.type, self.package)
+        plugin_load_context = PluginLoadContext(self.type, self.package, ignore_deprecated=ignore_deprecated)
         plugin_load_context.original_name = name
         while True:
-            result = self._resolve_plugin_step(name, mod_type, ignore_deprecated, check_aliases, collection_list, plugin_load_context=plugin_load_context)
+            result = self._resolve_plugin_step(name, mod_type, check_aliases, collection_list, plugin_load_context=plugin_load_context)
             if result.pending_redirect:
                 if result.pending_redirect in result.redirect_list:
                     raise AnsiblePluginCircularRedirect('plugin redirect loop resolving {0} (path: {1})'.format(result.original_name, result.redirect_list))
@@ -733,7 +737,6 @@ class PluginLoader:
         self,
         name: str,
         mod_type: str = '',
-        ignore_deprecated: bool = False,
         check_aliases: bool = False,
         collection_list: list[str] | None = None,
         plugin_load_context: PluginLoadContext | None = None,
@@ -773,11 +776,10 @@ class PluginLoader:
                         # 'ansible.legacy' refers to the plugin finding behavior used before collections existed.
                         # They need to search 'library' and the various '*_plugins' directories in order to find the file.
                         plugin_load_context = self._find_plugin_legacy(name.removeprefix('ansible.legacy.'),
-                                                                       plugin_load_context, ignore_deprecated, check_aliases, suffix)
+                                                                       plugin_load_context, check_aliases, suffix)
                     else:
                         # 'ansible.builtin' should be handled here. This means only internal, or builtin, paths are searched.
-                        plugin_load_context = self._find_fq_plugin(candidate_name, suffix, plugin_load_context=plugin_load_context,
-                                                                   ignore_deprecated=ignore_deprecated)
+                        plugin_load_context = self._find_fq_plugin(candidate_name, suffix, plugin_load_context=plugin_load_context)
 
                         # Pending redirects are added to the redirect_list at the beginning of _resolve_plugin_step.
                         # Once redirects are resolved, ensure the final FQCN is added here.
@@ -810,9 +812,28 @@ class PluginLoader:
 
         # if we got here, there's no collection list and it's not an FQ name, so do legacy lookup
 
-        return self._find_plugin_legacy(name, plugin_load_context, ignore_deprecated, check_aliases, suffix)
+        return self._find_plugin_legacy(name, plugin_load_context, check_aliases, suffix)
 
-    def _find_plugin_legacy(self, name, plugin_load_context, ignore_deprecated=False, check_aliases=False, suffix=None):
+    @functools.lru_cache(maxsize=100)
+    def _get_builtin_routing_metadata(self, name: str) -> dict[str, t.Any]:
+        """Cached metadata lookups for core plugins."""
+        routing_metadata = self._query_collection_routing_meta(acr := AnsibleCollectionRef.from_fqcr(f'ansible.builtin.{name}', self.type), self.type)
+
+        return routing_metadata or {}
+
+    def _check_core_deprecation(self, name: str, plugin_load_context: PluginLoadContext) -> None:
+        """
+        Inspect core runtime metadata for deprecations on core plugins loaded through a non-collection name.
+
+        This method has no effect for non-core plugins loaded through a short name, and is not needed for collection plugins.
+        """
+        if not plugin_load_context.resolved or plugin_load_context.plugin_resolved_collection != 'ansible.builtin':
+            return
+
+        if (routing_metadata := self._get_builtin_routing_metadata(name)) and (deprecation := routing_metadata.get('deprecation')):
+            plugin_load_context.record_deprecation(name, deprecation, 'ansible.builtin')
+
+    def _find_plugin_legacy(self, name, plugin_load_context, check_aliases=False, suffix=None):
         """Search library and various *_plugins paths in order to find the file.
         This was behavior prior to the existence of collections.
         """
@@ -825,7 +846,10 @@ class PluginLoader:
         # requested mod_type
         pull_cache = self._plugin_path_cache[suffix]
         try:
-            return plugin_load_context.resolve_legacy(name=name, pull_cache=pull_cache)
+            resolved = plugin_load_context.resolve_legacy(name=name, pull_cache=pull_cache)
+            self._check_core_deprecation(name, plugin_load_context)
+
+            return resolved
         except KeyError:
             # Cache miss.  Now let's find the plugin
             pass
@@ -878,7 +902,10 @@ class PluginLoader:
 
             self._searched_paths.add(path)
             try:
-                return plugin_load_context.resolve_legacy(name=name, pull_cache=pull_cache)
+                resolved = plugin_load_context.resolve_legacy(name=name, pull_cache=pull_cache)
+                self._check_core_deprecation(name, plugin_load_context)
+
+                return resolved
             except KeyError:
                 # Didn't find the plugin in this directory. Load modules from the next one
                 pass
@@ -903,7 +930,7 @@ class PluginLoader:
         # last ditch, if it's something that can be redirected, look for a builtin redirect before giving up
         candidate_fqcr = 'ansible.builtin.{0}'.format(name)
         if '.' not in name and AnsibleCollectionRef.is_valid_fqcr(candidate_fqcr):
-            return self._find_fq_plugin(fq_name=candidate_fqcr, extension=suffix, plugin_load_context=plugin_load_context, ignore_deprecated=ignore_deprecated)
+            return self._find_fq_plugin(fq_name=candidate_fqcr, extension=suffix, plugin_load_context=plugin_load_context)
 
         return plugin_load_context.nope('{0} is not eligible for last-chance resolution'.format(name))
 

--- a/test/integration/targets/plugin_loader/deprecated_core_plugins.yml
+++ b/test/integration/targets/plugin_loader/deprecated_core_plugins.yml
@@ -1,0 +1,17 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: run a deprecated core module
+      deprecated_core_module:
+      register: deprecated_module
+
+    - name: run a task under a deprecated core connection
+      ping:
+      vars:
+        ansible_connection: deprecated_core_connection
+      register: deprecated_connection
+
+    - assert:
+        that:
+          - deprecated_module.deprecations | selectattr('msg', 'search', 'test module deprecation warning text') | length == 1
+          - deprecated_connection.deprecations | selectattr('msg', 'search', 'test connection deprecation warning text') | length == 1

--- a/test/integration/targets/plugin_loader/deprecated_core_plugins/deprecated_core_connection.py
+++ b/test/integration/targets/plugin_loader/deprecated_core_plugins/deprecated_core_connection.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from ansible.plugins.connection import local
+
+
+class Connection(local.Connection): ...

--- a/test/integration/targets/plugin_loader/deprecated_core_plugins/deprecated_core_module.py
+++ b/test/integration/targets/plugin_loader/deprecated_core_plugins/deprecated_core_module.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from __future__ import annotations
 
 from ansible.module_utils.basic import AnsibleModule

--- a/test/integration/targets/plugin_loader/deprecated_core_plugins/deprecated_core_module.py
+++ b/test/integration/targets/plugin_loader/deprecated_core_plugins/deprecated_core_module.py
@@ -1,0 +1,8 @@
+#!/usr/bin/python
+
+from __future__ import annotations
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+AnsibleModule({}).exit_json(passed=True)

--- a/test/integration/targets/plugin_loader/runme.sh
+++ b/test/integration/targets/plugin_loader/runme.sh
@@ -4,13 +4,23 @@ set -eux
 
 cleanup() {
     unlink normal/library/_symlink.py
+
+    rm "$core_module_path/modules/deprecated_core_module.py"
+    rm "$core_module_path/plugins/connection/deprecated_core_connection.py"
 }
 
 pushd normal/library
 ln -s _underscore.py _symlink.py
 popd
 
+# inject a couple of phony deprecated core plugins
+core_module_path=$(dirname "$(python -c 'from importlib.util import find_spec; print(find_spec("ansible").origin)')")
+
+cp deprecated_core_plugins/deprecated_core_module.py "$core_module_path/modules"
+cp deprecated_core_plugins/deprecated_core_connection.py "$core_module_path/plugins/connection"
+
 trap 'cleanup' EXIT
+
 
 # check normal execution
 for myplay in normal/*.yml
@@ -37,3 +47,7 @@ ansible-playbook use_coll_name.yml -i ../../inventory -e 'ansible_connection=ans
 
 # test filter loading ignoring duplicate file basename
 ansible-playbook file_collision/play.yml "$@"
+
+# validate warnings from deprecated core plugins
+unset ANSIBLE_DEPRECATION_WARNINGS
+ansible-playbook deprecated_core_plugins.yml

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -99,7 +99,6 @@ test/integration/targets/module_precedence/lib_with_extension/ping.ini shebang
 test/integration/targets/module_precedence/roles_with_extension/foo/library/a.ini shebang
 test/integration/targets/module_precedence/roles_with_extension/foo/library/ping.ini shebang
 test/integration/targets/old_style_modules_posix/library/helloworld.sh shebang
-test/integration/targets/plugin_loader/deprecated_core_plugins/deprecated_core_module.py shebang
 test/integration/targets/template/files/encoding_1252_utf-8.expected no-smart-quotes
 test/integration/targets/template/files/encoding_1252_utf-8.expected no-unwanted-characters
 test/integration/targets/template/files/encoding_1252_windows-1252.expected no-smart-quotes

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -99,6 +99,7 @@ test/integration/targets/module_precedence/lib_with_extension/ping.ini shebang
 test/integration/targets/module_precedence/roles_with_extension/foo/library/a.ini shebang
 test/integration/targets/module_precedence/roles_with_extension/foo/library/ping.ini shebang
 test/integration/targets/old_style_modules_posix/library/helloworld.sh shebang
+test/integration/targets/plugin_loader/deprecated_core_plugins/deprecated_core_module.py shebang
 test/integration/targets/template/files/encoding_1252_utf-8.expected no-smart-quotes
 test/integration/targets/template/files/encoding_1252_utf-8.expected no-unwanted-characters
 test/integration/targets/template/files/encoding_1252_windows-1252.expected no-smart-quotes


### PR DESCRIPTION
##### SUMMARY
* Ensures deprecation warnings on core builtin plugins are issued whether loaded via FQCN or legacy short-name.
* Re-homed `ignore_deprecated` on PluginLoadContext
* Added tests

##### ISSUE TYPE
- Bugfix Pull Request
