### PR TITLE
Collection finder Python loader updates

### DIFF
--- a/changelogs/fragments/py-loader-updates.yml
+++ b/changelogs/fragments/py-loader-updates.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- collection finder - Remove exec side effects from our loader implementation
+- collection finder - Align ``_AnsibleTraversableResources`` with behavior changes in py3.12+ with a file/module
+- collection finder - Address ``importlib.resources`` issues with ``ansible_collections.ansible.builtin``

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -20,6 +20,7 @@ import yaml
 
 from collections import defaultdict, namedtuple
 from importlib import import_module
+from importlib.util import find_spec
 from yaml.parser import ParserError
 
 from ansible import __version__ as ansible_version
@@ -681,14 +682,18 @@ class PluginLoader:
             n_resource += extension
 
         pkg = sys.modules.get(acr.n_python_package_name)
-        if not pkg:
-            # FIXME: there must be cheaper/safer way to do this
+        if pkg:
+            pkg_path = os.path.dirname(pkg.__file__)
+        else:
+            # Use find_spec to locate package without executing it
             try:
-                pkg = import_module(acr.n_python_package_name)
+                spec = find_spec(acr.n_python_package_name)
             except ImportError:
+                # find_spec can raise if traversing through a non-existent intermediate package
+                spec = None
+            if not spec or not spec.origin:
                 return plugin_load_context.nope('Python package {0} not found'.format(acr.n_python_package_name))
-
-        pkg_path = os.path.dirname(pkg.__file__)
+            pkg_path = os.path.dirname(spec.origin)
 
         n_resource_path = os.path.join(pkg_path, n_resource)
 

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -169,7 +169,11 @@ class _AnsibleTraversableResources(TraversableResources):
         is_ns = parts[0] == 'ansible_collections' and len(parts) < 3
 
         if isinstance(package, str):
-            if is_ns:
+            # Check if the module is already loaded - if so, use it directly
+            # This handles redirected modules correctly
+            if package in sys.modules:
+                package = sys.modules[package]
+            elif is_ns:
                 # Don't use ``spec_from_loader`` here, because that will point
                 # to exactly 1 location for a namespace. Use ``find_spec``
                 # to get a list of all locations for the namespace
@@ -177,12 +181,20 @@ class _AnsibleTraversableResources(TraversableResources):
                 if package is None:
                     raise ImportError(f'No module named {self._package!r}')
             else:
-                package = spec_from_loader(package, self._loader)
+                # Use find_spec to get the proper spec with origin set
+                package = find_spec(package)
+                if package is None:
+                    raise ImportError(f'No module named {self._package!r}')
         elif not isinstance(package, ModuleType):
             raise TypeError('Expected string or module, got %r' % package.__class__.__name__)
 
         if is_ns:
-            return _AnsibleNSTraversable(*package.submodule_search_locations)
+            # Handle both spec objects (which have submodule_search_locations)
+            # and module objects (which have __path__)
+            if isinstance(package, ModuleType):
+                return _AnsibleNSTraversable(*package.__path__)
+            else:
+                return _AnsibleNSTraversable(*package.submodule_search_locations)
         # In Python 3.12+, files() returns the parent directory for both packages
         # and modules, so a module and its containing package return the same path
         return pathlib.Path(self._get_path(package)).parent

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -16,8 +16,7 @@ import sys
 
 from contextlib import contextmanager
 from importlib import import_module, reload as reload_module
-from importlib.machinery import FileFinder
-from importlib.util import find_spec, spec_from_loader
+from importlib.util import find_spec, module_from_spec, spec_from_loader
 from keyword import iskeyword
 from types import ModuleType
 
@@ -37,6 +36,17 @@ except ImportError:
     # is deprecated as of Python 3.12.
     # deprecated: description='TraversableResources move' python_version='3.10'
     from importlib.abc import TraversableResources  # type: ignore[assignment,no-redef]
+
+if sys.version_info >= (3, 10):
+    from importlib.resources import files
+else:
+    # Python 3.9 compatibility: files() behavior differs from 3.10+
+    # deprecated: description='reliable importlib.resources.files' python_version='3.10'
+    def files(name):
+        if (spec := find_spec(name)) is None:
+            raise ImportError(name)
+        origin = pathlib.Path(spec.origin)
+        return origin.parent
 
 # NB: this supports import sanity test providing a different impl
 try:
@@ -171,6 +181,8 @@ class _AnsibleTraversableResources(TraversableResources):
                 # to exactly 1 location for a namespace. Use ``find_spec``
                 # to get a list of all locations for the namespace
                 package = find_spec(package)
+                if package is None:
+                    raise ImportError(f'No module named {self._package!r}')
             else:
                 package = spec_from_loader(package, self._loader)
         elif not isinstance(package, ModuleType):
@@ -343,10 +355,6 @@ class _AnsibleCollectionFinder:
             # TODO: log attempt to load context
             return None
 
