### PR TITLE
[stable-2.21] Changelog-only deprecation notice for rc

### DIFF
--- a/changelogs/fragments/rc_fail_inference.yml
+++ b/changelogs/fragments/rc_fail_inference.yml
@@ -1,0 +1,4 @@
+deprecated_features:
+  - task result - Inferred task failure from a non-zero ``rc`` key and absence of a ``failed`` key will be deprecated in Ansible Core 2.22.
+    Actions and modules must explicitly communicate failure by setting the ``failed`` key, using APIs that do so, or raising an unhandled exception.
+    In future releases, the ``rc`` key will receive no special handling during task result processing.


### PR DESCRIPTION
##### SUMMARY
Developer-only deprecation of inferred failure from non-zero `rc` with no `failed` key.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Docs Pull Request