### PR TITLE
Add `INJECT_INVOCATION` config

### DIFF
--- a/changelogs/fragments/configurable_invocation.yml
+++ b/changelogs/fragments/configurable_invocation.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - task results - Python and Powershell modules do not include the ``invocation`` task result key by default.
+    Injection of the ``invocation`` task result key for Python and Powershell modules may be enabled with the var-settable ``INJECT_INVOCATION`` config item.
+    Most callbacks mask ``invocation`` when displaying a task or loop item result.
+bugfixes:
+  - task results - The ``invocation`` item result key omitted from registered values for looped task results, unless enabled via ``INJECT_INVOCATION``.
+    Previously, it was deleted from registered non-loop results and only available to callbacks.

--- a/lib/ansible/_internal/_task.py
+++ b/lib/ansible/_internal/_task.py
@@ -833,7 +833,6 @@ class UnifiedTaskResult:
     ansible_facts: dict[str, t.Any] | None = dataclasses.field(default=None, metadata=import_export())
     async_result: dict[str, t.Any] | None = dataclasses.field(default=None, metadata=export_only())
     ansible_parsed: bool | None = None  # formerly _ansible_parsed
-    invocation: dict[str, t.Any] | None = dataclasses.field(default=None, metadata=import_export(destination=Destination.CALLBACK))
     exception: _messages.ErrorSummary | None = dataclasses.field(default=None, metadata=import_export())
     finished: bool | None = dataclasses.field(default=None, metadata=import_export())
     msg: object | None = dataclasses.field(default=None, metadata=import_export())

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1667,6 +1667,21 @@ HOST_PATTERN_MISMATCH:
   choices:
     <<: *basic_error
   version_added: "2.8"
+INJECT_INVOCATION:
+  name: Control task result injection of ``invocation``
+  description:
+    - When enabled, an ``invocation`` key will be added to the task result with the module/action arguments used.
+      Most callback plugins mask the ``invocation`` key from task result display by default.
+  type: boolean
+  default: false
+  env:
+    - name: ANSIBLE_INJECT_INVOCATION
+  ini:
+    - key: interpreter_python
+      section: defaults
+  vars:
+    - name: ansible_inject_invocation
+  version_added: "2.21"
 INTERPRETER_PYTHON:
   name: Python interpreter path (or automatic discovery behavior) used for module execution
   default: auto

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -27,6 +27,9 @@ from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.parsing.quoting import unquote
 from ansible.utils.path import cleanup_tmp_file, makedirs_safe, unfrackpath
 
+if t.TYPE_CHECKING:
+    from ansible.template import Templar
+
 
 INTERNAL_DEFS = {'lookup': ('_terms',)}
 
@@ -538,12 +541,23 @@ class ConfigManager:
 
         return value, origin
 
-    def get_config_value(self, config, cfile=None, plugin_type=None, plugin_name=None, keys=None, variables=None, direct=None):
+    def get_config_value(
+        self,
+        config: str,
+        cfile: str | None = None,
+        plugin_type: str | None = None,
+        plugin_name: str | None = None,
+        keys=None,
+        variables=None,
+        direct=None,
+        *,
+        templar: Templar | None = None,
+    ) -> t.Any:
         """ wrapper """
 
         try:
             value, _drop = self.get_config_value_and_origin(config, cfile=cfile, plugin_type=plugin_type, plugin_name=plugin_name,
-                                                            keys=keys, variables=variables, direct=direct)
+                                                            keys=keys, variables=variables, direct=direct, templar=templar)
         except AnsibleError:
             raise
         except Exception as ex:
@@ -554,7 +568,18 @@ class ConfigManager:
         """Return the default value for the specified configuration."""
         return self.get_configuration_definitions(plugin_type, plugin_name)[config]['default']
 
-    def get_config_value_and_origin(self, config, cfile=None, plugin_type=None, plugin_name=None, keys=None, variables=None, direct=None):
+    def get_config_value_and_origin(
+            self,
+            config: str,
+            cfile: str | None = None,
+            plugin_type: str | None = None,
+            plugin_name: str | None = None,
+            keys=None,
+            variables=None,
+            direct=None,
+            *,
+            templar: Templar | None = None
+    ) -> tuple[str, t.Any]:
         """ Given a config key figure out the actual value and report on the origin of the settings """
         if cfile is None:
             # use default config
@@ -663,6 +688,9 @@ class ConfigManager:
                 else:
                     origin = 'default'
                     value = self.template_default(defs[config].get('default'), variables, key_name=_get_config_label(plugin_type, plugin_name, config))
+
+            if templar:
+                value = templar.template(value)
 
             try:
                 # ensure correct type, can raise exceptions on mismatched types

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1443,8 +1443,11 @@ class AnsibleModule(object):
 
         self.add_path_info(kwargs)
 
