### PR TITLE
Disable ansible-test azure cloud self-test

### DIFF
--- a/test/integration/targets/ansible-test-cloud-azure/aliases
+++ b/test/integration/targets/ansible-test-cloud-azure/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 shippable/generic/group1
 context/controller
+disabled/yes  # Azure credential provisioner pool broken in Core CI (likely SP policy)


### PR DESCRIPTION
##### SUMMARY
* Core CI service principal pool is broken, likely new global policy. This service is not used by core.

##### ISSUE TYPE
- Test Pull Request
