### PR TITLE
tests: handle early test exits

### DIFF
--- a/test/integration/targets/fetch/cleanup.yml
+++ b/test/integration/targets/fetch/cleanup.yml
@@ -13,4 +13,5 @@
       file:
         path: "{{ remote_tmp_dir }}"
         state: absent
+      when: remote_tmp_dir is defined
       no_log: yes

--- a/test/integration/targets/fetch/roles/fetch_tests/tasks/setup.yml
+++ b/test/integration/targets/fetch/roles/fetch_tests/tasks/setup.yml
@@ -8,11 +8,6 @@
       paths:
         - "{{ role_path }}/vars"
 
-- name: Work-around for locked users on Alpine
-  # see https://github.com/ansible/ansible/issues/68676
-  set_fact:
-    password: '*'
-  when: ansible_distribution == 'Alpine'
 
 - name: Create test user
   user:


### PR DESCRIPTION
##### SUMMARY

When clean up runs before setup_remote_tmp_dir role, leaving
remote_tmp_dir undefined.
This fix runs only when remote_tmp_dir is defined

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE



- Test Pull Request

##### COMPONENT NAME
test/integration/targets/fetch/cleanup.yml