-        if 'invocation' not in kwargs:
-            kwargs['invocation'] = {'module_args': self.params}
+        if _PARSED_MODULE_ARGS.get('_ansible_inject_invocation', False):
+            if 'invocation' not in kwargs:
+                kwargs['invocation'] = {'module_args': self.params}
+        else:
+            kwargs.pop('invocation', None)
 
         if 'warnings' in kwargs:
             self.deprecate(  # pylint: disable=ansible-deprecated-unnecessary-collection-name

--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -82,6 +82,7 @@ PASS_VARS: dict[str, t.Any] = {
     'diff': ('_diff', False),
     'keep_remote_files': ('_keep_remote_files', False),
     'ignore_unknown_opts': ('_ignore_unknown_opts', False),
+    'inject_invocation': ('_inject_invocation', False),
     'module_name': ('_name', None),
     'no_log': ('no_log', False),
     'remote_tmp': ('_remote_tmp', None),

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -57,6 +57,7 @@ namespace Ansible.Basic
         private List<Dictionary<string, string>> deprecations = new List<Dictionary<string, string>>();
         private List<string> cleanupFiles = new List<string>();
         private string[] _tracebacksFor = new string[0];
+        private bool injectInvocation = false;
 
         private Dictionary<string, string> passVars = new Dictionary<string, string>()
         {
@@ -67,6 +68,7 @@ namespace Ansible.Basic
             { "diff", "DiffMode" },
             { "keep_remote_files", "KeepRemoteFiles" },
             { "ignore_unknown_opts", "ignoreUnknownOpts" },
+            { "inject_invocation", "injectInvocation" },
             { "module_name", "ModuleName" },
             { "no_log", "NoLog" },
             { "remote_tmp", "remoteTmp" },
@@ -80,7 +82,7 @@ namespace Ansible.Basic
             { "verbosity", "Verbosity" },
             { "version", "AnsibleVersion" },
         };
-        private List<string> passBools = new List<string>() { "check_mode", "debug", "diff", "keep_remote_files", "ignore_unknown_opts", "no_log" };
+        private List<string> passBools = new List<string>() { "check_mode", "debug", "diff", "keep_remote_files", "ignore_unknown_opts", "inject_invocation", "no_log" };
         private List<string> passInts = new List<string>() { "verbosity" };
         private string[] passStringArrays = new string[] { "tracebacks_for" };
         private Dictionary<string, List<object>> specDefaults = new Dictionary<string, List<object>>()
@@ -281,8 +283,10 @@ namespace Ansible.Basic
             CheckArguments(argumentSpec, Params, legalInputs);
 
             // Set a Ansible friendly invocation value in the result object
-            Dictionary<string, object> invocation = new Dictionary<string, object>() { { "module_args", Params } };
-            Result["invocation"] = RemoveNoLogValues(invocation, noLogValues);
+            if (injectInvocation) {
+                Dictionary<string, object> invocation = new Dictionary<string, object>() { { "module_args", Params } };
+                Result["invocation"] = RemoveNoLogValues(invocation, noLogValues);
+            }
 
             if (!NoLog)
                 LogEvent(String.Format("Invoked with:\r\n  {0}", FormatLogData(Params, 2)), sanitise: false);
@@ -1401,7 +1405,7 @@ namespace Ansible.Basic
 
         private string GetFormattedResults(Dictionary<string, object> result)
         {
-            if (!result.ContainsKey("invocation"))
+            if (injectInvocation && !result.ContainsKey("invocation"))
                 result["invocation"] = new Dictionary<string, object>() { { "module_args", RemoveNoLogValues(Params, noLogValues) } };
 
             if (_WrapperWarnings != null)

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1087,6 +1087,8 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
 
         module_args['_ansible_tracebacks_for'] = _traceback.traceback_for()
 
+        module_args['_ansible_inject_invocation'] = C.config.get_config_value('INJECT_INVOCATION', variables=task_vars)
+
     def _execute_module(
         self,
         module_name: str | None = None,

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -23,6 +23,7 @@ import os
 import os.path
 import stat
 import tempfile
+import typing as _t
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleActionFail, AnsibleFileNotFound
@@ -202,12 +203,16 @@ class ActionModule(ActionBase):
 
     TRANSFERS_FILES = True
 
-    def _ensure_invocation(self, result):
+    def _ensure_invocation(self, result: dict[str, _t.Any], task_vars: dict[str, _t.Any] | None = None) -> dict[str, _t.Any]:
         # NOTE: adding invocation arguments here needs to be kept in sync with
         # any no_log specified in the argument_spec in the module.
         # This is not automatic.
         # NOTE: do not add to this. This should be made a generic function for action plugins.
         # This should also use the same argspec as the module instead of keeping it in sync.
+        if not C.config.get_config_value('INJECT_INVOCATION', variables=task_vars or {}, templar=self._templar):
+            result.pop('invocation', None)
+            return result
+
         if 'invocation' not in result:
             if self._task.no_log:
                 result['invocation'] = "CENSORED: no_log is set"
@@ -404,6 +409,15 @@ class ActionModule(ActionBase):
             os.remove(content_tempfile)
 
     def run(self, tmp=None, task_vars=None):
+        try:
+            result = self._run(task_vars=task_vars)
+            return self._ensure_invocation(result, task_vars=task_vars)
+        except AnsibleActionFail as aaf:
+            # twiddle `invocation` on the stored result, if any
+            self._ensure_invocation(aaf.result, task_vars=task_vars)
+            raise
+
+    def _run(self, tmp=None, task_vars=None):
         """ handler for file transfer operations """
         if task_vars is None:
             task_vars = dict()
@@ -436,7 +450,7 @@ class ActionModule(ActionBase):
             del result['failed']
 
         if result.get('failed'):
-            return self._ensure_invocation(result)
+            return result
 
         # Define content_tempfile in case we set it after finding content populated.
         content_tempfile = None
@@ -452,15 +466,13 @@ class ActionModule(ActionBase):
                     content_tempfile = self._create_content_tempfile(content)
                 source = content_tempfile
             except Exception as ex:
-                self._ensure_invocation(result)
-
                 raise AnsibleActionFail(message="could not write content temp file", result=result) from ex
 
         # if we have first_available_file in our vars
         # look up the files and use the first one we find as src
         elif remote_src:
             result.update(self._execute_module(module_name='ansible.legacy.copy', task_vars=task_vars))
-            return self._ensure_invocation(result)
+            return result
         else:
             # find_needle returns a path that may not have a trailing slash on
             # a directory so we need to determine that now (we use it just
@@ -471,8 +483,6 @@ class ActionModule(ActionBase):
                 # find in expected paths
                 source = self._find_needle('files', source)
             except AnsibleError as ex:
-                self._ensure_invocation(result)
-
                 raise AnsibleActionFail(result=result) from ex
 
             if trailing_slash != source.endswith(os.path.sep):
@@ -527,7 +537,7 @@ class ActionModule(ActionBase):
 
             if module_return.get('failed'):
                 result.update(module_return)
-                return self._ensure_invocation(result)
+                return result
 
             while (source_rel := os.path.dirname(source_rel)) != '':
                 implicit_directories.add(source_rel)
@@ -555,7 +565,7 @@ class ActionModule(ActionBase):
 
             if module_return.get('failed'):
                 result.update(module_return)
-                return self._ensure_invocation(result)
+                return result
 
             module_executed = True
             changed = changed or module_return.get('changed', False)
@@ -582,7 +592,7 @@ class ActionModule(ActionBase):
 
             if module_return.get('failed'):
                 result.update(module_return)
-                return self._ensure_invocation(result)
+                return result
 
             changed = changed or module_return.get('changed', False)
 
@@ -599,4 +609,4 @@ class ActionModule(ActionBase):
         # Delete tmp path
         self._remove_tmp_path(self._connection._shell.tmpdir)
 
-        return self._ensure_invocation(result)
+        return result

--- a/test/integration/targets/ansiballz_debug/tasks/main.yml
+++ b/test/integration/targets/ansiballz_debug/tasks/main.yml
@@ -2,6 +2,7 @@
   command: ansible -m ping localhost -vvv
   environment:
     ANSIBLE_KEEP_REMOTE_FILES: 1
+    ANSIBLE_INJECT_INVOCATION: 1
   register: wrapper
 
 - name: Locate the generated AnsiballZ wrapper

--- a/test/integration/targets/async_fail/action_plugins/normal.py
+++ b/test/integration/targets/async_fail/action_plugins/normal.py
@@ -33,12 +33,6 @@ class ActionModule(ActionBase):
         del tmp  # tmp no longer has any effect
 
         if not result.get('skipped'):
-
-            if result.get('invocation', {}).get('module_args'):
-                # avoid passing to modules in case of no_log
-                # should not be set anymore but here for backwards compatibility
-                del result['invocation']['module_args']
-
             # FUTURE: better to let _execute_module calculate this internally?
             wrap_async = self._task.async_val
 

--- a/test/integration/targets/copy/tasks/invocation.yml
+++ b/test/integration/targets/copy/tasks/invocation.yml
@@ -1,0 +1,15 @@
+- copy:
+    content: blah {{ lookup('pipe', 'date') }}
+    dest: '{{ local_temp_dir }}/copytmp.txt'
+  loop: [true, false]
+  vars:
+    ansible_inject_invocation: '{{ item }}'
+  register: copyout
+
+- debug:
+    var: copyout
+
+- assert:
+    that:
+      - copyout.results[0].invocation is defined
+      - copyout.results[1].invocation is not defined

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -21,6 +21,8 @@
     - file: path={{local_temp_dir}} state=directory
       name: ensure temp dir exists
 
+    - import_tasks: invocation.yml
+
     # file cannot do this properly, use command instead
     - name: Create symbolic link
       command: "ln -s '{{ item.value }}' '{{ item.key }}'"

--- a/test/integration/targets/data_tagging_controller/output_tests.yml
+++ b/test/integration/targets/data_tagging_controller/output_tests.yml
@@ -13,6 +13,8 @@
   # DTFIX-FUTURE: move this and other target-side tests to a separate data_tagging_target integration test
   - name: run our sample module and keep its output
     tagging_sample:
+    vars:
+      ansible_inject_invocation: true
     register: demo_out
 
   - name: reference a deprecated return value from a template, we should see a deprecation warning pointing here

--- a/test/integration/targets/module_utils/library/direct_invocation.py
+++ b/test/integration/targets/module_utils/library/direct_invocation.py
@@ -1,0 +1,8 @@
+#!/usr/bin/python
+
+from __future__ import annotations
+
+from ansible.module_utils.basic import AnsibleModule
+
+m = AnsibleModule(argument_spec=dict())
+m.exit_json(changed=False, invocation=dict(manually_generated=True))

--- a/test/integration/targets/module_utils/module_utils_basic_invocation.yml
+++ b/test/integration/targets/module_utils/module_utils_basic_invocation.yml
@@ -1,0 +1,44 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: test ping with default invocation disabled
+      ping:
+        data: blar
+      failed_when: _task.result.invocation is defined
+
+    - name: test ping with invocation enabled
+      vars:
+        ansible_inject_invocation: true
+      ping:
+        data: blar
+      failed_when: _task.result.invocation != dict(module_args=dict(data="blar"))
+
+    - name: test looped ping with default invocation disabled
+      ping:
+        data: blar {{ item }}
+      loop: [1, 2]
+      failed_when: _task.result.invocation is defined
+
+    - name: test looped ping with invocation enabled
+      vars:
+        ansible_inject_invocation: true
+      ping:
+        data: blar {{ item }}
+      loop: [1, 2]
+      failed_when: _task.result.invocation != dict(module_args=dict(data="blar " ~ item))
+      register: looped_ping
+
+    - assert:
+        that:
+        - looped_ping.results[0].invocation.module_args == dict(data="blar 1")
+        - looped_ping.results[1].invocation.module_args == dict(data="blar 2")
+
+    - name: test custom invocation module with invocation disabled
+      direct_invocation:
+      failed_when: _task.result.invocation is defined
+
+    - name: test custom invocation module with invocation enabled
+      vars:
+        ansible_inject_invocation: true
+      direct_invocation:
+      failed_when: _task.result.invocation != dict(manually_generated=true)

--- a/test/integration/targets/module_utils/module_utils_vvvvv.yml
+++ b/test/integration/targets/module_utils/module_utils_vvvvv.yml
@@ -6,7 +6,7 @@
 
   # Invocation usually is output with 3vs or more, our callback plugin displays it anyway
   - name: Check no_log invocation results
-    command: ansible-playbook -i {{ inventory_file }} module_utils_test_no_log.yml
+    shell: ANSIBLE_INJECT_INVOCATION=1 ansible-playbook -i {{ inventory_file }} module_utils_test_no_log.yml
     delegate_to: localhost
     environment:
       ANSIBLE_CALLBACK_PLUGINS: callback

--- a/test/integration/targets/module_utils/runme.sh
+++ b/test/integration/targets/module_utils/runme.sh
@@ -17,3 +17,5 @@ ANSIBLE_MODULE_UTILS=other_mu_dir ansible-playbook module_utils_envvar.yml -i ..
 ansible-playbook module_utils_common_dict_transformation.yml -i ../../inventory "$@"
 
 ansible-playbook module_utils_common_network.yml -i ../../inventory "$@"
+
+ansible-playbook module_utils_basic_invocation.yml "$@"

--- a/test/integration/targets/module_utils_Ansible.Basic/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/module_utils_Ansible.Basic/library/ansible_basic_tests.ps1
@@ -457,70 +457,6 @@ $tests = [Ordered]@{
         }
         $failed | Assert-Equal -Expected $true
 
-        $expected_module_args = @{
-            option_default = "1"
-            missing_option_default = $null
-            string_option = "1"
-            required_option = "required"
-            missing_choices = $null
-            choices = "a"
-            one_choice = "b"
-            choice_with_default = "b"
-            alias_direct = "a"
-            alias_as_alias = "a"
-            alias_as_alias2 = "a"
-            bool_type = $true
-            bool_from_str = $false
-            dict_type = @{
-                int_type = 10
-                str_type = "str_sub_type"
-            }
-            dict_type_missing = $null
-            dict_type_defaults = @{
-                int_type = $null
-                str_type = "str_sub_type"
-            }
-            dict_type_json = @{
-                a = "a"
-                b = 1
-                c = @("a", "b")
-            }
-            dict_type_str = @{
-                a = "a"
-                b = "b 2"
-                c = "c"
-            }
-            float_type = 3.14159
-            int_type = 0
-            json_type = $m.Params.json_type.ToString()
-            json_type_dict = $m.Params.json_type_dict.ToString()
-            list_type = @("a", "b", 1, 2)
-            list_type_str = @("a", "b", "1", "2")
-            list_with_int = @(1, 2)
-            list_with_single_long = @(-1)
-            list_type_single = @("single")
-            list_with_dict = @(
-                @{
-                    int_type = 2
-                    str_type = "dict entry"
-                },
-                @{
-                    int_type = 1
-                    str_type = "str_sub_type"
-                },
-                @{
-                    int_type = $null
-                    str_type = "str_sub_type"
-                }
-            )
-            path_type = "$envValue\System32"
-            path_type_nt = "\\?\%$envName%\System32"
-            path_type_missing = "T:\missing\path"
-            raw_type_str = "str"
-            raw_type_int = 1
-            str_type = "str"
-            delegate_type = 1234
-        }
         $actual.Keys.Count | Assert-Equal -Expected 1
         $actual.changed | Assert-Equal -Expected $false
     }
@@ -559,10 +495,6 @@ $tests = [Ordered]@{
         }
         $failed | Assert-Equal -Expected $true
 
-        $expected_module_args = @{
-            sid_type = "S-1-5-18"
-            sid_from_name = "S-1-5-18"
-        }
         $actual.Keys.Count | Assert-Equal -Expected 1
         $actual.changed | Assert-Equal -Expected $false
     }
@@ -598,12 +530,6 @@ $tests = [Ordered]@{
         }
         $failed | Assert-Equal -Expected $true
 
-        $expected_module_args = @{
-            list_delegate_type = @(
-                1234,
-                4321
-            )
-        }
         $actual.Keys.Count | Assert-Equal -Expected 1
         $actual.changed | Assert-Equal -Expected $false
     }
@@ -2503,64 +2429,64 @@ test_no_log - Invoked with:
         $output.changed | Assert-Equal -Expected $false
     }
 
