### PR TITLE
ansible-doc: skip _protomatter while metadata dump

### DIFF
--- a/changelogs/fragments/ansible-doc-metadump.yml
+++ b/changelogs/fragments/ansible-doc-metadump.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - ansible-doc - skip _protomatter while metadata dump (https://github.com/ansible/ansible/issues/85689).

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -86,6 +86,7 @@ if t.TYPE_CHECKING:
         format: int
 
 import ansible.constants as C
+from ansible import _internal
 from ansible.errors import AnsibleError
 from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.collection.concrete_artifact_manager import (
@@ -1478,7 +1479,10 @@ def find_existing_collections(path_filter, artifacts_manager, namespace_filter=N
         b_collection_path = to_bytes(collection_path.as_posix())
 
         try:
-            req = Candidate.from_dir_path_as_unknown(b_collection_path, artifacts_manager)
+            if collection_path.is_relative_to(os.path.dirname(_internal.__file__)):
+                req = Candidate.from_dir_path_implicit(b_collection_path)
+            else:
+                req = Candidate.from_dir_path_as_unknown(b_collection_path, artifacts_manager)
         except ValueError as val_err:
             display.warning(f'{val_err}')
             continue

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -30,6 +30,13 @@ ansible-doc -t keyword -l | grep "${GREP_OPTS[@]}" 'vars_prompt: list of variabl
 ansible-doc -t keyword vars_prompt | grep "${GREP_OPTS[@]}" 'description: list of variables to prompt for.'
 ansible-doc -t keyword asldkfjaslidfhals 2>&1 | grep "${GREP_OPTS[@]}" 'Skipping invalid keyword'
 
+echo "test metadata dump"
+ansible-doc --metadata-dump 2>&1 | tee metadata-dump.txt
+if grep -q "ansible._protomatter" metadata-dump.txt; then
+  echo "Internal collection 'ansible._protomatter' is printed in metadata dump"
+  exit 1
+fi
+
 echo "Check if deprecation collection name is printed"
 ansible-doc --playbook-dir ./ testns.testcol.randommodule 2>&1 | grep "${GREP_OPTS[@]}" "Will be removed in: testns.testcol"
 


### PR DESCRIPTION
##### SUMMARY

* Do not raise a warning for MANIFEST.json in ansible._protomatter,
  while dumping metadata.

Fixes: #85689

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/ansible-doc-metadump.yml
lib/ansible/galaxy/collection/__init__.py
test/integration/targets/ansible-doc/runme.sh


