### PR TITLE
Improvement for child worker signal race

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -223,6 +223,12 @@ class TaskQueueManager:
         """
         signal.signal(signum, signal.SIG_DFL)
 
+        if (my_pid := os.getpid()) in [worker.pid for worker in self._workers if worker is not None]:
+            # Race condition: forked child may receive SIGTERM/SIGINT before
+            # the inherited handlers from the parent have been replaced.
+            display.error(f'Worker PID {my_pid} received signal "{signum}: {signal.strsignal(signum)}" before detachment.')
+            return
+
         for worker in self._workers:
             if worker is None or not worker.is_alive():
                 continue

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -223,34 +223,34 @@ class TaskQueueManager:
         """
         signal.signal(signum, signal.SIG_DFL)
 
-        if (my_pid := os.getpid()) in [worker.pid for worker in self._workers if worker is not None]:
+        my_pid = os.getpid()
+        signame = signal.strsignal(signum)
+
+        if my_pid in [worker.pid for worker in self._workers if worker is not None]:
             # Race condition: forked child may receive SIGTERM/SIGINT before
             # the inherited handlers from the parent have been replaced.
-            display.error(f'Worker PID {my_pid} received signal "{signum}: {signal.strsignal(signum)}" before detachment.')
-            return
+            display.error(f'Worker PID {my_pid} received signal "{signum}: {signame}" before detachment.')
+        else:
+            for worker in self._workers:
+                if worker is None or not worker.is_alive():
+                    continue
+                if worker.pid:
+                    try:
+                        # notify workers
+                        os.kill(worker.pid, signum)
+                    except OSError as e:
+                        if e.errno != errno.ESRCH:
+                            display.error(f'Unable to send {signame} to child[{worker.pid}]: {e}')
 
-        for worker in self._workers:
-            if worker is None or not worker.is_alive():
-                continue
-            if worker.pid:
-                try:
-                    # notify workers
-                    os.kill(worker.pid, signum)
-                except OSError as e:
-                    if e.errno != errno.ESRCH:
-                        signame = signal.strsignal(signum)
-                        display.error(f'Unable to send {signame} to child[{worker.pid}]: {e}')
+            if signum == signal.SIGINT:
+                # Defer to CLI handling
+                raise KeyboardInterrupt()
 
-        if signum == signal.SIGINT:
-            # Defer to CLI handling
-            raise KeyboardInterrupt()
-
-        pid = os.getpid()
+        # Default signal handler was restored, so resend the signal to self.
         try:
-            os.kill(pid, signum)
+            os.kill(my_pid, signum)
         except OSError as e:
