### PR TITLE
Sort galaxy FILES.json for build reproducibility

### DIFF
--- a/changelogs/fragments/82792-sort entries in FILES_json.yml
+++ b/changelogs/fragments/82792-sort entries in FILES_json.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "sort the FILES.json for ansible galaxy build based on name with ASCII2 ordering (https://github.com/ansible/ansible/issues/82792)."

--- a/changelogs/fragments/82792-sort entries in FILES_json.yml
+++ b/changelogs/fragments/82792-sort entries in FILES_json.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "sort the FILES.json for ansible galaxy build based on name with ASCII2 ordering (https://github.com/ansible/ansible/issues/82792)."

--- a/changelogs/fragments/82792-sort-entries-in-FILES_json.yml
+++ b/changelogs/fragments/82792-sort-entries-in-FILES_json.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-galaxy - sort the FILES.json for ansible galaxy build based on name. (https://github.com/ansible/ansible/issues/82792).

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -80,7 +80,10 @@ if t.TYPE_CHECKING:
     ManifestValueType = t.Dict[CollectionInfoKeysType, t.Union[int, str, t.List[str], t.Dict[str, str], None]]
     CollectionManifestType = t.Dict[ManifestKeysType, ManifestValueType]
     FileManifestEntryType = t.Dict[FileMetaKeysType, t.Union[str, int, None]]
-    FilesManifestType = t.Dict[t.Literal['files', 'format'], t.Union[t.List[FileManifestEntryType], int]]
+
+    class FilesManifestType(t.TypedDict):
+        files: t.List[FileManifestEntryType]
+        format: int
 
 import ansible.constants as C
 from ansible.errors import AnsibleError

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1299,6 +1299,7 @@ def _build_collection_tar(
 ):  # type: (...) -> str
     """Build a tar.gz collection artifact from the manifest data."""
     files_manifest_json = to_bytes(json.dumps(file_manifest, indent=True, sort_keys=True), errors='surrogate_or_strict')
+    collection_manifest['file_manifest_file']['chksum_sha256'] = secure_hash_s(files_manifest_json, hash_func=sha256)
     collection_manifest_json = to_bytes(json.dumps(collection_manifest, indent=True), errors='surrogate_or_strict')
 
     with _tempdir() as b_temp_path:

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1180,7 +1180,7 @@ def _build_files_manifest_distlib(b_collection_path, namespace, name, manifest_c
             )
 
         manifest['files'].append(manifest_entry)
-
+    manifest["files"].sort(key=lambda x: x["name"])
     return manifest
 
 
@@ -1253,6 +1253,7 @@ def _build_files_manifest_walk(b_collection_path, namespace, name, ignore_patter
                 )
 
     _walk(b_collection_path, b_collection_path)
+    manifest["files"].sort(key=lambda x: x["name"])
 
     return manifest
 
@@ -1299,7 +1300,7 @@ def _build_collection_tar(
     """Build a tar.gz collection artifact from the manifest data."""
     file_manifest["files"].sort(key=lambda x: x["name"])
     files_manifest_json = to_bytes(json.dumps(file_manifest, indent=True), errors='surrogate_or_strict')
-    collection_manifest['file_manifest_file']['chksum_sha256'] = secure_hash_s(files_manifest_json, hash_func=sha256)
+    files_manifest_json = to_bytes(json.dumps(file_manifest, indent=True, sort_keys=True), errors='surrogate_or_strict')
     collection_manifest_json = to_bytes(json.dumps(collection_manifest, indent=True), errors='surrogate_or_strict')
 
     with _tempdir() as b_temp_path:

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1373,7 +1373,7 @@ def _build_collection_dir(b_collection_path, b_collection_output, collection_man
     """
     os.makedirs(b_collection_output, mode=S_IRWXU_RXG_RXO)
 
-    files_manifest_json = to_bytes(json.dumps(file_manifest, indent=True), errors='surrogate_or_strict')
+    files_manifest_json = to_bytes(json.dumps(file_manifest, indent=True, sort_keys=True), errors='surrogate_or_strict')
     collection_manifest['file_manifest_file']['chksum_sha256'] = secure_hash_s(files_manifest_json, hash_func=sha256)
     collection_manifest_json = to_bytes(json.dumps(collection_manifest, indent=True), errors='surrogate_or_strict')
 
@@ -1386,7 +1386,7 @@ def _build_collection_dir(b_collection_path, b_collection_output, collection_man
         os.chmod(b_path, S_IRWU_RG_RO)
 
     base_directories = []
-    for file_info in sorted(file_manifest['files'], key=lambda x: x['name']):
+    for file_info in file_manifest['files']:
         if file_info['name'] == '.':
             continue
 

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1297,6 +1297,7 @@ def _build_collection_tar(
         file_manifest,  # type: FilesManifestType
 ):  # type: (...) -> str
     """Build a tar.gz collection artifact from the manifest data."""
+    file_manifest["files"].sort(key=lambda x: x["name"])
     files_manifest_json = to_bytes(json.dumps(file_manifest, indent=True), errors='surrogate_or_strict')
     collection_manifest['file_manifest_file']['chksum_sha256'] = secure_hash_s(files_manifest_json, hash_func=sha256)
     collection_manifest_json = to_bytes(json.dumps(collection_manifest, indent=True), errors='surrogate_or_strict')

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1298,8 +1298,6 @@ def _build_collection_tar(
         file_manifest,  # type: FilesManifestType
 ):  # type: (...) -> str
     """Build a tar.gz collection artifact from the manifest data."""
-    file_manifest["files"].sort(key=lambda x: x["name"])
-    files_manifest_json = to_bytes(json.dumps(file_manifest, indent=True), errors='surrogate_or_strict')
     files_manifest_json = to_bytes(json.dumps(file_manifest, indent=True, sort_keys=True), errors='surrogate_or_strict')
     collection_manifest_json = to_bytes(json.dumps(collection_manifest, indent=True), errors='surrogate_or_strict')
 

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -32,6 +32,7 @@ from io import BytesIO
 from importlib.metadata import distribution
 from importlib.resources import files
 from itertools import chain
+from operator import itemgetter
 
 try:
     from packaging.requirements import Requirement as PkgReq
@@ -1070,15 +1071,19 @@ def _build_files_manifest(b_collection_path, namespace, name, ignore_patterns,
         raise AnsibleError('"build_ignore" and "manifest" are mutually exclusive')
 
     if manifest_control is not Sentinel:
-        return _build_files_manifest_distlib(
+        manifest = _build_files_manifest_distlib(
             b_collection_path,
             namespace,
             name,
             manifest_control,
             license_file,
         )
+    else:
+        manifest = _build_files_manifest_walk(b_collection_path, namespace, name, ignore_patterns)
 
-    return _build_files_manifest_walk(b_collection_path, namespace, name, ignore_patterns)
+    manifest['files'].sort(key=itemgetter('name'))
+
+    return manifest
 
 
 def _build_files_manifest_distlib(b_collection_path, namespace, name, manifest_control,
@@ -1180,7 +1185,6 @@ def _build_files_manifest_distlib(b_collection_path, namespace, name, manifest_c
             )
 
         manifest['files'].append(manifest_entry)
-    manifest["files"].sort(key=lambda x: x["name"])
     return manifest
 
 
@@ -1253,7 +1257,6 @@ def _build_files_manifest_walk(b_collection_path, namespace, name, ignore_patter
                 )
 
     _walk(b_collection_path, b_collection_path)
-    manifest["files"].sort(key=lambda x: x["name"])
 
     return manifest
 

--- a/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
@@ -83,7 +83,7 @@
 
 - name: Define extraction path
   set_fact:
-    extraction_path: "/tmp/ansible_collections_extraction"
+    extraction_path: "/tmp/new_ansible_collections_extraction"
 
 - name: Ensure extraction directory exists
   file:
@@ -99,7 +99,7 @@
 
 - name: Slurp FILES.json content
   slurp:
-    src: "/tmp/ansible_collections_extraction/FILES.json"
+    src: "/tmp/new_ansible_collections_extraction/FILES.json"
   register: files_content
 
 - name: Decode FILES.json content

--- a/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
@@ -77,6 +77,60 @@
     - '"use --force to re-create the collection artifact" in build_existing_no_force.stderr'
     - '"Created collection for ansible_test.my_collection" in build_existing_force.stdout'
 
+- name: Extract the path to the built artifact
+  set_fact:
+    artifact_path: "{{ build_existing_force.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first }}"
+
+- name: Define extraction path
+  set_fact:
+    extraction_path: "/tmp/ansible_collections_extraction"
+
+- name: Ensure extraction directory exists
+  file:
+    path: "{{ extraction_path }}"
+    state: directory
+    mode: '0755'
+
+- name: Extract collection artifact
+  unarchive:
+    src: "{{ artifact_path }}"
+    dest: "{{ extraction_path }}"
+    remote_src: yes
+
+- name: Slurp FILES.json content
+  slurp:
+    src: "/tmp/ansible_collections_extraction/FILES.json"
+  register: files_content
+
+- name: Decode FILES.json content
+  set_fact:
+    decoded_files_json: "{{ files_content['content'] | b64decode | from_json }}"
+
+
+- name: Set expected order of file names in FILES.json
+  set_fact:
+    expected_files_order: [
+      ".",
+      "README.md",
+      "docs",
+      "meta",
+      "meta/runtime.yml",
+      "plugins",
+      "plugins/README.md",
+      "roles"
+    ]
+
+- name: Set files_names for later use
+  set_fact:
+    files_names: "{{ decoded_files_json['files'] | map(attribute='name') | list }}"
+
+- name: Assert that files are sorted in the predefined ASCII order
+  assert:
+    that:
+      - files_names == expected_files_order
+    fail_msg: "The files are not sorted in the predefined ASCII order."
+    success_msg: "The files are sorted in the predefined ASCII order."
+
 - name: build collection containing ignored files
   command: ansible-galaxy collection build
   args:

--- a/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
@@ -151,3 +151,127 @@
     that:
     - item not in tar_output.stdout_lines
   loop: '{{ collection_ignored_directories }}'
+
+# Additional comprehensive tests for FILES.json sorting robustness
+
+- name: Clean up previous extraction for new tests
+  file:
+    path: "{{ extraction_path }}"
+    state: absent
+
+- name: Test multiple builds produce identical FILES.json - Build 1
+  command: ansible-galaxy collection build scratch/ansible_test/my_collection --force {{ galaxy_verbosity }}
+  args:
+    chdir: '{{ galaxy_dir }}'
+  register: first_build
+
+- name: Extract first build artifact
+  set_fact:
+    first_artifact: "{{ first_build.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first }}"
+
+- name: Create directory for first extraction
+  file:
+    path: "{{ extraction_path }}_1"
+    state: directory
+    mode: '0755'
+
+- name: Extract first build
+  unarchive:
+    src: "{{ first_artifact }}"
+    dest: "{{ extraction_path }}_1"
+    remote_src: yes
+
+- name: Read FILES.json from first build
+  slurp:
+    src: "{{ extraction_path }}_1/FILES.json"
+  register: first_files_json
+
+- name: Remove first build artifact to ensure clean build
+  file:
+    path: "{{ first_artifact }}"
+    state: absent
+
+- name: Test multiple builds produce identical FILES.json - Build 2
+  command: ansible-galaxy collection build scratch/ansible_test/my_collection --force {{ galaxy_verbosity }}
+  args:
+    chdir: '{{ galaxy_dir }}'
+  register: second_build
+
+- name: Extract second build artifact
+  set_fact:
+    second_artifact: "{{ second_build.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first }}"
+
+- name: Create directory for second extraction
+  file:
+    path: "{{ extraction_path }}_2"
+    state: directory
+    mode: '0755'
+
+- name: Extract second build
+  unarchive:
+    src: "{{ second_artifact }}"
+    dest: "{{ extraction_path }}_2"
+    remote_src: yes
+
+- name: Read FILES.json from second build
+  slurp:
+    src: "{{ extraction_path }}_2/FILES.json"
+  register: second_files_json
+
+- name: Parse both FILES.json contents
+  set_fact:
+    first_files_content: "{{ first_files_json['content'] | b64decode | from_json }}"
+    second_files_content: "{{ second_files_json['content'] | b64decode | from_json }}"
+
+- name: Extract file order from both builds
+  set_fact:
+    first_order: "{{ first_files_content['files'] | map(attribute='name') | list }}"
+    second_order: "{{ second_files_content['files'] | map(attribute='name') | list }}"
+
+- name: Verify FILES.json is reproducible across builds
+  assert:
+    that:
+      - first_files_content == second_files_content
+      - first_order == second_order
+    fail_msg: "FILES.json differs between builds - reproducible build failed"
+    success_msg: "FILES.json is identical across multiple builds - reproducible build successful"
+
+- name: Verify all files in order are ASCII sorted
+  assert:
+    that:
+      - first_order == (first_order | sort)
+    fail_msg: "Files in first build are not ASCII sorted: {{ first_order }}"
+    success_msg: "All files in first build are correctly ASCII sorted"
+
+- name: Verify second build files are also ASCII sorted
+  assert:
+    that:
+      - second_order == (second_order | sort)
+    fail_msg: "Files in second build are not ASCII sorted: {{ second_order }}"
+    success_msg: "All files in second build are correctly ASCII sorted"
+
+- name: Validate FILES.json format and keys
+  assert:
+    that:
+      - first_files_content['format'] == 1
+      - second_files_content['format'] == 1
+      - first_files_content['files'] | length > 0
+      - second_files_content['files'] | length > 0
+    fail_msg: "FILES.json format or structure is invalid"
+
+- name: Verify each file entry has required fields
+  assert:
+    that:
+      - item | dict2items | map(attribute='key') | list | sort == ['chksum_sha256', 'chksum_type', 'ftype', 'format', 'name'] | sort
+    fail_msg: "File entry missing required fields: {{ item }}"
+  loop: "{{ first_files_content['files'][1:] }}"  # Skip root directory entry
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Clean up extraction directories
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ extraction_path }}_1"
+    - "{{ extraction_path }}_2"

--- a/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
@@ -1,277 +1,283 @@
 ---
 - name: create a dangling symbolic link inside collection directory
-  ansible.builtin.file:
-    src: '/non-existent-path/README.md'
-    dest: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/docs/README.md'
-    state: link
-    force: yes
+   ansible.builtin.file:
+        src: '/non-existent-path/README.md'
+        dest: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/docs/README.md'
+        state: link
+        force: yes
 
 - name: build basic collection based on current directory with dangling symlink
-  command: ansible-galaxy collection build {{ galaxy_verbosity }}
-  args:
-    chdir: '{{ galaxy_dir }}/scratch/ansible_test/my_collection'
-  register: fail_symlink_build
-  ignore_errors: yes
+    command: ansible - galaxy collection build {{galaxy_verbosity}}
+    args:
+        chdir: '{{ galaxy_dir }}/scratch/ansible_test/my_collection'
+    register: fail_symlink_build
+    ignore_errors: yes
 
 - name: assert that build fails due to dangling symlink
-  assert:
-    that:
-      - fail_symlink_build.failed
-      - '"Failed to find the target path" in fail_symlink_build.stderr'
+   assert:
+        that:
+            - fail_symlink_build.failed
+            - '"Failed to find the target path" in fail_symlink_build.stderr'
 
 - name: remove dangling symbolic link
-  ansible.builtin.file:
-    path: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/docs/README.md'
-    state: absent
+   ansible.builtin.file:
+        path: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/docs/README.md'
+        state: absent
 
 - name: build basic collection based on current directory
-  command: ansible-galaxy collection build {{ galaxy_verbosity }}
-  args:
-    chdir: '{{ galaxy_dir }}/scratch/ansible_test/my_collection'
-  register: build_current_dir
+    command: ansible - galaxy collection build {{galaxy_verbosity}}
+    args:
+        chdir: '{{ galaxy_dir }}/scratch/ansible_test/my_collection'
+    register: build_current_dir
 
 - name: get result of build basic collection on current directory
-  stat:
-    path: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/ansible_test-my_collection-1.0.0.tar.gz'
-  register: build_current_dir_actual
+   stat:
+        path: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/ansible_test-my_collection-1.0.0.tar.gz'
+    register: build_current_dir_actual
 
 - name: assert build basic collection based on current directory
-  assert:
-    that:
-    - '"Created collection for ansible_test.my_collection" in build_current_dir.stdout'
-    - build_current_dir_actual.stat.exists
+   assert:
+        that:
+        - '"Created collection for ansible_test.my_collection" in build_current_dir.stdout'
+        - build_current_dir_actual.stat.exists
 
 - name: build basic collection based on relative dir
-  command: ansible-galaxy collection build scratch/ansible_test/my_collection {{ galaxy_verbosity }}
-  args:
-    chdir: '{{ galaxy_dir }}'
-  register: build_relative_dir
+    command: ansible-galaxy collection build scratch/ansible_test/my_collection {{galaxy_verbosity }}
+    args:
+        chdir: '{{ galaxy_dir }}'
+    register: build_relative_dir
 
 - name: get result of build basic collection based on relative dir
-  stat:
-    path: '{{ galaxy_dir }}/ansible_test-my_collection-1.0.0.tar.gz'
-  register: build_relative_dir_actual
+   stat:
+        path: '{{ galaxy_dir }}/ansible_test-my_collection-1.0.0.tar.gz'
+    register: build_relative_dir_actual
 
 - name: assert build basic collection based on relative dir
-  assert:
-    that:
-    - '"Created collection for ansible_test.my_collection" in build_relative_dir.stdout'
-    - build_relative_dir_actual.stat.exists
+   assert:
+        that:
+        - '"Created collection for ansible_test.my_collection" in build_relative_dir.stdout'
+        - build_relative_dir_actual.stat.exists
 
 - name: fail to build existing collection without force
-  command: ansible-galaxy collection build scratch/ansible_test/my_collection {{ galaxy_verbosity }}
-  args:
-    chdir: '{{ galaxy_dir }}'
-  ignore_errors: yes
-  register: build_existing_no_force
+    command: ansible-galaxy collection build scratch/ansible_test/my_collection {{galaxy_verbosity }}
+    args:
+        chdir: '{{ galaxy_dir }}'
+    ignore_errors: yes
+    register: build_existing_no_force
 
 - name: build existing collection with force
-  command: ansible-galaxy collection build scratch/ansible_test/my_collection --force {{ galaxy_verbosity }}
-  args:
-    chdir: '{{ galaxy_dir }}'
-  register: build_existing_force
+    command: ansible-galaxy collection build scratch/ansible_test/my_collection - -force {{ galaxy_verbosity }}
+    args:
+        chdir: '{{ galaxy_dir }}'
+    register: build_existing_force
 
 - name: assert build existing collection
-  assert:
-    that:
-    - '"use --force to re-create the collection artifact" in build_existing_no_force.stderr'
-    - '"Created collection for ansible_test.my_collection" in build_existing_force.stdout'
+   assert:
+        that:
+        - '"use --force to re-create the collection artifact" in build_existing_no_force.stderr'
+        - '"Created collection for ansible_test.my_collection" in build_existing_force.stdout'
 
 - name: Extract the path to the built artifact
-  set_fact:
-    artifact_path: "{{ build_existing_force.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first }}"
+   set_fact:
+        artifact_path: "{{ build_existing_force.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first }}"
 
 - name: Define extraction path
-  set_fact:
-    extraction_path: "/tmp/new_ansible_collections_extraction"
+   set_fact:
+        extraction_path: "/tmp/new_ansible_collections_extraction"
 
 - name: Ensure extraction directory exists
-  file:
-    path: "{{ extraction_path }}"
-    state: directory
-    mode: '0755'
+   file:
+        path: "{{ extraction_path }}"
+        state: directory
+        mode: '0755'
 
 - name: Extract collection artifact
-  unarchive:
-    src: "{{ artifact_path }}"
-    dest: "{{ extraction_path }}"
-    remote_src: yes
+   unarchive:
+        src: "{{ artifact_path }}"
+        dest: "{{ extraction_path }}"
+        remote_src: yes
 
 - name: Slurp FILES.json content
-  slurp:
-    src: "/tmp/new_ansible_collections_extraction/FILES.json"
-  register: files_content
+   slurp:
+        src: "/tmp/new_ansible_collections_extraction/FILES.json"
+    register: files_content
 
 - name: Decode FILES.json content
-  set_fact:
-    decoded_files_json: "{{ files_content['content'] | b64decode | from_json }}"
+   set_fact:
+        decoded_files_json: "{{ files_content['content'] | b64decode | from_json }}"
 
 
 - name: Set expected order of file names in FILES.json
-  set_fact:
-    expected_files_order: [
-      ".",
-      "README.md",
-      "docs",
-      "meta",
-      "meta/runtime.yml",
-      "plugins",
-      "plugins/README.md",
-      "roles"
-    ]
+   set_fact:
+        expected_files_order: [
+            ".",
+          "README.md",
+          "docs",
+          "meta",
+          "meta/runtime.yml",
+          "plugins",
+          "plugins/README.md",
+          "roles"
+        ]
 
 - name: Set files_names for later use
-  set_fact:
-    files_names: "{{ decoded_files_json['files'] | map(attribute='name') | list }}"
+   set_fact:
+        files_names: "{{ decoded_files_json['files'] | map(attribute='name') | list }}"
 
 - name: Assert that files are sorted in the predefined ASCII order
-  assert:
-    that:
-      - files_names == expected_files_order
-    fail_msg: "The files are not sorted in the predefined ASCII order."
-    success_msg: "The files are sorted in the predefined ASCII order."
+   assert:
+        that:
+            - files_names == expected_files_order
+        fail_msg: "The files are not sorted in the predefined ASCII order."
+        success_msg: "The files are sorted in the predefined ASCII order."
 
 - name: build collection containing ignored files
-  command: ansible-galaxy collection build
-  args:
-    chdir: '{{ galaxy_dir }}/scratch/ansible_test/ignore'
+   command: ansible-galaxy collection build
+    args:
+        chdir: '{{ galaxy_dir }}/scratch/ansible_test/ignore'
 
 - name: list the created tar contents
-  command: tar -tf {{ galaxy_dir }}/scratch/ansible_test/ignore/ansible_test-ignore-1.0.0.tar.gz
-  register: tar_output
+    command: tar - tf {{ galaxy_dir }}/scratch/ansible_test/ignore/ansible_test-ignore-1.0.0.tar.gz
+    register: tar_output
 
-- name: assert ignored files are not present in the archive
-  assert:
-    that:
-    - item not in tar_output.stdout_lines
-  loop: '{{ collection_ignored_files }}'
+- name: assert ignored files are present not in the archive
+   assert:
+        that:
+        - item not in tar_output.stdout_lines
+    loop: '{{ collection_ignored_files }}'
 
-- name: assert ignored directories are not present in the archive
-  assert:
-    that:
-    - item not in tar_output.stdout_lines
-  loop: '{{ collection_ignored_directories }}'
+- name: assert ignored directories are present not in the archive
+   assert:
+        that:
+        - item not in tar_output.stdout_lines
+    loop: '{{ collection_ignored_directories }}'
 
 # Additional comprehensive tests for FILES.json sorting robustness
 
 - name: Clean up previous extraction for new tests
-  file:
-    path: "{{ extraction_path }}"
-    state: absent
+   file:
+        path: "{{ extraction_path }}"
+        state: absent
 
 - name: Test multiple builds produce identical FILES.json - Build 1
-  command: ansible-galaxy collection build scratch/ansible_test/my_collection --force {{ galaxy_verbosity }}
-  args:
-    chdir: '{{ galaxy_dir }}'
-  register: first_build
+    command: ansible-galaxy collection build scratch/ansible_test/my_collection - -force {{ galaxy_verbosity }}
+    args:
+        chdir: '{{ galaxy_dir }}'
+    register: first_build
 
 - name: Extract first build artifact
-  set_fact:
-    first_artifact: "{{ first_build.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first }}"
+   set_fact:
+        first_artifact: "{{ first_build.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first }}"
 
 - name: Create directory for first extraction
-  file:
-    path: "{{ extraction_path }}_1"
-    state: directory
-    mode: '0755'
+   file:
+        path: "{{ extraction_path }}_1"
+        state: directory
+        mode: '0755'
 
 - name: Extract first build
-  unarchive:
-    src: "{{ first_artifact }}"
-    dest: "{{ extraction_path }}_1"
-    remote_src: yes
+   unarchive:
+        src: "{{ first_artifact }}"
+        dest: "{{ extraction_path }}_1"
+        remote_src: yes
 
 - name: Read FILES.json from first build
-  slurp:
-    src: "{{ extraction_path }}_1/FILES.json"
-  register: first_files_json
+   slurp:
+        src: "{{ extraction_path }}_1/FILES.json"
+    register: first_files_json
 
 - name: Remove first build artifact to ensure clean build
-  file:
-    path: "{{ first_artifact }}"
-    state: absent
+   file:
+        path: "{{ first_artifact }}"
+        state: absent
 
 - name: Test multiple builds produce identical FILES.json - Build 2
-  command: ansible-galaxy collection build scratch/ansible_test/my_collection --force {{ galaxy_verbosity }}
-  args:
-    chdir: '{{ galaxy_dir }}'
-  register: second_build
+    command: ansible-galaxy collection build scratch/ansible_test/my_collection - -force {{ galaxy_verbosity }}
+    args:
+        chdir: '{{ galaxy_dir }}'
+    register: second_build
 
 - name: Extract second build artifact
-  set_fact:
-    second_artifact: "{{ second_build.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first }}"
+   set_fact:
+        second_artifact: "{{ second_build.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first }}"
 
 - name: Create directory for second extraction
-  file:
-    path: "{{ extraction_path }}_2"
-    state: directory
-    mode: '0755'
+   file:
+        path: "{{ extraction_path }}_2"
+        state: directory
+        mode: '0755'
 
 - name: Extract second build
-  unarchive:
-    src: "{{ second_artifact }}"
-    dest: "{{ extraction_path }}_2"
-    remote_src: yes
+   unarchive:
+        src: "{{ second_artifact }}"
+        dest: "{{ extraction_path }}_2"
+        remote_src: yes
 
 - name: Read FILES.json from second build
-  slurp:
-    src: "{{ extraction_path }}_2/FILES.json"
-  register: second_files_json
+   slurp:
+        src: "{{ extraction_path }}_2/FILES.json"
+    register: second_files_json
 
 - name: Parse both FILES.json contents
-  set_fact:
-    first_files_content: "{{ first_files_json['content'] | b64decode | from_json }}"
-    second_files_content: "{{ second_files_json['content'] | b64decode | from_json }}"
+   set_fact:
+        first_files_content: "{{ first_files_json['content'] | b64decode | from_json }}"
+        second_files_content: "{{ second_files_json['content'] | b64decode | from_json }}"
 
 - name: Extract file order from both builds
-  set_fact:
-    first_order: "{{ first_files_content['files'] | map(attribute='name') | list }}"
-    second_order: "{{ second_files_content['files'] | map(attribute='name') | list }}"
+   set_fact:
+        first_order: "{{ first_files_content['files'] | map(attribute='name') | list }}"
+        second_order: "{{ second_files_content['files'] | map(attribute='name') | list }}"
 
 - name: Verify FILES.json is reproducible across builds
-  assert:
-    that:
-      - first_files_content == second_files_content
-      - first_order == second_order
-    fail_msg: "FILES.json differs between builds - reproducible build failed"
-    success_msg: "FILES.json is identical across multiple builds - reproducible build successful"
+   assert:
+        that:
+            - first_files_content == second_files_content
+            - first_order == second_order
+        fail_msg: "FILES.json differs between builds - reproducible build failed"
+        success_msg: "FILES.json is identical across multiple builds - reproducible build successful"
 
 - name: Verify all files in order are ASCII sorted
-  assert:
-    that:
-      - first_order == (first_order | sort)
-    fail_msg: "Files in first build are not ASCII sorted: {{ first_order }}"
-    success_msg: "All files in first build are correctly ASCII sorted"
+   assert:
+        that:
+            - first_order == (first_order | sort)
+        fail_msg: "Files in first build are not ASCII sorted: {{ first_order }}"
+        success_msg: "All files in first build are correctly ASCII sorted"
 
 - name: Verify second build files are also ASCII sorted
-  assert:
-    that:
-      - second_order == (second_order | sort)
-    fail_msg: "Files in second build are not ASCII sorted: {{ second_order }}"
-    success_msg: "All files in second build are correctly ASCII sorted"
+   assert:
+        that:
+            - second_order == (second_order | sort)
+        fail_msg: "Files in second build are not ASCII sorted: {{ second_order }}"
+        success_msg: "All files in second build are correctly ASCII sorted"
 
 - name: Validate FILES.json format and keys
-  assert:
-    that:
-      - first_files_content['format'] == 1
-      - second_files_content['format'] == 1
-      - first_files_content['files'] | length > 0
-      - second_files_content['files'] | length > 0
-    fail_msg: "FILES.json format or structure is invalid"
+   assert:
+        that:
+            - first_files_content['format'] == 1
+            - second_files_content['format'] == 1
+            - first_files_content['files'] | length > 0
+            - second_files_content['files'] | length > 0
+        fail_msg: "FILES.json format or structure is invalid"
 
 - name: Verify each file entry has required fields
-  assert:
-    that:
-      - item | dict2items | map(attribute='key') | list | sort == ['chksum_sha256', 'chksum_type', 'ftype', 'format', 'name'] | sort
-    fail_msg: "File entry missing required fields: {{ item }}"
-  loop: "{{ first_files_content['files'][1:] }}"  # Skip root directory entry
-  loop_control:
-    label: "{{ item.name }}"
+   assert:
+        that:
+            - item | dict2items | map(
+    attribute='key') | list | sort == [
+        'chksum_sha256',
+        'chksum_type',
+        'ftype',
+        'format',
+         'name'] | sort
+        fail_msg: "File entry missing required fields: {{ item }}"
+    loop: "{{ first_files_content['files'][1:] }}"  # Skip root directory entry
+    loop_control:
+        label: "{{ item.name }}"
 
 - name: Clean up extraction directories
-  file:
-    path: "{{ item }}"
-    state: absent
-  loop:
-    - "{{ extraction_path }}_1"
-    - "{{ extraction_path }}_2"
+   file:
+        path: "{{ item }}"
+        state: absent
+    loop:
+        - "{{ extraction_path }}_1"
+        - "{{ extraction_path }}_2"

--- a/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
@@ -7,7 +7,7 @@
     force: yes
 
 - name: build basic collection based on current directory with dangling symlink
-  command: ansible-galaxy collection build {{galaxy_verbosity}}
+  command: ansible-galaxy collection build {{ galaxy_verbosity }}
   args:
     chdir: '{{ galaxy_dir }}/scratch/ansible_test/my_collection'
   register: fail_symlink_build
@@ -25,7 +25,7 @@
     state: absent
 
 - name: build basic collection based on current directory
-  command: ansible-galaxy collection build {{galaxy_verbosity}}
+  command: ansible-galaxy collection build {{ galaxy_verbosity }}
   args:
     chdir: '{{ galaxy_dir }}/scratch/ansible_test/my_collection'
   register: build_current_dir
@@ -38,11 +38,11 @@
 - name: assert build basic collection based on current directory
   assert:
     that:
-      - '"Created collection for ansible_test.my_collection" in build_current_dir.stdout'
-      - build_current_dir_actual.stat.exists
+    - '"Created collection for ansible_test.my_collection" in build_current_dir.stdout'
+    - build_current_dir_actual.stat.exists
 
 - name: build basic collection based on relative dir
-  command: ansible-galaxy collection build scratch/ansible_test/my_collection {{galaxy_verbosity }}
+  command: ansible-galaxy collection build scratch/ansible_test/my_collection {{ galaxy_verbosity }}
   args:
     chdir: '{{ galaxy_dir }}'
   register: build_relative_dir
@@ -55,11 +55,11 @@
 - name: assert build basic collection based on relative dir
   assert:
     that:
-      - '"Created collection for ansible_test.my_collection" in build_relative_dir.stdout'
-      - build_relative_dir_actual.stat.exists
+    - '"Created collection for ansible_test.my_collection" in build_relative_dir.stdout'
+    - build_relative_dir_actual.stat.exists
 
 - name: fail to build existing collection without force
-  command: ansible-galaxy collection build scratch/ansible_test/my_collection {{galaxy_verbosity }}
+  command: ansible-galaxy collection build scratch/ansible_test/my_collection {{ galaxy_verbosity }}
   args:
     chdir: '{{ galaxy_dir }}'
   ignore_errors: yes
@@ -70,14 +70,13 @@
   args:
     chdir: '{{ galaxy_dir }}'
   register:
-    build_existing_force_stdout: _task.result.stdout
     artifact_path: _task.result.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first
 
 - name: assert build existing collection
   assert:
     that:
-      - '"use --force to re-create the collection artifact" in build_existing_no_force.stderr'
-      - '"Created collection for ansible_test.my_collection" in build_existing_force_stdout'
+    - '"use --force to re-create the collection artifact" in build_existing_no_force.stderr'
+    - '"Created collection for ansible_test.my_collection" in build_existing_force.stdout'
 
 - name: Define extraction path
   set_fact:
@@ -130,13 +129,13 @@
 - name: assert ignored files are not present in the archive
   assert:
     that:
-      - item not in tar_output.stdout_lines
+    - item not in tar_output.stdout_lines
   loop: '{{ collection_ignored_files }}'
 
 - name: assert ignored directories are not present in the archive
   assert:
     that:
-      - item not in tar_output.stdout_lines
+    - item not in tar_output.stdout_lines
   loop: '{{ collection_ignored_directories }}'
 
 # Additional comprehensive tests for FILES.json sorting robustness

--- a/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
@@ -70,7 +70,8 @@
   args:
     chdir: '{{ galaxy_dir }}'
   register:
-    artifact_path: _task.result.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first
+    build_existing_force: _task.result
+    artifact_path: build_existing_force.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first
 
 - name: assert build existing collection
   assert:

--- a/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/build.yml
@@ -1,283 +1,251 @@
 ---
 - name: create a dangling symbolic link inside collection directory
-   ansible.builtin.file:
-        src: '/non-existent-path/README.md'
-        dest: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/docs/README.md'
-        state: link
-        force: yes
+  ansible.builtin.file:
+    src: '/non-existent-path/README.md'
+    dest: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/docs/README.md'
+    state: link
+    force: yes
 
 - name: build basic collection based on current directory with dangling symlink
-    command: ansible - galaxy collection build {{galaxy_verbosity}}
-    args:
-        chdir: '{{ galaxy_dir }}/scratch/ansible_test/my_collection'
-    register: fail_symlink_build
-    ignore_errors: yes
+  command: ansible-galaxy collection build {{galaxy_verbosity}}
+  args:
+    chdir: '{{ galaxy_dir }}/scratch/ansible_test/my_collection'
+  register: fail_symlink_build
+  ignore_errors: yes
 
 - name: assert that build fails due to dangling symlink
-   assert:
-        that:
-            - fail_symlink_build.failed
-            - '"Failed to find the target path" in fail_symlink_build.stderr'
+  assert:
+    that:
+      - fail_symlink_build.failed
+      - '"Failed to find the target path" in fail_symlink_build.stderr'
 
 - name: remove dangling symbolic link
-   ansible.builtin.file:
-        path: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/docs/README.md'
-        state: absent
+  ansible.builtin.file:
+    path: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/docs/README.md'
+    state: absent
 
 - name: build basic collection based on current directory
-    command: ansible - galaxy collection build {{galaxy_verbosity}}
-    args:
-        chdir: '{{ galaxy_dir }}/scratch/ansible_test/my_collection'
-    register: build_current_dir
+  command: ansible-galaxy collection build {{galaxy_verbosity}}
+  args:
+    chdir: '{{ galaxy_dir }}/scratch/ansible_test/my_collection'
+  register: build_current_dir
 
 - name: get result of build basic collection on current directory
-   stat:
-        path: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/ansible_test-my_collection-1.0.0.tar.gz'
-    register: build_current_dir_actual
+  stat:
+    path: '{{ galaxy_dir }}/scratch/ansible_test/my_collection/ansible_test-my_collection-1.0.0.tar.gz'
+  register: build_current_dir_actual
 
 - name: assert build basic collection based on current directory
-   assert:
-        that:
-        - '"Created collection for ansible_test.my_collection" in build_current_dir.stdout'
-        - build_current_dir_actual.stat.exists
+  assert:
+    that:
+      - '"Created collection for ansible_test.my_collection" in build_current_dir.stdout'
+      - build_current_dir_actual.stat.exists
 
 - name: build basic collection based on relative dir
-    command: ansible-galaxy collection build scratch/ansible_test/my_collection {{galaxy_verbosity }}
-    args:
-        chdir: '{{ galaxy_dir }}'
-    register: build_relative_dir
+  command: ansible-galaxy collection build scratch/ansible_test/my_collection {{galaxy_verbosity }}
+  args:
+    chdir: '{{ galaxy_dir }}'
+  register: build_relative_dir
 
 - name: get result of build basic collection based on relative dir
-   stat:
-        path: '{{ galaxy_dir }}/ansible_test-my_collection-1.0.0.tar.gz'
-    register: build_relative_dir_actual
+  stat:
+    path: '{{ galaxy_dir }}/ansible_test-my_collection-1.0.0.tar.gz'
+  register: build_relative_dir_actual
 
 - name: assert build basic collection based on relative dir
-   assert:
-        that:
-        - '"Created collection for ansible_test.my_collection" in build_relative_dir.stdout'
-        - build_relative_dir_actual.stat.exists
+  assert:
+    that:
+      - '"Created collection for ansible_test.my_collection" in build_relative_dir.stdout'
+      - build_relative_dir_actual.stat.exists
 
 - name: fail to build existing collection without force
-    command: ansible-galaxy collection build scratch/ansible_test/my_collection {{galaxy_verbosity }}
-    args:
-        chdir: '{{ galaxy_dir }}'
-    ignore_errors: yes
-    register: build_existing_no_force
+  command: ansible-galaxy collection build scratch/ansible_test/my_collection {{galaxy_verbosity }}
+  args:
+    chdir: '{{ galaxy_dir }}'
+  ignore_errors: yes
+  register: build_existing_no_force
 
 - name: build existing collection with force
-    command: ansible-galaxy collection build scratch/ansible_test/my_collection - -force {{ galaxy_verbosity }}
-    args:
-        chdir: '{{ galaxy_dir }}'
-    register: build_existing_force
+  command: ansible-galaxy collection build scratch/ansible_test/my_collection --force {{ galaxy_verbosity }}
+  args:
+    chdir: '{{ galaxy_dir }}'
+  register:
+    build_existing_force_stdout: _task.result.stdout
+    artifact_path: _task.result.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first
 
 - name: assert build existing collection
-   assert:
-        that:
-        - '"use --force to re-create the collection artifact" in build_existing_no_force.stderr'
-        - '"Created collection for ansible_test.my_collection" in build_existing_force.stdout'
-
-- name: Extract the path to the built artifact
-   set_fact:
-        artifact_path: "{{ build_existing_force.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first }}"
+  assert:
+    that:
+      - '"use --force to re-create the collection artifact" in build_existing_no_force.stderr'
+      - '"Created collection for ansible_test.my_collection" in build_existing_force_stdout'
 
 - name: Define extraction path
-   set_fact:
-        extraction_path: "/tmp/new_ansible_collections_extraction"
+  set_fact:
+    extraction_path: "{{ remote_tmp_dir }}/new_ansible_collections_extraction"
 
 - name: Ensure extraction directory exists
-   file:
-        path: "{{ extraction_path }}"
-        state: directory
-        mode: '0755'
+  file:
+    path: "{{ extraction_path }}"
+    state: directory
+    mode: '0755'
 
 - name: Extract collection artifact
-   unarchive:
-        src: "{{ artifact_path }}"
-        dest: "{{ extraction_path }}"
-        remote_src: yes
+  unarchive:
+    src: "{{ artifact_path }}"
+    dest: "{{ extraction_path }}"
+    remote_src: yes
 
 - name: Slurp FILES.json content
-   slurp:
-        src: "/tmp/new_ansible_collections_extraction/FILES.json"
-    register: files_content
-
-- name: Decode FILES.json content
-   set_fact:
-        decoded_files_json: "{{ files_content['content'] | b64decode | from_json }}"
-
-
-- name: Set expected order of file names in FILES.json
-   set_fact:
-        expected_files_order: [
-            ".",
-          "README.md",
-          "docs",
-          "meta",
-          "meta/runtime.yml",
-          "plugins",
-          "plugins/README.md",
-          "roles"
-        ]
-
-- name: Set files_names for later use
-   set_fact:
-        files_names: "{{ decoded_files_json['files'] | map(attribute='name') | list }}"
+  slurp:
+    src: "{{ extraction_path }}/FILES.json"
+  register:
+    decoded_files_json: _task.result.content | b64decode | from_json
+    files_names: decoded_files_json.files | map(attribute='name') | list
 
 - name: Assert that files are sorted in the predefined ASCII order
-   assert:
-        that:
-            - files_names == expected_files_order
-        fail_msg: "The files are not sorted in the predefined ASCII order."
-        success_msg: "The files are sorted in the predefined ASCII order."
+  assert:
+    that:
+      - files_names == expected_files_order
+  vars:
+    expected_files_order: [
+      ".",
+      "README.md",
+      "docs",
+      "meta",
+      "meta/runtime.yml",
+      "plugins",
+      "plugins/README.md",
+      "roles"
+    ]
 
 - name: build collection containing ignored files
-   command: ansible-galaxy collection build
-    args:
-        chdir: '{{ galaxy_dir }}/scratch/ansible_test/ignore'
+  command: ansible-galaxy collection build
+  args:
+    chdir: '{{ galaxy_dir }}/scratch/ansible_test/ignore'
 
 - name: list the created tar contents
-    command: tar - tf {{ galaxy_dir }}/scratch/ansible_test/ignore/ansible_test-ignore-1.0.0.tar.gz
-    register: tar_output
+  command: tar -tf {{ galaxy_dir }}/scratch/ansible_test/ignore/ansible_test-ignore-1.0.0.tar.gz
+  register: tar_output
 
-- name: assert ignored files are present not in the archive
-   assert:
-        that:
-        - item not in tar_output.stdout_lines
-    loop: '{{ collection_ignored_files }}'
+- name: assert ignored files are not present in the archive
+  assert:
+    that:
+      - item not in tar_output.stdout_lines
+  loop: '{{ collection_ignored_files }}'
 
-- name: assert ignored directories are present not in the archive
-   assert:
-        that:
-        - item not in tar_output.stdout_lines
-    loop: '{{ collection_ignored_directories }}'
+- name: assert ignored directories are not present in the archive
+  assert:
+    that:
+      - item not in tar_output.stdout_lines
+  loop: '{{ collection_ignored_directories }}'
 
 # Additional comprehensive tests for FILES.json sorting robustness
-
 - name: Clean up previous extraction for new tests
-   file:
-        path: "{{ extraction_path }}"
-        state: absent
+  file:
+    path: "{{ extraction_path }}"
+    state: absent
 
 - name: Test multiple builds produce identical FILES.json - Build 1
-    command: ansible-galaxy collection build scratch/ansible_test/my_collection - -force {{ galaxy_verbosity }}
-    args:
-        chdir: '{{ galaxy_dir }}'
-    register: first_build
-
-- name: Extract first build artifact
-   set_fact:
-        first_artifact: "{{ first_build.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first }}"
+  command: ansible-galaxy collection build scratch/ansible_test/my_collection --force {{ galaxy_verbosity }}
+  args:
+    chdir: '{{ galaxy_dir }}'
+  register:
+    first_artifact: _task.result.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first
 
 - name: Create directory for first extraction
-   file:
-        path: "{{ extraction_path }}_1"
-        state: directory
-        mode: '0755'
+  file:
+    path: "{{ extraction_path }}_1"
+    state: directory
+    mode: '0755'
 
 - name: Extract first build
-   unarchive:
-        src: "{{ first_artifact }}"
-        dest: "{{ extraction_path }}_1"
-        remote_src: yes
+  unarchive:
+    src: "{{ first_artifact }}"
+    dest: "{{ extraction_path }}_1"
+    remote_src: yes
 
 - name: Read FILES.json from first build
-   slurp:
-        src: "{{ extraction_path }}_1/FILES.json"
-    register: first_files_json
+  slurp:
+    src: "{{ extraction_path }}_1/FILES.json"
+  register:
+    first_files_content: _task.result.content | b64decode | from_json
+    first_order: first_files_content.files | map(attribute='name') | list
 
 - name: Remove first build artifact to ensure clean build
-   file:
-        path: "{{ first_artifact }}"
-        state: absent
+  file:
+    path: "{{ first_artifact }}"
+    state: absent
 
 - name: Test multiple builds produce identical FILES.json - Build 2
-    command: ansible-galaxy collection build scratch/ansible_test/my_collection - -force {{ galaxy_verbosity }}
-    args:
-        chdir: '{{ galaxy_dir }}'
-    register: second_build
-
-- name: Extract second build artifact
-   set_fact:
-        second_artifact: "{{ second_build.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first }}"
+  command: ansible-galaxy collection build scratch/ansible_test/my_collection --force {{ galaxy_verbosity }}
+  args:
+    chdir: '{{ galaxy_dir }}'
+  register:
+    second_artifact: _task.result.stdout_lines | select('search', 'Created collection for ansible_test.my_collection at ') | map('regex_replace', '.* at (.*)$', '\\1') | first
 
 - name: Create directory for second extraction
-   file:
-        path: "{{ extraction_path }}_2"
-        state: directory
-        mode: '0755'
+  file:
+    path: "{{ extraction_path }}_2"
+    state: directory
+    mode: '0755'
 
 - name: Extract second build
-   unarchive:
-        src: "{{ second_artifact }}"
-        dest: "{{ extraction_path }}_2"
-        remote_src: yes
+  unarchive:
+    src: "{{ second_artifact }}"
+    dest: "{{ extraction_path }}_2"
+    remote_src: yes
 
 - name: Read FILES.json from second build
-   slurp:
-        src: "{{ extraction_path }}_2/FILES.json"
-    register: second_files_json
-
-- name: Parse both FILES.json contents
-   set_fact:
-        first_files_content: "{{ first_files_json['content'] | b64decode | from_json }}"
-        second_files_content: "{{ second_files_json['content'] | b64decode | from_json }}"
-
-- name: Extract file order from both builds
-   set_fact:
-        first_order: "{{ first_files_content['files'] | map(attribute='name') | list }}"
-        second_order: "{{ second_files_content['files'] | map(attribute='name') | list }}"
+  slurp:
+    src: "{{ extraction_path }}_2/FILES.json"
+  register:
+    second_files_content: _task.result.content | b64decode | from_json
+    second_order: second_files_content.files | map(attribute='name') | list
 
 - name: Verify FILES.json is reproducible across builds
-   assert:
-        that:
-            - first_files_content == second_files_content
-            - first_order == second_order
-        fail_msg: "FILES.json differs between builds - reproducible build failed"
-        success_msg: "FILES.json is identical across multiple builds - reproducible build successful"
+  assert:
+    that:
+      - first_files_content == second_files_content
+      - first_order == second_order
+
+- debug: var=first_order
+- debug:
+    var: "{{ item }}"
+  loop:
+    - first_order
+    - first_order | sort(case_sensitive=True)
 
 - name: Verify all files in order are ASCII sorted
-   assert:
-        that:
-            - first_order == (first_order | sort)
-        fail_msg: "Files in first build are not ASCII sorted: {{ first_order }}"
-        success_msg: "All files in first build are correctly ASCII sorted"
-
-- name: Verify second build files are also ASCII sorted
-   assert:
-        that:
-            - second_order == (second_order | sort)
-        fail_msg: "Files in second build are not ASCII sorted: {{ second_order }}"
-        success_msg: "All files in second build are correctly ASCII sorted"
+  assert:
+    that:
+      - first_order == (first_order | sort(case_sensitive=True))
+      - second_order == (second_order | sort(case_sensitive=True))
 
 - name: Validate FILES.json format and keys
-   assert:
-        that:
-            - first_files_content['format'] == 1
-            - second_files_content['format'] == 1
-            - first_files_content['files'] | length > 0
-            - second_files_content['files'] | length > 0
-        fail_msg: "FILES.json format or structure is invalid"
+  assert:
+    that:
+      - first_files_content['format'] == 1
+      - second_files_content['format'] == 1
+      - first_files_content['files'] | length > 0
+      - second_files_content['files'] | length > 0
 
 - name: Verify each file entry has required fields
-   assert:
-        that:
-            - item | dict2items | map(
-    attribute='key') | list | sort == [
+  assert:
+    that:
+      - item | dict2items | map(attribute='key') | list | sort == [
         'chksum_sha256',
         'chksum_type',
         'ftype',
         'format',
-         'name'] | sort
-        fail_msg: "File entry missing required fields: {{ item }}"
-    loop: "{{ first_files_content['files'][1:] }}"  # Skip root directory entry
-    loop_control:
-        label: "{{ item.name }}"
+        'name'] | sort
+  loop: "{{ first_files_content['files'][1:] }}"  # Skip root directory entry
+  loop_control:
+    label: "{{ item.name }}"
 
 - name: Clean up extraction directories
-   file:
-        path: "{{ item }}"
-        state: absent
-    loop:
-        - "{{ extraction_path }}_1"
-        - "{{ extraction_path }}_2"
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ extraction_path }}_1"
+    - "{{ extraction_path }}_2"

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright: (c) 2019, Ansible Project
-# GNU General Public License v3.0+ (see COPYING or
-# https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import annotations
 
@@ -52,29 +51,13 @@ def collection_input(tmp_path_factory, collection_path_suffix):
 
     namespace = 'ansible_namespace'
     collection = 'collection'
-    skeleton = os.path.join(
-        os.path.dirname(
-            os.path.split(__file__)[0]),
-        'cli',
-        'test_data',
-        'collection_skeleton')
+    skeleton = os.path.join(os.path.dirname(os.path.split(__file__)[0]), 'cli', 'test_data', 'collection_skeleton')
 
-    galaxy_args = [
-        'ansible-galaxy',
-        'collection',
-        'init',
-        '%s.%s' %
-        (namespace,
-         collection),
-        '-c',
-        '--init-path',
-        test_dir,
-        '--collection-skeleton',
-        skeleton]
+    galaxy_args = ['ansible-galaxy', 'collection', 'init', '%s.%s' % (namespace, collection),
+                   '-c', '--init-path', test_dir, '--collection-skeleton', skeleton]
     GalaxyCLI(args=galaxy_args).run()
     collection_dir = os.path.join(test_dir, namespace, collection)
-    output_dir = to_text(tmp_path_factory.mktemp(
-        'test-ÅÑŚÌβŁÈ Collections Output'))
+    output_dir = to_text(tmp_path_factory.mktemp('test-ÅÑŚÌβŁÈ Collections Output'))
 
     return collection_dir, output_dir
 
@@ -83,10 +66,7 @@ def collection_input(tmp_path_factory, collection_path_suffix):
 def collection_artifact(monkeypatch, tmp_path_factory):
     """ Creates a temp collection artifact and mocked open_url instance for publishing tests """
     mock_open = MagicMock()
-    monkeypatch.setattr(
-        collection.concrete_artifact_manager,
-        'open_url',
-        mock_open)
+    monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
 
     mock_uuid = MagicMock()
     mock_uuid.return_value.hex = 'uuid'
@@ -119,10 +99,7 @@ def galaxy_yml_dir(request, tmp_path_factory):
 def tmp_tarfile(tmp_path_factory, manifest_info):
     """ Creates a temporary tar file for _extract_tar_file tests """
     filename = u'ÅÑŚÌβŁÈ'
-    temp_dir = to_bytes(
-        tmp_path_factory.mktemp(
-            'test-%s Collections' %
-            to_native(filename)))
+    temp_dir = to_bytes(tmp_path_factory.mktemp('test-%s Collections' % to_native(filename)))
     tar_file = os.path.join(temp_dir, to_bytes('%s.tar.gz' % filename))
     data = os.urandom(8)
 
@@ -133,11 +110,7 @@ def tmp_tarfile(tmp_path_factory, manifest_info):
         tar_info.mode = S_IRWU_RG_RO
         tfile.addfile(tarinfo=tar_info, fileobj=b_io)
 
-        b_data = to_bytes(
-            json.dumps(
-                manifest_info,
-                indent=True),
-            errors='surrogate_or_strict')
+        b_data = to_bytes(json.dumps(manifest_info, indent=True), errors='surrogate_or_strict')
         b_io = BytesIO(b_data)
         tar_info = tarfile.TarInfo('MANIFEST.json')
         tar_info.size = len(b_data)
@@ -154,21 +127,14 @@ def tmp_tarfile(tmp_path_factory, manifest_info):
 @pytest.fixture()
 def galaxy_server():
     context.CLIARGS._store = {'ignore_certs': False}
-    galaxy_api = api.GalaxyAPI(
-        None,
-        'test_server',
-        'https://galaxy.ansible.com',
-        token=token.GalaxyToken(
-            token='key'))
+    galaxy_api = api.GalaxyAPI(None, 'test_server', 'https://galaxy.ansible.com',
+                               token=token.GalaxyToken(token='key'))
     return galaxy_api
 
 
 @pytest.fixture()
 def manifest_template():
-    def get_manifest_info(
-            namespace='ansible_namespace',
-            name='collection',
-            version='0.1.0'):
+    def get_manifest_info(namespace='ansible_namespace', name='collection', version='0.1.0'):
         return {
             "collection_info": {
                 "namespace": namespace,
@@ -247,10 +213,7 @@ def test_cli_options(required_signature_count, valid, monkeypatch):
 
     galaxy_cli = GalaxyCLI(args=cli_args)
     mock_execute_install = MagicMock()
-    monkeypatch.setattr(
-        galaxy_cli,
-        '_execute_install_collection',
-        mock_execute_install)
+    monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
 
     if valid:
         galaxy_cli.run()
@@ -311,10 +274,7 @@ def test_bool_type_server_config_options(config, server, monkeypatch):
                 C.config._parse_config_file()
                 galaxy_cli = GalaxyCLI(args=cli_args)
                 mock_execute_install = MagicMock()
-                monkeypatch.setattr(
-                    galaxy_cli,
-                    '_execute_install_collection',
-                    mock_execute_install)
+                monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
                 galaxy_cli.run()
 
     assert galaxy_cli.api_servers[0].name == 'server1'
@@ -334,10 +294,7 @@ def test_validate_certs(global_ignore_certs, monkeypatch):
 
     galaxy_cli = GalaxyCLI(args=cli_args)
     mock_execute_install = MagicMock()
-    monkeypatch.setattr(
-        galaxy_cli,
-        '_execute_install_collection',
-        mock_execute_install)
+    monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
     galaxy_cli.run()
 
     assert len(galaxy_cli.api_servers) == 1
@@ -355,11 +312,7 @@ def test_validate_certs(global_ignore_certs, monkeypatch):
         (True, False, False),
     ]
 )
-def test_validate_certs_with_server_url(
-        ignore_certs_cli,
-        ignore_certs_cfg,
-        expected_validate_certs,
-        monkeypatch):
+def test_validate_certs_with_server_url(ignore_certs_cli, ignore_certs_cfg, expected_validate_certs, monkeypatch):
     cli_args = [
         'ansible-galaxy',
         'collection',
@@ -375,51 +328,25 @@ def test_validate_certs_with_server_url(
 
     galaxy_cli = GalaxyCLI(args=cli_args)
     mock_execute_install = MagicMock()
-    monkeypatch.setattr(
-        galaxy_cli,
-        '_execute_install_collection',
-        mock_execute_install)
+    monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
     galaxy_cli.run()
 
     assert len(galaxy_cli.api_servers) == 1
     assert galaxy_cli.api_servers[0].validate_certs == expected_validate_certs
 
 
-@pytest.mark.parametrize(["ignore_certs_cli",
-                          "ignore_certs_cfg",
-                          "expected_server2_validate_certs",
-                          "expected_server3_validate_certs"],
-                         [(None,
-                           None,
-                           True,
-                           True),
-                          (None,
-                           True,
-                           True,
-                           False),
-                          (None,
-                             False,
-                             True,
-                             True),
-                          (True,
-                             None,
-                             False,
-                             False),
-                          (True,
-                             True,
-                             False,
-                             False),
-                          (True,
-                             False,
-                             False,
-                             False),
-                          ])
-def test_validate_certs_server_config(
-        ignore_certs_cfg,
-        ignore_certs_cli,
-        expected_server2_validate_certs,
-        expected_server3_validate_certs,
-        monkeypatch):
+@pytest.mark.parametrize(
+    ["ignore_certs_cli", "ignore_certs_cfg", "expected_server2_validate_certs", "expected_server3_validate_certs"],
+    [
+        (None, None, True, True),
+        (None, True, True, False),
+        (None, False, True, True),
+        (True, None, False, False),
+        (True, True, False, False),
+        (True, False, False, False),
+    ]
+)
+def test_validate_certs_server_config(ignore_certs_cfg, ignore_certs_cli, expected_server2_validate_certs, expected_server3_validate_certs, monkeypatch):
     server_names = ['server1', 'server2', 'server3']
     cfg_lines = [
         "[galaxy]",
@@ -447,20 +374,14 @@ def test_validate_certs_server_config(
     monkeypatch.setattr(C, 'GALAXY_SERVER_LIST', server_names)
 
     with tempfile.NamedTemporaryFile(suffix='.cfg') as tmp_file:
-        tmp_file.write(
-            to_bytes(
-                '\n'.join(cfg_lines),
-                errors='surrogate_or_strict'))
+        tmp_file.write(to_bytes('\n'.join(cfg_lines), errors='surrogate_or_strict'))
         tmp_file.flush()
 
         monkeypatch.setattr(C.config, '_config_file', tmp_file.name)
         C.config._parse_config_file()
         galaxy_cli = GalaxyCLI(args=cli_args)
         mock_execute_install = MagicMock()
-        monkeypatch.setattr(
-            galaxy_cli,
-            '_execute_install_collection',
-            mock_execute_install)
+        monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
         galaxy_cli.run()
 
     # (not) --ignore-certs > server's validate_certs > (not) GALAXY_IGNORE_CERTS > True
@@ -478,12 +399,7 @@ def test_validate_certs_server_config(
         (30, 20, 10, 30),
     ]
 )
-def test_timeout_server_config(
-        timeout_cli,
-        timeout_cfg,
-        timeout_fallback,
-        expected_timeout,
-        monkeypatch):
+def test_timeout_server_config(timeout_cli, timeout_cfg, timeout_fallback, expected_timeout, monkeypatch):
     cli_args = [
         'ansible-galaxy',
         'collection',
@@ -497,27 +413,19 @@ def test_timeout_server_config(
     if timeout_fallback is not None:
         cfg_lines.append(f"server_timeout={timeout_fallback}")
 
-        # fix default in server config since C.GALAXY_SERVER_TIMEOUT was
-        # already evaluated
+        # fix default in server config since C.GALAXY_SERVER_TIMEOUT was already evaluated
         server_additional = manager.GALAXY_SERVER_ADDITIONAL.copy()
         server_additional['timeout']['default'] = timeout_fallback
-        monkeypatch.setattr(
-            manager,
-            'GALAXY_SERVER_ADDITIONAL',
-            server_additional)
+        monkeypatch.setattr(manager, 'GALAXY_SERVER_ADDITIONAL', server_additional)
 
-    cfg_lines.extend(["[galaxy_server.server1]",
-                      "url=https://galaxy.ansible.com/api/"])
+    cfg_lines.extend(["[galaxy_server.server1]", "url=https://galaxy.ansible.com/api/"])
     if timeout_cfg is not None:
         cfg_lines.append(f"timeout={timeout_cfg}")
 
     monkeypatch.setattr(C, 'GALAXY_SERVER_LIST', ['server1'])
 
     with tempfile.NamedTemporaryFile(suffix='.cfg') as tmp_file:
-        tmp_file.write(
-            to_bytes(
-                '\n'.join(cfg_lines),
-                errors='surrogate_or_strict'))
+        tmp_file.write(to_bytes('\n'.join(cfg_lines), errors='surrogate_or_strict'))
         tmp_file.flush()
 
         monkeypatch.setattr(C.config, '_config_file', tmp_file.name)
@@ -525,10 +433,7 @@ def test_timeout_server_config(
 
         galaxy_cli = GalaxyCLI(args=cli_args)
         mock_execute_install = MagicMock()
-        monkeypatch.setattr(
-            galaxy_cli,
-            '_execute_install_collection',
-            mock_execute_install)
+        monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
         galaxy_cli.run()
 
     assert galaxy_cli.api_servers[0].timeout == expected_timeout
@@ -536,9 +441,7 @@ def test_timeout_server_config(
 
 def test_build_collection_no_galaxy_yaml():
     fake_path = u'/fake/ÅÑŚÌβŁÈ/path'
-    expected = to_native(
-        "The collection galaxy.yml path '%s/galaxy.yml' does not exist." %
-        fake_path)
+    expected = to_native("The collection galaxy.yml path '%s/galaxy.yml' does not exist." % fake_path)
 
     with pytest.raises(AnsibleError, match=expected):
         collection.build_collection(fake_path, u'output', False)
@@ -547,24 +450,19 @@ def test_build_collection_no_galaxy_yaml():
 def test_build_existing_output_file(collection_input):
     input_dir, output_dir = collection_input
 
-    existing_output_dir = os.path.join(
-        output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+    existing_output_dir = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
     os.makedirs(existing_output_dir)
 
     expected = "The output collection artifact '%s' already exists, but is a directory - aborting" \
                % to_native(existing_output_dir)
     with pytest.raises(AnsibleError, match=expected):
-        collection.build_collection(
-            to_text(
-                input_dir, errors='surrogate_or_strict'), to_text(
-                output_dir, errors='surrogate_or_strict'), False)
+        collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
 
 
 def test_build_existing_output_without_force(collection_input):
     input_dir, output_dir = collection_input
 
-    existing_output = os.path.join(output_dir,
-                                   'ansible_namespace-collection-0.1.0.tar.gz')
+    existing_output = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
     with open(existing_output, 'w+') as out_file:
         out_file.write("random garbage")
         out_file.flush()
@@ -572,10 +470,7 @@ def test_build_existing_output_without_force(collection_input):
     expected = "The file '%s' already exists. You can use --force to re-create the collection artifact." \
                % to_native(existing_output)
     with pytest.raises(AnsibleError, match=expected):
-        collection.build_collection(
-            to_text(
-                input_dir, errors='surrogate_or_strict'), to_text(
-                output_dir, errors='surrogate_or_strict'), False)
+        collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
 
 
 @pytest.mark.parametrize(
@@ -589,16 +484,12 @@ def test_build_existing_output_without_force(collection_input):
 def test_build_existing_output_with_force(collection_input):
     input_dir, output_dir = collection_input
 
-    existing_output = os.path.join(output_dir,
-                                   'ansible_namespace-collection-0.1.0.tar.gz')
+    existing_output = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
     with open(existing_output, 'w+') as out_file:
         out_file.write("random garbage")
         out_file.flush()
 
-    collection.build_collection(
-        to_text(
-            input_dir, errors='surrogate_or_strict'), to_text(
-            output_dir, errors='surrogate_or_strict'), True)
+    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), True)
 
     # Verify the file was replaced with an actual tar file
     assert tarfile.is_tarfile(existing_output)
@@ -616,13 +507,9 @@ def test_build_with_existing_files_and_manifest(collection_input):
     with open(os.path.join(input_dir, "plugins", "MANIFEST.json"), "wb") as fd:
         fd.write(b"test data that should be in build")
 
-    collection.build_collection(
-        to_text(
-            input_dir, errors='surrogate_or_strict'), to_text(
-            output_dir, errors='surrogate_or_strict'), False)
+    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
 
-    output_artifact = os.path.join(output_dir,
-                                   'ansible_namespace-collection-0.1.0.tar.gz')
+    output_artifact = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
     assert tarfile.is_tarfile(output_artifact)
 
     with tarfile.open(output_artifact, mode='r') as actual:
@@ -640,63 +527,47 @@ def test_build_with_existing_files_and_manifest(collection_input):
         json_file_obj.close()
         assert json_file_text != b'{"files": [], "format": 1}'
 
-        sub_manifest_file = [
-            m for m in members if m.path == "plugins/MANIFEST.json"][0]
+        sub_manifest_file = [m for m in members if m.path == "plugins/MANIFEST.json"][0]
         sub_manifest_file_obj = actual.extractfile(sub_manifest_file.name)
         sub_manifest_file_text = sub_manifest_file_obj.read()
         sub_manifest_file_obj.close()
         assert sub_manifest_file_text == b"test data that should be in build"
 
 
-@pytest.mark.parametrize('galaxy_yml_dir',
-                         [b'namespace: value: broken'],
-                         indirect=True)
+@pytest.mark.parametrize('galaxy_yml_dir', [b'namespace: value: broken'], indirect=True)
 def test_invalid_yaml_galaxy_file(galaxy_yml_dir):
     galaxy_file = os.path.join(galaxy_yml_dir, b'galaxy.yml')
-    expected = to_native(
-        b"Failed to parse the galaxy.yml at '%s' with the following error:" %
-        galaxy_file)
+    expected = to_native(b"Failed to parse the galaxy.yml at '%s' with the following error:" % galaxy_file)
 
     with pytest.raises(AnsibleError, match=expected):
-        collection.concrete_artifact_manager._get_meta_from_src_dir(
-            galaxy_yml_dir)
+        collection.concrete_artifact_manager._get_meta_from_src_dir(galaxy_yml_dir)
 
 
-@pytest.mark.parametrize('galaxy_yml_dir',
-                         [b'namespace: test_namespace'],
-                         indirect=True)
+@pytest.mark.parametrize('galaxy_yml_dir', [b'namespace: test_namespace'], indirect=True)
 def test_missing_required_galaxy_key(galaxy_yml_dir):
     galaxy_file = os.path.join(galaxy_yml_dir, b'galaxy.yml')
     expected = "The collection galaxy.yml at '%s' is missing the following mandatory keys: authors, name, " \
                "readme, version" % to_native(galaxy_file)
 
     with pytest.raises(AnsibleError, match=expected):
-        collection.concrete_artifact_manager._get_meta_from_src_dir(
-            galaxy_yml_dir)
+        collection.concrete_artifact_manager._get_meta_from_src_dir(galaxy_yml_dir)
 
 
-@pytest.mark.parametrize('galaxy_yml_dir',
-                         [b'namespace: test_namespace'],
-                         indirect=True)
+@pytest.mark.parametrize('galaxy_yml_dir', [b'namespace: test_namespace'], indirect=True)
 def test_galaxy_yaml_no_mandatory_keys(galaxy_yml_dir):
     expected = "The collection galaxy.yml at '%s/galaxy.yml' is missing the " \
                "following mandatory keys: authors, name, readme, version" % to_native(galaxy_yml_dir)
 
     with pytest.raises(ValueError, match=expected):
-        assert collection.concrete_artifact_manager._get_meta_from_src_dir(
-            galaxy_yml_dir, require_build_metadata=False) == expected
+        assert collection.concrete_artifact_manager._get_meta_from_src_dir(galaxy_yml_dir, require_build_metadata=False) == expected
 
 
-@pytest.mark.parametrize('galaxy_yml_dir',
-                         [b'My life story is so very interesting'],
-                         indirect=True)
+@pytest.mark.parametrize('galaxy_yml_dir', [b'My life story is so very interesting'], indirect=True)
 def test_galaxy_yaml_no_mandatory_keys_bad_yaml(galaxy_yml_dir):
-    expected = "The collection galaxy.yml at '%s/galaxy.yml' is incorrectly formatted." % to_native(
-        galaxy_yml_dir)
+    expected = "The collection galaxy.yml at '%s/galaxy.yml' is incorrectly formatted." % to_native(galaxy_yml_dir)
 
     with pytest.raises(AnsibleError, match=expected):
-        collection.concrete_artifact_manager._get_meta_from_src_dir(
-            galaxy_yml_dir)
+        collection.concrete_artifact_manager._get_meta_from_src_dir(galaxy_yml_dir)
 
 
 @pytest.mark.parametrize('galaxy_yml_dir', [b"""
@@ -724,8 +595,7 @@ authors: Jordan
 version: 0.1.0
 readme: README.md"""], indirect=True)
 def test_defaults_galaxy_yml(galaxy_yml_dir):
-    actual = collection.concrete_artifact_manager._get_meta_from_src_dir(
-        galaxy_yml_dir)
+    actual = collection.concrete_artifact_manager._get_meta_from_src_dir(galaxy_yml_dir)
 
     assert actual['namespace'] == 'namespace'
     assert actual['name'] == 'collection'
@@ -757,8 +627,7 @@ readme: README.md
 license:
 - MIT""")], indirect=True)
 def test_galaxy_yml_list_value(galaxy_yml_dir):
