### PR TITLE
Add WORKER_SESSION_ISOLATION config for TTY sharing

### DIFF
--- a/changelogs/fragments/configurable_worker_session_isolation.yml
+++ b/changelogs/fragments/configurable_worker_session_isolation.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - worker process - When controller and forked child workers must share a TTY, the ``WORKER_SESSION_ISOLATION`` config item can be set to ``false``
+    (via variable/config/envvar) to disable forked worker session isolation.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -2109,6 +2109,22 @@ _TEMPLAR_UNTRUSTED_TEMPLATE_BEHAVIOR:
   choices: *basic_error
   env: [{name: _ANSIBLE_TEMPLAR_UNTRUSTED_TEMPLATE_BEHAVIOR}]
   version_added: '2.19'
+WORKER_SESSION_ISOLATION:
+  name: Control worker session isolation
+  description:
+    - Ansible forked workers run session-isolated by default to avoid contention on shared TTYs.
+    - If access to the inherited parent TTY is required, set this option to ``false`` to disable session isolation.
+    - Disabling session isolation should be limited to the smallest possible scope by setting the ``ansible_worker_session_isolation`` variable on individual tasks, blocks, plays, roles, or hosts as needed.
+  default: true
+  env:
+  - name: ANSIBLE_WORKER_SESSION_ISOLATION
+  ini:
+    - key: worker_session_isolation
+      section: defaults
+  vars:
+  - { name: ansible_worker_session_isolation }
+  type: boolean
+  version_added: '2.21'
 WORKER_SHUTDOWN_POLL_COUNT:
   name: Worker Shutdown Poll Count
   default: 0

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -155,7 +155,10 @@ class WorkerProcess(multiprocessing_context.Process):  # type: ignore[name-defin
         """
         try:
             if C.config.get_config_value('WORKER_SESSION_ISOLATION', variables=self._task_vars):
-                os.setsid()
+                os.setsid()  # create a new session and process group for this worker (fully isolated from parent session resources, e.g., inherited TTY)
+            else:
+                os.setpgid(0, 0)  # isolation disabled, just make this worker a new process group leader for granular child process tracking
+
             # Create new fds for stdin/stdout/stderr, but also capture python uses of sys.stdout/stderr
             for fds, mode in (
                     ((STDIN_FILENO,), os.O_RDWR | os.O_NONBLOCK),

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -30,6 +30,7 @@ import typing as t
 from multiprocessing.queues import Queue
 
 from ansible._internal import _task
+from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.executor.task_executor import TaskExecutor
 from ansible.executor.task_queue_manager import FinalQueue, STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO
@@ -153,7 +154,8 @@ class WorkerProcess(multiprocessing_context.Process):  # type: ignore[name-defin
         with stdio fds.
         """
         try:
-            os.setsid()
+            if C.config.get_config_value('WORKER_SESSION_ISOLATION', variables=self._task_vars):
+                os.setsid()
             # Create new fds for stdin/stdout/stderr, but also capture python uses of sys.stdout/stderr
             for fds, mode in (
                     ((STDIN_FILENO,), os.O_RDWR | os.O_NONBLOCK),

--- a/test/integration/targets/fork_safe_stdio/runme.sh
+++ b/test/integration/targets/fork_safe_stdio/runme.sh
@@ -2,6 +2,10 @@
 
 set -eu
 
+echo "testing optional pty inheritance"
+
+python run-with-pty.py ansible-playbook test_pty_inherit.yml
+
 echo "testing for stdio deadlock on forked workers (10s timeout)..."
 
 # Enable a callback that trips deadlocks on forked-child stdout, time out after 10s; forces running

--- a/test/integration/targets/fork_safe_stdio/test_pty_inherit.yml
+++ b/test/integration/targets/fork_safe_stdio/test_pty_inherit.yml
@@ -1,0 +1,15 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  # NB: this test must be run under a tty/pty
+  - name: ensure /dev/tty is not available to forked worker with session isolation enabled
+    raw: python -c 'import os; print(os.isatty(os.open("/dev/tty", os.O_RDWR | os.O_NOCTTY)))'
+    vars:
+      ansible_worker_session_isolation: true
+    failed_when: _task.result.rc == 0
+
+  - name: ensure /dev/tty is available to forked worker with session isolation disabled
+    raw: python -c 'import os; print(os.isatty(os.open("/dev/tty", os.O_RDWR | os.O_NOCTTY)))'
+    vars:
+      ansible_worker_session_isolation: false
+    failed_when: _task.result.rc != 0

--- a/test/integration/targets/signal_propagation/runme.sh
+++ b/test/integration/targets/signal_propagation/runme.sh
@@ -2,20 +2,24 @@
 
 set -x
 
-../test_utils/scripts/timeout.py -s SIGINT 3 -- \
-    ansible all -i inventory -m debug -a 'msg={{lookup("pipe", "sleep 33")}}' -f 10
-if [[ "$?" != "124" ]]; then
-    echo "Process was not terminated due to timeout"
-    exit 1
-fi
+echo "Test signal propagation with isolated and non-isolated workers"
+for isolation in 0 1
+do
+  ANSIBLE_WORKER_SESSION_ISOLATION=$isolation ../test_utils/scripts/timeout.py -s SIGINT 3 -- \
+      ansible all -i inventory -m debug -a 'msg={{lookup("pipe", "sleep 33")}}' -f 10
+  if [[ "$?" != "124" ]]; then
+      echo "Process was not terminated due to timeout"
+      exit 1
+  fi
 
-# a short sleep to let processes die
-sleep 2
+  # a short sleep to let processes die
+  sleep 2
 
-sleeps="$(pgrep -alf 'sleep\ 33')"
-rc="$?"
-if [[ "$rc" == "0" ]]; then
-    echo "Found lingering processes:"
-    echo "$sleeps"
-    exit 1
-fi
+  sleeps="$(pgrep -alf 'sleep\ 33')"
+  rc="$?"
+  if [[ "$rc" == "0" ]]; then
+      echo "Found lingering processes:"
+      echo "$sleeps"
+      exit 1
+  fi
+done


### PR DESCRIPTION
##### SUMMARY
New var-settable config `WORKER_SESSION_ISOLATION` allows granular control over worker TTY inheritance.

See [forum discussion](https://forum.ansible.com/t/1password-broken-due-to-each-fork-calling-setsid-without-tty) for use case. Verified that 1Password CLI desktop integration (which assumes a persistent shared TTY) behaves correctly when the calling tasks disable worker session isolation.

With some non-exhaustive spot-checking, it looks like the worker termination code still more-or-less does the right thing when worker isolation is disabled, though I can't find any docs about what `killpg` on a non-leader pid is supposed to do- there are several documented situations (not unique to this new functionality) where we might want to suppress exceptions from the `killpg` call...


##### ISSUE TYPE
- Feature Pull Request
