### PR TITLE
Update module return value documentation

### DIFF
--- a/changelogs/fragments/module-return-documentation.yml
+++ b/changelogs/fragments/module-return-documentation.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "core modules - added missing RETURN documentation to 22 modules and removed redundant common return value documentation from 8 modules to standardize module documentation."

--- a/lib/ansible/modules/add_host.py
+++ b/lib/ansible/modules/add_host.py
@@ -112,3 +112,27 @@ EXAMPLES = r"""
     groups: done
   loop: "{{ ansible_play_hosts }}"
 """
+
+RETURN = r"""
+add_host:
+  description: Information about the host that was added to inventory.
+  returned: always
+  type: dict
+  contains:
+    host_name:
+      description: The name of the host that was added.
+      returned: always
+      type: str
+      sample: "new_server.example.com"
+    groups:
+      description: The list of groups the host was added to.
+      returned: always
+      type: list
+      elements: str
+      sample: ["webservers", "production"]
+    host_vars:
+      description: The variables that were assigned to the host.
+      returned: always
+      type: dict
+      sample: {"ansible_port": 2222, "foo": 42}
+"""

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -348,21 +348,6 @@ cache_update_time:
     returned: success, in some cases
     type: int
     sample: 1425828348000
-stdout:
-    description: output from apt
-    returned: success, when needed
-    type: str
-    sample: |-
-        Reading package lists...
-        Building dependency tree...
-        Reading state information...
-        The following extra packages will be installed:
-          apache2-bin ...
-stderr:
-    description: error output from apt
-    returned: success, when needed
-    type: str
-    sample: "AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 127.0.1.1. Set the 'ServerName' directive globally to ..."
 """  # NOQA
 
 # added to stave off future warnings about apt api

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -170,6 +170,12 @@ sources_removed:
   type: list
   sample: ["/etc/apt/sources.list.d/artifacts_elastic_co_packages_6_x_apt.list"]
   version_added: "2.15"
+
+state:
+  description: The source string state passed into the module
+  returned: always
+  type: str
+  sample: "absent", "present"
 """
 
 import copy

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -175,7 +175,7 @@ state:
   description: The source string state passed into the module
   returned: always
   type: str
-  sample: "absent", "present"
+  sample: "absent"
 """
 
 import copy

--- a/lib/ansible/modules/assemble.py
+++ b/lib/ansible/modules/assemble.py
@@ -124,6 +124,7 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+# This module will sometimes include return values from the copy module (when file content changes) or file module (when only attributes are managed).
 src:
     description: Source directory path containing the fragments.
     returned: always

--- a/lib/ansible/modules/assemble.py
+++ b/lib/ansible/modules/assemble.py
@@ -123,8 +123,6 @@ EXAMPLES = r"""
     validate: /usr/sbin/sshd -t -f %s
 """
 
-RETURN = r"""#"""
-
 import codecs
 import os
 import re

--- a/lib/ansible/modules/assemble.py
+++ b/lib/ansible/modules/assemble.py
@@ -140,12 +140,10 @@ checksum:
     type: str
     sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
 md5sum:
-    description: MD5 checksum of the assembled file.
+    description: MD5 checksum of the assembled file. Returns V(null) when FIPS mode is active.
     returned: always
     type: str
     sample: 2a5aeecc61dc98c4d780b14b330e3282
-    notes:
-        - Returns V(null) when FIPS mode is active.
 validation:
     description: Output from the validation command.
     returned: when O(validate) parameter is specified

--- a/lib/ansible/modules/assemble.py
+++ b/lib/ansible/modules/assemble.py
@@ -123,6 +123,51 @@ EXAMPLES = r"""
     validate: /usr/sbin/sshd -t -f %s
 """
 
+RETURN = r"""
+src:
+    description: Source directory path containing the fragments.
+    returned: always
+    type: str
+    sample: /etc/someapp/fragments
+dest:
+    description: Destination file path where fragments are assembled.
+    returned: always
+    type: str
+    sample: /etc/someapp/someapp.conf
+checksum:
+    description: SHA1 checksum of the assembled file.
+    returned: always
+    type: str
+    sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
+md5sum:
+    description: MD5 checksum of the assembled file.
+    returned: always
+    type: str
+    sample: 2a5aeecc61dc98c4d780b14b330e3282
+    notes:
+        - Returns V(null) when FIPS mode is active.
+validation:
+    description: Output from the validation command.
+    returned: when O(validate) parameter is specified
+    type: dict
+    contains:
+        rc:
+            description: Return code from the validation command.
+            returned: always
+            type: int
+            sample: 0
+        stdout:
+            description: Standard output from the validation command.
+            returned: always
+            type: str
+            sample: "configuration OK"
+        stderr:
+            description: Standard error from the validation command.
+            returned: always
+            type: str
+            sample: ""
+"""
+
 import codecs
 import os
 import re

