### PR TITLE
Allow positional for lookup plugins

### DIFF
--- a/changelogs/fragments/86986-validate-modules-positional-lookup.yml
+++ b/changelogs/fragments/86986-validate-modules-positional-lookup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "validate-modules sanity test - allow lookups to use ``positional`` to mark which options are actually positional arguments, similar to test and filter plugins (https://github.com/ansible/ansible/pull/86986)."

--- a/lib/ansible/plugins/lookup/config.py
+++ b/lib/ansible/plugins/lookup/config.py
@@ -12,6 +12,7 @@ DOCUMENTATION = """
         CLI, and variables, but not keywords.
       - The values returned assume the context of the current host or C(inventory_hostname).
       - You can use C(ansible-config list) to see the global available settings, add C(-t all) to also show plugin options.
+    positional: _terms
     options:
       _terms:
         description: The option(s) to look up.

--- a/lib/ansible/plugins/lookup/dict.py
+++ b/lib/ansible/plugins/lookup/dict.py
@@ -10,6 +10,7 @@ DOCUMENTATION = """
     description:
         - Takes dictionaries as input and returns a list with each item in the list being a dictionary with 'key' and 'value' as
           keys to the previous dictionary's structure.
+    positional: _terms
     options:
         _terms:
             description:

--- a/lib/ansible/plugins/lookup/env.py
+++ b/lib/ansible/plugins/lookup/env.py
@@ -11,6 +11,7 @@ DOCUMENTATION = """
     description:
       - Allows you to query the environment variables available on the
         controller when you invoked Ansible.
+    positional: _terms
     options:
       _terms:
         description:

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -10,6 +10,7 @@ DOCUMENTATION = """
     short_description: read file contents
     description:
         - This lookup returns the contents from a file on the Ansible controller's file system.
+    positional: _terms
     options:
       _terms:
         description: path(s) of files to read

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -11,6 +11,7 @@ DOCUMENTATION = """
     description:
         - Matches all files in a single directory, non-recursively, that match a pattern.
           It calls Python's "glob" library.
+    positional: _terms
     options:
       _terms:
         description: path(s) of files to read

--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -17,6 +17,7 @@ DOCUMENTATION = """
       - Either a list of files O(_terms) or a key O(files) with a list of files is required for this plugin to operate.
     notes:
       - This lookup can be used in 'dual mode', either passing a list of file names or a dictionary that has O(files) and O(paths).
+    positional: _terms
     options:
       _terms:
         description: A list of file names.

--- a/lib/ansible/plugins/lookup/indexed_items.py
+++ b/lib/ansible/plugins/lookup/indexed_items.py
@@ -11,6 +11,7 @@ DOCUMENTATION = """
     description:
       - use this lookup if you want to loop over an array and also get the numeric index of where you are in the array as you go
       - any list given will be transformed with each resulting element having the it's previous position in item.0 and its value in item.1
+    positional: _terms
     options:
       _terms:
         description: list of items

--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -12,6 +12,7 @@ DOCUMENTATION = """
       - "The ini lookup reads the contents of a file in INI format C(key1=value1).
         This plugin retrieves the value on the right side after the equal sign C('=') of a given section C([section])."
       - "You can also read a property file which - in this case - does not contain section."
+    positional: _terms
     options:
       _terms:
         description: The key(s) to look up.

--- a/lib/ansible/plugins/lookup/items.py
+++ b/lib/ansible/plugins/lookup/items.py
@@ -14,6 +14,7 @@ DOCUMENTATION = """
       - this is the standard lookup used for loops in most examples
       - check out the 'flattened' lookup for recursive flattening
       - if you do not want flattening nor any other transformation look at the 'list' lookup.
+    positional: _terms
     options:
       _terms:
         description: list of items

--- a/lib/ansible/plugins/lookup/lines.py
+++ b/lib/ansible/plugins/lookup/lines.py
@@ -11,6 +11,7 @@ DOCUMENTATION = """
     short_description: read lines from command
     description:
       - Run one or more commands and split the output into lines, returning them as a list
