### PR TITLE
add: source.json metadata for PURL generation

### DIFF
--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -337,6 +337,7 @@ def verify_local_collection(local_collection, remote_collection, artifacts_manag
 
     b_ignore_patterns = [
         b'*.pyc',
+        b'*source.json',  # Created at install time for PURL generation, not in original tarball
     ]
 
     # Find any paths not in the FILES.json
@@ -1534,6 +1535,9 @@ def install(collection, path, artifacts_manager):  # FIXME: mv to dataclasses?
                 artifacts_manager
             )
 
+    # Write source.json for all collection types to enable PURL generation by scanners
+    write_source_json(collection, b_collection_path, artifacts_manager)
+
     display.display(
         '{coll!s} was installed successfully'.
         format(coll=to_text(collection)),
@@ -1561,6 +1565,24 @@ def write_source_metadata(collection, b_collection_path, artifacts_manager):
         if os.path.isdir(b_info_dir):
             shutil.rmtree(b_info_dir)
         raise
+
+
+def write_source_json(collection: Candidate, b_collection_path: bytes, artifacts_manager: ConcreteArtifactsManager) -> None:
+    """Write source.json for PURL generation by scanners.
+
+    This file is created for all collection types (galaxy, git, url, file, dir)
+    to enable tools like Syft to generate correct Package URLs for SBOMs.
+    """
+    source_data = artifacts_manager.get_artifact_source_json(collection)
+
+    b_source_json_path = os.path.join(b_collection_path, b'source.json')
+
+    try:
+        with open(b_source_json_path, mode='w') as fd:
+            json.dump(source_data, fd, indent=2)
+        os.chmod(b_source_json_path, S_IRWU_RG_RO)
+    except Exception as e:
+        display.warning(f"Failed to write source.json for {collection}: {e}")
 
 
 def remove_source_metadata(collection, b_collection_path):

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -125,6 +125,42 @@ class ConcreteArtifactsManager:
             "signatures": metadata.signatures,
         }
 
