### PR TITLE
Add winrm hostname to stdin error

### DIFF
--- a/changelogs/fragments/86749-winrm-stdin-error-message.yml
+++ b/changelogs/fragments/86749-winrm-stdin-error-message.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - winrm connection plugin - improved error message to include target host when stdin transfer fails (https://github.com/ansible/ansible/issues/86749)

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -620,7 +620,7 @@ class Connection(ConnectionBase):
                     self._winrm_write_stdin(command_id, stdin_iterator)
 
             except Exception as ex:
-                display.error_as_warning("ERROR DURING WINRM SEND INPUT. Attempting to recover.", ex)
+                display.error_as_warning(f"ERROR DURING WINRM SEND INPUT TO {self._winrm_host}. Attempting to recover.", ex)
                 stdin_push_failed = True
 
             # Even on a failure above we try at least once to get the output

--- a/test/integration/targets/connection_winrm/action_plugins/test_stdin_failure.py
+++ b/test/integration/targets/connection_winrm/action_plugins/test_stdin_failure.py
@@ -1,0 +1,45 @@
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+    """
+    Custom action plugin to test WinRM stdin failure recovery (lines 618-624).
+    This patches the connection's _winrm_write_stdin to fail deterministically.
+    """
+
+    def run(self, tmp=None, task_vars=None):
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        # Get the connection object
+        connection = self._connection
+
+        # Save the original method
+        original_write_stdin = connection._winrm_write_stdin
+
+        def failing_write_stdin(_command_id, _stdin_iterator):
+            """Replacement that always fails"""
+            # Now raise the injected exception
+            raise Exception("INJECTED TEST FAILURE: stdin write failed")
+
+        try:
+            # Patch the method to inject failure
+            connection._winrm_write_stdin = failing_write_stdin
+
+            # Execute a module that will use stdin (pipelining is on by default)
+            # win_ping returns valid JSON: {"ping": "pong"}
+            module_result = self._execute_module(
+                module_name='ansible.windows.win_ping',
+                module_args={},
+                task_vars=task_vars,
+            )
+
+            # Merge the module result
+            result.update(module_result)
+        finally:
+            # Always restore original method
+            connection._winrm_write_stdin = original_write_stdin
+
+        return result

--- a/test/integration/targets/connection_winrm/action_plugins/test_stdin_failure.py
+++ b/test/integration/targets/connection_winrm/action_plugins/test_stdin_failure.py
@@ -6,7 +6,7 @@ from ansible.plugins.action import ActionBase
 
 class ActionModule(ActionBase):
     """
-    Custom action plugin to test WinRM stdin failure recovery (lines 618-624).
+    Custom action plugin to trip a failure using the winrm connection plugin.
     This patches the connection's _winrm_write_stdin to fail deterministically.
     """
 
@@ -15,17 +15,13 @@ class ActionModule(ActionBase):
 
         # Get the connection object
         connection = self._connection
-
-        # Save the original method
         original_write_stdin = connection._winrm_write_stdin
 
         def failing_write_stdin(_command_id, _stdin_iterator):
             """Replacement that always fails"""
-            # Now raise the injected exception
             raise Exception("INJECTED TEST FAILURE: stdin write failed")
 
         try:
-            # Patch the method to inject failure
             connection._winrm_write_stdin = failing_write_stdin
 
             # Execute a module that will use stdin (pipelining is on by default)
@@ -39,7 +35,7 @@ class ActionModule(ActionBase):
             # Merge the module result
             result.update(module_result)
         finally:
-            # Always restore original method
+            # Restore original method
             connection._winrm_write_stdin = original_write_stdin
 
         return result

--- a/test/integration/targets/connection_winrm/action_plugins/test_stdin_failure.py
+++ b/test/integration/targets/connection_winrm/action_plugins/test_stdin_failure.py
@@ -13,29 +13,24 @@ class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None):
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        # Get the connection object
         connection = self._connection
         original_write_stdin = connection._winrm_write_stdin
 
         def failing_write_stdin(_command_id, _stdin_iterator):
-            """Replacement that always fails"""
             raise Exception("INJECTED TEST FAILURE: stdin write failed")
 
         try:
             connection._winrm_write_stdin = failing_write_stdin
 
             # Execute a module that will use stdin (pipelining is on by default)
-            # win_ping returns valid JSON: {"ping": "pong"}
             module_result = self._execute_module(
                 module_name='ansible.windows.win_ping',
                 module_args={},
                 task_vars=task_vars,
             )
 
-            # Merge the module result
             result.update(module_result)
         finally:
-            # Restore original method
             connection._winrm_write_stdin = original_write_stdin
 
         return result

--- a/test/integration/targets/connection_winrm/tests.yml
+++ b/test/integration/targets/connection_winrm/tests.yml
@@ -81,3 +81,15 @@
     assert:
       that:
       - stderr_clixml.stderr_lines == ['Test 🎵 _x005F_ _x005Z_.']
+
+  - name: Test stdin write failure error message
+    test_stdin_failure:
+    ignore_errors: true
+    register: stdin_write_fail
+
+  - assert:
+      that:
+        - stdin_write_fail is failed
+        - stdin_write_fail.warnings | default([]) | select('search', warning_substring) | list | length > 0
+    vars:
+      warning_substring: "ERROR DURING WINRM SEND INPUT TO "


### PR DESCRIPTION
##### SUMMARY

Improves error messages in the winrm connection plugin by adding the `winrm_hostname` to warning messages when stdin pipelining fails.

Fixes #86749

##### ISSUE TYPE

- Feature Pull Request

