### PR TITLE
Optimize playbook objects copying

### DIFF
--- a/changelogs/fragments/playbook-copy-perf.yml
+++ b/changelogs/fragments/playbook-copy-perf.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - internals - optimize playbook objects' copy mechanisms in order to reduce overhead from redundant copies of blocks and tasks during playbook execution (https://github.com/ansible/ansible/pull/86936)

--- a/lib/ansible/_internal/_task.py
+++ b/lib/ansible/_internal/_task.py
@@ -202,8 +202,7 @@ class TaskContext(AmbientContextBase):
         original_task = self.task
         original_play_context = te._play_context
 
-        loop_item_task = self.task.copy(exclude_parent=True, exclude_tasks=True)
-        loop_item_task._parent = self.task._parent
+        loop_item_task = self.task.copy()
         loop_item_play_context = te._play_context.copy()
 
         self._task = loop_item_task

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -209,7 +209,7 @@ class PlaybookCLI(CLI):
 
                         all_vars = variable_manager.get_vars(play=play)
                         for block in play.compile():
-                            block = block.filter_tagged_tasks(all_vars)
+                            block.filter_tagged_tasks(all_vars)
                             if not block.has_tasks():
                                 continue
                             taskmsg += _process_block(block)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -17,7 +17,9 @@
 
 from __future__ import annotations
 
+import copy
 import fnmatch
+import typing as t
 
 from enum import IntEnum, IntFlag
 
@@ -28,6 +30,8 @@ from ansible.playbook.block import Block
 from ansible.playbook.task import Task
 from ansible.utils.display import Display
 
+if t.TYPE_CHECKING:
+    from ansible.inventory.host import Host
 
 display = Display()
 
@@ -71,9 +75,7 @@ class HostState:
         self.fail_state = FailedStates.NONE
         self.pre_flushing_run_state = None
         self.update_handlers = True
-        self.tasks_child_state = None
-        self.rescue_child_state = None
-        self.always_child_state = None
+        self.child_state = None
         self.did_rescue = False
         self.did_start_at_task = False
 
@@ -83,7 +85,7 @@ class HostState:
     def __str__(self):
         return ("HOST STATE: block=%d, task=%d, rescue=%d, always=%d, handlers=%d, run_state=%s, fail_state=%s, "
                 "pre_flushing_run_state=%s, update_handlers=%s, "
-                "tasks child state? (%s), rescue child state? (%s), always child state? (%s), "
+                "child state? (%s), "
                 "did rescue? %s, did start at task? %s" % (
                     self.cur_block,
                     self.cur_regular_task,
@@ -94,9 +96,7 @@ class HostState:
                     self.fail_state,
                     self.pre_flushing_run_state,
                     self.update_handlers,
-                    self.tasks_child_state,
-                    self.rescue_child_state,
-                    self.always_child_state,
+                    self.child_state,
                     self.did_rescue,
                     self.did_start_at_task,
                 ))
@@ -108,7 +108,7 @@ class HostState:
         for attr in ('_blocks',
                      'cur_block', 'cur_regular_task', 'cur_rescue_task', 'cur_always_task', 'cur_handlers_task',
                      'run_state', 'fail_state', 'pre_flushing_run_state', 'update_handlers',
-                     'tasks_child_state', 'rescue_child_state', 'always_child_state'):
+                     'child_state'):
             if getattr(self, attr) != getattr(other, attr):
                 return False
 
@@ -118,26 +118,12 @@ class HostState:
         return self._blocks[self.cur_block]
 
     def copy(self):
-        new_state = HostState(self._blocks)
+        new_state = copy.copy(self)
+        new_state._blocks = self._blocks[:]
         new_state.handlers = self.handlers[:]
         new_state.handler_notifications = self.handler_notifications[:]
-        new_state.cur_block = self.cur_block
-        new_state.cur_regular_task = self.cur_regular_task
-        new_state.cur_rescue_task = self.cur_rescue_task
-        new_state.cur_always_task = self.cur_always_task
-        new_state.cur_handlers_task = self.cur_handlers_task
-        new_state.run_state = self.run_state
-        new_state.fail_state = self.fail_state
-        new_state.pre_flushing_run_state = self.pre_flushing_run_state
-        new_state.update_handlers = self.update_handlers
-        new_state.did_rescue = self.did_rescue
-        new_state.did_start_at_task = self.did_start_at_task
-        if self.tasks_child_state is not None:
-            new_state.tasks_child_state = self.tasks_child_state.copy()
-        if self.rescue_child_state is not None:
-            new_state.rescue_child_state = self.rescue_child_state.copy()
-        if self.always_child_state is not None:
-            new_state.always_child_state = self.always_child_state.copy()
+        if self.child_state is not None:
+            new_state.child_state = self.child_state.copy()
         return new_state
 
 
@@ -194,7 +180,7 @@ class PlayIterator:
             validation_task.when = self._play._included_conditional[:]
         setup_block.block.append(validation_task)
 
-        setup_block = setup_block.filter_tagged_tasks(all_vars)
+        setup_block.filter_tagged_tasks(all_vars)
         self._blocks.append(setup_block)
 
         # keep flatten (no blocks) list of all tasks from the play
@@ -202,10 +188,10 @@ class PlayIterator:
         self.all_tasks = setup_block.get_tasks()
 
         for block in self._play.compile():
-            new_block = block.filter_tagged_tasks(all_vars)
-            if new_block.has_tasks():
-                self._blocks.append(new_block)
-                self.all_tasks.extend(new_block.get_tasks())
+            block.filter_tagged_tasks(all_vars)
+            if block.has_tasks():
+                self._blocks.append(block)
+                self.all_tasks.extend(block.get_tasks())
 
         # keep list of all handlers, it is copied into each HostState
         # at the beginning of IteratingStates.HANDLERS
@@ -317,26 +303,24 @@ class PlayIterator:
                     state.cur_regular_task = 0
                     state.cur_rescue_task = 0
                     state.cur_always_task = 0
-                    state.tasks_child_state = None
-                    state.rescue_child_state = None
-                    state.always_child_state = None
+                    state.child_state = None
 
             elif state.run_state == IteratingStates.TASKS:
                 # First, we check for a child task state that is not failed, and if we
                 # have one recurse into it for the next task. If we're done with the child
                 # state, we clear it and drop back to getting the next task from the list.
-                if state.tasks_child_state:
-                    (state.tasks_child_state, task) = self._get_next_task_from_state(state.tasks_child_state, host=host)
-                    if self._check_failed_state(state.tasks_child_state):
+                if state.child_state:
+                    (state.child_state, task) = self._get_next_task_from_state(state.child_state, host=host)
+                    if self._check_failed_state(state.child_state):
                         # failed child state, so clear it and move into the rescue portion
-                        state.tasks_child_state = None
+                        state.child_state = None
                         self._set_failed_state(state)
                     else:
                         # get the next task recursively
-                        if task is None or state.tasks_child_state.run_state == IteratingStates.COMPLETE:
+                        if task is None or state.child_state.run_state == IteratingStates.COMPLETE:
                             # we're done with the child state, so clear it and continue
                             # back to the top of the loop to get the next task
-                            state.tasks_child_state = None
+                            state.child_state = None
                             continue
                 else:
                     # First here, we check to see if we've failed anywhere down the chain
@@ -353,8 +337,8 @@ class PlayIterator:
                         # if the current task is actually a child block, create a child
                         # state for us to recurse into on the next pass
                         if isinstance(task, Block):
-                            state.tasks_child_state = HostState(blocks=[task])
-                            state.tasks_child_state.run_state = IteratingStates.TASKS
+                            state.child_state = HostState(blocks=[task])
+                            state.child_state.run_state = IteratingStates.TASKS
                             # since we've created the child state, clear the task
                             # so we can pick up the child state on the next pass
                             task = None
@@ -363,14 +347,14 @@ class PlayIterator:
             elif state.run_state == IteratingStates.RESCUE:
                 # The process here is identical to IteratingStates.TASKS, except instead
                 # we move into the always portion of the block.
-                if state.rescue_child_state:
-                    (state.rescue_child_state, task) = self._get_next_task_from_state(state.rescue_child_state, host=host)
-                    if self._check_failed_state(state.rescue_child_state):
-                        state.rescue_child_state = None
+                if state.child_state:
+                    (state.child_state, task) = self._get_next_task_from_state(state.child_state, host=host)
+                    if self._check_failed_state(state.child_state):
+                        state.child_state = None
                         self._set_failed_state(state)
                     else:
-                        if task is None or state.rescue_child_state.run_state == IteratingStates.COMPLETE:
-                            state.rescue_child_state = None
+                        if task is None or state.child_state.run_state == IteratingStates.COMPLETE:
+                            state.child_state = None
                             continue
                 else:
                     if state.fail_state & FailedStates.RESCUE == FailedStates.RESCUE:
@@ -383,8 +367,8 @@ class PlayIterator:
                     else:
                         task = block.rescue[state.cur_rescue_task]
                         if isinstance(task, Block):
-                            state.rescue_child_state = HostState(blocks=[task])
-                            state.rescue_child_state.run_state = IteratingStates.TASKS
+                            state.child_state = HostState(blocks=[task])
+                            state.child_state.run_state = IteratingStates.TASKS
                             task = None
                         state.cur_rescue_task += 1
 
@@ -393,14 +377,14 @@ class PlayIterator:
                 # instead we either move onto the next block in the list, or we set the
                 # run state to IteratingStates.COMPLETE in the event of any errors, or when we
                 # have hit the end of the list of blocks.
-                if state.always_child_state:
-                    (state.always_child_state, task) = self._get_next_task_from_state(state.always_child_state, host=host)
-                    if self._check_failed_state(state.always_child_state):
-                        state.always_child_state = None
+                if state.child_state:
+                    (state.child_state, task) = self._get_next_task_from_state(state.child_state, host=host)
+                    if self._check_failed_state(state.child_state):
+                        state.child_state = None
                         self._set_failed_state(state)
                     else:
-                        if task is None or state.always_child_state.run_state == IteratingStates.COMPLETE:
-                            state.always_child_state = None
+                        if task is None or state.child_state.run_state == IteratingStates.COMPLETE:
+                            state.child_state = None
                             continue
                 else:
                     if state.cur_always_task >= len(block.always):
@@ -412,15 +396,13 @@ class PlayIterator:
                             state.cur_rescue_task = 0
                             state.cur_always_task = 0
                             state.run_state = IteratingStates.TASKS
-                            state.tasks_child_state = None
-                            state.rescue_child_state = None
-                            state.always_child_state = None
+                            state.child_state = None
                             state.did_rescue = False
                     else:
                         task = block.always[state.cur_always_task]
                         if isinstance(task, Block):
-                            state.always_child_state = HostState(blocks=[task])
-                            state.always_child_state.run_state = IteratingStates.TASKS
+                            state.child_state = HostState(blocks=[task])
+                            state.child_state.run_state = IteratingStates.TASKS
                             task = None
                         state.cur_always_task += 1
 
@@ -485,8 +467,8 @@ class PlayIterator:
             state.fail_state |= FailedStates.VALIDATE
             state.run_state = IteratingStates.COMPLETE
         elif state.run_state == IteratingStates.TASKS:
-            if state.tasks_child_state is not None:
-                state.tasks_child_state = self._set_failed_state(state.tasks_child_state)
+            if state.child_state is not None:
+                state.child_state = self._set_failed_state(state.child_state)
             else:
                 state.fail_state |= FailedStates.TASKS
                 if state._blocks[state.cur_block].rescue:
@@ -496,8 +478,8 @@ class PlayIterator:
                 else:
                     state.run_state = IteratingStates.COMPLETE
         elif state.run_state == IteratingStates.RESCUE:
-            if state.rescue_child_state is not None:
-                state.rescue_child_state = self._set_failed_state(state.rescue_child_state)
+            if state.child_state is not None:
+                state.child_state = self._set_failed_state(state.child_state)
             else:
                 state.fail_state |= FailedStates.RESCUE
                 if state._blocks[state.cur_block].always:
@@ -505,8 +487,8 @@ class PlayIterator:
                 else:
                     state.run_state = IteratingStates.COMPLETE
         elif state.run_state == IteratingStates.ALWAYS:
-            if state.always_child_state is not None:
-                state.always_child_state = self._set_failed_state(state.always_child_state)
+            if state.child_state is not None:
+                state.child_state = self._set_failed_state(state.child_state)
             else:
                 state.fail_state |= FailedStates.ALWAYS
                 state.run_state = IteratingStates.COMPLETE
@@ -531,9 +513,7 @@ class PlayIterator:
     def _check_failed_state(self, state):
         if state is None:
             return False
-        elif state.run_state == IteratingStates.RESCUE and self._check_failed_state(state.rescue_child_state):
-            return True
-        elif state.run_state == IteratingStates.ALWAYS and self._check_failed_state(state.always_child_state):
+        elif state.run_state in {IteratingStates.RESCUE, IteratingStates.ALWAYS} and self._check_failed_state(state.child_state):
             return True
         elif state.fail_state != FailedStates.NONE:
             if state.run_state == IteratingStates.RESCUE and state.fail_state & FailedStates.RESCUE == 0:
@@ -542,7 +522,7 @@ class PlayIterator:
                 return False
             else:
                 return not (state.did_rescue and state.fail_state & FailedStates.ALWAYS == 0)
-        elif state.run_state == IteratingStates.TASKS and self._check_failed_state(state.tasks_child_state):
+        elif state.run_state == IteratingStates.TASKS and self._check_failed_state(state.child_state):
             cur_block = state._blocks[state.cur_block]
             if len(cur_block.rescue) > 0 and state.fail_state & FailedStates.RESCUE == 0:
                 return False
@@ -560,23 +540,19 @@ class PlayIterator:
     def _clear_state_errors(self, state: HostState) -> None:
         state.fail_state = FailedStates.NONE
 
-        if state.tasks_child_state is not None:
-            self._clear_state_errors(state.tasks_child_state)
-        elif state.rescue_child_state is not None:
-            self._clear_state_errors(state.rescue_child_state)
-        elif state.always_child_state is not None:
-            self._clear_state_errors(state.always_child_state)
+        if state.child_state is not None:
+            self._clear_state_errors(state.child_state)
 
     def get_active_state(self, state):
         """
         Finds the active state, recursively if necessary when there are child states.
         """
-        if state.run_state == IteratingStates.TASKS and state.tasks_child_state is not None:
-            return self.get_active_state(state.tasks_child_state)
-        elif state.run_state == IteratingStates.RESCUE and state.rescue_child_state is not None:
-            return self.get_active_state(state.rescue_child_state)
-        elif state.run_state == IteratingStates.ALWAYS and state.always_child_state is not None:
-            return self.get_active_state(state.always_child_state)
+        if state.run_state in {
+            IteratingStates.TASKS,
+            IteratingStates.RESCUE,
+            IteratingStates.ALWAYS
+        } and state.child_state is not None:
+            return self.get_active_state(state.child_state)
         return state
 
     def is_any_block_rescuing(self, state):
@@ -586,47 +562,29 @@ class PlayIterator:
         """
         if state.run_state in (IteratingStates.TASKS, IteratingStates.HANDLERS) and state.get_current_block().rescue:
             return True
-        if state.tasks_child_state is not None:
-            return self.is_any_block_rescuing(state.tasks_child_state)
-        if state.rescue_child_state is not None:
-            return self.is_any_block_rescuing(state.rescue_child_state)
-        if state.always_child_state is not None:
-            return self.is_any_block_rescuing(state.always_child_state)
+        if state.child_state is not None:
+            return self.is_any_block_rescuing(state.child_state)
         return False
 
-    def _insert_tasks_into_state(self, state, task_list):
-        # if we've failed at all, or if the task list is empty, just return the current state
-        if (state.fail_state != FailedStates.NONE and state.run_state == IteratingStates.TASKS) or not task_list:
-            return state
+    def add_tasks(self, host: Host, block_list: list[Block]) -> None:
+        """Create a new child state for the given host and include the given list of blocks there.
+        This ensures that the next time the ``PlayIterator`` is asked for the next task in the play,
+        the included tasks take precedence. This method is used for including tasks
+        from within ``include_tasks`` and ``include_role``.
+        """
+        if not block_list:
+            return
 
-        if state.run_state == IteratingStates.TASKS:
-            if state.tasks_child_state:
-                state.tasks_child_state = self._insert_tasks_into_state(state.tasks_child_state, task_list)
-            else:
-                target_block = state._blocks[state.cur_block].copy(exclude_tasks=True)
-                target_block.block[state.cur_regular_task:state.cur_regular_task] = task_list
-                state._blocks[state.cur_block] = target_block
-        elif state.run_state == IteratingStates.RESCUE:
-            if state.rescue_child_state:
-                state.rescue_child_state = self._insert_tasks_into_state(state.rescue_child_state, task_list)
-            else:
-                target_block = state._blocks[state.cur_block].copy(exclude_tasks=True)
-                target_block.rescue[state.cur_rescue_task:state.cur_rescue_task] = task_list
-                state._blocks[state.cur_block] = target_block
-        elif state.run_state == IteratingStates.ALWAYS:
-            if state.always_child_state:
-                state.always_child_state = self._insert_tasks_into_state(state.always_child_state, task_list)
-            else:
-                target_block = state._blocks[state.cur_block].copy(exclude_tasks=True)
-                target_block.always[state.cur_always_task:state.cur_always_task] = task_list
-                state._blocks[state.cur_block] = target_block
-        elif state.run_state == IteratingStates.HANDLERS:
-            state.handlers[state.cur_handlers_task:state.cur_handlers_task] = [h for b in task_list for h in b.block]
-
-        return state
-
-    def add_tasks(self, host, task_list):
-        self.set_state_for_host(host.name, self._insert_tasks_into_state(self.get_host_state(host), task_list))
+        state = self.get_state_for_host(host.name)
+        match state.run_state:
+            case IteratingStates.TASKS | IteratingStates.RESCUE | IteratingStates.ALWAYS:
+                cur_state = state
+                while cur_state.child_state is not None:
+                    cur_state = cur_state.child_state
+                cur_state.child_state = HostState(blocks=block_list)
+                cur_state.child_state.run_state = IteratingStates.TASKS
+            case IteratingStates.HANDLERS:
+                state.handlers[state.cur_handlers_task:state.cur_handlers_task] = [h for b in block_list for h in b.block]
 
     @property
     def host_states(self):

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -9,9 +9,9 @@ import itertools
 import operator
 import os
 
+import copy
 import typing as t
 
-from copy import copy as shallowcopy
 from functools import cache
 
 from ansible import constants as C
@@ -423,29 +423,12 @@ class FieldAttributeBase:
             self._squashed = True
 
     def copy(self):
-        """
-        Create a copy of this object and return it.
-        """
-
-        try:
-            new_me = self.__class__()
-        except RecursionError as ex:
-            raise AnsibleError("Exceeded maximum object depth. This may have been caused by excessive role recursion.") from ex
-
+        new_me = copy.copy(self)
+        nd = new_me.__dict__
         for name in self.fattributes:
-            setattr(new_me, name, shallowcopy(getattr(self, f'_{name}', Sentinel)))
-
-        new_me._loader = self._loader
-        new_me._variable_manager = self._variable_manager
-        new_me._origin = self._origin
-        new_me._validated = self._validated
-        new_me._finalized = self._finalized
-        new_me._uuid = self._uuid
-
-        # if the ds value was set on the object, copy it to the new copy too
-        if hasattr(self, '_ds'):
-            new_me._ds = self._ds
-
+            n = f'_{name}'
+            if (v := nd.get(n)) is not None and isinstance(v, (list, dict)):
+                nd[n] = v.copy()
         return new_me
 
     def get_validated_value(self, name, attribute, value, templar):

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -427,7 +427,7 @@ class FieldAttributeBase:
         nd = new_me.__dict__
         for name in self.fattributes:
             n = f'_{name}'
-            if (v := nd.get(n)) is not None and isinstance(v, (list, dict)):
+            if isinstance(v := nd.get(n), (list, dict)):
                 nd[n] = v.copy()
         return new_me
 

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -273,7 +273,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
 
     def filter_tagged_tasks(self, all_vars):
         """
-        Creates a new block, with task lists filtered based on the tags.
+        Mutates the block, with task lists filtered based on the tags.
         """
         def evaluate_and_append_task(target):
             tmp_list = []

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -17,6 +17,9 @@
 
 from __future__ import annotations
 
+import itertools
+import typing as t
+
 from ansible.errors import AnsibleParserError
 from ansible.module_utils.common.sentinel import Sentinel
 from ansible.playbook.attribute import NonInheritableFieldAttribute
@@ -27,6 +30,9 @@ from ansible.playbook.delegatable import Delegatable
 from ansible.playbook.helpers import load_list_of_tasks
 from ansible.playbook.notifiable import Notifiable
 from ansible.playbook.taggable import Taggable
+
+if t.TYPE_CHECKING:
+    from ansible.playbook.task import Task
 
 
 class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatable):
@@ -40,13 +46,12 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
     # similar to the 'else' clause for exceptions
     # otherwise = FieldAttribute(isa='list')
 
-    def __init__(self, play=None, parent_block=None, role=None, task_include=None, use_handlers=False, implicit=False):
+    def __init__(self, play=None, parent_block=None, role=None, task_include=None, use_handlers=False):
         self._play = play
         self._role = role
         self._parent = None
         self._dep_chain = None
         self._use_handlers = use_handlers
-        self._implicit = implicit
 
         if task_include:
             self._parent = task_include
@@ -83,8 +88,7 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
 
     @staticmethod
     def load(data, play=None, parent_block=None, role=None, task_include=None, use_handlers=False, variable_manager=None, loader=None):
-        implicit = not Block.is_block(data)
-        b = Block(play=play, parent_block=parent_block, role=role, task_include=task_include, use_handlers=use_handlers, implicit=implicit)
+        b = Block(play=play, parent_block=parent_block, role=role, task_include=task_include, use_handlers=use_handlers)
         return b.load_data(data, variable_manager=variable_manager, loader=loader)
 
     @staticmethod
@@ -150,49 +154,36 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
         else:
             return self._dep_chain[:]
 
-    def copy(self, exclude_parent=False, exclude_tasks=False):
-        def _dupe_task_list(task_list, new_block):
-            new_task_list = []
-            for task in task_list:
-                new_task = task.copy(exclude_parent=True, exclude_tasks=exclude_tasks)
-                if task._parent:
-                    new_task._parent = task._parent.copy(exclude_tasks=True)
-                    if task._parent == new_block:
-                        # If task._parent is the same as new_block, just replace it
-                        new_task._parent = new_block
-                    else:
-                        # task may not be a direct child of new_block, search for the correct place to insert new_block
-                        cur_obj = new_task._parent
-                        while cur_obj._parent and cur_obj._parent != new_block:
-                            cur_obj = cur_obj._parent
+    def _copy_tasks(self, tasks: list[Block | Task]) -> list[Block | Task]:
+        new_tasks = []
+        for task in tasks:
+            new_task = task.copy()
+            if task._parent._uuid == self._uuid:
+                new_task._parent = self
+            else:
+                if new_task._parent.statically_loaded:
+                    new_task._parent = new_task._parent.copy()
+                # parent is include/import, skip one level
+                new_task._parent._parent = self
+            new_tasks.append(new_task)
+        return new_tasks
 
-                        cur_obj._parent = new_block
-                else:
-                    new_task._parent = new_block
-                new_task_list.append(new_task)
-            return new_task_list
+    def copy(self) -> t.Self:
+        """Copy this block and return the new copy.
 
-        new_me = super(Block, self).copy()
-        new_me._play = self._play
-        new_me._use_handlers = self._use_handlers
+        The blocks and tasks within are recursively copied and re-parented.
+        The new copy still points to its original parent. It is the responsibility
+        of the caller to change the ``_parent`` attribute if needed.
+        """
+        new_me = super().copy()
 
         if self._dep_chain is not None:
             new_me._dep_chain = self._dep_chain[:]
 
-        new_me._parent = None
-        if self._parent and not exclude_parent:
-            new_me._parent = self._parent.copy(exclude_tasks=True)
+        new_me.block = new_me._copy_tasks(self.block)
+        new_me.rescue = new_me._copy_tasks(self.rescue)
+        new_me.always = new_me._copy_tasks(self.always)
 
-        if not exclude_tasks:
-            new_me.block = _dupe_task_list(self.block or [], new_me)
-            new_me.rescue = _dupe_task_list(self.rescue or [], new_me)
-            new_me.always = _dupe_task_list(self.always or [], new_me)
-
-        new_me._role = None
-        if self._role:
-            new_me._role = self._role
-
-        new_me.validate()
         return new_me
 
     def set_loader(self, loader):
@@ -284,45 +275,29 @@ class Block(Base, Conditional, CollectionSearch, Taggable, Notifiable, Delegatab
         """
         Creates a new block, with task lists filtered based on the tags.
         """
-
         def evaluate_and_append_task(target):
             tmp_list = []
             for task in target:
                 if isinstance(task, Block):
-                    filtered_block = evaluate_block(task)
-                    if filtered_block.has_tasks():
-                        tmp_list.append(filtered_block)
+                    task.filter_tagged_tasks(all_vars)
+                    if task.has_tasks():
+                        tmp_list.append(task)
                 elif task.evaluate_tags(self._play.only_tags, self._play.skip_tags, all_vars=all_vars):
                     tmp_list.append(task)
             return tmp_list
 
-        def evaluate_block(block):
-            new_block = block.copy(exclude_parent=True, exclude_tasks=True)
-            new_block._parent = block._parent
-            new_block.block = evaluate_and_append_task(block.block)
-            new_block.rescue = evaluate_and_append_task(block.rescue)
-            new_block.always = evaluate_and_append_task(block.always)
-            return new_block
-
-        return evaluate_block(self)
+        self.block = evaluate_and_append_task(self.block)
+        self.rescue = evaluate_and_append_task(self.rescue)
+        self.always = evaluate_and_append_task(self.always)
 
     def get_tasks(self):
-        def evaluate_and_append_task(target):
-            tmp_list = []
-            for task in target:
-                if isinstance(task, Block):
-                    tmp_list.extend(evaluate_block(task))
-                else:
-                    tmp_list.append(task)
-            return tmp_list
-
-        def evaluate_block(block):
-            rv = evaluate_and_append_task(block.block)
-            rv.extend(evaluate_and_append_task(block.rescue))
-            rv.extend(evaluate_and_append_task(block.always))
-            return rv
-
-        return evaluate_block(self)
+        task_list = []
+        for task in itertools.chain(self.block, self.rescue, self.always):
+            if isinstance(task, Block):
+                task_list.extend(task.get_tasks())
+            else:
+                task_list.append(task)
+        return task_list
 
     def has_tasks(self):
         return len(self.block) > 0 or len(self.rescue) > 0 or len(self.always) > 0

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -219,13 +219,11 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     # nested includes, and we want the include order printed correctly
                     display.vv("statically imported: %s" % include_file)
 
-                    ti_copy = task.copy(exclude_parent=True)
-                    ti_copy._parent = block
                     included_blocks = load_list_of_blocks(
                         data,
                         play=play,
                         parent_block=None,
-                        task_include=ti_copy,
+                        task_include=task,
                         role=role,
                         use_handlers=use_handlers,
                         loader=loader,

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -320,7 +320,7 @@ class Play(Base, Taggable, CollectionSearch):
             if self.pre_tasks:
                 b.block = self.pre_tasks
             else:
-                nt = noop_task.copy(exclude_parent=True)
+                nt = noop_task.copy()
                 nt._parent = b
                 b.block = [nt]
             b.always = [flush_block]
@@ -331,7 +331,7 @@ class Play(Base, Taggable, CollectionSearch):
             if tasks:
                 b.block = tasks
             else:
-                nt = noop_task.copy(exclude_parent=True)
+                nt = noop_task.copy()
                 nt._parent = b
                 b.block = [nt]
             b.always = [flush_block]
@@ -341,7 +341,7 @@ class Play(Base, Taggable, CollectionSearch):
             if self.post_tasks:
                 b.block = self.post_tasks
             else:
-                nt = noop_task.copy(exclude_parent=True)
+                nt = noop_task.copy()
                 nt._parent = b
                 b.block = [nt]
             b.always = [flush_block]
@@ -385,12 +385,8 @@ class Play(Base, Taggable, CollectionSearch):
         return tasklist
 
     def copy(self):
-        new_me = super(Play, self).copy()
+        new_me = super().copy()
         new_me.role_cache = self.role_cache.copy()
-        new_me._included_conditional = self._included_conditional
-        new_me._included_path = self._included_path
-        new_me._action_groups = self._action_groups
-        new_me._group_actions = self._group_actions
         return new_me
 
     def _post_validate_validate_argspec(self, attr: NonInheritableFieldAttribute, value: object, templar: _TE) -> str | None:

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -384,11 +384,6 @@ class Play(Base, Taggable, CollectionSearch):
                 tasklist.append(task)
         return tasklist
 
-    def copy(self):
-        new_me = super().copy()
-        new_me.role_cache = self.role_cache.copy()
-        return new_me
-
     def _post_validate_validate_argspec(self, attr: NonInheritableFieldAttribute, value: object, templar: _TE) -> str | None:
         """Validate user input is a bool or string, and return the corresponding argument spec name."""
 

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -601,10 +601,8 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
             block_list.extend(dep_blocks)
 
         for task_block in self._handler_blocks:
-            new_task_block = task_block.copy()
-            new_task_block._dep_chain = new_dep_chain
-            new_task_block._play = play
-            block_list.append(new_task_block)
+            task_block._dep_chain = new_dep_chain
+            block_list.append(task_block)
 
         return block_list
 
@@ -642,10 +640,8 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
             block_list.extend(dep_blocks)
 
         for task_block in self._task_blocks:
-            new_task_block = task_block.copy()
-            new_task_block._dep_chain = new_dep_chain
-            new_task_block._play = play
-            block_list.append(new_task_block)
+            task_block._dep_chain = new_dep_chain
+            block_list.append(task_block)
 
         eor_block = Block(play=play)
         eor_block._loader = self._loader

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -164,15 +164,9 @@ class IncludeRole(TaskInclude):
 
         return ir
 
-    def copy(self, exclude_parent=False, exclude_tasks=False):
-
-        new_me = super(IncludeRole, self).copy(exclude_parent=exclude_parent, exclude_tasks=exclude_tasks)
-        new_me.statically_loaded = self.statically_loaded
+    def copy(self):
+        new_me = super().copy()
         new_me._from_files = self._from_files.copy()
-        new_me._parent_role = self._parent_role
-        new_me._role_name = self._role_name
-        new_me._role_path = self._role_path
-
         return new_me
 
     def get_include_params(self):

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -485,23 +485,6 @@ class Task(Base, Conditional, Taggable, CollectionSearch, Notifiable, Delegatabl
             all_vars |= self.vars
         return all_vars
 
-    def copy(self, exclude_parent: bool = False, exclude_tasks: bool = False) -> Task:
-        new_me = super(Task, self).copy()
-
-        new_me._parent = None
-        if self._parent and not exclude_parent:
-            new_me._parent = self._parent.copy(exclude_tasks=exclude_tasks)
-
-        new_me._role = None
-        if self._role:
-            new_me._role = self._role
-
-        new_me.implicit = self.implicit
-        new_me._resolved_action = self._resolved_action
-        new_me._uuid = self._uuid
-
-        return new_me
-
     def set_loader(self, loader):
         """
         Sets the loader on this object and recursively on parent, child objects.

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -98,11 +98,6 @@ class TaskInclude(Task):
 
         return ds
 
