### PR TITLE
Remove Windows Server 2016 support

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -69,8 +69,6 @@ stages:
           nameFormat: Server {0}
           testFormat: windows/{0}/1
           targets:
-            - name: 2016 WinRM HTTP WinPS
-              test: 2016/winrm/http/5.1
             - name: 2019 WinRM HTTPS WinPS
               test: 2019/winrm/https/5.1
             - name: 2022 WinRM HTTPS WinPS
@@ -234,8 +232,6 @@ stages:
           nameFormat: Server {0}
           testFormat: i/windows/{0}
           targets:
-            - name: 2016 WinRM HTTP WinPS
-              test: 2016/winrm/http/5.1
             - name: 2019 WinRM HTTPS WinPS
               test: 2019/winrm/https/5.1
             - name: 2022 WinRM HTTPS WinPS

--- a/changelogs/fragments/ansible-test-windows-server-2016.yml
+++ b/changelogs/fragments/ansible-test-windows-server-2016.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Remove support for Windows Server 2016 managed remote.

--- a/changelogs/fragments/psrp-2016.yml
+++ b/changelogs/fragments/psrp-2016.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - psrp connection plugin - Remove explicit error handling support for Windows Server 2016.

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -746,17 +746,7 @@ class Connection(ConnectionBase):
             # NativeCommandError and NativeCommandErrorMessage are special
             # cases used for stderr from a subprocess, we will just print the
             # error message
-            if error.fq_error == 'NativeCommandErrorMessage' and not error.target_name:
-                # This can be removed once Server 2016 is EOL and no longer
-                # supported. PS 5.1 on 2016 will emit 1 error record under
-                # NativeCommandError being the first line, subsequent records
-                # are the raw stderr up to 4096 chars. Each entry is the raw
-                # stderr value without any newlines appended so we just use the
-                # value as is. We know it's 2016 as the target_name is empty in
-                # this scenario.
-                stderr_list.append(str(error))
-                continue
-            elif error.fq_error in ['NativeCommandError', 'NativeCommandErrorMessage']:
+            if error.fq_error in ['NativeCommandError', 'NativeCommandErrorMessage']:
                 stderr_list.append(f"{error}\r\n")
                 continue
 

--- a/test/integration/targets/module_utils_Ansible.Basic/library/ansible_basic_tests.ps1
+++ b/test/integration/targets/module_utils_Ansible.Basic/library/ansible_basic_tests.ps1
@@ -2045,33 +2045,10 @@ test_no_log - Invoked with:
             $output = [Ansible.Basic.AnsibleModule]::FromJson($_.Exception.InnerException.Output)
         }
 
-        if ([System.Environment]::OSVersion.Version -lt [Version]'10.0') {
-            # Older hosts can only do delete on close. This means Dir1 and its
-            # file will still be present but Dir2 should be deleted.
-            $expected_msg = "Failure cleaning temp path '$actual_tmpdir': IOException Directory contains files still open by other processes"
-            $output.warnings.Count | Assert-Equal -Expected 1
-            $output.warnings[0] | Assert-Equal -Expected $expected_msg
+        (Test-Path -LiteralPath $actual_tmpdir -PathType Container) | Assert-Equal -Expected $false
+        $output.warnings.Count | Assert-Equal -Expected 0
 
-            (Test-Path -LiteralPath $actual_tmpdir -PathType Container) | Assert-Equal -Expected $true
-            (Test-Path -LiteralPath $dir1 -PathType Container) | Assert-Equal -Expected $true
-            # Test-Path tries to open the file in a way that fails if it's marked as deleted
-            (Get-ChildItem -LiteralPath $dir1 -File).Count | Assert-Equal -Expected 1
-            (Test-Path -LiteralPath $dir2 -PathType Container) | Assert-Equal -Expected $false
-            (Test-Path -LiteralPath $file3 -PathType Leaf) | Assert-Equal -Expected $false
-
-            # Releasing the file handle releases the lock on the file deleting
-            # it. Unfortunately the parent dir will still be present
-            $fs.Dispose()
-            (Test-Path -LiteralPath $dir1 -PathType Container) | Assert-Equal -Expected $true
-            (Test-Path -LiteralPath $file1 -PathType Leaf) | Assert-Equal -Expected $false
-        }
-        else {
-            # Server 2016+ can use the POSIX APIs which will delete it straight away
-            (Test-Path -LiteralPath $actual_tmpdir -PathType Container) | Assert-Equal -Expected $false
-            $output.warnings.Count | Assert-Equal -Expected 0
-
-            $fs.Dispose()
-        }
+        $fs.Dispose()
 
         Remove-Item -LiteralPath $remote_tmp -Force -Recurse
     }