-    def find_module(self, fullname, path=None):
-        # Figure out what's being asked for, and delegate to a special-purpose loader
-        return self._get_loader(fullname, path)
-
     def find_spec(self, fullname, path, target=None):
         loader = self._get_loader(fullname, path)
 
@@ -409,20 +417,6 @@ class _AnsiblePathHookFinder:
 
             return self._file_finder
 
-    def find_module(self, fullname, path=None):
-        # we ignore the passed in path here- use what we got from the path hook init
-        finder = self._get_finder(fullname)
-
-        if finder is None:
-            return None
-        elif isinstance(finder, FileFinder):
-            # this codepath is erroneously used under some cases in py3,
-            # and the find_module method on FileFinder does not accept the path arg
-            # see https://github.com/pypa/setuptools/pull/2918
-            return finder.find_module(fullname)
-        else:
-            return finder.find_module(fullname, path=[self._pathctx])
-
     def find_spec(self, fullname, target=None):
         split_name = fullname.split('.')
         toplevel_pkg = split_name[0]
@@ -450,6 +444,7 @@ class _AnsibleCollectionPkgLoaderBase:
     def __init__(self, fullname, path_list=None):
         self._fullname = fullname
         self._redirect_module = None
+        self._redirect_module_spec = None
         self._split_name = fullname.split('.')
         self._rpart_name = fullname.rpartition('.')
         self._parent_package_name = self._rpart_name[0]  # eg ansible_collections for ansible_collections.somens, '' for toplevel
@@ -532,8 +527,16 @@ class _AnsibleCollectionPkgLoaderBase:
         return _AnsibleTraversableResources(fullname, self)
 
     def exec_module(self, module):
-        # short-circuit redirect; avoid reinitializing existing modules
-        if self._redirect_module:
+        if self._redirect_module_spec and not sys.modules.get(self._redirect_module_spec.name):
+            # mirror import_module behavior
+            sys.modules[self._redirect_module_spec.name] = self._redirect_module
+            parent, _sep, child = self._redirect_module_spec.name.rpartition('.')
+            parent_module = sys.modules[parent]
+            setattr(parent_module, child, self._redirect_module)
+
+            # Actually exec the module
+            self._redirect_module_spec.loader.exec_module(self._redirect_module)
+
             return
 
         # execute the module's code in its namespace
@@ -542,37 +545,15 @@ class _AnsibleCollectionPkgLoaderBase:
             exec(code_obj, module.__dict__)
 
     def create_module(self, spec):
-        # short-circuit redirect; we've already imported the redirected module, so just alias it and return it
+        if self._redirect_module_spec and (module := sys.modules.get(self._redirect_module_spec.name)):
+            self._redirect_module = module
+        elif self._redirect_module_spec:
+            self._redirect_module = module_from_spec(self._redirect_module_spec)
+
         if self._redirect_module:
             return self._redirect_module
         else:
             return None
-
-    def load_module(self, fullname):
-        # short-circuit redirect; we've already imported the redirected module, so just alias it and return it
-        if self._redirect_module:
-            sys.modules[self._fullname] = self._redirect_module
-            return self._redirect_module
-
-        # we're actually loading a module/package
-        module_attrs = dict(
-            __loader__=self,
-            __file__=self.get_filename(fullname),
-            __package__=self._parent_package_name  # sane default for non-packages
-        )
-
-        # eg, I am a package
-        if self._subpackage_search_paths is not None:  # empty is legal
-            module_attrs['__path__'] = self._subpackage_search_paths
-            module_attrs['__package__'] = fullname  # per PEP366
-
-        with self._new_or_existing_module(fullname, **module_attrs) as module:
-            # execute the module's code in its namespace
-            code_obj = self.get_code(fullname)
-            if code_obj is not None:  # things like NS packages that can't have code on disk will return None
-                exec(code_obj, module.__dict__)
-
-            return module
 
     def is_package(self, fullname):
         if fullname != self._fullname:
@@ -713,9 +694,9 @@ class _AnsibleCollectionPkgLoader(_AnsibleCollectionPkgLoaderBase):
 
         if collection_name == 'ansible.builtin':
             # ansible.builtin is a synthetic collection, get its routing config from the Ansible distro
-            ansible_pkg_path = os.path.dirname(import_module('ansible').__file__)
-            metadata_path = os.path.join(ansible_pkg_path, 'config/ansible_builtin_runtime.yml')
-            with open(_to_bytes(metadata_path), 'rb') as fd:
+            ansible_pkg_path = files('ansible')
+            metadata_path = ansible_pkg_path / 'config/ansible_builtin_runtime.yml'
+            with metadata_path.open('rb') as fd:
                 raw_routing = fd.read()
         else:
             b_routing_meta_path = _to_bytes(os.path.join(module.__path__[0], 'meta/runtime.yml'))
@@ -741,10 +722,6 @@ class _AnsibleCollectionPkgLoader(_AnsibleCollectionPkgLoaderBase):
 
     def create_module(self, spec):
         return None