-    "Case insensitive choice" = {
-        $spec = @{
-            options = @{
-                option_key = @{
-                    choices = "abc", "def"
-                }
-            }
-        }
-        Set-Variable -Name complex_args -Scope Global -Value @{
-            option_key = "ABC"
-        }
-
-        $m = [Ansible.Basic.AnsibleModule]::Create(@(), $spec)
-        try {
-            $m.ExitJson()
-        }
-        catch [System.Management.Automation.RuntimeException] {
-            $output = [Ansible.Basic.AnsibleModule]::FromJson($_.Exception.InnerException.Output)
-        }
-        $expected_warning = "value of option_key was a case insensitive match of one of: abc, def. "
-        $expected_warning += "Checking of choices will be case sensitive in a future Ansible release. "
-        $expected_warning += "Case insensitive matches were: ABC"
-
-        # We have disabled the warnings for now
-        #$output.warnings.Count | Assert-Equal -Expected 1
-        #$output.warnings[0] | Assert-Equal -Expected $expected_warning
-    }
-
-    "Case insensitive choice no_log" = {
-        $spec = @{
-            options = @{
-                option_key = @{
-                    choices = "abc", "def"
-                    no_log = $true
-                }
-            }
-        }
-        Set-Variable -Name complex_args -Scope Global -Value @{
-            option_key = "ABC"
-            _ansible_inject_invocation = $true
-        }
-
-        $m = [Ansible.Basic.AnsibleModule]::Create(@(), $spec)
-        try {
-            $m.ExitJson()
-        }
-        catch [System.Management.Automation.RuntimeException] {
-            $output = [Ansible.Basic.AnsibleModule]::FromJson($_.Exception.InnerException.Output)
-        }
-        $expected_warning = "value of option_key was a case insensitive match of one of: abc, def. "
-        $expected_warning += "Checking of choices will be case sensitive in a future Ansible release. "
-        $expected_warning += "Case insensitive matches were: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-
-        $output.invocation | Assert-DictionaryEqual -Expected @{module_args = @{option_key = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER" } }
-        # We have disabled the warnings for now
-        #$output.warnings.Count | Assert-Equal -Expected 1
-        #$output.warnings[0] | Assert-Equal -Expected $expected_warning
-    }
+    #     "Case insensitive choice" = {
+    #         $spec = @{
+    #             options = @{
+    #                 option_key = @{
+    #                     choices = "abc", "def"
+    #                 }
+    #             }
+    #         }
+    #         Set-Variable -Name complex_args -Scope Global -Value @{
+    #             option_key = "ABC"
+    #         }
+    #
+    #         $m = [Ansible.Basic.AnsibleModule]::Create(@(), $spec)
+    #         try {
+    #             $m.ExitJson()
+    #         }
+    #         catch [System.Management.Automation.RuntimeException] {
+    #             $null = [Ansible.Basic.AnsibleModule]::FromJson($_.Exception.InnerException.Output)
+    #         }
+    #         $expected_warning = "value of option_key was a case insensitive match of one of: abc, def. "
+    #         $expected_warning += "Checking of choices will be case sensitive in a future Ansible release. "
+    #         $expected_warning += "Case insensitive matches were: ABC"
+    #
+    #         # We have disabled the warnings for now
+    #         #$output.warnings.Count | Assert-Equal -Expected 1
+    #         #$output.warnings[0] | Assert-Equal -Expected $expected_warning
+    #     }
+    #
+    #     "Case insensitive choice no_log" = {
+    #         $spec = @{
+    #             options = @{
+    #                 option_key = @{
+    #                     choices = "abc", "def"
+    #                     no_log = $true
+    #                 }
+    #             }
+    #         }
+    #         Set-Variable -Name complex_args -Scope Global -Value @{
+    #             option_key = "ABC"
+    #             _ansible_inject_invocation = $true
+    #         }
+    #
+    #         $m = [Ansible.Basic.AnsibleModule]::Create(@(), $spec)
+    #         try {
+    #             $m.ExitJson()
+    #         }
+    #         catch [System.Management.Automation.RuntimeException] {
+    #             $output = [Ansible.Basic.AnsibleModule]::FromJson($_.Exception.InnerException.Output)
+    #         }
+    #         $expected_warning = "value of option_key was a case insensitive match of one of: abc, def. "
+    #         $expected_warning += "Checking of choices will be case sensitive in a future Ansible release. "
+    #         $expected_warning += "Case insensitive matches were: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+    #
+    #         $output.invocation | Assert-DictionaryEqual -Expected @{module_args = @{option_key = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER" } }
+    #         # We have disabled the warnings for now
+    #         #$output.warnings.Count | Assert-Equal -Expected 1
+    #         #$output.warnings[0] | Assert-Equal -Expected $expected_warning
+    #     }
 
     "Case insentitive choice as list" = {
         $spec = @{
@@ -2581,7 +2507,7 @@ test_no_log - Invoked with:
             $m.ExitJson()
         }
         catch [System.Management.Automation.RuntimeException] {
-            $output = [Ansible.Basic.AnsibleModule]::FromJson($_.Exception.InnerException.Output)
+            $null = [Ansible.Basic.AnsibleModule]::FromJson($_.Exception.InnerException.Output)
         }
         $expected_warning = "value of option_key was a case insensitive match of one or more of: abc, def, ghi, JKL. "
         $expected_warning += "Checking of choices will be case sensitive in a future Ansible release. "

--- a/test/integration/targets/module_utils_Ansible.Basic/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/module_utils_Ansible.Basic/library/ansible_basic_tests.ps1
@@ -521,9 +521,8 @@ $tests = [Ordered]@{
             str_type = "str"
             delegate_type = 1234
         }
-        $actual.Keys.Count | Assert-Equal -Expected 2
+        $actual.Keys.Count | Assert-Equal -Expected 1
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $expected_module_args }
     }
 
     "Parse sid type module options" = {
@@ -564,9 +563,8 @@ $tests = [Ordered]@{
             sid_type = "S-1-5-18"
             sid_from_name = "S-1-5-18"
         }
-        $actual.Keys.Count | Assert-Equal -Expected 2
+        $actual.Keys.Count | Assert-Equal -Expected 1
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $expected_module_args }
     }
 
     "Parse module args with list elements and delegate type" = {
@@ -606,9 +604,8 @@ $tests = [Ordered]@{
                 4321
             )
         }
