### PR TITLE
Fix include_role block/rescue handling when role is not found (#86721)

### DIFF
--- a/changelogs/fragments/86721-fix-include-role-block-rescue.yml
+++ b/changelogs/fragments/86721-fix-include-role-block-rescue.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - include_role - Properly handle block/rescue when ``include_role`` references a nonexistent role inside a ``block/rescue``. Previously the host was unconditionally marked as failed, rescue stats were not incremented, and subsequent plays would skip the host. The error handling now mirrors normal task failure behavior by transitioning to the rescue section and correctly tracking rescued stats (https://github.com/ansible/ansible/issues/86721).

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -33,6 +33,7 @@ import time
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.executor.play_iterator import IteratingStates
 from ansible.playbook.handler import Handler
 from ansible.playbook.included_file import IncludedFile
 from ansible.plugins.loader import action_loader
@@ -253,9 +254,29 @@ class StrategyModule(StrategyBase):
                         for r in included_file._results:
                             r._return_data['failed'] = True
                             r._return_data['reason'] = str(ex)
-                            self._tqm._stats.increment('failures', r.host.name)
+                            if r.host not in failed_includes_hosts:
+                                state_when_failed = iterator.get_state_for_host(r.host.name)
+                                iterator.mark_host_failed(r.host)
+
+                                state, dummy = iterator.get_next_task_for_host(r.host, peek=True)
+                                if iterator.is_failed(r.host) and state and state.run_state == IteratingStates.COMPLETE:
+                                    self._tqm._failed_hosts[r.host.name] = True
+
+                                if iterator.is_any_block_rescuing(state_when_failed):
+                                    self._tqm._stats.increment('rescued', r.host.name)
+                                    iterator._play._removed_hosts.remove(r.host.name)
+                                    self._variable_manager.set_nonpersistent_facts(
+                                        r.host.name,
+                                        dict(
+                                            ansible_failed_task=r.task.dump_attrs(),
+                                            ansible_failed_result=r._return_data,
+                                        ),
+                                    )
+                                else:
+                                    self._tqm._stats.increment('failures', r.host.name)
+
+                                failed_includes_hosts.add(r.host)
                             self._tqm.send_callback('v2_runner_on_failed', r)
-                            failed_includes_hosts.add(r.host)
                         continue
                     else:
                         # since we skip incrementing the stats when the task result is
@@ -281,10 +302,6 @@ class StrategyModule(StrategyBase):
                             if host in included_file._hosts:
                                 all_blocks[host].append(final_block)
                     display.debug("done collecting new blocks for %s" % included_file)
-
-                for host in failed_includes_hosts:
-                    self._tqm._failed_hosts[host.name] = True
-                    iterator.mark_host_failed(host)
 
                 display.debug("adding all collected blocks from %d included file(s) to iterator" % len(included_files))
                 for host in hosts_left:

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -39,7 +39,7 @@ from ansible._internal._templating._engine import TemplateEngine
 from ansible.utils.display import Display
 from ansible.inventory.host import Host
 from ansible.playbook.task import Task
-from ansible.executor.play_iterator import PlayIterator
+from ansible.executor.play_iterator import IteratingStates, PlayIterator
 from ansible.playbook.play_context import PlayContext
 from ansible.executor import task_result as _task_result
 
@@ -288,19 +288,35 @@ class StrategyModule(StrategyBase):
                             for r in included_file._results:
                                 r._return_data['failed'] = True
                                 r._return_data['reason'] = str(ex)
-                                self._tqm._stats.increment('failures', r.host.name)
+                                if r.host not in failed_includes_hosts:
+                                    state_when_failed = iterator.get_state_for_host(r.host.name)
+                                    iterator.mark_host_failed(r.host)
+
+                                    state, dummy = iterator.get_next_task_for_host(r.host, peek=True)
+                                    if iterator.is_failed(r.host) and state and state.run_state == IteratingStates.COMPLETE:
+                                        self._tqm._failed_hosts[r.host.name] = True
+
+                                    if iterator.is_any_block_rescuing(state_when_failed):
+                                        self._tqm._stats.increment('rescued', r.host.name)
+                                        iterator._play._removed_hosts.remove(r.host.name)
+                                        self._variable_manager.set_nonpersistent_facts(
+                                            r.host.name,
+                                            dict(
+                                                ansible_failed_task=r.task.dump_attrs(),
+                                                ansible_failed_result=r._return_data,
+                                            ),
+                                        )
+                                    else:
+                                        self._tqm._stats.increment('failures', r.host.name)
+
+                                    failed_includes_hosts.add(r.host)
                                 self._tqm.send_callback('v2_runner_on_failed', r)
-                                failed_includes_hosts.add(r.host)
                         else:
                             # since we skip incrementing the stats when the task result is
                             # first processed, we do so now for each host in the list
                             for host in included_file._hosts:
                                 self._tqm._stats.increment('ok', host.name)
                             self._tqm.send_callback('v2_playbook_on_include', included_file)
-
-                    for host in failed_includes_hosts:
-                        self._tqm._failed_hosts[host.name] = True
-                        iterator.mark_host_failed(host)
 
                     # finally go through all of the hosts and append the
                     # accumulated blocks to their list of tasks


### PR DESCRIPTION
When include_role inside a block/rescue references a nonexistent role, the error handling in both linear and free strategies unconditionally marked the host as failed, skipping rescue and preventing subsequent plays from executing for that host.

The fix mirrors the normal task failure logic from _process_pending_results: after mark_host_failed, we check is_any_block_rescuing to determine if the failure should be rescued rather than unconditionally counted as a failure.

##### SUMMARY

When `include_role` references a nonexistent role inside a `block/rescue`, the host was unconditionally marked as failed, rescue stats were not incremented, and subsequent plays would skip the host.

This PR fixes the error handling in both the `linear` and `free` strategy plugins so that `include_role` failures inside a `block/rescue` correctly transition to the rescue section instead of unconditionally counting as a failure.

Changes:
- After `mark_host_failed`, check `is_any_block_rescuing` to decide whether to increment `rescued` or `failures` stats
- When rescuing, set `ansible_failed_task` and `ansible_failed_result` facts and remove the host from `_removed_hosts`, matching the behavior of `_process_pending_results`
- Only mark the host in `_failed_hosts` if the iterator reaches `COMPLETE` state after failure
- Move `mark_host_failed` and stat tracking inside the per-result loop (before it was deferred and done unconditionally after all includes)

Fixes #86721

##### ISSUE TYPE

- Bugfix Pull Request