--- a/lib/ansible/modules/assert.py
+++ b/lib/ansible/modules/assert.py
@@ -107,3 +107,16 @@ EXAMPLES = r"""
       - my_param >= 0
     quiet: true
 """
+
+RETURN = r"""
+evaluated_to:
+  description: The boolean result of the failed assertion.
+  returned: failure
+  type: bool
+  sample: false
+assertion:
+  description: The specific assertion expression that failed.
+  returned: failure
+  type: str
+  sample: "my_param <= 100"
+"""

--- a/lib/ansible/modules/async_status.py
+++ b/lib/ansible/modules/async_status.py
@@ -96,18 +96,15 @@ started:
   returned: always
   type: bool
   sample: true
-stdout:
-  description: Any output returned by async_wrapper
-  returned: always
-  type: str
-stderr:
-  description: Any errors returned by async_wrapper
-  returned: always
-  type: str
 erased:
   description: Path to erased job file
   returned: when file is erased
   type: str
+results_file:
+  description: Path to the async job status file
+  returned: when job is running or when parsing job output fails
+  type: str
+  sample: /home/user/.ansible_async/360874038559.4169
 """
 
 import json

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -176,11 +176,6 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
-msg:
-  description: changed
-  returned: always
-  type: bool
-  sample: True
 start:
   description: The command execution start time.
   returned: always
@@ -196,16 +191,6 @@ delta:
   returned: always
   type: str
   sample: '0:00:00.001529'
-stdout:
-  description: The command standard output.
-  returned: always
-  type: str
-  sample: 'Clustering node rabbit@slave1 with rabbit@master …'
-stderr:
-  description: The command standard error.
-  returned: always
-  type: str
-  sample: 'ls cannot access foo: No such file or directory'
 cmd:
   description: The command executed by the task.
   returned: always
@@ -213,21 +198,6 @@ cmd:
   sample:
   - echo
   - hello
-rc:
-  description: The command return code (0 means success).
-  returned: always
-  type: int
-  sample: 0
-stdout_lines:
-  description: The command standard output split in lines.
-  returned: always
-  type: list
-  sample: [u'Clustering node rabbit@slave1 with rabbit@master …']
-stderr_lines:
-  description: The command standard error split in lines.
-  returned: always
-  type: list
-  sample: [u'ls cannot access foo: No such file or directory', u'ls …']
 """
 
 import datetime

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -191,6 +191,13 @@ delta:
   returned: always
   type: str
   sample: '0:00:00.001529'
+stdout:
+  description:
+    - The standard output from the command execution.
+    - When O(creates) or O(removes) causes the task to skip, contains an informational skip message instead of command output.
+  returned: always
+  type: str
+  sample: 'Clustering node rabbit@slave1 with rabbit@master …'
 cmd:
   description: The command executed by the task.
   returned: always
@@ -199,6 +206,7 @@ cmd:
   - echo
   - hello
 """
+# TODO: Deprecate the skip message usage of stdout in favor of skip_reason
 
 import datetime
 import glob

--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -242,11 +242,6 @@ checksum:
     returned: success
     type: str
     sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
-backup_file:
-    description: Name of backup file created.
-    returned: changed and if backup=yes
-    type: str
-    sample: /path/to/file.txt.2015-02-12@22:09~
 gid:
     description: Group id of the file, after execution.
     returned: success

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -213,7 +213,28 @@ EXAMPLES = r"""
     state: absent
 """
 
-RETURN = r"""#"""
+RETURN = r"""
+jobs:
+    description: List of all job names in the crontab.
+    returned: always
+    type: list
+    sample: ["check dirs", "do the job"]
+envs:
+    description: List of all environment variable names in the crontab.
+    returned: always
+    type: list
+    sample: ["PATH", "APP_HOME"]
+cron_file:
+    description: Path to the cron file managed by this module.
+    returned: when O(cron_file) parameter is specified
+    type: str
+    sample: /etc/cron.d/ansible_yum-autoupdate
+state:
+    description: State of the cron file.
+    returned: when removing a job causes the entire cron file to be deleted
+    type: str
+    sample: absent
+"""
 
 import os
 import platform

