### PR TITLE
Fix ansiballz FileNotFoundError by eager-loading JSON profile before module execution

### DIFF
--- a/changelogs/fragments/fix-ansiballz-json-profile-eager-load.yml
+++ b/changelogs/fragments/fix-ansiballz-json-profile-eager-load.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - ansiballz - Eagerly load the JSON serialization profile in the module loader
+    to prevent ``FileNotFoundError`` when ``exit_json()`` attempts to resolve
+    the profile after the ansiballz zip payload has been deleted by
+    ``do_cleanup_files()``
+    (https://github.com/ansible/ansible/issues/86738).

--- a/changelogs/fragments/fix-ansiballz-json-profile-eager-load.yml
+++ b/changelogs/fragments/fix-ansiballz-json-profile-eager-load.yml
@@ -2,5 +2,7 @@ bugfixes:
   - ansiballz - Eagerly load the JSON serialization profile in the module loader
     to prevent ``FileNotFoundError`` when ``exit_json()`` attempts to resolve
     the profile after the ansiballz zip payload has been deleted by
-    ``do_cleanup_files()``
+    ``do_cleanup_files()``. Additionally, the ansiballz zip payload extraction
+    now uses ``scriptdir`` (under ``remote_tmp``) instead of the system tempdir,
+    with a fallback for permission errors
     (https://github.com/ansible/ansible/issues/86738).

--- a/lib/ansible/_internal/_ansiballz/_wrapper.py
+++ b/lib/ansible/_internal/_ansiballz/_wrapper.py
@@ -240,13 +240,15 @@ def _ansiballz_main(
 
     encoded_params = params.encode()
 
-    # There's a race condition with the controller removing the
-    # remote_tmpdir and this module executing under async.  So we cannot
-    # store this in remote_tmpdir (use system tempdir instead)
+    # Uses scriptdir to ensure we stay on the common remote_tmp
     # Only need to use [ansible_module]_payload_ in the temp_path until we move to zipimport
     # (this helps ansible-test produce coverage stats)
     # IMPORTANT: The real path must be used here to ensure a remote debugger such as PyCharm (using pydevd) can resolve paths correctly.
-    temp_path = os.path.realpath(tempfile.mkdtemp(prefix='ansible_' + ansible_module + '_payload_'))
+    try:
+        temp_path = os.path.realpath(tempfile.mkdtemp(prefix='ansible_' + ansible_module + '_payload_', dir=scriptdir))
+    except OSError:
+        # fallback to system temp on permission error, normally due to becoming unprivileged user
+        temp_path = os.path.realpath(tempfile.mkdtemp(prefix='ansible_' + ansible_module + '_payload_'))
 
     try:
         zipped_mod = os.path.join(temp_path, 'ansible_' + ansible_module + '_payload.zip')

--- a/lib/ansible/module_utils/_internal/_ansiballz/_loader.py
+++ b/lib/ansible/module_utils/_internal/_ansiballz/_loader.py
@@ -32,6 +32,12 @@ def run_module(
             extension_module = importlib.import_module(f'{_ansiballz.__name__}._extensions.{extension}')
             extension_module.run(args)
 
+        # Eagerly resolve and cache the JSON serialization profile module
+        # before running the user module. This ensures the profile is in
+        # sys.modules and available during exit_json() even after
+        # do_cleanup_files() has deleted the ansiballz zip payload.
+        get_module_encoder(profile, Direction.MODULE_TO_CONTROLLER)
+
         _run_module(
             json_params=json_params,
             profile=profile,

--- a/test/integration/targets/ansiballz_json_profile/aliases
+++ b/test/integration/targets/ansiballz_json_profile/aliases
@@ -1,3 +1,3 @@
 shippable/posix/group4
-needs/ssh
-needs/root
+context/controller
+gather_facts/no

--- a/test/integration/targets/ansiballz_json_profile/aliases
+++ b/test/integration/targets/ansiballz_json_profile/aliases
@@ -1,0 +1,3 @@
+shippable/posix/group4
+needs/ssh
+needs/root

--- a/test/integration/targets/ansiballz_json_profile/tasks/main.yml
+++ b/test/integration/targets/ansiballz_json_profile/tasks/main.yml
@@ -1,0 +1,57 @@
+---
+# Integration test: Verify that ansiballz modules can serialize results
+# across multiple module invocations where sys.modules may be empty and
+# the zip payload may be cleaned up between invocations.
+#
+# This test validates the fix for the FileNotFoundError caused by
+# _internal/_json lazy-import after do_cleanup_files() deletes the
+# ansiballz zip payload.
+
+- name: "Task 1 -- command module (establishes baseline)"
+  ansible.builtin.command: echo "task 1 works"
+  register: task1_result
+
+- name: Verify task 1 result
+  ansible.builtin.assert:
+    that:
+      - task1_result.rc == 0
+      - "'task 1 works' in task1_result.stdout"
+
+- name: "Task 2 -- shell module (different module type)"
+  ansible.builtin.shell: echo "task 2 works"
+  register: task2_result
+
+- name: Verify task 2 result
+  ansible.builtin.assert:
+    that:
+      - task2_result.rc == 0
+      - "'task 2 works' in task2_result.stdout"
+
+- name: "Task 3 -- file module (tests stat-based module)"
+  ansible.builtin.file:
+    path: /tmp/ansiballz_json_profile_test
+    state: touch
+    mode: "0644"
+  register: file_result
+
+- name: Verify file result serialized correctly
+  ansible.builtin.assert:
+    that:
+      - file_result is changed or file_result is not changed
+
+- name: "Task 4 -- copy module (tests content transfer + serialization)"
+  ansible.builtin.copy:
+    content: "ansiballz json profile test"
+    dest: /tmp/ansiballz_json_profile_test
+    mode: "0644"
+  register: copy_result
+
+- name: Verify copy result serialized correctly
+  ansible.builtin.assert:
+    that:
+      - copy_result is changed or copy_result is not changed
+
+- name: "Cleanup test files"
+  ansible.builtin.file:
+    path: /tmp/ansiballz_json_profile_test
+    state: absent

--- a/test/units/module_utils/_internal/test_ansiballz_loader_json_cache.py
+++ b/test/units/module_utils/_internal/test_ansiballz_loader_json_cache.py
@@ -1,0 +1,64 @@
+"""Tests for ansiballz loader JSON profile eager-loading fix.
+
+Verifies that calling get_module_encoder() caches the JSON serialization
+profile module in sys.modules, so subsequent importlib.util.find_spec()
+calls succeed even when the source zip is no longer available.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+
+import pytest
+
+from ansible.module_utils.common.json import get_module_encoder, Direction
+from ansible.module_utils._internal._json import (
+    get_module_serialization_profile_name,
+    get_serialization_module_name,
+)
+
+
+class TestJsonProfileEagerLoad:
+    """Verify that eager-loading the JSON profile populates sys.modules."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_profile_cache(self):
+        """Remove cached JSON profile modules from sys.modules before each test."""
+        profile_prefix = 'ansible.module_utils._internal._json._profiles.'
+        cached = [k for k in sys.modules if k.startswith(profile_prefix)]
+        saved = {k: sys.modules.pop(k) for k in cached}
+        yield
+        # Restore after test to avoid side effects on other tests
+        sys.modules.update(saved)
+
+    @pytest.mark.parametrize('profile', ['legacy', 'modern'])
+    def test_get_module_encoder_caches_profile_in_sys_modules(self, profile):
+        """After calling get_module_encoder(), the profile module must be in sys.modules."""
+        # Derive the expected fully-qualified module name for module-to-controller direction
+        profile_name = get_module_serialization_profile_name(profile, controller_to_module=False)
+        expected_module_name = get_serialization_module_name(profile_name)
+
+        # Ensure it is NOT in sys.modules before the call
+        sys.modules.pop(expected_module_name, None)
+        assert expected_module_name not in sys.modules
+
+        # This is the call the fix adds to run_module() -- it should cache the profile
+        get_module_encoder(profile, Direction.MODULE_TO_CONTROLLER)
+
+        # Now the profile module must be cached
+        assert expected_module_name in sys.modules
+
+    @pytest.mark.parametrize('profile', ['legacy', 'modern'])
+    def test_find_spec_succeeds_after_eager_load(self, profile):
+        """After eager-loading, importlib.util.find_spec() must succeed for the profile module."""
+        profile_name = get_module_serialization_profile_name(profile, controller_to_module=False)
+        expected_module_name = get_serialization_module_name(profile_name)
+
+        # Eager-load (simulates the fix in run_module)
+        get_module_encoder(profile, Direction.MODULE_TO_CONTROLLER)
+
+        # find_spec must resolve without touching the filesystem
+        spec = importlib.util.find_spec(expected_module_name)
+        assert spec is not None
+        assert spec.name == expected_module_name


### PR DESCRIPTION
##### SUMMARY

Two complementary fixes for the ansiballz `FileNotFoundError` during module result serialization.

Fixes #86738

**Fix 1 — Eager-load JSON profile (`_loader.py`):**

Eagerly call `get_module_encoder(profile, Direction.MODULE_TO_CONTROLLER)` in
`_loader.py:run_module()` before executing the user module. This populates
`sys.modules` with the JSON serialization profile so that `find_spec()` finds
it in cache during `exit_json()` and never attempts to read from the deleted
ansiballz zip payload.

**Fix 2 — Use scriptdir for zip extraction (`_wrapper.py`):**

Move ansiballz zip payload extraction from the system tempdir to `scriptdir`
(under `remote_tmp`), falling back to the system tempdir on `OSError`. This
prevents the cleanup race condition by keeping the zip in a managed directory
that isn't prematurely cleaned up. This approach is incorporated from
PR #82041 by @bcoca.

**Why both fixes:**

The two fixes address different layers of the same problem and provide
defense-in-depth:
- Fix 1 eliminates the *dependency* on the zip being present during result serialization
- Fix 2 changes *where* the zip is stored, preventing premature deletion

Both have been independently tested against the reproducer repository across
`pipelining=True` and `pipelining=False` configurations. They modify different
files (`_loader.py` vs `_wrapper.py`) and do not conflict.

##### BACKGROUND

The `_internal/_json` lazy-import system introduced in ansible-core 2.19 calls
`importlib.util.find_spec()` during `exit_json()` to resolve the JSON
serialization profile. When the ansiballz zip payload has already been deleted
by `do_cleanup_files()` (which runs earlier in `exit_json()`), this triggers a
`FileNotFoundError` from `zipimport._get_data()`.

**Reproducer repository**: https://github.com/ArmandoHerra/ansible-ansiballz-bug

**Test results**: Both fixes tested independently and combined across 8 EC2
Packer builds — all pass with `ok=10 changed=6 failed=0`. Full results in the
PR comments.

##### ISSUE TYPE

- Bugfix Pull Request