### PR TITLE
docs: clarify agnostic become prompt

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -221,7 +221,10 @@ AGNOSTIC_BECOME_PROMPT:
   name: Display an agnostic become prompt
   default: True
   type: boolean
-  description: Display an agnostic become prompt instead of displaying a prompt containing the command line supplied become method.
+  description:
+    - When enabled, become password prompts begin with ``BECOME`` instead of the uppercased become method name.
+    - This lets callers detect become password prompts without knowing which become method is in use.
+    - When password prompting for the connection is also enabled, the become prompt also indicates that it defaults to the connection password.
   env: [{name: ANSIBLE_AGNOSTIC_BECOME_PROMPT}]
   ini:
     - {key: agnostic_become_prompt, section: privilege_escalation}


### PR DESCRIPTION
##### SUMMARY
Clarifies the AGNOSTIC_BECOME_PROMPT configuration description so users can understand what the generic BECOME prompt does and why it exists.

Fixes #81501.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
lib/ansible/config/base.yml

##### ADDITIONAL INFORMATION
Validation:
- Parsed lib/ansible/config/base.yml with PyYAML and confirmed AGNOSTIC_BECOME_PROMPT.description is a list
- git diff --check

Note: A broader compileall check could not run in this local environment because the system python3 is 3.9.6 and current Ansible sources use Python 3.10 match syntax.