--- a/test/integration/targets/win_app_control/main.yml
+++ b/test/integration/targets/win_app_control/main.yml
@@ -20,14 +20,7 @@
       - ansible_install_dir is defined
       - local_tmp_dir is defined
 
-  - name: get OS version
-    ansible.windows.win_powershell:
-      script: (Get-Item -LiteralPath $env:SystemRoot\System32\kernel32.dll).VersionInfo.ProductVersion.ToString()
-    register: os_version
-
-  - name: setup and test block for 2019 and later
-    when:
-    - os_version.output[0] is version('10.0.17763', '>=')  # 2019+
+  - name: setup and test block
     block:
     - name: get test remote tmp dir
       import_role:

--- a/test/integration/targets/win_app_control/main.yml
+++ b/test/integration/targets/win_app_control/main.yml
@@ -20,87 +20,96 @@
       - ansible_install_dir is defined
       - local_tmp_dir is defined
 
-  - name: get test remote tmp dir
-    import_role:
-      name: ../setup_remote_tmp_dir
-
-  - name: get current user
+  - name: get OS version
     ansible.windows.win_powershell:
-      script: '[Environment]::UserName'
-    register: current_user_raw
+      script: (Get-Item -LiteralPath $env:SystemRoot\System32\kernel32.dll).VersionInfo.ProductVersion.ToString()
+    register: os_version
 
-  - name: set current user fact
-    set_fact:
-      current_user: '{{ current_user_raw.output[0] }}'
-
-  # Environment.UserName is SYSTEM on .NET Framework and the computer name on .NET 5+
-  - name: get SYSTEM username
-    ansible.windows.win_powershell:
-      script: '[Environment]::UserName'
-    register: system_user_raw
-    become: true
-    become_method: runas
-    become_user: SYSTEM
-
-  - name: set system user fact
-    set_fact:
-      system_user: '{{ system_user_raw.output[0] }}'
-
-  - name: setup App Control
-    import_tasks: setup.yml
-
-  - name: run content before enabling App Control
-    import_tasks: test_not_enabled.yml
-
-  - name: enable App Control
-    wdac_enable:
-      remote_tmp_dir: '{{ remote_tmp_dir }}'
-    register: policy_info
-
-  - name: run content after enabling App Control
-    import_tasks: test_enabled.yml
-
-  - name: run invalid manifest tests
-    import_tasks: test_manifest.yml
-
-  always:
-  - name: disable policy through CiTool if present
-    win_shell: CiTool.exe --remove-policy {{ policy_info.policy_id }}
+  - name: setup and test block for 2019 and later
     when:
-    - policy_info is defined
-    - policy_info.policy_id is truthy
+    - os_version.output[0] is version('10.0.17763', '>=')  # 2019+
+    block:
+    - name: get test remote tmp dir
+      import_role:
+        name: ../setup_remote_tmp_dir
 
-  - name: remove App Control policy
-    win_file:
-      path: '{{ policy_info.path }}'
-      state: absent
-    register: policy_removal
-    when:
-    - policy_info is defined
+    - name: get current user
+      ansible.windows.win_powershell:
+        script: '[Environment]::UserName'
+      register: current_user_raw
 
-  - name: reboot after removing policy file
-    win_reboot:
-    when: policy_removal is changed
+    - name: set current user fact
+      set_fact:
+        current_user: '{{ current_user_raw.output[0] }}'
 
-  - name: remove certificates
-    ansible.windows.win_powershell:
-      script: |
-        param($CAThumbprint, $Thumbprint)
+    # Environment.UserName is SYSTEM on .NET Framework and the computer name on .NET 5+
+    - name: get SYSTEM username
+      ansible.windows.win_powershell:
+        script: '[Environment]::UserName'
+      register: system_user_raw
+      become: true
+      become_method: runas
+      become_user: SYSTEM
 
-        $ErrorActionPreference = 'Stop'
+    - name: set system user fact
+      set_fact:
+        system_user: '{{ system_user_raw.output[0] }}'
 
-        Remove-Item -LiteralPath "Cert:\LocalMachine\Root\$CAThumbprint" -Force
-        Remove-Item -LiteralPath "Cert:\LocalMachine\TrustedPublisher\$Thumbprint" -Force
-      parameters:
-        CAThumbprint: '{{ cert_info.ca_thumbprint }}'
-        Thumbprint: '{{ cert_info.thumbprint }}'
-    when: cert_info is defined
+    - name: setup App Control
+      import_tasks: setup.yml
 
