### PR TITLE
user: add password_last_change parameter

### DIFF
--- a/changelogs/fragments/86828-user-module-add-password-last-change.yml
+++ b/changelogs/fragments/86828-user-module-add-password-last-change.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+   - user - add support for password_last_change parameter

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -271,6 +271,12 @@ options:
             - Supported on Linux only.
         type: int
         version_added: "2.16"
+    password_last_change:
+        description:
+            - The date of the last password change in epoch (days since 1970-01-01).
+            - Supported on Linux only, not supported on distributions using BusyBox.
+        type: int
+        version_added: "2.22"
     umask:
         description:
             - Sets the umask of the user.
@@ -634,6 +640,7 @@ class User(object):
         self.password_expire_max = module.params['password_expire_max']
         self.password_expire_min = module.params['password_expire_min']
         self.password_expire_warn = module.params['password_expire_warn']
+        self.password_last_change = module.params['password_last_change']
         self.umask = module.params['umask']
         self.inactive = module.params['password_expire_account_disable']
         self.uid_min = module.params['uid_min']
@@ -1167,6 +1174,7 @@ class User(object):
         min_needs_change = self.password_expire_min is not None
         max_needs_change = self.password_expire_max is not None
         warn_needs_change = self.password_expire_warn is not None
+        lstchg_needs_change = self.password_last_change is not None
 
         if HAVE_SPWD:
             try:
@@ -1177,8 +1185,9 @@ class User(object):
             min_needs_change &= self.password_expire_min != shadow_info.sp_min
             max_needs_change &= self.password_expire_max != shadow_info.sp_max
             warn_needs_change &= self.password_expire_warn != shadow_info.sp_warn
+            lstchg_needs_change &= self.password_last_change != shadow_info.sp_lstchg
 
-        if not (min_needs_change or max_needs_change or warn_needs_change):
+        if not (min_needs_change or max_needs_change or warn_needs_change or lstchg_needs_change):
             return (None, '', '')  # target state already reached
 
         command_name = 'chage'
@@ -1189,6 +1198,8 @@ class User(object):
             cmd.extend(["-M", self.password_expire_max])
         if warn_needs_change:
             cmd.extend(["-W", self.password_expire_warn])
+        if lstchg_needs_change:
+            cmd.extend(["-d", self.password_last_change])
         cmd.append(self.name)
 
         return self.execute_command(cmd)
@@ -3419,6 +3430,7 @@ def main():
             ssh_key_passphrase=dict(type='str', no_log=True),
             update_password=dict(type='str', default='always', choices=['always', 'on_create'], no_log=False),
             expires=dict(type='float'),
+            password_last_change=dict(type='int', no_log=False),
             password_lock=dict(type='bool', no_log=False),
             local=dict(type='bool'),
             profile=dict(type='str'),

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -12,6 +12,7 @@
 - import_tasks: test_no_home_fallback.yml
 - include_tasks: test_expires.yml
   when: ansible_distribution != 'Alpine'
+- include_tasks: test_password_last_change.yml
 - import_tasks: test_expires_new_account.yml
 - import_tasks: test_expires_new_account_epoch_negative.yml
 - import_tasks: test_expires_no_shadow.yml

--- a/test/integration/targets/user/tasks/test_password_last_change.yml
+++ b/test/integration/targets/user/tasks/test_password_last_change.yml
@@ -1,0 +1,68 @@
+# Date is May 1, 2026
+- name: Test password_last_change attribute
+  when: ansible_facts.os_family in ['RedHat', 'Debian']
+  block:
+  - name: Remove ansibulluser
+    user:
+      name: ansibulluser
+      state: absent
+
+  - name: Create user with password last change date
+    user:
+      name: ansibulluser
+      state: present
+      password_last_change: 20574
+    register: user_test_password_last_change1
+
+  - name: Set user password last change again to ensure no change is made
+    user:
+      name: ansibulluser
+      state: present
+      password_last_change: 20574
+    register: user_test_password_last_change2
+    
+  - name: Ensure that account with password last change was created and did not change on subsequent run
+    assert:
+      that:
+        - user_test_password_last_change1 is changed
+        - user_test_password_last_change2 is not changed
+
+  - name: Get password change date for ansibulluser
+    getent:
+      database: shadow
+      key: ansibulluser
+
+  - name: Ensure proper expiration date was set
+    assert:
+      that:
+        - getent_shadow['ansibulluser'][1] == '20574'
+
+  - name: Change password last change date
+    user:
+      name: ansibulluser
+      state: present
+      password_last_change: 20575
+    register: user_test_password_last_change1
+
+  - name: Set user password last change again to ensure no change is made
+    user:
+      name: ansibulluser
+      state: present
+      password_last_change: 20575
+    register: user_test_password_last_change2
+    
+  - name: Ensure that account with password last change was created and did not change on subsequent run
+    assert:
+      that:
+        - user_test_password_last_change1 is changed
+        - user_test_password_last_change2 is not changed
+
+  - name: Get password change date for ansibulluser
+    getent:
+      database: shadow
+      key: ansibulluser
+
+  - name: Ensure proper expiration date was set
+    assert:
+      that:
+        - getent_shadow['ansibulluser'][1] == '20575'


### PR DESCRIPTION
##### SUMMARY

The user module already supports sp_min, sp_max, and sp_warn via password_expire_* parameters and chage. Parameter password_last_change added to set sp_lstchg via chage -d, which allows setting password last change date.

Fixes #86828 

##### ISSUE TYPE

- Feature Pull Request
