### PR TITLE
ssh: fix false UNREACHABLE errors on task failure with sshpass

### DIFF
--- a/changelogs/fragments/sshpass-passthrough-unreachable.yml
+++ b/changelogs/fragments/sshpass-passthrough-unreachable.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - >-
+    ssh connection plugin - fix ``sshpass`` falsely marking a host ``UNREACHABLE`` when a task
+    fails. ``fail_json()`` always exits with code 1, which ``sshpass`` propagates back to Ansible.
+    Exit code 1 was being treated as a ``sshpass`` protocol error and raised as a connection failure.
+    Only exit code 5 (bad password) now raises an authentication failure; all other non-zero exit
+    codes are passed through as task failures.

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -3,7 +3,6 @@
 # Copyright 2017 Toshio Kuratomi <tkuratomi@ansible.com>
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
 from __future__ import annotations
 
 DOCUMENTATION = """
@@ -490,8 +489,10 @@ def _handle_error(
 ) -> None:
 
     # sshpass errors
-    if command == b'sshpass':
-        # Error 5 is invalid/incorrect password. Raise an exception to prevent retries from locking the account.
+    # Identification: Either the command is b'sshpass', or the stderr starts with 'sshpass:' (standard for sshpass errors).
+    is_sshpass = command == b'sshpass' or return_tuple[2].startswith(b'sshpass:')
+
+    if is_sshpass:
         if return_tuple[0] == 5:
             msg = 'Invalid/incorrect username/password. Skipping remaining {0} retries to prevent account lockout:'.format(remaining_retries)
             if remaining_retries <= 0:
@@ -502,21 +503,11 @@ def _handle_error(
                 msg = '{0} {1}'.format(msg, to_native(return_tuple[2]).rstrip())
             raise AnsibleAuthenticationFailure(msg)
 
-        # sshpass returns codes are 1-6. We handle 5 previously, so this catches other scenarios.
-        # No exception is raised, so the connection is retried - except when attempting to use
-        # sshpass_prompt with an sshpass that won't let us pass -P, in which case we fail loudly.
-        elif return_tuple[0] in [1, 2, 3, 4, 6]:
-            msg = 'sshpass error:'
-            if no_log:
-                msg = '{0} <error censored due to no log>'.format(msg)
-            else:
-                details = to_native(return_tuple[2]).rstrip()
-                if "sshpass: invalid option -- 'P'" in details:
-                    details = 'Installed sshpass version does not support customized password prompts. ' \
-                              'Upgrade sshpass to use sshpass_prompt, or otherwise switch to ssh keys.'
-                    raise AnsibleError('{0} {1}'.format(msg, details))
-                msg = '{0} {1}'.format(msg, details)
-            raise AnsibleConnectionFailure(msg)
+        if not no_log and b"sshpass: invalid option -- 'P'" in return_tuple[2]:
+            raise AnsibleError(
+                "Installed sshpass version does not support customized password prompts. "
+                "Upgrade sshpass to use sshpass_prompt, or otherwise switch to ssh keys."
+            )
 
     if return_tuple[0] == 255:
         SSH_ERROR = True
@@ -1102,10 +1093,6 @@ class Connection(ConnectionBase):
         Starts the command and communicates with it until it ends.
         """
 
-        # We don't use _shell.quote as this is run on the controller and independent from the shell plugin chosen
-        display_cmd = u' '.join(shlex.quote(to_text(c)) for c in cmd)
-        display.vvv(u'SSH: EXEC {0}'.format(display_cmd), host=self.host)
-
         conn_password = self.get_option('password') or self._play_context.password
         password_mechanism = self.get_option('password_mechanism')
 
@@ -1117,15 +1104,24 @@ class Connection(ConnectionBase):
         p = None
 
         if isinstance(cmd, (str, bytes)):
-            cmd = to_bytes(cmd)
+            cmd = [to_bytes(cmd)]
         else:
-            cmd = list(map(to_bytes, cmd))
+            # Modify in-place so decorators like _ssh_retry see the byte-converted list
+            cmd[:] = [to_bytes(c) for c in cmd]
 
         popen_kwargs = self._init_shm()
 
         if b_ssh_pass_cmd := self._sshpass_cmd():
