### PR TITLE
Fix incorrect type for services in service_facts documentation

### DIFF
--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -67,10 +67,12 @@ ansible_facts:
   type: complex
   contains:
     services:
-      description: States of the services with service name as key.
+      description:
+       - Dictionary containing service information.
+       - Keys are service names.
+       - Values contain details such as state, status, and source.
       returned: always
-      type: list
-      elements: dict
+      type: dict
       contains:
         source:
           description:


### PR DESCRIPTION
##### SUMMARY

Fixes incorrect documentation for the `services` return value in the `service_facts` module.

The documentation previously described `services` as a list of dictionaries, which is incorrect.

In reality:
- `services` is a dictionary
- Keys are service names
- Values contain details such as state, status, and source

This PR updates the type to `dict` and improves the description for better clarity.

##### ISSUE TYPE

- Docs Pull Request