-  - name: remove signed Ansible content
-    file:
-      path: '{{ ansible_install_dir }}/{{ item }}'
-      state: absent
-    loop:
-    - config/powershell_signatures.psd1
-    - executor/powershell/exec_wrapper.ps1.authenticode
-    delegate_to: localhost
+    - name: run content before enabling App Control
+      import_tasks: test_not_enabled.yml
+
+    - name: enable App Control
+      wdac_enable:
+        remote_tmp_dir: '{{ remote_tmp_dir }}'
+      register: policy_info
+
+    - name: run content after enabling App Control
+      import_tasks: test_enabled.yml
+
+    - name: run invalid manifest tests
+      import_tasks: test_manifest.yml
+
+    always:
+    - name: disable policy through CiTool if present
+      win_shell: CiTool.exe --remove-policy {{ policy_info.policy_id }}
+      when:
+      - policy_info is defined
+      - policy_info.policy_id is truthy
+
+    - name: remove App Control policy
+      win_file:
+        path: '{{ policy_info.path }}'
+        state: absent
+      register: policy_removal
+      when:
+      - policy_info is defined
+
+    - name: reboot after removing policy file
+      win_reboot:
+      when: policy_removal is changed
+
+    - name: remove certificates
+      ansible.windows.win_powershell:
+        script: |
+          param($CAThumbprint, $Thumbprint)
+
+          $ErrorActionPreference = 'Stop'
+
+          Remove-Item -LiteralPath "Cert:\LocalMachine\Root\$CAThumbprint" -Force
+          Remove-Item -LiteralPath "Cert:\LocalMachine\TrustedPublisher\$Thumbprint" -Force
+        parameters:
+          CAThumbprint: '{{ cert_info.ca_thumbprint }}'
+          Thumbprint: '{{ cert_info.thumbprint }}'
+      when: cert_info is defined
+
+    - name: remove signed Ansible content
+      file:
+        path: '{{ ansible_install_dir }}/{{ item }}'
+        state: absent
+      loop:
+      - config/powershell_signatures.psd1
+      - executor/powershell/exec_wrapper.ps1.authenticode
+      delegate_to: localhost

--- a/test/integration/targets/win_app_control/main.yml
+++ b/test/integration/targets/win_app_control/main.yml
@@ -20,96 +20,87 @@
       - ansible_install_dir is defined
       - local_tmp_dir is defined
 
-  - name: get OS version
+  - name: get test remote tmp dir
+    import_role:
+      name: ../setup_remote_tmp_dir
+
+  - name: get current user
     ansible.windows.win_powershell:
-      script: (Get-Item -LiteralPath $env:SystemRoot\System32\kernel32.dll).VersionInfo.ProductVersion.ToString()
-    register: os_version
+      script: '[Environment]::UserName'
+    register: current_user_raw
 
-  - name: setup and test block for 2019 and later
+  - name: set current user fact
+    set_fact:
+      current_user: '{{ current_user_raw.output[0] }}'
+
+  # Environment.UserName is SYSTEM on .NET Framework and the computer name on .NET 5+
+  - name: get SYSTEM username
+    ansible.windows.win_powershell:
+      script: '[Environment]::UserName'
+    register: system_user_raw
+    become: true
+    become_method: runas
+    become_user: SYSTEM
+
+  - name: set system user fact
+    set_fact:
+      system_user: '{{ system_user_raw.output[0] }}'
+
+  - name: setup App Control
+    import_tasks: setup.yml
+
+  - name: run content before enabling App Control
+    import_tasks: test_not_enabled.yml
+
+  - name: enable App Control
+    wdac_enable:
+      remote_tmp_dir: '{{ remote_tmp_dir }}'
+    register: policy_info
+
+  - name: run content after enabling App Control
+    import_tasks: test_enabled.yml
+
+  - name: run invalid manifest tests
+    import_tasks: test_manifest.yml
+
+  always:
+  - name: disable policy through CiTool if present
+    win_shell: CiTool.exe --remove-policy {{ policy_info.policy_id }}
     when:
-    - os_version.output[0] is version('10.0.17763', '>=')  # 2019+
-    block:
-    - name: get test remote tmp dir
-      import_role:
-        name: ../setup_remote_tmp_dir
+    - policy_info is defined
+    - policy_info.policy_id is truthy
 
-    - name: get current user
-      ansible.windows.win_powershell:
-        script: '[Environment]::UserName'
-      register: current_user_raw
+  - name: remove App Control policy
+    win_file:
+      path: '{{ policy_info.path }}'
+      state: absent
+    register: policy_removal
+    when:
+    - policy_info is defined
 
-    - name: set current user fact
-      set_fact:
-        current_user: '{{ current_user_raw.output[0] }}'
+  - name: reboot after removing policy file
+    win_reboot:
+    when: policy_removal is changed
 