--- a/lib/ansible/modules/debconf.py
+++ b/lib/ansible/modules/debconf.py
@@ -123,7 +123,18 @@ EXAMPLES = r"""
   no_log: True
 """
 
-RETURN = r"""#"""
+RETURN = r"""
+current:
+    description: Current value(s) of the debconf selection(s).
+    returned: always
+    type: dict
+    sample: {'locales/default_environment_locale': 'fr_FR.UTF-8'}
+previous:
+    description: Previous value(s) of the debconf selection(s) before change.
+    returned: changed
+    type: dict
+    sample: {'locales/default_environment_locale': 'en_US.UTF-8'}
+"""
 
 from ansible.module_utils.common.text.converters import to_text, to_native
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/debug.py
+++ b/lib/ansible/modules/debug.py
@@ -96,3 +96,12 @@ EXAMPLES = r"""
     - "Provisioning based on YOUR_KEY which is: {{ lookup('ansible.builtin.env', 'YOUR_KEY') }}"
     - "These servers were built using the password of '{{ password_used }}'. Please retain this for later use."
 """
+
+RETURN = r"""
+# When using the 'var' option, the variable name is used as the return key with its value.
+skipped_reason:
+  description: Reason why the debug task was skipped.
+  returned: when verbosity threshold is not met
+  type: str
+  sample: "Verbosity threshold not met."
+"""

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -391,6 +391,20 @@ EXAMPLES = """
     state: present
 """
 
+# FIXME: These should NOT be module return keys. Ditto for dnf5 module. Follow up with deprecations to rename.
+RETURN = """
+results:
+  description: A list of the dnf transaction results
+  returned: success
+  type: list
+  sample: ["Installed: lsof-4.94.0-4.fc37.x86_64"]
+failures:
+  description: A list of the dnf transaction failures
+  returned: failure
+  type: list
+  sample: ["No package lsof available."]
+"""
+
 import json
 import sys
 

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -328,12 +328,8 @@ EXAMPLES = """
     autoremove: no
 """
 
+# FIXME: These should NOT be module return keys. Ditto for dnf module. Follow up with deprecations to rename.
 RETURN = """
-msg:
-  description: Additional information about the result
-  returned: always
-  type: str
-  sample: "Nothing to do"
 results:
   description: A list of the dnf transaction results
   returned: success
@@ -344,11 +340,6 @@ failures:
   returned: failure
   type: list
   sample: ["Argument 'lsof' matches only excluded packages."]
-rc:
-  description: For compatibility, 0 for success, 1 for failure
-  returned: always
-  type: int
-  sample: 0
 """
 
 import os

--- a/lib/ansible/modules/dpkg_selections.py
+++ b/lib/ansible/modules/dpkg_selections.py
@@ -52,6 +52,19 @@ EXAMPLES = """
     selection: install
 """
 
+RETURN = """
+before:
+    description: The package selection state before any change.
+    returned: always
+    type: str
+    sample: install
+after:
+    description: The package selection state after the module runs.
+    returned: always
+    type: str
+    sample: hold
+"""
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.locale import get_best_parsable_locale
 

--- a/lib/ansible/modules/expect.py
+++ b/lib/ansible/modules/expect.py
@@ -118,6 +118,29 @@ EXAMPLES = r"""
             - "{{ db_password }}"
 """
 
+RETURN = r"""
+cmd:
+    description: The command executed by the task.
+    returned: always
+    type: str
+    sample: passwd username
+start:
+    description: The command execution start time.
+    returned: always
+    type: str
+    sample: '2017-09-29 22:03:48.083128'
+end:
+    description: The command execution end time.
+    returned: always
+    type: str
+    sample: '2017-09-29 22:03:48.084657'
+delta:
+    description: The command execution delta time.
+    returned: always
+    type: str
+    sample: '0:00:00.001529'
+"""
+
 import datetime
 import os
 

--- a/lib/ansible/modules/fetch.py
+++ b/lib/ansible/modules/fetch.py
@@ -121,3 +121,35 @@ EXAMPLES = r"""
     dest: special/prefix-{{ inventory_hostname }}
     flat: yes
 """