+    positional: _terms
     options:
       _terms:
         description: command(s) to run

--- a/lib/ansible/plugins/lookup/nested.py
+++ b/lib/ansible/plugins/lookup/nested.py
@@ -9,6 +9,7 @@ DOCUMENTATION = """
     short_description: composes a list with nested elements of other lists
     description:
         - Takes the input lists and returns a list with elements that are lists composed of the elements of the input lists
+    positional: _raw
     options:
       _raw:
          description:

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -20,6 +20,7 @@ DOCUMENTATION = """
         which simplifies password management in C("host_vars") variables.'
       - A special case is using /dev/null as a path. The password lookup will generate a new random password each time,
         but will not write it to /dev/null. This can be used when you need a password without storing it on the controller.
+    positional: _terms
     options:
       _terms:
          description:

--- a/lib/ansible/plugins/lookup/pipe.py
+++ b/lib/ansible/plugins/lookup/pipe.py
@@ -10,6 +10,7 @@ DOCUMENTATION = r"""
     short_description: read output from a command
     description:
       - Run a command and return the output.
+    positional: _terms
     options:
       _terms:
         description: command(s) to run.

--- a/lib/ansible/plugins/lookup/subelements.py
+++ b/lib/ansible/plugins/lookup/subelements.py
@@ -10,6 +10,7 @@ DOCUMENTATION = """
     short_description: traverse nested key from a list of dictionaries
     description:
       - Subelements walks a list of hashes (aka dictionaries) and then traverses a list with a given (nested sub-)key inside of those records.
+    positional: _terms
     options:
       _terms:
          description: tuple of list of dictionaries and dictionary key to extract

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -11,6 +11,7 @@ DOCUMENTATION = """
     short_description: retrieve contents of file after templating with Jinja2
     description:
       - Returns a list of strings; for each template in the list of templates you pass in, returns a string containing the results of processing that template.
+    positional: _terms
     options:
       _terms:
         description: list of files to template

--- a/lib/ansible/plugins/lookup/together.py
+++ b/lib/ansible/plugins/lookup/together.py
@@ -13,6 +13,7 @@ DOCUMENTATION = """
       - "To clarify with an example, [ 'a', 'b' ] and [ 1, 2 ] turn into [ ('a',1), ('b', 2) ]"
       - This is basically the same as the 'zip_longest' filter and Python function
       - Any 'unbalanced' elements will be substituted with 'None'
+    positional: _terms
     options:
       _terms:
         description: list of lists to merge

--- a/lib/ansible/plugins/lookup/unvault.py
+++ b/lib/ansible/plugins/lookup/unvault.py
@@ -9,6 +9,7 @@ DOCUMENTATION = """
     short_description: read vaulted file(s) contents
     description:
         - This lookup returns the contents from vaulted (or not) file(s) on the Ansible controller's file system.
+    positional: _terms
     options:
       _terms:
         description: path(s) of files to read

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -10,6 +10,7 @@ version_added: "1.9"
 short_description: return contents from URL
 description:
     - Returns the content of the URL requested to be used as data in play.
+positional: _terms
 options:
   _terms:
     description: urls to query

--- a/lib/ansible/plugins/lookup/varnames.py
+++ b/lib/ansible/plugins/lookup/varnames.py
@@ -9,6 +9,7 @@ DOCUMENTATION = """
     short_description: Lookup matching variable names
     description:
       - Retrieves a list of matching Ansible variable names.
+    positional: _terms
     options:
       _terms:
         description: List of Python regex patterns to search for in variable names.