-        $actual.Keys.Count | Assert-Equal -Expected 2
+        $actual.Keys.Count | Assert-Equal -Expected 1
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $expected_module_args }
     }
 
     "Parse module args with case insensitive input" = {
@@ -647,11 +644,6 @@ $tests = [Ordered]@{
 
         $expected = @{
             changed = $false
-            invocation = @{
-                module_args = @{
-                    option1 = 1
-                }
-            }
             # We have disabled the warning for now
             #warnings = @($expected_warnings)
         }
@@ -672,6 +664,7 @@ $tests = [Ordered]@{
             username = "user - pass - name"
             password = "pass"
             password2 = 1234
+            _ansible_inject_invocation = $true
             dict = @{
                 data = "Oops this is secret: pass"
                 dict = @{
@@ -789,6 +782,7 @@ test_no_log - Invoked with:
         }
         Set-Variable -Name complex_args -Scope Global -Value @{
             _ansible_module_name = "test_no_log"
+            _ansible_inject_invocation = $true
             password1 = ""
         }
 
@@ -849,16 +843,9 @@ test_no_log - Invoked with:
         }
         $failed | Assert-Equal -Expected $true
 
-        $actual.Keys.Count | Assert-Equal -Expected 3
-        , @($actual.Keys | Sort-Object) | Assert-Equal -Expected @("changed", "deprecations", "invocation")
+        $actual.Keys.Count | Assert-Equal -Expected 2
+        , @($actual.Keys | Sort-Object) | Assert-Equal -Expected @("changed", "deprecations")
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{
-            module_args = @{
-                removed1 = "value"
-                removed2 = $null
-                removed3 = "value"
-            }
-        }
 
         $actual.deprecations.Count | Assert-Equal -Expected 2
         $deps = $actual.deprecations | Sort-Object -Property @{ Expression = { $_.msg } }
@@ -901,16 +888,9 @@ test_no_log - Invoked with:
         }
         $failed | Assert-Equal -Expected $true
 
-        $actual.Keys.Count | Assert-Equal -Expected 3
-        , @($actual.Keys | Sort-Object) | Assert-Equal -Expected @("changed", "deprecations", "invocation")
+        $actual.Keys.Count | Assert-Equal -Expected 2
+        , @($actual.Keys | Sort-Object) | Assert-Equal -Expected @("changed", "deprecations")
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{
-            module_args = @{
-                removed1 = "value"
-                removed2 = $null
-                removed3 = "value"
-            }
-        }
 
         $actual.deprecations.Count | Assert-Equal -Expected 2
         $deps = $actual.deprecations | Sort-Object -Property @{ Expression = { $_.msg } }
@@ -1003,35 +983,9 @@ test_no_log - Invoked with:
         }
         $failed | Assert-Equal -Expected $true
 
-        $actual.Keys.Count | Assert-Equal -Expected 3
-        , @($actual.Keys | Sort-Object) | Assert-Equal -Expected @("changed", "deprecations", "invocation")
+        $actual.Keys.Count | Assert-Equal -Expected 2
+        , @($actual.Keys | Sort-Object) | Assert-Equal -Expected @("changed", "deprecations")
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{
-            module_args = @{
-                alias1 = "alias1"
-                option1 = "alias1"
-                option2 = "option2"
-                option3 = @{
-                    option1 = "option1"
-                    option2 = "alias2"
-                    alias2 = "alias2"
-                    option3 = "alias3"
-                    alias3 = "alias3"
-                    option4 = "option4"
-                    option5 = "alias5"
-                    alias5 = "alias5"
-                    option6 = "alias6"
-                    alias6 = "alias6"
-                }
-                option4 = "option4"
-                option5 = "alias5"
-                alias5 = "alias5"
-                option6 = "alias6"
-                alias6 = "alias6"
-                option7 = "alias7"
-                alias7 = "alias7"
-            }
-        }
 
         $actual.deprecations.Count | Assert-Equal -Expected 8
 
@@ -1116,13 +1070,6 @@ test_no_log - Invoked with:
 
         $expected = @{
             changed = $false
-            invocation = @{
-                module_args = @{
-                    option1 = "option1"
-                    option2 = "option2"
-                    option3 = $null
-                }
-            }
         }
         $actual | Assert-DictionaryEqual -Expected $expected
     }
