### PR TITLE
ansible-test acme cloud plugin: upgrade ACME test image to 2.4.0

### DIFF
--- a/changelogs/fragments/86740-acme.yml
+++ b/changelogs/fragments/86740-acme.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "ansible-test acme cloud plugin - update to the 2.4.0 ACME test image, which upgrades Pebble to 2.10.0, Go to 1.26, and Python to 3.14,
+     and generally updates all contained Python dependencies (https://github.com/ansible/ansible/pull/86740)."

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
@@ -29,7 +29,7 @@ class ACMEProvider(CloudProvider):
         if os.environ.get('ANSIBLE_ACME_CONTAINER'):
             self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
         else:
-            self.image = 'quay.io/ansible/acme-test-container:2.3.0'
+            self.image = 'quay.io/ansible/acme-test-container:2.4.0'
 
         self.uses_docker = True
 


### PR DESCRIPTION
##### SUMMARY

https://github.com/ansible/acme-test-container/releases/tag/2.4.0

##### ISSUE TYPE

- Feature Pull Request