+
+RETURN = r"""
+dest:
+  description: Path to the local file that was fetched.
+  returned: success
+  type: str
+  sample: /tmp/fetched/host.example.com/tmp/somefile
+file:
+  description: Path to the remote source file.
+  returned: success
+  type: str
+  sample: /tmp/somefile
+checksum:
+  description: SHA1 checksum of the local file.
+  returned: success
+  type: str
+  sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
+md5sum:
+  description: MD5 checksum of the local file.
+  returned: success or checksum validation failure
+  type: str
+  sample: 2a5aeecc61dc98c4d780b14b330e3282
+remote_checksum:
+  description: SHA1 checksum of the remote file.
+  returned: when file is changed
+  type: str
+  sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
+remote_md5sum:
+  description: MD5 checksum of the remote file (currently always None).
+  returned: when file is changed
+  type: str
+"""

--- a/lib/ansible/modules/fetch.py
+++ b/lib/ansible/modules/fetch.py
@@ -123,6 +123,7 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+# This module will sometimes include return values from the slurp module (for files with checksum '1' or empty/None).
 dest:
   description: Path to the local file that was fetched.
   returned: success

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -231,6 +231,16 @@ path:
     returned: O(state=absent), O(state=directory), O(state=file)
     type: str
     sample: /path/to/file.txt
+src:
+    description: Source path of the symlink or hardlink.
+    returned: O(state=link), O(state=hard)
+    type: str
+    sample: /file/to/link/to
+state:
+    description: State of the target after module execution.
+    returned: O(state=absent)
+    type: str
+    sample: absent
 """
 
 import errno

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -279,6 +279,16 @@ skipped_paths:
     type: dict
     sample: {"/laskdfj": "'/laskdfj' is not a directory"}
     version_added: '2.12'
+age:
+    description: The age parameter value that failed to be parsed.
+    returned: when age parameter parsing fails
+    type: str
+    sample: "1x"
+size:
+    description: The size parameter value that failed to be parsed.
+    returned: when size parameter parsing fails
+    type: str
+    sample: "10x"
 """
 
 import errno

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -365,6 +365,11 @@ url:
     returned: always
     type: str
     sample: https://www.ansible.com/
+response:
+    description: the HTTP response message from a failed request
+    returned: when request fails
+    type: str
+    sample: HTTP Error 404: Not Found
 """
 
 import email.message

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -369,7 +369,7 @@ response:
     description: the HTTP response message from a failed request
     returned: when request fails
     type: str
-    sample: HTTP Error 404: Not Found
+    sample: "HTTP Error 404: Not Found"
 """
 
 import email.message

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -275,11 +275,6 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
-backup_file:
-    description: name of backup file created after download
-    returned: changed and if backup=yes
-    type: str
-    sample: /path/to/file.txt.2015-02-12@22:09~
 checksum_dest:
     description: sha1 checksum of the file after copy
     returned: success
@@ -320,11 +315,6 @@ mode:
     returned: success
     type: str
     sample: "0644"
-msg:
-    description: the HTTP message from the request
-    returned: always
-    type: str
-    sample: OK (unknown bytes)
 owner:
     description: owner of the file
     returned: success

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -325,6 +325,21 @@ git_dir_before:
     returned: success
     type: str
     sample: /path/to/old/git/dir
+submodules_changed:
+    description: Whether submodules were updated during the operation.
+    returned: when submodules are updated
+    type: bool
+    sample: true
+cmd:
+    description: The git command that failed.
+    returned: when git command fails
+    type: str
+    sample: git fetch origin
+details:
+    description: Additional details about a failure.
+    returned: when an operation fails
+    type: str
+    sample: "Git archive command failed to create archive"
 """
 
 import filecmp

--- a/lib/ansible/modules/group_by.py
+++ b/lib/ansible/modules/group_by.py
@@ -86,3 +86,17 @@ EXAMPLES = r"""
   ansible.builtin.group_by:
     key: done
 """
+
+RETURN = r"""
+add_group:
+  description: The name of the group that was added (spaces converted to dashes).
+  returned: always
+  type: str
+  sample: "red-hat-linux"
+parent_groups:
+  description: List of parent groups for the newly created group (spaces converted to dashes).
+  returned: always
+  type: list
+  elements: str
+  sample: ["all"]
+"""

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -64,6 +64,15 @@ EXAMPLES = """
     use: systemd
 """
 
+RETURN = r"""
+name:
+    description:
+      - The hostname that was set.
+    returned: always
+    type: str
+    sample: web01
+"""
+
 import os
 import platform
 import socket

--- a/lib/ansible/modules/include_vars.py
+++ b/lib/ansible/modules/include_vars.py
@@ -182,11 +182,6 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
-ansible_facts:
-  description: Variables that were included and their values
-  returned: success
-  type: dict
-  sample: {'variable': 'value'}
 ansible_included_var_files:
   description: A list of files that were successfully included
   returned: success

--- a/lib/ansible/modules/include_vars.py
+++ b/lib/ansible/modules/include_vars.py
@@ -188,4 +188,10 @@ ansible_included_var_files:
   type: list
   sample: [ /path/to/file.json, /path/to/file.yaml ]
   version_added: '2.4'
+message:
+  description: Error message if the module failed
+  returned: failure
+  type: str
+  sample: "/path/to/vars directory does not exist"
 """
