### PR TITLE
[stable-2.21] Fix internal exception type on result thread

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -29,7 +29,6 @@ import typing as t
 import collections.abc as _c
 
 from collections import deque
-from sqlite3 import NotSupportedError
 
 from ansible import constants as C, constants
 from ansible import context
@@ -685,7 +684,7 @@ class StrategyBase:
                                         for var_name, var_value in variables.items():
                                             self._variable_manager.set_host_variable(target_host, var_name, var_value)
                                 case _:
-                                    raise NotSupportedError(f"Unsupported variable layer: {variable_layer}")
+                                    raise NotImplementedError(f"Unsupported variable layer: {variable_layer}")
 
                     if result_utr.stats is not None:
                         stats_data = result_utr.stats['data']


### PR DESCRIPTION
##### SUMMARY
* Bogus auto-import of sqlite.NotSupportedError instead of stdlib NotImplementedError
* No meaningful external visibility

(cherry picked from commit 30260d8e5595ad928d5c53f27136147c08d60472)

##### ISSUE TYPE
- Bugfix Pull Request
