### PR TITLE
tests/integration: find: use directly variables and str concat

### DIFF
--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -507,8 +507,8 @@
           - permission_issue is success
           - not permission_issue.changed
           - permission_issue.skipped_paths|length == 1
-          - "'{{ test_dir }}/readable/1-unreadable' in permission_issue.skipped_paths"
-          - "'Permission denied' in permission_issue.skipped_paths['{{ test_dir }}/readable/1-unreadable']"
+          - (test_dir + '/readable/1-unreadable') in permission_issue.skipped_paths
+          - "'Permission denied' in permission_issue.skipped_paths[test_dir + '/readable/1-unreadable']"
           - permission_issue.matched == 1
   always:
     - name: cleanup test directory
@@ -543,6 +543,6 @@
         that:
           - homedir_search is success
           - homedir_search.matched == 1
-          - '"{{ homedir }}/wharevs.txt" in astest_list'
+          - (homedir + '/wharevs.txt') in astest_list
       vars:
         homedir: "{{ test_user.home }}"


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
When running integration tests, the following warnings show up:

    # ANSIBLE_TEST_PREFER_PODMAN=y bin/ansible-test integration find --docker --python 3.12
    [...]
    TASK [find : Check if the skipped_paths are populated correctly with permission error] ***
    [WARNING]: Jinja constant strings should not contain embedded templates. This feature will be disabled by default in ansible-core 2.23.
    Origin: /root/ansible/test/results/.tmp/integration/find-kalccpc2-ÅÑŚÌβŁÈ/test/integration/targets/find/tasks/main.yml:510:13

    508           - not permission_issue.changed
    509           - permission_issue.skipped_paths|length == 1
    510           - "'{{ test_dir }}/readable/1-unreadable' in permission_issue.skipped_paths"
                    ^ column 13

    Use inline expressions, for example: `when: "{{ a_var }}" == 42` becomes `when: a_var == 42`

    [WARNING]: Jinja constant strings should not contain embedded templates. This feature will be disabled by default in ansible-core 2.23.
    Origin: /root/ansible/test/results/.tmp/integration/find-kalccpc2-ÅÑŚÌβŁÈ/test/integration/targets/find/tasks/main.yml:511:13

    509           - permission_issue.skipped_paths|length == 1
    510           - "'{{ test_dir }}/readable/1-unreadable' in permission_issue.skipped_paths"
    511           - "'Permission denied' in permission_issue.skipped_paths['{{ test_dir }}/readable/1-unreadable']"
                    ^ column 13
    [...]
    TASK [find : Check if found] ***************************************************
    [WARNING]: Jinja constant strings should not contain embedded templates. This feature will be disabled by default in ansible-core 2.23.
    Origin: /root/ansible/test/results/.tmp/integration/find-kalccpc2-ÅÑŚÌβŁÈ/test/integration/targets/find/tasks/main.yml:546:13

    544           - homedir_search is success
    545           - homedir_search.matched == 1
    546           - '"{{ homedir }}/wharevs.txt" in astest_list'
                    ^ column 13

    Use inline expressions, for example: `when: "{{ a_var }}" == 42` becomes `when: a_var == 42`
    [...]
    PLAY RECAP *********************************************************************
    testhost                   : ok=111  changed=19   unreachable=0    failed=0    skipped=3    rescued=0    ignored=0

From ansible-core 2.19, [ `that` clauses are evaluated as Jinja templates](https://docs.ansible.com/projects/ansible/latest/porting_guides/porting_guide_12.html#example-unnecessary-template-in-expression).

Use directly variables and string concatenations:

    # ANSIBLE_TEST_PREFER_PODMAN=y bin/ansible-test integration find --docker --python 3.12 2>&1 | grep Jinja; echo $?
    1

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Test Pull Request