+# FIXME: 'message' should not be a module result key (confusing with msg). We already have exception, stderr, and msg.

--- a/lib/ansible/modules/iptables.py
+++ b/lib/ansible/modules/iptables.py
@@ -547,6 +547,49 @@ EXAMPLES = r"""
     jump: ACCEPT
 """
 
+RETURN = r"""
+ip_version:
+    description: The IP version used for the rule.
+    returned: always
+    type: str
+    sample: ipv4
+table:
+    description: The table the rule was applied to.
+    returned: always
+    type: str
+    sample: filter
+chain:
+    description: The chain the rule was applied to.
+    returned: always
+    type: str
+    sample: INPUT
+flush:
+    description: Whether the chain was flushed.
+    returned: always
+    type: bool
+    sample: false
+rule:
+    description: The constructed iptables rule as a string.
+    returned: always
+    type: str
+    sample: -p tcp -m tcp --dport 22 -j ACCEPT
+state:
+    description: The state of the rule (present or absent).
+    returned: always
+    type: str
+    sample: present
+chain_management:
+    description: Whether chain management was enabled.
+    returned: always
+    type: bool
+    sample: false
+wait:
+    description: The wait option used with iptables command.
+    returned: always
+    type: str
+    sample: null
+"""
+
 import re
 
 from ansible.module_utils.compat.version import LooseVersion

--- a/lib/ansible/modules/known_hosts.py
+++ b/lib/ansible/modules/known_hosts.py
@@ -89,17 +89,6 @@ EXAMPLES = r"""
     state: present
 """
 
-# Makes sure public host keys are present or absent in the given known_hosts
-# file.
-#
-# Arguments
-# =========
-#    name = hostname whose key should be added (alias: host)
-#    key = line(s) to add to known_hosts file
-#    path = the known_hosts file to edit (default: ~/.ssh/known_hosts)
-#    hash_host = yes|no (default: no) hash the hostname in the known_hosts file
-#    state = absent|present (default: present)
-
 import base64
 import copy
 import hashlib

--- a/lib/ansible/modules/known_hosts.py
+++ b/lib/ansible/modules/known_hosts.py
@@ -89,6 +89,34 @@ EXAMPLES = r"""
     state: present
 """
 
+RETURN = r"""
+name:
+  description: The hostname that was added or removed.
+  returned: always
+  type: str
+  sample: "host1.example.com"
+key:
+  description: The SSH public host key.
+  returned: when provided
+  type: str
+  sample: "host1.example.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQ..."
+path:
+  description: The path to the known_hosts file.
+  returned: always
+  type: str
+  sample: "/etc/ssh/ssh_known_hosts"
+hash_host:
+  description: Whether the hostname should be hashed.
+  returned: always
+  type: bool
+  sample: false
+state:
+  description: The desired state of the host key.
+  returned: always
+  type: str
+  sample: "present"
+"""
+
 import base64
 import copy
 import hashlib

--- a/lib/ansible/modules/lineinfile.py
+++ b/lib/ansible/modules/lineinfile.py
@@ -246,7 +246,14 @@ EXAMPLES = r"""
     backrefs: yes
 """
 
-RETURN = r"""#"""
+RETURN = r"""
+found:
+    description:
+      - Number of lines found matching the search criteria.
+    returned: when state=absent
+    type: int
+    sample: 3
+"""
 
 import os
 import re

--- a/lib/ansible/modules/package.py
+++ b/lib/ansible/modules/package.py
@@ -92,3 +92,8 @@ EXAMPLES = """
     state: present
     use: dnf
 """
+
+RETURN = """
+# Return values depend on the underlying package manager module that is invoked.
+# See the documentation for the specific package manager module (dnf, apt, yum, etc.) for details.
+"""

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -290,6 +290,11 @@ virtualenv:
   returned: success, if a virtualenv path was provided
   type: str
   sample: "/tmp/virtualenv"
