### PR TITLE
ansible-test - Replace Fedora 43 with 44

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -132,8 +132,8 @@ stages:
           targets:
             - name: Alpine 3.23
               test: alpine/3.23
-            - name: Fedora 43
-              test: fedora/43
+            - name: Fedora 44
+              test: fedora/44
             - name: RHEL 9.7
               test: rhel/9.7
             - name: RHEL 10.1
@@ -161,8 +161,8 @@ stages:
           targets:
             - name: Alpine 3.23
               test: alpine323
-            - name: Fedora 43
-              test: fedora43
+            - name: Fedora 44
+              test: fedora44
             - name: Ubuntu 22.04
               test: ubuntu2204
             - name: Ubuntu 24.04
@@ -176,8 +176,8 @@ stages:
           targets:
             - name: Alpine 3.23
               test: alpine323
-            - name: Fedora 43
-              test: fedora43
+            - name: Fedora 44
+              test: fedora44
             - name: Ubuntu 24.04
               test: ubuntu2404
           groups:
@@ -188,8 +188,8 @@ stages:
         parameters:
           testFormat: linux/{0}
           targets:
-            - name: Fedora 43
-              test: fedora43
+            - name: Fedora 44
+              test: fedora44
           groups:
             - 7
   - stage: PowerShell

--- a/changelogs/fragments/ansible-test-fedora-44.yml
+++ b/changelogs/fragments/ansible-test-fedora-44.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Replace Fedora 43 container and remote with 44.

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -2,6 +2,6 @@ base image=quay.io/ansible/base-test-container:v2.22-0 python=3.14,3.9,3.10,3.11
 default image=quay.io/ansible/default-test-container:v2.22-0 python=3.14,3.9,3.10,3.11,3.12,3.13,3.15 powershell=7.6 context=collection
 default image=quay.io/ansible/ansible-core-test-container:v2.22-0 python=3.14,3.9,3.10,3.11,3.12,3.13,3.15 powershell=7.6 context=ansible-core
 alpine323 image=quay.io/ansible/alpine-test-container:3.23-v2.22-0 python=3.12 cgroup=none audit=none alias=alpine
-fedora43 image=quay.io/ansible/fedora-test-container:43-v2.22-0 python=3.14 cgroup=v2-only alias=fedora
+fedora44 image=quay.io/ansible/fedora-test-container:44-v2.22-1 python=3.14 cgroup=v2-only alias=fedora
 ubuntu2204 image=quay.io/ansible/ubuntu-test-container:22.04-v2.22-0 python=3.10
 ubuntu2404 image=quay.io/ansible/ubuntu-test-container:24.04-v2.22-0 python=3.12 alias=ubuntu

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -1,6 +1,6 @@
 alpine/3.23 python=3.12 become=doas_sudo provider=aws arch=x86_64 alias=alpine/3,alpine/latest
 alpine become=doas_sudo provider=aws arch=x86_64
-fedora/43 python=3.14 become=sudo provider=aws arch=x86_64 alias=fedora/latest
+fedora/44 python=3.14 become=sudo provider=aws arch=x86_64 alias=fedora/latest
 fedora become=sudo provider=aws arch=x86_64
 freebsd/14.4 python=3.14 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64 alias=freebsd/14
 freebsd/15.0 python=3.12 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64 alias=freebsd/15,freebsd/latest


### PR DESCRIPTION
##### SUMMARY

ansible-test - Replace Fedora 43 with 44.

##### ISSUE TYPE

Feature Pull Request
