### PR TITLE
Deprecate modules/actions returning `skipped`

### DIFF
--- a/changelogs/fragments/deprecate-return-values.yml
+++ b/changelogs/fragments/deprecate-return-values.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - task result - Returning ``skipped`` from a module or action plugin is deprecated and will be removed in ansible-core 2.25. Use task-level conditionals (``when:``) to control execution.
+  - action plugins - ``AnsibleActionSkip`` is deprecated and will be removed in ansible-core 2.25. A sanity test detects imports of this exception. Return a results dict from action plugins and don't include a ``skipped`` key, or raise ``AnsibleActionNoCheckMode`` if necessary.

--- a/lib/ansible/_internal/_errors/_error_utils.py
+++ b/lib/ansible/_internal/_errors/_error_utils.py
@@ -24,7 +24,7 @@ class ContributesToTaskResult(metaclass=abc.ABCMeta):
 
     @property
     def omit_exception_key(self) -> bool:
-        """Non-error exceptions (e.g., `AnsibleActionSkip`) must return `True` to ensure omission of the `exception` key."""
+        """Non-error exceptions (e.g., `AnsibleActionNoCheckMode`) must return `True` to ensure omission of the `exception` key."""
         return False
 
     @property

--- a/lib/ansible/_internal/_task.py
+++ b/lib/ansible/_internal/_task.py
@@ -949,7 +949,6 @@ class UnifiedTaskResult:
                 #     display.deprecated(
                 #         msg="Returning 'skipped' from a module or action plugin is deprecated.",
                 #         version="2.25",
-                #         help_text="Check for `is success` and/or `not changed` and the `msg` text instead.",
                 #     )
                 if resolved_field is DROP_AND_WARN:
                     display.warning(f"Removed reserved key {key!r} from module result.", obj=value)

--- a/lib/ansible/_internal/_task.py
+++ b/lib/ansible/_internal/_task.py
@@ -944,6 +944,13 @@ class UnifiedTaskResult:
 
         for key, value in result.items():
             if resolved_field := fields.get(key):
+                # deprecated: description='uncomment to enable user-facing warnings for modules/actions returning skipped' core_version='2.23'
+                # if key == 'skipped':
+                #     display.deprecated(
+                #         msg="Returning 'skipped' from a module or action plugin is deprecated.",
+                #         version="2.25",
+                #         help_text="Check for `is success` and/or `not changed` and the `msg` text instead.",
+                #     )
                 if resolved_field is DROP_AND_WARN:
                     display.warning(f"Removed reserved key {key!r} from module result.", obj=value)
                 else:

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -364,16 +364,44 @@ class AnsibleAction(AnsibleRuntimeError, _error_utils.ContributesToTaskResult):
         return self._result
 
 
-class AnsibleActionSkip(AnsibleAction):
+class AnsibleActionSkip(AnsibleAction):  # deprecated: description='remove class AnsibleActionSkip', core_version='2.25'
     """
     An action runtime skip.
 
     This exception provides a result dictionary via the ContributesToTaskResult mixin.
+
+    DEPRECATED for removal in 2.25
     """
 
     def as_task_result(self, utr: _t_task.UnifiedTaskResult) -> _t_task.UnifiedTaskResult:
         utr = super().as_task_result(utr)
         utr.skipped = True
+        utr.msg = self.message
+
+        return utr
+
+    @property
+    def omit_failed_key(self) -> bool:
+        return True
+
+    @property
+    def omit_exception_key(self) -> bool:
+        return True
+
+
+class AnsibleActionNoCheckMode(AnsibleAction):
+    """
+    An action runtime indication of lack of check_mode support.
+
+    This exception provides a result dictionary via the ContributesToTaskResult mixin.
+
+    Replacement for AnsibleActionSkip that does not return skipped=True.
+    Available for use in ansible-core 2.23+.
+    """
+
+    def as_task_result(self, utr: _t_task.UnifiedTaskResult) -> _t_task.UnifiedTaskResult:
+        utr = super().as_task_result(utr)
+        utr.changed = False
         utr.msg = self.message
 
         return utr

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -436,7 +436,10 @@ class AnsibleModule(object):
             self.fail_json(msg=msg)
 
         if self.check_mode and not self.supports_check_mode:
-            self.exit_json(skipped=True, msg="remote module (%s) does not support check mode" % self._name)
+            self.exit_json(
+                skipped=True,  # deprecated: description='remove this skipped return', core_version='2.25'
+                msg="remote module (%s) does not support check mode" % self._name,
+            )
 
         # This is for backwards compatibility only.
         self._CHECK_ARGUMENT_TYPES_DISPATCHER = DEFAULT_TYPE_VALIDATORS

--- a/lib/ansible/module_utils/csharp/Ansible.Basic.cs
+++ b/lib/ansible/module_utils/csharp/Ansible.Basic.cs
@@ -981,7 +981,7 @@ namespace Ansible.Basic
             // Only run this check if we are at the root argument (optionsContext.Count == 0)
             if (CheckMode && !(bool)spec["supports_check_mode"] && optionsContext.Count == 0)
             {
-                Result["skipped"] = true;
+                Result["skipped"] = true;  // deprecated: description='remove this skipped return', core_version='2.25'
                 Result["msg"] = String.Format("remote module ({0}) does not support check mode", ModuleName);
                 ExitJson();
             }

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
@@ -324,7 +324,7 @@ Function Parse-Args {
     $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
     If ($check_mode -and -not $supports_check_mode) {
         Exit-Json @{
-            skipped = $true
+            skipped = $true  # deprecated: description='remove this skipped return', core_version='2.25'
             changed = $false
             msg = "remote module does not support check mode"
         }

--- a/lib/ansible/modules/command.py
+++ b/lib/ansible/modules/command.py
@@ -103,7 +103,7 @@ notes:
     -  O(creates), O(removes), and O(chdir) can be specified after the command.
        For instance, if you only want to run a command if a certain file does not exist, use this.
     -  Check mode is supported when passing O(creates) or O(removes). If running in check mode and either of these are specified, the module will
-       check for the existence of the file and report the correct changed status. If these are not supplied, the task will be skipped.
+       check for the existence of the file and report the correct changed status. If these are not supplied, the task will return RV(ignore:changed=False).
     -  The O(ignore:executable) parameter is removed since version 2.4. If you have a need for this parameter, use the M(ansible.builtin.shell) module instead.
     -  For Windows targets, use the M(ansible.windows.win_command) module instead.
     -  For rebooting systems, use the M(ansible.builtin.reboot) or M(ansible.windows.win_reboot) module.
@@ -341,7 +341,7 @@ def main():
         r['rc'] = 0
         r['msg'] = "Command would have run if not in check mode"
         if creates is None and removes is None:
-            r['skipped'] = True
+            r['skipped'] = True  # deprecated: description='remove this skipped value return' core_version='2.25'
             # skipped=True and changed=True are mutually exclusive
             r['changed'] = False
 

--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -512,7 +512,10 @@ def main():
         if svc:
             all_services.update(svc)
     if len(all_services) == 0:
-        results = dict(skipped=True, msg="Failed to find any services. This can be due to privileges or some other configuration issue.")
+        results = dict(
+            skipped=True,  # deprecated: description='remove this skipped return', core_version='2.25'
+            msg="Failed to find any services. This can be due to privileges or some other configuration issue.",
+        )
     else:
         results = dict(ansible_facts=dict(services=all_services))
     module.exit_json(**results)

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -809,7 +809,10 @@ class TgzArchive(object):
         self.opts = module.params['extra_opts']
         self.module = module
         if self.module.check_mode:
-            self.module.exit_json(skipped=True, msg="remote module (%s) does not support check mode when using gtar" % self.module._name)
+            self.module.exit_json(
+                skipped=True,  # deprecated: description='remove this skipped return', core_version='2.25'
+                msg="remote module (%s) does not support check mode when using gtar" % self.module._name,
+            )
         self.excludes = [path.rstrip('/') for path in self.module.params['exclude']]
         self.include_files = self.module.params['include']
         self.cmd_path = None

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -138,7 +138,9 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         if self._task.async_val and not self._supports_async:
             raise AnsibleActionFail('This action (%s) does not support async.' % self._task.action)
         elif self._task.check_mode and not self._supports_check_mode:
-            raise AnsibleActionSkip('This action (%s) does not support check mode.' % self._task.action)
+            # deprecated: description='switch to AnsibleActionNoCheckMode' core_version='2.25'
+            raise AnsibleActionSkip(f'This action ({self._task.action}) does not support check mode.')
+            # raise AnsibleActionNoCheckMode(f'This action ({self._task.action}) does not support check mode.')
 
         # Error if invalid argument is passed
         if self._VALID_ARGS:

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from ansible.errors import AnsibleValueOmittedError, AnsibleError
 from ansible.module_utils.common.validation import _check_type_str_no_conversion
+from ansible.module_utils.datatag import deprecate_value
 from ansible.plugins.action import ActionBase, VariableLayer
 from ansible._internal._templating._jinja_common import UndefinedMarker, TruncationMarker
 from ansible._internal._templating._utils import Omit
@@ -83,8 +84,15 @@ class ActionModule(ActionBase):
             replacing_behavior.emit_warnings()
 
         else:
-            result['skipped_reason'] = "Verbosity threshold not met."
-            result['skipped'] = True
+            result['skipped_reason'] = deprecate_value(
+                'Verbosity threshold not met.',
+                msg='modules returning `skipped_reason` is deprecated.',
+                version='2.25',
+                help_text='Use the `msg` return value instead.`'
+            )
+            result['skipped'] = True  # deprecated: description='returning skipped from actions/modules' core_version='2.25'
+            result['changed'] = False
+            result['msg'] = 'Verbosity threshold not met.'
 
         result['failed'] = False
 

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import os
 import base64
-from ansible.errors import AnsibleConnectionFailure, AnsibleError, AnsibleActionFail, AnsibleActionSkip
+from ansible.errors import AnsibleConnectionFailure, AnsibleError, AnsibleActionFail
 from ansible.module_utils.common.text.converters import to_bytes, to_text
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
@@ -41,7 +41,11 @@ class ActionModule(ActionBase):
 
         try:
             if self._task.check_mode:
-                raise AnsibleActionSkip('check mode not (yet) supported for this module')
+                return dict(
+                    msg='check mode not (yet) supported for this module',
+                    changed=False,
+                    skipped=True,  # deprecated: description='remove this skipped return', core_version='2.25'
+                )
 
             source = self._task.args.get('src', None)
             original_dest = dest = self._task.args.get('dest', None)

--- a/lib/ansible/plugins/action/gather_facts.py
+++ b/lib/ansible/plugins/action/gather_facts.py
@@ -180,7 +180,8 @@ class ActionModule(ActionBase):
             result['msg'] = f"The following modules were skipped: {', '.join(skipped.keys())}."
             result['skipped_modules'] = skipped
             if len(skipped) == len(modules):
-                result['skipped'] = True
+                result['skipped'] = True  # deprecated: description='returning skipped from actions/modules' core_version='2.25'
+                result['changed'] = False
 
         if failed:
             result['failed_modules'] = failed

--- a/lib/ansible/plugins/action/raw.py
+++ b/lib/ansible/plugins/action/raw.py
@@ -33,8 +33,10 @@ class ActionModule(ActionBase):
         del tmp  # tmp no longer has any effect
 
         if self._task.check_mode:
-            # in --check mode, always skip this module execution
-            result['skipped'] = True
+            # in --check mode, always indicate raw didn't run
+            result['skipped'] = True  # deprecated: description='returning skipped from actions/modules' core_version='2.25'
+            result['changed'] = False
+            result['msg'] = "Task `raw` did not execute due to check_mode"
             return result
 
         executable = self._task.args.get('executable', False)

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -23,7 +23,7 @@ import shlex
 import typing as _t
 
 from ansible._internal._powershell import _script as _ps_script
-from ansible.errors import AnsibleError, AnsibleActionFail, AnsibleActionSkip
+from ansible.errors import AnsibleError, AnsibleActionFail
 from ansible.executor.powershell import module_manifest as ps_manifest
 from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.action import ActionBase
@@ -65,7 +65,11 @@ class ActionModule(ActionBase):
                 # and the filename already exists. This allows idempotence
                 # of command executions.
                 if self._remote_file_exists(creates):
-                    raise AnsibleActionSkip("%s exists, matching creates option" % creates)
+                    return dict(
+                        changed=False,
+                        skipped=True,  # deprecated: description='remove this skipped return', core_version='2.25'
+                        msg=f'{creates} exists, matching creates option',
+                    )
 
             removes = new_module_args['removes']
             if removes:
@@ -73,7 +77,11 @@ class ActionModule(ActionBase):
                 # and the filename does not exist. This allows idempotence
                 # of command executions.
                 if not self._remote_file_exists(removes):
-                    raise AnsibleActionSkip("%s does not exist, matching removes option" % removes)
+                    return dict(
+                        changed=False,
+                        skipped=True,  # deprecated: description='remove this skipped return', core_version='2.25'
+                        msg=f'{removes} does not exist, matching removes option',
+                    )
 
             # The chdir must be absolute, because a relative path would rely on
             # remote node behaviour & user config.
@@ -111,7 +119,11 @@ class ActionModule(ActionBase):
                 # If the script doesn't return changed in the result, it defaults to True,
                 # but since the script may override 'changed', just skip instead of guessing.
                 else:
-                    raise AnsibleActionSkip('Check mode is not supported for this task.', result=dict(changed=False))
+                    return dict(
+                        msg='Check mode is not supported for this task.',
+                        changed=False,
+                        skipped=True,  # deprecated: description='remove this skipped return', core_version='2.25'
+                    )
 
             # transfer the file to a remote tmp location
             tmp_src = self._connection._shell.join_path(self._connection._shell.tmpdir,

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import os
 
-from ansible.errors import AnsibleActionFail, AnsibleActionSkip
+from ansible.errors import AnsibleActionFail
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.urls import mask_url
 from ansible.plugins.action import ActionBase
@@ -62,7 +62,11 @@ class ActionModule(ActionBase):
                 # of command executions.
                 creates = self._remote_expand_user(creates)
                 if self._remote_file_exists(creates):
-                    raise AnsibleActionSkip("skipped, since %s exists" % creates)
+                    return dict(
+                        msg=f'skipped, since {creates} exists',
+                        changed=False,
+                        skipped=True,  # deprecated: description='remove this skipped return', core_version='2.25'
+                    )
 
             dest = self._remote_expand_user(dest)  # CCTODO: Fix path for Windows hosts.
 

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -69,8 +69,10 @@ class ActionModule(ActionBase):
         timeout = int(self._task.args.get('timeout', self.DEFAULT_TIMEOUT))
 
         if self._task.check_mode:
-            display.vvv("wait_for_connection: skipping for check_mode")
-            return dict(skipped=True)
+            display.vvv("wait_for_connection: not executing in check_mode")
+            return dict(skipped=True,  # deprecated: description='returning skipped from actions/modules' core_version='2.25'
+                        changed=False,
+                        msg='`wait_for_connection` did not execute due to check mode')
 
         result = super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect

--- a/test/integration/targets/fetch/roles/fetch_tests/tasks/normal.yml
+++ b/test/integration/targets/fetch/roles/fetch_tests/tasks/normal.yml
@@ -36,5 +36,5 @@
       - fetched_again.file == remote_tmp_dir ~ "/orig"
       - fetched.remote_checksum == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
       - lookup("file", output_dir + "/fetched/" + inventory_hostname + remote_tmp_dir + "/orig") == "test"
-      - fetch_check_mode is skipped
+      - fetch_check_mode is not changed
       - fetch_check_mode.msg is search('not \(yet\) supported')

--- a/test/integration/targets/script/tasks/main.yml
+++ b/test/integration/targets/script/tasks/main.yml
@@ -124,18 +124,19 @@
     path: "{{ remote_tmp_dir_test | expanduser }}/afile.txt"
   register: _create_stat1
 
-- name: Run create_afile.sh again to ensure it is skipped
+- name: Run create_afile.sh again to ensure it isn't changed
   script: create_afile.sh {{ remote_tmp_dir_test | expanduser }}/afile.txt
   args:
     creates: "{{ remote_tmp_dir_test | expanduser }}/afile.txt"
   register: _create_test2
 
-- name: Assert that script report a change, file was created, second run was skipped
+- name: Assert that script report a change, file was created, second run wasn't changed
   assert:
     that:
       - _create_test1 is changed
       - _create_stat1.stat.exists
-      - _create_test2 is skipped
+      - _create_test2 is not changed
+      - _create_test2.msg is contains "matching creates option"
 
 
 # removes
@@ -155,18 +156,19 @@
     path: "{{ remote_tmp_dir_test | expanduser }}/afile.txt"
   register: _remove_stat1
 
-- name: Run remote_afile.sh again to enure it is skipped
+- name: Run remote_afile.sh again to enure it isn't changed
   script: remove_afile.sh {{ remote_tmp_dir_test | expanduser }}/afile.txt
   args:
     removes: "{{ remote_tmp_dir_test | expanduser }}/afile.txt"
   register: _remove_test2
 
-- name: Assert that script report a change, file was removed, second run was skipped
+- name: Assert that script report a change, file was removed, second run wasn't changed
   assert:
     that:
       - _remove_test1 is changed
       - not _remove_stat1.stat.exists
-      - _remove_test2 is skipped
+      - _remove_test2 is not changed
+      - _remove_test2.msg is contains "matching removes option"
 
 
 # async
@@ -211,7 +213,6 @@
   assert:
     that:
       - _check_mode_test is not changed
-      - _check_mode_test is skipped
       - not _afile_stat.stat.exists
 
 - name: Run script to create a file
@@ -228,10 +229,10 @@
     var: _check_mode_test2
     verbosity: 2
 
-- name: Assert that task was skipped and message was returned
+- name: Assert that task was not changed and message was returned
   assert:
     that:
-      - _check_mode_test2 is skipped
+      - _check_mode_test2 is not changed
       - '_check_mode_test2.msg == (remote_tmp_dir_test | expanduser) + "/afile2.txt exists, matching creates option"'
 
 - name: Remove afile2.txt
@@ -250,10 +251,10 @@
     var: _check_mode_test3
     verbosity: 2
 
-- name: Assert that task was skipped and message was returned
+- name: Assert that task was not changed and message was returned
   assert:
     that:
-      - _check_mode_test3 is skipped
+      - _check_mode_test3 is not changed
       - '_check_mode_test3.msg == (remote_tmp_dir_test | expanduser) + "/afile2.txt does not exist, matching removes option"'
 
 # executable

--- a/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/unwanted.py
+++ b/test/lib/ansible_test/_util/controller/sanity/pylint/plugins/unwanted.py
@@ -127,6 +127,15 @@ class AnsibleUnwantedChecker(BaseChecker):
                                             '/lib/ansible/module_utils/basic.py',
                                         ),
                                         modules_only=True),
+
+        # deprecated: description='remove this entire AnsibleActionSkip entry when the exception is removed' core_version='2.25'
+        'ansible.errors.AnsibleActionSkip': UnwantedEntry(
+            'AnsibleActionNoCheckMode if the desired skip is for lacking check_mode, otherwise returning `skipped` from actions is deprecated.',
+            ignore_paths=(
+                # deprecated: description='remove ignore when action/__init__.py switches to AnsibleActionNoCheckMode' core_version='2.25'
+                '/lib/ansible/plugins/action/__init__.py',
+            ),
+        ),
     }
 
     for method in (


### PR DESCRIPTION
##### SUMMARY

Adds deprecation warnings when modules/actions attempt to return Skipped.

- Universal message when a module/action returns the `skipped` key

##### ISSUE TYPE

- Feature Pull Request