-    actual = collection.concrete_artifact_manager._get_meta_from_src_dir(
-        galaxy_yml_dir)
+    actual = collection.concrete_artifact_manager._get_meta_from_src_dir(galaxy_yml_dir)
     assert actual['license'] == ['MIT']
 
 
@@ -785,17 +654,11 @@ def test_build_ignore_files_and_folders(collection_input, monkeypatch):
         tests_file.write('random')
         tests_file.flush()
 
-    actual = collection._build_files_manifest(
-        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
 
     assert actual['format'] == 1
     for manifest_entry in actual['files']:
-        assert manifest_entry['name'] not in [
-            '.git',
-            'ansible.retry',
-            'galaxy.yml',
-            'tests/output',
-            'tests/output/result.txt']
+        assert manifest_entry['name'] not in ['.git', 'ansible.retry', 'galaxy.yml', 'tests/output', 'tests/output/result.txt']
 
     expected_msgs = [
         "Skipping '%s/galaxy.yml' for collection build" % to_text(input_dir),
@@ -819,18 +682,15 @@ def test_build_ignore_older_release_in_root(collection_input, monkeypatch):
     # This is expected to be ignored because it is in the root collection dir.
     release_file = os.path.join(input_dir, 'namespace-collection-0.0.0.tar.gz')
 
-    # This is not expected to be ignored because it is not in the root
-    # collection dir.
-    fake_release_file = os.path.join(
-        input_dir, 'plugins', 'namespace-collection-0.0.0.tar.gz')
+    # This is not expected to be ignored because it is not in the root collection dir.
+    fake_release_file = os.path.join(input_dir, 'plugins', 'namespace-collection-0.0.0.tar.gz')
 
     for filename in [release_file, fake_release_file]:
         with open(filename, 'w+') as file_obj:
             file_obj.write('random')
             file_obj.flush()
 
-    actual = collection._build_files_manifest(
-        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
     assert actual['format'] == 1
 
     plugin_release_found = False
@@ -856,9 +716,9 @@ def test_build_ignore_patterns(collection_input, monkeypatch):
     mock_display = MagicMock()
     monkeypatch.setattr(Display, 'vvv', mock_display)
 
-    actual = collection._build_files_manifest(
-        to_bytes(input_dir), 'namespace', 'collection', [
-            '*.md', 'plugins/action', 'playbooks/*.j2'], Sentinel, None)
+    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection',
+                                              ['*.md', 'plugins/action', 'playbooks/*.j2'],
+                                              Sentinel, None)
     assert actual['format'] == 1
 
     expected_missing = [
@@ -869,8 +729,7 @@ def test_build_ignore_patterns(collection_input, monkeypatch):
         'playbooks/templates/subfolder/test.conf.j2',
     ]
 
-    # Files or dirs that are close to a match but are not, make sure they are
-    # present
+    # Files or dirs that are close to a match but are not, make sure they are present
     expected_present = [
         'docs',
         'roles/common/templates/test.conf.j2',
@@ -885,18 +744,12 @@ def test_build_ignore_patterns(collection_input, monkeypatch):
         assert p in actual_files
 
     expected_msgs = [
-        "Skipping '%s/galaxy.yml' for collection build" %
-        to_text(input_dir),
-        "Skipping '%s/README.md' for collection build" %
-        to_text(input_dir),
-        "Skipping '%s/docs/My Collection.md' for collection build" %
-        to_text(input_dir),
-        "Skipping '%s/plugins/action' for collection build" %
-        to_text(input_dir),
-        "Skipping '%s/playbooks/templates/test.conf.j2' for collection build" %
-        to_text(input_dir),
-        "Skipping '%s/playbooks/templates/subfolder/test.conf.j2' for collection build" %
-        to_text(input_dir),
+        "Skipping '%s/galaxy.yml' for collection build" % to_text(input_dir),
+        "Skipping '%s/README.md' for collection build" % to_text(input_dir),
+        "Skipping '%s/docs/My Collection.md' for collection build" % to_text(input_dir),
+        "Skipping '%s/plugins/action' for collection build" % to_text(input_dir),
+        "Skipping '%s/playbooks/templates/test.conf.j2' for collection build" % to_text(input_dir),
+        "Skipping '%s/playbooks/templates/subfolder/test.conf.j2' for collection build" % to_text(input_dir),
     ]
     assert mock_display.call_count == len(expected_msgs)
     assert mock_display.mock_calls[0][1][0] in expected_msgs
@@ -907,8 +760,7 @@ def test_build_ignore_patterns(collection_input, monkeypatch):
     assert mock_display.mock_calls[5][1][0] in expected_msgs
 
 
-def test_build_ignore_symlink_target_outside_collection(
-        collection_input, monkeypatch):
+def test_build_ignore_symlink_target_outside_collection(collection_input, monkeypatch):
     input_dir, outside_dir = collection_input
 
     mock_display = MagicMock()
@@ -917,8 +769,7 @@ def test_build_ignore_symlink_target_outside_collection(
     link_path = os.path.join(input_dir, 'plugins', 'connection')
     os.symlink(outside_dir, link_path)
 
-    actual = collection._build_files_manifest(
-        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
     for manifest_entry in actual['files']:
         assert manifest_entry['name'] != 'plugins/connection'
 
@@ -942,11 +793,9 @@ def test_build_copy_symlink_target_inside_collection(collection_input):
 
     os.symlink(roles_target, roles_link)
 
-    actual = collection._build_files_manifest(
-        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
 
-    linked_entries = [e for e in actual['files']
-                      if e['name'].startswith('playbooks/roles/linked')]
+    linked_entries = [e for e in actual['files'] if e['name'].startswith('playbooks/roles/linked')]
     assert len(linked_entries) == 1
     assert linked_entries[0]['name'] == 'playbooks/roles/linked'
     assert linked_entries[0]['ftype'] == 'dir'
@@ -969,20 +818,15 @@ def test_build_with_symlink_inside_collection(collection_input):
     os.symlink(roles_target, roles_link)
     os.symlink(os.path.join(input_dir, 'README.md'), file_link)
 
-    collection.build_collection(
-        to_text(
-            input_dir, errors='surrogate_or_strict'), to_text(
-            output_dir, errors='surrogate_or_strict'), False)
+    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
 
-    output_artifact = os.path.join(output_dir,
-                                   'ansible_namespace-collection-0.1.0.tar.gz')
+    output_artifact = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
     assert tarfile.is_tarfile(output_artifact)
 
     with tarfile.open(output_artifact, mode='r') as actual:
         members = actual.getmembers()
 
-        linked_folder = [m for m in members if m.path ==
-                         'playbooks/roles/linked'][0]
+        linked_folder = [m for m in members if m.path == 'playbooks/roles/linked'][0]
         assert linked_folder.type == tarfile.SYMTYPE
         assert linked_folder.linkname == '../../roles/linked'
 
@@ -1037,8 +881,7 @@ def test_build_files_manifest_walk_sorted_output(collection_input):
         with open(filepath, 'w') as f:
             f.write('content')
 
-    actual = collection._build_files_manifest(
-        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
 
     assert actual['format'] == 1
     file_names = [entry['name'] for entry in actual['files']]
@@ -1052,13 +895,9 @@ def test_build_collection_reproducible_build(collection_input):
     input_dir, output_dir = collection_input
 
     # First build
-    collection.build_collection(
-        to_text(
-            input_dir, errors='surrogate_or_strict'), to_text(
-            output_dir, errors='surrogate_or_strict'), False)
+    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
 
-    artifact1_path = os.path.join(output_dir,
-                                  'ansible_namespace-collection-0.1.0.tar.gz')
+    artifact1_path = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
     assert tarfile.is_tarfile(artifact1_path)
 
     # Extract FILES.json from first build
@@ -1072,13 +911,9 @@ def test_build_collection_reproducible_build(collection_input):
     os.remove(artifact1_path)
 
     # Second build - should produce identical FILES.json
-    collection.build_collection(
-        to_text(
-            input_dir, errors='surrogate_or_strict'), to_text(
-            output_dir, errors='surrogate_or_strict'), True)
+    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), True)
 
-    artifact2_path = os.path.join(output_dir,
-                                  'ansible_namespace-collection-0.1.0.tar.gz')
+    artifact2_path = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
     assert tarfile.is_tarfile(artifact2_path)
 
     with tarfile.open(artifact2_path, mode='r') as tar:
@@ -1115,12 +950,10 @@ def test_build_files_manifest_special_characters_sorted(collection_input):
         with open(filepath, 'w') as f:
             f.write('test')
 
-    manifest = collection._build_files_manifest(
-        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    manifest = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
 
     # Get file names (excluding '.' which is added by default)
-    file_names = [entry['name']
-                  for entry in manifest['files'] if entry['name'] != '.']
+    file_names = [entry['name'] for entry in manifest['files'] if entry['name'] != '.']
 
     # Verify ASCII sorting
     expected_sorted = sorted(file_names)
@@ -1131,13 +964,9 @@ def test_files_json_has_sorted_keys(collection_input):
     """Validate that FILES.json output has sorted keys when using sort_keys=True."""
     input_dir, output_dir = collection_input
 
-    collection.build_collection(
-        to_text(
-            input_dir, errors='surrogate_or_strict'), to_text(
-            output_dir, errors='surrogate_or_strict'), False)
+    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
 
-    artifact_path = os.path.join(output_dir,
-                                 'ansible_namespace-collection-0.1.0.tar.gz')
+    artifact_path = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
 
     with tarfile.open(artifact_path, mode='r') as tar:
         files_json_member = tar.getmember('FILES.json')
@@ -1151,8 +980,7 @@ def test_files_json_has_sorted_keys(collection_input):
 
     # The content should be identical if keys are already sorted
     # (accounting for potential formatting differences)
-    assert files_data == json.loads(
-        resorted_content), "FILES.json keys are not in sorted order"
+    assert files_data == json.loads(resorted_content), "FILES.json keys are not in sorted order"
 
 
 def test_build_collection_large_number_of_files_sorted(collection_input):
@@ -1171,8 +999,7 @@ def test_build_collection_large_number_of_files_sorted(collection_input):
             with open(filepath, 'w') as f:
                 f.write(f'content {i}')
 
-    manifest = collection._build_files_manifest(
-        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    manifest = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
 
     file_names = [entry['name'] for entry in manifest['files']]
 
@@ -1180,8 +1007,7 @@ def test_build_collection_large_number_of_files_sorted(collection_input):
     assert len(file_names) > 10, "Expected more than 10 files in manifest"
 
     # Verify sorted order
-    assert file_names == sorted(
-        file_names), f"Files not sorted correctly with many files: {file_names}"
+    assert file_names == sorted(file_names), f"Files not sorted correctly with many files: {file_names}"
 
 
 def test_publish_no_wait(galaxy_server, collection_artifact, monkeypatch):
@@ -1242,17 +1068,10 @@ def test_download_file(tmp_path_factory, monkeypatch):
 
     mock_open = MagicMock()
     mock_open.return_value = BytesIO(data)
-    monkeypatch.setattr(
-        collection.concrete_artifact_manager,
-        'open_url',
-        mock_open)
+    monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
 
     expected = temp_dir
-    actual = collection._download_file(
-        'http://google.com/file',
-        temp_dir,
-        sha256_hash.hexdigest(),
-        True)
+    actual = collection._download_file('http://google.com/file', temp_dir, sha256_hash.hexdigest(), True)
 
     assert actual.startswith(expected)
     assert os.path.isfile(actual)
@@ -1270,32 +1089,25 @@ def test_download_file_hash_mismatch(tmp_path_factory, monkeypatch):
 
     mock_open = MagicMock()
     mock_open.return_value = BytesIO(data)
-    monkeypatch.setattr(
-        collection.concrete_artifact_manager,
-        'open_url',
-        mock_open)
+    monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
 
     expected = "Mismatch artifact hash with downloaded file"
     with pytest.raises(AnsibleError, match=expected):
-        collection._download_file(
-            'http://google.com/file', temp_dir, 'bad', True)
+        collection._download_file('http://google.com/file', temp_dir, 'bad', True)
 
 
 def test_extract_tar_file_invalid_hash(tmp_tarfile):
     temp_dir, tfile, filename, dummy = tmp_tarfile
 
-    expected = "Checksum mismatch for '%s' inside collection at '%s'" % (
-        to_native(filename), to_native(tfile.name))
+    expected = "Checksum mismatch for '%s' inside collection at '%s'" % (to_native(filename), to_native(tfile.name))
     with pytest.raises(AnsibleError, match=expected):
-        collection._extract_tar_file(
-            tfile, filename, temp_dir, temp_dir, "fakehash")
+        collection._extract_tar_file(tfile, filename, temp_dir, temp_dir, "fakehash")
 
 
 def test_extract_tar_file_missing_member(tmp_tarfile):
     temp_dir, tfile, dummy, dummy = tmp_tarfile
 
-    expected = "Collection tar at '%s' does not contain the expected file 'missing'." % to_native(
-        tfile.name)
+    expected = "Collection tar at '%s' does not contain the expected file 'missing'." % to_native(tfile.name)
     with pytest.raises(AnsibleError, match=expected):
         collection._extract_tar_file(tfile, 'missing', temp_dir, temp_dir)
 
@@ -1305,17 +1117,13 @@ def test_extract_tar_file_missing_parent_dir(tmp_tarfile):
     output_dir = os.path.join(temp_dir, b'output')
     output_file = os.path.join(output_dir, to_bytes(filename))
 
-    collection._extract_tar_file(
-        tfile, filename, output_dir, temp_dir, checksum)
+    collection._extract_tar_file(tfile, filename, output_dir, temp_dir, checksum)
     os.path.isfile(output_file)
 
 
 def test_extract_tar_file_outside_dir(tmp_path_factory):
     filename = u'ÅÑŚÌβŁÈ'
-    temp_dir = to_bytes(
-        tmp_path_factory.mktemp(
-            'test-%s Collections' %
-            to_native(filename)))
+    temp_dir = to_bytes(tmp_path_factory.mktemp('test-%s Collections' % to_native(filename)))
     tar_file = os.path.join(temp_dir, to_bytes('%s.tar.gz' % filename))
     data = os.urandom(8)
 
@@ -1327,29 +1135,18 @@ def test_extract_tar_file_outside_dir(tmp_path_factory):
         tar_info.mode = S_IRWU_RG_RO
         tfile.addfile(tarinfo=tar_info, fileobj=b_io)
 
-    expected = re.escape(
-        "Cannot extract tar entry '%s' as it will be placed outside the collection directory" %
-        to_native(tar_filename))
+    expected = re.escape("Cannot extract tar entry '%s' as it will be placed outside the collection directory"
+                         % to_native(tar_filename))
     with tarfile.open(tar_file, 'r') as tfile:
         with pytest.raises(AnsibleError, match=expected):
-            collection._extract_tar_file(
-                tfile, tar_filename, os.path.join(
-                    temp_dir, to_bytes(filename)), temp_dir)
+            collection._extract_tar_file(tfile, tar_filename, os.path.join(temp_dir, to_bytes(filename)), temp_dir)
 
 
 def test_require_one_of_collections_requirements_with_both():
-    cli = GalaxyCLI(
-        args=[
-            'ansible-galaxy',
-            'collection',
-            'verify',
-            'namespace.collection',
-            '-r',
-            'requirements.yml'])
+    cli = GalaxyCLI(args=['ansible-galaxy', 'collection', 'verify', 'namespace.collection', '-r', 'requirements.yml'])
 
     with pytest.raises(AnsibleError) as req_err:
-        cli._require_one_of_collections_requirements(
-            ('namespace.collection',), 'requirements.yml')
+        cli._require_one_of_collections_requirements(('namespace.collection',), 'requirements.yml')
 
     with pytest.raises(AnsibleError) as cli_err:
         cli.run()
@@ -1370,52 +1167,20 @@ def test_require_one_of_collections_requirements_with_neither():
 
 
 def test_require_one_of_collections_requirements_with_collections():
-    cli = GalaxyCLI(
-        args=[
-            'ansible-galaxy',
-            'collection',
-            'verify',
-            'namespace1.collection1',
-            'namespace2.collection1:1.0.0'])
+    cli = GalaxyCLI(args=['ansible-galaxy', 'collection', 'verify', 'namespace1.collection1', 'namespace2.collection1:1.0.0'])
     collections = ('namespace1.collection1', 'namespace2.collection1:1.0.0',)
 
-    requirements = cli._require_one_of_collections_requirements(collections, '')[
-        'collections']
+    requirements = cli._require_one_of_collections_requirements(collections, '')['collections']
 
-    req_tuples = [
-        ('%s.%s' %
-         (req.namespace,
-          req.name),
-            req.ver,
-            req.src,
-            req.type,
-         ) for req in requirements]
-    assert req_tuples == [
-        ('namespace1.collection1',
-         '*',
-         None,
-         'galaxy'),
-        ('namespace2.collection1',
-         '1.0.0',
-         None,
-         'galaxy')]
+    req_tuples = [('%s.%s' % (req.namespace, req.name), req.ver, req.src, req.type,) for req in requirements]
+    assert req_tuples == [('namespace1.collection1', '*', None, 'galaxy'), ('namespace2.collection1', '1.0.0', None, 'galaxy')]
 
 
 @patch('ansible.cli.galaxy.GalaxyCLI._parse_requirements_file')
-def test_require_one_of_collections_requirements_with_requirements(
-        mock_parse_requirements_file, galaxy_server):
-    cli = GalaxyCLI(
-        args=[
-            'ansible-galaxy',
-            'collection',
-            'verify',
-            '-r',
-            'requirements.yml',
-            'namespace.collection'])
-    mock_parse_requirements_file.return_value = {
-        'collections': [('namespace.collection', '1.0.5', galaxy_server)]}
-    requirements = cli._require_one_of_collections_requirements(
-        (), 'requirements.yml')['collections']
+def test_require_one_of_collections_requirements_with_requirements(mock_parse_requirements_file, galaxy_server):
+    cli = GalaxyCLI(args=['ansible-galaxy', 'collection', 'verify', '-r', 'requirements.yml', 'namespace.collection'])
+    mock_parse_requirements_file.return_value = {'collections': [('namespace.collection', '1.0.5', galaxy_server)]}
+    requirements = cli._require_one_of_collections_requirements((), 'requirements.yml')['collections']
 
     assert mock_parse_requirements_file.call_count == 1
     assert requirements == [('namespace.collection', '1.0.5', galaxy_server)]
@@ -1423,11 +1188,7 @@ def test_require_one_of_collections_requirements_with_requirements(
 
 @patch('ansible.cli.galaxy.GalaxyCLI.execute_verify', spec=True)
 def test_call_GalaxyCLI(execute_verify):
-    galaxy_args = [
-        'ansible-galaxy',
-        'collection',
-        'verify',
-        'namespace.collection']
+    galaxy_args = ['ansible-galaxy', 'collection', 'verify', 'namespace.collection']
 
     GalaxyCLI(args=galaxy_args).run()
 
@@ -1456,21 +1217,15 @@ def test_call_GalaxyCLI_with_role(execute_verify):
 
 @patch('ansible.cli.galaxy.verify_collections', spec=True)
 def test_execute_verify_with_defaults(mock_verify_collections):
-    galaxy_args = [
-        'ansible-galaxy',
-        'collection',
-        'verify',
-        'namespace.collection:1.0.4']
+    galaxy_args = ['ansible-galaxy', 'collection', 'verify', 'namespace.collection:1.0.4']
     GalaxyCLI(args=galaxy_args).run()
 
     assert mock_verify_collections.call_count == 1
 
     print("Call args {0}".format(mock_verify_collections.call_args[0]))
-    requirements, search_paths, galaxy_apis, ignore_errors = mock_verify_collections.call_args[
-        0]
+    requirements, search_paths, galaxy_apis, ignore_errors = mock_verify_collections.call_args[0]
 
-    assert [('%s.%s' % (r.namespace, r.name), r.ver, r.src, r.type)
-            for r in requirements] == [('namespace.collection', '1.0.4', None, 'galaxy')]
+    assert [('%s.%s' % (r.namespace, r.name), r.ver, r.src, r.type) for r in requirements] == [('namespace.collection', '1.0.4', None, 'galaxy')]
     for install_path in search_paths:
         assert install_path.endswith('ansible_collections')
     assert galaxy_apis[0].api_server == 'https://galaxy.ansible.com'
@@ -1479,27 +1234,16 @@ def test_execute_verify_with_defaults(mock_verify_collections):
 
 @patch('ansible.cli.galaxy.verify_collections', spec=True)
 def test_execute_verify(mock_verify_collections):
-    GalaxyCLI(
-        args=[
-            'ansible-galaxy',
-            'collection',
-            'verify',
-            'namespace.collection:1.0.4',
-            '--ignore-certs',
-            '-p',
-            '~/.ansible',
-            '--ignore-errors',
-            '--server',
-            'http://galaxy-dev.com',
-        ]).run()
+    GalaxyCLI(args=[
+        'ansible-galaxy', 'collection', 'verify', 'namespace.collection:1.0.4', '--ignore-certs',
+        '-p', '~/.ansible', '--ignore-errors', '--server', 'http://galaxy-dev.com',
+    ]).run()
 
     assert mock_verify_collections.call_count == 1
 
-    requirements, search_paths, galaxy_apis, ignore_errors = mock_verify_collections.call_args[
-        0]
+    requirements, search_paths, galaxy_apis, ignore_errors = mock_verify_collections.call_args[0]
 
-    assert [('%s.%s' % (r.namespace, r.name), r.ver, r.src, r.type)
-            for r in requirements] == [('namespace.collection', '1.0.4', None, 'galaxy')]
+    assert [('%s.%s' % (r.namespace, r.name), r.ver, r.src, r.type) for r in requirements] == [('namespace.collection', '1.0.4', None, 'galaxy')]
     for install_path in search_paths:
         assert install_path.endswith('ansible_collections')
     assert galaxy_apis[0].api_server == 'http://galaxy-dev.com'
@@ -1564,8 +1308,7 @@ def test_verify_file_hash_mismatching_hash(manifest_info):
 
     with patch.object(builtins, 'open', mock_open(read_data=data)) as m:
         with patch.object(collection.os.path, 'isfile', MagicMock(return_value=True)) as mock_isfile:
-            collection._verify_file_hash(
-                b'path/', 'file', different_digest, error_queue)
+            collection._verify_file_hash(b'path/', 'file', different_digest, error_queue)
 
             mock_isfile.assert_called_once()
 
@@ -1609,10 +1352,7 @@ def test_get_nonexistent_tar_file_member(tmp_tarfile):
     with pytest.raises(AnsibleError) as err:
         collection._get_tar_file_member(tfile, file_does_not_exist)
 
-    assert to_text(
-        err.value.message) == "Collection tar at '%s' does not contain the expected file '%s'." % (to_text(
-            tfile.name),
-        file_does_not_exist)
+    assert to_text(err.value.message) == "Collection tar at '%s' does not contain the expected file '%s'." % (to_text(tfile.name), file_does_not_exist)
 
 
 def test_get_tar_file_hash(tmp_tarfile):

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -841,6 +841,171 @@ def test_build_with_symlink_inside_collection(collection_input):
         assert actual_file == '08f24200b9fbe18903e7a50930c9d0df0b8d7da3'  # shasum test/units/cli/test_data/collection_skeleton/README.md
 
 
+def test_build_files_manifest_sorted_by_name(collection_input):
+    """Validate that FILES.json entries are sorted by name in ASCII order."""
+    input_dir, output_dir = collection_input
+
+    # Create multiple files to ensure sorting is tested
+    test_files = ['test_z.txt', 'test_a.txt', 'test_m.txt', 'beta.py', 'alpha.py']
+    for filename in test_files:
+        filepath = os.path.join(input_dir, filename)
+        with open(filepath, 'w') as f:
+            f.write('test content')
+
+    # Build manifest using _build_files_manifest_walk
+    manifest = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+
+    # Extract file names from manifest
+    file_names = [entry['name'] for entry in manifest['files']]
+
+    # Verify files are sorted by name (ASCII order)
+    expected_sorted = sorted(file_names)
+    assert file_names == expected_sorted, f"Files not in ASCII order. Got {file_names}, expected {expected_sorted}"
+
+
+def test_build_files_manifest_walk_sorted_output(collection_input):
+    """Validate _build_files_manifest_walk produces sorted output."""
+    input_dir = collection_input[0]
+
+    # Create files in reverse alphabetical order
+    files_to_create = ['zebra.txt', 'yak.txt', 'xray.txt', 'alpha.txt']
+    for filename in files_to_create:
+        filepath = os.path.join(input_dir, filename)
+        with open(filepath, 'w') as f:
+            f.write('content')
+
+    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+
+    assert actual['format'] == 1
+    file_names = [entry['name'] for entry in actual['files']]
+
+    # Verify sorting
+    assert file_names == sorted(file_names), f"Files not sorted: {file_names}"
+
+
+def test_build_collection_reproducible_build(collection_input):
+    """Validate that building the same collection twice produces identical FILES.json content."""
+    input_dir, output_dir = collection_input
+
+    # First build
+    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'),
+                               to_text(output_dir, errors='surrogate_or_strict'), False)
+
+    artifact1_path = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+    assert tarfile.is_tarfile(artifact1_path)
+
+    # Extract FILES.json from first build
+    with tarfile.open(artifact1_path, mode='r') as tar:
+        files_json_member = tar.getmember('FILES.json')
+        files_obj = tar.extractfile(files_json_member)
+        files_json_1 = json.loads(files_obj.read().decode('utf-8'))
+        files_obj.close()
+
+    # Remove the artifact for second build
+    os.remove(artifact1_path)
+
+    # Second build - should produce identical FILES.json
+    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'),
+                               to_text(output_dir, errors='surrogate_or_strict'), True)
+
+    artifact2_path = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+    assert tarfile.is_tarfile(artifact2_path)
+
+    with tarfile.open(artifact2_path, mode='r') as tar:
+        files_json_member = tar.getmember('FILES.json')
+        files_obj = tar.extractfile(files_json_member)
+        files_json_2 = json.loads(files_obj.read().decode('utf-8'))
+        files_obj.close()
+
+    # Verify FILES.json is identical
+    assert files_json_1 == files_json_2, "FILES.json content differs between builds"
+
+    # Verify file order is identical
+    files_1 = [f['name'] for f in files_json_1['files']]
+    files_2 = [f['name'] for f in files_json_2['files']]
+    assert files_1 == files_2, f"File order differs: {files_1} vs {files_2}"
+
+
+def test_build_files_manifest_special_characters_sorted(collection_input):
+    """Validate sorting works correctly with special characters in filenames."""
+    input_dir = collection_input[0]
+
+    # Create files with various special characters (within filesystem limits)
+    test_files = [
+        'z_underscore.txt',
+        'a-dash.txt',
+        'b_underscore.txt',
+        'a_underscore.txt',
+        '1_numeric.txt',
+        '0_numeric.txt',
+    ]
+
+    for filename in test_files:
+        filepath = os.path.join(input_dir, filename)
+        with open(filepath, 'w') as f:
+            f.write('test')
+
+    manifest = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+
+    # Get file names (excluding '.' which is added by default)
+    file_names = [entry['name'] for entry in manifest['files'] if entry['name'] != '.']
+
+    # Verify ASCII sorting
+    expected_sorted = sorted(file_names)
+    assert file_names == expected_sorted, f"Not sorted in ASCII order: {file_names}"
+
+
+def test_files_json_has_sorted_keys(collection_input):
+    """Validate that FILES.json output has sorted keys when using sort_keys=True."""
+    input_dir, output_dir = collection_input
+
+    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'),
+                               to_text(output_dir, errors='surrogate_or_strict'), False)
+
+    artifact_path = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+
+    with tarfile.open(artifact_path, mode='r') as tar:
+        files_json_member = tar.getmember('FILES.json')
+        files_obj = tar.extractfile(files_json_member)
+        files_content = files_obj.read().decode('utf-8')
+        files_obj.close()
+
+    # Parse and re-dump to check if keys are sorted
+    files_data = json.loads(files_content)
+    resorted_content = json.dumps(files_data, indent=True, sort_keys=True)
+
+    # The content should be identical if keys are already sorted
+    # (accounting for potential formatting differences)
+    assert files_data == json.loads(resorted_content), "FILES.json keys are not in sorted order"
+
+
+def test_build_collection_large_number_of_files_sorted(collection_input):
+    """Validate sorting performance and correctness with many files."""
+    input_dir = collection_input[0]
+
+    # Create a subdirectory structure with many files
+    dirs_to_create = ['dir_a', 'dir_z', 'dir_m', 'dir_b']
+    for dirname in dirs_to_create:
+        dirpath = os.path.join(input_dir, dirname)
+        os.makedirs(dirpath, exist_ok=True)
+
+        # Create multiple files in each directory
+        for i in range(5):
+            filepath = os.path.join(dirpath, f'file_{i:02d}.txt')
+            with open(filepath, 'w') as f:
+                f.write(f'content {i}')
+
+    manifest = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+
+    file_names = [entry['name'] for entry in manifest['files']]
+
+    # Verify all files are present
+    assert len(file_names) > 10, "Expected more than 10 files in manifest"
+
+    # Verify sorted order
+    assert file_names == sorted(file_names), f"Files not sorted correctly with many files: {file_names}"
+
+
 def test_publish_no_wait(galaxy_server, collection_artifact, monkeypatch):
     mock_display = MagicMock()
     monkeypatch.setattr(Display, 'display', mock_display)

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -838,8 +838,7 @@ def test_build_with_symlink_inside_collection(collection_input):
         actual_file = secure_hash_s(linked_file_obj.read())
         linked_file_obj.close()
 
-        # shasum test/units/cli/test_data/collection_skeleton/README.md
-        assert actual_file == '08f24200b9fbe18903e7a50930c9d0df0b8d7da3'
+        assert actual_file == '08f24200b9fbe18903e7a50930c9d0df0b8d7da3'  # shasum test/units/cli/test_data/collection_skeleton/README.md
 
 
 def test_build_files_manifest_sorted_by_name(collection_input):

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -842,171 +842,17 @@ def test_build_with_symlink_inside_collection(collection_input):
 
 
 def test_build_files_manifest_sorted_by_name(collection_input):
-    """Validate that FILES.json entries are sorted by name in ASCII order."""
-    input_dir, output_dir = collection_input
-
-    # Create multiple files to ensure sorting is tested
-    test_files = [
-        'test_z.txt',
-        'test_a.txt',
-        'test_m.txt',
-        'beta.py',
-        'alpha.py']
-    for filename in test_files:
-        filepath = os.path.join(input_dir, filename)
-        with open(filepath, 'w') as f:
-            f.write('test content')
-
-    # Build manifest using _build_files_manifest_walk
-    manifest = collection._build_files_manifest(
-        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
-
-    # Extract file names from manifest
-    file_names = [entry['name'] for entry in manifest['files']]
-
-    # Verify files are sorted by name (ASCII order)
-    expected_sorted = sorted(file_names)
-    assert file_names == expected_sorted, f"Files not in ASCII order. Got {file_names}, expected {expected_sorted}"
-
-
-def test_build_files_manifest_walk_sorted_output(collection_input):
-    """Validate _build_files_manifest_walk produces sorted output."""
+    """Verify _build_files_manifest returns files sorted by name."""
     input_dir = collection_input[0]
 
-    # Create files in reverse alphabetical order
-    files_to_create = ['zebra.txt', 'yak.txt', 'xray.txt', 'alpha.txt']
-    for filename in files_to_create:
-        filepath = os.path.join(input_dir, filename)
-        with open(filepath, 'w') as f:
-            f.write('content')
-
-    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
-
-    assert actual['format'] == 1
-    file_names = [entry['name'] for entry in actual['files']]
-
-    # Verify sorting
-    assert file_names == sorted(file_names), f"Files not sorted: {file_names}"
-
-
-def test_build_collection_reproducible_build(collection_input):
-    """Validate that building the same collection twice produces identical FILES.json content."""
-    input_dir, output_dir = collection_input
-
-    # First build
-    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
-
-    artifact1_path = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
-    assert tarfile.is_tarfile(artifact1_path)
-
-    # Extract FILES.json from first build
-    with tarfile.open(artifact1_path, mode='r') as tar:
-        files_json_member = tar.getmember('FILES.json')
-        files_obj = tar.extractfile(files_json_member)
-        files_json_1 = json.loads(files_obj.read().decode('utf-8'))
-        files_obj.close()
-
-    # Remove the artifact for second build
-    os.remove(artifact1_path)
-
-    # Second build - should produce identical FILES.json
-    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), True)
-
-    artifact2_path = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
-    assert tarfile.is_tarfile(artifact2_path)
-
-    with tarfile.open(artifact2_path, mode='r') as tar:
-        files_json_member = tar.getmember('FILES.json')
-        files_obj = tar.extractfile(files_json_member)
-        files_json_2 = json.loads(files_obj.read().decode('utf-8'))
-        files_obj.close()
-
-    # Verify FILES.json is identical
-    assert files_json_1 == files_json_2, "FILES.json content differs between builds"
-
-    # Verify file order is identical
-    files_1 = [f['name'] for f in files_json_1['files']]
-    files_2 = [f['name'] for f in files_json_2['files']]
-    assert files_1 == files_2, f"File order differs: {files_1} vs {files_2}"
-
-
-def test_build_files_manifest_special_characters_sorted(collection_input):
-    """Validate sorting works correctly with special characters in filenames."""
-    input_dir = collection_input[0]
-
-    # Create files with various special characters (within filesystem limits)
-    test_files = [
-        'z_underscore.txt',
-        'a-dash.txt',
-        'b_underscore.txt',
-        'a_underscore.txt',
-        '1_numeric.txt',
-        '0_numeric.txt',
-    ]
-
-    for filename in test_files:
-        filepath = os.path.join(input_dir, filename)
-        with open(filepath, 'w') as f:
+    for filename in ['z.txt', 'a.txt', 'm.txt']:
+        with open(os.path.join(input_dir, filename), 'w') as f:
             f.write('test')
 
     manifest = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    names = [entry['name'] for entry in manifest['files']]
 
-    # Get file names (excluding '.' which is added by default)
-    file_names = [entry['name'] for entry in manifest['files'] if entry['name'] != '.']
-
-    # Verify ASCII sorting
-    expected_sorted = sorted(file_names)
-    assert file_names == expected_sorted, f"Not sorted in ASCII order: {file_names}"
-
-
-def test_files_json_has_sorted_keys(collection_input):
-    """Validate that FILES.json output has sorted keys when using sort_keys=True."""
-    input_dir, output_dir = collection_input
-
-    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
-
-    artifact_path = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
-
-    with tarfile.open(artifact_path, mode='r') as tar:
-        files_json_member = tar.getmember('FILES.json')
-        files_obj = tar.extractfile(files_json_member)
-        files_content = files_obj.read().decode('utf-8')
-        files_obj.close()
-
-    # Parse and re-dump to check if keys are sorted
-    files_data = json.loads(files_content)
-    resorted_content = json.dumps(files_data, indent=True, sort_keys=True)
-
-    # The content should be identical if keys are already sorted
-    # (accounting for potential formatting differences)
-    assert files_data == json.loads(resorted_content), "FILES.json keys are not in sorted order"
-
-
-def test_build_collection_large_number_of_files_sorted(collection_input):
-    """Validate sorting performance and correctness with many files."""
-    input_dir = collection_input[0]
-
-    # Create a subdirectory structure with many files
-    dirs_to_create = ['dir_a', 'dir_z', 'dir_m', 'dir_b']
-    for dirname in dirs_to_create:
-        dirpath = os.path.join(input_dir, dirname)
-        os.makedirs(dirpath, exist_ok=True)
-
-        # Create multiple files in each directory
-        for i in range(5):
-            filepath = os.path.join(dirpath, f'file_{i:02d}.txt')
-            with open(filepath, 'w') as f:
-                f.write(f'content {i}')
-
-    manifest = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
-
-    file_names = [entry['name'] for entry in manifest['files']]
-
-    # Verify all files are present
-    assert len(file_names) > 10, "Expected more than 10 files in manifest"
-
-    # Verify sorted order
-    assert file_names == sorted(file_names), f"Files not sorted correctly with many files: {file_names}"
+    assert names == sorted(names)
 
 
 def test_publish_no_wait(galaxy_server, collection_artifact, monkeypatch):

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright: (c) 2019, Ansible Project
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import annotations
 
@@ -51,13 +52,29 @@ def collection_input(tmp_path_factory, collection_path_suffix):
 
     namespace = 'ansible_namespace'
     collection = 'collection'
-    skeleton = os.path.join(os.path.dirname(os.path.split(__file__)[0]), 'cli', 'test_data', 'collection_skeleton')
+    skeleton = os.path.join(
+        os.path.dirname(
+            os.path.split(__file__)[0]),
+        'cli',
+        'test_data',
+        'collection_skeleton')
 
-    galaxy_args = ['ansible-galaxy', 'collection', 'init', '%s.%s' % (namespace, collection),
-                   '-c', '--init-path', test_dir, '--collection-skeleton', skeleton]
+    galaxy_args = [
+        'ansible-galaxy',
+        'collection',
+        'init',
+        '%s.%s' %
+        (namespace,
+         collection),
+        '-c',
+        '--init-path',
+        test_dir,
+        '--collection-skeleton',
+        skeleton]
     GalaxyCLI(args=galaxy_args).run()
     collection_dir = os.path.join(test_dir, namespace, collection)
-    output_dir = to_text(tmp_path_factory.mktemp('test-ÅÑŚÌβŁÈ Collections Output'))
+    output_dir = to_text(tmp_path_factory.mktemp(
+        'test-ÅÑŚÌβŁÈ Collections Output'))
 
     return collection_dir, output_dir
 
@@ -66,7 +83,10 @@ def collection_input(tmp_path_factory, collection_path_suffix):
 def collection_artifact(monkeypatch, tmp_path_factory):
     """ Creates a temp collection artifact and mocked open_url instance for publishing tests """
     mock_open = MagicMock()
-    monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
+    monkeypatch.setattr(
+        collection.concrete_artifact_manager,
+        'open_url',
+        mock_open)
 
     mock_uuid = MagicMock()
     mock_uuid.return_value.hex = 'uuid'
@@ -99,7 +119,10 @@ def galaxy_yml_dir(request, tmp_path_factory):
 def tmp_tarfile(tmp_path_factory, manifest_info):
     """ Creates a temporary tar file for _extract_tar_file tests """
     filename = u'ÅÑŚÌβŁÈ'
-    temp_dir = to_bytes(tmp_path_factory.mktemp('test-%s Collections' % to_native(filename)))
+    temp_dir = to_bytes(
+        tmp_path_factory.mktemp(
+            'test-%s Collections' %
+            to_native(filename)))
     tar_file = os.path.join(temp_dir, to_bytes('%s.tar.gz' % filename))
     data = os.urandom(8)
 
@@ -110,7 +133,11 @@ def tmp_tarfile(tmp_path_factory, manifest_info):
         tar_info.mode = S_IRWU_RG_RO
         tfile.addfile(tarinfo=tar_info, fileobj=b_io)
 
-        b_data = to_bytes(json.dumps(manifest_info, indent=True), errors='surrogate_or_strict')
+        b_data = to_bytes(
+            json.dumps(
+                manifest_info,
+                indent=True),
+            errors='surrogate_or_strict')
         b_io = BytesIO(b_data)
         tar_info = tarfile.TarInfo('MANIFEST.json')
         tar_info.size = len(b_data)
@@ -127,14 +154,21 @@ def tmp_tarfile(tmp_path_factory, manifest_info):
 @pytest.fixture()
 def galaxy_server():
     context.CLIARGS._store = {'ignore_certs': False}
-    galaxy_api = api.GalaxyAPI(None, 'test_server', 'https://galaxy.ansible.com',
-                               token=token.GalaxyToken(token='key'))
+    galaxy_api = api.GalaxyAPI(
+        None,
+        'test_server',
+        'https://galaxy.ansible.com',
+        token=token.GalaxyToken(
+            token='key'))
     return galaxy_api
 
 
 @pytest.fixture()
 def manifest_template():
-    def get_manifest_info(namespace='ansible_namespace', name='collection', version='0.1.0'):
+    def get_manifest_info(
+            namespace='ansible_namespace',
+            name='collection',
+            version='0.1.0'):
         return {
             "collection_info": {
                 "namespace": namespace,
@@ -213,7 +247,10 @@ def test_cli_options(required_signature_count, valid, monkeypatch):
 
     galaxy_cli = GalaxyCLI(args=cli_args)
     mock_execute_install = MagicMock()
-    monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
+    monkeypatch.setattr(
+        galaxy_cli,
+        '_execute_install_collection',
+        mock_execute_install)
 
     if valid:
         galaxy_cli.run()
@@ -274,7 +311,10 @@ def test_bool_type_server_config_options(config, server, monkeypatch):
                 C.config._parse_config_file()
                 galaxy_cli = GalaxyCLI(args=cli_args)
                 mock_execute_install = MagicMock()
-                monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
+                monkeypatch.setattr(
+                    galaxy_cli,
+                    '_execute_install_collection',
+                    mock_execute_install)
                 galaxy_cli.run()
 
     assert galaxy_cli.api_servers[0].name == 'server1'
@@ -294,7 +334,10 @@ def test_validate_certs(global_ignore_certs, monkeypatch):
 
     galaxy_cli = GalaxyCLI(args=cli_args)
     mock_execute_install = MagicMock()
-    monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
+    monkeypatch.setattr(
+        galaxy_cli,
+        '_execute_install_collection',
+        mock_execute_install)
     galaxy_cli.run()
 
     assert len(galaxy_cli.api_servers) == 1
@@ -312,7 +355,11 @@ def test_validate_certs(global_ignore_certs, monkeypatch):
         (True, False, False),
     ]
 )
-def test_validate_certs_with_server_url(ignore_certs_cli, ignore_certs_cfg, expected_validate_certs, monkeypatch):
+def test_validate_certs_with_server_url(
+        ignore_certs_cli,
+        ignore_certs_cfg,
+        expected_validate_certs,
+        monkeypatch):
     cli_args = [
         'ansible-galaxy',
         'collection',
@@ -328,25 +375,51 @@ def test_validate_certs_with_server_url(ignore_certs_cli, ignore_certs_cfg, expe
 
     galaxy_cli = GalaxyCLI(args=cli_args)
     mock_execute_install = MagicMock()
-    monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
+    monkeypatch.setattr(
+        galaxy_cli,
+        '_execute_install_collection',
+        mock_execute_install)
     galaxy_cli.run()
 
     assert len(galaxy_cli.api_servers) == 1
     assert galaxy_cli.api_servers[0].validate_certs == expected_validate_certs
 
 
-@pytest.mark.parametrize(
-    ["ignore_certs_cli", "ignore_certs_cfg", "expected_server2_validate_certs", "expected_server3_validate_certs"],
-    [
-        (None, None, True, True),
-        (None, True, True, False),
-        (None, False, True, True),
-        (True, None, False, False),
-        (True, True, False, False),
-        (True, False, False, False),
-    ]
-)
-def test_validate_certs_server_config(ignore_certs_cfg, ignore_certs_cli, expected_server2_validate_certs, expected_server3_validate_certs, monkeypatch):
+@pytest.mark.parametrize(["ignore_certs_cli",
+                          "ignore_certs_cfg",
+                          "expected_server2_validate_certs",
+                          "expected_server3_validate_certs"],
+                         [(None,
+                           None,
+                           True,
+                           True),
+                          (None,
+                           True,
+                           True,
+                           False),
+                          (None,
+                             False,
+                             True,
+                             True),
+                          (True,
+                             None,
+                             False,
+                             False),
+                          (True,
+                             True,
+                             False,
+                             False),
+                          (True,
+                             False,
+                             False,
+                             False),
+                          ])
+def test_validate_certs_server_config(
+        ignore_certs_cfg,
+        ignore_certs_cli,
+        expected_server2_validate_certs,
+        expected_server3_validate_certs,
+        monkeypatch):
     server_names = ['server1', 'server2', 'server3']
     cfg_lines = [
         "[galaxy]",
@@ -374,14 +447,20 @@ def test_validate_certs_server_config(ignore_certs_cfg, ignore_certs_cli, expect
     monkeypatch.setattr(C, 'GALAXY_SERVER_LIST', server_names)
 
     with tempfile.NamedTemporaryFile(suffix='.cfg') as tmp_file:
-        tmp_file.write(to_bytes('\n'.join(cfg_lines), errors='surrogate_or_strict'))
+        tmp_file.write(
+            to_bytes(
+                '\n'.join(cfg_lines),
+                errors='surrogate_or_strict'))
         tmp_file.flush()
 
         monkeypatch.setattr(C.config, '_config_file', tmp_file.name)
         C.config._parse_config_file()
         galaxy_cli = GalaxyCLI(args=cli_args)
         mock_execute_install = MagicMock()
-        monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
+        monkeypatch.setattr(
+            galaxy_cli,
+            '_execute_install_collection',
+            mock_execute_install)
         galaxy_cli.run()
 
     # (not) --ignore-certs > server's validate_certs > (not) GALAXY_IGNORE_CERTS > True
@@ -399,7 +478,12 @@ def test_validate_certs_server_config(ignore_certs_cfg, ignore_certs_cli, expect
         (30, 20, 10, 30),
     ]
 )
-def test_timeout_server_config(timeout_cli, timeout_cfg, timeout_fallback, expected_timeout, monkeypatch):
+def test_timeout_server_config(
+        timeout_cli,
+        timeout_cfg,
+        timeout_fallback,
+        expected_timeout,
+        monkeypatch):
     cli_args = [
         'ansible-galaxy',
         'collection',
@@ -413,19 +497,27 @@ def test_timeout_server_config(timeout_cli, timeout_cfg, timeout_fallback, expec
     if timeout_fallback is not None:
         cfg_lines.append(f"server_timeout={timeout_fallback}")
 
-        # fix default in server config since C.GALAXY_SERVER_TIMEOUT was already evaluated
+        # fix default in server config since C.GALAXY_SERVER_TIMEOUT was
+        # already evaluated
         server_additional = manager.GALAXY_SERVER_ADDITIONAL.copy()
         server_additional['timeout']['default'] = timeout_fallback
-        monkeypatch.setattr(manager, 'GALAXY_SERVER_ADDITIONAL', server_additional)
+        monkeypatch.setattr(
+            manager,
+            'GALAXY_SERVER_ADDITIONAL',
+            server_additional)
 
-    cfg_lines.extend(["[galaxy_server.server1]", "url=https://galaxy.ansible.com/api/"])
+    cfg_lines.extend(["[galaxy_server.server1]",
+                      "url=https://galaxy.ansible.com/api/"])
     if timeout_cfg is not None:
         cfg_lines.append(f"timeout={timeout_cfg}")
 
     monkeypatch.setattr(C, 'GALAXY_SERVER_LIST', ['server1'])
 
     with tempfile.NamedTemporaryFile(suffix='.cfg') as tmp_file:
-        tmp_file.write(to_bytes('\n'.join(cfg_lines), errors='surrogate_or_strict'))
+        tmp_file.write(
+            to_bytes(
+                '\n'.join(cfg_lines),
+                errors='surrogate_or_strict'))
         tmp_file.flush()
 
         monkeypatch.setattr(C.config, '_config_file', tmp_file.name)
@@ -433,7 +525,10 @@ def test_timeout_server_config(timeout_cli, timeout_cfg, timeout_fallback, expec
 
         galaxy_cli = GalaxyCLI(args=cli_args)
         mock_execute_install = MagicMock()
-        monkeypatch.setattr(galaxy_cli, '_execute_install_collection', mock_execute_install)
+        monkeypatch.setattr(
+            galaxy_cli,
+            '_execute_install_collection',
+            mock_execute_install)
         galaxy_cli.run()
 
     assert galaxy_cli.api_servers[0].timeout == expected_timeout
@@ -441,7 +536,9 @@ def test_timeout_server_config(timeout_cli, timeout_cfg, timeout_fallback, expec
 
 def test_build_collection_no_galaxy_yaml():
     fake_path = u'/fake/ÅÑŚÌβŁÈ/path'
-    expected = to_native("The collection galaxy.yml path '%s/galaxy.yml' does not exist." % fake_path)
+    expected = to_native(
+        "The collection galaxy.yml path '%s/galaxy.yml' does not exist." %
+        fake_path)
 
     with pytest.raises(AnsibleError, match=expected):
         collection.build_collection(fake_path, u'output', False)
@@ -450,19 +547,24 @@ def test_build_collection_no_galaxy_yaml():
 def test_build_existing_output_file(collection_input):
     input_dir, output_dir = collection_input
 
-    existing_output_dir = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+    existing_output_dir = os.path.join(
+        output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
     os.makedirs(existing_output_dir)
 
     expected = "The output collection artifact '%s' already exists, but is a directory - aborting" \
                % to_native(existing_output_dir)
     with pytest.raises(AnsibleError, match=expected):
-        collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
+        collection.build_collection(
+            to_text(
+                input_dir, errors='surrogate_or_strict'), to_text(
+                output_dir, errors='surrogate_or_strict'), False)
 
 
 def test_build_existing_output_without_force(collection_input):
     input_dir, output_dir = collection_input
 
-    existing_output = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+    existing_output = os.path.join(output_dir,
+                                   'ansible_namespace-collection-0.1.0.tar.gz')
     with open(existing_output, 'w+') as out_file:
         out_file.write("random garbage")
         out_file.flush()
@@ -470,7 +572,10 @@ def test_build_existing_output_without_force(collection_input):
     expected = "The file '%s' already exists. You can use --force to re-create the collection artifact." \
                % to_native(existing_output)
     with pytest.raises(AnsibleError, match=expected):
-        collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
+        collection.build_collection(
+            to_text(
+                input_dir, errors='surrogate_or_strict'), to_text(
+                output_dir, errors='surrogate_or_strict'), False)
 
 
 @pytest.mark.parametrize(
@@ -484,12 +589,16 @@ def test_build_existing_output_without_force(collection_input):
 def test_build_existing_output_with_force(collection_input):
     input_dir, output_dir = collection_input
 
-    existing_output = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+    existing_output = os.path.join(output_dir,
+                                   'ansible_namespace-collection-0.1.0.tar.gz')
     with open(existing_output, 'w+') as out_file:
         out_file.write("random garbage")
         out_file.flush()
 
-    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), True)
+    collection.build_collection(
+        to_text(
+            input_dir, errors='surrogate_or_strict'), to_text(
+            output_dir, errors='surrogate_or_strict'), True)
 
     # Verify the file was replaced with an actual tar file
     assert tarfile.is_tarfile(existing_output)
@@ -507,9 +616,13 @@ def test_build_with_existing_files_and_manifest(collection_input):
     with open(os.path.join(input_dir, "plugins", "MANIFEST.json"), "wb") as fd:
         fd.write(b"test data that should be in build")
 
-    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
+    collection.build_collection(
+        to_text(
+            input_dir, errors='surrogate_or_strict'), to_text(
+            output_dir, errors='surrogate_or_strict'), False)
 
-    output_artifact = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+    output_artifact = os.path.join(output_dir,
+                                   'ansible_namespace-collection-0.1.0.tar.gz')
     assert tarfile.is_tarfile(output_artifact)
 
     with tarfile.open(output_artifact, mode='r') as actual:
@@ -527,47 +640,63 @@ def test_build_with_existing_files_and_manifest(collection_input):
         json_file_obj.close()
         assert json_file_text != b'{"files": [], "format": 1}'
 
-        sub_manifest_file = [m for m in members if m.path == "plugins/MANIFEST.json"][0]
+        sub_manifest_file = [
+            m for m in members if m.path == "plugins/MANIFEST.json"][0]
         sub_manifest_file_obj = actual.extractfile(sub_manifest_file.name)
         sub_manifest_file_text = sub_manifest_file_obj.read()
         sub_manifest_file_obj.close()
         assert sub_manifest_file_text == b"test data that should be in build"
 
 
-@pytest.mark.parametrize('galaxy_yml_dir', [b'namespace: value: broken'], indirect=True)
+@pytest.mark.parametrize('galaxy_yml_dir',
+                         [b'namespace: value: broken'],
+                         indirect=True)
 def test_invalid_yaml_galaxy_file(galaxy_yml_dir):
     galaxy_file = os.path.join(galaxy_yml_dir, b'galaxy.yml')
-    expected = to_native(b"Failed to parse the galaxy.yml at '%s' with the following error:" % galaxy_file)
+    expected = to_native(
+        b"Failed to parse the galaxy.yml at '%s' with the following error:" %
+        galaxy_file)
 
     with pytest.raises(AnsibleError, match=expected):
-        collection.concrete_artifact_manager._get_meta_from_src_dir(galaxy_yml_dir)
+        collection.concrete_artifact_manager._get_meta_from_src_dir(
+            galaxy_yml_dir)
 
 
-@pytest.mark.parametrize('galaxy_yml_dir', [b'namespace: test_namespace'], indirect=True)
+@pytest.mark.parametrize('galaxy_yml_dir',
+                         [b'namespace: test_namespace'],
+                         indirect=True)
 def test_missing_required_galaxy_key(galaxy_yml_dir):
     galaxy_file = os.path.join(galaxy_yml_dir, b'galaxy.yml')
     expected = "The collection galaxy.yml at '%s' is missing the following mandatory keys: authors, name, " \
                "readme, version" % to_native(galaxy_file)
 
     with pytest.raises(AnsibleError, match=expected):
-        collection.concrete_artifact_manager._get_meta_from_src_dir(galaxy_yml_dir)
+        collection.concrete_artifact_manager._get_meta_from_src_dir(
+            galaxy_yml_dir)
 
 
-@pytest.mark.parametrize('galaxy_yml_dir', [b'namespace: test_namespace'], indirect=True)
+@pytest.mark.parametrize('galaxy_yml_dir',
+                         [b'namespace: test_namespace'],
+                         indirect=True)
 def test_galaxy_yaml_no_mandatory_keys(galaxy_yml_dir):
     expected = "The collection galaxy.yml at '%s/galaxy.yml' is missing the " \
                "following mandatory keys: authors, name, readme, version" % to_native(galaxy_yml_dir)
 
     with pytest.raises(ValueError, match=expected):
-        assert collection.concrete_artifact_manager._get_meta_from_src_dir(galaxy_yml_dir, require_build_metadata=False) == expected
+        assert collection.concrete_artifact_manager._get_meta_from_src_dir(
+            galaxy_yml_dir, require_build_metadata=False) == expected
 
 
-@pytest.mark.parametrize('galaxy_yml_dir', [b'My life story is so very interesting'], indirect=True)
+@pytest.mark.parametrize('galaxy_yml_dir',
+                         [b'My life story is so very interesting'],
+                         indirect=True)
 def test_galaxy_yaml_no_mandatory_keys_bad_yaml(galaxy_yml_dir):
-    expected = "The collection galaxy.yml at '%s/galaxy.yml' is incorrectly formatted." % to_native(galaxy_yml_dir)
+    expected = "The collection galaxy.yml at '%s/galaxy.yml' is incorrectly formatted." % to_native(
+        galaxy_yml_dir)
 
     with pytest.raises(AnsibleError, match=expected):
-        collection.concrete_artifact_manager._get_meta_from_src_dir(galaxy_yml_dir)
+        collection.concrete_artifact_manager._get_meta_from_src_dir(
+            galaxy_yml_dir)
 
 
 @pytest.mark.parametrize('galaxy_yml_dir', [b"""
@@ -595,7 +724,8 @@ authors: Jordan
 version: 0.1.0
 readme: README.md"""], indirect=True)
 def test_defaults_galaxy_yml(galaxy_yml_dir):
-    actual = collection.concrete_artifact_manager._get_meta_from_src_dir(galaxy_yml_dir)
+    actual = collection.concrete_artifact_manager._get_meta_from_src_dir(
+        galaxy_yml_dir)
 
     assert actual['namespace'] == 'namespace'
     assert actual['name'] == 'collection'
@@ -627,7 +757,8 @@ readme: README.md
 license:
 - MIT""")], indirect=True)
 def test_galaxy_yml_list_value(galaxy_yml_dir):
-    actual = collection.concrete_artifact_manager._get_meta_from_src_dir(galaxy_yml_dir)
+    actual = collection.concrete_artifact_manager._get_meta_from_src_dir(
+        galaxy_yml_dir)
     assert actual['license'] == ['MIT']
 
 
@@ -654,11 +785,17 @@ def test_build_ignore_files_and_folders(collection_input, monkeypatch):
         tests_file.write('random')
         tests_file.flush()
 
-    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    actual = collection._build_files_manifest(
+        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
 
     assert actual['format'] == 1
     for manifest_entry in actual['files']:
-        assert manifest_entry['name'] not in ['.git', 'ansible.retry', 'galaxy.yml', 'tests/output', 'tests/output/result.txt']
+        assert manifest_entry['name'] not in [
+            '.git',
+            'ansible.retry',
+            'galaxy.yml',
+            'tests/output',
+            'tests/output/result.txt']
 
     expected_msgs = [
         "Skipping '%s/galaxy.yml' for collection build" % to_text(input_dir),
@@ -682,15 +819,18 @@ def test_build_ignore_older_release_in_root(collection_input, monkeypatch):
     # This is expected to be ignored because it is in the root collection dir.
     release_file = os.path.join(input_dir, 'namespace-collection-0.0.0.tar.gz')
 
-    # This is not expected to be ignored because it is not in the root collection dir.
-    fake_release_file = os.path.join(input_dir, 'plugins', 'namespace-collection-0.0.0.tar.gz')
+    # This is not expected to be ignored because it is not in the root
+    # collection dir.
+    fake_release_file = os.path.join(
+        input_dir, 'plugins', 'namespace-collection-0.0.0.tar.gz')
 
     for filename in [release_file, fake_release_file]:
         with open(filename, 'w+') as file_obj:
             file_obj.write('random')
             file_obj.flush()
 
-    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    actual = collection._build_files_manifest(
+        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
     assert actual['format'] == 1
 
     plugin_release_found = False
@@ -716,9 +856,9 @@ def test_build_ignore_patterns(collection_input, monkeypatch):
     mock_display = MagicMock()
     monkeypatch.setattr(Display, 'vvv', mock_display)
 
-    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection',
-                                              ['*.md', 'plugins/action', 'playbooks/*.j2'],
-                                              Sentinel, None)
+    actual = collection._build_files_manifest(
+        to_bytes(input_dir), 'namespace', 'collection', [
+            '*.md', 'plugins/action', 'playbooks/*.j2'], Sentinel, None)
     assert actual['format'] == 1
 
     expected_missing = [
@@ -729,7 +869,8 @@ def test_build_ignore_patterns(collection_input, monkeypatch):
         'playbooks/templates/subfolder/test.conf.j2',
     ]
 
-    # Files or dirs that are close to a match but are not, make sure they are present
+    # Files or dirs that are close to a match but are not, make sure they are
+    # present
     expected_present = [
         'docs',
         'roles/common/templates/test.conf.j2',
@@ -744,12 +885,18 @@ def test_build_ignore_patterns(collection_input, monkeypatch):
         assert p in actual_files
 
     expected_msgs = [
-        "Skipping '%s/galaxy.yml' for collection build" % to_text(input_dir),
-        "Skipping '%s/README.md' for collection build" % to_text(input_dir),
-        "Skipping '%s/docs/My Collection.md' for collection build" % to_text(input_dir),
-        "Skipping '%s/plugins/action' for collection build" % to_text(input_dir),
-        "Skipping '%s/playbooks/templates/test.conf.j2' for collection build" % to_text(input_dir),
-        "Skipping '%s/playbooks/templates/subfolder/test.conf.j2' for collection build" % to_text(input_dir),
+        "Skipping '%s/galaxy.yml' for collection build" %
+        to_text(input_dir),
+        "Skipping '%s/README.md' for collection build" %
+        to_text(input_dir),
+        "Skipping '%s/docs/My Collection.md' for collection build" %
+        to_text(input_dir),
+        "Skipping '%s/plugins/action' for collection build" %
+        to_text(input_dir),
+        "Skipping '%s/playbooks/templates/test.conf.j2' for collection build" %
+        to_text(input_dir),
+        "Skipping '%s/playbooks/templates/subfolder/test.conf.j2' for collection build" %
+        to_text(input_dir),
     ]
     assert mock_display.call_count == len(expected_msgs)
     assert mock_display.mock_calls[0][1][0] in expected_msgs
@@ -760,7 +907,8 @@ def test_build_ignore_patterns(collection_input, monkeypatch):
     assert mock_display.mock_calls[5][1][0] in expected_msgs
 
 
-def test_build_ignore_symlink_target_outside_collection(collection_input, monkeypatch):
+def test_build_ignore_symlink_target_outside_collection(
+        collection_input, monkeypatch):
     input_dir, outside_dir = collection_input
 
     mock_display = MagicMock()
@@ -769,7 +917,8 @@ def test_build_ignore_symlink_target_outside_collection(collection_input, monkey
     link_path = os.path.join(input_dir, 'plugins', 'connection')
     os.symlink(outside_dir, link_path)
 
-    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    actual = collection._build_files_manifest(
+        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
     for manifest_entry in actual['files']:
         assert manifest_entry['name'] != 'plugins/connection'
 
@@ -793,9 +942,11 @@ def test_build_copy_symlink_target_inside_collection(collection_input):
 
     os.symlink(roles_target, roles_link)
 
-    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    actual = collection._build_files_manifest(
+        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
 
-    linked_entries = [e for e in actual['files'] if e['name'].startswith('playbooks/roles/linked')]
+    linked_entries = [e for e in actual['files']
+                      if e['name'].startswith('playbooks/roles/linked')]
     assert len(linked_entries) == 1
     assert linked_entries[0]['name'] == 'playbooks/roles/linked'
     assert linked_entries[0]['ftype'] == 'dir'
@@ -818,15 +969,20 @@ def test_build_with_symlink_inside_collection(collection_input):
     os.symlink(roles_target, roles_link)
     os.symlink(os.path.join(input_dir, 'README.md'), file_link)
 
-    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'), to_text(output_dir, errors='surrogate_or_strict'), False)
+    collection.build_collection(
+        to_text(
+            input_dir, errors='surrogate_or_strict'), to_text(
+            output_dir, errors='surrogate_or_strict'), False)
 
-    output_artifact = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+    output_artifact = os.path.join(output_dir,
+                                   'ansible_namespace-collection-0.1.0.tar.gz')
     assert tarfile.is_tarfile(output_artifact)
 
     with tarfile.open(output_artifact, mode='r') as actual:
         members = actual.getmembers()
 
-        linked_folder = [m for m in members if m.path == 'playbooks/roles/linked'][0]
+        linked_folder = [m for m in members if m.path ==
+                         'playbooks/roles/linked'][0]
         assert linked_folder.type == tarfile.SYMTYPE
         assert linked_folder.linkname == '../../roles/linked'
 
@@ -838,7 +994,8 @@ def test_build_with_symlink_inside_collection(collection_input):
         actual_file = secure_hash_s(linked_file_obj.read())
         linked_file_obj.close()
 
-        assert actual_file == '08f24200b9fbe18903e7a50930c9d0df0b8d7da3'  # shasum test/units/cli/test_data/collection_skeleton/README.md
+        # shasum test/units/cli/test_data/collection_skeleton/README.md
+        assert actual_file == '08f24200b9fbe18903e7a50930c9d0df0b8d7da3'
 
 
 def test_build_files_manifest_sorted_by_name(collection_input):
@@ -846,14 +1003,20 @@ def test_build_files_manifest_sorted_by_name(collection_input):
     input_dir, output_dir = collection_input
 
     # Create multiple files to ensure sorting is tested
-    test_files = ['test_z.txt', 'test_a.txt', 'test_m.txt', 'beta.py', 'alpha.py']
+    test_files = [
+        'test_z.txt',
+        'test_a.txt',
+        'test_m.txt',
+        'beta.py',
+        'alpha.py']
     for filename in test_files:
         filepath = os.path.join(input_dir, filename)
         with open(filepath, 'w') as f:
             f.write('test content')
 
     # Build manifest using _build_files_manifest_walk
-    manifest = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    manifest = collection._build_files_manifest(
+        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
 
     # Extract file names from manifest
     file_names = [entry['name'] for entry in manifest['files']]
@@ -874,7 +1037,8 @@ def test_build_files_manifest_walk_sorted_output(collection_input):
         with open(filepath, 'w') as f:
             f.write('content')
 
-    actual = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    actual = collection._build_files_manifest(
+        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
 
     assert actual['format'] == 1
     file_names = [entry['name'] for entry in actual['files']]
@@ -888,10 +1052,13 @@ def test_build_collection_reproducible_build(collection_input):
     input_dir, output_dir = collection_input
 
     # First build
-    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'),
-                               to_text(output_dir, errors='surrogate_or_strict'), False)
+    collection.build_collection(
+        to_text(
+            input_dir, errors='surrogate_or_strict'), to_text(
+            output_dir, errors='surrogate_or_strict'), False)
 
-    artifact1_path = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+    artifact1_path = os.path.join(output_dir,
+                                  'ansible_namespace-collection-0.1.0.tar.gz')
     assert tarfile.is_tarfile(artifact1_path)
 
     # Extract FILES.json from first build
@@ -905,10 +1072,13 @@ def test_build_collection_reproducible_build(collection_input):
     os.remove(artifact1_path)
 
     # Second build - should produce identical FILES.json
-    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'),
-                               to_text(output_dir, errors='surrogate_or_strict'), True)
+    collection.build_collection(
+        to_text(
+            input_dir, errors='surrogate_or_strict'), to_text(
+            output_dir, errors='surrogate_or_strict'), True)
 
-    artifact2_path = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+    artifact2_path = os.path.join(output_dir,
+                                  'ansible_namespace-collection-0.1.0.tar.gz')
     assert tarfile.is_tarfile(artifact2_path)
 
     with tarfile.open(artifact2_path, mode='r') as tar:
@@ -945,10 +1115,12 @@ def test_build_files_manifest_special_characters_sorted(collection_input):
         with open(filepath, 'w') as f:
             f.write('test')
 
-    manifest = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    manifest = collection._build_files_manifest(
+        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
 
     # Get file names (excluding '.' which is added by default)
-    file_names = [entry['name'] for entry in manifest['files'] if entry['name'] != '.']
+    file_names = [entry['name']
+                  for entry in manifest['files'] if entry['name'] != '.']
 
     # Verify ASCII sorting
     expected_sorted = sorted(file_names)
@@ -959,10 +1131,13 @@ def test_files_json_has_sorted_keys(collection_input):
     """Validate that FILES.json output has sorted keys when using sort_keys=True."""
     input_dir, output_dir = collection_input
 
-    collection.build_collection(to_text(input_dir, errors='surrogate_or_strict'),
-                               to_text(output_dir, errors='surrogate_or_strict'), False)
+    collection.build_collection(
+        to_text(
+            input_dir, errors='surrogate_or_strict'), to_text(
+            output_dir, errors='surrogate_or_strict'), False)
 
-    artifact_path = os.path.join(output_dir, 'ansible_namespace-collection-0.1.0.tar.gz')
+    artifact_path = os.path.join(output_dir,
+                                 'ansible_namespace-collection-0.1.0.tar.gz')
 
     with tarfile.open(artifact_path, mode='r') as tar:
         files_json_member = tar.getmember('FILES.json')
@@ -976,7 +1151,8 @@ def test_files_json_has_sorted_keys(collection_input):
 
     # The content should be identical if keys are already sorted
     # (accounting for potential formatting differences)
-    assert files_data == json.loads(resorted_content), "FILES.json keys are not in sorted order"
+    assert files_data == json.loads(
+        resorted_content), "FILES.json keys are not in sorted order"
 
 
 def test_build_collection_large_number_of_files_sorted(collection_input):
@@ -995,7 +1171,8 @@ def test_build_collection_large_number_of_files_sorted(collection_input):
             with open(filepath, 'w') as f:
                 f.write(f'content {i}')
 
-    manifest = collection._build_files_manifest(to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
+    manifest = collection._build_files_manifest(
+        to_bytes(input_dir), 'namespace', 'collection', [], Sentinel, None)
 
     file_names = [entry['name'] for entry in manifest['files']]
 
@@ -1003,7 +1180,8 @@ def test_build_collection_large_number_of_files_sorted(collection_input):
     assert len(file_names) > 10, "Expected more than 10 files in manifest"
 
     # Verify sorted order
-    assert file_names == sorted(file_names), f"Files not sorted correctly with many files: {file_names}"
+    assert file_names == sorted(
+        file_names), f"Files not sorted correctly with many files: {file_names}"
 
 
 def test_publish_no_wait(galaxy_server, collection_artifact, monkeypatch):
@@ -1064,10 +1242,17 @@ def test_download_file(tmp_path_factory, monkeypatch):
 
     mock_open = MagicMock()
     mock_open.return_value = BytesIO(data)
-    monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
+    monkeypatch.setattr(
+        collection.concrete_artifact_manager,
+        'open_url',
+        mock_open)
 
     expected = temp_dir
-    actual = collection._download_file('http://google.com/file', temp_dir, sha256_hash.hexdigest(), True)
+    actual = collection._download_file(
+        'http://google.com/file',
+        temp_dir,
+        sha256_hash.hexdigest(),
+        True)
 
     assert actual.startswith(expected)
     assert os.path.isfile(actual)
@@ -1085,25 +1270,32 @@ def test_download_file_hash_mismatch(tmp_path_factory, monkeypatch):
 
     mock_open = MagicMock()
     mock_open.return_value = BytesIO(data)
-    monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
+    monkeypatch.setattr(
+        collection.concrete_artifact_manager,
+        'open_url',
+        mock_open)
 
     expected = "Mismatch artifact hash with downloaded file"
     with pytest.raises(AnsibleError, match=expected):
-        collection._download_file('http://google.com/file', temp_dir, 'bad', True)
+        collection._download_file(
+            'http://google.com/file', temp_dir, 'bad', True)
 
 
 def test_extract_tar_file_invalid_hash(tmp_tarfile):
     temp_dir, tfile, filename, dummy = tmp_tarfile
 
-    expected = "Checksum mismatch for '%s' inside collection at '%s'" % (to_native(filename), to_native(tfile.name))
+    expected = "Checksum mismatch for '%s' inside collection at '%s'" % (
+        to_native(filename), to_native(tfile.name))
     with pytest.raises(AnsibleError, match=expected):
-        collection._extract_tar_file(tfile, filename, temp_dir, temp_dir, "fakehash")
+        collection._extract_tar_file(
+            tfile, filename, temp_dir, temp_dir, "fakehash")
 
 
 def test_extract_tar_file_missing_member(tmp_tarfile):
     temp_dir, tfile, dummy, dummy = tmp_tarfile
 
-    expected = "Collection tar at '%s' does not contain the expected file 'missing'." % to_native(tfile.name)
+    expected = "Collection tar at '%s' does not contain the expected file 'missing'." % to_native(
+        tfile.name)
     with pytest.raises(AnsibleError, match=expected):
         collection._extract_tar_file(tfile, 'missing', temp_dir, temp_dir)
 
@@ -1113,13 +1305,17 @@ def test_extract_tar_file_missing_parent_dir(tmp_tarfile):
     output_dir = os.path.join(temp_dir, b'output')
     output_file = os.path.join(output_dir, to_bytes(filename))
 
-    collection._extract_tar_file(tfile, filename, output_dir, temp_dir, checksum)
+    collection._extract_tar_file(
+        tfile, filename, output_dir, temp_dir, checksum)
     os.path.isfile(output_file)
 
 
 def test_extract_tar_file_outside_dir(tmp_path_factory):
     filename = u'ÅÑŚÌβŁÈ'
-    temp_dir = to_bytes(tmp_path_factory.mktemp('test-%s Collections' % to_native(filename)))
+    temp_dir = to_bytes(
+        tmp_path_factory.mktemp(
+            'test-%s Collections' %
+            to_native(filename)))
     tar_file = os.path.join(temp_dir, to_bytes('%s.tar.gz' % filename))
     data = os.urandom(8)
 
@@ -1131,18 +1327,29 @@ def test_extract_tar_file_outside_dir(tmp_path_factory):
         tar_info.mode = S_IRWU_RG_RO
         tfile.addfile(tarinfo=tar_info, fileobj=b_io)
 
-    expected = re.escape("Cannot extract tar entry '%s' as it will be placed outside the collection directory"
-                         % to_native(tar_filename))
+    expected = re.escape(
+        "Cannot extract tar entry '%s' as it will be placed outside the collection directory" %
+        to_native(tar_filename))
     with tarfile.open(tar_file, 'r') as tfile:
         with pytest.raises(AnsibleError, match=expected):
-            collection._extract_tar_file(tfile, tar_filename, os.path.join(temp_dir, to_bytes(filename)), temp_dir)
+            collection._extract_tar_file(
+                tfile, tar_filename, os.path.join(
+                    temp_dir, to_bytes(filename)), temp_dir)
 
 
 def test_require_one_of_collections_requirements_with_both():
-    cli = GalaxyCLI(args=['ansible-galaxy', 'collection', 'verify', 'namespace.collection', '-r', 'requirements.yml'])
+    cli = GalaxyCLI(
+        args=[
+            'ansible-galaxy',
+            'collection',
+            'verify',
+            'namespace.collection',
+            '-r',
+            'requirements.yml'])
 
     with pytest.raises(AnsibleError) as req_err:
-        cli._require_one_of_collections_requirements(('namespace.collection',), 'requirements.yml')
+        cli._require_one_of_collections_requirements(
+            ('namespace.collection',), 'requirements.yml')
 
     with pytest.raises(AnsibleError) as cli_err:
         cli.run()
@@ -1163,20 +1370,52 @@ def test_require_one_of_collections_requirements_with_neither():
 
 
 def test_require_one_of_collections_requirements_with_collections():
-    cli = GalaxyCLI(args=['ansible-galaxy', 'collection', 'verify', 'namespace1.collection1', 'namespace2.collection1:1.0.0'])
+    cli = GalaxyCLI(
+        args=[
+            'ansible-galaxy',
+            'collection',
+            'verify',
+            'namespace1.collection1',
+            'namespace2.collection1:1.0.0'])
     collections = ('namespace1.collection1', 'namespace2.collection1:1.0.0',)
 
-    requirements = cli._require_one_of_collections_requirements(collections, '')['collections']
+    requirements = cli._require_one_of_collections_requirements(collections, '')[
+        'collections']
 
-    req_tuples = [('%s.%s' % (req.namespace, req.name), req.ver, req.src, req.type,) for req in requirements]
-    assert req_tuples == [('namespace1.collection1', '*', None, 'galaxy'), ('namespace2.collection1', '1.0.0', None, 'galaxy')]
+    req_tuples = [
+        ('%s.%s' %
+         (req.namespace,
+          req.name),
+            req.ver,
+            req.src,
+            req.type,
+         ) for req in requirements]
+    assert req_tuples == [
+        ('namespace1.collection1',
+         '*',
+         None,
+         'galaxy'),
+        ('namespace2.collection1',
+         '1.0.0',
+         None,
+         'galaxy')]
 
 
 @patch('ansible.cli.galaxy.GalaxyCLI._parse_requirements_file')
-def test_require_one_of_collections_requirements_with_requirements(mock_parse_requirements_file, galaxy_server):
-    cli = GalaxyCLI(args=['ansible-galaxy', 'collection', 'verify', '-r', 'requirements.yml', 'namespace.collection'])
-    mock_parse_requirements_file.return_value = {'collections': [('namespace.collection', '1.0.5', galaxy_server)]}
-    requirements = cli._require_one_of_collections_requirements((), 'requirements.yml')['collections']
+def test_require_one_of_collections_requirements_with_requirements(
+        mock_parse_requirements_file, galaxy_server):
+    cli = GalaxyCLI(
+        args=[
+            'ansible-galaxy',
+            'collection',
+            'verify',
+            '-r',
+            'requirements.yml',
+            'namespace.collection'])
+    mock_parse_requirements_file.return_value = {
+        'collections': [('namespace.collection', '1.0.5', galaxy_server)]}
+    requirements = cli._require_one_of_collections_requirements(
+        (), 'requirements.yml')['collections']
 
     assert mock_parse_requirements_file.call_count == 1
     assert requirements == [('namespace.collection', '1.0.5', galaxy_server)]
@@ -1184,7 +1423,11 @@ def test_require_one_of_collections_requirements_with_requirements(mock_parse_re
 
 @patch('ansible.cli.galaxy.GalaxyCLI.execute_verify', spec=True)
 def test_call_GalaxyCLI(execute_verify):
-    galaxy_args = ['ansible-galaxy', 'collection', 'verify', 'namespace.collection']
+    galaxy_args = [
+        'ansible-galaxy',
+        'collection',
+        'verify',
+        'namespace.collection']
 
     GalaxyCLI(args=galaxy_args).run()
 
@@ -1213,15 +1456,21 @@ def test_call_GalaxyCLI_with_role(execute_verify):
 
 @patch('ansible.cli.galaxy.verify_collections', spec=True)
 def test_execute_verify_with_defaults(mock_verify_collections):
-    galaxy_args = ['ansible-galaxy', 'collection', 'verify', 'namespace.collection:1.0.4']
+    galaxy_args = [
+        'ansible-galaxy',
+        'collection',
+        'verify',
+        'namespace.collection:1.0.4']
     GalaxyCLI(args=galaxy_args).run()
 
     assert mock_verify_collections.call_count == 1
 
     print("Call args {0}".format(mock_verify_collections.call_args[0]))
-    requirements, search_paths, galaxy_apis, ignore_errors = mock_verify_collections.call_args[0]
+    requirements, search_paths, galaxy_apis, ignore_errors = mock_verify_collections.call_args[
+        0]
 
-    assert [('%s.%s' % (r.namespace, r.name), r.ver, r.src, r.type) for r in requirements] == [('namespace.collection', '1.0.4', None, 'galaxy')]
+    assert [('%s.%s' % (r.namespace, r.name), r.ver, r.src, r.type)
+            for r in requirements] == [('namespace.collection', '1.0.4', None, 'galaxy')]
     for install_path in search_paths:
         assert install_path.endswith('ansible_collections')
     assert galaxy_apis[0].api_server == 'https://galaxy.ansible.com'
@@ -1230,16 +1479,27 @@ def test_execute_verify_with_defaults(mock_verify_collections):
 
 @patch('ansible.cli.galaxy.verify_collections', spec=True)
 def test_execute_verify(mock_verify_collections):
-    GalaxyCLI(args=[
-        'ansible-galaxy', 'collection', 'verify', 'namespace.collection:1.0.4', '--ignore-certs',
-        '-p', '~/.ansible', '--ignore-errors', '--server', 'http://galaxy-dev.com',
-    ]).run()
+    GalaxyCLI(
+        args=[
+            'ansible-galaxy',
+            'collection',
+            'verify',
+            'namespace.collection:1.0.4',
+            '--ignore-certs',
+            '-p',
+            '~/.ansible',
+            '--ignore-errors',
+            '--server',
+            'http://galaxy-dev.com',
+        ]).run()
 
     assert mock_verify_collections.call_count == 1
 
-    requirements, search_paths, galaxy_apis, ignore_errors = mock_verify_collections.call_args[0]
+    requirements, search_paths, galaxy_apis, ignore_errors = mock_verify_collections.call_args[
+        0]
 
-    assert [('%s.%s' % (r.namespace, r.name), r.ver, r.src, r.type) for r in requirements] == [('namespace.collection', '1.0.4', None, 'galaxy')]
+    assert [('%s.%s' % (r.namespace, r.name), r.ver, r.src, r.type)
+            for r in requirements] == [('namespace.collection', '1.0.4', None, 'galaxy')]
     for install_path in search_paths:
         assert install_path.endswith('ansible_collections')
     assert galaxy_apis[0].api_server == 'http://galaxy-dev.com'
@@ -1304,7 +1564,8 @@ def test_verify_file_hash_mismatching_hash(manifest_info):
 
     with patch.object(builtins, 'open', mock_open(read_data=data)) as m:
         with patch.object(collection.os.path, 'isfile', MagicMock(return_value=True)) as mock_isfile:
-            collection._verify_file_hash(b'path/', 'file', different_digest, error_queue)
+            collection._verify_file_hash(
+                b'path/', 'file', different_digest, error_queue)
 
             mock_isfile.assert_called_once()
 
@@ -1348,7 +1609,10 @@ def test_get_nonexistent_tar_file_member(tmp_tarfile):
     with pytest.raises(AnsibleError) as err:
         collection._get_tar_file_member(tfile, file_does_not_exist)
 
-    assert to_text(err.value.message) == "Collection tar at '%s' does not contain the expected file '%s'." % (to_text(tfile.name), file_does_not_exist)
+    assert to_text(
+        err.value.message) == "Collection tar at '%s' does not contain the expected file '%s'." % (to_text(
+            tfile.name),
+        file_does_not_exist)
 
 
 def test_get_tar_file_hash(tmp_tarfile):


### PR DESCRIPTION
##### SUMMARY

This PR sorts the content of `FILES.json` to make builds more reproducible, and adds associated integration tests.

Misc changes:

 - Fixes the type of `FilesManifestType`.
 - Fixes some odd spacing choices from previous PRs.
 - Adjust the integration tests to use register projections instead of set_facts.
 - Removes the unnecessary unit tests (almost all of them) and replaces it with a simple smoke test.

Fixes #82792

Refreshes the work done in #86262 (which refreshes the work done in #82829).

##### ISSUE TYPE

Feature Pull Request