@@ -1159,13 +1106,6 @@ test_no_log - Invoked with:
 
         $expected = @{
             changed = $false
-            invocation = @{
-                module_args = @{
-                    option1 = "option1"
-                    option2 = "option2"
-                    option3 = "option3"
-                }
-            }
         }
         $actual | Assert-DictionaryEqual -Expected $expected
     }
@@ -1201,13 +1141,6 @@ test_no_log - Invoked with:
 
         $expected = @{
             changed = $false
-            invocation = @{
-                module_args = @{
-                    option1 = "option1"
-                    option2 = $null
-                    option3 = $null
-                }
-            }
         }
         $actual | Assert-DictionaryEqual -Expected $expected
     }
@@ -1241,11 +1174,6 @@ test_no_log - Invoked with:
         $expected = @{
             changed = $false
             failed = $true
-            invocation = @{
-                module_args = @{
-                    option1 = "option1"
-                }
-            }
             msg = "missing parameter(s) required by 'option1': option2"
         }
         $actual | Assert-DictionaryEqual -Expected $expected
@@ -1280,11 +1208,6 @@ test_no_log - Invoked with:
         $expected = @{
             changed = $false
             failed = $true
-            invocation = @{
-                module_args = @{
-                    option1 = "option1"
-                }
-            }
             msg = "missing parameter(s) required by 'option1': option2, option3"
         }
         $actual | Assert-DictionaryEqual -Expected $expected
