### PR TITLE
Defer patch target attribute failure until verified needed

### DIFF
--- a/changelogs/fragments/patch_resilience.yml
+++ b/changelogs/fragments/patch_resilience.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Internal patch framework - Defer failure on missing target patch attribute until `is_patch_needed` validator has confirmed that the behavior to be patched is present.

--- a/lib/ansible/module_utils/_internal/_patches/__init__.py
+++ b/lib/ansible/module_utils/_internal/_patches/__init__.py
@@ -42,7 +42,7 @@ class CallablePatch(abc.ABC):
     @classmethod
     def get_current_implementation(cls) -> t.Any:
         """Get the current (possibly patched) implementation from the patch target container."""
-        return getattr(cls.target_container, cls.target_attribute)
+        return getattr(cls.target_container, cls.target_attribute, ...)
 
     @classmethod
     def patch(cls) -> None:
@@ -54,6 +54,12 @@ class CallablePatch(abc.ABC):
 
         if not cls.is_patch_needed():
             return
+
+        if cls.unpatched_implementation is ...:
+            raise RuntimeError(
+                f"Patch {cls.__name__!r} appears to be needed, but implementation to be patched "
+                f"('{cls.target_container.__name__}.{cls.target_attribute}') is not present."
+            )
 
         # __call__ requires an instance (otherwise it'll be __new__)
         setattr(cls.target_container, cls.target_attribute, cls())

--- a/test/units/_internal/_patches/test_patch.py
+++ b/test/units/_internal/_patches/test_patch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 import typing as t
 

--- a/test/units/_internal/_patches/test_patch.py
+++ b/test/units/_internal/_patches/test_patch.py
@@ -17,7 +17,7 @@ class BogusPatch(CallablePatch):
         return True
 
     def __call__(self, annotation, cls, a_module, a_type, is_type_predicate) -> bool:
-        raise NotImplementedError("should not be called")
+        raise NotImplementedError("should not be called")  # pragma: nocover
 
 
 def test_bogus_patch():

--- a/test/units/_internal/_patches/test_patch.py
+++ b/test/units/_internal/_patches/test_patch.py
@@ -1,0 +1,23 @@
+import pytest
+import typing as t
+
+from ansible.module_utils._internal._patches import CallablePatch
+
+
+class BogusPatch(CallablePatch):
+    """Coverage-oriented simulated patch where the patch is required but the original implementation to be patched does not exist."""
+
+    target_container: t.ClassVar = dict
+    target_attribute = '_bogus_dict_attr'
+
+    @classmethod
+    def is_patch_needed(cls) -> bool:
+        return True
+
+    def __call__(self, annotation, cls, a_module, a_type, is_type_predicate) -> bool:
+        raise NotImplementedError("should not be called")
+
+
+def test_bogus_patch():
+    with pytest.raises(RuntimeError, match="implementation to be patched .* is not present"):
+        BogusPatch.patch()


### PR DESCRIPTION
##### SUMMARY
* Fixes startup failure under Python 3.15.0b1 on dataclass ClassVar annotation patch (which appears to no longer require patching under 3.15 :tada: ).
* Adds explicit failure if the target attribute does not exist but `is_patch_needed` is True.
* Added surrogate test coverage for the new defensive error case.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
