### PR TITLE
fix: builtin.find: use re.fullmatch on patterns

### DIFF
--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -310,16 +310,16 @@ def pfilter(f, patterns=None, excludes=None, use_regex=False):
         if patterns and not excludes:
             for p in patterns:
                 r = re.compile(p)
-                if r.match(f):
+                if r.fullmatch(f):
                     return True
 
         elif patterns and excludes:
             for p in patterns:
                 r = re.compile(p)
-                if r.match(f):
+                if r.fullmatch(f):
                     for e in excludes:
                         r = re.compile(e)
-                        if r.match(f):
+                        if r.fullmatch(f):
                             return False
                     return True
 


### PR DESCRIPTION
Documentation for patterns says:
   When using regexen, the pattern MUST match the ENTIRE file name

However, Python re.match() attempts to match against "zero or more characters at the beginning of string".

To implement what the documentation for this module's `patterns` parameter says, the matching should use re.fullmatch()

##### SUMMARY

When the `builtin.find` module is used with `use_regex: true`, documentation says patterns must match ENTIRE file name, but as the code uses `re.match()`, it also matches any files or directories where the beginning of the name matches the pattern, even if the full name does not match.

For example, a find with pattern `[0-9]+` also returns `123abc`, even though it should not.

This PR fixes the issue by using `re.fullmatch()` instead, making the code implement what the specification for `patterns` says.

##### ISSUE TYPE

- Bugfix Pull Request
