### PR TITLE
Increase support for ftp urls across modules

### DIFF
--- a/changelogs/fragments/83321-rpm-key-ftp-support.yml
+++ b/changelogs/fragments/83321-rpm-key-ftp-support.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - rpm_key - Fix module failure when fetching GPG keys from FTP URLs (https://github.com/ansible/ansible/issues/83321).
+minor_changes:
+  - module_utils.urls - Added ``is_fetch_success()`` function for protocol-aware success detection of ``fetch_url()`` responses.

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1315,6 +1315,32 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     return r, info
 
 
+def is_fetch_success(info: dict, additional_codes: list = None) -> bool:
+    """Determine if a fetch_url response is successful independent of the protocol.
+    :arg info: info dictionary returned from fetch_url
+
+    :kwarg additional_codes: (Optional) List of additional status codes that will be considered a success"""
+
+    status = info.get('status', -1)
+    url = info.get('url', '').lower()
+
+    # Allow user to override with specific codes
+    if additional_codes and status in additional_codes:
+        return True
+
+    # General failure
+    if status == -1:
+        return False
+
+    if url.startswith('http'):
+        return status == 200
+    elif url.startswith('ftp'):
+        return status is None
+
+    # Should never reach here, assume failure
+    return False
+
+
 def _suffixes(name):
     """A list of the final component's suffixes, if any."""
     if name.endswith('.'):

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1337,8 +1337,8 @@ def is_fetch_success(info: dict, additional_codes: list = None) -> bool:
     elif url.startswith('ftp'):
         return status is None
 
-    # Should never reach here, assume failure
-    return False
+    # Should never reach here, assume it behaves like http and ftp
+    return status == 200 or status is None
 
 
 def _suffixes(name):

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1334,7 +1334,7 @@ def is_fetch_success(info: dict, additional_codes: list = None) -> bool:
 
     if url.startswith('http'):
         return status == 200
-    elif url.startswith('ftp'):
+    if url.startswith('ftp'):
         return status is None
 
     # Should never reach here, assume it behaves like http and ftp

--- a/lib/ansible/modules/apt_key.py
+++ b/lib/ansible/modules/apt_key.py
@@ -179,7 +179,7 @@ import os
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.locale import get_best_parsable_locale
-from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.urls import fetch_url, is_fetch_success
 
 
 apt_key_bin = None
@@ -316,7 +316,7 @@ def download_key(module, url):
     try:
         # note: validate_certs and other args are pulled from module directly
         rsp, info = fetch_url(module, url, use_proxy=True)
-        if info['status'] != 200:
+        if not is_fetch_success(info):
             module.fail_json(msg="Failed to download key at %s: %s" % (url, info['msg']))
 
         return rsp.read()

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -186,7 +186,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.file import S_IRWU_RG_RO as DEFAULT_SOURCES_PERM
 from ansible.module_utils.common.respawn import has_respawned, probe_interpreters_for_module, respawn_module
 from ansible.module_utils.common.text.converters import to_native
-from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.urls import fetch_url, is_fetch_success
 
 from ansible.module_utils.common.locale import get_best_parsable_locale
 
@@ -470,7 +470,7 @@ class UbuntuSourcesList(SourcesList):
 
         headers = dict(Accept='application/json')
         response, info = fetch_url(self.module, lp_api, headers=headers)
-        if info['status'] != 200:
+        if not is_fetch_success(info):
             self.module.fail_json(msg="failed to fetch PPA information, error was: %s" % info['msg'])
         return json.loads(to_native(response.read()))
 

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -378,7 +378,7 @@ from urllib.parse import urlsplit
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible.module_utils.urls import fetch_url, url_argument_spec
+from ansible.module_utils.urls import fetch_url, is_fetch_success, url_argument_spec
 
 # ==============================================================
 # url handling
@@ -407,11 +407,7 @@ def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, head
     if info['status'] == 304:
         module.exit_json(url=url, dest=dest, changed=False, msg=info.get('msg', ''), status_code=info['status'], elapsed=elapsed)
 
-    # Exceptions in fetch_url may result in a status -1, the ensures a proper error to the user in all cases
-    if info['status'] == -1:
-        module.fail_json(msg=info['msg'], url=url, dest=dest, elapsed=elapsed)
-
-    if info['status'] != 200 and not url.startswith('file:/') and not (url.startswith('ftp:/') and info.get('msg', '').startswith('OK')):
+    if not is_fetch_success(info) and not url.startswith('file:/'):
         module.fail_json(msg="Request failed", status_code=info['status'], response=info['msg'], url=url, dest=dest, elapsed=elapsed)
 
     # create a temporary file and copy content to do checksum-based replacement

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -408,7 +408,7 @@ def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, head
         module.exit_json(url=url, dest=dest, changed=False, msg=info.get('msg', ''), status_code=info['status'], elapsed=elapsed)
 
     if not is_fetch_success(info) and not url.startswith('file:/'):
-        module.fail_json(msg="Request failed", status_code=info['status'], response=info['msg'], url=url, dest=dest, elapsed=elapsed)
+        module.fail_json(msg=f"Request failed with msg {info['msg']}", status_code=info['status'], response=info['msg'], url=url, dest=dest, elapsed=elapsed)
 
     # create a temporary file and copy content to do checksum-based replacement
     if tmp_dest:

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -96,7 +96,7 @@ import typing as _t
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.urls import fetch_url, is_fetch_success
 from ansible.module_utils.compat.version import LooseVersion
 from ansible.module_utils.common.text.converters import to_native
 
@@ -474,7 +474,8 @@ class RpmKey(object):
     def fetch_key(self, url: str) -> str:
         """Downloads a key from url, returns a valid path to a gpg key"""
         rsp, info = fetch_url(self.module, url)
-        if info['status'] != 200:
+
+        if not is_fetch_success(info):
             self.module.fail_json(msg="failed to fetch key at %s , error was: %s" % (url, info['msg']))
 
         key = rsp.read()

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -213,6 +213,7 @@ def test_is_fetch_success():
         ('http://foo.com/file', 220, (220,), True),
         ('http://foo.com/file', 200, (220,), True),
         ('http://foo.com/file', 400, (220,), False),
+        ("Some nonsense fetch didn't catch", -1, None, False),
     ]
 
     for url, status, additional, expected in infos:

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -10,7 +10,7 @@ import http.client
 import urllib.error
 from http.cookiejar import Cookie
 
