### PR TITLE
fix role include error for collection roles with invalid name characters

### DIFF
--- a/lib/ansible/playbook/role/include.py
+++ b/lib/ansible/playbook/role/include.py
@@ -17,6 +17,8 @@
 
 from __future__ import annotations
 
+import re
+
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.playbook.delegatable import Delegatable
 from ansible.playbook.role.definition import RoleDefinition
@@ -37,13 +39,40 @@ class RoleInclude(RoleDefinition, Delegatable):
                                           loader=loader, collection_list=collection_list)
 
     @staticmethod
-    def load(data, play, current_role_path=None, parent_role=None, variable_manager=None, loader=None, collection_list=None):
+    def load(data, play, current_role_path=None, parent_role=None,
+             variable_manager=None, loader=None, collection_list=None):
 
-        if not (isinstance(data, str) or isinstance(data, dict)):
+        if not isinstance(data, (str, dict)):
             raise AnsibleParserError("Invalid role definition.", obj=data)
 
         if isinstance(data, str) and ',' in data:
             raise AnsibleError("Invalid old style role requirement: %s" % data)
 
-        ri = RoleInclude(play=play, role_basedir=current_role_path, variable_manager=variable_manager, loader=loader, collection_list=collection_list)
-        return ri.load_data(data, variable_manager=variable_manager, loader=loader)
+        # Detect collection role names with invalid characters.
+        # Collection role names must only contain lowercase letters, digits
+        # and underscores. Catch this early to give a clear error instead of
+        # the misleading "role not found" message. Fixes: #75023
+        if isinstance(data, str) and data.count('.') == 2:
+            role_name_part = data.split('.')[-1]
+            if not re.match(r'^[a-z0-9_]+$', role_name_part):
+                suggested_name = re.sub(r'[^a-z0-9_]', '_', role_name_part.lower())
+                raise AnsibleError(
+                    "Invalid collection role name '%s'. "
+                    "Role names in collections may contain only "
+                    "lowercase letters, numbers, and underscores. "
+                    "Consider renaming '%s' to '%s'."
+                    % (role_name_part, role_name_part, suggested_name)
+                )
+
+        ri = RoleInclude(
+            play=play,
+            role_basedir=current_role_path,
+            variable_manager=variable_manager,
+            loader=loader,
+            collection_list=collection_list
+        )
+        return ri.load_data(
+            data,
+            variable_manager=variable_manager,
+            loader=loader
+        )

--- a/lib/ansible/playbook/role/include.py
+++ b/lib/ansible/playbook/role/include.py
@@ -52,17 +52,20 @@ class RoleInclude(RoleDefinition, Delegatable):
         # Collection role names must only contain lowercase letters, digits
         # and underscores. Catch this early to give a clear error instead of
         # the misleading "role not found" message. Fixes: #75023
