### PR TITLE
ansible-doc: fix errant warning when enumerating collections

### DIFF
--- a/changelogs/fragments/ansible-doc-metadata.yml
+++ b/changelogs/fragments/ansible-doc-metadata.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - ansible-doc - fix errant warning about internal collections when enumerating collections (https://github.com/ansible/ansible/issues/85689).

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -233,7 +233,7 @@ class RoleMixin(object):
         :returns: A set of tuples consisting of: role name, collection name, collection path
         """
         found = set()
-        b_colldirs = list_collection_dirs(coll_filter=collection_filter)
+        b_colldirs = list_collection_dirs(coll_filter=collection_filter, include_internal=False)
         for b_path in b_colldirs:
             path = to_text(b_path, errors='surrogate_or_strict')
             if not (collname := _get_collection_name_from_path(b_path)):
@@ -795,11 +795,7 @@ class DocCLI(CLI, RoleMixin):
         DocCLI._prep_loader(plugin_type)
 
         coll_filter = self._get_collection_filter()
-        plugins = _list_plugins_with_info(plugin_type, coll_filter)
-
-        # Remove the internal ansible._protomatter plugins if getting all plugins
-        if not coll_filter:
-            plugins = {k: v for k, v in plugins.items() if not k.startswith('ansible._protomatter.')}
+        plugins = _list_plugins_with_info(plugin_type, coll_filter, include_internal=False)
 
         # get appropriate content depending on option
         if content == 'dir':

--- a/lib/ansible/collections/list.py
+++ b/lib/ansible/collections/list.py
@@ -13,10 +13,10 @@ display = Display()
 
 
 @with_collection_artifacts_manager
-def list_collections(coll_filter=None, search_paths=None, dedupe=True, artifacts_manager=None):
+def list_collections(coll_filter=None, search_paths=None, dedupe=True, artifacts_manager=None, include_internal=True):
 
     collections = {}
-    for candidate in list_collection_dirs(search_paths=search_paths, coll_filter=coll_filter, artifacts_manager=artifacts_manager, dedupe=dedupe):
+    for candidate in list_collection_dirs(search_paths=search_paths, coll_filter=coll_filter, artifacts_manager=artifacts_manager, dedupe=dedupe, include_internal=include_internal):
         if collection := _get_collection_name_from_path(candidate):
             collections[collection] = candidate
         else:
@@ -25,7 +25,7 @@ def list_collections(coll_filter=None, search_paths=None, dedupe=True, artifacts
 
 
 @with_collection_artifacts_manager
-def list_collection_dirs(search_paths=None, coll_filter=None, artifacts_manager=None, dedupe=True):
+def list_collection_dirs(search_paths=None, coll_filter=None, artifacts_manager=None, dedupe=True, include_internal=True):
     """
     Return paths for the specific collections found in passed or configured search paths
     :param search_paths: list of text-string paths, if none load default config
@@ -58,7 +58,7 @@ def list_collection_dirs(search_paths=None, coll_filter=None, artifacts_manager=
         namespace_filter = sorted(namespace_filter)
 
     for req in find_existing_collections(search_paths, artifacts_manager, namespace_filter=namespace_filter,
-                                         collection_filter=collection_filter, dedupe=dedupe):
+                                         collection_filter=collection_filter, dedupe=dedupe, include_internal=include_internal):
 
         if not has_pure_namespace_filter and coll_filter is not None and req.fqcn not in coll_filter:
             continue

--- a/lib/ansible/collections/list.py
+++ b/lib/ansible/collections/list.py
@@ -16,7 +16,14 @@ display = Display()
 def list_collections(coll_filter=None, search_paths=None, dedupe=True, artifacts_manager=None, include_internal=True):
 
     collections = {}
-    for candidate in list_collection_dirs(search_paths=search_paths, coll_filter=coll_filter, artifacts_manager=artifacts_manager, dedupe=dedupe, include_internal=include_internal):
+    candidates = list_collection_dirs(
+        search_paths=search_paths,
+        coll_filter=coll_filter,
+        artifacts_manager=artifacts_manager,
+        dedupe=dedupe,
+        include_internal=include_internal,
+    )
+    for candidate in candidates:
         if collection := _get_collection_name_from_path(candidate):
             collections[collection] = candidate
         else:

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -130,7 +130,7 @@ from ansible.module_utils.common.sentinel import Sentinel
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.common.collections import is_sequence
 from ansible.module_utils.common.yaml import yaml_dump
-from ansible.utils.collection_loader import AnsibleCollectionRef
+from ansible.utils.collection_loader import AnsibleCollectionRef, AnsibleCollectionConfig
 from ansible.utils.display import Display
 from ansible.utils.hashing import secure_hash, secure_hash_s
 
@@ -1426,11 +1426,15 @@ def _normalize_collection_path(path):
     ).expanduser().absolute()
 
 