-            cmd[:0] = b_ssh_pass_cmd
+            if cmd and cmd[0] == b'sshpass':
+                # sshpass already added by a previous attempt
+                cmd[1] = b_ssh_pass_cmd[1]
+            else:
+                cmd[:0] = b_ssh_pass_cmd
             popen_kwargs['pass_fds'] = self.sshpass_pipe
+
+        # We don't use _shell.quote as this is run on the controller and independent from the shell plugin chosen
+        display_cmd = u' '.join(shlex.quote(to_text(c)) for c in cmd)
+        display.vvv(u'SSH: EXEC {0}'.format(display_cmd), host=self.host)
 
         if not in_data:
             try:

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -25,7 +25,7 @@ import pytest
 
 import unittest
 from unittest.mock import patch, MagicMock, PropertyMock
-from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
+from ansible.errors import AnsibleAuthenticationFailure, AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
 import shlex
 from ansible.module_utils.common.text.converters import to_bytes
 from ansible.playbook.play_context import PlayContext
@@ -209,7 +209,7 @@ class TestConnectionBaseClass(unittest.TestCase):
 
         mock_ospe.return_value = True
         conn._build_command.return_value = 'some command to run'
-        conn._bare_run.return_value = (0, '', '')
+        conn._bare_run.return_value = (0, b'', b'')
 
         conn.set_option("host", "some_host")
         conn.set_option('reconnection_retries', 9)
@@ -228,27 +228,27 @@ class TestConnectionBaseClass(unittest.TestCase):
         conn._bare_run.assert_called_with('some command to run', expected_in_data, checkrc=False)
 
         # Test when SFTP doesn't work but SCP does
-        conn._bare_run.side_effect = [(1, 'stdout', 'some errors'), (0, '', '')]
+        conn._bare_run.side_effect = [(1, b'stdout', b'some errors'), (0, b'', b'')]
         conn.put_file('/path/to/in/file', '/path/to/dest/file')
         conn._bare_run.assert_called_with('some command to run', None, checkrc=False)
         conn._bare_run.side_effect = None
 
         # Test that a non-zero rc raises an error
         conn.set_option('ssh_transfer_method', 'sftp')
-        conn._bare_run.return_value = (1, 'stdout', 'some errors')
+        conn._bare_run.return_value = (1, b'stdout', b'some errors')
         self.assertRaises(AnsibleError, conn.put_file, '/path/to/bad/file', '/remote/path/to/file')
 
         # Test that rc=255 raises an error
-        conn._bare_run.return_value = (255, 'stdout', 'some errors')
+        conn._bare_run.return_value = (255, b'stdout', b'some errors')
         self.assertRaises(AnsibleConnectionFailure, conn.put_file, '/path/to/bad/file', '/remote/path/to/file')
 
         # Test that rc=256 raises an error
-        conn._bare_run.return_value = (256, 'stdout', 'some errors')
+        conn._bare_run.return_value = (256, b'stdout', b'some errors')
         self.assertRaises(AnsibleError, conn.put_file, '/path/to/bad/file', '/remote/path/to/file')
 
         # Test that a not-found path raises an error
         mock_ospe.return_value = False
-        conn._bare_run.return_value = (0, 'stdout', '')
+        conn._bare_run.return_value = (0, b'stdout', b'')
         self.assertRaises(AnsibleFileNotFound, conn.put_file, '/path/to/bad/file', '/remote/path/to/file')
 
     @patch('time.sleep')
@@ -260,7 +260,7 @@ class TestConnectionBaseClass(unittest.TestCase):
         conn._load_name = 'ssh'
 
         conn._build_command.return_value = 'some command to run'
-        conn._bare_run.return_value = (0, '', '')
+        conn._bare_run.return_value = (0, b'', b'')
 
         conn.set_option("host", "some_host")
         conn.set_option('reconnection_retries', 9)
@@ -273,7 +273,7 @@ class TestConnectionBaseClass(unittest.TestCase):
         conn._bare_run.assert_called_with('some command to run', expected_in_data, checkrc=False)
 
         # Test when SFTP doesn't work but SCP does
-        conn._bare_run.side_effect = [(1, 'stdout', 'some errors'), (0, '', '')]
+        conn._bare_run.side_effect = [(1, b'stdout', b'some errors'), (0, b'', b'')]
         conn.fetch_file('/path/to/in/file', '/path/to/dest/file')
         conn._bare_run.assert_called_with('some command to run', None, checkrc=False)
         conn._bare_run.side_effect = None