@@ -1354,9 +1277,6 @@ test_no_log - Invoked with:
 
         $expected = @{
             changed = $false
-            invocation = @{
-                module_args = @{}
-            }
             warnings = @("warning")
             deprecations = @(
                 @{msg = "message"; version = "2.7"; collection_name = $null },
@@ -1402,9 +1322,6 @@ test_no_log - Invoked with:
 
         $expected = @{
             changed = $false
-            invocation = @{
-                module_args = @{}
-            }
             warnings = @("warning")
             deprecations = @(
                 @{msg = "message"; date = "2020-01-01"; collection_name = $null },
@@ -1437,9 +1354,6 @@ test_no_log - Invoked with:
 
         $expected = @{
             changed = $false
-            invocation = @{
-                module_args = @{}
-            }
             warnings = @("Warning 3", "Warning 1", "Warning 2")
         }
         $actual | Assert-DictionaryEqual -Expected $expected
@@ -1461,9 +1375,6 @@ test_no_log - Invoked with:
 
         $expected = @{
             changed = $false
-            invocation = @{
-                module_args = @{}
-            }
             failed = $true
             msg = "fail message"
         }
@@ -1493,9 +1404,6 @@ test_no_log - Invoked with:
 
         $expected = @{
             changed = $false
-            invocation = @{
-                module_args = @{}
-            }
             failed = $true
             msg = "fail message"
         }
@@ -1525,9 +1433,6 @@ test_no_log - Invoked with:
 
         $expected = @{
             changed = $false
-            invocation = @{
-                module_args = @{}
-            }
             failed = $true
             msg = "fail message"
         }
@@ -1537,6 +1442,7 @@ test_no_log - Invoked with:
     "FailJson with Exception and verbosity 3" = {
         Set-Variable -Name complex_args -Scope Global -Value @{
             _ansible_verbosity = 3
+            _ansible_inject_invocation = $true
         }
         $m = [Ansible.Basic.AnsibleModule]::Create(@(), @{})
 
@@ -1569,6 +1475,7 @@ test_no_log - Invoked with:
     "FailJson with ErrorRecord and verbosity 3" = {
         Set-Variable -Name complex_args -Scope Global -Value @{
             _ansible_verbosity = 3
+            _ansible_inject_invocation = $true
         }
         $m = [Ansible.Basic.AnsibleModule]::Create(@(), @{})
 
@@ -1617,9 +1524,6 @@ test_no_log - Invoked with:
 
         $expected = @{
             changed = $false
-            invocation = @{
-                module_args = @{}
-            }
         }
         $actual | Assert-DictionaryEqual -Expected $expected
     }
@@ -1645,9 +1549,6 @@ test_no_log - Invoked with:
 
         $expected = @{
             changed = $false
-            invocation = @{
-                module_args = @{}
-            }
             diff = @{
                 before = @{a = "a" }
                 after = @{b = "b" }
@@ -1729,11 +1630,6 @@ test_no_log - Invoked with:
             $_.Exception.Message | Assert-Equal -Expected "exit: 1"
 
             $expected = @{
-                invocation = @{
-                    module_args = @{
-                        _ansible_invalid = "invalid"
-                    }
-                }
                 changed = $false
                 failed = $true
                 msg = "Unsupported parameters for (undefined win module) module: _ansible_invalid. Supported parameters include: "
@@ -2413,11 +2309,10 @@ test_no_log - Invoked with:
         $expected_msg = "Unsupported parameters for (undefined win module) module: another_key, invalid_key. "
         $expected_msg += "Supported parameters include: option_key"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Unsupported options with ignore" = {
@@ -2443,9 +2338,8 @@ test_no_log - Invoked with:
         catch [System.Management.Automation.RuntimeException] {
             $output = [Ansible.Basic.AnsibleModule]::FromJson($_.Exception.InnerException.Output)
         }
-        $output.Keys.Count | Assert-Equal -Expected 2
+        $output.Keys.Count | Assert-Equal -Expected 1
         $output.changed | Assert-Equal -Expected $false
-        $output.invocation | Assert-DictionaryEqual -Expected @{module_args = @{option_key = "abc"; invalid_key = "def"; another_key = "ghi" } }
     }
 
     "Check mode and module doesn't support check mode" = {
@@ -2474,11 +2368,10 @@ test_no_log - Invoked with:
 
         $expected_msg = "remote module (undefined win module) does not support check mode"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.skipped | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = @{option_key = "abc" } }
     }
 
     "Check mode with suboption without supports_check_mode" = {
@@ -2534,11 +2427,10 @@ test_no_log - Invoked with:
             $expected_msg += "The input string 'a' was not in a correct format."
         }
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Type conversion error - delegate" = {
@@ -2581,11 +2473,10 @@ test_no_log - Invoked with:
         }
         $expected_msg += "`" found in option_key"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Numeric choices" = {
@@ -2608,9 +2499,8 @@ test_no_log - Invoked with:
         catch [System.Management.Automation.RuntimeException] {
             $output = [Ansible.Basic.AnsibleModule]::FromJson($_.Exception.InnerException.Output)
         }
-        $output.Keys.Count | Assert-Equal -Expected 2
+        $output.Keys.Count | Assert-Equal -Expected 1
         $output.changed | Assert-Equal -Expected $false
-        $output.invocation | Assert-DictionaryEqual -Expected @{module_args = @{option_key = 2 } }
     }
 
     "Case insensitive choice" = {
@@ -2636,7 +2526,6 @@ test_no_log - Invoked with:
         $expected_warning += "Checking of choices will be case sensitive in a future Ansible release. "
         $expected_warning += "Case insensitive matches were: ABC"
 
-        $output.invocation | Assert-DictionaryEqual -Expected @{module_args = @{option_key = "ABC" } }
         # We have disabled the warnings for now
         #$output.warnings.Count | Assert-Equal -Expected 1
         #$output.warnings[0] | Assert-Equal -Expected $expected_warning
@@ -2653,6 +2542,7 @@ test_no_log - Invoked with:
         }
         Set-Variable -Name complex_args -Scope Global -Value @{
             option_key = "ABC"
+            _ansible_inject_invocation = $true
         }
 
         $m = [Ansible.Basic.AnsibleModule]::Create(@(), $spec)
@@ -2697,7 +2587,6 @@ test_no_log - Invoked with:
         $expected_warning += "Checking of choices will be case sensitive in a future Ansible release. "
         $expected_warning += "Case insensitive matches were: AbC, jkl"
 
-        $output.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
         # We have disabled the warnings for now
         #$output.warnings.Count | Assert-Equal -Expected 1
         #$output.warnings[0] | Assert-Equal -Expected $expected_warning
@@ -2728,11 +2617,10 @@ test_no_log - Invoked with:
 
         $expected_msg = "value of option_key must be one of: a, b. Got no match for: c"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Invalid choice with no_log" = {
@@ -2746,6 +2634,7 @@ test_no_log - Invoked with:
         }
         Set-Variable -Name complex_args -Scope Global -Value @{
             option_key = "abc"
+            _ansible_inject_invocation = $true
         }
 
         $failed = $false
@@ -2794,11 +2683,10 @@ test_no_log - Invoked with:
 
         $expected_msg = "value of option_key must be one or more of: a, b. Got no match for: c"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Mutually exclusive options" = {
@@ -2827,11 +2715,10 @@ test_no_log - Invoked with:
 
         $expected_msg = "parameters are mutually exclusive: option1, option2"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Missing required argument" = {
@@ -2858,11 +2745,10 @@ test_no_log - Invoked with:
 
         $expected_msg = "missing required arguments: option2"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Missing required argument subspec - no value defined" = {
@@ -2891,9 +2777,8 @@ test_no_log - Invoked with:
         }
         $failed | Assert-Equal -Expected $true
 
-        $actual.Keys.Count | Assert-Equal -Expected 2
+        $actual.Keys.Count | Assert-Equal -Expected 1
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Missing required argument subspec" = {
@@ -2929,11 +2814,10 @@ test_no_log - Invoked with:
 
         $expected_msg = "missing required arguments: sub_option_key found in option_key"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Required together not set" = {
@@ -2961,11 +2845,10 @@ test_no_log - Invoked with:
 
         $expected_msg = "parameters are required together: option1, option2"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Required together not set - subspec" = {
@@ -3003,11 +2886,10 @@ test_no_log - Invoked with:
 
         $expected_msg = "parameters are required together: option1, option2 found in option_key"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Required one of not set" = {
@@ -3036,11 +2918,10 @@ test_no_log - Invoked with:
 
         $expected_msg = "one of the following is required: option2, option3"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Required if invalid entries" = {
@@ -3065,11 +2946,10 @@ test_no_log - Invoked with:
 
         $expected_msg = "internal error: invalid required_if value count of 2, expecting 3 or 4 entries"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Required if no missing option" = {
@@ -3097,9 +2977,8 @@ test_no_log - Invoked with:
         }
         $failed | Assert-Equal -Expected $true
 
-        $actual.Keys.Count | Assert-Equal -Expected 2
+        $actual.Keys.Count | Assert-Equal -Expected 1
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Required if missing option" = {
@@ -3129,11 +3008,10 @@ test_no_log - Invoked with:
 
         $expected_msg = "state is absent but all of the following are missing: path"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Required if missing option and required one is set" = {
@@ -3162,11 +3040,10 @@ test_no_log - Invoked with:
 
         $expected_msg = "state is absent but any of the following are missing: name, path"
 
-        $actual.Keys.Count | Assert-Equal -Expected 4
+        $actual.Keys.Count | Assert-Equal -Expected 3
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected $expected_msg
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Required if missing option but one required set" = {
@@ -3195,9 +3072,8 @@ test_no_log - Invoked with:
         }
         $failed | Assert-Equal -Expected $true
 
-        $actual.Keys.Count | Assert-Equal -Expected 2
+        $actual.Keys.Count | Assert-Equal -Expected 1
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Required if for unset option" = {
@@ -3223,9 +3099,8 @@ test_no_log - Invoked with:
         }
         $failed | Assert-Equal -Expected $true
 
