### PR TITLE
fix: validate src parameter type in copy action

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -466,6 +466,8 @@ class ActionModule(ActionBase):
             # a directory so we need to determine that now (we use it just
             # like rsync does to figure out whether to include the directory
             # or only the files inside the directory
+            if not isinstance(source, str):
+                raise AnsibleActionFail("'src' must be a string, got %s" % type(source).__name__)
             trailing_slash = source.endswith(os.path.sep)
             try:
                 # find in expected paths


### PR DESCRIPTION
## Summary
Fixes #86607.
**Root cause:** The copy action assumed src was always a string and called source.endswith() without type checking. When src was a dict or other non-string type, this caused AttributeError: '_AnsibleTaggedDict' object has no attribute 'endswith'.
**Fix:** Added type validation for the src parameter before string operations are performed.
## Changes
- lib/ansible/plugins/action/copy.py: Added type check for src parameter
## Testing
- Verified fix addresses reported AttributeError scenario
- Change is minimal and follows existing validation patterns

Made with [Cursor](https://cursor.com)