### PR TITLE
ansible-vault - keep the original contents on EDITOR failure

### DIFF
--- a/changelogs/fragments/ansible-vault-edit-editor-failure.yml
+++ b/changelogs/fragments/ansible-vault-edit-editor-failure.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-vault - keep the original contents when the EDITOR returns failure when using ``ansible-vault edit``.

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -830,7 +830,7 @@ class VaultEditor:
 
         try:
             # drop the user into an editor on the tmp file
-            subprocess.call(cmd)
+            subprocess.check_call(cmd)
         except Exception as e:
             # if an error happens, destroy the decrypted file
             self._shred_file(tmp_path)

--- a/test/integration/targets/ansible-vault/fail-editor.py
+++ b/test/integration/targets/ansible-vault/fail-editor.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from __future__ import annotations
+
+import sys
+import pathlib
+
+
+def main():
+    pathlib.Path(sys.argv[1]).write_text("CORRUPTED")
+    sys.exit('intentional editor failure')
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -399,6 +399,18 @@ head -1 "${TEST_FILE_EDIT2}" | grep "${FORMAT_1_2_HEADER};vault_password"
 EDITOR=./faux-editor.py ansible-vault edit "$@" --vault-password-file vault-password "${TEST_FILE_EDIT2}"
 head -1 "${TEST_FILE_EDIT2}" | grep "${FORMAT_1_2_HEADER};vault_password"
 
+# verify an aborted edit reports an error and does not corrupt the vault file
+ORIGINAL_FILE_EDIT="${TEST_FILE_EDIT}.original"
+
+cp "${TEST_FILE_EDIT}" "${ORIGINAL_FILE_EDIT}"
+
+if EDITOR=./fail-editor.py ansible-vault edit "$@" --vault-password-file vault-password "${TEST_FILE_EDIT}"; then
+    echo "ansible-vault did not fail after an edit was aborted"
+    exit 1
+fi
+
+diff "${TEST_FILE_EDIT}" "${ORIGINAL_FILE_EDIT}" >/dev/null || (echo "vault file corrupted after failed edit"; exit 1)
+
 # encrypt with a password from a vault encrypted password file and multiple vault-ids
 # should fail because we dont know which vault id to use to encrypt with
 ansible-vault encrypt "$@" --vault-id vault-password --vault-id encrypted-vault-password "${TEST_FILE_ENC_PASSWORD}" && :


### PR DESCRIPTION
##### SUMMARY

Currently when the editor returns a failure exit code in `ansible-vault edit`, the original file is still being overwritten by whatever is in the temporary file. This is undesirable when some process already made edits to the temporary file and then later fails for some reason, since the file might only be partially modified and thus corrupt.

Fix this by using `check_call()` instead of `call()` to throw an Exception when the exit code is non-zero.

This can be tested manually with `vim` by saving some changes with `:w` and then exiting with failure using `:cq`. The changes that were made should not persist.

##### ISSUE TYPE

- Bugfix Pull Request