### PR TITLE
ansible-test - Only add volume bind mount for docker.sock when using docker

### DIFF
--- a/changelogs/fragments/ansible-test-container-options-docker-sock.yml
+++ b/changelogs/fragments/ansible-test-container-options-docker-sock.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ansible-test - Only add volume bind mount for ``docker.sock`` when using docker

--- a/test/lib/ansible_test/_internal/host_profiles.py
+++ b/test/lib/ansible_test/_internal/host_profiles.py
@@ -926,6 +926,11 @@ class DockerProfile(ControllerHostProfile[DockerConfig], SshTargetHostProfile[Do
         command_privileged = False
         expected_mounts: tuple[CGroupMount, ...]
 
+        docker_socket = '/var/run/docker.sock'
+
+        if get_docker_hostname() != 'localhost' or os.path.exists(docker_socket):
+            options.extend(['--volume', f'{docker_socket}:{docker_socket}'])
+
         cgroup_version = get_docker_info(self.args).cgroup_version
 
         if self.config.cgroup == CGroupVersion.NONE:
@@ -1359,11 +1364,6 @@ class DockerProfile(ControllerHostProfile[DockerConfig], SshTargetHostProfile[Do
 
         if self.config.seccomp != 'default':
             options.extend(['--security-opt', f'seccomp={self.config.seccomp}'])
-
-        docker_socket = '/var/run/docker.sock'
-
-        if get_docker_hostname() != 'localhost' or os.path.exists(docker_socket):
-            options.extend(['--volume', f'{docker_socket}:{docker_socket}'])
 
         return options
 


### PR DESCRIPTION
##### SUMMARY
ansible-test - Only add volume bind mount for docker.sock when using docker

This resolves an issue where when `ANSIBLE_TEST_PREFER_PODMAN=1` is set, but also `DOCKER_HOST` is set to a remote host.

##### ISSUE TYPE

- Test Pull Request