-            signame = signal.strsignal(signum)
-            display.error(f'Unable to send {signame} to {pid}: {e}')
+            display.error(f'Unable to send {signame} to {my_pid}: {e}')
 
     def load_callbacks(self):
         """

--- a/test/units/executor/test_task_queue_manager.py
+++ b/test/units/executor/test_task_queue_manager.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import signal
+
+import pytest
+
+from ansible.executor.task_queue_manager import TaskQueueManager
+
+
+class TestTQMSignalHandler:
+    @pytest.mark.parametrize("signum,signame", [
+        (signal.SIGTERM, signal.strsignal(signal.SIGTERM)),
+        (signal.SIGINT, signal.strsignal(signal.SIGINT)),
+    ])
+    def test_signal_handler_detects_child_process_race_condition(self, mocker, signum, signame):
+        """
+        Test that the signal handler detects when called from a forked child.
+
+        This tests the race condition where a forked child receives SIGTERM/SIGINT
+        before the inherited handlers from the parent have been replaced.
+        When os.getpid() matches a worker PID, we're in the child and should
+        return early without attempting worker management.
+        """
+        mock_inventory = mocker.Mock()
+        mock_var_manager = mocker.Mock()
+        mock_loader = mocker.Mock()
+
+        mocker.patch('ansible.executor.task_queue_manager.FinalQueue')
+        mocker.patch('ansible.executor.task_queue_manager._rpc_host.LocalManager.shared_instance')
+        mocker.patch('ansible.executor.task_queue_manager.context.CLIARGS', {})
+
+        tqm = TaskQueueManager(
+            inventory=mock_inventory,
+            variable_manager=mock_var_manager,
+            loader=mock_loader,
+            passwords={},
+        )
+
+        # Create mock workers
+        mock_worker1 = mocker.Mock()
+        mock_worker1.pid = 12345
+        mock_worker2 = mocker.Mock()
+        mock_worker2.pid = 67890
+
+        tqm._workers = [mock_worker1, mock_worker2]
+
+        # Mock os.getpid() to return a worker PID (simulate being in child process)
+        mock_getpid = mocker.patch('ansible.executor.task_queue_manager.os.getpid')
+        mock_getpid.return_value = 12345
+
+        mock_display = mocker.patch('ansible.executor.task_queue_manager.display')
+        mocker.patch('ansible.executor.task_queue_manager.signal.signal')
+        mock_os_kill = mocker.patch('ansible.executor.task_queue_manager.os.kill')
+
+        # Call signal handler
+        tqm._signal_handler(signum, None)
+
+        # Verify error was logged with correct signal number and name
+        mock_display.error.assert_called_once()
+        error_msg = mock_display.error.call_args[0][0]
+        assert f'Worker PID 12345 received signal "{signum}: {signame}" before detachment' in error_msg
+
+        # Verify no workers were signaled (early return)
+        assert not mock_os_kill.called
+
+    def test_signal_handler_normal_operation(self, mocker):
+        """Test signal handler in a normal parent process operation."""
+        mock_inventory = mocker.Mock()
+        mock_var_manager = mocker.Mock()
+        mock_loader = mocker.Mock()
+
+        mocker.patch('ansible.executor.task_queue_manager.FinalQueue')
+        mocker.patch('ansible.executor.task_queue_manager._rpc_host.LocalManager.shared_instance')
+        mocker.patch('ansible.executor.task_queue_manager.context.CLIARGS', {})
+
+        tqm = TaskQueueManager(
+            inventory=mock_inventory,
+            variable_manager=mock_var_manager,
+            loader=mock_loader,
+            passwords={},
+        )
+
+        # Create an alive mock worker
+        mock_worker = mocker.Mock()
+        mock_worker.pid = 12345
+        mock_worker.is_alive.return_value = True
+
+        tqm._workers = [mock_worker]
+
+        # Mock os.getpid() to return a PID that's NOT a worker (normal parent case)
+        mock_getpid = mocker.patch('ansible.executor.task_queue_manager.os.getpid')
+        mock_getpid.return_value = 99999
+
+        mock_display = mocker.patch('ansible.executor.task_queue_manager.display')
+        mocker.patch('ansible.executor.task_queue_manager.signal.signal')
+        mock_os_kill = mocker.patch('ansible.executor.task_queue_manager.os.kill')
+
+        # Call signal handler
+        tqm._signal_handler(signal.SIGTERM, None)
+
+        # Verify no race condition error was logged
+        mock_display.error.assert_not_called()
+
+        # Verify worker was signaled
+        kill_calls = [call for call in mock_os_kill.call_args_list if call[0][0] == 12345]
+        assert len(kill_calls) == 1
+        assert kill_calls[0][0] == (12345, signal.SIGTERM)
+
+    def test_signal_handler_skips_none_workers(self, mocker):
+        """Test that None workers don't cause issues."""
+        mock_inventory = mocker.Mock()
+        mock_var_manager = mocker.Mock()
+        mock_loader = mocker.Mock()
+
+        mocker.patch('ansible.executor.task_queue_manager.FinalQueue')
+        mocker.patch('ansible.executor.task_queue_manager._rpc_host.LocalManager.shared_instance')
+        mocker.patch('ansible.executor.task_queue_manager.context.CLIARGS', {})
+
+        tqm = TaskQueueManager(
+            inventory=mock_inventory,
+            variable_manager=mock_var_manager,
+            loader=mock_loader,
+            passwords={},
+        )
+
+        # Mix of None and real workers
+        mock_worker = mocker.Mock()
+        mock_worker.pid = 12345
+        mock_worker.is_alive.return_value = True
+
+        tqm._workers = [None, mock_worker, None]
+
+        mock_getpid = mocker.patch('ansible.executor.task_queue_manager.os.getpid')
+        mock_getpid.return_value = 99999
+
+        mocker.patch('ansible.executor.task_queue_manager.display')
+        mocker.patch('ansible.executor.task_queue_manager.signal.signal')
+        mock_os_kill = mocker.patch('ansible.executor.task_queue_manager.os.kill')
+
+        # Should not crash
+        tqm._signal_handler(signal.SIGTERM, None)
+
+        # Verify worker was signaled
+        kill_calls = [call for call in mock_os_kill.call_args_list if call[0][0] == 12345]
+        assert len(kill_calls) == 1
+
+    def test_signal_handler_skips_dead_workers(self, mocker):
+        """Test that dead workers are skipped."""
+        mock_inventory = mocker.Mock()
+        mock_var_manager = mocker.Mock()
+        mock_loader = mocker.Mock()
+
+        mocker.patch('ansible.executor.task_queue_manager.FinalQueue')
+        mocker.patch('ansible.executor.task_queue_manager._rpc_host.LocalManager.shared_instance')
+        mocker.patch('ansible.executor.task_queue_manager.context.CLIARGS', {})
+
+        tqm = TaskQueueManager(
+            inventory=mock_inventory,
+            variable_manager=mock_var_manager,
+            loader=mock_loader,
+            passwords={},
+        )
+
+        # Create a dead worker
+        mock_worker = mocker.Mock()
+        mock_worker.pid = 12345
+        mock_worker.is_alive.return_value = False
+
+        tqm._workers = [mock_worker]
+
+        mock_getpid = mocker.patch('ansible.executor.task_queue_manager.os.getpid')
+        mock_getpid.return_value = 99999
+
+        mocker.patch('ansible.executor.task_queue_manager.display')
+        mocker.patch('ansible.executor.task_queue_manager.signal.signal')
+        mock_os_kill = mocker.patch('ansible.executor.task_queue_manager.os.kill')
+
+        tqm._signal_handler(signal.SIGTERM, None)
+
+        # Verify dead worker was NOT signaled
+        kill_calls = [call for call in mock_os_kill.call_args_list if call[0][0] == 12345]
+        assert len(kill_calls) == 0
+
+    def test_signal_handler_with_sigint_raises_keyboard_interrupt(self, mocker):
+        """Test that SIGINT raises KeyboardInterrupt after handling."""
+        mock_inventory = mocker.Mock()
+        mock_var_manager = mocker.Mock()
+        mock_loader = mocker.Mock()
+
+        mocker.patch('ansible.executor.task_queue_manager.FinalQueue')
+        mocker.patch('ansible.executor.task_queue_manager._rpc_host.LocalManager.shared_instance')
+        mocker.patch('ansible.executor.task_queue_manager.context.CLIARGS', {})
+
+        tqm = TaskQueueManager(
+            inventory=mock_inventory,
+            variable_manager=mock_var_manager,
+            loader=mock_loader,
+            passwords={},
+        )
+
+        mock_worker = mocker.Mock()
+        mock_worker.pid = 12345
+        mock_worker.is_alive.return_value = True
+
+        tqm._workers = [mock_worker]
+
+        mock_getpid = mocker.patch('ansible.executor.task_queue_manager.os.getpid')
+        mock_getpid.return_value = 99999
+
+        mocker.patch('ansible.executor.task_queue_manager.display')
+        mocker.patch('ansible.executor.task_queue_manager.signal.signal')
+        mocker.patch('ansible.executor.task_queue_manager.os.kill')
+
+        # SIGINT should raise KeyboardInterrupt
+        with pytest.raises(KeyboardInterrupt):
+            tqm._signal_handler(signal.SIGINT, None)

