### PR TITLE
ansible-test - Update base/default containers

### DIFF
--- a/lib/ansible/module_utils/_internal/_patches/_dataclass_annotation_patch.py
+++ b/lib/ansible/module_utils/_internal/_patches/_dataclass_annotation_patch.py
@@ -6,6 +6,8 @@ import dataclasses
 import sys
 import typing as t
 
+# deprecated: description='remove this patch once Python 3.14 is no longer supported on targets' python_version='3.14'
+
 from . import CallablePatch
 
 # trigger the bug by exposing typing.ClassVar via a module reference that is not `typing`
@@ -24,7 +26,7 @@ class DataclassesIsTypePatch(CallablePatch):
         @dataclasses.dataclass
         class CheckClassVar:
             # this is the broken case requiring patching: ClassVar dot-referenced from a module that is not `typing` is treated as an instance field
-            # DTFIX-FUTURE: file/link CPython bug report, deprecate this patch if/when it's fixed in CPython
+            # fixed in CPython 3.15.0b1, see: https://github.com/python/cpython/pull/140541
             a_classvar: _ts.ClassVar[int]  # type: ignore[name-defined]
             a_field: int
 

--- a/test/integration/targets/ansible-test-sanity-pylint/aliases
+++ b/test/integration/targets/ansible-test-sanity-pylint/aliases
@@ -2,3 +2,4 @@ shippable/posix/group3  # runs in the distro test containers
 shippable/generic/group1  # runs in the default test container
 context/controller
 needs/target/collection
+skip/python3.15  # see: https://github.com/uqfoundation/dill/issues/753

--- a/test/lib/ansible_test/_data/completion/docker.txt
+++ b/test/lib/ansible_test/_data/completion/docker.txt
@@ -1,6 +1,6 @@
-base image=quay.io/ansible/base-test-container:v2.22-0 python=3.14,3.9,3.10,3.11,3.12,3.13,3.15 powershell=7.6
-default image=quay.io/ansible/default-test-container:v2.22-0 python=3.14,3.9,3.10,3.11,3.12,3.13,3.15 powershell=7.6 context=collection
-default image=quay.io/ansible/ansible-core-test-container:v2.22-0 python=3.14,3.9,3.10,3.11,3.12,3.13,3.15 powershell=7.6 context=ansible-core
+base image=quay.io/ansible/base-test-container:v2.22-1 python=3.14,3.9,3.10,3.11,3.12,3.13,3.15 powershell=7.6
+default image=quay.io/ansible/default-test-container:v2.22-1 python=3.14,3.9,3.10,3.11,3.12,3.13,3.15 powershell=7.6 context=collection
+default image=quay.io/ansible/ansible-core-test-container:v2.22-1 python=3.14,3.9,3.10,3.11,3.12,3.13,3.15 powershell=7.6 context=ansible-core
 alpine323 image=quay.io/ansible/alpine-test-container:3.23-v2.22-0 python=3.12 cgroup=none audit=none alias=alpine
 fedora44 image=quay.io/ansible/fedora-test-container:44-v2.22-1 python=3.14 cgroup=v2-only alias=fedora
 ubuntu2404 image=quay.io/ansible/ubuntu-test-container:24.04-v2.22-0 python=3.12

--- a/test/lib/ansible_test/_internal/commands/sanity/pylint.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/pylint.py
@@ -13,6 +13,7 @@ from . import (
     SanitySingleVersion,
     SanityMessage,
     SanityFailure,
+    SanitySkipped,
     SanitySuccess,
     SanityTargets,
     SANITY_ROOT,
@@ -39,6 +40,7 @@ from ...util import (
     SubprocessError,
     display,
     is_subdir,
+    str_to_version,
 )
 
 from ...util_common import (
@@ -86,6 +88,12 @@ class PylintTest(SanitySingleVersion):
         return [target for target in targets if os.path.splitext(target.path)[1] == '.py' or is_subdir(target.path, 'bin')]
 
     def test(self, args: SanityConfig, targets: SanityTargets, python: PythonConfig) -> TestResult:
+        if str_to_version(python.version) >= (3, 15):
+            # see: https://github.com/uqfoundation/dill/issues/753
+            result = SanitySkipped(self.name, python.version)
+            result.reason = f'Skipping sanity test "{self.name}" due to lack of support for Python version {python.version} in the "dill" package.'
+            return result
+
         target_paths = set(target.path for target in self.filter_remote_targets(list(targets.targets)))
 
         plugin_dir = os.path.join(SANITY_ROOT, 'pylint', 'plugins')

--- a/test/units/module_utils/_internal/_patches/test_patches.py
+++ b/test/units/module_utils/_internal/_patches/test_patches.py
@@ -10,7 +10,7 @@ import typing as t
 import pytest
 
 from ansible.module_utils._internal import _patches
-from ansible.module_utils._internal._patches import _socket_patch
+from ansible.module_utils._internal._patches import _socket_patch, _dataclass_annotation_patch
 from ansible.module_utils.common._utils import get_all_subclasses
 
 module_to_patch = sys.modules[__name__]
@@ -38,6 +38,7 @@ def get_patch_required_test_cases() -> list:
         # Example:
         # _patches._some_patch_module.SomePatchClass: sys.version_info >= (3, 13),
         _socket_patch.GetAddrInfoPatch: sys.version_info >= (3, 14),
+        _dataclass_annotation_patch.DataclassesIsTypePatch: sys.version_info >= (3, 15, 0, 'beta', 1),
     }
 
     patches = sorted(get_all_subclasses(_patches.CallablePatch), key=lambda item: item.__name__)


### PR DESCRIPTION
##### SUMMARY

ansible-test - Update base/default containers to include Python 3.15.0b1.

##### ISSUE TYPE

Feature Pull Request
