### PR TITLE
Don't raise AttributeError when building manpages with Python 3.15

### DIFF
--- a/lib/ansible/module_utils/_internal/_patches/_dataclass_annotation_patch.py
+++ b/lib/ansible/module_utils/_internal/_patches/_dataclass_annotation_patch.py
@@ -22,6 +22,15 @@ class DataclassesIsTypePatch(CallablePatch):
     target_attribute = '_is_type'
 
     @classmethod
+    def get_current_implementation(cls) -> t.Any:
+        # the codepath for this patch is triggered while building manpages
+        # resulting with an AttributeError with Python 3.15
+        # make it harmless by returning None instead
+        if not hasattr(dataclasses, '_is_type'):
+            return None
+        return super().get_current_implementation()
+
+    @classmethod
     def is_patch_needed(cls) -> bool:
         @dataclasses.dataclass
         class CheckClassVar:


### PR DESCRIPTION
The dataclass patch is no longer relevant for Python 3.15 (the underlying bug has been fixed, and the patched attribute renamed). It has been skipped in tests:
https://github.com/ansible/ansible/commit/d60f11409 but in order to build manpages, we need to not trigger the missing attribute exception in the patch itself.

Assisted-By: Claude Sonnet 4.6

##### SUMMARY

In Fedora 45, I am building ansible with Python 3.15. The build failed on building manpages, see full traceback below.
To avoid raising AttributeError, `get_current_implementation` is overriden to return None if the desired attribute is not present. The attribute has been renamed, and the bug that's hotfixed by the patched - fixed in Python.
If you prefer a different approach to solving this, feel free to propose changes.

Fedora build traceback:
```
+ /usr/bin/python3 packaging/cli-doc/build.py man --output-dir docs/man/man1
Traceback (most recent call last):
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/packaging/cli-doc/build.py", line 282, in <module>
    main()
    ~~~~^^
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/packaging/cli-doc/build.py", line 60, in main
    args.func(**kwargs)
    ~~~~~~~~~^^^^^^^^^^
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/packaging/cli-doc/build.py", line 73, in build_man
    for cli_name, source in generate_rst(template_file).items():
                            ~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/packaging/cli-doc/build.py", line 105, in generate_rst
    for cli_name, template_vars in collect_programs().items():
                                   ~~~~~~~~~~~~~~~~^^
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/packaging/cli-doc/build.py", line 120, in collect_programs
    programs.append(generate_options_docs(source_file, cli_bin_name_list))
                    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/packaging/cli-doc/build.py", line 141, in generate_options_docs
    cli_module = importlib.import_module(cli_module_fqn)
  File "/usr/lib64/python3.15/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1381, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1346, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1277, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 549, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1381, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1346, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1305, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 915, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 747, in exec_module
  File "<frozen importlib._bootstrap>", line 549, in _call_with_frames_removed
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/lib/ansible/cli/__init__.py", line 86, in <module>
    from ansible import _internal  # do not remove or defer; ensures controller-specific state is set early
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/lib/ansible/_internal/__init__.py", line 7, in <module>
    from ansible.module_utils._internal._json import _profiles
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/lib/ansible/module_utils/_internal/_json/__init__.py", line 9, in <module>
    from ansible.module_utils._internal._json._profiles import AnsibleProfileJSONEncoder, AnsibleProfileJSONDecoder, _JSONSerializationProfile
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/lib/ansible/module_utils/_internal/_json/_profiles/__init__.py", line 9, in <module>
    from ansible.module_utils._internal import _messages
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/lib/ansible/module_utils/_internal/_messages.py", line 15, in <module>
    from ansible.module_utils._internal import _datatag, _dataclass_validation
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/lib/ansible/module_utils/_internal/_datatag/__init__.py", line 15, in <module>
    from ansible.module_utils.compat import typing as t
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/lib/ansible/module_utils/compat/typing.py", line 25, in <module>
    _dataclass_annotation_patch.DataclassesIsTypePatch.patch()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/lib/ansible/module_utils/_internal/_patches/__init__.py", line 50, in patch
    if cls.is_patched():
       ~~~~~~~~~~~~~~^^
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/lib/ansible/module_utils/_internal/_patches/__init__.py", line 40, in is_patched
    return isinstance(cls.get_current_implementation(), PatchedTarget)  # using a protocol lets us be more resilient to module unload weirdness
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/builddir/build/BUILD/ansible-core-2.20.6-build/ansible-2.20.6/lib/ansible/module_utils/_internal/_patches/__init__.py", line 45, in get_current_implementation
    return getattr(cls.target_container, cls.target_attribute)
AttributeError: module 'dataclasses' has no attribute '_is_type'
```

##### ISSUE TYPE

- Bugfix Pull Request