+state:
+  description: The state of the Python package
+  returned: success
+  type: str
+  sample: "present"
 """
 
 import argparse

--- a/lib/ansible/modules/reboot.py
+++ b/lib/ansible/modules/reboot.py
@@ -137,4 +137,9 @@ elapsed:
   returned: always
   type: int
   sample: 23
+start:
+  description: The time when the reboot was initiated.
+  returned: when reboot command fails
+  type: str
+  sample: "2024-04-15 10:30:45.123456+00:00"
 """

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -156,6 +156,8 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+# This module acts as a proxy and may return additional values from the underlying
+# service manager module that is invoked (systemd, sysvinit, etc.).
 name:
   description: The name of the service
   returned: always

--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -155,7 +155,23 @@ EXAMPLES = r"""
     args: eth0
 """
 
-RETURN = r"""#"""
+RETURN = r"""
+name:
+  description: The name of the service
+  returned: always
+  type: str
+  sample: httpd
+state:
+  description: The state of the service
+  returned: always
+  type: str
+  sample: started
+enabled:
+  description: Whether the service is enabled to start on boot
+  returned: when O(enabled) parameter is provided
+  type: bool
+  sample: true
+"""
 
 import glob
 import json

--- a/lib/ansible/modules/set_stats.py
+++ b/lib/ansible/modules/set_stats.py
@@ -79,3 +79,26 @@ EXAMPLES = r"""
       the_answer: 42
     aggregate: no
 """
+
+RETURN = r"""
+ansible_stats:
+  description: Dictionary containing the custom stats that were set.
+  returned: always
+  type: dict
+  contains:
+    data:
+      description: The statistics data that was set.
+      returned: always
+      type: dict
+      sample: {"packages_installed": 31, "the_answer": 42}
+    per_host:
+      description: Whether the stats are per host or for all hosts in the run.
+      returned: always
+      type: bool
+      sample: false
+    aggregate:
+      description: Whether the provided value is aggregated to the existing stat or replaces it.
+      returned: always
+      type: bool
+      sample: true
+"""

--- a/lib/ansible/modules/shell.py
+++ b/lib/ansible/modules/shell.py
@@ -153,11 +153,6 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
-msg:
-    description: changed
-    returned: always
-    type: bool
-    sample: True
 start:
     description: The command execution start time.
     returned: always
@@ -168,39 +163,4 @@ end:
     returned: always
     type: str
     sample: '2016-02-25 09:18:26.755339'
-delta:
-    description: The command execution delta time.
-    returned: always
-    type: str
-    sample: '0:00:00.325771'
-stdout:
-    description: The command standard output.
-    returned: always
-    type: str
-    sample: 'Clustering node rabbit@slave1 with rabbit@master …'
-stderr:
-    description: The command standard error.
-    returned: always
-    type: str
-    sample: 'ls: cannot access foo: No such file or directory'
-cmd:
-    description: The command executed by the task.
-    returned: always
-    type: str
-    sample: 'rabbitmqctl join_cluster rabbit@master'
-rc:
-    description: The command return code (0 means success).
-    returned: always
-    type: int
-    sample: 0
-stdout_lines:
-    description: The command standard output split in lines.
-    returned: always
-    type: list
-    sample: [u'Clustering node rabbit@slave1 with rabbit@master …']
-stderr_lines:
-    description: The command standard error split in lines.
-    returned: always
-    type: list
-    sample: [u'ls cannot access foo: No such file or directory', u'ls …']
 """

--- a/lib/ansible/modules/shell.py
+++ b/lib/ansible/modules/shell.py
@@ -153,6 +153,7 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+# This module will always include return values from the command module.
 start:
     description: The command execution start time.
     returned: always

--- a/lib/ansible/modules/shell.py
+++ b/lib/ansible/modules/shell.py
@@ -163,4 +163,13 @@ end:
     returned: always
     type: str
     sample: '2016-02-25 09:18:26.755339'
+stdout:
+    description:
+      - The standard output from the command execution.
+      - When O(creates) or O(removes) causes the task to skip, contains an informational skip message instead of command output.
+      - This module delegates to M(ansible.builtin.command), so see that module's return values for additional details.
+    returned: always
+    type: str
+    sample: 'Clustering node rabbit@slave1 with rabbit@master …'
 """
+# TODO: Deprecate the skip message usage of stdout in favor of skip_reason