-
-    def load_module(self, fullname):
-        module = super(_AnsibleCollectionPkgLoader, self).load_module(fullname)
-        return self._load_module(module)
 
     def _canonicalize_meta(self, meta_dict):
         # TODO: rewrite import keys and all redirect targets that start with .. (current namespace) and . (current collection)
@@ -807,8 +784,11 @@ class _AnsibleCollectionLoader(_AnsibleCollectionPkgLoaderBase):
         # see the redirected ancestor package contents instead of the package where they actually live).
         if redirect:
             # FIXME: wrap this so we can be explicit about a failed redirection
-            self._redirect_module = import_module(redirect)
-            if explicit_redirect and hasattr(self._redirect_module, '__path__') and self._redirect_module.__path__:
+            if not (spec := find_spec(redirect)):
+                raise ImportError(redirect)
+            self._redirect_module_spec = spec
+            self.path = spec.origin
+            if explicit_redirect and spec.loader.is_package(redirect):
                 # if the import target looks like a package, store its name so we can rewrite future descendent loads
                 self._redirected_package_map[self._fullname] = redirect
 
@@ -869,20 +849,6 @@ class _AnsibleInternalRedirectLoader:
 
     def create_module(self, spec):
         return None
-
-    def load_module(self, fullname):
-        # since we're delegating to other loaders, this should only be called for internal redirects where we answered
-        # find_module with this loader, in which case we'll just directly import the redirection target, insert it into
-        # sys.modules under the name it was requested by, and return the original module.
-
-        # should never see this
-        if not self._redirect:
-            raise ValueError('no redirect found for {0}'.format(fullname))
-
-        # FIXME: smuggle redirection context, provide warning/error that we tried and failed to redirect
-        mod = import_module(self._redirect)
-        sys.modules[fullname] = mod
-        return mod
 
 
 class AnsibleCollectionRef:
@@ -1079,11 +1045,11 @@ def _get_collection_path(collection_name):
     if not collection_name or not isinstance(collection_name, str) or len(collection_name.split('.')) != 2:
         raise ValueError('collection_name must be a non-empty string of the form namespace.collection')
     try:
-        collection_pkg = import_module('ansible_collections.' + collection_name)
+        collection_pkg = files('ansible_collections.' + collection_name)
     except ImportError:
         raise ValueError('unable to locate collection {0}'.format(collection_name))
 
-    return _to_text(os.path.dirname(_to_bytes(collection_pkg.__file__)))
+    return str(collection_pkg)
 
 
 def _get_collection_playbook_path(playbook):
@@ -1092,27 +1058,26 @@ def _get_collection_playbook_path(playbook):
     if acr:
         try:
             # get_collection_path
-            pkg = import_module(acr.n_python_collection_package_name)
+            pkg = files(acr.n_python_collection_package_name)
         except (OSError, ModuleNotFoundError) as ex:
             # leaving ex as debug target, even though not used in normal code
             pkg = None
 
         if pkg:
-            cpath = os.path.join(sys.modules[acr.n_python_collection_package_name].__file__.replace('__synthetic__', 'playbooks'))
+            cpath = pkg / 'playbooks'
 
             if acr.subdirs:
                 paths = [_to_text(x) for x in acr.subdirs.split(u'.')]
-                paths.insert(0, cpath)
-                cpath = os.path.join(*paths)
+                cpath = cpath.joinpath(*paths)
 
-            path = os.path.join(cpath, _to_text(acr.resource))
-            if os.path.exists(_to_bytes(path)):
-                return acr.resource, path, acr.collection
+            path = cpath / _to_text(acr.resource)
+            if path.exists():
+                return acr.resource, str(path), acr.collection
             elif not acr.resource.endswith(PB_EXTENSIONS):
                 for ext in PB_EXTENSIONS:
-                    path = os.path.join(cpath, _to_text(acr.resource + ext))
-                    if os.path.exists(_to_bytes(path)):
-                        return acr.resource, path, acr.collection
+                    path = (cpath / _to_text(acr.resource)).with_suffix(ext)
+                    if path.exists():
+                        return acr.resource, str(path), acr.collection
     return None
 
 
@@ -1142,13 +1107,8 @@ def _get_collection_resource_path(name, ref_type, collection_list=None):
         try:
             acr = AnsibleCollectionRef(collection_name=collection_name, subdirs=subdirs, resource=resource, ref_type=ref_type)
             # FIXME: error handling/logging; need to catch any import failures and move along
-            pkg = import_module(acr.n_python_package_name)
-
-            if pkg is not None:
-                # the package is now loaded, get the collection's package and ask where it lives
-                path = os.path.dirname(_to_bytes(sys.modules[acr.n_python_package_name].__file__))
-                return resource, _to_text(path), collection_name
-
+            pkg = files(acr.n_python_package_name)
+            return resource, str(pkg), collection_name
         except (OSError, ModuleNotFoundError) as ex:
             continue
         except Exception as ex:
