### PR TITLE
Fix no_log substring redaction order to prevent partial leakage

### DIFF
--- a/lib/ansible/module_utils/common/parameters.py
+++ b/lib/ansible/module_utils/common/parameters.py
@@ -415,7 +415,9 @@ def _remove_values_conditions(value, no_log_strings, deferred_removals):
 
         if native_str_value in no_log_strings:
             return 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
-        for omit_me in no_log_strings:
+        # Sort by length descending to ensure longer strings are replaced first,
+        # preventing partial leakage when one string is a substring of another.
+        for omit_me in sorted(no_log_strings, key=len, reverse=True):
             native_str_value = native_str_value.replace(omit_me, '*' * 8)
 
         if value_is_text and isinstance(native_str_value, bytes):
@@ -447,7 +449,8 @@ def _remove_values_conditions(value, no_log_strings, deferred_removals):
         stringy_value = to_native(value, encoding='utf-8', errors='surrogate_or_strict')
         if stringy_value in no_log_strings:
             return 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
-        for omit_me in no_log_strings:
+        # Sort by length descending to ensure longer strings are replaced first
+        for omit_me in sorted(no_log_strings, key=len, reverse=True):
             if omit_me in stringy_value:
                 return 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
 

--- a/test/units/module_utils/basic/test_no_log.py
+++ b/test/units/module_utils/basic/test_no_log.py
@@ -160,3 +160,20 @@ class TestRemoveValues:
 
         assert inner_list == self.OMIT
         assert levels == 10000
+
+    def test_substring_redaction_order(self):
+        """Test that longer strings are redacted first to prevent partial leakage.
+
+        When one no_log string is a substring of another, the longer string
+        must be redacted first. Otherwise, replacing the shorter string first
+        would leave parts of the longer string exposed.
+        """
+        # 'test_pass2' is a substring of 'test_pass222'
+        no_log_strings = frozenset(['test_pass2', 'test_pass222'])
+        value = ['test_pass2', 'test_pass222']
+
+        result = remove_values(value, no_log_strings)
+
+        # Both should be fully redacted, not partially
+        assert result[0] == self.OMIT
+        assert result[1] == self.OMIT


### PR DESCRIPTION
When one no_log string is a substring of another, the shorter string was being redacted first, leaving parts of the longer string exposed.

## Issue
Fixes #86930

## Solution
Sort no_log_strings by length descending so longer strings are matched and redacted first, preventing partial leakage.

## Testing
- Added unit test to verify substring redaction order
- Existing tests pass