### PR TITLE
Fix get_url re-downloading when force=no and no checksum given

### DIFF
--- a/changelogs/fragments/get_url-checksum-fix.yml
+++ b/changelogs/fragments/get_url-checksum-fix.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - get_url - fix re-downloading file when force=no and destination
+    already exists but no checksum is specified
+    (https://github.com/ansible/ansible/issues/64016).

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -605,7 +605,7 @@ def main():
                 checksum_mismatch = True
 
         # Not forcing redownload, unless checksum does not match
-        if not force and checksum and not checksum_mismatch:
+        if not force and (not checksum or not checksum_mismatch):
             # Not forcing redownload, unless checksum does not match
             # allow file attribute changes
             file_args = module.load_file_common_arguments(module.params, path=dest)

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -835,3 +835,33 @@
 - assert:
     that:
       - get_dir_filename.dest == remote_tmp_dir ~ "/filename.json"
+
+# https://github.com/ansible/ansible/issues/64016
+# Test that get_url does not re-download when force=no, no checksum
+# specified, and destination file already exists
+- name: Define test file for no-checksum force=no test
+  set_fact:
+    no_checksum_dstfile: "{{ remote_tmp_dir }}/no_checksum_force_no_test.txt"
+
+- name: Download file initially (first download)
+  get_url:
+    url: "file://{{ source_file_copied.dest }}"
+    dest: "{{ no_checksum_dstfile }}"
+  register: result_first_download
+
+- name: Assert first download was successful
+  assert:
+    that:
+      - result_first_download is changed
+
+- name: Download same file again with force=no and no checksum
+  get_url:
+    url: "file://{{ source_file_copied.dest }}"
+    dest: "{{ no_checksum_dstfile }}"
+    force: no
+  register: result_no_redownload
+
+- name: Assert file was not re-downloaded when force=no and no checksum
+  assert:
+    that:
+      - result_no_redownload is not changed


### PR DESCRIPTION
When no checksum is specified, get_url was always re-downloading the file even when force=no and destination already existed.

Fixed condition to also skip download when checksum is empty and force=no.

Fixes: #64016

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

- Bugfix Pull Request
