### PR TITLE
git: Honor check mode in set_remote_url

### DIFF
--- a/changelogs/fragments/git-check-mode.yml
+++ b/changelogs/fragments/git-check-mode.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - git - honor check mode in set_remote_url (https://github.com/ansible/ansible/issues/76221).

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -875,11 +875,12 @@ def set_remote_url(git_path, module, repo, dest, remote):
     if remote_url == repo or unfrackgitpath(remote_url) == unfrackgitpath(repo):
         return False
 
-    command = [git_path, 'remote', 'set-url', remote, repo]
-    (rc, out, err) = module.run_command(command, cwd=dest)
-    if rc != 0:
-        label = "set a new url %s for %s" % (repo, remote)
-        module.fail_json(msg="Failed to %s: %s %s" % (label, out, err))
+    if not module.check_mode:
+        command = [git_path, 'remote', 'set-url', remote, repo]
+        (rc, out, err) = module.run_command(command, cwd=dest)
+        if rc != 0:
+            label = "set a new url %s for %s" % (repo, remote)
+            module.fail_json(msg="Failed to %s: %s %s" % (label, out, err))
 
     # Return False if remote_url is None to maintain previous behavior
     # for Git versions prior to 1.7.5 that lack required functionality.

--- a/test/integration/targets/git/tasks/change-repo-url.yml
+++ b/test/integration/targets/git/tasks/change-repo-url.yml
@@ -65,6 +65,27 @@
     that:
       - checkout_same_url is not changed
 
+- name: CHANGE-REPO-URL | clone repo with new url to same destination in check mode and diff mode
+  git:
+    repo: "{{ repo_update_url_2 }}"
+    dest: "{{ checkout_dir }}"
+  register: checkout_new_url_check_mode
+  check_mode: True
+  diff: True
+
+- name: CHANGE-REPO-URL | check repo reported changed in check mode and diff mode
+  shell: git remote -v | grep origin
+  register: remote_url_check_mode
+  args:
+    chdir: "{{ checkout_dir }}"
+  environment:
+    LC_ALL: C
+
+- name: CHANGE-REPO-URL | assert repo reported is not changed in check mode and diff mode
+  assert:
+    that:
+      - repo_update_url_1 in remote_url_check_mode.stdout
+      - checkout_new_url_check_mode is changed
 
 - name: CHANGE-REPO-URL | clone repo with new url to same destination
   git:


### PR DESCRIPTION
##### SUMMARY

* Do not change remote URL in check mode

Fixes: #76221

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/git-check-mode.yml
lib/ansible/modules/git.py
test/integration/targets/git/tasks/change-repo-url.yml


