### PR TITLE
[stable-2.20] Skip podman rootful tests on RHEL10 (#86785)

### DIFF
--- a/test/integration/targets/ansible-test-container/runme.py
+++ b/test/integration/targets/ansible-test-container/runme.py
@@ -192,8 +192,10 @@ def get_test_scenarios() -> list[TestScenario]:
             ]
 
             if engine == 'podman':
-                if os_release.id not in ('ubuntu',):
+                if os_release.id not in ('ubuntu',) \
+                        and not (os_release.id == 'rhel' and os_release.version_id.startswith('10.')):
                     # rootfull podman is not supported by all systems
+                    # RHEL >= 10 is also excluded due to https://github.com/containers/crun/issues/2059
                     user_scenarios.append(UserScenario(ssh=ROOT_USER))
 
                 # TODO: test podman remote on Alpine and Ubuntu hosts
@@ -201,8 +203,10 @@ def get_test_scenarios() -> list[TestScenario]:
                 if os_release.id not in ('alpine', 'ubuntu'):
                     user_scenarios.append(UserScenario(remote=unprivileged_user))
 
-                if LOGINUID_MISMATCH and os_release.id not in ('ubuntu',):
+                if LOGINUID_MISMATCH and os_release.id not in ('ubuntu',) \
+                        and not (os_release.id == 'rhel' and os_release.version_id.startswith('10.')):
                     # rootfull podman is not supported by all systems
+                    # RHEL >= 10 is also excluded due to https://github.com/containers/crun/issues/2059
                     user_scenarios.append(UserScenario())
 
             for user_scenario in user_scenarios:


### PR DESCRIPTION
(cherry picked from commit 9ade959713bb7ffe98117ce960d0eb0f0fdefdbb)