### PR TITLE
Handle invalid 'forks' argument in console like other commands

### DIFF
--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -273,7 +273,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
         if arg:
             try:
                 forks = int(arg)
-            except TypeError:
+            except (TypeError, ValueError) as e:
                 display.error('Invalid argument for "forks"')
                 self.usage_forks()
 

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -282,7 +282,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
                 self.set_prompt()
 
             else:
-                display.display('forks must be greater than or equal to 1')
+                display.error('forks must be greater than or equal to 1')
         else:
             self.usage_forks()
 

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -274,7 +274,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
             try:
                 forks = int(arg)
             except (TypeError, ValueError) as e:
-                display.error('Invalid argument for "forks"')
+                display.error('The number of forks must be a valid positive integer: %s' % to_text(e))
                 self.usage_forks()
 
             if forks > 0:


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

Handle invalid arguments given to the `forks` command in ansible-console similarly to other commands that expect a valid (positive) integer.

Previously, providing input that could not be parsed to an `int` would cause an uncaught `ValueError` and crash the console; I discovered this with the erroneous `forks -h`. Change to print an error including that exception. Also make the message for a negative input print as an error, matching behavior of `timeout`.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
