### PR TITLE
Deprecate is_module parameter

### DIFF
--- a/changelogs/fragments/doc_string_dep.yml
+++ b/changelogs/fragments/doc_string_dep.yml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+    - Deprecate is_module in get_docstring API in favor of passing ``plugin_type='module'``.

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -484,7 +484,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
         if module_name:
             in_path = module_loader.find_plugin(module_name)
             if in_path:
-                oc, a, _dummy1, _dummy2 = plugin_docs.get_docstring(in_path, fragment_loader)
+                oc, a, _dummy1, _dummy2 = plugin_docs.get_docstring(filename=in_path, fragment_loader=fragment_loader)
                 if oc:
                     display.display(oc['short_description'])
                     display.display('Parameters:')
@@ -519,7 +519,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
     def module_args(self, module_name):
         in_path = module_loader.find_plugin(module_name)
-        oc, a, _dummy1, _dummy2 = plugin_docs.get_docstring(in_path, fragment_loader, is_module=True)
+        oc, a, _dummy1, _dummy2 = plugin_docs.get_docstring(filename=in_path, fragment_loader=fragment_loader, plugin_type='module')
         return list(oc['options'].keys())
 
     def run(self):

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -1066,8 +1066,13 @@ class DocCLI(CLI, RoleMixin):
         collection_name = result.plugin_resolved_collection
 
         try:
-            doc, __, __, __ = get_docstring(filename, fragment_loader, verbose=(context.CLIARGS['verbosity'] > 0),
-                                            collection_name=collection_name, plugin_type=plugin_type)
+            doc, __, __, __ = get_docstring(
+                filename=filename,
+                fragment_loader=fragment_loader,
+                verbose=(context.CLIARGS['verbosity'] > 0),
+                collection_name=collection_name,
+                plugin_type=plugin_type,
+            )
         except Exception as ex:
             raise AnsibleError(f"{plugin_type} {plugin_name} at {filename!r} has a documentation formatting error or is missing documentation.") from ex
 

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -16,6 +16,7 @@ from ansible.module_utils.common.text.converters import to_native
 from ansible.parsing.plugin_docs import read_docstring
 from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.utils.display import Display
+from ansible.utils.sentinel import Sentinel
 from ansible._internal._datatag import _tags
 
 _FRAGMENTABLE = ('DOCUMENTATION', 'RETURN')
@@ -212,19 +213,24 @@ def add_fragments(doc, filename, fragment_loader, is_module=False, section='DOCU
         raise AnsibleFragmentError('unknown doc_fragment(s) in file {0}: {1}'.format(filename, to_native(', '.join(unknown_fragments))))
 
 
-def get_docstring(filename, fragment_loader, verbose=False, ignore_errors=False, collection_name=None, is_module=None, plugin_type=None):
+def get_docstring(filename, fragment_loader, verbose=False, ignore_errors=False, collection_name=None, is_module=Sentinel, plugin_type=None):
     """
     DOCUMENTATION can be extended using documentation fragments loaded by the PluginLoader from the doc_fragments plugins.
     """
 
+    if is_module is Sentinel:
+        is_module = None
+    else:
+        display.deprecated(
+            msg="The is_module argument is deprecated.",
+            version="2.25",
+            help_text="Use plugin_type='module' instead.",
+        )
     if is_module is None:
         if plugin_type is None:
             is_module = False
         else:
             is_module = (plugin_type == 'module')
-    else:
-        # TODO deprecate is_module argument, now that we have 'type'
-        pass
 
     data = read_docstring(filename, verbose=verbose, ignore_errors=ignore_errors)
 
@@ -335,7 +341,13 @@ def get_plugin_docs(plugin, plugin_type, loader, fragment_loader, verbose):
     collection_name = context.plugin_resolved_collection
 
     try:
-        docs = get_docstring(filename, fragment_loader, verbose=verbose, collection_name=collection_name, plugin_type=plugin_type)
+        docs = get_docstring(
+            filename=filename,
+            fragment_loader=fragment_loader,
+            verbose=verbose,
+            collection_name=collection_name,
+            plugin_type=plugin_type,
+        )
     except Exception as ex:
         raise AnsibleParserError(f'{plugin_type} plugin {plugin!r} did not contain a DOCUMENTATION attribute in {filename!r}.') from ex
 
@@ -343,7 +355,13 @@ def get_plugin_docs(plugin, plugin_type, loader, fragment_loader, verbose):
     if not docs[0]:
         for newfile in _find_adjacent(filename, plugin, C.DOC_EXTENSIONS):
             try:
-                docs = get_docstring(newfile, fragment_loader, verbose=verbose, collection_name=collection_name, plugin_type=plugin_type)
+                docs = get_docstring(
+                    filename=newfile,
+                    fragment_loader=fragment_loader,
+                    verbose=verbose,
+                    collection_name=collection_name,
+                    plugin_type=plugin_type,
+                )
                 filename = newfile
                 if docs[0] is not None:
                     break

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -971,10 +971,13 @@ class ModuleValidator(Validator):
 
             with CaptureStd():
                 try:
-                    get_docstring(os.path.abspath(self.path), fragment_loader=fragment_loader,
-                                  verbose=True,
-                                  collection_name=self.collection_name,
-                                  plugin_type=self.plugin_type)
+                    get_docstring(
+                        filename=os.path.abspath(self.path),
+                        fragment_loader=fragment_loader,
+                        verbose=True,
+                        collection_name=self.collection_name,
+                        plugin_type=self.plugin_type,
+                    )
                 except AnsibleFragmentError:
                     # Will be re-triggered below when explicitly calling add_fragments()
                     pass
@@ -2181,8 +2184,11 @@ class ModuleValidator(Validator):
         with CaptureStd():
             try:
                 existing_doc, dummy_examples, dummy_return, existing_metadata = get_docstring(
-                    os.path.abspath(self.base_module), fragment_loader, verbose=True, collection_name=self.collection_name,
-                    is_module=self.plugin_type == 'module')
+                    filename=os.path.abspath(self.base_module),
+                    fragment_loader=fragment_loader,
+                    verbose=True,
+                    collection_name=self.collection_name,
+                    plugin_type=self.plugin_type)
                 existing_options = existing_doc.get('options', {}) or {}
             except AssertionError:
                 fragment = doc['extends_documentation_fragment']

--- a/test/sanity/code-smell/deprecated-config.py
+++ b/test/sanity/code-smell/deprecated-config.py
@@ -81,7 +81,7 @@ def main():
 
     for plugin in plugins:
         data = {}
-        data['doc'], data['examples'], data['return'], data['metadata'] = get_docstring(os.path.abspath(plugin), fragment_loader)
+        data['doc'], data['examples'], data['return'], data['metadata'] = get_docstring(filename=os.path.abspath(plugin), fragment_loader=fragment_loader)
         for result in find_deprecations(data['doc']):
             print('%s: %s is scheduled for removal in %s' % (plugin, '.'.join(str(i) for i in result[0][:-2]), result[1]))
 


### PR DESCRIPTION
##### SUMMARY

* Use plugin_type=module instead of is_module=True

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/doc_string_dep.yml
lib/ansible/cli/console.py
lib/ansible/cli/doc.py
lib/ansible/utils/plugin_docs.py
test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
test/sanity/code-smell/deprecated-config.py


