### PR TITLE
Fix windows test with coverage

### DIFF
--- a/lib/ansible/executor/powershell/coverage_wrapper.ps1
+++ b/lib/ansible/executor/powershell/coverage_wrapper.ps1
@@ -113,9 +113,10 @@ try {
             $scriptInfo = Get-AnsibleScript -Name $scriptName
 
             if (Compare-PathFilterPattern -Patterns $coveragePathFilter -Path $scriptInfo.Path) {
+                $ast = [Parser]::ParseInput($scriptInfo.Script, [ref]$null, [ref]$null)
                 $covParams = @{
                     ScriptName = $scriptInfo.Name
-                    ScriptBlockAst = [ScriptBlock]::Create($scriptInfo.Script).Ast
+                    ScriptBlockAst = $ast
                     AnsiblePath = $scriptInfo.Path
                 }
                 New-CoverageBreakpointsForScriptBlock @covParams


### PR DESCRIPTION
##### SUMMARY
The changes in https://github.com/ansible/ansible/pull/86627 added a new test which verified the behaviour when an invalid PowerShell script was used as a module. This works normally but when run with coverage on the overnight run an additional path needs to handle an invalid script as well.

No changelog is needed as the changes were only recently merged into devel.

##### ISSUE TYPE
- Bugfix Pull Request
