### PR TITLE
Allow dataclasses.asdict with lazy containers

### DIFF
--- a/changelogs/fragments/86947-lazy-containers-dataclasses.yml
+++ b/changelogs/fragments/86947-lazy-containers-dataclasses.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - templating - allow ``dataclasses.asdict`` to handle lazy list, dict, and tuple values without raising ``UnsupportedConstructionMethodError``.

--- a/lib/ansible/_internal/_templating/_lazy_containers.py
+++ b/lib/ansible/_internal/_templating/_lazy_containers.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import collections.abc as c
 import copy
 import dataclasses
 import functools
+import sys
 import types
 import typing as t
 
@@ -62,6 +64,20 @@ class UnsupportedConstructionMethodError(RuntimeError):
 
     def __init__(self):
         super().__init__("Direct construction of lazy containers is not supported.")
+
+
+def _is_dataclasses_asdict_constructor() -> bool:
+    """Return True when called from the `dataclasses.asdict` reconstruction path."""
+    for depth in range(3, 5):
+        try:
+            caller = sys._getframe(depth)
+        except ValueError:  # pragma: nocover
+            return False
+
+        if caller.f_globals.get('__name__') == 'dataclasses' and caller.f_code.co_name == '_asdict_inner':
+            return True
+
+    return False
 
 
 @t.final
@@ -131,7 +147,28 @@ class _AnsibleLazyTemplateMixin:
 
         register_known_types(cls)
 
+    @staticmethod
+    def _coerce_implicit_constructor_source(contents: t.Iterable | _LazyValueSource) -> t.Iterable | _LazyValueSource:
+        """
+        Coerce `dataclasses.asdict` reconstruction to a lazy value source.
+
+        `dataclasses.asdict` reconstructs list/dict/tuple subclasses using `type(obj)(generator)`.
+        For lazy containers, that pattern must preserve constructor metadata without enabling direct
+        iterator-based construction.
+        """
+        if isinstance(contents, c.Iterator) and _is_dataclasses_asdict_constructor():
+            if template_context := TemplateContext.current(optional=True):
+                return _LazyValueSource(
+                    source=contents,
+                    templar=template_context.templar,
+                    lazy_options=LazyOptions.SKIP_TEMPLATES_AND_ACCESS,
+                )
+
+        return contents
+
     def __init__(self, contents: t.Iterable | _LazyValueSource) -> None:
+        contents = self._coerce_implicit_constructor_source(contents)
+
         if isinstance(contents, _LazyValueSource):
             self._templar = contents.templar
             self._lazy_options = contents.lazy_options
@@ -229,6 +266,8 @@ class _AnsibleLazyTemplateDict(_AnsibleTaggedDict, _AnsibleLazyTemplateMixin):
     __slots__ = _AnsibleLazyTemplateMixin._SLOTS
 
     def __init__(self, contents: t.Iterable | _LazyValueSource, /, **kwargs) -> None:
+        contents = self._coerce_implicit_constructor_source(contents)
+
         if isinstance(contents, _AnsibleLazyTemplateDict):
             super().__init__(dict.items(contents), **kwargs)
         elif isinstance(contents, _LazyValueSource):
@@ -372,6 +411,8 @@ class _AnsibleLazyTemplateList(_AnsibleTaggedList, _AnsibleLazyTemplateMixin):
     __slots__ = _AnsibleLazyTemplateMixin._SLOTS
 
     def __init__(self, contents: t.Iterable | _LazyValueSource, /) -> None:
+        contents = self._coerce_implicit_constructor_source(contents)
+
         if isinstance(contents, _AnsibleLazyTemplateList):
             super().__init__(list.__iter__(contents))
         elif isinstance(contents, _LazyValueSource):
@@ -554,6 +595,8 @@ class _AnsibleLazyAccessTuple(_AnsibleTaggedTuple, _AnsibleLazyTemplateMixin):
     # nonempty __slots__ not supported for subtype of 'tuple'
 
     def __new__(cls, contents: t.Iterable | _LazyValueSource, /) -> t.Self:
+        contents = cls._coerce_implicit_constructor_source(contents)
+
         if isinstance(contents, _AnsibleLazyAccessTuple):
             return super().__new__(cls, tuple.__iter__(contents))
 

--- a/test/units/_internal/templating/test_lazy_containers.py
+++ b/test/units/_internal/templating/test_lazy_containers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import collections.abc as c
 import copy
+import dataclasses
 import re
 import sys
 import typing as t
@@ -31,6 +32,21 @@ CONTAINER_VALUES = (
     dict(hello=VALUE_TO_TEMPLATE),
     [VALUE_TO_TEMPLATE],
 )
+
+
+@pytest.mark.parametrize(("value", "expected"), (
+    ([TRUST.tag('{{ 1 }}')], [1]),
+    ((TRUST.tag('{{ 1 }}'),), (1,)),
+    (dict(key=TRUST.tag('{{ 1 }}')), dict(key=1)),
+))
+def test_dataclasses_asdict_with_lazy_containers(template_context, value: t.Any, expected: t.Any) -> None:
+    @dataclasses.dataclass
+    class Example:
+        data: t.Any
+
+    lazy = _AnsibleLazyTemplateMixin._try_create(value)
+
+    assert dataclasses.asdict(Example(data=lazy)) == dict(data=expected)
 
 
 @pytest.mark.parametrize("value", CONTAINER_VALUES, ids=[type(value).__name__ for value in CONTAINER_VALUES])
@@ -370,8 +386,11 @@ def test_lazy_list_adapter_operators(template, variables, expected) -> None:
     ('tuple() + d1', 'can only concatenate tuple (not "_AnsibleLazyTemplateDict") to tuple', TypeError),  # relies on tuple.__add__
     ('l1.pop(42)', "pop index out of range", IndexError),
     ('type(l1)([])', 'Direct construction of lazy containers is not supported.', UnsupportedConstructionMethodError),
+    ('type(l1)(iter([]))', 'Direct construction of lazy containers is not supported.', UnsupportedConstructionMethodError),
     ('type(t1)([])', 'Direct construction of lazy containers is not supported.', UnsupportedConstructionMethodError),
+    ('type(t1)(iter([]))', 'Direct construction of lazy containers is not supported.', UnsupportedConstructionMethodError),
     ('type(d1)({})', 'Direct construction of lazy containers is not supported.', UnsupportedConstructionMethodError),
+    ('type(d1)(iter([]))', 'Direct construction of lazy containers is not supported.', UnsupportedConstructionMethodError),
 ], ids=str)
 def test_lazy_container_operators(expression: str, expected_value: t.Any, expected_type: type) -> None:
     """


### PR DESCRIPTION
##### SUMMARY

Fixes #86947.

Allow Python's `dataclasses.asdict` to serialize lazy list, dict, and tuple values without raising `UnsupportedConstructionMethodError`. The change is limited to the stdlib dataclasses reconstruction path, so explicit lazy-container construction remains blocked.

Added regression coverage for lazy list, dict, and tuple values inside a dataclass, plus guard coverage for explicit iterator construction.

Tests passed:

- `ansible-test units -v --python 3.12 test/units/_internal/templating/test_lazy_containers.py`
- `ansible-test sanity -v --python 3.12 --test pep8 --test pylint --test changelog lib/ansible/_internal/_templating/_lazy_containers.py test/units/_internal/templating/test_lazy_containers.py changelogs/fragments/86947-lazy-containers-dataclasses.yml`

##### ISSUE TYPE

- Bugfix Pull Request