### PR TITLE
[stable-2.16] Disable ansible-test azure cloud self-test (#86866)

### DIFF
--- a/test/integration/targets/ansible-test-cloud-azure/aliases
+++ b/test/integration/targets/ansible-test-cloud-azure/aliases
@@ -1,3 +1,4 @@
 cloud/azure
 shippable/generic/group1
 context/controller
+disabled/yes  # Azure credential provisioner pool broken in Core CI (likely SP policy)


### PR DESCRIPTION
##### SUMMARY
* Core CI service principal pool is broken, likely new global policy. This service is not used by core.

(cherry picked from commit 7678502c77216e4fc4abf7acdf7ca11f037f5553)

##### ISSUE TYPE
- Bugfix Pull Request
