### PR TITLE
Fix deepcopy support for imported templates

### DIFF
--- a/changelogs/fragments/ansible-template-deepcopy.yml
+++ b/changelogs/fragments/ansible-template-deepcopy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - templating - Fix traceback when using ``deepcopy`` on an imported template (https://github.com/ansible/ansible/issues/86723).

--- a/lib/ansible/_internal/_templating/_jinja_bits.py
+++ b/lib/ansible/_internal/_templating/_jinja_bits.py
@@ -332,6 +332,9 @@ class AnsibleTemplate(Template):
     def __call__(self, jinja_vars: c.Mapping[str, t.Any]) -> t.Any:
         return self.render(ArgSmuggler.package_jinja_vars(jinja_vars))
 
+    def __deepcopy__(self, memo):
+        return self  # templates are immutable, so a deep copy is not needed (it would also fail if not implemented here)
+
     # noinspection PyShadowingBuiltins
     def new_context(
         self,

--- a/test/units/_internal/templating/test_jinja_bits.py
+++ b/test/units/_internal/templating/test_jinja_bits.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import pathlib
 import sys
 import typing as t
@@ -467,3 +468,11 @@ def test_marker_access_getattr_and_getitem(template: str) -> None:
         TemplateEngine(variables=dict(adict={})).template(TRUST.tag(template))
 
     assert type(tracker._markers[0]) is UndefinedMarker  # pylint: disable=unidiomatic-typecheck
+
+
+def test_ansible_template_deepcopy() -> None:
+    """Ensure that AnsibleTemplate instances return themselves when a deep copy is made."""
+    template = AnsibleEnvironment().from_string("Hello")
+    deep_copy = copy.deepcopy(template)
+
+    assert deep_copy is template


### PR DESCRIPTION
##### SUMMARY

This allows a template to import another template and then perform operations that result in a deep copy of a variable. For example, if `deepcopy` is a filter that deep copies its input and `input` is a list, the following template will result in a deep copy of a lazy container, its template engine and ultimately the `AnsibleTemplate` instance which represents the imported template:

```
{% import 'macro.j2' as unused %}
{{ input | deepcopy }}
```

Resolves https://github.com/ansible/ansible/issues/86723

##### ISSUE TYPE

Bugfix Pull Request
