### PR TITLE
Support file overrides for the role definition backed by `RoleDefinition` and use smarter role hashing

### DIFF
--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -158,6 +158,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
         if from_files is None:
             from_files = {}
         self._from_files: dict[str, list[str]] = from_files
+        self._effective_files: dict[str, list[str]] = dict()
 
         # Indicates whether this role was included via include/import_role
         self.from_include: bool = from_include
@@ -185,6 +186,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
     def _get_hash_dict(self):
         if self._hash:
             return self._hash
+
         self._hash = MappingProxyType(
             {
                 'name': self.get_name(),
@@ -192,7 +194,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
                 'params': MappingProxyType(self.get_role_params()),
                 'when': self.when,
                 'tags': self.tags,
-                'from_files': MappingProxyType(self._from_files),
+                'effective_files': MappingProxyType(self._effective_files),
                 'vars': MappingProxyType(self.vars),
                 'from_include': self.from_include,
             }
@@ -251,20 +253,20 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
             setattr(self, f'_{attr_name}', getattr(role_include, f'_{attr_name}', Sentinel))
 
         # vars and default vars are regular dictionaries
-        self._role_vars = self._load_role_yaml('vars', main=self._from_files.get('vars'), allow_dir=True)
+        self._role_vars, self._effective_files['vars'] = self._load_role_yaml('vars', main=self._from_files.get('vars'), allow_dir=True)
         if self._role_vars is None:
             self._role_vars = {}
         elif not isinstance(self._role_vars, Mapping):
             raise AnsibleParserError("The vars/main.yml file for role '%s' must contain a dictionary of variables" % self._role_name)
 
-        self._default_vars = self._load_role_yaml('defaults', main=self._from_files.get('defaults'), allow_dir=True)
+        self._default_vars, self._effective_files['defaults'] = self._load_role_yaml('defaults', main=self._from_files.get('defaults'), allow_dir=True)
         if self._default_vars is None:
             self._default_vars = {}
         elif not isinstance(self._default_vars, Mapping):
             raise AnsibleParserError("The defaults/main.yml file for role '%s' must contain a dictionary of variables" % self._role_name)
 
         # load the role's other files, if they exist
-        metadata = self._load_role_yaml('meta')
+        metadata, self._effective_files['meta'] = self._load_role_yaml('meta')
         if metadata:
             self._metadata = RoleMetadata.load(metadata, owner=self, variable_manager=self._variable_manager, loader=self._loader)
             self._dependencies = self._load_dependencies()
@@ -295,7 +297,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
             if 'ansible.builtin' not in self.collections and 'ansible.legacy' not in self.collections:
                 self.collections.append(default_append_collection)
 
-        task_data = self._load_role_yaml('tasks', main=self._from_files.get('tasks'))
+        task_data, self._effective_files['tasks'] = self._load_role_yaml('tasks', main=self._from_files.get('tasks'))
 
         if self._should_validate:
             role_argspecs = self._get_role_argspecs()
@@ -307,7 +309,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
             except AssertionError as ex:
                 raise AnsibleParserError(f"The tasks/main.yml file for role {self._role_name!r} must contain a list of tasks.", obj=task_data) from ex
 
-        handler_data = self._load_role_yaml('handlers', main=self._from_files.get('handlers'))
+        handler_data, self._effective_files['handlers'] = self._load_role_yaml('handlers', main=self._from_files.get('handlers'))
         if handler_data:
             try:
                 self._handler_blocks = load_list_of_blocks(handler_data, play=self._play, role=self, use_handlers=True, loader=self._loader,
@@ -333,7 +335,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
             full_path = base_argspec_path + ext
             if self._loader.path_exists(full_path):
                 # Note: _load_role_yaml() takes care of rebuilding the path.
-                argument_specs = self._load_role_yaml('meta', main='argument_specs')
+                argument_specs = self._load_role_yaml('meta', main='argument_specs')[0]
                 try:
                     return argument_specs.get('argument_specs') or {}
                 except AttributeError:
@@ -415,10 +417,13 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
                           If false, highlander rules. Only for vars(dicts) and not tasks(lists).
         :type allow_dir: bool
 
-        :returns: data from the matched file(s), type can be dict or list depending on vars or tasks.
+        :returns: two-element tuple with data from the matched file(s)
+                  and list containing the matched files relative to the role subdir.
+                  The type of data can be dict or list depending on vars or tasks.
         """
         data = None
         file_path = os.path.join(self._role_path, subdir)
+        evaluated_files = []
         if self._loader.path_exists(file_path) and self._loader.is_directory(file_path):
             # Valid extensions and ordering for roles is hard-coded to maintain portability
             extensions = ['.yml', '.yaml', '.json']  # same as default for YAML_FILENAME_EXTENSIONS
@@ -433,6 +438,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
                 extensions.insert(0, '')
 
             # not really 'find_vars_files' but find_files_with_extensions_default_to_yaml_filename_extensions
+            # note that 'find_vars_files' sorts the results so there's no reason to do it manually for evaluated_files
             found_files = self._loader.find_vars_files(file_path, _main, extensions, allow_dir)
             if found_files:
                 for found in found_files:
@@ -442,15 +448,22 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
                                          f"as it is not inside the expected role path: {file_path!r}")
 
                     new_data = self._loader.load_from_file(found, trusted_as_template=True)
-                    if new_data:
-                        if data is not None and isinstance(new_data, Mapping):
-                            data = combine_vars(data, new_data)
-                        else:
-                            data = new_data
 
-                        # found data so no need to continue unless we want to merge
-                        if not allow_dir:
-                            break
+                    # resolve the path and store only the relevant portion of it (i.e., meaningful for hashing)
+                    evaluated_files.append(os.path.relpath(found, file_path))
+
+                    # skip empty data from further assignment/merging
+                    if not new_data:
+                        continue
+
+                    if data is not None and isinstance(new_data, Mapping):
+                        data = combine_vars(data, new_data)
+                    else:
+                        data = new_data
+
+                    # found data so no need to continue unless we want to merge
+                    if not allow_dir:
+                        break
 
             elif main is not None:
                 # this won't trigger with default only when <subdir>_from is specified
@@ -459,7 +472,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
             # this won't trigger with default only when <subdir>_from is specified
             raise self._FAIL(f"Could not find specified file in role, its '{subdir}/' is not usable.")
 
-        return data
+        return data, evaluated_files
 
     def _load_dependencies(self):
         """

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -207,8 +207,10 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
 
     @staticmethod
     def load(role_include, play, parent_role=None, from_files=None, from_include=False, validate=True, public=None, static=True, rescuable=True):
+        # try to load from_files from the role itself if it is not passed directly
         if from_files is None:
-            from_files = {}
+            from_files = role_include.get_role_from_files()
+
         try:
             # TODO: need to fix cycle detection in role load (maybe use an empty dict
             #  for the in-flight in role cache as a sentinel that we're already trying to load

--- a/lib/ansible/playbook/role/definition.py
+++ b/lib/ansible/playbook/role/definition.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import os
 
 from ansible import constants as C
-from ansible.errors import AnsibleError, AnsibleAssertionError
+from ansible.errors import AnsibleError, AnsibleParserError, AnsibleAssertionError
 from ansible.module_utils._internal._datatag import AnsibleTagHelper
 from ansible.playbook.attribute import NonInheritableFieldAttribute
 from ansible.playbook.base import Base
@@ -33,6 +33,7 @@ from ansible.utils.collection_loader._collection_finder import _get_collection_r
 from ansible.utils.path import unfrackpath
 from ansible.utils.display import Display
 
+
 __all__ = ['RoleDefinition']
 
 display = Display()
@@ -41,6 +42,17 @@ display = Display()
 class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
 
     role = NonInheritableFieldAttribute(isa='string')
+
+    defaults_from = NonInheritableFieldAttribute(isa='string')
+    handlers_from = NonInheritableFieldAttribute(isa='string')
+    tasks_from = NonInheritableFieldAttribute(isa='string')
+    vars_from = NonInheritableFieldAttribute(isa='string')
+
+    # A mapping from role definition keys (tasks_from, vars_from, ...)
+    # to dedicated from_files dictionary keys (tasks, vars)
+    FROM_FILES_ASSOC = {
+        ('%s_from' % k): k for k in ('defaults', 'handlers', 'tasks', 'vars')
+    }
 
     def __init__(self, play=None, role_basedir=None, variable_manager=None, loader=None, collection_list=None):
 
@@ -53,6 +65,7 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
         self._role_path = None
         self._role_collection = None
         self._role_basedir = role_basedir
+        self._role_from_files = dict()
         self._role_params = dict()
         self._collection_list = collection_list
 
@@ -88,6 +101,9 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
         role_name = self._load_role_name(ds)
         (role_name, role_path) = self._load_role_path(role_name)
 
+        # then pull the role-specific file overrides
+        role_from_files = self._load_role_from_files(ds)
+
         # next, we split the role params out from the valid role
         # attributes and update the new datastructure with that
         # result and the role name
@@ -99,8 +115,9 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
         # set the role name in the new ds
         new_ds['role'] = role_name
 
-        # we store the role path internally
+        # we store the role path and file overrides internally
         self._role_path = role_path
+        self._role_from_files = role_from_files
 
         # and return the cleaned-up data structure
         return new_ds
@@ -127,6 +144,33 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
             role_name = templar.template(role_name)
 
         return role_name
+
+    def _load_role_from_files(self, ds):
+        """
+        Returns a dictionary specifying the role-specific file overrides
+        (e.g., tasks) from the role definition (e.g., tasks_from).
+        It is typically expected to be used by the Role.load
+        """
+
+        # if the role definition is a plain string, there is nothing to process
+        if isinstance(ds, str):
+            return dict()
+
+        # create a template engine instance in order to handle dynamic values
+        if self._variable_manager is not None:
+            templar = TemplateEngine(loader=self._loader, variables=self._variable_manager.get_vars(play=self._play))
+        else:
+            templar = TemplateEngine(loader=self._loader)
+
+        from_files = dict()
+        for role_key in set(RoleDefinition.FROM_FILES_ASSOC.keys()).intersection(ds):
+            value = templar.template(ds.get(role_key))
+            if not isinstance(value, str):
+                raise AnsibleParserError('Expected a string for %s but got %s instead' % (role_key, type(value)))
+
+            from_files[RoleDefinition.FROM_FILES_ASSOC[role_key]] = value
+
+        return from_files
 
     def _load_role_path(self, role_name):
         """
@@ -228,6 +272,9 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
 
     def get_role_path(self):
         return self._role_path
+
+    def get_role_from_files(self):
+        return self._role_from_files.copy()
 
     def get_name(self, include_role_fqcn=True):
         if include_role_fqcn:

--- a/test/integration/targets/roles/from_files.yml
+++ b/test/integration/targets/roles/from_files.yml
@@ -1,0 +1,7 @@
+- name: test that roles definition supports _from overrides
+  hosts: localhost
+  tags: [ 'syntax' ]
+  gather_facts: false
+  roles:
+    - role: a
+      tasks_from: subdir/entrypoint.yml

--- a/test/integration/targets/roles/from_files.yml
+++ b/test/integration/targets/roles/from_files.yml
@@ -5,3 +5,31 @@
   roles:
     - role: a
       tasks_from: subdir/entrypoint.yml
+
+- name: test that deduping allows for 1 successful execution if the role duplicated with _from overrides
+  hosts: localhost
+  gather_facts: false
+  tags: [ 'dupes' ]
+  roles:
+    - role: a
+      tasks_from: subdir/entrypoint.yml
+    - role: a
+      tasks_from: subdir/entrypoint.yml
+
+- name: test that deduping differentiates role definition with and without _from overrides
+  hosts: localhost
+  gather_facts: false
+  tags: [ 'mixed' ]
+  roles:
+    - role: a
+    - role: a
+      tasks_from: subdir/entrypoint.yml
+
+- name: test that deduping handles _from overrides evaluated to default
+  hosts: localhost
+  gather_facts: false
+  tags: [ 'default' ]
+  roles:
+    - role: a
+    - role: a
+      tasks_from: "./../tasks/{{ 'ma' ~ 'in' }}.yml"

--- a/test/integration/targets/roles/runme.sh
+++ b/test/integration/targets/roles/runme.sh
@@ -22,6 +22,9 @@ ansible-playbook role_complete.yml -i ../../inventory -i fake, --tags unreachabl
 
 [ "$(ansible-playbook dupe_inheritance.yml -i ../../inventory | grep -c '"msg": "abc"')" = "3" ]
 
+# ensure _from role overrides are supported
+[ "$(ansible-playbook from_files.yml -i ../../inventory --tags syntax | grep -c '"msg": "subdir"')" = "1" ]
+
 # ensure role data is merged correctly
 ansible-playbook data_integrity.yml -i ../../inventory "$@"
 

--- a/test/integration/targets/roles/runme.sh
+++ b/test/integration/targets/roles/runme.sh
@@ -24,6 +24,12 @@ ansible-playbook role_complete.yml -i ../../inventory -i fake, --tags unreachabl
 
 # ensure _from role overrides are supported
 [ "$(ansible-playbook from_files.yml -i ../../inventory --tags syntax | grep -c '"msg": "subdir"')" = "1" ]
+# test no dupes when role specified multiple times with _from overrides
+[ "$(ansible-playbook from_files.yml -i ../../inventory --tags dupes | grep -c '"msg": "subdir"')" = "1" ]
+# ensure no dedups happens for role that points to different tasks
+[ "$(ansible-playbook from_files.yml -i ../../inventory --tags mixed | grep -c '"msg": "A\|subdir"')" = "2" ]
+# test no dupes when role uses default main value for _from overrides
+[ "$(ansible-playbook from_files.yml -i ../../inventory --tags default | grep -c '"msg": "A"')" = "1" ]
 
 # ensure role data is merged correctly
 ansible-playbook data_integrity.yml -i ../../inventory "$@"

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -161,6 +161,39 @@ def test_play_with_roles(mocker):
     assert isinstance(p.get_roles()[0], Role)
 
 
+def test_play_with_roles_with_from_files(mocker):
+    mocker.patch('ansible.playbook.role.definition.RoleDefinition._load_role_path', return_value=('foo', '/etc/ansible/roles/foo'))
+    fake_loader = DictDataLoader({
+        "/etc/ansible/roles/foo/tasks/main.yml": """
+        - name: bar
+          command: bar
+        """,
+        "/etc/ansible/roles/foo/tasks/custom.yml": """
+        - name: baz
+          command: baz
+        """,
+    })
+
+    mock_var_manager = mocker.MagicMock()
+    mock_var_manager.get_vars.return_value = {}
+
+    p = Play.load(dict(
+        name="test play",
+        hosts=['foo'],
+        gather_facts=False,
+        roles=[dict(name='foo', tasks_from='custom.yml')],
+    ), loader=fake_loader, variable_manager=mock_var_manager)
+
+    blocks = p.compile()
+
+    # filter meta blocks and only retrieve the command block
+    tasks = [block.get_tasks()[0] for block in blocks if 'meta' not in block.get_tasks()[0].get_name()]
+
+    # only one command block is expected to be loaded, and it must be what tasks_from overrides
+    assert len(tasks) == 1
+    assert tasks[0].name == 'baz'
+
+
 def test_play_compile():
     p = Play.load(dict(
         name="test play",


### PR DESCRIPTION
##### SUMMARY

Fixes #86891

Expand role definition syntax to support well-known file overrides (also called `from_files` internally, that is `defaults_from`, `handlers_from`, `tasks_from`, and `vars_from`).

Since the new syntax introduces new deduplication caveats with `allow_duplicates:`, this feature also modifies the role hashing mechanism by taking into account effective (evaluated) file paths. This allows similar role definitions to be caught more precisely. For example, `tasks_from: main` and  `tasks_from: mail.yaml` are only considered similar if the first is actually evaluated to `main.yaml` (and not `main.yml`). See the integration tests for more examples.

##### ISSUE TYPE

- Feature Pull Request
- Test Pull Request
