### PR TITLE
undefect playbook/role: dedupe dependency vars via set (O(D²) → O(D))

### DIFF
--- a/changelogs/fragments/role-get-vars-seen-set.yml
+++ b/changelogs/fragments/role-get-vars-seen-set.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - role - ``Role.get_vars()`` now deduplicates transitive dependencies via a set rather than a list, reducing complexity from O(D\ :sup:`2`\ ) to O(D); ``Role`` gains an ``__hash__`` method consistent with its existing ``__eq__``.

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -205,6 +205,10 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
 
         return self._get_hash_dict() == other._get_hash_dict()
 
+    def __hash__(self):
+        # Subset of _get_hash_dict fields; any two roles that compare equal share the same (name, path).
+        return hash((self.get_name(), self.get_role_path()))
+
     @staticmethod
     def load(role_include, play, parent_role=None, from_files=None, from_include=False, validate=True, public=None, static=True, rescuable=True):
         if from_files is None:
@@ -536,14 +540,14 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
         all_vars = self.get_inherited_vars(dep_chain, only_exports=only_exports)
 
         # get exported variables from meta/dependencies
-        seen = []
+        seen = set()
         for dep in self.get_all_dependencies():
             # Avoid rerunning dupe deps since they can have vars from previous invocations and they accumulate in deps
             # TODO: re-examine dep loading to see if we are somehow improperly adding the same dep too many times
             if dep not in seen:
                 # only take 'exportable' vars from deps
                 all_vars = combine_vars(all_vars, dep.get_vars(include_params=False, only_exports=True))
-                seen.append(dep)
+                seen.add(dep)
 
         # role_vars come from vars/ in a role
         all_vars = combine_vars(all_vars, self._role_vars)

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -410,3 +410,22 @@ class TestRole(unittest.TestCase):
         r = Role.load(i, play=mock_play)
 
         self.assertEqual(r.get_name(), "foo_complex")
+
+    @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
+    def test_role_is_hashable_and_set_dedupes(self):
+        fake_loader = DictDataLoader({
+            "/etc/ansible/roles/foo_hashable/tasks/main.yml": "- shell: echo hi",
+        })
+
+        mock_play = MagicMock()
+        mock_play.role_cache = {}
+
+        i1 = RoleInclude.load(dict(role='foo_hashable'), play=mock_play, loader=fake_loader)
+        r1 = Role.load(i1, play=mock_play)
+        i2 = RoleInclude.load(dict(role='foo_hashable'), play=mock_play, loader=fake_loader)
+        r2 = Role.load(i2, play=mock_play)
+
+        hash(r1)
+        self.assertEqual(r1, r2)
+        self.assertEqual(hash(r1), hash(r2))
+        self.assertEqual(len({r1, r2}), 1)


### PR DESCRIPTION
**playbook/role: dedupe dependency vars via set (O(D²) → O(D))**

# Body

##### SUMMARY

`Role.get_vars()` dedupes transitive dependencies with `seen = []` and `dep not in seen`, which is O(D²) over D transitive deps. For enterprise playbooks with deeply nested roles (D=100+) that's measurable CPU cost on every play.

Switch `seen` to a `set` — O(D).

Side effect: `Role` defines `__eq__` (at `lib/ansible/playbook/role/__init__.py:202`) without a matching `__hash__`, which implicitly makes instances unhashable (a naive `seen = set()` swap raises `TypeError: unhashable type: 'Role'`). This PR adds `__hash__` hashing `(name, path)` — a stable subset of the fields `_get_hash_dict()` compares for equality — so any two roles that are equal share the same hash, preserving the `eq`/`hash` contract. Hash collisions on differing params/when/tags fall through to `__eq__` and resolve correctly.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`lib/ansible/playbook/role/__init__.py`

##### ADDITIONAL INFORMATION

**Complexity change**

| D (transitive deps) | Before | After |
|---------------------|--------|-------|
| 100                 | 0.5 ms | 0.06 ms |
| 500                 | 15 ms  | 0.2 ms  |
| 1000                | 55 ms  | 0.4 ms  |
| 2000                | 205 ms | 0.8 ms  |

(Bench: `MockRole` with `__eq__` + `__hash__`, min of 3 trials on CPython 3.12 — 10x–270x measured speedup across D=100..2000.)

**Tests**

- Unit: `test/units/playbook/role/test_role.py::TestRole::test_role_is_hashable_and_set_dedupes` (new) — verifies `Role` is hashable, eq/hash contract holds, and set dedup collapses equal instances.
- Existing `test/units/playbook/role/test_role.py` suite — 22/22 pass, no regressions.
- Integration: `test/integration/targets/roles_var_inheritance` — exercises the exact code path (roles A + B both depend on `common_dep` → `nested_dep`). PLAY RECAP `ok=5 failed=0`, all 3 assertions (`nested_var=A`, `nested_var=B`, `var_precedence=dependency ×2`) pass.
- Sanity: `ansible-test sanity --docker default` across the changed .py + changelog fragment + test file — green.

reference: https://undefect.com/