### PR TITLE
Fix using the server's validate_certs config when downloading

### DIFF
--- a/changelogs/fragments/ansible-galaxy-validate_certs-server-config.yml
+++ b/changelogs/fragments/ansible-galaxy-validate_certs-server-config.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    ansible-galaxy collection - Fix using the server configuration for ``validate_certs``
+    when downloading collections. (https://github.com/ansible/ansible/issues/86694)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -78,8 +78,10 @@ def with_collection_artifacts_manager(wrapped_method):
         if 'artifacts_manager' in kwargs:
             return wrapped_method(*args, **kwargs)
 
-        # FIXME: use validate_certs context from Galaxy servers when downloading collections
-        # .get used here for when this is used in a non-CLI context
+        # configures validate_certs for type 'url' only
+        # type 'galaxy' inherits and overrides resolved_validate_certs
+        # type 'git' recalculates resolved_validate_certs
+        # NOTE: .get used here for when this is used in a non-CLI context
         artifacts_manager_kwargs = {'validate_certs': context.CLIARGS.get('resolved_validate_certs', True)}
 
         keyring = context.CLIARGS.get('keyring', None)

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -71,8 +71,7 @@ class ConcreteArtifactsManager:
         self._artifact_cache = {}  # type: dict[bytes, bytes]
         self._galaxy_artifact_cache = {}  # type: dict[Candidate | Requirement, bytes]
         self._artifact_meta_cache = {}  # type: dict[bytes, dict[str, str | list[str] | dict[str, str] | None | t.Type[Sentinel]]]
-        self._galaxy_collection_cache: dict[Candidate, tuple[str, str, GalaxyToken, bool] = {}
-        self._galaxy_collection_origin_cache = {}  # type: dict[Candidate, tuple[str, list[dict[str, str]]]]
+        self._galaxy_collection_cache: dict[Candidate, tuple[CollectionVersionMetadata, GalaxyAPI]] = {}
         self._b_working_directory = b_working_directory  # type: bytes
         self._supplemental_signature_cache = {}  # type: dict[str, str]
         self._keyring = keyring  # type: str
@@ -107,15 +106,12 @@ class ConcreteArtifactsManager:
 
     def get_galaxy_artifact_source_info(self, collection):
         # type: (Candidate) -> dict[str, t.Union[str, list[dict[str, str]]]]
-        server = collection.src.api_server
 
         try:
-            download_url = self._galaxy_collection_cache[collection][0]
-            signatures_url, signatures = self._galaxy_collection_origin_cache[collection]
+            metadata, server = self._galaxy_collection_cache[collection]
         except KeyError as key_err:
             raise RuntimeError(
-                'The is no known source for {coll!s}'.
-                format(coll=collection),
+                f"There is no known source for {collection!s}"
             ) from key_err
 
         return {
@@ -123,10 +119,10 @@ class ConcreteArtifactsManager:
             "namespace": collection.namespace,
             "name": collection.name,
             "version": collection.ver,
-            "server": server,
-            "version_url": signatures_url,
-            "download_url": download_url,
-            "signatures": signatures,
+            "server": server.api_server,
+            "version_url": metadata.signatures_url,
+            "download_url": metadata.download_url,
+            "signatures": metadata.signatures,
         }
 
     def get_galaxy_artifact_path(self, collection: Candidate) -> bytes:
@@ -140,11 +136,10 @@ class ConcreteArtifactsManager:
             pass
 
         try:
-            url, sha256_hash, token, validate_certs = self._galaxy_collection_cache[collection]
+            metadata, api = self._galaxy_collection_cache[collection]
         except KeyError as key_err:
             raise RuntimeError(
-                'There is no known source for {coll!s}'.
-                format(coll=collection),
+                f'There is no known source for {collection!s}'
             ) from key_err
 
         display.vvvv(
@@ -154,39 +149,27 @@ class ConcreteArtifactsManager:
 
         try:
             b_artifact_path = _download_file(
-                url,
+                metadata.download_url,
                 self._b_working_directory,
-                expected_hash=sha256_hash,
-                validate_certs=validate_certs,
-                token=token,
+                expected_hash=metadata.artifact_sha256,
+                validate_certs=api.validate_certs,
+                token=api.token,
             )  # type: bytes
         except URLError as err:
             raise AnsibleError(
                 'Failed to download collection tar '
-                "from '{coll_src!s}': {download_err!s}".
-                format(
-                    coll_src=to_native(collection.src),
-                    download_err=to_native(err),
-                ),
+                f"from '{api!s}': {err!s}"
             ) from err
         except Exception as err:
             raise AnsibleError(
                 'Failed to download collection tar '
-                "from '{coll_src!s}' due to the following unforeseen error: "
-                '{download_err!s}'.
-                format(
-                    coll_src=to_native(collection.src),
-                    download_err=to_native(err),
-                ),
+                f"from '{api!s}' due to the following unforeseen error: "
+                f'{err!s}'
             ) from err
         else:
             display.vvv(
-                "Collection '{coll!s}' obtained from "
-                'server {server!s} {url!s}'.format(
-                    coll=collection, server=collection.src or 'Galaxy',
-                    url=collection.src.api_server if collection.src is not None
-                    else '',
-                )
+                f"Collection '{collection!s}' obtained from server {api!s} "
+                f"{api.api_server!s}"
             )
 
         self._galaxy_artifact_cache[collection] = b_artifact_path
@@ -373,8 +356,7 @@ class ConcreteArtifactsManager:
         This is a hook that is supposed to be called before attempting to
         download Galaxy-based collections with ``get_galaxy_artifact_path()``.
         """
-        self._galaxy_collection_cache[collection] = metadata.download_url, metadata.artifact_sha256, api.token, api.validate_certs
-        self._galaxy_collection_origin_cache[collection] = metadata.signatures_url, metadata.signatures
+        self._galaxy_collection_cache[collection] = (metadata, api)
 
     @classmethod
     @contextmanager

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -158,7 +158,7 @@ class ConcreteArtifactsManager:
                 url,
                 self._b_working_directory,
                 expected_hash=sha256_hash,
-                validate_certs=self._validate_certs,
+                validate_certs=collection.src.validate_certs,
                 token=token,
             )  # type: bytes
         except URLError as err:

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -71,7 +71,7 @@ class ConcreteArtifactsManager:
         self._artifact_cache = {}  # type: dict[bytes, bytes]
         self._galaxy_artifact_cache = {}  # type: dict[Candidate | Requirement, bytes]
         self._artifact_meta_cache = {}  # type: dict[bytes, dict[str, str | list[str] | dict[str, str] | None | t.Type[Sentinel]]]
-        self._galaxy_collection_cache = {}  # type: dict[Candidate | Requirement, tuple[str, str, GalaxyToken]]
+        self._galaxy_collection_cache = {}  # type: dict[Candidate | Requirement, tuple[str, str, GalaxyToken, bool]]
         self._galaxy_collection_origin_cache = {}  # type: dict[Candidate, tuple[str, list[dict[str, str]]]]
         self._b_working_directory = b_working_directory  # type: bytes
         self._supplemental_signature_cache = {}  # type: dict[str, str]
@@ -141,7 +141,7 @@ class ConcreteArtifactsManager:
             pass
 
         try:
-            url, sha256_hash, token = self._galaxy_collection_cache[collection]
+            url, sha256_hash, token, validate_certs = self._galaxy_collection_cache[collection]
         except KeyError as key_err:
             raise RuntimeError(
                 'There is no known source for {coll!s}'.
@@ -158,7 +158,7 @@ class ConcreteArtifactsManager:
                 url,
                 self._b_working_directory,
                 expected_hash=sha256_hash,
-                validate_certs=collection.src.validate_certs,
+                validate_certs=validate_certs,
                 token=token,
             )  # type: bytes
         except URLError as err:
@@ -368,14 +368,14 @@ class ConcreteArtifactsManager:
         # NOTE: Using None as a sentinel since it's not a valid value otherwise.
         return runtime.get("requires_ansible")
 
-    def save_collection_source(self, collection, url, sha256_hash, token, signatures_url, signatures):
-        # type: (Candidate, str, str, GalaxyToken, str, list[dict[str, str]]) -> None
+    def save_collection_source(self, collection, url, sha256_hash, token, signatures_url, signatures, validate_certs):
+        # type: (Candidate, str, str, GalaxyToken, str, list[dict[str, str]], bool) -> None
         """Store collection URL, SHA256 hash and Galaxy API token.
 
         This is a hook that is supposed to be called before attempting to
         download Galaxy-based collections with ``get_galaxy_artifact_path()``.
         """
-        self._galaxy_collection_cache[collection] = url, sha256_hash, token
+        self._galaxy_collection_cache[collection] = url, sha256_hash, token, validate_certs
         self._galaxy_collection_origin_cache[collection] = signatures_url, signatures
 
     @classmethod

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -31,7 +31,7 @@ if t.TYPE_CHECKING:
 from ansible import context
 from ansible.errors import AnsibleError
 from ansible.galaxy import get_collections_galaxy_meta_info
-from ansible.galaxy.api import should_retry_error
+from ansible.galaxy.api import should_retry_error, CollectionVersionMetadata, GalaxyAPI
 from ansible.galaxy.dependency_resolution.dataclasses import _GALAXY_YAML
 from ansible.galaxy.user_agent import user_agent
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
@@ -71,7 +71,7 @@ class ConcreteArtifactsManager:
         self._artifact_cache = {}  # type: dict[bytes, bytes]
         self._galaxy_artifact_cache = {}  # type: dict[Candidate | Requirement, bytes]
         self._artifact_meta_cache = {}  # type: dict[bytes, dict[str, str | list[str] | dict[str, str] | None | t.Type[Sentinel]]]
-        self._galaxy_collection_cache = {}  # type: dict[Candidate | Requirement, tuple[str, str, GalaxyToken, bool]]
+        self._galaxy_collection_cache: dict[Candidate, tuple[str, str, GalaxyToken, bool] = {}
         self._galaxy_collection_origin_cache = {}  # type: dict[Candidate, tuple[str, list[dict[str, str]]]]
         self._b_working_directory = b_working_directory  # type: bytes
         self._supplemental_signature_cache = {}  # type: dict[str, str]
@@ -129,8 +129,7 @@ class ConcreteArtifactsManager:
             "signatures": signatures,
         }
 
-    def get_galaxy_artifact_path(self, collection):
-        # type: (t.Union[Candidate, Requirement]) -> bytes
+    def get_galaxy_artifact_path(self, collection: Candidate) -> bytes:
         """Given a Galaxy-stored collection, return a cached path.
 
         If it's not yet on disk, this method downloads the artifact first.
@@ -368,15 +367,14 @@ class ConcreteArtifactsManager:
         # NOTE: Using None as a sentinel since it's not a valid value otherwise.
         return runtime.get("requires_ansible")
 
-    def save_collection_source(self, collection, url, sha256_hash, token, signatures_url, signatures, validate_certs):
-        # type: (Candidate, str, str, GalaxyToken, str, list[dict[str, str]], bool) -> None
-        """Store collection URL, SHA256 hash and Galaxy API token.
+    def save_collection_source(self, collection: Candidate, metadata: CollectionVersionMetadata, api: GalaxyAPI) -> None:
+        """Store collection version metadata and origin.
 
         This is a hook that is supposed to be called before attempting to
         download Galaxy-based collections with ``get_galaxy_artifact_path()``.
         """
-        self._galaxy_collection_cache[collection] = url, sha256_hash, token, validate_certs
-        self._galaxy_collection_origin_cache[collection] = signatures_url, signatures
+        self._galaxy_collection_cache[collection] = metadata.download_url, metadata.artifact_sha256, api.token, api.validate_certs
+        self._galaxy_collection_origin_cache[collection] = metadata.signatures_url, metadata.signatures
 
     @classmethod
     @contextmanager

--- a/lib/ansible/galaxy/collection/galaxy_api_proxy.py
+++ b/lib/ansible/galaxy/collection/galaxy_api_proxy.py
@@ -151,6 +151,7 @@ class MultiGalaxyAPIProxy:
                     api.token,
                     version_metadata.signatures_url,
                     version_metadata.signatures,
+                    api.validate_certs
                 )
                 return version_metadata
 

--- a/lib/ansible/galaxy/collection/galaxy_api_proxy.py
+++ b/lib/ansible/galaxy/collection/galaxy_api_proxy.py
@@ -146,12 +146,8 @@ class MultiGalaxyAPIProxy:
             else:
                 self._concrete_art_mgr.save_collection_source(
                     collection_candidate,
-                    version_metadata.download_url,
-                    version_metadata.artifact_sha256,
-                    api.token,
-                    version_metadata.signatures_url,
-                    version_metadata.signatures,
-                    api.validate_certs
+                    version_metadata,
+                    api
                 )
                 return version_metadata
 

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -831,6 +831,30 @@ def test_install_collection(collection_artifact, monkeypatch):
     assert mock_display.mock_calls[1][1][0] == "ansible_namespace.collection:0.1.0 was installed successfully"
 
 
+def test_download_validate_certs(galaxy_server, collection_artifact, monkeypatch):
+    collection_path, collection_tar = collection_artifact
+    collections_dir = (os.path.sep).join(to_text(collection_path).split(os.path.sep)[:-2])
+    temp_path = f"{collection_tar}/.."
+
+    # The ConcreteArtifactsManager uses the global value for validate_certs
+    cam = collection.concrete_artifact_manager.ConcreteArtifactsManager(temp_path, validate_certs=True)
+    # The GalaxyAPI overrides the global value or inherits it
+    galaxy_server.validate_certs = False
+
+    galaxy_candidate = Candidate('ansible_namespace.collection', '0.1.0', galaxy_server, 'galaxy', None)
+    url_candidate = Candidate('ansible_namespace.collection', '0.1.0', f'file://{collection_tar}', 'url', None)
+
+    mock_download = MagicMock()
+    monkeypatch.setattr(collection.concrete_artifact_manager, '_download_file', mock_download)
+
+    cam._galaxy_collection_cache[galaxy_candidate] = ("download url", "hash", "token")
+    cam.get_artifact_path_from_unknown(galaxy_candidate)
+    assert mock_download.call_args.kwargs['validate_certs'] is False
+
+    cam.get_artifact_path_from_unknown(url_candidate)
+    assert mock_download.call_args.kwargs['validate_certs'] is True
+
+
 def test_install_collection_with_download(galaxy_server, collection_artifact, monkeypatch):
     collection_path, collection_tar = collection_artifact
     shutil.rmtree(collection_path)

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -831,30 +831,6 @@ def test_install_collection(collection_artifact, monkeypatch):
     assert mock_display.mock_calls[1][1][0] == "ansible_namespace.collection:0.1.0 was installed successfully"
 
 
-def test_download_validate_certs(galaxy_server, collection_artifact, monkeypatch):
-    collection_path, collection_tar = collection_artifact
-    collections_dir = (os.path.sep).join(to_text(collection_path).split(os.path.sep)[:-2])
-    temp_path = f"{collection_tar}/.."
-
-    # The ConcreteArtifactsManager uses the global value for validate_certs
-    cam = collection.concrete_artifact_manager.ConcreteArtifactsManager(temp_path, validate_certs=True)
-    # The GalaxyAPI overrides the global value or inherits it
-    galaxy_server.validate_certs = False
-
-    galaxy_candidate = Candidate('ansible_namespace.collection', '0.1.0', galaxy_server, 'galaxy', None)
-    url_candidate = Candidate('ansible_namespace.collection', '0.1.0', f'file://{collection_tar}', 'url', None)
-
-    mock_download = MagicMock()
-    monkeypatch.setattr(collection.concrete_artifact_manager, '_download_file', mock_download)
-
-    cam._galaxy_collection_cache[galaxy_candidate] = ("download url", "hash", "token")
-    cam.get_artifact_path_from_unknown(galaxy_candidate)
-    assert mock_download.call_args.kwargs['validate_certs'] is False
-
-    cam.get_artifact_path_from_unknown(url_candidate)
-    assert mock_download.call_args.kwargs['validate_certs'] is True
-
-
 def test_install_collection_with_download(galaxy_server, collection_artifact, monkeypatch):
     collection_path, collection_tar = collection_artifact
     shutil.rmtree(collection_path)


### PR DESCRIPTION
##### SUMMARY

The server-specific validate_certs configuration was previously only used for GalaxyAPI calls. Now the ConcreteArtifactsManager uses that value when downloading as well.

Fixes #86694

##### ISSUE TYPE

- Bugfix Pull Request