--- a/lib/ansible/modules/subversion.py
+++ b/lib/ansible/modules/subversion.py
@@ -128,7 +128,18 @@ EXAMPLES = """
     update: no
 """
 
-RETURN = r"""#"""
+RETURN = r"""
+before:
+  description: The revision and URL before the update
+  returned: success, when repository exists
+  type: raw
+  sample: "Revision: 1889134"
+after:
+  description: The revision and URL after the update
+  returned: success
+  type: raw
+  sample: "Revision: 1889134"
+"""
 
 import os
 import re

--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -152,6 +152,21 @@ EXAMPLES = """
 """
 
 RETURN = """
+name:
+    description: The name of the systemd unit
+    returned: always
+    type: str
+    sample: "httpd"
+state:
+    description: The state of the systemd unit
+    returned: when O(state) is provided
+    type: str
+    sample: "started"
+enabled:
+    description: Whether the systemd unit is enabled
+    returned: when O(enabled) is provided
+    type: bool
+    sample: true
 status:
     description: A dictionary with the key=value pairs returned from C(systemctl show).
     returned: success

--- a/lib/ansible/modules/template.py
+++ b/lib/ansible/modules/template.py
@@ -111,6 +111,7 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+# This module will always include return values from the copy action plugin.
 dest:
     description: Destination file/path, equal to the value passed to I(dest).
     returned: success

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -237,6 +237,27 @@ uid:
   returned: always
   type: int
   sample: 1000
+extract_results:
+  description: Results from the extraction command
+  returned: when archive was extracted
+  type: dict
+  contains:
+    cmd:
+      description: Command used to extract the archive
+      type: list
+      sample: ["/usr/bin/unzip", "-o", "/tmp/archive.zip", "-d", "/opt/software"]
+    rc:
+      description: Return code from the extraction command
+      type: int
+      sample: 0
+    out:
+      description: Standard output from the extraction command
+      type: str
+      sample: ""
+    err:
+      description: Standard error from the extraction command
+      type: str
+      sample: ""
 """
 
 import binascii

--- a/lib/ansible/modules/uri.py
+++ b/lib/ansible/modules/uri.py
@@ -430,7 +430,13 @@ url:
   returned: always
   type: str
   sample: https://www.ansible.com/
+stdout:
+  description: Informational message when creates or removes causes the task to skip.
+  returned: when creates or removes causes a skip
+  type: str
+  sample: "skipped, since '/path/to/file' exists"
 """
+# TODO: Deprecate this use of stdout in favor of msg
 
 import http
 import json

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -477,16 +477,6 @@ ssh_public_key:
     'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC95opt4SPEC06tOYsJQJIuN23BbLMGmYo8ysVZQc4h2DZE9ugbjWWGS1/pweUGjVstgzMkBEeBCByaEf/RJKNecKRPeGd2Bw9DCj/bn5Z6rGfNENKBmo
     618mUJBvdlEgea96QGjOwSB7/gmonduC7gsWDMNcOdSE3wJMTim4lddiBx4RgC9yXsJ6Tkz9BHD73MXPpT5ETnse+A3fw3IGVSjaueVnlUyUmOBf7fzmZbhlFVXf2Zi2rFTXqvbdGHKkzpw1U8eB8xFPP7y
     d5u1u0e6Acju/8aZ/l17IDFiLke5IzlqIMRTEbDwLNeO84YQKWTm9fODHzhYe0yvxqLiK07 ansible-generated on host'
-stderr:
-  description: Standard error from running commands.
-  returned: When stderr is returned by a command that is run
-  type: str
-  sample: Group wheels does not exist
-stdout:
-  description: Standard output from running commands.
-  returned: When standard output is returned by the command that is run
-  type: str
-  sample:
 system:
   description: Whether or not the account is a system account.
   returned: When O(system) is passed to the module and the account does not exist
@@ -497,6 +487,11 @@ uid:
   returned: When O(uid) is passed to the module
   type: int
   sample: 1044
+state:
+  description: The state of the user account.
+  returned: always
+  type: str
+  sample: present
 """
 
 

--- a/lib/ansible/modules/wait_for.py
+++ b/lib/ansible/modules/wait_for.py
@@ -215,6 +215,26 @@ elapsed:
   returned: always
   type: int
   sample: 23
