### PR TITLE
fix: use subprocess instead of os.system in test-module.py

### DIFF
--- a/hacking/test-module.py
+++ b/hacking/test-module.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import glob
 import optparse
 import os
+import stat
 import subprocess
 import sys
 import traceback
@@ -196,7 +197,7 @@ def boilerplate_module(modfile, args, interpreters, check, destfile):
 
 
 def ansiballz_setup(modfile, modname, interpreters):
-    os.system("chmod +x %s" % modfile)
+    os.chmod(modfile, os.stat(modfile).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     if 'ansible_python_interpreter' in interpreters:
         command = [interpreters['ansible_python_interpreter']]
@@ -242,7 +243,7 @@ def runtest(modfile, argspath, modname, module_style, interpreters):
         if 'ansible_python_interpreter' in interpreters:
             invoke = "%s " % interpreters['ansible_python_interpreter']
 
-    os.system("chmod +x %s" % modfile)
+    os.chmod(modfile, os.stat(modfile).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     invoke = "%s%s" % (invoke, modfile)
     if argspath is not None:


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `hacking/test-module.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `hacking/test-module.py:199` |

**Description**: The test-module.py script uses os.system() with Python string formatting to execute shell commands. The modfile variable representing a file path is directly interpolated into the shell command without sanitization, allowing shell metacharacter injection.

## Changes
- `hacking/test-module.py`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
