### PR TITLE
Pip `editable` now applies to all packages

### DIFF
--- a/changelogs/fragments/77755-pip-module-editable-flag-fix.yml
+++ b/changelogs/fragments/77755-pip-module-editable-flag-fix.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - pip - when editable set to true, '-e' flag is passed before each package.
+    When requirments file is used, editable flag does not pass '-e' to avoid
+    errors.

--- a/changelogs/fragments/77755-pip-module-editable-flag-fix.yml
+++ b/changelogs/fragments/77755-pip-module-editable-flag-fix.yml
@@ -1,4 +1,3 @@
 bugfixes:
-  - pip - when editable set to true, '-e' flag is passed before each package.
-    When requirments file is used, editable flag does not pass '-e' to avoid
-    errors.
+  - pip - When installing multiple packages with ``editable=True``, ensure each package is editable.
+  - pip - Prevent passing ``-e`` to ``pip`` when the ``editable`` parameter and ``requirements`` parameter are set.

--- a/changelogs/fragments/77755-pip-module-editable-flag-fix.yml
+++ b/changelogs/fragments/77755-pip-module-editable-flag-fix.yml
@@ -1,3 +1,0 @@
-bugfixes:
-  - pip - When installing multiple packages with ``editable=True``, ensure each package is editable.
-  - pip - Prevent passing ``-e`` to ``pip`` when the ``editable`` parameter and ``requirements`` parameter are set.

--- a/changelogs/fragments/86732-pip-module-editable-flag-fix.yml
+++ b/changelogs/fragments/86732-pip-module-editable-flag-fix.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - pip - When installing multiple packages with ``editable=True``, ensure each package is editable 
+   (https://github.com/ansible/ansible/issues/77755).
+  - pip - Prevent passing ``-e`` to ``pip`` when the ``editable`` and ``requirements`` parameters are both used.

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -80,7 +80,7 @@ options:
     version_added: "1.0"
   editable:
     description:
-      - Pass the editable flag.
+      - Pass the editable flag to all packages.
     type: bool
     default: 'no'
     version_added: "2.0"

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -757,7 +757,11 @@ def main():
             break_system_packages=dict(type='bool', default=False),
         ),
         required_one_of=[['name', 'requirements']],
-        mutually_exclusive=[['name', 'requirements'], ['executable', 'virtualenv']],
+        mutually_exclusive=[
+            ['name', 'requirements'],
+            ['executable', 'virtualenv'],
+            ['editable', 'requirements'],
+        ],
         supports_check_mode=True,
     )
 
@@ -773,6 +777,7 @@ def main():
     chdir = module.params['chdir']
     umask = module.params['umask']
     env = module.params['virtualenv']
+    editable = module.params['editable']
 
     venv_created = False
     if env and chdir:
@@ -848,15 +853,6 @@ def main():
                 # if the version specifier is provided by version, append that into the package
                 packages[0] = Package(to_native(packages[0]), version)
 
-        if module.params['editable']:
-            args_list = []  # used if extra_args is not used at all
-            if extra_args:
-                args_list = extra_args.split(' ')
-            if '-e' not in args_list:
-                args_list.append('-e')
-                # Ok, we will reconstruct the option string
-                extra_args = ' '.join(args_list)
-
         if extra_args:
             cmd.extend(shlex.split(extra_args))
 
@@ -866,7 +862,10 @@ def main():
             os.environ['PIP_BREAK_SYSTEM_PACKAGES'] = '1'
 
         if name:
-            cmd.extend(to_native(p) for p in packages)
+            for p in packages:
+                if editable:
+                    cmd.append('-e')
+                cmd.append(to_native(p))
         elif requirements:
             cmd.extend(['-r', requirements])
         elif venv_created and not name and not requirements:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -592,3 +592,93 @@
         - pip_prereleases is successful
         - pip_prereleases is not changed
         - '"fallible==0.0.1a2" in pip_prereleases.stdout_lines'
+
+- name: Test editable
+  vars:
+    venv_path: "{{ remote_tmp_dir }}/emptyvenv"
+  block:
+    - name: Ensure fresh venv
+      file:
+        state: absent
+        path: "{{ venv_path }}"
+
+    - name: Create an empty venv
+      pip:
+        name: []
+        virtualenv: "{{ venv_path }}"
+      register: empty_venv
+
+    - name: Create test package directories
+      file:
+        state: directory
+        name: "{{ remote_tmp_dir }}/{{ item }}"
+      loop:
+        - sample-project
+        - another-project
+
+    - name: Copy test packages to remote
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+      loop:
+        - { src: "sample-project/", dest: "{{ remote_tmp_dir }}/sample-project/" }
+        - { src: "sample-project/", dest: "{{ remote_tmp_dir }}/another-project/" } # Reusing same source for simplicity
+
+    - name: Update project name in another-project's pyproject.toml
+      lineinfile:
+        path: "{{ remote_tmp_dir }}/another-project/pyproject.toml"
+        regexp: '^name = "sample-project"$'
+        line: 'name = "another-project"'
+
+    - name: Install a package normally
+      pip:
+        name: "{{ remote_tmp_dir }}/sample-project"
+        virtualenv: "{{ venv_path }}"
+
+    - name: Install a package as editable
+      pip:
+        name: "{{ remote_tmp_dir }}/sample-project"
+        virtualenv: "{{ venv_path }}"
+        editable: True
+      register: editable_install
+
+    - name: Assert changed
+      assert:
+        that:
+          - editable_install is changed
+
+    - name: Check status
+      command: "{{ venv_path }}/bin/pip list"
+      register: pip_list_check
+      changed_when: false
+
+    - name: Assert editable
+      assert:
+        that:
+          - pip_list_check.stdout is search("sample-project\s+1.0.0\s+" ~ remote_tmp_dir ~ "/sample-project")
+
+    - name: Clear packages
+      file:
+        state: absent
+        name: "{{ venv_path }}"
+
+    - name: Install multiple packages as editable
+      pip:
+        name:
+          - "{{ remote_tmp_dir }}/sample-project"
+          - "{{ remote_tmp_dir }}/another-project"
+        virtualenv: "{{ venv_path }}"
+        editable: True
+      register: multi_editable_install
+
+    - name: Check status
+      command: "{{ venv_path }}/bin/pip list"
+      register: multi_pip_list_check
+      changed_when: false
+
+    - name: Assert editable
+      assert:
+        that:
+          - multi_editable_install is changed
+          - multi_pip_list_check.stdout is search('sample-project\s+1.0.0\s+' ~ remote_tmp_dir ~ '/sample-project')
+          - multi_pip_list_check.stdout is search('another-project\s+1.0.0\s+' ~ remote_tmp_dir ~ '/another-project')


### PR DESCRIPTION
##### SUMMARY

When the `editable` param is set to `True`, all packages should be installed as editable. Also, when using `requirements` instead of `name`, the `-e` flag causes pip to error. This PR also fixes this. 

Fixes #77755

Succeeds #78039

##### ISSUE TYPE

Bugfix Pull Request