--- a/lib/ansible/plugins/lookup/vars.py
+++ b/lib/ansible/plugins/lookup/vars.py
@@ -9,6 +9,7 @@ DOCUMENTATION = """
     short_description: Lookup templated value of variables
     description:
       - 'Retrieves the value of an Ansible variable. Note: Only returns top level variable names.'
+    positional: _terms
     options:
       _terms:
         description: The variable names to look up.

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -842,9 +842,9 @@ class ModuleValidator(Validator):
                     )
                 prev_positional.add(pos_opt)
 
-        normalized_option_alias_names = dict()
+        normalized_option_alias_names: dict[str, dict[str, set[str]]] = dict()
 
-        def add_option_alias_name(name, option_name):
+        def add_option_alias_name(name: str, option_name: str) -> None:
             normalized_name = str(name).lower()
             normalized_option_alias_names.setdefault(normalized_name, {}).setdefault(option_name, set()).add(name)
 

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/main.py
@@ -26,6 +26,7 @@ import os
 import re
 import sys
 import traceback
+import typing as t
 import warnings
 
 from collections import OrderedDict
@@ -816,11 +817,30 @@ class ModuleValidator(Validator):
                 msg='%s: %s' % (combined_path, error_message)
             )
 
-    def _validate_option_docs(self, options, context=None):
+    def _validate_option_docs(self, options: t.Any, *, context: list[str] | None = None, positional: t.Any | None = None) -> None:
         if not isinstance(options, dict):
             return
         if context is None:
             context = []
+
+        if isinstance(positional, str):
+            positional = [part.strip() for part in positional.split(",")] if positional else []
+        if isinstance(positional, list):
+            prev_positional = set()
+            for pos_opt in positional:
+                if pos_opt in prev_positional:
+                    self.reporter.error(
+                        path=self.object_path,
+                        code='positional-repeated',
+                        msg=f"The option {pos_opt!r} is listed as a positional option more than once",
+                    )
+                if pos_opt not in options:
+                    self.reporter.error(
+                        path=self.object_path,
+                        code='positional-not-option',
+                        msg=f"{pos_opt!r} is listed as a positional option, but is not an option of the plugin",
+                    )
+                prev_positional.add(pos_opt)
 
         normalized_option_alias_names = dict()
 
@@ -830,7 +850,7 @@ class ModuleValidator(Validator):
 
         for option, data in options.items():
             if 'suboptions' in data:
-                self._validate_option_docs(data.get('suboptions'), context + [option])
+                self._validate_option_docs(data.get('suboptions'), context=context + [option])
             add_option_alias_name(option, option)
             if 'aliases' in data and isinstance(data['aliases'], list):
                 for alias in data['aliases']:
@@ -1045,7 +1065,7 @@ class ModuleValidator(Validator):
             )
 
             if doc:
-                self._validate_option_docs(doc.get('options'))
+                self._validate_option_docs(doc.get('options'), positional=doc.get('positional'))
 
             self._validate_all_semantic_markup(doc, returns)
 

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -860,6 +860,8 @@ def doc_schema(module_name, for_collection=False, deprecated_module=False, plugi
         doc_schema_dict['author'] = All(Any(None, list_string_types, str), author)
     if plugin_type == 'callback':
         doc_schema_dict[Required('type')] = Any('aggregate', 'notification', 'stdout')
+    if plugin_type in ('lookup', 'filter', 'test'):
+        doc_schema_dict['positional'] = Any(list_string_types, str)
 
     if for_collection:
         # Optional


### PR DESCRIPTION
##### SUMMARY

Right now `positional` can be used to list positional arguments for filter and test plugins. While lookup plugins also have positional arguments, using `positional` there leads to rejection by the validate-modules sanity test, even though other tools such as antsibull-docs accept it (but currently ignores it for lookups). ansible-doc already handles `positional` no matter what plugin type is used.

This PR extends validate-modules to allow `positional` also for lookup plugins. (The `if` also mentions filter and test plugins, but these are not handled by validate-modules so far.)

This is also useful for #86963, since it can be used to determine which options shouldn't show up in `kwargs`.

It also would help antsibull-docs, which currently expects the magic name `_terms`, which is commonly used in ansible-core and community.general, but not even there in all cases.

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request
