### PR TITLE
Handle sudo-rs i18n

### DIFF
--- a/changelogs/fragments/sudo_moar_rs.yml
+++ b/changelogs/fragments/sudo_moar_rs.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sudo become plugin, sudo-rs compatibility fix for non english locales

--- a/lib/ansible/plugins/become/sudo.py
+++ b/lib/ansible/plugins/become/sudo.py
@@ -106,7 +106,7 @@ class BecomeModule(BecomeBase):
         matched = super().check_password_prompt(b_output)
         if not matched:
             # might be using sudo-rs, which is not backwards compatible
-            sudo_rs = re.compile(f"[sudo: {self.prompt.strip()}] \\S.+?\\S\\Z".encode())  # I18N
+            sudo_rs = re.compile(re.escape(f"[sudo: {self.prompt.strip()}] \\S.+?\\S\\Z".encode()))  # I18N
             # use match as line MUST start with this
             matched = any(sudo_rs.match(l) for l in b_output.splitlines())
         return matched

--- a/lib/ansible/plugins/become/sudo.py
+++ b/lib/ansible/plugins/become/sudo.py
@@ -106,7 +106,7 @@ class BecomeModule(BecomeBase):
         matched = super().check_password_prompt(b_output)
         if not matched:
             # try sudo-rs, which is not backwards compatible and does i18n
-            sudo_rs = re.compile(re.escape(f"[sudo: {self.prompt.strip()}] \\S.+?\\S\\Z".encode()))
+            sudo_rs = re.compile(fr"\[sudo: {self.prompt.strip()}\] \S.+\Z".encode())
             # using match as the line MUST start with this
             matched = any(sudo_rs.match(l) for l in b_output.splitlines())
         return matched

--- a/lib/ansible/plugins/become/sudo.py
+++ b/lib/ansible/plugins/become/sudo.py
@@ -106,7 +106,7 @@ class BecomeModule(BecomeBase):
         matched = super().check_password_prompt(b_output)
         if not matched:
             # might be using sudo-rs, which is not backwards compatible
-            sudo_rs = re.compile(f"[sudo: {self.prompt.strip()}] \\S.+?\\S\\Z?".encode())  # \w is for Password i18n
+            sudo_rs = re.compile(f"[sudo: {self.prompt.strip()}] \\S.+?\\S\\Z".encode())  # I18N
             # use match as line MUST start with this
             matched = any(sudo_rs.match(l) for l in b_output.splitlines())
         return matched

--- a/lib/ansible/plugins/become/sudo.py
+++ b/lib/ansible/plugins/become/sudo.py
@@ -102,14 +102,13 @@ class BecomeModule(BecomeBase):
     missing = ('Sorry, a password is required to run sudo', 'sudo: a password is required')
 
     def check_password_prompt(self, b_output):
+
         matched = super().check_password_prompt(b_output)
         if not matched:
             # might be using sudo-rs, which is not backwards compatible
-            prompt = self.prompt
-            self.prompt = f"[sudo: {prompt}] Password:"  # handle extra text from sudo-rs
-            matched = super().check_password_prompt(b_output)
-            self.prompt = prompt
-
+            sudo_rs = re.compile(f"[sudo: {self.prompt.strip()}] \\w+?:".encode())  # \w is for Password i18n
+            # use match as line MUST start with this
+            matched = any(sudo_rs.match(l) for l in b_output.splitlines())
         return matched
 
     def build_become_command(self, cmd, shell):

--- a/lib/ansible/plugins/become/sudo.py
+++ b/lib/ansible/plugins/become/sudo.py
@@ -106,7 +106,7 @@ class BecomeModule(BecomeBase):
         matched = super().check_password_prompt(b_output)
         if not matched:
             # might be using sudo-rs, which is not backwards compatible
-            sudo_rs = re.compile(f"[sudo: {self.prompt.strip()}] \\w+?:".encode())  # \w is for Password i18n
+            sudo_rs = re.compile(f"[sudo: {self.prompt.strip()}] \\S.+?\\S\\Z?".encode())  # \w is for Password i18n
             # use match as line MUST start with this
             matched = any(sudo_rs.match(l) for l in b_output.splitlines())
         return matched

--- a/lib/ansible/plugins/become/sudo.py
+++ b/lib/ansible/plugins/become/sudo.py
@@ -101,13 +101,13 @@ class BecomeModule(BecomeBase):
     fail = ('Sorry, try again.',)
     missing = ('Sorry, a password is required to run sudo', 'sudo: a password is required')
 
-    def check_password_prompt(self, b_output):
-
+    def check_password_prompt(self, b_output: bytes) -> bool:
+        # try GNU sudo first
         matched = super().check_password_prompt(b_output)
         if not matched:
-            # might be using sudo-rs, which is not backwards compatible
-            sudo_rs = re.compile(re.escape(f"[sudo: {self.prompt.strip()}] \\S.+?\\S\\Z".encode()))  # I18N
-            # use match as line MUST start with this
+            # try sudo-rs, which is not backwards compatible and does i18n
+            sudo_rs = re.compile(re.escape(f"[sudo: {self.prompt.strip()}] \\S.+?\\S\\Z".encode()))
+            # using match as the line MUST start with this
             matched = any(sudo_rs.match(l) for l in b_output.splitlines())
         return matched
 

--- a/test/integration/targets/become_sudo/tasks/sudo-rs.yml
+++ b/test/integration/targets/become_sudo/tasks/sudo-rs.yml
@@ -1,0 +1,33 @@
+
+- name: Test sudo with i18n, required for sudo-rs
+  become: yes
+  when: ansible_facts[''] == 'Linux'
+  vars:
+    testlocales:
+      - en_US.UTF-8   # Password
+      - de_DE.UTF-8   # Passwort
+      - ja_JP.UTF-8   # パスワード
+  block:
+    - name: Ensure we have locales ready to use
+      block:
+        - name: ensure debian locale package is available
+          apt:
+            name: locales
+            state: present
+          when: ansible_facts['os_family'] == "Debian"
+
+        - name: Configure locales
+          replace:
+            path: /etc/locale.gen
+          loop: '{{testlocales}}'
+
+        - name: Generate locales
+          shell: 'locale-gen --keep-existing 
+
+    - name: Actually test sudo with locales
+      become_method: sudo
+      environment:
+        LC_ALL: '{{item}}'
+        LANG: '{{item}}'
+      shell: whoami
+      loop: '{{testlocales}}'

--- a/test/integration/targets/become_sudo/tasks/sudo-rs.yml
+++ b/test/integration/targets/become_sudo/tasks/sudo-rs.yml
@@ -1,7 +1,6 @@
-
 - name: Test sudo with i18n, required for sudo-rs
   become: yes
-  when: ansible_facts[''] == 'Linux'
+  when: ansible_facts['system'] == 'Linux' and ansible_facts['os_distribution'] == 'Ubuntu'
   vars:
     testlocales:
       - en_US.UTF-8   # Password
@@ -22,7 +21,7 @@
           loop: '{{testlocales}}'
 
         - name: Generate locales
-          shell: 'locale-gen --keep-existing 
+          shell: locale-gen --keep-existing
 
     - name: Actually test sudo with locales
       become_method: sudo


### PR DESCRIPTION
This is not needed in sudo as it does not interject it's own content in custom prompts (-p),
but sudo-rs does, and it is i18n so we cannot match the word `Password`, using regex instead of 
adding full list or user defined option.

##### ISSUE TYPE

- Bugfix Pull Request
