### PR TITLE
Update skills for compat with non-claude agents

### DIFF
--- a/.claude/skills/azp-logs/SKILL.md
+++ b/.claude/skills/azp-logs/SKILL.md
@@ -1,7 +1,9 @@
 ---
+name: azp-logs
 description: Download Azure Pipelines CI logs for analysis
 argument-hint: <pr_number|build_id|build_url>
 allowed-tools: [Bash(gh pr view:*), Bash(gh pr checks:*), Bash(ls:*), Read, Grep]
+user-invocable: true
 ---
 
 Azure Pipelines Logs Downloader

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,7 +1,9 @@
 ---
+name: review
 description: Review an Ansible PR following the project's standardized process from CLAUDE.md
 argument-hint: <pr_number>
 allowed-tools: [TodoWrite, Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr checkout:*), Bash(gh pr checks:*), Read, Grep, Glob, Search]
+user-invocable: true
 ---
 
 PR Review Command


### PR DESCRIPTION
##### SUMMARY

Various agents other than claude code can use the skills in the `.claude` directory, but often require a `name` instead of inferring from the directory, as well as requiring explicit `user-invocable: true` to call as a command.

##### ISSUE TYPE

- Docs Pull Request