+state:
+  description: The state that was waited for
+  returned: always
+  type: str
+  sample: started
+port:
+  description: The port number that was waited for
+  returned: when O(port) is provided
+  type: int
+  sample: 22
+search_regex:
+  description: The search regex pattern that was used
+  returned: when O(search_regex) is provided
+  type: str
+  sample: "completed"
+path:
+  description: The file path that was waited for
+  returned: when O(path) is provided
+  type: str
+  sample: /tmp/foo
 match_groups:
   description: Tuple containing all the subgroups of the match as returned by U(https://docs.python.org/3/library/re.html#re.Match.groups)
   returned: always

--- a/lib/ansible/plugins/action/set_stats.py
+++ b/lib/ansible/plugins/action/set_stats.py
@@ -28,7 +28,6 @@ class ActionModule(ActionBase):
     _VALID_ARGS = frozenset(('aggregate', 'data', 'per_host'))
     _requires_connection = False
 
-    # TODO: document this in non-empty set_stats.py module
     def run(self, tmp=None, task_vars=None):
         if task_vars is None:
             task_vars = dict()


### PR DESCRIPTION
##### SUMMARY

  - **Adds missing RETURN documentation to 19 modules**: ``add_host``, ``assemble``, ``assert``, ``cron``, ``debconf``, ``debug``, ``dpkg_selections``, ``expect``, ``fetch``, ``group_by``, ``hostname``, ``include_vars``, ``iptables``, ``known_hosts``, ``lineinfile``, ``package``, ``service``, ``set_stats``, ``subversion``                                                                                         
  - **Removes redundant common return value documentation from 8 modules**:
    - ``apt`` (stdout/stderr)
    - ``async_status`` (stdout/stderr)
    - ``command`` (msg, stderr, rc, stdout_lines, stderr_lines)
    - ``copy`` (backup_file), ``dnf5`` (msg, rc)
    - ``get_url`` (backup_file, msg)
    - ``shell`` (msg, delta, stderr, cmd, rc, stdout_lines, stderr_lines)
    - ``user`` (stderr, stdout)
  - **Adds module-specific return values to 14 modules**: 
    - ``apt_repository`` (state)
    - ``async_status`` (results_file)
    - ``dnf`` (results, failures)
    - ``file`` (src, state)
    - ``find`` (age, size)
    - ``get_url`` (response)
    - ``git`` (submodules_changed, cmd, details)
    - ``pip`` (state)
    - ``reboot`` (start)
    - ``systemd_service`` (name, state, enabled)
    - ``unarchive`` (extract_results)
    - ``uri`` (stdout)
    - ``user`` (state)
    - ``wait_for`` (state, port, search_regex, path)
  - Documents return value delegation in 4 modules:
    - assemble (sometimes includes copy or file module return values)
    - shell (always includes command module return values)
    - template (always includes copy action plugin return values)
    - fetch (sometimes includes slurp module return values)  

##### FOLLOWUPS

This PR is the first in a series of return value normalization PRs. Planned followup work (note some of these aren't *planned* but these are just some ideas):

  - **``dnf``/``dnf5`` modules - ``results`` and ``failures`` keys**: These use generic names that conflict with common task result patterns and should be renamed to module-specific names (e.g., ``packages_installed``, ``package_failures``). Already reported in #70003
  - **``include_vars`` module - ``message`` key**: Confusing overlap with the standard ``msg`` return value; should use ``msg`` or a more specific key.                                                       
  - **``command``/``shell``/``uri`` modules - ``stdout`` for various messages**: Using ``stdout`` to return skip messages when ``creates``/``removes`` conditions are met is inconsistent; should migrate to ``skip_reason`` or ``msg`` - related to https://github.com/ansible/ansible/issues/84107#issuecomment-4158261907
  - **Many modules** - Always include stdout, stderr, and rc together (potentially other consistency/QOL changes in this same vein) note: some modules like getent don't expose any of these when they probably should.
  - **Many modules** - Assess module arg echoing (Comments seem to indicate that this isn't desired behavior).
  - **expand RETURN documentation block functionality** - Expand functionality of RETURN docs block to have a structure mimicking the DOCUMENTATION block. This allows for better inclusion of notes (`# Depends on module yada yada`). Furthermore, it would allow for the introduction of fragment extensions when a module invokes another module. I'm thinking something like `This module sometimes/always/whatever includes the return values of the `copy` module with either a link or a copy of the module's doc fragment.
  - **Common return fields** - Move `skip*_reason` to common return args and mark deprecated (note: many modules are using `msg` (some are even using `stdout`) to communicate some kind of skip message. fix this)

##### ISSUE TYPE

- Docs Pull Request