-        if isinstance(data, str) and data.count('.') == 2:
-            role_name_part = data.split('.')[-1]
-            if not re.match(r'^[a-z0-9_]+$', role_name_part):
-                suggested_name = re.sub(r'[^a-z0-9_]', '_', role_name_part.lower())
-                raise AnsibleError(
-                    "Invalid collection role name '%s'. "
-                    "Role names in collections may contain only "
-                    "lowercase letters, numbers, and underscores. "
-                    "Consider renaming '%s' to '%s'."
-                    % (role_name_part, role_name_part, suggested_name)
-                )
+        if isinstance(data, str) and '.' in data:
+            parts = data.split('.')
+            if len(parts) == 3:
+                namespace, collection, role_name_part = parts
+                if re.match(r'^[a-z0-9_]+$', namespace) and re.match(r'^[a-z0-9_]+$', collection):
+                    if not re.match(r'^[a-z0-9_]+$', role_name_part):
+                        suggested_name = re.sub(r'[^a-z0-9_]', '_', role_name_part.lower())
+                        raise AnsibleError(
+                            "Invalid collection role name '%s'. "
+                            "Role names in collections may contain only "
+                            "lowercase letters, numbers, and underscores. "
+                            "Consider renaming '%s' to '%s'."
+                            % (role_name_part, role_name_part, suggested_name)
+                        )
 
         ri = RoleInclude(
             play=play,

--- a/test/integration/targets/roles/invalid_collection_role_name.yml
+++ b/test/integration/targets/roles/invalid_collection_role_name.yml
@@ -1,0 +1,8 @@
+# Test that including a collection role with invalid name characters
+# raises a clear error message (https://github.com/ansible/ansible/issues/75023)
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: include role with invalid collection role name (dash in role name)
+      include_role:
+        name: "namespace.my_collection.autoupdate-apt"

--- a/test/integration/targets/roles/runme.sh
+++ b/test/integration/targets/roles/runme.sh
@@ -64,3 +64,13 @@ done
 
 # include_role should work in rescue, even if error is from magic variable templating
 ansible-playbook 75240.yml -i ../../inventory "$@"
+
+# Test that invalid collection role names raise a clear error (issue 75023)
+ansible-playbook invalid_collection_role_name.yml -i ../../inventory > invalid_role_name_output.log 2>&1 || true
+if grep "Invalid collection role name" invalid_role_name_output.log >/dev/null; then
+    echo "Test passed: invalid collection role name raised expected error."
+else
+    echo "Test failed: expected error message not found."
+    cat invalid_role_name_output.log
+    exit 1
+fi

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -413,38 +413,3 @@ class TestRole(unittest.TestCase):
         self.assertEqual(r.get_name(), "foo_complex")
 
 
-class TestRoleIncludeInvalidCollectionName(unittest.TestCase):
-
-    @patch('ansible.playbook.role.definition.unfrackpath',
-           mock_unfrackpath_noop)
-    def test_invalid_char_dash_raises_error(self):
-        """Collection role names with dashes should raise a clear error."""
-        mock_play = MagicMock()
-        mock_play.collections = None
-
-        with self.assertRaises(AnsibleError) as cm:
-            RoleInclude.load(
-                'namespace.my_collection.autoupdate-apt',
-                play=mock_play,
-                loader=DictDataLoader({})
-            )
-        self.assertIn('autoupdate-apt', str(cm.exception))
-        self.assertIn('autoupdate_apt', str(cm.exception))
-
-    @patch('ansible.playbook.role.definition.unfrackpath',
-           mock_unfrackpath_noop)
-    def test_valid_collection_role_not_blocked(self):
-        """Valid collection role names should not be blocked by the check."""
-        mock_play = MagicMock()
-        mock_play.collections = None
-
-        # Should NOT raise AnsibleError for valid name — may raise other
-        # errors (role not found etc) but not our new validation error
-        try:
-            RoleInclude.load(
-                'namespace.my_collection.valid_role',
-                play=mock_play,
-                loader=DictDataLoader({})
-            )
-        except AnsibleError as e:
-            self.assertNotIn('Invalid collection role name', str(e))

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -24,7 +24,6 @@ import pytest
 import unittest
 from unittest.mock import patch, MagicMock
 
-from ansible.errors import AnsibleError
 from ansible.errors import AnsibleParserError
 from ansible.playbook.block import Block
 
@@ -411,5 +410,3 @@ class TestRole(unittest.TestCase):
         r = Role.load(i, play=mock_play)
 
         self.assertEqual(r.get_name(), "foo_complex")
-
-

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -410,3 +410,39 @@ class TestRole(unittest.TestCase):
         r = Role.load(i, play=mock_play)
 
         self.assertEqual(r.get_name(), "foo_complex")
+
+class TestRoleIncludeInvalidCollectionName(unittest.TestCase):
+
+    @patch('ansible.playbook.role.definition.unfrackpath',
+           mock_unfrackpath_noop)
+    def test_invalid_char_dash_raises_error(self):
+        """Collection role names with dashes should raise a clear error."""
+        mock_play = MagicMock()
+        mock_play.collections = None
+
+        with self.assertRaises(AnsibleError) as cm:
+            RoleInclude.load(
+                'namespace.my_collection.autoupdate-apt',
+                play=mock_play,
+                loader=DictDataLoader({})
+            )
+        self.assertIn('autoupdate-apt', str(cm.exception))
+        self.assertIn('autoupdate_apt', str(cm.exception))
+
+    @patch('ansible.playbook.role.definition.unfrackpath',
+           mock_unfrackpath_noop)
+    def test_valid_collection_role_not_blocked(self):
+        """Valid collection role names should not be blocked by the check."""
+        mock_play = MagicMock()
+        mock_play.collections = None
+
+        # Should NOT raise AnsibleError for valid name — may raise other
+        # errors (role not found etc) but not our new validation error
+        try:
+            RoleInclude.load(
+                'namespace.my_collection.valid_role',
+                play=mock_play,
+                loader=DictDataLoader({})
+            )
+        except AnsibleError as e:
+            self.assertNotIn('Invalid collection role name', str(e))

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -24,6 +24,7 @@ import pytest
 import unittest
 from unittest.mock import patch, MagicMock
 
+from ansible.errors import AnsibleError
 from ansible.errors import AnsibleParserError
 from ansible.playbook.block import Block
 
@@ -410,6 +411,7 @@ class TestRole(unittest.TestCase):
         r = Role.load(i, play=mock_play)
 
         self.assertEqual(r.get_name(), "foo_complex")
+
 
 class TestRoleIncludeInvalidCollectionName(unittest.TestCase):
 


### PR DESCRIPTION
##### SUMMARY

When a collection role name contains invalid characters (for example, a dash `-`),
Ansible previously reported a generic `role not found` error without explaining
the actual cause.

This change detects when a role reference appears to be a collection FQCN
(`namespace.collection.role_name`) but the role name contains characters
outside `[a-z0-9_]`, and raises a clearer validation error with a suggested
underscore-based replacement.

Example — before this fix:

```text
ERROR! the role 'namespace.my_collection.autoupdate-apt' was not found
```

After this fix:

```text
ERROR! Invalid collection role name 'autoupdate-apt'. Role names in
collections may contain only lowercase letters, numbers, and
underscores. Consider renaming 'autoupdate-apt' to 'autoupdate_apt'.
```

Fixes: #75023

##### ISSUE TYPE

* Bugfix Pull Request

##### COMPONENT NAME

```text
lib/ansible/playbook/role/include.py
```

##### ANSIBLE VERSION

Reproduced on:

* devel
* 2.11
* 2.12

##### ADDITIONAL INFORMATION

No new dependencies introduced. The `re` module is part of Python's
standard library and is already used throughout the Ansible codebase.