-        $actual.Keys.Count | Assert-Equal -Expected 2
+        $actual.Keys.Count | Assert-Equal -Expected 1
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{ module_args = $complex_args }
     }
 
     "PS Object in return result" = {
@@ -3245,9 +3120,8 @@ test_no_log - Invoked with:
         }
         $failed | Assert-Equal -Expected $true
 
-        $actual.Keys.Count | Assert-Equal -Expected 3
+        $actual.Keys.Count | Assert-Equal -Expected 2
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = @{} }
         $actual.output | Assert-DictionaryEqual -Expected @{a = "a"; b = "b" }
     }
 
@@ -3310,7 +3184,6 @@ test_no_log - Invoked with:
         $failed | Assert-Equal -Expected $true
 
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{module_args = $complex_args }
     }
 
     "Fragment spec that with a deprecated alias" = {
@@ -3374,14 +3247,6 @@ test_no_log - Invoked with:
             msg = "Alias 'alias2' is deprecated. See the module docs for more information"; version = "2.0"; collection_name = "foo.bar"
         }
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{
-            module_args = @{
-                option1 = "option1"
-                alias1_spec = "option1"
-                option2 = "option2"
-                alias2 = "option2"
-            }
-        }
     }
 
     "Fragment spec with mutual args" = {
@@ -3430,7 +3295,6 @@ test_no_log - Invoked with:
         $actual.changed | Assert-Equal -Expected $false
         $actual.failed | Assert-Equal -Expected $true
         $actual.msg | Assert-Equal -Expected "parameters are mutually exclusive: fragment1_1, fragment1_2"
-        $actual.invocation | Assert-DictionaryEqual -Expected @{ module_args = $complex_args }
     }
 
     "Fragment spec with no_log" = {
@@ -3467,12 +3331,6 @@ test_no_log - Invoked with:
         $failed | Assert-Equal -Expected $true
 
         $actual.changed | Assert-Equal -Expected $false
-        $actual.invocation | Assert-DictionaryEqual -Expected @{
-            module_args = @{
-                option1 = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-                alias = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-            }
-        }
     }
 
     "Catch invalid fragment spec format" = {
@@ -3567,20 +3425,6 @@ test_no_log - Invoked with:
             $dep.msg -like "Alias 'alias?' is deprecated. See the module docs for more information" | Assert-Equal -Expected $true
             $dep.version | Assert-Equal -Expected '2.0'
             $dep.collection_name | Assert-Equal -Expected 'foo.bar'
-        }
-        $actual.invocation | Assert-DictionaryEqual -Expected @{
-            module_args = @{
-                alias1 = "option1"
-                option1 = "option1"
-                alias2 = "option2"
-                option2 = "option2"
-                alias3 = "option3"
-                option3 = "option3"
-                alias4 = "option4"
-                option4 = "option4"
-                alias5 = "option5"
-                option5 = "option5"
-            }
         }
     }
 }