-    # Environment.UserName is SYSTEM on .NET Framework and the computer name on .NET 5+
-    - name: get SYSTEM username
-      ansible.windows.win_powershell:
-        script: '[Environment]::UserName'
-      register: system_user_raw
-      become: true
-      become_method: runas
-      become_user: SYSTEM
+  - name: remove certificates
+    ansible.windows.win_powershell:
+      script: |
+        param($CAThumbprint, $Thumbprint)
 
-    - name: set system user fact
-      set_fact:
-        system_user: '{{ system_user_raw.output[0] }}'
+        $ErrorActionPreference = 'Stop'
 
-    - name: setup App Control
-      import_tasks: setup.yml
+        Remove-Item -LiteralPath "Cert:\LocalMachine\Root\$CAThumbprint" -Force
+        Remove-Item -LiteralPath "Cert:\LocalMachine\TrustedPublisher\$Thumbprint" -Force
+      parameters:
+        CAThumbprint: '{{ cert_info.ca_thumbprint }}'
+        Thumbprint: '{{ cert_info.thumbprint }}'
+    when: cert_info is defined
 
-    - name: run content before enabling App Control
-      import_tasks: test_not_enabled.yml
-
-    - name: enable App Control
-      wdac_enable:
-        remote_tmp_dir: '{{ remote_tmp_dir }}'
-      register: policy_info
-
-    - name: run content after enabling App Control
-      import_tasks: test_enabled.yml
-
-    - name: run invalid manifest tests
-      import_tasks: test_manifest.yml
-
-    always:
-    - name: disable policy through CiTool if present
-      win_shell: CiTool.exe --remove-policy {{ policy_info.policy_id }}
-      when:
-      - policy_info is defined
-      - policy_info.policy_id is truthy
-
-    - name: remove App Control policy
-      win_file:
-        path: '{{ policy_info.path }}'
-        state: absent
-      register: policy_removal
-      when:
-      - policy_info is defined
-
-    - name: reboot after removing policy file
-      win_reboot:
-      when: policy_removal is changed
-
-    - name: remove certificates
-      ansible.windows.win_powershell:
-        script: |
-          param($CAThumbprint, $Thumbprint)
-
-          $ErrorActionPreference = 'Stop'
-
-          Remove-Item -LiteralPath "Cert:\LocalMachine\Root\$CAThumbprint" -Force
-          Remove-Item -LiteralPath "Cert:\LocalMachine\TrustedPublisher\$Thumbprint" -Force
-        parameters:
-          CAThumbprint: '{{ cert_info.ca_thumbprint }}'
-          Thumbprint: '{{ cert_info.thumbprint }}'
-      when: cert_info is defined
-
-    - name: remove signed Ansible content
-      file:
-        path: '{{ ansible_install_dir }}/{{ item }}'
-        state: absent
-      loop:
-      - config/powershell_signatures.psd1
-      - executor/powershell/exec_wrapper.ps1.authenticode
-      delegate_to: localhost
+  - name: remove signed Ansible content
+    file:
+      path: '{{ ansible_install_dir }}/{{ item }}'
+      state: absent
+    loop:
+    - config/powershell_signatures.psd1
+    - executor/powershell/exec_wrapper.ps1.authenticode
+    delegate_to: localhost

--- a/test/integration/targets/win_script/tasks/main.yml
+++ b/test/integration/targets/win_script/tasks/main.yml
@@ -335,9 +335,9 @@
     that:
     - script_stderr.rc == 0
     - script_stderr.stdout == ""
-    # SSH includes debug output in stderr, and WinRM on 2016 includes a trailing newline
+    # SSH includes debug output in stderr and includes a trailing newline
     # Use a simple search to ensure the expected stderr is present but ignoring any extra output
-    - script_stderr.stderr is search("stderr 1\r\nstderr 2\r\n")
+    - script_stderr.stderr == "stderr 1\r\nstderr 2\r\n"
 
 - name: run script with non-ASCII contents
   script: test_script_unicode.ps1

--- a/test/lib/ansible_test/_data/completion/windows.txt
+++ b/test/lib/ansible_test/_data/completion/windows.txt
@@ -1,4 +1,3 @@
-windows/2016 provider=aws arch=x86_64 connection=winrm+http
 windows/2019 provider=aws arch=x86_64 connection=winrm+https
 windows/2022 provider=aws arch=x86_64 connection=winrm+https
 windows/2025 provider=aws arch=x86_64 connection=psrp+http alias=windows/latest


### PR DESCRIPTION
##### SUMMARY

Remove Windows Server 2016 support.

Extended support for Windows Server 2016 [ends](https://www.microsoft.com/en-us/windows-server/blog/2026/02/25/planning-ahead-for-windows-server-2016-end-of-support/) on January 12, 2027.

##### ISSUE TYPE

Feature Pull Request
