### PR TITLE
Truthy value should be true or false

### DIFF
--- a/lib/ansible/modules/service.py
+++ b/lib/ansible/modules/service.py
@@ -140,7 +140,7 @@ EXAMPLES = r"""
 - name: Enable service httpd, and not touch the state
   ansible.builtin.service:
     name: httpd
-    enabled: yes
+    enabled: true
 
 - name: Start service foo, based on running process /usr/bin/foo
   ansible.builtin.service:


### PR DESCRIPTION
##### SUMMARY

One of the examples for the `ansible.builtin.service` module still shows `enabled: yes`. In accordance with `ansible-lint` this should be either `true` or `false`.

##### ISSUE TYPE

- Docs Pull Request
