### PR TITLE
winrm/psrp - apply no_log to stdout/stderr logs

### DIFF
--- a/changelogs/fragments/winrm-psrp-nolog.yml
+++ b/changelogs/fragments/winrm-psrp-nolog.yml
@@ -1,0 +1,5 @@
+security_fixes:
+  - >-
+    winrm - Do not log raw stdout/stderr on verbosity 5 when task has ``no_log: true`` set
+  - >-
+    psrp - Do not log raw stdout/stderr on verbosity 5 when task has ``no_log: true`` set

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -772,8 +772,8 @@ class Connection(ConnectionBase):
             log_stdout = log_stderr = '<censored due to no log>'
 
         display.vvvvv("PSRP RC: %d" % rc, host=self._psrp_host)
-        display.vvvvv("PSRP STDOUT: %s" % log_stdout, host=self._psrp_host)
-        display.vvvvv("PSRP STDERR: %s" % log_stderr, host=self._psrp_host)
+        display.vvvvv(f"PSRP STDOUT: {log_stdout}", host=self._psrp_host)
+        display.vvvvv(f"PSRP STDERR: {log_stderr}", host=self._psrp_host)
 
         # reset the host back output back to defaults, needed if running
         # multiple pipelines on the same RunspacePool

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -766,9 +766,14 @@ class Connection(ConnectionBase):
             stderr_list += self.host.ui.stderr
         stderr = "".join([to_text(o) for o in stderr_list])
 
+        log_stdout = stdout
+        log_stderr = stderr
+        if self._play_context.no_log:
+            log_stdout = log_stderr = '<censored due to no log>'
+
         display.vvvvv("PSRP RC: %d" % rc, host=self._psrp_host)
-        display.vvvvv("PSRP STDOUT: %s" % stdout, host=self._psrp_host)
-        display.vvvvv("PSRP STDERR: %s" % stderr, host=self._psrp_host)
+        display.vvvvv("PSRP STDOUT: %s" % log_stdout, host=self._psrp_host)
+        display.vvvvv("PSRP STDERR: %s" % log_stderr, host=self._psrp_host)
 
         # reset the host back output back to defaults, needed if running
         # multiple pipelines on the same RunspacePool

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -634,11 +634,16 @@ class Connection(ConnectionBase):
             stdout = to_text(b_stdout)
             stderr = to_text(b_stderr)
 
+            log_stdout = stdout
+            log_stderr = stderr
+            if self._play_context.no_log:
+                log_stdout = log_stderr = '<censored due to no log>'
+
             if from_exec:
-                display.vvvvv('WINRM RESULT <Response code %d, out %r, err %r>' % (rc, stdout, stderr), host=self._winrm_host)
+                display.vvvvv('WINRM RESULT <Response code %d, out %r, err %r>' % (rc, log_stdout, log_stderr), host=self._winrm_host)
             display.vvvvvv('WINRM RC %d' % rc, host=self._winrm_host)
-            display.vvvvvv('WINRM STDOUT %s' % stdout, host=self._winrm_host)
-            display.vvvvvv('WINRM STDERR %s' % stderr, host=self._winrm_host)
+            display.vvvvvv('WINRM STDOUT %s' % log_stdout, host=self._winrm_host)
+            display.vvvvvv('WINRM STDERR %s' % log_stderr, host=self._winrm_host)
 
             # This is done after logging so we can still see the raw stderr for
             # debugging purposes.

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -640,10 +640,10 @@ class Connection(ConnectionBase):
                 log_stdout = log_stderr = '<censored due to no log>'
 
             if from_exec:
-                display.vvvvv('WINRM RESULT <Response code %d, out %r, err %r>' % (rc, log_stdout, log_stderr), host=self._winrm_host)
+                display.vvvvv(f'WINRM RESULT <Response code {rc}, out {log_stdout!r}, err {log_stderr!r}>', host=self._winrm_host)
             display.vvvvvv('WINRM RC %d' % rc, host=self._winrm_host)
-            display.vvvvvv('WINRM STDOUT %s' % log_stdout, host=self._winrm_host)
-            display.vvvvvv('WINRM STDERR %s' % log_stderr, host=self._winrm_host)
+            display.vvvvvv(f'WINRM STDOUT {log_stdout}', host=self._winrm_host)
+            display.vvvvvv(f'WINRM STDERR {log_stderr}', host=self._winrm_host)
 
             # This is done after logging so we can still see the raw stderr for
             # debugging purposes.


### PR DESCRIPTION
##### SUMMARY
This change censors the raw stdout/stderr logging used on the `winrm` and `psrp` connection plugins with a verbosity level of 5 being set. While by default the raw output isn't sensitive if a user has set a task with `no_log: true` we shouldn't be displaying the raw results of that task.

##### ISSUE TYPE
- Bugfix Pull Request