### PR TITLE
Fix incorrect type for services in service_facts docume

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -276,7 +276,7 @@ CACHE_PLUGIN_TIMEOUT:
   type: integer
   yaml: {key: facts.cache.timeout}
 COLLECTIONS_SCAN_SYS_PATH:
-  name: Scan PYTHONPATH for installed collections
+  name: Scan Python Path for Installed Collections
   description: A boolean to enable or disable scanning the sys.path for installed collections.
   default: true
   type: boolean
@@ -285,9 +285,10 @@ COLLECTIONS_SCAN_SYS_PATH:
   ini:
   - {key: collections_scan_sys_path, section: defaults}
 COLLECTIONS_PATHS:
-  name: An ordered list of root paths for loading installed Ansible collections content.
+  name: Collections Paths
   description: >
-    Colon-separated paths in which Ansible will search for collections content.
+    Colon-separated paths where Ansible searches for collections.
+    Corresponds to the ANSIBLE_COLLECTIONS_PATH environment variable.
     Collections must be in nested *subdirectories*, not directly in these directories.
     For example, if ``COLLECTIONS_PATHS`` includes ``'{{ ANSIBLE_HOME ~ "/collections" }}'``,
     and you want to add ``my.collection`` to that directory, it must be saved as


### PR DESCRIPTION
##### SUMMARY

Improved readability of configuration option names in the configuration settings by replacing long descriptive names with concise, human-readable titles.

This helps reduce confusion between configuration options and environment variables.

Fixes #60880

##### ISSUE TYPE

- Docs Pull Request