### PR TITLE
facts: classify UnionTech OS Server as RedHat os_family

### DIFF
--- a/changelogs/fragments/86957-uniontechos-server-redhat-family.yml
+++ b/changelogs/fragments/86957-uniontechos-server-redhat-family.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - distribution facts - classify UnionTech OS Server (UOS Server) as ``RedHat`` ``os_family`` instead of ``Debian``. UOS Server is RPM-based and built on top of openAnolis (A version, codename ``kongzi``) or openEuler (E version, codename ``fuyu``), and advertises ``PLATFORM_ID="platform:uel*"`` in ``/etc/os-release``. The Debian-based Desktop edition is unchanged (https://github.com/ansible/ansible/issues/86957).

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -56,6 +56,8 @@ class DistributionFiles:
         {'path': '/etc/oracle-release', 'name': 'OracleLinux'},
         {'path': '/etc/slackware-version', 'name': 'Slackware'},
         {'path': '/etc/centos-release', 'name': 'CentOS'},
+        # Must precede RedHat: A-version UOS Server symlinks redhat-release to uos-release.
+        {'path': '/etc/redhat-release', 'name': 'UnionTech'},
         {'path': '/etc/redhat-release', 'name': 'RedHat'},
         {'path': '/etc/vmware-release', 'name': 'VMwareESX', 'allowempty': True},
         {'path': '/etc/openwrt_release', 'name': 'OpenWrt'},
@@ -67,6 +69,7 @@ class DistributionFiles:
         {'path': '/etc/os-release', 'name': 'SUSE'},
         {'path': '/etc/SuSE-release', 'name': 'SUSE'},
         {'path': '/etc/gentoo-release', 'name': 'Gentoo'},
+        {'path': '/etc/os-release', 'name': 'UnionTech'},
         {'path': '/etc/os-release', 'name': 'Debian'},
         {'path': '/etc/lsb-release', 'name': 'Debian'},
         {'path': '/etc/lsb-release', 'name': 'Mandriva'},
@@ -393,6 +396,11 @@ class DistributionFiles:
                 debian_facts['distribution_version'] = version.group(1)
                 debian_facts['distribution_major_version'] = version.group(1).split('.')[0]
         elif 'UOS' in data or 'Uos' in data or 'uos' in data:
+            # The RHEL-based UnionTech OS Server variants are handled by
+            # parse_distribution_file_UnionTech via the dedicated OSDIST_LIST entry,
+            # so skip them here to avoid mis-classifying them as the Debian-based Uos.
+            if re.search(r'PLATFORM_ID="?platform:uel', data):
+                return False, debian_facts
             debian_facts['distribution'] = 'Uos'
             release = re.search(r"VERSION_CODENAME=\"?([^\"]+)\"?", data)
             if release:
@@ -513,6 +521,37 @@ class DistributionFiles:
 
         return False, centos_facts
 
+    def parse_distribution_file_UnionTech(self, name, data, path, collected_facts):
+        # UOS Server (RHEL-based) is identified by PLATFORM_ID="platform:uel*" in
+        # /etc/os-release, or "UOS Server release" / "UnionTech OS Server release"
+        # in /etc/redhat-release. UOS Desktop (Debian-based, no PLATFORM_ID) is
+        # left to parse_distribution_file_Debian.
+        uniontech_facts = {}
+        is_uos_release_file = bool(re.search(r'(UnionTech OS Server|UOS Server) release', data))
+        has_uel_platform_id = bool(re.search(r'PLATFORM_ID="?platform:uel', data))
+        if not (is_uos_release_file or has_uel_platform_id):
+            return False, uniontech_facts
+
+        uniontech_facts['distribution'] = 'UnionTech'
+        release = re.search(r'VERSION_CODENAME="?([^"\n]+)"?', data)
+        if release:
+            uniontech_facts['distribution_release'] = release.group(1)
+        else:
+            # /etc/redhat-release style: "UnionTech OS Server release 20 (kongzi)"
+            release = re.search(r'release\s+\S+\s+\(([^)]+)\)', data)
+            if release:
+                uniontech_facts['distribution_release'] = release.group(1)
+        version = re.search(r'VERSION_ID="?([^"\n]+)"?', data)
+        if version:
+            uniontech_facts['distribution_version'] = version.group(1)
+            uniontech_facts['distribution_major_version'] = version.group(1).split('.')[0]
+        else:
+            version = re.search(r'release\s+(\S+)', data)
+            if version:
+                uniontech_facts['distribution_version'] = version.group(1)
+                uniontech_facts['distribution_major_version'] = version.group(1).split('.')[0]
+        return True, uniontech_facts
+
 
 class Distribution(object):
     """
@@ -528,7 +567,8 @@ class Distribution(object):
                                 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS',
                                 'OEL', 'Amazon', 'Amzn', 'Virtuozzo', 'XenServer', 'Alibaba',
                                 'EulerOS', 'openEuler', 'AlmaLinux', 'Rocky', 'TencentOS',
-                                'EuroLinux', 'Kylin Linux Advanced Server', 'MIRACLE'],
+                                'EuroLinux', 'Kylin Linux Advanced Server', 'MIRACLE',
+                                'UnionTech'],
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon',
                                 'Linux Mint', 'SteamOS', 'Devuan', 'Kali', 'Cumulus Linux',
                                 'Pop!_OS', 'Parrot', 'Pardus GNU/Linux', 'Uos', 'Deepin', 'OSMC',

--- a/test/units/module_utils/facts/system/distribution/fixtures/uniontech_os_server_20_uel20.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/uniontech_os_server_20_uel20.json
@@ -1,0 +1,29 @@
+{
+    "name": "UnionTech OS Server 20 (uel20)",
+    "distro": {
+        "codename": "fuyu",
+        "id": "uos",
+        "name": "UnionTech OS Server 20",
+        "version": "20",
+        "version_best": "20",
+        "os_release_info": {},
+        "lsb_release_info": {}
+    },
+    "input": {
+        "/etc/os-release": "PRETTY_NAME=\"UnionTech OS Server 20\"\nNAME=\"UnionTech OS Server 20\"\nVERSION_ID=\"20\"\nVERSION=\"20\"\nID=\"uos\"\nPLATFORM_ID=\"platform:uel20\"\nHOME_URL=\"https://www.chinauos.com/\"\nBUG_REPORT_URL=\"https://bbs.chinauos.com/\"\nVERSION_CODENAME=\"fuyu\"\n",
+        "/etc/lsb-release": "DISTRIB_ID=\"Uos\"\nDISTRIB_RELEASE=\"20\"\nDISTRIB_DESCRIPTION=\"UnionTech OS Server 20\"\nDISTRIB_CODENAME=\"fuyu\"\n",
+        "/etc/system-release": "uos release 20 (fuyu)\n"
+    },
+    "platform.dist": [
+        "uos",
+        "20",
+        "fuyu"
+    ],
+    "result": {
+        "distribution": "UnionTech",
+        "distribution_version": "20",
+        "distribution_release": "fuyu",
+        "distribution_major_version": "20",
+        "os_family": "RedHat"
+    }
+}

--- a/test/units/module_utils/facts/system/distribution/fixtures/uniontech_os_server_20_uelc20.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/uniontech_os_server_20_uelc20.json
@@ -1,0 +1,30 @@
+{
+    "name": "UnionTech OS Server 20 (uelc20)",
+    "distro": {
+        "codename": "kongzi",
+        "id": "uos",
+        "name": "UnionTech OS Server 20",
+        "version": "20",
+        "version_best": "20",
+        "os_release_info": {},
+        "lsb_release_info": {}
+    },
+    "input": {
+        "/etc/os-release": "PRETTY_NAME=\"UnionTech OS Server 20\"\nNAME=\"UnionTech OS Server 20\"\nVERSION_ID=\"20\"\nVERSION=\"20\"\nID=uos\nHOME_URL=\"https://www.chinauos.com/\"\nBUG_REPORT_URL=\"https://bbs.chinauos.com/\"\nVERSION_CODENAME=kongzi\nPLATFORM_ID=\"platform:uelc20\"\n",
+        "/etc/lsb-release": "DISTRIB_ID=Uos\nDISTRIB_RELEASE=20\nDISTRIB_DESCRIPTION=\"UnionTech OS Server 20\"\nDISTRIB_CODENAME=kongzi\n",
+        "/etc/system-release": "UnionTech OS Server release 20 (kongzi)\n",
+        "/etc/redhat-release": "UnionTech OS Server release 20 (kongzi)\n"
+    },
+    "platform.dist": [
+        "uos",
+        "20",
+        "kongzi"
+    ],
+    "result": {
+        "distribution": "UnionTech",
+        "distribution_version": "20",
+        "distribution_release": "kongzi",
+        "distribution_major_version": "20",
+        "os_family": "RedHat"
+    }
+}

--- a/test/units/module_utils/facts/system/distribution/fixtures/uos_server_20_uel20.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/uos_server_20_uel20.json
@@ -1,0 +1,29 @@
+{
+    "name": "UOS Server 20 (uel20)",
+    "distro": {
+        "codename": "fuyu",
+        "id": "uos",
+        "name": "UOS Server 20",
+        "version": "20",
+        "version_best": "20",
+        "os_release_info": {},
+        "lsb_release_info": {}
+    },
+    "input": {
+        "/etc/os-release": "PRETTY_NAME=\"UOS Server 20\"\nNAME=\"UOS Server 20\"\nVERSION_ID=\"20\"\nVERSION=\"20\"\nID=uos\nHOME_URL=\"https://www.chinauos.com/\"\nBUG_REPORT_URL=\"https://bbs.chinauos.com/\"\nVERSION_CODENAME=fuyu\nPLATFORM_ID=\"platform:uel20\"\n",
+        "/etc/lsb-release": "DISTRIB_ID=Uos\nDISTRIB_RELEASE=20\nDISTRIB_DESCRIPTION=\"UOS Server 20\"\nDISTRIB_CODENAME=fuyu\n",
+        "/etc/system-release": "uos release 20 (fuyu)\n"
+    },
+    "platform.dist": [
+        "uos",
+        "20",
+        "fuyu"
+    ],
+    "result": {
+        "distribution": "UnionTech",
+        "distribution_version": "20",
+        "distribution_release": "fuyu",
+        "distribution_major_version": "20",
+        "os_family": "RedHat"
+    }
+}

--- a/test/units/module_utils/facts/system/distribution/fixtures/uos_server_20_uelc20.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/uos_server_20_uelc20.json
@@ -1,0 +1,30 @@
+{
+    "name": "UOS Server 20 (uelc20)",
+    "distro": {
+        "codename": "kongzi",
+        "id": "uos",
+        "name": "UOS Server 20",
+        "version": "20",
+        "version_best": "20",
+        "os_release_info": {},
+        "lsb_release_info": {}
+    },
+    "input": {
+        "/etc/os-release": "PRETTY_NAME=\"UOS Server 20\"\nNAME=\"UOS Server 20\"\nVERSION_ID=\"20\"\nVERSION=\"20\"\nID=uos\nHOME_URL=\"https://www.chinauos.com/\"\nBUG_REPORT_URL=\"https://bbs.chinauos.com/\"\nVERSION_CODENAME=kongzi\nPLATFORM_ID=\"platform:uelc20\"\n",
+        "/etc/lsb-release": "DISTRIB_ID=Uos\nDISTRIB_RELEASE=20\nDISTRIB_DESCRIPTION=\"UOS Server 20\"\nDISTRIB_CODENAME=kongzi\n",
+        "/etc/system-release": "UOS Server release 20 (kongzi)\n",
+        "/etc/redhat-release": "UOS Server release 20 (kongzi)\n"
+    },
+    "platform.dist": [
+        "uos",
+        "20",
+        "kongzi"
+    ],
+    "result": {
+        "distribution": "UnionTech",
+        "distribution_version": "20",
+        "distribution_release": "kongzi",
+        "distribution_major_version": "20",
+        "os_family": "RedHat"
+    }
+}


### PR DESCRIPTION
##### SUMMARY

Fixes #86957.

UOS Server is RPM-based (built on openAnolis or openEuler) but the existing ``Uos`` branch in ``parse_distribution_file_Debian`` (#77275) classifies it as ``Debian``, so ``ansible_os_family == 'RedHat'`` tasks are skipped.

This PR adds ``parse_distribution_file_UnionTech``, gated on ``PLATFORM_ID="platform:uel*"`` in ``/etc/os-release`` — a marker present on every UOS Server image but never on Desktop. Resulting facts:

```
ansible_distribution         = "UnionTech"
ansible_distribution_release = "kongzi"  # A version (openAnolis-based)
                            or "fuyu"    # E version (openEuler-based)
ansible_os_family            = "RedHat"
```

UOS Desktop (Debian-based, no ``PLATFORM_ID``) is unchanged — addressing the backward-compat concern that closed #79290.

###### Why ``UnionTech`` (not ``Anolis OS`` / ``openEuler``)

Same precedent as Rocky/AlmaLinux (RHEL rebuilds → own brand) and openEuler (CentOS Stream downstream → own brand). ``/etc/os-release`` says ``ID=uos``. Users who need to distinguish A vs. E can use ``ansible_distribution_release`` (``kongzi`` / ``fuyu``).

###### Evidence

Verified ``PLATFORM_ID="platform:uel*"`` on 12 real UOS Server images from Docker Hub across 5 publishers (cnxc, xudingjun3131, quanshengli, macrosan, liwanggui) and point releases 1050/1060/1070. All RPM-based. Raw data: <https://github.com/yankay/ansible/tree/wip/86957-uos-research-backup/research/86957-uos-os-family>.

###### Tests

4 new fixtures cover A/E × old/new ``NAME``. Existing ``uos_20.json`` (Desktop) kept as backward-compat regression. ``98 passed`` locally.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/facts/system/distribution.py