-def find_existing_collections(path_filter, artifacts_manager, namespace_filter=None, collection_filter=None, dedupe=True):
+def find_existing_collections(
+    path_filter,
+    artifacts_manager,
+    namespace_filter=None,
+    collection_filter=None,
+    dedupe=True,
+    include_internal=True,
+):
     """Locate all collections under a given path.
-
-    :param path: Collection dirs layout search path.
-    :param artifacts_manager: Artifacts manager.
     """
     if path_filter and not is_sequence(path_filter):
         path_filter = [path_filter]
@@ -1444,6 +1448,13 @@ def find_existing_collections(path_filter, artifacts_manager, namespace_filter=N
         path = _normalize_collection_path(path)
         if not path.is_dir():
             continue
+        if not include_internal:
+            try:
+                path.relative_to(AnsibleCollectionConfig._internal_collections)
+            except ValueError:
+                pass
+            else:
+                continue
         if path_filter:
             for pf in path_filter:
                 try:

--- a/lib/ansible/module_utils/common/collections.py
+++ b/lib/ansible/module_utils/common/collections.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 
-import typing as t
 from collections.abc import Hashable, Mapping, MutableMapping, Sequence  # pylint: disable=unused-import
 
 from ansible.module_utils._internal import _no_six

--- a/lib/ansible/module_utils/common/collections.py
+++ b/lib/ansible/module_utils/common/collections.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 
+import typing as t
 from collections.abc import Hashable, Mapping, MutableMapping, Sequence  # pylint: disable=unused-import
 
 from ansible.module_utils._internal import _no_six

--- a/lib/ansible/plugins/list.py
+++ b/lib/ansible/plugins/list.py
@@ -231,6 +231,7 @@ def _list_plugins_with_info(
     ptype: str,
     collections: list[str] = None,
     search_paths: list[str] | None = None,
+    include_internal: bool = True,
 ) -> dict[str, _PluginDocMetadata]:
     if isinstance(collections, str):
         collections = [collections]
@@ -242,7 +243,7 @@ def _list_plugins_with_info(
         # list all collections, add synthetic ones
         plugin_collections['ansible.builtin'] = b''
         plugin_collections['ansible.legacy'] = b''
-        plugin_collections.update(list_collections(search_paths=search_paths, dedupe=True))
+        plugin_collections.update(list_collections(search_paths=search_paths, dedupe=True, include_internal=include_internal))
     else:
         for collection in collections:
             if collection == 'ansible.legacy':

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -35,8 +35,8 @@ ansible-doc --playbook-dir ./ testns.testcol.randommodule 2>&1 | grep "${GREP_OP
 
 echo "test metadata dump for internal collection"
 ansible-doc --metadata-dump 2>&1 | tee metadata-dump.txt
-if grep -q "ansible._protomatter" metadata-dump.txt; then
-	# NOTE: detect FQCN
+if grep -q "lib/ansible/_internal/ansible_collections/ansible/_protomatter" metadata-dump.txt; then
+	# NOTE: detect FQCN or internal path
 	echo "Found internal collection 'ansible._protomatter' in metadata dump, instead of skipping it"
 	exit 1
 fi

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -33,6 +33,14 @@ ansible-doc -t keyword asldkfjaslidfhals 2>&1 | grep "${GREP_OPTS[@]}" 'Skipping
 echo "Check if deprecation collection name is printed"
 ansible-doc --playbook-dir ./ testns.testcol.randommodule 2>&1 | grep "${GREP_OPTS[@]}" "Will be removed in: testns.testcol"
 
+echo "test metadata dump for internal collection"
+ansible-doc --metadata-dump 2>&1 | tee metadata-dump.txt
+if grep -q "ansible._protomatter" metadata-dump.txt; then
+    # NOTE: detect FQCN
+	echo "Found internal collection 'ansible._protomatter' in metadata dump, instead of skipping it"
+	exit 1
+fi
+
 # collections testing
 (
 unset ANSIBLE_PLAYBOOK_DIR

--- a/test/integration/targets/ansible-doc/runme.sh
+++ b/test/integration/targets/ansible-doc/runme.sh
@@ -36,7 +36,7 @@ ansible-doc --playbook-dir ./ testns.testcol.randommodule 2>&1 | grep "${GREP_OP
 echo "test metadata dump for internal collection"
 ansible-doc --metadata-dump 2>&1 | tee metadata-dump.txt
 if grep -q "ansible._protomatter" metadata-dump.txt; then
-    # NOTE: detect FQCN
+	# NOTE: detect FQCN
 	echo "Found internal collection 'ansible._protomatter' in metadata dump, instead of skipping it"
 	exit 1
 fi


### PR DESCRIPTION
##### SUMMARY

* Added a parameter to find_existing_collections API to filter
  internal collections

Fixes: #85689

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/ansible-doc-metadata.yml
lib/ansible/cli/doc.py
lib/ansible/collections/list.py
lib/ansible/galaxy/collection/__init__.py
lib/ansible/module_utils/common/collections.py
lib/ansible/plugins/list.py
test/integration/targets/ansible-doc/runme.sh