+    def get_artifact_source_json(self, collection: Candidate) -> dict[str, str]:
+        """Generate source.json data for PURL generation.
+
+        This method handles all collection types (galaxy, git, url, file, dir)
+        and returns metadata that enables scanners to generate correct PURLs.
+        """
+        base = {
+            "format_version": "1.0.0",
+            "namespace": collection.namespace,
+            "name": collection.name,
+            "version": collection.ver,
+            "type": collection.type,
+        }
+
+        if collection.type == "galaxy":
+            try:
+                metadata, server = self._galaxy_collection_cache[collection]
+                base["repository_url"] = server.api_server
+                base["download_url"] = metadata.download_url
+            except KeyError:
+                # Fall back to just the server URL if available
+                if hasattr(collection.src, 'api_server'):
+                    base["repository_url"] = collection.src.api_server
+        elif collection.type == "git":
+            # Format as VCS URL per PURL spec
+            src = collection.src
+            if not src.startswith(('git+', 'git@')):
+                src = f"git+{src}"
+            base["vcs_url"] = src
+        elif collection.type == "url":
+            base["download_url"] = collection.src
+        # For 'file' and 'dir' types, we only record the type
+        # The local path is not useful after container builds
+
+        return base
+
     def get_galaxy_artifact_path(self, collection: Candidate) -> bytes:
         """Given a Galaxy-stored collection, return a cached path.
 

--- a/lib/ansible/galaxy/dependency_resolution/dataclasses.py
+++ b/lib/ansible/galaxy/dependency_resolution/dataclasses.py
@@ -43,6 +43,7 @@ _ALLOW_CONCRETE_POINTER_IN_SOURCE = False  # NOTE: This is a feature flag
 _GALAXY_YAML = b'galaxy.yml'
 _MANIFEST_JSON = b'MANIFEST.json'
 _SOURCE_METADATA_FILE = b'GALAXY.yml'
+_SOURCE_JSON_FILE = b'source.json'
 
 display = Display()
 
@@ -115,6 +116,75 @@ def _validate_v1_source_info_schema(
     validation_result = validator.validate(provided_arguments)
 
     return validation_result.error_messages
+
+
+def _validate_source_json_schema(
+    namespace: str,
+    name: str,
+    version: str,
+    provided_arguments: dict[str, object],
+) -> list[str]:
+    """Validate source.json schema for PURL generation."""
+    argument_spec_data = dict(
+        format_version=dict(choices=["1.0.0"]),
+        namespace=dict(choices=[namespace]),
+        name=dict(choices=[name]),
+        version=dict(choices=[version]),
+        type=dict(choices=["galaxy", "git", "url", "file", "dir"]),
+        repository_url=dict(),
+        download_url=dict(),
+        vcs_url=dict(),
+    )
+
+    if not isinstance(provided_arguments, dict):
+        raise AnsibleError(
+            f'Invalid source.json for {namespace}.{name}:{version}, expected a dict and got {type(provided_arguments)}'
+        )
+    validator = ArgumentSpecValidator(argument_spec_data)
+    validation_result = validator.validate(provided_arguments)
+
+    return validation_result.error_messages
+
+
+def get_validated_source_json(
+    b_source_json_path: bytes,
+    namespace: str,
+    name: str,
+    version: str,
+) -> dict[str, object] | None:
+    """Read and validate source.json for PURL generation."""
+    source_json_path = to_text(b_source_json_path, errors='surrogate_or_strict')
+
+    if not os.path.isfile(b_source_json_path):
+        return None
+
+    try:
+        import json
+        with open(b_source_json_path, mode='rb') as fd:
+            metadata = json.load(fd)
+    except OSError as e:
+        display.warning(
+            f"Error reading source.json at '{source_json_path}': {to_text(e, errors='surrogate_or_strict')}"
+        )
+        return None
+    except json.JSONDecodeError as e:
+        display.warning(
+            f"Error parsing source.json at '{source_json_path}': {to_text(e, errors='surrogate_or_strict')}"
+        )
+        return None
+
+    if not isinstance(metadata, dict):
+        display.warning(f"Error reading source.json at '{source_json_path}': expected a JSON object")
+        return None
+
+    schema_errors = _validate_source_json_schema(namespace, name, version, metadata)
+    if schema_errors:
+        display.warning(f"Ignoring source.json at {source_json_path} due to the following errors:")
+        display.warning("\n".join(schema_errors))
+        display.warning("Correct the source.json by reinstalling the collection.")
+        return None
+
+    return metadata
 
 
 def _is_collection_src_dir(dir_path: bytes | str) -> bool:

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -35,10 +35,11 @@
   assert:
     that:
     - '"Installing ''namespace1.name1:1.0.9'' to" in from_first_good_server.stdout'
-    - install_normal_files.files | length == 3
-    - install_normal_files.files[0].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md']
-    - install_normal_files.files[1].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md']
-    - install_normal_files.files[2].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md']
+    - install_normal_files.files | length == 4
+    - install_normal_files.files[0].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md', 'source.json']
+    - install_normal_files.files[1].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md', 'source.json']
+    - install_normal_files.files[2].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md', 'source.json']
+    - install_normal_files.files[3].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md', 'source.json']
     - (install_normal_manifest.content | b64decode | from_json).collection_info.version == '1.0.9'
     - "info_dir is is_dir"
   vars:
@@ -70,10 +71,11 @@
   assert:
     that:
     - '"Installing ''namespace1.name1:1.0.9'' to" in install_normal.stdout'
-    - install_normal_files.files | length == 3
-    - install_normal_files.files[0].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md']
-    - install_normal_files.files[1].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md']
-    - install_normal_files.files[2].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md']
+    - install_normal_files.files | length == 4
+    - install_normal_files.files[0].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md', 'source.json']
+    - install_normal_files.files[1].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md', 'source.json']
+    - install_normal_files.files[2].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md', 'source.json']
+    - install_normal_files.files[3].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md', 'source.json']
     - (install_normal_manifest.content | b64decode | from_json).collection_info.version == '1.0.9'
 
 - name: install existing without --force - {{ test_id }}
@@ -1053,10 +1055,11 @@
   assert:
     that:
     - '"Installing ''namespace1.name1:1.0.9'' to" in from_first_good_server.stdout'
-    - install_normal_files.files | length == 3
-    - install_normal_files.files[0].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md']
-    - install_normal_files.files[1].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md']
-    - install_normal_files.files[2].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md']
+    - install_normal_files.files | length == 4
+    - install_normal_files.files[0].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md', 'source.json']
+    - install_normal_files.files[1].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md', 'source.json']
+    - install_normal_files.files[2].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md', 'source.json']
+    - install_normal_files.files[3].path | basename in ['MANIFEST.json', 'FILES.json', 'README.md', 'source.json']
     - (install_normal_manifest.content | b64decode | from_json).collection_info.version == '1.0.9'
 
 - name: Remove the collection

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -819,7 +819,7 @@ def test_install_collection(collection_artifact, monkeypatch):
     actual_files = os.listdir(collection_path)
     actual_files.sort()
     assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'playbooks', b'plugins', b'roles',
-                            b'runme.sh']
+                            b'runme.sh', b'source.json']
 
     assert stat.S_IMODE(os.stat(os.path.join(collection_path, b'plugins')).st_mode) == S_IRWXU_RXG_RXO
     assert stat.S_IMODE(os.stat(os.path.join(collection_path, b'README.md')).st_mode) == S_IRWU_RG_RO
@@ -855,7 +855,7 @@ def test_install_collection_with_download(galaxy_server, collection_artifact, mo
     actual_files = os.listdir(collection_path)
     actual_files.sort()
     assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'playbooks', b'plugins', b'roles',
-                            b'runme.sh']
+                            b'runme.sh', b'source.json']
 
     assert mock_display.call_count == 2
     assert mock_display.mock_calls[0][1][0] == "Installing 'ansible_namespace.collection:0.1.0' to '%s'" \
@@ -886,7 +886,7 @@ def test_install_collections_from_tar(collection_artifact, monkeypatch):
     actual_files = os.listdir(collection_path)
     actual_files.sort()
     assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'playbooks', b'plugins', b'roles',
-                            b'runme.sh']
+                            b'runme.sh', b'source.json']
 
     with open(os.path.join(collection_path, b'MANIFEST.json'), 'rb') as manifest_obj:
         actual_manifest = json.loads(to_text(manifest_obj.read()))
@@ -926,7 +926,7 @@ def test_install_collection_with_circular_dependency(collection_artifact, monkey
     actual_files = os.listdir(collection_path)
     actual_files.sort()
     assert actual_files == [b'FILES.json', b'MANIFEST.json', b'README.md', b'docs', b'playbooks', b'plugins', b'roles',
-                            b'runme.sh']
+                            b'runme.sh', b'source.json']
 
     with open(os.path.join(collection_path, b'MANIFEST.json'), 'rb') as manifest_obj:
         actual_manifest = json.loads(to_text(manifest_obj.read()))

--- a/test/units/galaxy/test_source_json.py
+++ b/test/units/galaxy/test_source_json.py
@@ -1,0 +1,463 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for source.json functionality for PURL generation."""
+
+from __future__ import annotations
+
+import json
+import os
+import pytest
+import tempfile
+
+from unittest.mock import MagicMock
+
+from ansible.galaxy import api, collection, token
+from ansible.galaxy.collection import concrete_artifact_manager
+from ansible.galaxy.dependency_resolution import dataclasses
+from ansible.module_utils.common.text.converters import to_bytes
+from ansible import context
+from ansible.utils import context_objects as co
+
+
+@pytest.fixture(autouse=True)
+def reset_cli_args():
+    co.GlobalCLIArgs._Singleton__instance = None
+    yield
+    co.GlobalCLIArgs._Singleton__instance = None
+
+
+@pytest.fixture
+def galaxy_server():
+    context.CLIARGS._store = {'ignore_certs': False}
+    galaxy_api = api.GalaxyAPI(
+        None, 'test_server', 'https://galaxy.ansible.com',
+        token=token.GalaxyToken(token='key')
+    )
+    return galaxy_api
+
+
+@pytest.fixture
+def automation_hub_server():
+    context.CLIARGS._store = {'ignore_certs': False}
+    galaxy_api = api.GalaxyAPI(
+        None, 'automation_hub', 'https://console.redhat.com/api/automation-hub',
+        token=token.GalaxyToken(token='key')
+    )
+    return galaxy_api
+
+
+class TestSourceJsonSchema:
+    """Tests for source.json schema validation."""
+
+    def test_validate_source_json_schema_valid_galaxy(self):
+        """Test valid galaxy source.json schema."""
+        data = {
+            "format_version": "1.0.0",
+            "namespace": "cisco",
+            "name": "aci",
+            "version": "2.13.0",
+            "type": "galaxy",
+            "repository_url": "https://galaxy.ansible.com",
+            "download_url": "https://galaxy.ansible.com/api/v3/artifacts/cisco-aci-2.13.0.tar.gz",
+        }
+        errors = dataclasses._validate_source_json_schema("cisco", "aci", "2.13.0", data)
+        assert errors == []
+
+    def test_validate_source_json_schema_valid_git(self):
+        """Test valid git source.json schema."""
+        data = {
+            "format_version": "1.0.0",
+            "namespace": "myorg",
+            "name": "mycollection",
+            "version": "1.0.0",
+            "type": "git",
+            "vcs_url": "git+https://github.com/myorg/mycollection.git@v1.0.0",
+        }
+        errors = dataclasses._validate_source_json_schema("myorg", "mycollection", "1.0.0", data)
+        assert errors == []
+
+    def test_validate_source_json_schema_valid_url(self):
+        """Test valid url source.json schema."""
+        data = {
+            "format_version": "1.0.0",
+            "namespace": "custom",
+            "name": "collection",
+            "version": "2.0.0",
+            "type": "url",
+            "download_url": "https://example.com/collection-2.0.0.tar.gz",
+        }
+        errors = dataclasses._validate_source_json_schema("custom", "collection", "2.0.0", data)
+        assert errors == []
+
+    def test_validate_source_json_schema_valid_file(self):
+        """Test valid file source.json schema (no URL fields)."""
+        data = {
+            "format_version": "1.0.0",
+            "namespace": "local",
+            "name": "collection",
+            "version": "1.0.0",
+            "type": "file",
+        }
+        errors = dataclasses._validate_source_json_schema("local", "collection", "1.0.0", data)
+        assert errors == []
+
+    def test_validate_source_json_schema_valid_dir(self):
+        """Test valid dir source.json schema (no URL fields)."""
+        data = {
+            "format_version": "1.0.0",
+            "namespace": "local",
+            "name": "collection",
+            "version": "1.0.0",
+            "type": "dir",
+        }
+        errors = dataclasses._validate_source_json_schema("local", "collection", "1.0.0", data)
+        assert errors == []
+
+    def test_validate_source_json_schema_invalid_type(self):
+        """Test invalid type in source.json schema."""
+        data = {
+            "format_version": "1.0.0",
+            "namespace": "test",
+            "name": "collection",
+            "version": "1.0.0",
+            "type": "invalid_type",
+        }
+        errors = dataclasses._validate_source_json_schema("test", "collection", "1.0.0", data)
+        assert len(errors) > 0
+        assert any("type" in e for e in errors)
+
+    def test_validate_source_json_schema_invalid_format_version(self):
+        """Test invalid format_version in source.json schema."""
+        data = {
+            "format_version": "2.0.0",
+            "namespace": "test",
+            "name": "collection",
+            "version": "1.0.0",
+            "type": "galaxy",
+        }
+        errors = dataclasses._validate_source_json_schema("test", "collection", "1.0.0", data)
+        assert len(errors) > 0
+        assert any("format_version" in e for e in errors)
+
+    def test_validate_source_json_schema_mismatched_namespace(self):
+        """Test mismatched namespace in source.json schema."""
+        data = {
+            "format_version": "1.0.0",
+            "namespace": "wrong_namespace",
+            "name": "collection",
+            "version": "1.0.0",
+            "type": "galaxy",
+        }
+        errors = dataclasses._validate_source_json_schema("correct_namespace", "collection", "1.0.0", data)
+        assert len(errors) > 0
+        assert any("namespace" in e for e in errors)
+
+
+class TestGetValidatedSourceJson:
+    """Tests for get_validated_source_json function."""
+
+    def test_get_validated_source_json_file_not_found(self, tmp_path):
+        """Test get_validated_source_json returns None when file doesn't exist."""
+        b_path = to_bytes(str(tmp_path / "nonexistent" / "source.json"))
+        result = dataclasses.get_validated_source_json(b_path, "ns", "name", "1.0.0")
+        assert result is None
+
+    def test_get_validated_source_json_valid_file(self, tmp_path):
+        """Test get_validated_source_json returns data for valid file."""
+        source_json_path = tmp_path / "source.json"
+        data = {
+            "format_version": "1.0.0",
+            "namespace": "cisco",
+            "name": "aci",
+            "version": "2.13.0",
+            "type": "galaxy",
+            "repository_url": "https://galaxy.ansible.com",
+        }
+        source_json_path.write_text(json.dumps(data))
+
+        result = dataclasses.get_validated_source_json(
+            to_bytes(str(source_json_path)), "cisco", "aci", "2.13.0"
+        )
+        assert result is not None
+        assert result["type"] == "galaxy"
+        assert result["repository_url"] == "https://galaxy.ansible.com"
+
+    def test_get_validated_source_json_invalid_json(self, tmp_path):
+        """Test get_validated_source_json returns None for invalid JSON."""
+        source_json_path = tmp_path / "source.json"
+        source_json_path.write_text("not valid json {")
+
+        result = dataclasses.get_validated_source_json(
+            to_bytes(str(source_json_path)), "ns", "name", "1.0.0"
+        )
+        assert result is None
+
+
+class TestGetArtifactSourceJson:
+    """Tests for ConcreteArtifactsManager.get_artifact_source_json method."""
+
+    def test_get_artifact_source_json_galaxy(self, galaxy_server):
+        """Test get_artifact_source_json for galaxy type collection."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            b_tmp_dir = to_bytes(tmp_dir)
+            manager = concrete_artifact_manager.ConcreteArtifactsManager(
+                b_tmp_dir, validate_certs=True
+            )
+
+            # Create a mock candidate
+            candidate = MagicMock()
+            candidate.namespace = "cisco"
+            candidate.name = "aci"
+            candidate.ver = "2.13.0"
+            candidate.type = "galaxy"
+            candidate.src = galaxy_server
+
+            # Mock the galaxy collection cache
+            metadata = MagicMock()
+            metadata.download_url = "https://galaxy.ansible.com/api/v3/artifacts/cisco-aci-2.13.0.tar.gz"
+            manager._galaxy_collection_cache[candidate] = (metadata, galaxy_server)
+
+            result = manager.get_artifact_source_json(candidate)
+
+            assert result["format_version"] == "1.0.0"
+            assert result["namespace"] == "cisco"
+            assert result["name"] == "aci"
+            assert result["version"] == "2.13.0"
+            assert result["type"] == "galaxy"
+            assert result["repository_url"] == "https://galaxy.ansible.com"
+            assert result["download_url"] == "https://galaxy.ansible.com/api/v3/artifacts/cisco-aci-2.13.0.tar.gz"
+
+    def test_get_artifact_source_json_automation_hub(self, automation_hub_server):
+        """Test get_artifact_source_json for automation hub collection."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            b_tmp_dir = to_bytes(tmp_dir)
+            manager = concrete_artifact_manager.ConcreteArtifactsManager(
+                b_tmp_dir, validate_certs=True
+            )
+
+            candidate = MagicMock()
+            candidate.namespace = "redhat"
+            candidate.name = "rhel_system_roles"
+            candidate.ver = "1.20.0"
+            candidate.type = "galaxy"
+            candidate.src = automation_hub_server
+
+            metadata = MagicMock()
+            metadata.download_url = "https://console.redhat.com/api/automation-hub/v3/artifacts/redhat-rhel_system_roles-1.20.0.tar.gz"
+            manager._galaxy_collection_cache[candidate] = (metadata, automation_hub_server)
+
+            result = manager.get_artifact_source_json(candidate)
+
+            assert result["type"] == "galaxy"
+            assert result["repository_url"] == "https://console.redhat.com/api/automation-hub"
+
+    def test_get_artifact_source_json_git(self):
+        """Test get_artifact_source_json for git type collection."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            b_tmp_dir = to_bytes(tmp_dir)
+            manager = concrete_artifact_manager.ConcreteArtifactsManager(
+                b_tmp_dir, validate_certs=True
+            )
+
+            candidate = MagicMock()
+            candidate.namespace = "myorg"
+            candidate.name = "mycollection"
+            candidate.ver = "1.0.0"
+            candidate.type = "git"
+            candidate.src = "https://github.com/myorg/mycollection.git"
+
+            result = manager.get_artifact_source_json(candidate)
+
+            assert result["format_version"] == "1.0.0"
+            assert result["namespace"] == "myorg"
+            assert result["name"] == "mycollection"
+            assert result["version"] == "1.0.0"
+            assert result["type"] == "git"
+            assert result["vcs_url"] == "git+https://github.com/myorg/mycollection.git"
+
+    def test_get_artifact_source_json_git_with_git_plus_prefix(self):
+        """Test get_artifact_source_json for git type with git+ prefix."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            b_tmp_dir = to_bytes(tmp_dir)
+            manager = concrete_artifact_manager.ConcreteArtifactsManager(
+                b_tmp_dir, validate_certs=True
+            )
+
+            candidate = MagicMock()
+            candidate.namespace = "myorg"
+            candidate.name = "mycollection"
+            candidate.ver = "1.0.0"
+            candidate.type = "git"
+            candidate.src = "git+https://github.com/myorg/mycollection.git@v1.0.0"
+
+            result = manager.get_artifact_source_json(candidate)
+
+            assert result["type"] == "git"
+            # Should not double-prefix
+            assert result["vcs_url"] == "git+https://github.com/myorg/mycollection.git@v1.0.0"
+
+    def test_get_artifact_source_json_git_with_git_at_prefix(self):
+        """Test get_artifact_source_json for git type with git@ prefix (SSH)."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            b_tmp_dir = to_bytes(tmp_dir)
+            manager = concrete_artifact_manager.ConcreteArtifactsManager(
+                b_tmp_dir, validate_certs=True
+            )
+
+            candidate = MagicMock()
+            candidate.namespace = "myorg"
+            candidate.name = "mycollection"
+            candidate.ver = "1.0.0"
+            candidate.type = "git"
+            candidate.src = "git@github.com:myorg/mycollection.git"
+
+            result = manager.get_artifact_source_json(candidate)
+
+            assert result["type"] == "git"
+            # Should not add prefix to git@ URLs
+            assert result["vcs_url"] == "git@github.com:myorg/mycollection.git"
+
+    def test_get_artifact_source_json_url(self):
+        """Test get_artifact_source_json for url type collection."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            b_tmp_dir = to_bytes(tmp_dir)
+            manager = concrete_artifact_manager.ConcreteArtifactsManager(
+                b_tmp_dir, validate_certs=True
+            )
+
+            candidate = MagicMock()
+            candidate.namespace = "custom"
+            candidate.name = "collection"
+            candidate.ver = "2.0.0"
+            candidate.type = "url"
+            candidate.src = "https://example.com/collection-2.0.0.tar.gz"
+
+            result = manager.get_artifact_source_json(candidate)
+
+            assert result["format_version"] == "1.0.0"
+            assert result["type"] == "url"
+            assert result["download_url"] == "https://example.com/collection-2.0.0.tar.gz"
+            assert "vcs_url" not in result
+            assert "repository_url" not in result
+
+    def test_get_artifact_source_json_file(self):
+        """Test get_artifact_source_json for file type collection."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            b_tmp_dir = to_bytes(tmp_dir)
+            manager = concrete_artifact_manager.ConcreteArtifactsManager(
+                b_tmp_dir, validate_certs=True
+            )
+
+            candidate = MagicMock()
+            candidate.namespace = "local"
+            candidate.name = "collection"
+            candidate.ver = "1.0.0"
+            candidate.type = "file"
+            candidate.src = "/path/to/collection.tar.gz"
+
+            result = manager.get_artifact_source_json(candidate)
+
+            assert result["format_version"] == "1.0.0"
+            assert result["namespace"] == "local"
+            assert result["name"] == "collection"
+            assert result["type"] == "file"
+            # Should NOT include the local path
+            assert "download_url" not in result
+            assert "vcs_url" not in result
+            assert "repository_url" not in result
+
+    def test_get_artifact_source_json_dir(self):
+        """Test get_artifact_source_json for dir type collection."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            b_tmp_dir = to_bytes(tmp_dir)
+            manager = concrete_artifact_manager.ConcreteArtifactsManager(
+                b_tmp_dir, validate_certs=True
+            )
+
+            candidate = MagicMock()
+            candidate.namespace = "local"
+            candidate.name = "collection"
+            candidate.ver = "1.0.0"
+            candidate.type = "dir"
+            candidate.src = "/path/to/collection"
+
+            result = manager.get_artifact_source_json(candidate)
+
+            assert result["format_version"] == "1.0.0"
+            assert result["type"] == "dir"
+            # Should NOT include the local path
+            assert "download_url" not in result
+            assert "vcs_url" not in result
+            assert "repository_url" not in result
+
+
+class TestWriteSourceJson:
+    """Tests for write_source_json function."""
+
+    def test_write_source_json_creates_file(self, tmp_path):
+        """Test that write_source_json creates the source.json file."""
+        b_collection_path = to_bytes(str(tmp_path / "namespace" / "collection"))
+        os.makedirs(b_collection_path)
+
+        candidate = MagicMock()
+        candidate.namespace = "namespace"
+        candidate.name = "collection"
+        candidate.ver = "1.0.0"
+        candidate.type = "galaxy"
+
+        artifacts_manager = MagicMock()
+        artifacts_manager.get_artifact_source_json.return_value = {
+            "format_version": "1.0.0",
+            "namespace": "namespace",
+            "name": "collection",
+            "version": "1.0.0",
+            "type": "galaxy",
+            "repository_url": "https://galaxy.ansible.com",
+        }
+
+        collection.write_source_json(candidate, b_collection_path, artifacts_manager)
+
+        source_json_path = tmp_path / "namespace" / "collection" / "source.json"
+        assert source_json_path.exists()
+
+        with open(source_json_path) as f:
+            data = json.load(f)
+
+        assert data["format_version"] == "1.0.0"
+        assert data["namespace"] == "namespace"
+        assert data["type"] == "galaxy"
+
+    def test_write_source_json_content_format(self, tmp_path):
+        """Test that write_source_json writes properly formatted JSON."""
+        b_collection_path = to_bytes(str(tmp_path / "cisco" / "aci"))
+        os.makedirs(b_collection_path)
+
+        candidate = MagicMock()
+        candidate.namespace = "cisco"
+        candidate.name = "aci"
+        candidate.ver = "2.13.0"
+        candidate.type = "galaxy"
+
+        artifacts_manager = MagicMock()
+        artifacts_manager.get_artifact_source_json.return_value = {
+            "format_version": "1.0.0",
+            "namespace": "cisco",
+            "name": "aci",
+            "version": "2.13.0",
+            "type": "galaxy",
+            "repository_url": "https://galaxy.ansible.com",
+            "download_url": "https://galaxy.ansible.com/api/v3/artifacts/cisco-aci-2.13.0.tar.gz",
+        }
+
+        collection.write_source_json(candidate, b_collection_path, artifacts_manager)
+
+        source_json_path = tmp_path / "cisco" / "aci" / "source.json"
+        content = source_json_path.read_text()
+
+        # Verify it's properly indented (indent=2)
+        assert '  "format_version"' in content or '"format_version"' in content
+
+        data = json.loads(content)
+        assert data["download_url"] == "https://galaxy.ansible.com/api/v3/artifacts/cisco-aci-2.13.0.tar.gz"


