### PR TITLE
Add hostname to WinRM error message for easier debugging

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -620,7 +620,7 @@ class Connection(ConnectionBase):
                     self._winrm_write_stdin(command_id, stdin_iterator)
 
             except Exception as ex:
-                display.error_as_warning("ERROR DURING WINRM SEND INPUT to %s. Attempting to recover." % self._winrm_host, ex)
+                display.error_as_warning(f"ERROR DURING WINRM SEND INPUT to {self._winrm_host}. Attempting to recover.", ex)
                 stdin_push_failed = True
 
             # Even on a failure above we try at least once to get the output

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -620,7 +620,7 @@ class Connection(ConnectionBase):
                     self._winrm_write_stdin(command_id, stdin_iterator)
 
             except Exception as ex:
-                display.error_as_warning("ERROR DURING WINRM SEND INPUT. Attempting to recover.", ex)
+                display.error_as_warning("ERROR DURING WINRM SEND INPUT to %s. Attempting to recover." % self._winrm_host, ex)
                 stdin_push_failed = True
 
             # Even on a failure above we try at least once to get the output


### PR DESCRIPTION
Good day,

This PR adds the target hostname to the WinRM error message "ERROR DURING WINRM SEND INPUT" to help identify which Windows host encountered the error during debugging.

**Before:*
```
ERROR DURING WINRM SEND INPUT. Attempting to recover.
```

**After:*
```
ERROR DURING WINRM SEND INPUT to hostname. Attempting to recover.
```

This addresses issue https://github.com/ansible/ansible/issues/86749

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithOutRoof