### PR TITLE
git: remove redundant error checking

### DIFF
--- a/changelogs/fragments/86937-git-rm-redundant-err-checks.yml
+++ b/changelogs/fragments/86937-git-rm-redundant-err-checks.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - git - remove redundant error checks after `run_command(check_rc=True)`

--- a/changelogs/fragments/86937-git-rm-redundant-err-checks.yml
+++ b/changelogs/fragments/86937-git-rm-redundant-err-checks.yml
@@ -1,2 +1,2 @@
-minor_changes:
+bugfixes:
   - git - remove redundant error checks after `run_command(check_rc=True)`

--- a/changelogs/fragments/86937-git-submodules-no-check-rc.yml
+++ b/changelogs/fragments/86937-git-submodules-no-check-rc.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - git - remove redundant `check_rc` to allow for the error condition to print a better message

--- a/changelogs/fragments/86937-git-submodules-no-check-rc.yml
+++ b/changelogs/fragments/86937-git-submodules-no-check-rc.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - git - remove redundant `check_rc` to allow for the error condition to print a better message

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -994,9 +994,6 @@ def submodules_fetch(git_path, module, remote, track_submodules, dest):
         begin = get_submodule_versions(git_path, module, dest)
         cmd = [git_path, 'submodule', 'foreach', git_path, 'fetch']
         (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
-        if rc != 0:
-            module.fail_json(msg="Failed to fetch submodules: %s" % out + err)
-
         if track_submodules:
             # Compare each submodule against its configured remote branch
             after = {}
@@ -1017,8 +1014,6 @@ def submodules_fetch(git_path, module, remote, track_submodules, dest):
             # Compare against the superproject's expectation
             cmd = [git_path, 'submodule', 'status']
             (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
-            if rc != 0:
-                module.fail_json(msg='Failed to retrieve submodule status: %s' % out + err)
             for line in out.splitlines():
                 if line[0] != ' ':
                     changed = True

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -993,7 +993,7 @@ def submodules_fetch(git_path, module, remote, track_submodules, dest):
         # Fetch updates
         begin = get_submodule_versions(git_path, module, dest)
         cmd = [git_path, 'submodule', 'foreach', git_path, 'fetch']
-        (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
+        (rc, out, err) = module.run_command(cmd, cwd=dest)
         if rc != 0:
             module.fail_json(msg="Failed to fetch submodules: %s" % out + err)
 
@@ -1016,7 +1016,7 @@ def submodules_fetch(git_path, module, remote, track_submodules, dest):
         else:
             # Compare against the superproject's expectation
             cmd = [git_path, 'submodule', 'status']
-            (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
+            (rc, out, err) = module.run_command(cmd, cwd=dest)
             if rc != 0:
                 module.fail_json(msg='Failed to retrieve submodule status: %s' % out + err)
             for line in out.splitlines():

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -993,7 +993,7 @@ def submodules_fetch(git_path, module, remote, track_submodules, dest):
         # Fetch updates
         begin = get_submodule_versions(git_path, module, dest)
         cmd = [git_path, 'submodule', 'foreach', git_path, 'fetch']
-        (rc, out, err) = module.run_command(cmd, cwd=dest)
+        (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
         if rc != 0:
             module.fail_json(msg="Failed to fetch submodules: %s" % out + err)
 
@@ -1016,7 +1016,7 @@ def submodules_fetch(git_path, module, remote, track_submodules, dest):
         else:
             # Compare against the superproject's expectation
             cmd = [git_path, 'submodule', 'status']
-            (rc, out, err) = module.run_command(cmd, cwd=dest)
+            (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
             if rc != 0:
                 module.fail_json(msg='Failed to retrieve submodule status: %s' % out + err)
             for line in out.splitlines():


### PR DESCRIPTION
##### SUMMARY

I am getting this error message when `git submodule fetch` fails:

```console
TASK [ansible : git clone ansible] *********************************************************************************
[ERROR]: Task failed: Module failed:
<redacted git CLI output>

Origin: /Users/simonleary/unity/unity-ansible-gitlab/roles/ansible/tasks/main.yml:28:3

26 # - ansible.builtin.import_tasks: bitwarden.yml
27
28 - name: git clone ansible
     ^ column 3

Traceback (most recent call last):
  File "<stdin>", line 266, in <module>
  File "<stdin>", line 260, in _ansiballz_main
  File "<stdin>", line 140, in invoke_module
  File "/tmp/ansible_ansible.builtin.git_payload_w9r64qbn/ansible_ansible.builtin.git_payload.zip/ansible/module_utils/_internal/_ansiballz/_loader.py", line 35, in run_module
    _run_module(
  File "/tmp/ansible_ansible.builtin.git_payload_w9r64qbn/ansible_ansible.builtin.git_payload.zip/ansible/module_utils/_internal/_ansiballz/_loader.py", line 62, in _run_module
    runpy.run_module(mod_name=module_fqn, init_globals=init_globals, run_name='__main__', alter_sys=True)
  File "<frozen runpy>", line 226, in run_module
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/tmp/ansible_ansible.builtin.git_payload_w9r64qbn/ansible_ansible.builtin.git_payload.zip/ansible/modules/git.py", line 1430, in <module>
    main()
  File "/tmp/ansible_ansible.builtin.git_payload_w9r64qbn/ansible_ansible.builtin.git_payload.zip/ansible/modules/git.py", line 1396, in main
    submodules_updated = submodules_fetch(git_path, module, remote, track_submodules, dest)
  File "/tmp/ansible_ansible.builtin.git_payload_w9r64qbn/ansible_ansible.builtin.git_payload.zip/ansible/modules/git.py", line 958, in submodules_fetch
    (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
  File "/tmp/ansible_ansible.builtin.git_payload_w9r64qbn/ansible_ansible.builtin.git_payload.zip/ansible/module_utils/basic.py", line 2140, in run_command
    self.fail_json(cmd=self._clean_args(args), rc=rc, stdout=stdout, stderr=stderr, msg=msg)
Message: <redacted git CLI output>

The above target exception was the direct cause of the following controller exception:
...
```

Notably, the error message does not include the command that failed, only that some command failed.

There are conditionals in the code written to handle this error and produce a message that contains more context, but they can never actually happen because `check_rc` applies first.

Here is my error message after:

```console
TASK [ansible : git clone ansible] *********************************************************************************
[ERROR]: Task failed: Module failed: Failed to fetch submodules:
<redacted git CLI output>

Origin: /Users/simonleary/unity/unity-ansible-gitlab/roles/ansible/tasks/main.yml:28:3

26 # - ansible.builtin.import_tasks: bitwarden.yml
27
28 - name: git clone ansible
     ^ column 3

Traceback (most recent call last):
  File "<stdin>", line 266, in <module>
  File "<stdin>", line 260, in _ansiballz_main
  File "<stdin>", line 140, in invoke_module
  File "/tmp/ansible_ansible.builtin.git_payload_cvoskn9_/ansible_ansible.builtin.git_payload.zip/ansible/module_utils/_internal/_ansiballz/_loader.py", line 35, in run_module
    _run_module(
  File "/tmp/ansible_ansible.builtin.git_payload_cvoskn9_/ansible_ansible.builtin.git_payload.zip/ansible/module_utils/_internal/_ansiballz/_loader.py", line 62, in _run_module
    runpy.run_module(mod_name=module_fqn, init_globals=init_globals, run_name='__main__', alter_sys=True)
  File "<frozen runpy>", line 226, in run_module
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/tmp/ansible_ansible.builtin.git_payload_cvoskn9_/ansible_ansible.builtin.git_payload.zip/ansible/modules/git.py", line 1430, in <module>
    main()
  File "/tmp/ansible_ansible.builtin.git_payload_cvoskn9_/ansible_ansible.builtin.git_payload.zip/ansible/modules/git.py", line 1396, in main
    submodules_updated = submodules_fetch(git_path, module, remote, track_submodules, dest)
  File "/tmp/ansible_ansible.builtin.git_payload_cvoskn9_/ansible_ansible.builtin.git_payload.zip/ansible/modules/git.py", line 960, in submodules_fetch
    module.fail_json(msg="Failed to fetch submodules: %s" % out + err)
Message: <redacted git CLI output>

The above target exception was the direct cause of the following controller exception:
...
```

They are pretty similar except that the second one says "Failed to fetch submodules". I think this is an important detail.

##### ISSUE TYPE

- Bugfix Pull Request