-from ansible.module_utils.urls import fetch_url, ConnectionError
+from ansible.module_utils.urls import fetch_url, is_fetch_success, ConnectionError
 
 import pytest
 from unittest.mock import MagicMock
@@ -197,3 +197,23 @@ def test_fetch_url_badstatusline(open_url_mock, fake_ansible_module):
     open_url_mock.side_effect = http.client.BadStatusLine('TESTS')
     r, info = fetch_url(fake_ansible_module, BASE_URL)
     assert info == {'msg': 'Connection failure: connection was closed before a valid response was received: TESTS', 'status': -1, 'url': BASE_URL}
+
+
+# is_fetch_success is highly coupled to fetch_url, unit test here.
+def test_is_fetch_success():
+    infos = [
+        ('ftp://some/dir/file.txt', None, None, True),
+        ('ftps://another/dir/f.txt', -1, None, False),
+        ('ftp://foo/dir/f.md', None, (-1,), True),
+        ('ftp://foo/dir/f.md', -1, (-1,), True),
+        ('https://foo.com/file', 200, None, True),
+        ('https://foo.com/file', 400, None, False),
+        ('http://foo.com/file', 200, None, True),
+        ('http://foo.com/file', 400, None, False),
+        ('http://foo.com/file', 220, (220,), True),
+        ('http://foo.com/file', 200, (220,), True),
+        ('http://foo.com/file', 400, (220,), False),
+    ]
+
+    for url, status, additional, expected in infos:
+        assert expected == is_fetch_success(dict(url=url, status=status), additional_codes=additional)


### PR DESCRIPTION
##### SUMMARY

Adds a `module_utils` function to detect `fetch_url` success independent of protocol (http or ftp).  Uses this new fn in relevant modules.

Fixes #83321 

Note: I have an integration test for this change, but it would require installing, configuring, starting, and tearing down an FTP server which seems excessive. If I'm wrong I can add it to the PR.

##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request