### PR DESCRIPTION
##### SUMMARY

Add source.json file creation when installing collections via ansible-galaxy.

This enables SBOM scanners (like Syft) to generate accurate Package URLs (PURLs) for Ansible collections by recording the installation source.

The source.json file is written to the collection directory and contains:
- format_version: Schema version (1.0.0)
- namespace, name, version: Collection identity
- type: Installation source type (galaxy, git, url, file, dir)
- repository_url: Galaxy-compatible server URL (for galaxy type)
- download_url: Direct artifact URL (for galaxy/url types)
- vcs_url: VCS URL with git+ prefix (for git type)

Examples:
- Galaxy: type=galaxy, repository_url=https://galaxy.ansible.com
- Automation Hub: type=galaxy, repository_url=https://console.redhat.com/api/automation-hub/
- Git: type=git, vcs_url=git+https://github.com/org/repo.git@tag
- URL: type=url, download_url=https://example.com/collection.tar.gz
- Local: type=file or type=dir (no path stored)

This change supports the new 'ansible' PURL type being proposed at: https://github.com/package-url/purl-spec/pull/854
This new feature implements a necessary step to meet Manufacturer and Stewardship responsibilities as mandated by the EU Cyber Resilience Act. 

##### ISSUE TYPE

- Feature Pull Request
