### PR TITLE
filter: add support for POSIX extended in regex_escape

### DIFF
--- a/changelogs/fragments/regex_escape-posix_extended.yml
+++ b/changelogs/fragments/regex_escape-posix_extended.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - filter plugin ``regex_escape`` - implement ``re_type=posix_extended`` for POSIX ERE literal escaping (https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html).

--- a/changelogs/fragments/regex_escape-posix_extended.yml
+++ b/changelogs/fragments/regex_escape-posix_extended.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - filter plugin ``regex_escape`` - implement ``re_type=posix_extended`` for POSIX ERE literal escaping (https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html).
+  - filter - ``regex_escape`` implement ``re_type=posix_extended`` for POSIX ERE literal escaping (https://github.com/ansible/ansible/pull/86949).

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -245,17 +245,19 @@ def ternary(value, true_val, false_val, none_val=None):
 def regex_escape(string, re_type='python'):
     """Escape all regular expressions special characters from STRING."""
     string = to_text(string, errors='surrogate_or_strict', nonstring='simplerepr')
-    if re_type == 'python':
-        return re.escape(string)
-    if re_type == 'posix_basic':
-        # list of BRE special chars:
-        # https://en.wikibooks.org/wiki/Regular_Expressions/POSIX_Basic_Regular_Expressions
-        return regex_replace(string, r'([].[^$*\\])', r'\\\1')
-    if re_type == 'posix_extended':
-        # IEEE Std 1003.1 ERE metacharacters (for literals, prefix backslash).
-        # https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html
-        return regex_replace(string, r'([\^\$\.\*\+\?\[\]\|\(\)\{\}\\])', r'\\\1')
-    raise AnsibleFilterError('Invalid regex type (%s)' % re_type)
+    match re_type:
+        case 'python':
+            return re.escape(string)
+        case 'posix_basic':
+            # list of BRE special chars:
+            # https://en.wikibooks.org/wiki/Regular_Expressions/POSIX_Basic_Regular_Expressions
+            return regex_replace(string, r'([].[^$*\\])', r'\\\1')
+        case 'posix_extended':
+            # IEEE Std 1003.1 ERE metacharacters (for literals, prefix backslash).
+            # https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html
+            return regex_replace(string, r'([\^\$\.\*\+\?\[\]\|\(\)\{\}\\])', r'\\\1')
+        case _:
+            raise AnsibleFilterError(f'Invalid regex type ({re_type})')
 
 
 def from_yaml(data):

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -247,18 +247,15 @@ def regex_escape(string, re_type='python'):
     string = to_text(string, errors='surrogate_or_strict', nonstring='simplerepr')
     if re_type == 'python':
         return re.escape(string)
-    elif re_type == 'posix_basic':
+    if re_type == 'posix_basic':
         # list of BRE special chars:
         # https://en.wikibooks.org/wiki/Regular_Expressions/POSIX_Basic_Regular_Expressions
         return regex_replace(string, r'([].[^$*\\])', r'\\\1')
-    # TODO: implement posix_extended
-    # It's similar to, but different from python regex, which is similar to,
-    # but different from PCRE.  It's possible that re.escape would work here.
-    # https://remram44.github.io/regex-cheatsheet/regex.html#programs
-    elif re_type == 'posix_extended':
-        raise AnsibleFilterError('Regex type (%s) not yet implemented' % re_type)
-    else:
-        raise AnsibleFilterError('Invalid regex type (%s)' % re_type)
+    if re_type == 'posix_extended':
+        # IEEE Std 1003.1 ERE metacharacters (for literals, prefix backslash).
+        # https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html
+        return regex_replace(string, r'([\^\$\.\*\+\?\[\]\|\(\)\{\}\\])', r'\\\1')
+    raise AnsibleFilterError('Invalid regex type (%s)' % re_type)
 
 
 def from_yaml(data):

--- a/lib/ansible/plugins/filter/regex_escape.yml
+++ b/lib/ansible/plugins/filter/regex_escape.yml
@@ -5,18 +5,21 @@ DOCUMENTATION:
   description:
     - Escape special characters in a string for use in a regular expression.
   positional: _input, re_type
-  notes:
-    - posix_extended is not implemented yet
   options:
     _input:
       description: String to escape.
       type: str
       required: true
     re_type:
-      description: Which type of escaping to use.
+      description:
+        - Which type of escaping to use.
+        - If set to V(python), Escape all regular expressions special characters from string.
+        - If set to V(posix_basic), Escape all POSIX Basic Regular Expressions special characters from string.
+        - If set to V(posix_extended), Escape all POSIX Extended Regular Expressions special characters from string.
+        - V(posix_extended) is added in Ansible Core 2.22.
       type: str
       default: python
-      choices: [python, posix_basic]
+      choices: [python, posix_basic, posix_extended]
 
 EXAMPLES: |
 

--- a/lib/ansible/plugins/filter/regex_escape.yml
+++ b/lib/ansible/plugins/filter/regex_escape.yml
@@ -13,18 +13,24 @@ DOCUMENTATION:
     re_type:
       description:
         - Which type of escaping to use.
-        - If set to V(python), Escape all regular expressions special characters from string.
-        - If set to V(posix_basic), Escape all POSIX Basic Regular Expressions special characters from string.
-        - If set to V(posix_extended), Escape all POSIX Extended Regular Expressions special characters from string.
         - V(posix_extended) is added in Ansible Core 2.22.
       type: str
       default: python
-      choices: [python, posix_basic, posix_extended]
+      choices:
+        python: Escape all regular expressions special characters from string.
+        posix_basic: Escape all POSIX Basic Regular Expressions special characters from string.
+        posix_extended: Escape all POSIX Extended Regular Expressions special characters from string.
 
 EXAMPLES: |
 
   # safe_for_regex => '\^f\.\*o\(\.\*\)\$'
   safe_for_regex: "{{ '^f.*o(.*)$' | regex_escape() }}"
+
+  # safe_for_posix_basic => '\\]\\]\\^'
+  safe_for_posix_basic: "{{ ']]^' | regex_escape(re_type='posix_basic') }}"
+
+  # safe_for_posix_extended => '\\^f\\.\\*o\\(\\.\\*\\)\\$'
+  safe_for_posix_extended: "{{ '^f.*o(.*)$' | regex_escape(re_type='posix_extended') }}"
 
 RETURN:
   _value:

--- a/lib/ansible/plugins/filter/regex_escape.yml
+++ b/lib/ansible/plugins/filter/regex_escape.yml
@@ -17,9 +17,9 @@ DOCUMENTATION:
       type: str
       default: python
       choices:
-        python: Escape all regular expressions special characters from string.
-        posix_basic: Escape all POSIX Basic Regular Expressions special characters from string.
-        posix_extended: Escape all POSIX Extended Regular Expressions special characters from string.
+        python: Preserves all regular expressions special characters in string.
+        posix_basic: Preserves all POSIX Basic Regular Expressions special characters in string.
+        posix_extended: Preserves all POSIX Extended Regular Expressions special characters in string.
 
 EXAMPLES: |
 

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -438,12 +438,6 @@
   vars:
     d: {}
 
-- name: Verify regex_escape raises on posix_extended (failure expected)
-  set_fact:
-    foo: '{{"]]^"|regex_escape(re_type="posix_extended")}}'
-  ignore_errors: yes
-  register: regex_escape_fail_1
-
 - name: Verify regex_escape raises on other re_type (failure expected)
   set_fact:
     foo: '{{"]]^"|regex_escape(re_type="haha")}}'
@@ -454,8 +448,9 @@
   assert:
     that:
       - '"]]^"|regex_escape(re_type="posix_basic") == "\\]\\]\\^"'
-      - regex_escape_fail_1 is failed
-      - '"Regex type (posix_extended) not yet implemented" is in regex_escape_fail_1.msg'
+      - '"]]^"|regex_escape(re_type="posix_extended") == "\\]\\]\\^"'
+      - '"^f.*o(.*)$"|regex_escape(re_type="posix_extended") == "\\^f\\.\\*o\\(\\.\\*\\)\\$"'
+      - '"(a|b)"|regex_escape(re_type="posix_extended") == "\\(a\\|b\\)"'
       - regex_escape_fail_2 is failed
       - '"Invalid regex type (haha)" is in regex_escape_fail_2.msg'
 


### PR DESCRIPTION
##### SUMMARY

* add support for POSIX extended in regex_escape filter

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/regex_escape-posix_extended.yml
lib/ansible/plugins/filter/core.py
lib/ansible/plugins/filter/regex_escape.yml
test/integration/targets/filter_core/tasks/main.yml


