### PR TITLE
SSH connection plugin: add ssh_askpass_command for dynamic credential and MFA handling

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -114,6 +114,7 @@ DOCUMENTATION = """
               - name: ANSIBLE_SSH_ASKPASS_COMMAND
           vars:
               - name: ansible_ssh_askpass_command
+          version_added: '2.22'
       ssh_args:
           description: Arguments to pass to all SSH CLI tools.
           default: '-C -o ControlMaster=auto -o ControlPersist=60s'
@@ -1088,7 +1089,7 @@ class Connection(ConnectionBase):
             # If the user has DISPLAY set, assume it is there for a reason
             env['DISPLAY'] = '-'
 
-        if askpass:= self.get_option('ssh_askpass_command'):
+        if askpass := self.get_option('ssh_askpass_command'):
             display.vvv(f'SSH_ASKPASS is set to {askpass}')
             env['SSH_ASKPASS'] = askpass
             env['ANSIBLE_PASSWORD'] = conn_password

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -91,6 +91,29 @@ DOCUMENTATION = """
           vars:
               - name: ansible_sshpass_prompt
           version_added: '2.10'
+      ssh_askpass_command:
+          description:
+              - Path to a program to use as the C(SSH_ASKPASS) helper when
+                C(password_mechanism=ssh_askpass) is enabled.
+              - The specified program is executed by the SSH client to obtain
+                authentication credentials such as passwords or multi-factor
+                authentication (MFA) responses.
+              - The helper receives the authentication prompt as its first argument
+                and must write the response to standard output.
+              - The program must be non-interactive and should not produce any output
+                other than the requested credential.
+              - This option allows custom implementations (for example, scripts that
+                generate one-time passwords or integrate with external authentication systems).
+              - When not set, a default helper may be used if available.
+          type: string
+          default: ''
+          ini:
+              - section: 'ssh_connection'
+                key: 'ssh_askpass_command'
+          env:
+              - name: ANSIBLE_SSH_ASKPASS_COMMAND
+          vars:
+              - name: ansible_ssh_askpass_command
       ssh_args:
           description: Arguments to pass to all SSH CLI tools.
           default: '-C -o ControlMaster=auto -o ControlPersist=60s'
@@ -1064,6 +1087,12 @@ class Connection(ConnectionBase):
         if not env.get('DISPLAY'):
             # If the user has DISPLAY set, assume it is there for a reason
             env['DISPLAY'] = '-'
+
+        if askpass:= self.get_option('ssh_askpass_command'):
+            display.vvv(f'SSH_ASKPASS is set to {askpass}')
+            env['SSH_ASKPASS'] = askpass
+            env['ANSIBLE_PASSWORD'] = conn_password
+            env['SSH_ASKPASS_REQUIRE'] = 'prefer'
 
         popen_kwargs['env'] = env
         # start_new_session runs setsid which detaches the tty to support the use of ASKPASS prior to openssh 8.4

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1092,7 +1092,6 @@ class Connection(ConnectionBase):
         if askpass := self.get_option('ssh_askpass_command'):
             display.vvv(f'SSH_ASKPASS is set to {askpass}')
             env['SSH_ASKPASS'] = askpass
-            env['ANSIBLE_PASSWORD'] = conn_password
             env['SSH_ASKPASS_REQUIRE'] = 'prefer'
 
         popen_kwargs['env'] = env


### PR DESCRIPTION
##### SUMMARY

This PR introduces a new SSH connection plugin option, ssh_askpass_command, which allows users to supply a custom command to dynamically provide authentication credentials (passwords and/or MFA tokens) via SSH_ASKPASS.

The command is executed on the controller and its output is passed to the SSH client whenever an authentication prompt is encountered.

##### ISSUE TYPE

- Feature Pull Request

##### Details
Currently, the SSH connection plugin relies on:
- sshpass for password authentication, or
- static credentials provided via variables

These approaches have limitations:

- sshpass does not support multi-factor authentication (MFA)
- static credentials cannot handle dynamic or time-based tokens (e.g. TOTP)
- integration with external secret managers or authentication providers is difficult

This makes it hard to use Ansible in environments with modern authentication requirements (MFA, OTP, hardware tokens, etc.).

###### What this PR adds

A new option:

```
ssh_askpass_command:
  type: str
  description:
    - Command used to provide authentication responses to SSH via SSH_ASKPASS.
```

Behavior:

When password_mechanism=ssh_askpass is enabled, the plugin:
- executes ssh_askpass_command when SSH prompts for input
- returns the command output as the response to SSH
The command:
- runs on the controller node
- receives the SSH prompt as input (optional, depending on implementation)
- must output the credential (password or MFA code) to stdout

##### Example
```
[ssh_connection]
password_mechanism = ssh_askpass
ssh_askpass_command = /usr/local/bin/custom_ssh_askpass.sh
```

Example command:
```
#!/usr/bin/env bash

prompt="$1"

if [[ "$prompt" == *"assword"* ]]; then
    echo "$ANSIBLE_PASSWORD"

elif [[ "$prompt" == *"Verification code"* ]]; then
    /usr/local/bin/get_otp

else
    echo ""
fi
```
###### Notes
The command must be non-interactive and write only the credential to stdout
It may be invoked multiple times during a play (e.g. on reconnect)
This feature is only active when password_mechanism=ssh_askpass

###### Rationale

This approach leverages native SSH mechanisms instead of introducing new authentication flows, keeping the implementation simple while significantly expanding flexibility.