### PR TITLE
ACME cloud plugin: update ACME simulator image; return more information; add better tests

### DIFF
--- a/changelogs/fragments/86741-acme.yml
+++ b/changelogs/fragments/86741-acme.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - "ansible-test acme cloud plugin - update to the 2.4.1 ACME test image, and add new variables ``acme_endpoint_root_ca_certificate_content``,
+     ``acme_endpoint_root_ca_certificate_filename``, and ``acme_directory`` to the ACME cloud plugin. The ``acme_host`` variable is now
+     consistently set to ``pebble``, which is covered by the certificate the ACME endpoint is using. There are now also module defaults set
+     for ``group/acme``, which define ``acme_version``, ``acme_directory``, and ``ca_path`` (https://github.com/ansible/ansible/pull/86741)."

--- a/test/integration/targets/ansible-test-cloud-acme/tasks/main.yml
+++ b/test/integration/targets/ansible-test-cloud-acme/tasks/main.yml
@@ -5,3 +5,47 @@
   with_items:
     - http://{{ acme_host }}:5000/
     - https://{{ acme_host }}:14000/dir
+
+- name: Read controller root
+  uri:
+    url: http://{{ acme_host }}:5000/
+    return_content: true
+    follow_redirects: "none"
+  register: root
+
+- name: Validate controller root
+  assert:
+    that:
+      - root.content == "ACME test environment controller"
+
+- name: Write CA certificate's root certificate
+  copy:
+    content: "{{ acme_endpoint_root_ca_certificate_content }}"
+    dest: "{{ acme_endpoint_root_ca_certificate_filename }}"
+    mode: "0600"
+
+- name: Read ACME directory
+  uri:
+    url: "{{ acme_directory }}"
+    return_content: true
+    follow_redirects: "none"
+    validate_certs: true
+    ca_path: "{{ acme_endpoint_root_ca_certificate_filename }}"
+  register: directory
+
+- name: Validate ACME directory
+  assert:
+    that:
+      - acme_directory == ('https://' ~ acme_host ~ ':14000/dir')
+      - "'json' in directory"
+      - "'keyChange' in directory.json"
+      - "'meta' in directory.json"
+      - "'caaIdentities' in directory.json.meta"
+      - "'externalAccountRequired' in directory.json.meta"
+      - "'profiles' in directory.json.meta"
+      - "'termsOfService' in directory.json.meta"
+      - "'newAccount' in directory.json"
+      - "'newNonce' in directory.json"
+      - "'newOrder' in directory.json"
+      - "'renewalInfo' in directory.json"
+      - "'revokeCert' in directory.json"

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
@@ -26,10 +26,10 @@ class ACMEProvider(CloudProvider):
         super().__init__(args)
 
         # The simulator must be pinned to a specific version to guarantee CI passes with the version used.
-        if os.environ.get('ANSIBLE_ACME_CONTAINER'):
-            self.image = os.environ.get('ANSIBLE_ACME_CONTAINER')
-        else:
-            self.image = 'quay.io/ansible/acme-test-container:2.4.0'
+        self.image = os.getenv(
+            'ANSIBLE_ACME_CONTAINER',
+            'quay.io/ansible/acme-test-container:2.4.1',
+        )
 
         self.uses_docker = True
 

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import random
 
 from ....config import (
     IntegrationConfig,
@@ -10,6 +11,7 @@ from ....config import (
 
 from ....containers import (
     run_support_container,
+    wait_for_file,
 )
 
 from . import (
@@ -63,6 +65,18 @@ class ACMEProvider(CloudProvider):
         if not descriptor:
             return
 
+        if not self.args.explain:
+            def check(content: str) -> bool:
+                return content.startswith("-----BEGIN CERTIFICATE-----")
+
+            # It would be better to query the controller's /root-certificate-for-acme-endpoint endpoint,
+            # but that's more expensive
+            root_ca = wait_for_file(self.args, descriptor.name, '/pebble-src/test/certs/pebble.minica.pem', sleep=1, tries=30, check=check)
+
+            self._set_cloud_config('acme_endpoint_root_ca_certificate_content', root_ca)
+            rnd = random.randbytes(6).hex()
+            self._set_cloud_config('acme_endpoint_root_ca_certificate_filename', f'/tmp/acme-simulator-ca-cert-{rnd}.pem')
+
         self._set_cloud_config('acme_host', hostname)
 
     def _setup_static(self) -> None:
@@ -74,8 +88,16 @@ class ACMEEnvironment(CloudEnvironment):
 
     def get_environment_config(self) -> CloudEnvironmentConfig:
         """Return environment configuration for use in the test environment after delegation."""
+        ca_path_content = self._get_cloud_config('acme_endpoint_root_ca_certificate_content')
+        ca_path = self._get_cloud_config('acme_endpoint_root_ca_certificate_filename')
+        acme_host = self._get_cloud_config('acme_host')
+        acme_directory = f'https://{acme_host}:14000/dir'
+
         ansible_vars = dict(
-            acme_host=self._get_cloud_config('acme_host'),
+            acme_endpoint_root_ca_certificate_content=ca_path_content,
+            acme_endpoint_root_ca_certificate_filename=ca_path,
+            acme_host=acme_host,
+            acme_directory=acme_directory,
         )
 
         return CloudEnvironmentConfig(

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
@@ -102,4 +102,11 @@ class ACMEEnvironment(CloudEnvironment):
 
         return CloudEnvironmentConfig(
             ansible_vars=ansible_vars,
+            module_defaults={
+                'group/acme': {
+                    'ca_path': ca_path,
+                    'acme_version': 2,
+                    'acme_directory': acme_directory,
+                },
+            },
         )

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import collections.abc as c
 import os
 import random
+import time
+import typing as t
 
 from ....config import (
     IntegrationConfig,
@@ -11,7 +14,19 @@ from ....config import (
 
 from ....containers import (
     run_support_container,
-    wait_for_file,
+)
+
+from ....http import (
+    HttpClient,
+)
+
+from ....util import (
+    ApplicationError,
+    display,
+)
+
+from ....util_common import (
+    CommonConfig,
 )
 
 from . import (
@@ -19,6 +34,41 @@ from . import (
     CloudEnvironmentConfig,
     CloudProvider,
 )
+
+
+def wait_for_url(
+    args: CommonConfig,
+    url: str,
+    *,
+    sleep: int,
+    tries: int,
+    check: t.Optional[c.Callable[[int, str], bool]] = None,
+) -> tuple[int, str]:
+    """Wait for the specified URL to become available and return its HTTP status code and contents."""
+    display.info(f"Waiting for URL {url!r}", verbosity=1)
+
+    if not check:
+        def check(status: int, content: str) -> bool:  # pylint: disable=unused-argument
+            return 200 <= status < 300
+
+    client = HttpClient(args)
+    for _iteration in range(1, tries):
+        if _iteration > 1:
+            time.sleep(sleep)
+
+        try:
+            response = client.get(url)
+            status, content = response.status_code, response.response
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            status, content = -1, f"Error: {exc}"
+            continue
+
+        display.info(f"GET {url} -> {status}: {content!r}", verbosity=2)
+
+        if check(status, content):
+            return status, content
+
+    raise ApplicationError(f"Timeout waiting for URL {url!r}; last status was {status} and last content was {content!r}")
 
 
 class ACMEProvider(CloudProvider):
@@ -66,12 +116,14 @@ class ACMEProvider(CloudProvider):
             return
 
         if not self.args.explain:
-            def check(content: str) -> bool:
-                return content.startswith("-----BEGIN CERTIFICATE-----")
+            def check(status: int, content: str) -> bool:
+                return 200 <= status < 300 and content.startswith("-----BEGIN CERTIFICATE-----")
 
-            # It would be better to query the controller's /root-certificate-for-acme-endpoint endpoint,
-            # but that's more expensive
-            root_ca = wait_for_file(self.args, descriptor.name, '/pebble-src/test/certs/pebble.minica.pem', sleep=1, tries=30, check=check)
+            if 5000 in descriptor.details.published_ports:
+                our_hostname = f"localhost:{descriptor.details.published_ports[5000]}"
+            else:
+                our_hostname = f"{descriptor.details.container_ip}:5000"
+            dummy, root_ca = wait_for_url(self.args, f"http://{our_hostname}/root-certificate-for-acme-endpoint", sleep=1, tries=30, check=check)
 
             self._set_cloud_config('acme_endpoint_root_ca_certificate_content', root_ca)
             rnd = random.randbytes(6).hex()

--- a/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
+++ b/test/lib/ansible_test/_internal/commands/integration/cloud/acme.py
@@ -49,18 +49,21 @@ class ACMEProvider(CloudProvider):
             14000,  # Pebble ACME CA
         ]
 
+        hostname = 'pebble'
+
         descriptor = run_support_container(
             self.args,
             self.platform,
             self.image,
             'acme-simulator',
             ports,
+            aliases=[hostname],
         )
 
         if not descriptor:
             return
 
-        self._set_cloud_config('acme_host', descriptor.name)
+        self._set_cloud_config('acme_host', hostname)
 
     def _setup_static(self) -> None:
         raise NotImplementedError()


### PR DESCRIPTION
##### SUMMARY

- Update ACME simulator image to 2.4.1: https://github.com/ansible/acme-test-container/releases/tag/2.4.1
- Set hostname to `pebble`, which is included in Pebble's ACME endpoint's TLS certificate
- Export CA ceritficate content (for ACME endpoint's TLS certificate) and randomized filename so tests can avoid `validate_certificates: false`
- Export `acme_directory` variable which directly points to `https://{{ acme_host }}:14000/dir`
- Export `group/acme` module defaults (for `ca_path`, `acme_version`, `acme_directory`)

Note that setting `ca_path` in module defaults is not a breaking change:
* Either existing usage in tests use `validate_certs: false`. In that case, `ca_path` is ignored.
* If tests use `validate_certs: true` with the ACME cloud plugin, they have to explicitly set `ca_path` to something already, which overwrites the module defaults.

The only thing that can be broken are integration tests where behavior of missing parameters is tested. These can easily be fixed for all ansible-core versions by explicitly providing empty module defaults for `group/acme`.

##### ISSUE TYPE

- Feature Pull Request
- Test Pull Request
