### PR TITLE
Validate apt_repository one-line components

### DIFF
--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -207,6 +207,23 @@ APT_KEY_DIRS = ['/etc/apt/keyrings', '/etc/apt/trusted.gpg.d', '/usr/share/keyri
 VALID_SOURCE_TYPES = ('deb', 'deb-src')
 
 
+def _source_has_components(chunks):
+    if len(chunks) < 4:
+        return False
+
+    first_spec_index = 1
+    if chunks[first_spec_index].startswith('['):
+        while first_spec_index < len(chunks) and not chunks[first_spec_index].endswith(']'):
+            first_spec_index += 1
+
+        if first_spec_index == len(chunks):
+            return False
+
+        first_spec_index += 1
+
+    return len(chunks[first_spec_index:]) >= 3
+
+
 def install_python_apt(module, apt_pkg_name):
 
     if not module.check_mode:
@@ -309,8 +326,9 @@ class SourcesList(object):
         if source:
             chunks = source.split()
             if chunks[0] in VALID_SOURCE_TYPES:
-                valid = True
-                source = ' '.join(chunks)
+                if _source_has_components(chunks):
+                    valid = True
+                    source = ' '.join(chunks)
 
         if raise_if_invalid_or_disabled and (not valid or not enabled):
             raise InvalidSource(line)

--- a/test/integration/targets/apt_repository/tasks/apt.yml
+++ b/test/integration/targets/apt_repository/tasks/apt.yml
@@ -314,6 +314,18 @@
       - result is failed
       - result.msg == 'Please set argument \'repo\' to a non-empty value'
 
+- name: Test apt_repository with missing component
+  apt_repository:
+    repo: deb http://archive.canonical.com/ubuntu jammy
+    state: present
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - result is failed
+      - result.msg == 'Invalid repository string: deb http://archive.canonical.com/ubuntu jammy'
+
 #
 # TEST: keep symlink
 #


### PR DESCRIPTION
##### SUMMARY
Fixes #85715

The apt_repository parser accepted one-line sources that only had type, URI, and suite. Those entries are malformed for apt because they are missing a component, and the module would write them before crashing during cache parsing.

This validates that deb/deb-src source lines include a component, including lines with bracketed options, so malformed input fails before any source file is written.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
apt_repository

##### ADDITIONAL INFORMATION
Validation:
- `python3 -m py_compile lib/ansible/modules/apt_repository.py`
- `PYTHONPATH=lib python3 - <<'PY' ...` helper smoke test for source component parsing
- `git diff --check`