-    def copy(self, exclude_parent=False, exclude_tasks=False):
-        new_me = super(TaskInclude, self).copy(exclude_parent=exclude_parent, exclude_tasks=exclude_tasks)
-        new_me.statically_loaded = self.statically_loaded
-        return new_me
-
     def build_parent_block(self):
         """
         This method is used to create the parent block for the included tasks

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -453,8 +453,7 @@ class StrategyBase:
 
             task = Task()
         else:
-            task = found_task.copy(exclude_parent=True, exclude_tasks=True)
-            task._parent = found_task._parent
+            task = found_task.copy()
 
         task.from_attrs(wire_task_result.task_fields)
 
@@ -775,8 +774,7 @@ class StrategyBase:
         """
         A proven safe and performant way to create a copy of an included file
         """
-        ti_copy = included_file._task.copy(exclude_parent=True)
-        ti_copy._parent = included_file._task._parent
+        ti_copy = included_file._task.copy()
 
         temp_vars = ti_copy.vars | included_file._vars
 

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -276,7 +276,6 @@ class StrategyModule(StrategyBase):
                         if is_handler:
                             for task in new_block.block:
                                 task.notified_hosts = included_file._hosts[:]
-                            final_block = new_block
                         else:
                             task_vars = self._variable_manager.get_vars(
                                 play=iterator._play,
@@ -284,10 +283,10 @@ class StrategyModule(StrategyBase):
                                 _hosts=self._hosts_cache,
                                 _hosts_all=self._hosts_cache_all,
                             )
-                            final_block = new_block.filter_tagged_tasks(task_vars)
+                            new_block.filter_tagged_tasks(task_vars)
                         for host in hosts_left:
                             if host in included_file._hosts:
-                                all_blocks[host].append(final_block)
+                                all_blocks[host].append(new_block)
                     display.debug("done collecting new blocks for %s" % included_file)
 
                 for host in failed_includes_hosts:

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -279,7 +279,6 @@ class StrategyModule(StrategyBase):
                                 if is_handler:
                                     for task in new_block.block:
                                         task.notified_hosts = included_file._hosts[:]
-                                    final_block = new_block
                                 else:
                                     task_vars = self._variable_manager.get_vars(
                                         play=iterator._play,
@@ -288,14 +287,14 @@ class StrategyModule(StrategyBase):
                                         _hosts_all=self._hosts_cache_all,
                                     )
                                     display.debug("filtering new block on tags")
-                                    final_block = new_block.filter_tagged_tasks(task_vars)
+                                    new_block.filter_tagged_tasks(task_vars)
                                     display.debug("done filtering new block on tags")
 
-                                included_tasks.extend(final_block.get_tasks())
+                                included_tasks.extend(new_block.get_tasks())
 
                                 for host in hosts_left:
                                     if host in included_file._hosts:
-                                        all_blocks[host].append(final_block)
+                                        all_blocks[host].append(new_block)
 
                             display.debug("done iterating over new_blocks loaded from include file")
                         except AnsibleParserError:

--- a/test/units/executor/test_play_iterator.py
+++ b/test/units/executor/test_play_iterator.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import unittest
 from unittest.mock import patch, MagicMock
 
-from ansible.executor.play_iterator import HostState, PlayIterator, IteratingStates, FailedStates
+from ansible.executor.play_iterator import HostState, PlayIterator
 from ansible.playbook import Playbook
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import init_plugin_loader
@@ -348,88 +348,3 @@ class TestPlayIterator(unittest.TestCase):
         # end of iteration
         (host_state, task) = itr.get_next_task_for_host(hosts[0])
         self.assertIsNone(task)
-
-    def test_play_iterator_add_tasks(self):
-        fake_loader = DictDataLoader({
-            'test_play.yml': """
-            - hosts: all
-              gather_facts: no
-              tasks:
-              - debug: msg="dummy task"
-            """,
-        })
-
-        mock_var_manager = MagicMock()
-        mock_var_manager._fact_cache = dict()
-        mock_var_manager.get_vars.return_value = dict()
-
-        p = Playbook.load('test_play.yml', loader=fake_loader, variable_manager=mock_var_manager)
-
-        hosts = []
-        for i in range(0, 10):
-            host = MagicMock()
-            host.name = host.get_name.return_value = 'host%02d' % i
-            hosts.append(host)
-
-        inventory = MagicMock()
-        inventory.get_hosts.return_value = hosts
-        inventory.filter_hosts.return_value = hosts
-
-        play_context = PlayContext(play=p._entries[0])
-
-        itr = PlayIterator(
-            inventory=inventory,
-            play=p._entries[0],
-            play_context=play_context,
-            variable_manager=mock_var_manager,
-            all_vars=dict(),
-        )
-
-        # test the high-level add_tasks() method
-        s = HostState(blocks=[0, 1, 2])
-        itr._insert_tasks_into_state = MagicMock(return_value=s)
-        itr.add_tasks(hosts[0], [MagicMock(), MagicMock(), MagicMock()])
-        self.assertEqual(itr._host_states[hosts[0].name], s)
-
-        # now actually test the lower-level method that does the work
-        itr = PlayIterator(
-            inventory=inventory,
-            play=p._entries[0],
-            play_context=play_context,
-            variable_manager=mock_var_manager,
-            all_vars=dict(),
-        )
-
-        # iterate past first task
-        dummy, task = itr.get_next_task_for_host(hosts[0])
-        while (task and task.action != 'debug'):
-            dummy, task = itr.get_next_task_for_host(hosts[0])
-
-        self.assertIsNotNone(task, 'iterated past end of play while looking for place to insert tasks')
-
-        # get the current host state and copy it so we can mutate it
-        s = itr.get_host_state(hosts[0])
-        s_copy = s.copy()
-
-        # assert with an empty task list, or if we're in a failed state, we simply return the state as-is
-        res_state = itr._insert_tasks_into_state(s_copy, task_list=[])
-        self.assertEqual(res_state, s_copy)
-
-        s_copy.fail_state = FailedStates.TASKS
-        res_state = itr._insert_tasks_into_state(s_copy, task_list=[MagicMock()])
-        self.assertEqual(res_state, s_copy)
-
-        # but if we've failed with a rescue/always block
-        mock_task = MagicMock()
-        s_copy.run_state = IteratingStates.RESCUE
-        res_state = itr._insert_tasks_into_state(s_copy, task_list=[mock_task])
-        self.assertEqual(res_state, s_copy)
-        self.assertIn(mock_task, res_state._blocks[res_state.cur_block].rescue)
-        itr.set_state_for_host(hosts[0].name, res_state)
-        (next_state, next_task) = itr.get_next_task_for_host(hosts[0], peek=True)
-        self.assertEqual(next_task, mock_task)
-        itr.set_state_for_host(hosts[0].name, s)
-
-        # test a regular insertion
-        s_copy = s.copy()
-        res_state = itr._insert_tasks_into_state(s_copy, task_list=[MagicMock()])

--- a/test/units/playbook/test_helpers.py
+++ b/test/units/playbook/test_helpers.py
@@ -365,3 +365,48 @@ class TestLoadListOfBlocks(unittest.TestCase, MixinForMocks):
         self.assertIsInstance(res, list)
         for block in res:
             self.assertIsInstance(block, Block)
+
+    def test_block_copy_parents(self):
+        ds = [
+            {
+                'block': [
+                    {'ping': None},
+                    {'import_tasks': '/dev/null/includes/other_test_include.yml'},
+                ]
+            },
+        ]
+        res = helpers.load_list_of_blocks(
+            ds,
+            play=self.mock_play,
+            variable_manager=self.mock_variable_manager,
+            loader=self.fake_include_loader,
+        )
+
+        block_orig = res[0]
+        block_copy = block_orig.copy()
+
+        assert isinstance(block_orig, Block)
+        assert isinstance(block_copy, Block)
+
+        task1_orig, task2_orig = block_orig.block
+        task1_copy, task2_copy = block_copy.block
+
+        assert isinstance(task1_orig, Task)
+        assert isinstance(task1_copy, Task)
+
+        assert isinstance(task2_orig, Block)
+        assert isinstance(task2_copy, Block)
+
+        assert isinstance(task1_orig._parent, Block)
+        assert task1_orig._parent is block_orig
+
+        assert isinstance(task1_copy._parent, Block)
+        assert task1_copy._parent is block_copy
+
+        assert isinstance(task2_orig._parent, TaskInclude)
+        assert task2_orig._parent._parent is block_orig
+
+        assert isinstance(task2_copy._parent, TaskInclude)
+        assert task2_copy._parent._parent is block_copy
+
+        assert task2_orig._parent is not task2_copy._parent


### PR DESCRIPTION
##### SUMMARY
Previously when including blocks into the play via `include_tasks` and
`include_role` we copied the current block, inserted the included
blocks into the copy and replaced the current block with it. We used
this copy-on-write mechanism due to the play objects (blocks and tasks)
being shared among `HostState` objects in the `PlayIterator` which would
cause issues when an include is only executed on a subset of hosts so we
needed to make a per-host copy of the block. We attempted to make this
more efficient by copying the block with `exclude_tasks=True` so we
only copy the block itself and not the tasks within with the goal of
sharing the task objects and not doing unnecessary copies.

Unfortunately this approach has a few problems:

  1. When multiple `include_tasks`/`include_role` tasks are present
     within one block (or rescue/always) the block is copied multiple
     times unnecessarily while only the first COW is needed.
  2. Since we leave `exclude_parent=False` the whole parent chain is
     copied as opposed to copying only the current block itself.
  3. The `exclude_tasks` of `Block.copy` contains a bug where the
     tasks are simply copied into a new `Block` but the `_parent`
     attribute on tasks isn't set to the new block copy, still
     pointing at the original block. We just cannot have the
     `exclude_tasks` feature when `_parent` is part of the `Task`'s
     identity.

We can actually solve the issues by not making any copies at all by
utilizing the `HostState.child_state` (normally used for nested
blocks) to store the included blocks. So instead of making a copy of the
current block and inserting the included blocks there, we create a new
`child_state` and add the shared reference of the included blocks
there. The next time a task is requested from the `PlayIterator`, the
`child_state` is consulted first so the included blocks take
precedence over the task following the include. Now all blocks and
tasks within the `PlayIterator` are shared references and should be
copied only before being mutated. Only the hosts where an include was
executed would have the included blocks in their `HostState`.

The `exclude_parent` and `exclude_tasks` parameters of
`Block.copy()` are removed with the default behavior being that both the
block itself and the tasks within are copied and the new copies of the
tasks within are changed to point at the new block as their parent
object. The new block copy still points at its original parent; the
method callers are responsible to change it if needed. A new unit test
is added to verify this behavior.

Additional changes were made, in short:
  - change the `Base.copy()` method to utilize `copy.copy` instead
    of creating a new object just to rewrite its attributes - simplifies
    defining the `copy()` method of the playbook objects in most cases
  - remove unnecessary playbook objects copying including filtering
    tasks in blocks based on tags in-place
  - remove unused `implicit` attribute on the Block object
  - remove `tasks_child_state`, `rescue_child_state` and
    `always_child_state` in favor of newly introduced
    `HostState.child_state` as there can be only one nested state
    at one point in time

To benchmark this change, a playbook that recursively executes
`include_tasks` was used. With this patch, the engine is able to run
almost twice as many recursive includes before hitting limits while
consuming roughly one-third of the memory.

```yaml
- hosts: localhost
  gather_facts: false
  tasks:
    - include_tasks: recursive_include.yml
```

recursive_include.yml:
```yaml
- set_fact:
    n: "{{ n|default(0) + 1 }}"
- debug:
    var: n
- include_tasks: recursive_include.yml
```

devel:
247 recursive includes
Memory Peak:    249.82MB  (working set, excl. cache)
Memory Peak:    260.51MB  (total incl. cache, cgroup tracked)

this patch:
489 recursive includes
Memory Peak:    65.43MB  (working set, excl. cache)
Memory Peak:    86.43MB  (total incl. cache, cgroup tracked)

ci_complete

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Feature Pull Request