@@ -1168,32 +1128,30 @@ def _get_collection_name_from_path(path):
     """
 
     # ensure we compare full paths since pkg path will be abspath
-    path = _to_text(os.path.abspath(_to_bytes(path)))
+    path = pathlib.Path(_to_text(path)).absolute()
 
-    path_parts = path.split('/')
-    if path_parts.count('ansible_collections') != 1:
+    if path.parts.count('ansible_collections') != 1:
         return None
 
-    ac_pos = path_parts.index('ansible_collections')
+    ac_pos = path.parts.index('ansible_collections')
 
     # make sure it's followed by at least a namespace and collection name
-    if len(path_parts) < ac_pos + 3:
+    if len(path.parts) < ac_pos + 3:
         return None
 
-    candidate_collection_name = '.'.join(path_parts[ac_pos + 1:ac_pos + 3])
+    candidate_collection_name = '.'.join(path.parts[ac_pos + 1:ac_pos + 3])
 
     try:
         # we've got a name for it, now see if the path prefix matches what the loader sees
-        imported_pkg_path = _to_text(os.path.dirname(_to_bytes(import_module('ansible_collections.' + candidate_collection_name).__file__)))
+        imported_pkg_path = files('ansible_collections.' + candidate_collection_name)
     except ImportError:
         return None
 
     # reassemble the original path prefix up the collection name, and it should match what we just imported. If not
     # this is probably a collection root that's not configured.
 
-    original_path_prefix = os.path.join('/', *path_parts[0:ac_pos + 3])
+    original_path_prefix = pathlib.Path(*path.parts[0:ac_pos + 3])
 
-    imported_pkg_path = _to_text(os.path.abspath(_to_bytes(imported_pkg_path)))
     if original_path_prefix != imported_pkg_path:
         return None
 

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -445,8 +445,6 @@ class _AnsiblePathHookFinder:
 
 
 class _AnsibleCollectionPkgLoaderBase:
-    _allows_package_code = False
-
     def __init__(self, fullname, path_list=None):
         self._fullname = fullname
         self._redirect_module = None
@@ -689,6 +687,10 @@ class _AnsibleCollectionPkgLoader(_AnsibleCollectionPkgLoaderBase):
             # only search within the first collection we found
             self._subpackage_search_paths = [self._subpackage_search_paths[0]]
 
+        # Force collection root packages to always be synthetic (no __init__.py execution)
+        # This prevents arbitrary code execution at the collection root level
+        self._source_code_path = None
+
     def _load_module(self, module):
         if not _meta_yml_to_dict:
             raise ValueError('ansible.utils.collection_loader._meta_yml_to_dict is not set')
@@ -752,7 +754,6 @@ class _AnsibleCollectionPkgLoader(_AnsibleCollectionPkgLoaderBase):
 class _AnsibleCollectionLoader(_AnsibleCollectionPkgLoaderBase):
     # HACK: stash this in a better place
     _redirected_package_map = {}  # type: dict[str, str]
-    _allows_package_code = True
 
     def _validate_args(self):
         super(_AnsibleCollectionLoader, self)._validate_args()
@@ -811,7 +812,13 @@ class _AnsibleCollectionLoader(_AnsibleCollectionPkgLoaderBase):
         found_path, has_code, package_path = self._module_file_from_path(self._package_to_load, candidate_paths[0])
 
         # still here? we found something to load...
-        if has_code:
+        # Detect if we're loading a module package (ansible_collections.*.*.plugins.modules.*)
+        # Modules are not allowed to have shared code in __init__.py
+        is_module = self._split_name[3:5] == ['plugins', 'modules']
+
+        # Only allow code execution for leaf modules or non-module packages
+        # For modules specifically, force packages to be synthetic (no __init__.py execution)
+        if has_code and not (package_path and is_module):
             self._source_code_path = found_path
 
         if package_path:

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -341,6 +341,7 @@ class _AnsibleCollectionFinder:
         if part_count > 1 and path is None:
             raise ValueError('path must be specified for subpackages (trying to find {0})'.format(fullname))
 
+        kwargs = {}
         if toplevel_pkg == 'ansible':
             # something under the ansible package, delegate to our internal loader in case of redirections
             initialize_loader = _AnsibleInternalRedirectLoader
@@ -353,10 +354,12 @@ class _AnsibleCollectionFinder:
         else:
             # anything below the collection
             initialize_loader = _AnsibleCollectionLoader
+            is_module = split_name[3:5] == ['plugins', 'modules']
+            kwargs['allows_package_code'] = not is_module
 
         # NB: actual "find"ing is delegated to the constructors on the various loaders; they'll ImportError if not found
         try:
-            return initialize_loader(fullname=fullname, path_list=path)
+            return initialize_loader(fullname=fullname, path_list=path, **kwargs)
         except ImportError:
             # TODO: log attempt to load context
             return None
@@ -755,6 +758,10 @@ class _AnsibleCollectionLoader(_AnsibleCollectionPkgLoaderBase):
     # HACK: stash this in a better place
     _redirected_package_map = {}  # type: dict[str, str]
 
+    def __init__(self, *args, allows_package_code=True, **kwargs):
+        self._allows_package_code = allows_package_code
+        super().__init__(*args, **kwargs)
+
     def _validate_args(self):
         super(_AnsibleCollectionLoader, self)._validate_args()
         if len(self._split_name) < 4:
@@ -812,13 +819,7 @@ class _AnsibleCollectionLoader(_AnsibleCollectionPkgLoaderBase):
         found_path, has_code, package_path = self._module_file_from_path(self._package_to_load, candidate_paths[0])
 
         # still here? we found something to load...
-        # Detect if we're loading a module package (ansible_collections.*.*.plugins.modules.*)
-        # Modules are not allowed to have shared code in __init__.py
-        is_module = self._split_name[3:5] == ['plugins', 'modules']
-
-        # Only allow code execution for leaf modules or non-module packages
-        # For modules specifically, force packages to be synthetic (no __init__.py execution)
-        if has_code and not (package_path and is_module):
+        if has_code and (self._allows_package_code or not package_path):
             self._source_code_path = found_path
 
         if package_path:

--- a/lib/ansible/utils/collection_loader/_collection_finder.py
+++ b/lib/ansible/utils/collection_loader/_collection_finder.py
@@ -163,13 +163,6 @@ class _AnsibleTraversableResources(TraversableResources):
         module_filename = os.path.basename(origin)
         return module_filename in {'__synthetic__', '__init__.py'}
 
-    def _ensure_package(self, package):
-        if self._is_ansible_ns_package(package):
-            # Short circuit our loaders
-            return
-        if self._get_package(package) != package.__name__:
-            raise TypeError('%r is not a package' % package.__name__)
-
     def files(self):
         package = self._package
         parts = package.split('.')
@@ -188,9 +181,10 @@ class _AnsibleTraversableResources(TraversableResources):
         elif not isinstance(package, ModuleType):
             raise TypeError('Expected string or module, got %r' % package.__class__.__name__)
 
-        self._ensure_package(package)
         if is_ns:
             return _AnsibleNSTraversable(*package.submodule_search_locations)
+        # In Python 3.12+, files() returns the parent directory for both packages
+        # and modules, so a module and its containing package return the same path
         return pathlib.Path(self._get_path(package)).parent
 
 

--- a/test/lib/ansible_test/_util/target/sanity/import/importer.py
+++ b/test/lib/ansible_test/_util/target/sanity/import/importer.py
@@ -51,14 +51,8 @@ def main():
             return sys.modules[name]
 
     from io import BytesIO, TextIOWrapper
-
-    try:
-        from importlib.util import spec_from_loader, module_from_spec
-        from importlib.machinery import SourceFileLoader, ModuleSpec  # pylint: disable=unused-import
-    except ImportError:
-        has_py3_loader = False
-    else:
-        has_py3_loader = True
+    from importlib.util import spec_from_loader, module_from_spec
+    from importlib.machinery import SourceFileLoader, ModuleSpec
 
     if collection_full_name:
         # allow importing code from collections when testing a collection
@@ -136,6 +130,16 @@ def main():
         ansible_module.__path__ = ansible.__path__
         ansible_module.__package__ = ansible.__package__
 
+        # Create a proper __spec__ for the synthetic module to support modern import machinery
+        # Use the original loader so resource access (files()) works correctly
+        ansible_module.__spec__ = ModuleSpec(
+            name=ansible.__name__,
+            loader=ansible.__spec__.loader if ansible.__spec__ else None,
+            origin=ansible.__file__,
+            is_package=True
+        )
+        ansible_module.__spec__.submodule_search_locations = ansible.__path__
+
         sys.modules[ansible.__name__] = ansible_module
 
     class ImporterAnsibleModuleException(Exception):
@@ -161,10 +165,8 @@ def main():
             """Return the spec from the loader or None"""
             loader = self._get_loader(fullname, path=path)
             if loader is not None:
-                if has_py3_loader:
-                    # loader is expected to be Optional[importlib.abc.Loader], but RestrictedModuleLoader does not inherit from importlib.abc.Loader
-                    return spec_from_loader(fullname, loader)  # type: ignore[arg-type]
-                raise ImportError("Failed to import '%s' due to a bug in ansible-test. Check importlib imports for typos." % fullname)
+                # loader is expected to be Optional[importlib.abc.Loader], but RestrictedModuleLoader does not inherit from importlib.abc.Loader
+                return spec_from_loader(fullname, loader)  # type: ignore[arg-type]
             return None
 
         def find_module(self, fullname, path=None):
@@ -203,7 +205,7 @@ def main():
                 if is_name_in_namepace(fullname, ['ansible_collections...plugins.module_utils', self.name]):
                     return None  # module_utils and module under test are always allowed
 
-                if collection_loader.find_module(fullname, path):
+                if collection_loader.find_spec(fullname, path):
                     return self  # restrict access to collection files that exist
 
                 return None  # collection file does not exist, do not restrict access

--- a/test/units/utils/collection_loader/test_collection_loader.py
+++ b/test/units/utils/collection_loader/test_collection_loader.py
@@ -10,6 +10,7 @@ import typing as t
 
 import importlib.util
 from importlib import import_module
+from importlib.util import find_spec
 
 from ansible.utils.collection_loader import AnsibleCollectionConfig, AnsibleCollectionRef
 from ansible.utils.collection_loader._collection_finder import (
@@ -618,6 +619,21 @@ def test_empty_vs_no_code():
     # ensure empty package inits do have a code object
     assert module_utils.__loader__.get_source(module_utils.__name__) == b''
     assert module_utils.__loader__.get_code(module_utils.__name__) is not None
+
+
+def test_module_packages_no_exec():
+    """Test that module packages don't execute __init__.py when using find_spec."""
+    finder = get_default_finder()
+    reset_collections_loader_state(finder)
+
+    # This should not execute the modules/__init__.py which has raise Exception('this should never run')
+    spec = find_spec('ansible_collections.testns.testcoll.plugins.modules')
+    assert spec is not None
+    assert spec.loader is not None
+
+    # Verify the package is synthetic (no source code)
+    assert spec.loader.get_source('ansible_collections.testns.testcoll.plugins.modules') is None
+    assert spec.loader.get_code('ansible_collections.testns.testcoll.plugins.modules') is None
 
 
 def test_finder_playbook_paths():

