### PR TITLE
Fix groupby filter default parameter not working with missing keys

### DIFF
--- a/changelogs/fragments/86827-fix-groupby-default.yaml
+++ b/changelogs/fragments/86827-fix-groupby-default.yaml
@@ -1,3 +1,2 @@
 bugfixes:
-  - groupby - fix default parameter when key is missing
-  - "https://github.com/ansible/ansible/issues/86827"
+  - groupby filter plugin - fix default parameter when key is missing (https://github.com/ansible/ansible/issues/86827).

--- a/changelogs/fragments/86827-fix-groupby-default.yaml
+++ b/changelogs/fragments/86827-fix-groupby-default.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - groupby - fix default parameter when key is missing
+  - "https://github.com/ansible/ansible/issues/86827"

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -52,7 +52,7 @@ def to_yaml(a, *_args, default_flow_style: bool | None = None, vault_behavior: s
     """Serialize input as terse flow-style YAML."""
 
     if vault_behavior and vault_behavior not in VaultBehaviors:
-        raise AnsibleFilterError(f"The vault parameter must be one of {", ".join(VaultBehaviors)}")
+        raise AnsibleFilterError(f"The vault parameter must be one of {', '.join(VaultBehaviors)}")
 
     behavior = VaultBehaviors(vault_behavior) if vault_behavior else VaultBehaviors.decrypt
 
@@ -663,15 +663,16 @@ class GroupTuple(t.NamedTuple):
         return tuple.__repr__(self)
 
 
-_lazy_containers.register_known_types(GroupTuple)
-
-
+@accept_lazy_markers
 @pass_environment
 def _cleansed_groupby(*args, **kwargs):
     res = sync_do_groupby(*args, **kwargs)
     res = [GroupTuple(grouper=g.grouper, list=g.list) for g in res]
 
     return res
+
+
+_lazy_containers.register_known_types(GroupTuple)
 
 # DTFIX-FUTURE: make these dumb wrappers more dynamic
 

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -31,6 +31,23 @@
       - |
         ([{'a': 1}] | groupby('a'))[0] | string == "(1, [{'a': 1}])"
 
+- name: test groupby filter with default parameter
+  vars:
+    test_data:
+      - name: apple
+        color: red
+      - name: banana
+      - name: cherry
+        color: red
+      - name: date
+  assert:
+    that:
+      - "(test_data | groupby('color', default='unknown'))[0].grouper == 'red'"
+      - "(test_data | groupby('color', default='unknown'))[0].list | length == 2"
+      - "(test_data | groupby('color', default='unknown'))[1].grouper == 'unknown'"
+      - "(test_data | groupby('color', default='unknown'))[1].list | length == 2"
+      - "(test_data | groupby('color', default='unknown') | map(attribute='grouper') | sort) == ['red', 'unknown']"
+
 - name: test updated default filter
   assert:
     that:


### PR DESCRIPTION
## Summary

The groupby filter was missing the `@accept_lazy_markers` decorator, which prevented the 'default' parameter from working correctly when a dict in the list was missing the key to group by.

When using `groupby('city', default='NY')`, dictionaries missing the 'city' key would cause an error instead of using the default value.

## Root Cause

The `_cleansed_groupby` function was missing the `@accept_lazy_markers` decorator that other similar filters (like `wrapped_map`, `wrapped_select`, etc.) have.

## Fix

1. Added `@accept_lazy_markers` decorator to `_cleansed_groupby`
2. Moved `_lazy_containers.register_known_types(GroupTuple)` after the function definition

## Issue

Fixes https://github.com/ansible/ansible/issues/86827

## ISSUE TYPE

- Bugfix Pull Request
