### PR TITLE
Fix user module interaction with non-local group sources

### DIFF
--- a/changelogs/fragments/75325-user-local-groups.yml
+++ b/changelogs/fragments/75325-user-local-groups.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - fix ``local: true`` group handling to ignore non-local NSS groups (https://github.com/ansible/ansible/issues/75325).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1073,16 +1073,19 @@ class User(object):
 
     def parse_local_groups(self):
         if not os.path.exists(self.GROUPFILE):
-            self.module.fail_json(msg="'local: true' specified but unable to find local group file {0} to parse.".format(self.GROUPFILE))
+            self.module.fail_json(msg=f"'local: true' specified but unable to find local group file {self.GROUPFILE} to parse.")
         groups = {}
         with open(self.GROUPFILE, 'r') as f:
-            for x, line in enumerate(f.readlines()):
-                entry = line[:-1].split(':')
+            for linenum, line in enumerate(f):
+                line = line.strip()
+                if not line:
+                    continue
+                entry = line.split(':')
                 if len(entry) != 4:
-                    self.module.fail_json(msg="unable to parse group file {0}: line {1}: incorrect number of fields".format(self.GROUPFILE, x))
-                groups[entry[0]] = entry[2]
-        if len(groups) == 0:
-            self.module.warn("'local: true' specified but found 0 local groups in file {0}".format(self.GROUPFILE))
+                    self.module.fail_json(msg=f"unable to parse group file {self.GROUPFILE}: line {linenum}: incorrect number of fields")
+                groups[entry[0]] = int(entry[2])
+        if not groups:
+            self.module.warn(f"'local: true' specified but found 0 local groups in file {self.GROUPFILE}")
         self.local_groups = groups
 
     def local_group_exists(self, group):
@@ -1091,10 +1094,7 @@ class User(object):
         try:
             # Try group as a gid first
             gid = int(group)
-            for v in self.local_groups.values():
-                if v == gid:
-                    return True
-            return False
+            return gid in self.local_groups.values()
         except ValueError:
             return group in self.local_groups
 

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -589,6 +589,7 @@ class User(object):
     distribution = None  # type: str | None
     PASSWORDFILE = '/etc/passwd'
     SHADOWFILE = '/etc/shadow'  # type: str | None
+    GROUPFILE = '/etc/group'
     SHADOWFILE_EXPIRE_INDEX = 7
     LOGIN_DEFS = '/etc/login.defs'
     DATE_FORMAT = '%Y-%m-%d'
@@ -627,6 +628,7 @@ class User(object):
         self.expires = None
         self.password_lock = module.params['password_lock']
         self.groups = None
+        self.local_groups = None
         self.local = module.params['local']
         self.profile = module.params['profile']
         self.authorization = module.params['authorization']
@@ -1069,7 +1071,36 @@ class User(object):
                 return (rc, out, err)
         return (rc, out, err)
 
+    def parse_local_groups(self):
+        if not os.path.exists(self.GROUPFILE):
+            self.module.fail_json(msg="'local: true' specified but unable to find local group file {0} to parse.".format(self.GROUPFILE))
+        groups = {}
+        with open(self.GROUPFILE, 'r') as f:
+            for x, line in enumerate(f.readlines()):
+                entry = line[:-1].split(':')
+                if len(entry) != 4:
+                    self.module.fail_json(msg="unable to parse group file {0}: line {1}: incorrect number of fields".format(self.GROUPFILE, x))
+                groups[entry[0]] = entry[2]
+        if len(groups) == 0:
+            self.module.warn("'local: true' specified but found 0 local groups in file {0}".format(self.GROUPFILE))
+        self.local_groups = groups
+
+    def local_group_exists(self, group):
+        if self.local_groups is None:
+            self.parse_local_groups()
+        try:
+            # Try group as a gid first
+            gid = int(group)
+            for v in self.local_groups.values():
+                if v == gid:
+                    return True
+            return False
+        except ValueError:
+            return group in self.local_groups
+
     def group_exists(self, group):
+        if self.local:
+            return self.local_group_exists(group)
         try:
             # Try group as a gid first
             grp.getgrgid(int(group))
@@ -1114,6 +1145,8 @@ class User(object):
         info = self.get_pwd_info()
         for group in grp.getgrall():
             if self.name in group.gr_mem:
+                if self.local and not self.local_group_exists(group[0]):
+                    continue
                 # Exclude the user's primary group by default
                 if not exclude_primary:
                     groups.append(group[0])

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -23,6 +23,10 @@
 - include_tasks: test_password_lock_new_user.yml
 - include_tasks: test_local.yml
   when: ansible_distribution != 'Alpine'
+- include_tasks: test_local_groups.yml
+  when: ansible_facts.os_family == 'Debian'
+  tags:
+    - user_test_local_mode
 - include_tasks: test_umask.yml
   when:
     - ansible_facts.system == 'Linux'

--- a/test/integration/targets/user/tasks/test_local_groups.yml
+++ b/test/integration/targets/user/tasks/test_local_groups.yml
@@ -1,0 +1,108 @@
+# Test that local: true correctly handles non-local NSS groups
+# https://github.com/ansible/ansible/issues/75325
+
+- name: Test local user groups with non-local NSS groups
+  become: true
+  vars:
+    local_groups_user: ansibletestlocal
+    local_group: localgroup
+    nonlocal_group: ldapgroup
+  block:
+    - name: Install libnss-extrausers
+      apt:
+        name: libnss-extrausers
+        state: present
+        update_cache: true
+
+    - name: Configure NSS to use extrausers
+      lineinfile:
+        path: /etc/nsswitch.conf
+        regexp: '^group:'
+        line: 'group: files extrausers systemd'
+        backup: true
+
+    - name: Create extrausers directory
+      file:
+        path: /var/lib/extrausers
+        state: directory
+        mode: '0755'
+
+    - name: Create extrausers group file with non-local group
+      copy:
+        content: "{{ nonlocal_group }}:x:9999:\n"
+        dest: /var/lib/extrausers/group
+        mode: '0644'
+
+    - name: Create user primary group
+      group:
+        name: "{{ local_groups_user }}"
+        state: present
+
+    - name: Create local group
+      group:
+        name: "{{ local_group }}"
+        state: present
+
+    - name: Create local user in both groups
+      user:
+        name: "{{ local_groups_user }}"
+        group: "{{ local_groups_user }}"
+        groups: "{{ local_group }}"
+        local: true
+        create_home: true
+
+    - name: Add user to non-local group
+      lineinfile:
+        path: /var/lib/extrausers/group
+        regexp: "^{{ nonlocal_group }}:x:9999:"
+        line: "{{ nonlocal_group }}:x:9999:{{ local_groups_user }}"
+
+    - name: Update user with local=true (first run)
+      user:
+        name: "{{ local_groups_user }}"
+        groups: "{{ local_group }}"
+        local: true
+        append: false
+      register: local_groups_first_run
+
+    - name: Update user with local=true (second run)
+      user:
+        name: "{{ local_groups_user }}"
+        groups: "{{ local_group }}"
+        local: true
+        append: false
+      register: local_groups_second_run
+
+    - name: Assert fix works and is idempotent
+      assert:
+        that:
+          - local_groups_first_run is not failed
+          - local_groups_second_run is not changed
+
+  always:
+    - name: Clean up test user
+      user:
+        name: "{{ local_groups_user }}"
+        state: absent
+        remove: true
+      ignore_errors: true
+
+    - name: Clean up groups
+      group:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ local_groups_user }}"
+        - "{{ local_group }}"
+      ignore_errors: true
+
+    - name: Remove extrausers directory
+      file:
+        path: /var/lib/extrausers
+        state: absent
+
+    - name: Restore NSS configuration
+      lineinfile:
+        path: /etc/nsswitch.conf
+        regexp: '^group:'
+        line: 'group: files systemd'


### PR DESCRIPTION
##### SUMMARY

Make user module respect `local: true` on systems with non-local group sources (LDAP, SSSD, etc.)

Refreshes the work done in #75333

Fixes #75325
Closes #75333

##### ISSUE TYPE

- Test Pull Request