--- a/test/units/utils/collection_loader/test_collection_loader.py
+++ b/test/units/utils/collection_loader/test_collection_loader.py
@@ -889,6 +889,29 @@ def test_importlib_resources_module():
     assert module_utils == my_util
 
 
+def test_importlib_resources_builtin_redirect():
+    """Test that files() works correctly with ansible.builtin redirects."""
+    from importlib.resources import files
+    from pathlib import Path
+
+    # Initialize the collection loader with builtin support
+    from ansible.plugins.loader import init_plugin_loader
+    init_plugin_loader()
+
+    # Test that builtin redirects work with files()
+    builtin_modules = files('ansible_collections.ansible.builtin.plugins.modules')
+    real_modules = files('ansible.modules')
+    assert builtin_modules == real_modules
+
+    builtin_module_utils = files('ansible_collections.ansible.builtin.plugins.module_utils')
+    real_module_utils = files('ansible.module_utils')
+    assert builtin_module_utils == real_module_utils
+
+    builtin_plugins = files('ansible_collections.ansible.builtin.plugins')
+    real_plugins = files('ansible.plugins')
+    assert builtin_plugins == real_plugins
+
+
 # BEGIN TEST SUPPORT
 
 default_test_collection_paths = [

--- a/test/units/utils/collection_loader/test_collection_loader.py
+++ b/test/units/utils/collection_loader/test_collection_loader.py
@@ -868,6 +868,27 @@ def test_importlib_resources():
     assert next(module_utils.glob('__init__.py')) == nestcoll_mu_init
 
 
+def test_importlib_resources_module():
+    """Test Python 3.12+ behavior where files() returns parent for both packages and modules."""
+    from importlib.resources import files
+    from pathlib import Path
+
+    f = get_default_finder()
+    reset_collections_loader_state(f)
+
+    # Test that calling files() on a module returns the same path as calling it on the package
+    module_utils = files('ansible_collections.testns.testcoll.plugins.module_utils')
+    my_util = files('ansible_collections.testns.testcoll.plugins.module_utils.my_util')
+
+    assert isinstance(module_utils, Path)
+    assert isinstance(my_util, Path)
+
+    assert module_utils.is_dir()
+    assert my_util.is_dir()
+    # This is the key assertion: module and package should return the same path
+    assert module_utils == my_util
+
+
 # BEGIN TEST SUPPORT
 
 default_test_collection_paths = [

--- a/test/units/utils/collection_loader/test_collection_loader.py
+++ b/test/units/utils/collection_loader/test_collection_loader.py
@@ -8,9 +8,9 @@ import re
 import sys
 import typing as t
 
+import importlib.util
 from importlib import import_module
 
-from ansible.modules import ping as ping_module
 from ansible.utils.collection_loader import AnsibleCollectionConfig, AnsibleCollectionRef
 from ansible.utils.collection_loader._collection_finder import (
     _AnsibleCollectionFinder, _AnsibleCollectionLoader, _AnsibleCollectionNSPkgLoader, _AnsibleCollectionPkgLoader,
@@ -28,35 +28,6 @@ def teardown(*args, **kwargs):
     reset_collections_loader_state()
 
 # BEGIN STANDALONE TESTS - these exercise behaviors of the individual components without the import machinery
-
-
-@pytest.mark.filterwarnings(
-    'ignore:'
-    r'find_module\(\) is deprecated and slated for removal in Python 3\.12; use find_spec\(\) instead'
-    ':DeprecationWarning',
-    'ignore:'
-    r'FileFinder\.find_loader\(\) is deprecated and slated for removal in Python 3\.12; use find_spec\(\) instead'
-    ':DeprecationWarning',
-)
-@pytest.mark.skipif(sys.version_info >= (3, 12), reason='Testing Python 2 codepath (find_module) on Python 3, <= 3.11')
-def test_find_module_py3_lt_312():
-    dir_to_a_file = os.path.dirname(ping_module.__file__)
-    path_hook_finder = _AnsiblePathHookFinder(_AnsibleCollectionFinder(), dir_to_a_file)
-
-    # setuptools may fall back to find_module on Python 3 if find_spec returns None
-    # see https://github.com/pypa/setuptools/pull/2918
-    assert path_hook_finder.find_spec('missing') is None
-    assert path_hook_finder.find_module('missing') is None
-
-
-@pytest.mark.skipif(sys.version_info < (3, 12), reason='Testing Python 2 codepath (find_module) on Python >= 3.12')
-def test_find_module_py3_gt_311():
-    dir_to_a_file = os.path.dirname(ping_module.__file__)
-    path_hook_finder = _AnsiblePathHookFinder(_AnsibleCollectionFinder(), dir_to_a_file)
-
-    # setuptools may fall back to find_module on Python 3 if find_spec returns None
-    # see https://github.com/pypa/setuptools/pull/2918
-    assert path_hook_finder.find_spec('missing') is None
 
 
 def test_finder_setup():
@@ -86,36 +57,36 @@ def test_finder_setup():
 
 def test_finder_not_interested():
     f = get_default_finder()
-    assert f.find_module('nothanks') is None
-    assert f.find_module('nothanks.sub', path=['/bogus/dir']) is None
+    assert f.find_spec('nothanks', path=None) is None
+    assert f.find_spec('nothanks.sub', path=['/bogus/dir']) is None
 
 
 def test_finder_ns():
     # ensure we can still load ansible_collections and ansible_collections.ansible when they don't exist on disk
     f = _AnsibleCollectionFinder(paths=['/bogus/bogus'])
-    loader = f.find_module('ansible_collections')
-    assert isinstance(loader, _AnsibleCollectionRootPkgLoader)
+    spec = f.find_spec('ansible_collections', path=None)
+    assert isinstance(spec.loader, _AnsibleCollectionRootPkgLoader)
 
-    loader = f.find_module('ansible_collections.ansible', path=['/bogus/bogus'])
-    assert isinstance(loader, _AnsibleCollectionNSPkgLoader)
+    spec = f.find_spec('ansible_collections.ansible', path=['/bogus/bogus'])
+    assert isinstance(spec.loader, _AnsibleCollectionNSPkgLoader)
 
     f = get_default_finder()
-    loader = f.find_module('ansible_collections')
-    assert isinstance(loader, _AnsibleCollectionRootPkgLoader)
+    spec = f.find_spec('ansible_collections', path=None)
+    assert isinstance(spec.loader, _AnsibleCollectionRootPkgLoader)
 
     # path is not allowed for top-level
     with pytest.raises(ValueError):
-        f.find_module('ansible_collections', path=['whatever'])
+        f.find_spec('ansible_collections', path=['whatever'])
 
     # path is required for subpackages
     with pytest.raises(ValueError):
-        f.find_module('ansible_collections.whatever', path=None)
+        f.find_spec('ansible_collections.whatever', path=None)
 
     paths = [os.path.join(p, 'ansible_collections/nonexistns') for p in default_test_collection_paths]
 
     # test missing
-    loader = f.find_module('ansible_collections.nonexistns', paths)
-    assert loader is None
+    spec = f.find_spec('ansible_collections.nonexistns', paths)
+    assert spec is None
 
 
 # keep these up top to make sure the loader install/remove are working, since we rely on them heavily in the tests
@@ -171,8 +142,8 @@ def test_finder_coll():
         parent_pkg = name.rpartition('.')[0]
         for paths in test_paths:
             paths = [os.path.join(p, parent_pkg.replace('.', '/')) for p in paths]
-            loader = f.find_module(name, path=paths)
-            assert isinstance(loader, _AnsibleCollectionPkgLoader)
+            spec = f.find_spec(name, path=paths)
+            assert isinstance(spec.loader, _AnsibleCollectionPkgLoader)
 
 
 def test_root_loader_not_interested():
@@ -190,13 +161,15 @@ def test_root_loader():
         sys.modules.pop(name, None)
         loader = _AnsibleCollectionRootPkgLoader(name, paths)
         assert repr(loader).startswith('_AnsibleCollectionRootPkgLoader(path=')
-        module = loader.load_module(name)
+        spec = importlib.util.spec_from_loader(name, loader)
+        spec.submodule_search_locations = loader._subpackage_search_paths
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
         assert module.__name__ == name
         assert module.__path__ == [p for p in extend_paths(paths, name) if os.path.isdir(p)]
         # even if the dir exists somewhere, this loader doesn't support get_data, so make __file__ a non-file
         assert module.__file__ == '<ansible_synthetic_collection_package>'
         assert module.__package__ == name
-        assert sys.modules.get(name) == module
 
 
 def test_nspkg_loader_not_interested():
@@ -217,13 +190,15 @@ def test_nspkg_loader_load_module():
         sys.modules.pop(name, None)
         loader = _AnsibleCollectionNSPkgLoader(name, path_list=paths)
         assert repr(loader).startswith('_AnsibleCollectionNSPkgLoader(path=')
-        module = loader.load_module(name)
+        spec = importlib.util.spec_from_loader(name, loader)
+        spec.submodule_search_locations = loader._subpackage_search_paths
+        module = importlib.util.module_from_spec(spec)
+        loader.exec_module(module)
         assert module.__name__ == name
         assert isinstance(module.__loader__, _AnsibleCollectionNSPkgLoader)
         assert module.__path__ == existing_child_paths
         assert module.__package__ == name
         assert module.__file__ == '<ansible_synthetic_collection_package>'
-        assert sys.modules.get(name) == module
 
 
 def test_collpkg_loader_not_interested():
@@ -246,7 +221,12 @@ def test_collpkg_loader_load_module():
             sys.modules.pop(name, None)
             loader = _AnsibleCollectionPkgLoader(name, path_list=paths)
             assert repr(loader).startswith('_AnsibleCollectionPkgLoader(path=')
-            module = loader.load_module(name)
+            spec = importlib.util.spec_from_loader(name, loader)
+            # Finder normally sets this, but we're bypassing it in this test
+            spec.submodule_search_locations = loader._subpackage_search_paths
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[name] = module
+            loader.exec_module(module)
             assert module.__name__ == name
             assert isinstance(module.__loader__, _AnsibleCollectionPkgLoader)
             if is_builtin:
@@ -272,7 +252,11 @@ def test_collpkg_loader_load_module():
 
             with patch.object(_collection_finder, '_meta_yml_to_dict', side_effect=Exception('bang')):
                 with pytest.raises(Exception) as ex:
-                    _AnsibleCollectionPkgLoader(name, path_list=paths).load_module(name)
+                    loader = _AnsibleCollectionPkgLoader(name, path_list=paths)
+                    spec = importlib.util.spec_from_loader(name, loader)
+                    spec.submodule_search_locations = loader._subpackage_search_paths
+                    module = importlib.util.module_from_spec(spec)
+                    loader.exec_module(module)
 
                 assert 'error parsing collection metadata' in str(ex.value)
 
@@ -305,12 +289,12 @@ def test_path_hook_setup():
 
 
 def test_path_hook_importerror():
-    # ensure that AnsiblePathHookFinder.find_module swallows ImportError from path hook delegation on Py3, eg if the delegated
+    # ensure that AnsiblePathHookFinder.find_spec swallows ImportError from path hook delegation on Py3, eg if the delegated
     # path hook gets passed a file on sys.path (python36.zip)
     reset_collections_loader_state()
     path_to_a_file = os.path.join(default_test_collection_paths[0], 'ansible_collections/testns/testcoll/plugins/action/my_action.py')
     # it's a bug if the following pops an ImportError...
-    assert _AnsiblePathHookFinder(_AnsibleCollectionFinder(), path_to_a_file).find_module('foo.bar.my_action') is None
+    assert _AnsiblePathHookFinder(_AnsibleCollectionFinder(), path_to_a_file).find_spec('foo.bar.my_action') is None
 
 
 def test_new_or_existing_module():


### PR DESCRIPTION
##### SUMMARY

There were a few actions, largely related to `ansible_collections.ansible.builtin`, that would exec the module as a side effect to gather or validate information, even when they the exec was unnecessary.  This was done for Python 2 support, before `exec_module` and `create_module` APIs existed, so much of the code operated off of the assumption that exec had to happen anyway.

An example would be something like:

```python
importlib.util.find_spec('ansible_collections.ansible.builtin.plugins.modules.ping')
```

That above would force `import_module` to run, and preemptively insert the module into `sys.modules` before necessary.

Additionally, there are a few locations where `importlib.resources` offers more aligned functionality that is needed for operations requiring getting paths for importable resources.

This PR aims to address the above issues by reducing the reliance on `importlib.import_module` for situations not requiring exec of the python code.

Additionally, since `Loader.load_module` is deprecated, and scheduled for removal in Python 3.15, this PR also removes those methods from our implementation

Additional changes:
- Align our implementation with changes to py3.12+ upstream loaders that will return a `pathlib.Path` of the `parent` of a file/module when provided to `files` instead of a package:

    ```
    modules = files('ansible_collections.ns.name.plugins.modules')
    foo = files('ansible_collections.ns.name.plugins.modules.foo')
    assert foo == modules
    ``` 
    https://github.com/python/importlib_resources/commit/5b1281d8abac08db0526b6f4876e8c67c97b774e
- Ensure that package `__init__.py` for all levels including and below `plugins/modules/` are never run, always insert synthetic `__init__.py`. `find_spec` will still exec parent packages when finding the spec for a nested package/module. This prevents module code from execing on controller during import or plugin loader steps.

##### ISSUE TYPE

- Feature Pull Request