@@ -288,15 +288,15 @@ class TestConnectionBaseClass(unittest.TestCase):
 
         # Test that a non-zero rc raises an error
         conn.set_option('ssh_transfer_method', 'sftp')
-        conn._bare_run.return_value = (1, 'stdout', 'some errors')
+        conn._bare_run.return_value = (1, b'stdout', b'some errors')
         self.assertRaises(AnsibleError, conn.fetch_file, '/path/to/bad/file', '/remote/path/to/file')
 
         # Test that rc=255 raises an error
-        conn._bare_run.return_value = (255, 'stdout', 'some errors')
+        conn._bare_run.return_value = (255, b'stdout', b'some errors')
         self.assertRaises(AnsibleConnectionFailure, conn.fetch_file, '/path/to/bad/file', '/remote/path/to/file')
 
         # Test that rc=256 raises an error
-        conn._bare_run.return_value = (256, 'stdout', 'some errors')
+        conn._bare_run.return_value = (256, b'stdout', b'some errors')
         self.assertRaises(AnsibleError, conn.fetch_file, '/path/to/bad/file', '/remote/path/to/file')
 
 
@@ -597,3 +597,38 @@ class TestSSHConnectionRetries(object):
         assert b_stdout == b"my_stdout\nsecond_line"
         assert b_stderr == b"my_stderr"
         assert self.mock_popen.call_count == 2
+
+
+class TestHandleError:
+    """Tests for the _handle_error helper function."""
+
+    @pytest.mark.parametrize('rc', [1, 2, 3, 4, 6])
+    def test_sshpass_nonzero_rc_does_not_raise(self, rc):
+        # sshpass propagates SSH's exit code which propagates the remote command's exit code.
+        # Any value in 1-254 is a legitimate remote command exit code, so none of them should
+        # cause a connection failure — doing so produces false UNREACHABLE results.
+        ssh._handle_error(0, b'sshpass', (rc, b'', b'Shared connection to 1.2.3.4 closed.\r\n'), False, 'host')
+
+    @pytest.mark.parametrize('rc', [1, 2, 3, 4, 6])
+    def test_sshpass_nonzero_rc_does_not_raise_no_log(self, rc):
+        ssh._handle_error(0, b'sshpass', (rc, b'', b'Shared connection to 1.2.3.4 closed.\r\n'), True, 'host')
+
+    @pytest.mark.parametrize('rc', [1, 2, 3, 4, 6])
+    def test_sshpass_nonzero_rc_with_sshpass_own_stderr_does_not_raise(self, rc):
+        # Even when stderr contains sshpass-specific output, no connection failure is raised —
+        # the exit code alone cannot distinguish a sshpass failure from a remote command result.
+        ssh._handle_error(0, b'sshpass', (rc, b'', b'SSHPASS: Failed to run command: No such file or directory\n'), False, 'host')
+
+    def test_sshpass_rc5_raises_authentication_failure(self):
+        with pytest.raises(AnsibleAuthenticationFailure):
+            ssh._handle_error(0, b'sshpass', (5, b'', b''), False, 'host')
+
+    def test_sshpass_invalid_P_option_raises_ansible_error(self):
+        # Old sshpass versions don't support -P; this should raise AnsibleError with a helpful message,
+        # not AnsibleConnectionFailure (UNREACHABLE).
+        with pytest.raises(AnsibleError, match='Upgrade sshpass'):
+            ssh._handle_error(0, b'sshpass', (1, b'', b"sshpass: invalid option -- 'P'\n"), False, 'host')
+
+    def test_sshpass_invalid_P_option_no_log_does_not_raise(self):
+        # When no_log is set, stderr is suppressed so we cannot safely inspect it; fall through.
+        ssh._handle_error(0, b'sshpass', (1, b'', b"sshpass: invalid option -- 'P'\n"), True, 'host')


### PR DESCRIPTION
When using sshpass, remote task failures were incorrectly treated as connection errors (UNREACHABLE). This occurred because sshpass propagates the remote command's exit code, which the plugin misinterpreted.

This fix ensures that only definitive sshpass failures (like invalid passwords) trigger a connection failure, while others correctly propagate as task failures. It also restores accurate verbose logging and ensures the command list is correctly updated in-place for decorators.

##### SUMMARY

Fixes https://github.com/ansible/ansible/issues/86961

##### ISSUE TYPE

- Bugfix Pull Request
