### PR TITLE
[stable-2.21] Fix ansible-test remote aliases for new-style args (#86844)

### DIFF
--- a/changelogs/fragments/core_ci_remote_alias.yml
+++ b/changelogs/fragments/core_ci_remote_alias.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ansible-test remote alias - Alias values for ``--controller`` and ``--target`` are properly resolved for ``remote``.
+    Previously, remote alias values (e.g. ``fedora/latest``) resolved to the correct name only for the legacy ``--remote`` arg, failing with an unknown image error for the newer args.

--- a/test/lib/ansible_test/_internal/host_configs.py
+++ b/test/lib/ansible_test/_internal/host_configs.py
@@ -420,6 +420,7 @@ class PosixRemoteConfig(RemoteConfig, ControllerHostConfig, PosixConfig):
         super().apply_defaults(context, defaults)
 
         self.become = self.become or defaults.become
+        self.name = defaults.name
 
     @property
     def have_root(self) -> bool:
@@ -450,6 +451,7 @@ class WindowsRemoteConfig(RemoteConfig, WindowsConfig):
         super().apply_defaults(context, defaults)
 
         self.connection = self.connection or defaults.connection
+        self.name = defaults.name
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
##### SUMMARY
* Always include `name` when applying remote config defaults for Posix/Windows.

(cherry picked from commit 00b1f27d9cc81bbb4e020397523af1470ea9e446)

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
