### PR TITLE
[stable-2.19] ansible-test - Switch macOS remote to aarch64 (#86653)

### DIFF
--- a/changelogs/fragments/ansible-test-macos-aarch64.yml
+++ b/changelogs/fragments/ansible-test-macos-aarch64.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ansible-test - Switch managed macOS remotes from x86_64 to aarch64.
+  - ansible-test - Replace the ``parallels`` managed macOS provider with a new ``mac`` provider.

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -5,8 +5,8 @@ fedora become=sudo provider=aws arch=x86_64
 freebsd/13.5 python=3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64 alias=freebsd/13
 freebsd/14.2 python=3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64 alias=freebsd/14,freebsd/latest
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
-macos/15.3 python=3.13 python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64 alias=macos/15,macos/latest
-macos python_dir=/usr/local/bin become=sudo provider=parallels arch=x86_64
+macos/15.3 python=3.13 python_dir=/usr/local/bin become=sudo provider=mac arch=aarch64 alias=macos/15,macos/latest
+macos python_dir=/usr/local/bin become=sudo provider=mac arch=aarch64
 rhel/9.7 python=3.9,3.12 become=sudo provider=aws arch=x86_64 alias=rhel/9
 rhel/10.1 python=3.12 become=sudo provider=aws arch=x86_64 alias=rhel/10,rhel/latest
 rhel become=sudo provider=aws arch=x86_64

--- a/test/lib/ansible_test/_internal/constants.py
+++ b/test/lib/ansible_test/_internal/constants.py
@@ -23,7 +23,7 @@ REMOTE_PROVIDERS = [
     'default',
     'aws',
     'azure',
-    'parallels',
+    'mac',
 ]
 
 SECCOMP_CHOICES = [


### PR DESCRIPTION
##### SUMMARY

Backport of #86653

(cherry picked from commit 3f10c2c0a910b15675534891ca567dcde355ad8e)

##### ISSUE TYPE

Feature Pull Request
