### PR TITLE
ansible-test - Upgrade macOS remote to 26.3

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -94,8 +94,8 @@ stages:
       - template: templates/matrix.yml  # context/target
         parameters:
           targets:
-            - name: macOS 15.3
-              test: macos/15.3
+            - name: macOS 26.3
+              test: macos/26.3
             - name: RHEL 9.7 py39
               test: rhel/9.7@3.9
             - name: RHEL 9.7 py312
@@ -112,8 +112,8 @@ stages:
       - template: templates/matrix.yml  # context/controller
         parameters:
           targets:
-            - name: macOS 15.3
-              test: macos/15.3
+            - name: macOS 26.3
+              test: macos/26.3
             - name: RHEL 9.7
               test: rhel/9.7
             - name: RHEL 10.1

--- a/changelogs/fragments/ansible-test-macos.yml
+++ b/changelogs/fragments/ansible-test-macos.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Replace macOS 15.3 remote with macOS 26.3.

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -5,7 +5,7 @@ fedora become=sudo provider=aws arch=x86_64
 freebsd/14.4 python=3.14 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64 alias=freebsd/14
 freebsd/15.0 python=3.12 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64 alias=freebsd/15,freebsd/latest
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
-macos/15.3 python=3.13 python_dir=/usr/local/bin become=sudo provider=mac arch=aarch64 alias=macos/15,macos/latest
+macos/26.3 python=3.14 python_dir=/usr/local/bin become=sudo provider=mac arch=aarch64 alias=macos/26,macos/latest
 macos python_dir=/usr/local/bin become=sudo provider=mac arch=aarch64
 rhel/9.7 python=3.9,3.12 become=sudo provider=aws arch=x86_64 alias=rhel/9
 rhel/10.1 python=3.12 become=sudo provider=aws arch=x86_64 alias=rhel/10,rhel/latest


### PR DESCRIPTION
##### SUMMARY

ansible-test - Upgrade macOS remote to 26.3.

##### ISSUE TYPE

Feature Pull Request