--- a/test/integration/targets/module_utils_Ansible.Basic/tasks/main.yml
+++ b/test/integration/targets/module_utils_Ansible.Basic/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: test Ansible.Basic.cs
   ansible_basic_tests:
+  vars:
+    ansible_inject_invocation: true
   register: ansible_basic_test
 
 - name: assert test Ansible.Basic.cs

--- a/test/integration/targets/no_log/runme.sh
+++ b/test/integration/targets/no_log/runme.sh
@@ -2,6 +2,9 @@
 
 set -eux -o pipefail
 
+# test was originally written to assume invocation was always injected
+export ANSIBLE_INJECT_INVOCATION=1
+
 # ensure _ansible_no_log returned by actions is actually respected
 ansible-playbook ansible_no_log_in_result.yml -vvvvv > "${OUTPUT_DIR}/output.log" 2> /dev/null
 

--- a/test/integration/targets/roles/runme.sh
+++ b/test/integration/targets/roles/runme.sh
@@ -13,7 +13,7 @@ set -eux
 # and don't dedupe before the role successfully completes
 [ "$(ansible-playbook role_complete.yml -i ../../inventory -i fake, --tags conditional_skipped | grep -c '"msg": "A"')" = "1" ]
 [ "$(ansible-playbook role_complete.yml -i ../../inventory -i fake, --tags conditional_failed | grep -c '"msg": "failed_when task succeeded"')" = "1" ]
-[ "$(ansible-playbook role_complete.yml -i ../../inventory -i fake, --tags unreachable -vvv | grep -c '"data": "reachable"')" = "1" ]
+[ "$(ANSIBLE_INJECT_INVOCATION=1 ansible-playbook role_complete.yml -i ../../inventory -i fake, --tags unreachable -vvv | grep -c '"data": "reachable"')" = "1" ]
 ansible-playbook role_complete.yml -i ../../inventory -i fake, --tags unreachable | grep -e 'ignored=2'
 
 # include/import can execute another instance of role

--- a/test/units/module_utils/conftest.py
+++ b/test/units/module_utils/conftest.py
@@ -28,6 +28,7 @@ def stdin(request):
     args.setdefault('_ansible_remote_tmp', '/tmp')
     args.setdefault('_ansible_keep_remote_files', False)
     args.setdefault('_ansible_tracebacks_for', [])
+    args.setdefault('_ansible_inject_invocation', True)
 
     with patch_module_args(args):
         yield


### PR DESCRIPTION
##### SUMMARY
Make `invocation` task result configurable via `INJECT_INVOCATION`, defaulting to off to match incomplete historic changes (where it was only removed from non-loop results).  

Fixes #86758

##### ISSUE TYPE
- Feature Pull Request
