### PR TITLE
fix: prevent Gentoo misdetection as ClearLinux

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -484,6 +484,13 @@ class DistributionFiles:
         if "clearlinux" not in name.lower():
             return False, clear_facts
 
+        # Validate that the os-release content actually belongs to Clear Linux
+        # before attempting to parse. Without this check, any system that has
+        # /usr/lib/os-release (e.g. Gentoo) could be misidentified as ClearLinux
+        # because the name parameter alone is not sufficient for identification.
+        if 'ID=clear-linux-os' not in data and 'Clear Linux' not in data:
+            return False, clear_facts
+
         pname = re.search('NAME="(.*)"', data)
         if pname:
             if 'Clear Linux' not in pname.groups()[0]:


### PR DESCRIPTION
## Summary
Fixes OS detection bug where Gentoo systems are incorrectly identified as ClearLinux.

## Root Cause
`parse_distribution_file_ClearLinux` is triggered when `/usr/lib/os-release` exists (via OSDIST_LIST), but it only validates the `name` parameter (which is always "ClearLinux") before attempting to parse the file content. On Gentoo systems, `/usr/lib/os-release` exists and the function could proceed past the name check, potentially misidentifying the distribution.

## Changes
- Added an early content validation guard in `parse_distribution_file_ClearLinux` that checks the os-release data for Clear Linux identifiers (`ID=clear-linux-os` or `Clear Linux` in the content) before proceeding with any parsing
- This ensures the function returns `(False, {})` immediately for non-Clear Linux os-release files, allowing the detection loop to continue and correctly identify Gentoo

Fixes #86779

---
*Built autonomously by [islo.dev](https://islo.dev) Builder*