--- a/test/units/executor/test_task_queue_manager.py
+++ b/test/units/executor/test_task_queue_manager.py
@@ -19,7 +19,7 @@ class TestTQMSignalHandler:
         This tests the race condition where a forked child receives SIGTERM/SIGINT
         before the inherited handlers from the parent have been replaced.
         When os.getpid() matches a worker PID, we're in the child and should
-        return early without attempting worker management.
+        skip worker management but still re-send the signal to self.
         """
         mock_inventory = mocker.Mock()
         mock_var_manager = mocker.Mock()
@@ -60,8 +60,14 @@ class TestTQMSignalHandler:
         error_msg = mock_display.error.call_args[0][0]
         assert f'Worker PID 12345 received signal "{signum}: {signame}" before detachment' in error_msg
 
-        # Verify no workers were signaled (early return)
-        assert not mock_os_kill.called
+        # Verify other workers were NOT signaled, but self was signaled
+        worker_kill_calls = [call for call in mock_os_kill.call_args_list if call[0][0] == 67890]
+        assert len(worker_kill_calls) == 0, "Other workers should not be signaled in race condition"
+
+        # Verify signal was resent to self (my_pid = 12345)
+        self_kill_calls = [call for call in mock_os_kill.call_args_list if call[0][0] == 12345]
+        assert len(self_kill_calls) == 1, "Signal should be resent to self"
+        assert self_kill_calls[0][0] == (12345, signum)
 
     def test_signal_handler_normal_operation(self, mocker):
         """Test signal handler in a normal parent process operation."""
@@ -182,7 +188,7 @@ class TestTQMSignalHandler:
         assert len(kill_calls) == 0
 
     def test_signal_handler_with_sigint_raises_keyboard_interrupt(self, mocker):
-        """Test that SIGINT raises KeyboardInterrupt after handling."""
+        """Test that SIGINT in the parent process raises KeyboardInterrupt after signaling workers."""
         mock_inventory = mocker.Mock()
         mock_var_manager = mocker.Mock()
         mock_loader = mocker.Mock()
@@ -209,8 +215,13 @@ class TestTQMSignalHandler:
 
         mocker.patch('ansible.executor.task_queue_manager.display')
         mocker.patch('ansible.executor.task_queue_manager.signal.signal')
-        mocker.patch('ansible.executor.task_queue_manager.os.kill')
+        mock_os_kill = mocker.patch('ansible.executor.task_queue_manager.os.kill')
 
-        # SIGINT should raise KeyboardInterrupt
+        # SIGINT in parent should raise KeyboardInterrupt
         with pytest.raises(KeyboardInterrupt):
             tqm._signal_handler(signal.SIGINT, None)
+
+        # Verify worker was signaled before raising
+        worker_kill_calls = [call for call in mock_os_kill.call_args_list if call[0][0] == 12345]
+        assert len(worker_kill_calls) == 1
+        assert worker_kill_calls[0][0] == (12345, signal.SIGINT)


### PR DESCRIPTION
##### SUMMARY

It's possible a child process can receive a signal before that child has fully detached from the parent. This would run the signal handler that is meant only for the parent process and cause an error. Eliminating that race is not practical, but we can handle it better and produce an error message to indicate what happened.

Fixes #86946 

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
