### PR TITLE
Add ANSIBLE_LIMIT env variable

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -791,6 +791,13 @@ DEFAULT_HOST_LIST:
       section: defaults
   type: pathlist
   yaml: {key: defaults.inventory}
+DEFAULT_SUBSET:
+  name: Default inventory subset
+  default: null
+  description: Pattern used to limit selected hosts subset
+  env:
+    - name: ANSIBLE_LIMIT
+  type: string
 DEFAULT_HTTPAPI_PLUGIN_PATH:
   name: HttpApi Plugins Path
   default: '{{ ANSIBLE_HOME ~ "/plugins/httpapi:/usr/share/ansible/plugins/httpapi" }}'

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -70,7 +70,6 @@ DOC_EXTENSIONS = PYTHON_DOC_EXTENSIONS + YAML_DOC_EXTENSIONS
 DEFAULT_BECOME_PASS = None
 DEFAULT_PASSWORD_CHARS = to_text(ascii_letters + digits + ".,:-_", errors='strict')  # characters included in auto-generated passwords
 DEFAULT_REMOTE_PASS = None
-DEFAULT_SUBSET = None
 # FIXME: expand to other plugins, but never doc fragments
 CONFIGURABLE_PLUGINS = ('become', 'cache', 'callback', 'cliconf', 'connection', 'httpapi', 'inventory', 'lookup', 'netconf', 'shell', 'vars')
 # NOTE: always update the docs/docsite/Makefile to match


### PR DESCRIPTION
##### SUMMARY

Adds `ANSIBLE_LIMIT` environment variable.

Complex multi-DC environments often require using `--limit dc-name` CLI argument to not to apply changes to all the hosts at once. Running multiple playbooks specifying the same argument each time makes makes the process error-prone. Organizing inventory in a different way in order to set `ANSIBLE_INVENTORY` to include the chosen DC would bring other difficulties - some variables must be shared between DCs, config file templates also rely on `groups` variable containing lists of all hosts. 

Using a variable `ANSIBLE_LIMIT` alongside `ANSIBLE_INVENTORY` allows for omitting repeated CLI args for the entire session.

##### ISSUE TYPE

- Feature Pull Request
