### PR TITLE
Deprecate reserved/confusing module returns

### DIFF
--- a/changelogs/fragments/deprecate-return-values.yml
+++ b/changelogs/fragments/deprecate-return-values.yml
@@ -1,0 +1,4 @@
+deprecated_features:
+  - dnf - The ``results`` return value is deprecated and will be removed in ansible-core 2.25. Use ``transactions`` instead.
+  - dnf - The ``failures`` return value is deprecated and will be removed in ansible-core 2.25. Use ``transaction_errors`` instead.
+  - include_vars - The ``message`` return value is deprecated and will be removed in ansible-core 2.25. Use ``msg`` instead.

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -396,6 +396,7 @@ import sys
 
 from ansible.module_utils.urls import fetch_file
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.datatag import deprecate_value
 from ansible.module_utils.common.respawn import get_env_with_pythonpath, probe_interpreters_for_module
 from ansible.module_utils.embed import EmbedManager
 from ansible.module_utils.yumdnf import YumDnf, yumdnf_argument_spec
@@ -459,7 +460,11 @@ class DnfModule(YumDnf):
             self.module.fail_json(
                 msg='Could not import the dnf python module. '
                     f'Please install `python3-dnf` package. (attempted {interpreters})',
-                results=[]
+                results = deprecate_value([],
+                                      msg='dnf result `results` is deprecated',
+                                      help_text='Use `transactions` instead',
+                                      version='2.25'),
+                transactions = [],
             )
 
         return interpreter
@@ -489,21 +494,33 @@ class DnfModule(YumDnf):
                 return {
                     'failed': True,
                     'msg': f'No output from dnf script. stderr: {stderr}',
-                    'results': [],
+                    'results': deprecate_value([],
+                                               msg="dnf result `results` is deprecated",
+                                               help_text="Use `transactions` instead",
+                                               version="2.25"),
+                    'transactions': [],
                     'rc': rc
                 }
         except json.JSONDecodeError as e:
             return {
                 'failed': True,
                 'msg': f'Failed to parse JSON from dnf script: {e}. stdout: {stdout}',
-                'results': [],
+                'results': deprecate_value([],
+                                          msg="dnf result `results` is deprecated",
+                                          help_text="Use `transactions` instead",
+                                          version="2.25"),
+                'transactions': [],
                 'rc': 1
             }
         except Exception as e:
             return {
                 'failed': True,
                 'msg': f'Failed to execute dnf script: {e}',
-                'results': [],
+                'results': deprecate_value([],
+                                           msg="dnf result `results` is deprecated",
+                                           help_text="Use `transactions` instead",
+                                           version="2.25"),
+                'transactions': [],
                 'rc': 1
             }
 
@@ -518,12 +535,23 @@ class DnfModule(YumDnf):
         )
 
         if result.get('failed'):
-            self.module.fail_json(msg=result['msg'], results=[], rc=1)
+            self.module.fail_json(msg=result['msg'],
+                                  results = deprecate_value([],
+                                                            msg="dnf result `results` is deprecated",
+                                                            help_text="Use `transactions` instead",
+                                                            version="2.25"),
+                                  transactions = [],
+                                  rc=1)
 
         for warning in result.get('warnings', []):
             self.module.warn(warning)
 
-        self.module.exit_json(msg='', results=result['results'])
+        self.module.exit_json(msg='',
+                              results = deprecate_value(result['results'],
+                                                        msg="dnf result `results` is deprecated",
+                                                        help_text="Use `transactions` instead",
+                                                        version="2.25"),
+                              transactions = result['results'])
 
     def ensure(self):
         names = [fetch_file(self.module, name) if '://' in name else name for name in self.names]
@@ -556,14 +584,26 @@ class DnfModule(YumDnf):
             if result.get('failures'):
                 self.module.fail_json(
                     msg=error_msg,
-                    failures=result['failures'],
-                    results=result.get('results', []),
+                    failures=deprecate_value(result['failures'],
+                                             msg="dnf result `failures` is deprecated",
+                                             help_text="Use `transaction_errors` instead.",
+                                             version="2.25"),
+                    transaction_errors=result['failures'],
+                    results=deprecate_value(result.get('results', []),
+                                            msg="dnf result `results` is deprecated",
+                                            help_text="Use `transactions` instead",
+                                            version="2.25"),
+                    transactions=result.get('results', []),
                     rc=result.get('rc', 1)
                 )
             else:
                 self.module.fail_json(
                     msg=error_msg,
-                    results=result.get('results', []),
+                    results=deprecate_value(result.get('results', []),
+                                            msg="dnf result `results` is deprecated",
+                                            help_text="Use `transactions` instead",
+                                            version="2.25"),
+                    transactions=result.get('results', []),
                     rc=result.get('rc', 1)
                 )
 
@@ -571,14 +611,22 @@ class DnfModule(YumDnf):
             self.module.exit_json(
                 msg=result.get('msg', ''),
                 changed=True,
-                results=result.get('results', []),
+                results=deprecate_value(result.get('results', []),
+                                        msg="dnf result `results` is deprecated",
+                                        help_text="Use `transactions` instead",
+                                        version="2.25"),
+                transactions=result.get('results', []),
                 rc=result.get('rc', 0)
             )
         else:
             self.module.exit_json(
                 msg=result.get('msg', 'Nothing to do'),
                 changed=False,
-                results=result.get('results', []),
+                results=deprecate_value(result.get('results', []),
+                                        msg="dnf result `results` is deprecated",
+                                        help_text="Use `transactions` instead",
+                                        version="2.25"),
+                transactions=result.get('results', []),
                 rc=result.get('rc', 0)
             )
 
@@ -593,7 +641,11 @@ class DnfModule(YumDnf):
         if result.get('failed'):
             self.module.fail_json(
                 msg=result['msg'],
-                results=[],
+                results=deprecate_value([],
+                                        msg="dnf result `results` is deprecated",
+                                        help_text="Use `transactions` instead",
+                                        version="2.25"),
+                transactions=[],
                 rc=1
             )
 
@@ -603,7 +655,11 @@ class DnfModule(YumDnf):
         self.module.exit_json(
             msg='Cache updated',
             changed=result.get('changed', False),
-            results=[],
+            results=deprecate_value([],
+                                    msg="dnf result `results` is deprecated",
+                                    help_text="Use `transactions` instead",
+                                    version="2.25"),
+            transactions=[],
             rc=0
         )
 

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -460,11 +460,9 @@ class DnfModule(YumDnf):
             self.module.fail_json(
                 msg='Could not import the dnf python module. '
                     f'Please install `python3-dnf` package. (attempted {interpreters})',
-                results = deprecate_value([],
-                                      msg='dnf result `results` is deprecated',
-                                      help_text='Use `transactions` instead',
-                                      version='2.25'),
-                transactions = [],
+                results=deprecate_value([], msg='dnf result `results` is deprecated.',
+                                        help_text='Use `transactions` instead.', version='2.25'),
+                transactions=[],
             )
 
         return interpreter
@@ -494,10 +492,12 @@ class DnfModule(YumDnf):
                 return {
                     'failed': True,
                     'msg': f'No output from dnf script. stderr: {stderr}',
-                    'results': deprecate_value([],
-                                               msg="dnf result `results` is deprecated",
-                                               help_text="Use `transactions` instead",
-                                               version="2.25"),
+                    'results': deprecate_value(
+                        [],
+                        msg="dnf result `results` is deprecated.",
+                        help_text="Use `transactions` instead.",
+                        version="2.25",
+                    ),
                     'transactions': [],
                     'rc': rc
                 }
@@ -505,10 +505,12 @@ class DnfModule(YumDnf):
             return {
                 'failed': True,
                 'msg': f'Failed to parse JSON from dnf script: {e}. stdout: {stdout}',
-                'results': deprecate_value([],
-                                          msg="dnf result `results` is deprecated",
-                                          help_text="Use `transactions` instead",
-                                          version="2.25"),
+                'results': deprecate_value(
+                    [],
+                    msg="dnf result `results` is deprecated.",
+                    help_text="Use `transactions` instead.",
+                    version="2.25",
+                ),
                 'transactions': [],
                 'rc': 1
             }
@@ -516,10 +518,12 @@ class DnfModule(YumDnf):
             return {
                 'failed': True,
                 'msg': f'Failed to execute dnf script: {e}',
-                'results': deprecate_value([],
-                                           msg="dnf result `results` is deprecated",
-                                           help_text="Use `transactions` instead",
-                                           version="2.25"),
+                'results': deprecate_value(
+                    [],
+                    msg="dnf result `results` is deprecated.",
+                    help_text="Use `transactions` instead.",
+                    version="2.25",
+                ),
                 'transactions': [],
                 'rc': 1
             }
@@ -535,23 +539,31 @@ class DnfModule(YumDnf):
         )
 
         if result.get('failed'):
-            self.module.fail_json(msg=result['msg'],
-                                  results = deprecate_value([],
-                                                            msg="dnf result `results` is deprecated",
-                                                            help_text="Use `transactions` instead",
-                                                            version="2.25"),
-                                  transactions = [],
-                                  rc=1)
+            self.module.fail_json(
+                msg=result['msg'],
+                results=deprecate_value(
+                    [],
+                    msg="dnf result `results` is deprecated.",
+                    help_text="Use `transactions` instead.",
+                    version="2.25",
+                ),
+                transactions=[],
+                rc=1,
+            )
 
         for warning in result.get('warnings', []):
             self.module.warn(warning)
 
-        self.module.exit_json(msg='',
-                              results = deprecate_value(result['results'],
-                                                        msg="dnf result `results` is deprecated",
-                                                        help_text="Use `transactions` instead",
-                                                        version="2.25"),
-                              transactions = result['results'])
+        self.module.exit_json(
+            msg='',
+            results=deprecate_value(
+                result['results'],
+                msg="dnf result `results` is deprecated.",
+                help_text="Use `transactions` instead.",
+                version="2.25",
+            ),
+            transactions=result['results'],
+        )
 
     def ensure(self):
         names = [fetch_file(self.module, name) if '://' in name else name for name in self.names]
@@ -584,50 +596,60 @@ class DnfModule(YumDnf):
             if result.get('failures'):
                 self.module.fail_json(
                     msg=error_msg,
-                    failures=deprecate_value(result['failures'],
-                                             msg="dnf result `failures` is deprecated",
-                                             help_text="Use `transaction_errors` instead.",
-                                             version="2.25"),
+                    failures=deprecate_value(
+                        result['failures'],
+                        msg="dnf result `failures` is deprecated.",
+                        help_text="Use `transaction_errors` instead.",
+                        version="2.25",
+                    ),
                     transaction_errors=result['failures'],
-                    results=deprecate_value(result.get('results', []),
-                                            msg="dnf result `results` is deprecated",
-                                            help_text="Use `transactions` instead",
-                                            version="2.25"),
+                    results=deprecate_value(
+                        result.get('results', []),
+                        msg="dnf result `results` is deprecated.",
+                        help_text="Use `transactions` instead.",
+                        version="2.25",
+                    ),
                     transactions=result.get('results', []),
-                    rc=result.get('rc', 1)
+                    rc=result.get('rc', 1),
                 )
             else:
                 self.module.fail_json(
                     msg=error_msg,
-                    results=deprecate_value(result.get('results', []),
-                                            msg="dnf result `results` is deprecated",
-                                            help_text="Use `transactions` instead",
-                                            version="2.25"),
+                    results=deprecate_value(
+                        result.get('results', []),
+                        msg="dnf result `results` is deprecated.",
+                        help_text="Use `transactions` instead.",
+                        version="2.25",
+                    ),
                     transactions=result.get('results', []),
-                    rc=result.get('rc', 1)
+                    rc=result.get('rc', 1),
                 )
 
         if result.get('changed', False):
             self.module.exit_json(
                 msg=result.get('msg', ''),
                 changed=True,
-                results=deprecate_value(result.get('results', []),
-                                        msg="dnf result `results` is deprecated",
-                                        help_text="Use `transactions` instead",
-                                        version="2.25"),
+                results=deprecate_value(
+                    result.get('results', []),
+                    msg="dnf result `results` is deprecated.",
+                    help_text="Use `transactions` instead.",
+                    version="2.25",
+                ),
                 transactions=result.get('results', []),
-                rc=result.get('rc', 0)
+                rc=result.get('rc', 0),
             )
         else:
             self.module.exit_json(
                 msg=result.get('msg', 'Nothing to do'),
                 changed=False,
-                results=deprecate_value(result.get('results', []),
-                                        msg="dnf result `results` is deprecated",
-                                        help_text="Use `transactions` instead",
-                                        version="2.25"),
+                results=deprecate_value(
+                    result.get('results', []),
+                    msg="dnf result `results` is deprecated.",
+                    help_text="Use `transactions` instead.",
+                    version="2.25",
+                ),
                 transactions=result.get('results', []),
-                rc=result.get('rc', 0)
+                rc=result.get('rc', 0),
             )
 
     def update_cache_only(self):
@@ -641,12 +663,14 @@ class DnfModule(YumDnf):
         if result.get('failed'):
             self.module.fail_json(
                 msg=result['msg'],
-                results=deprecate_value([],
-                                        msg="dnf result `results` is deprecated",
-                                        help_text="Use `transactions` instead",
-                                        version="2.25"),
+                results=deprecate_value(
+                    [],
+                    msg="dnf result `results` is deprecated.",
+                    help_text="Use `transactions` instead.",
+                    version="2.25",
+                ),
                 transactions=[],
-                rc=1
+                rc=1,
             )
 
         for warning in result.get('warnings', []):
@@ -655,12 +679,14 @@ class DnfModule(YumDnf):
         self.module.exit_json(
             msg='Cache updated',
             changed=result.get('changed', False),
-            results=deprecate_value([],
-                                    msg="dnf result `results` is deprecated",
-                                    help_text="Use `transactions` instead",
-                                    version="2.25"),
+            results=deprecate_value(
+                [],
+                msg="dnf result `results` is deprecated.",
+                help_text="Use `transactions` instead.",
+                version="2.25",
+            ),
             transactions=[],
-            rc=0
+            rc=0,
         )
 
     def run(self):

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -335,11 +335,21 @@ msg:
   type: str
   sample: "Nothing to do"
 results:
+  description: A list of the dnf transaction results (deprecated for removal in 2.25. Use transactions instead)
+  returned: success
+  type: list
+  sample: ["Installed: lsof-4.94.0-4.fc37.x86_64"]
+transactions:
   description: A list of the dnf transaction results
   returned: success
   type: list
   sample: ["Installed: lsof-4.94.0-4.fc37.x86_64"]
 failures:
+  description: A list of the dnf transaction failures (deprecated for removal in 2.25. Use transaction_errors instead)
+  returned: failure
+  type: list
+  sample: ["Argument 'lsof' matches only excluded packages."]
+transaction_errors:
   description: A list of the dnf transaction failures
   returned: failure
   type: list
@@ -357,6 +367,7 @@ import sys
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.locale import get_best_parsable_locale
 from ansible.module_utils.common.respawn import has_respawned, probe_interpreters_for_module, respawn_module
+from ansible.module_utils.datatag import deprecate_value
 from ansible.module_utils.yumdnf import YumDnf, yumdnf_argument_spec
 
 libdnf5 = None
@@ -549,14 +560,22 @@ class Dnf5Module(YumDnf):
             msg=f"Could not import the libdnf5 python module using {sys.executable} ({py_version}). "
             "Ensure python3-libdnf5 package is installed (either manually or via the auto_install_module_deps option) "
             f"or that you have specified the correct ansible_python_interpreter. (attempted {system_interpreters}).",
-            failures=[],
+            failures=deprecate_value([],
+                                     msg="dnf result `failures` is deprecated",
+                                     help_text="Use `transaction_errors` instead.",
+                                     version="2.25"),
+            transaction_errors=[],
         )
 
     def run(self):
         if not self.list and not self.download_only and os.geteuid() != 0:
             self.module.fail_json(
                 msg="This command has to be run under the root user.",
-                failures=[],
+                failures=deprecate_value([],
+                                         msg="dnf result `failures` is deprecated",
+                                         help_text="Use `transaction_errors` instead.",
+                                         version="2.25"),
+                transaction_errors=[],
                 rc=1,
             )
 
@@ -661,7 +680,11 @@ class Dnf5Module(YumDnf):
             self.module.exit_json(
                 msg="Cache updated",
                 changed=False,
-                results=[],
+                results=deprecate_value([],
+                                        msg='dnf result `results` is deprecated',
+                                        help_text='Use `transactions` instead',
+                                        version='2.25'),
+                transactions=[],
                 rc=0
             )
 
@@ -684,7 +707,13 @@ class Dnf5Module(YumDnf):
                 query.resolve_pkg_spec(command, resolve_spec_settings, True)
                 results = [package_to_dict(package) for package in query]
 
-            self.module.exit_json(msg="", results=results, rc=0)
+            self.module.exit_json(msg="",
+                                  results=deprecate_value(results,
+                                                          msg='dnf result `results` is deprecated',
+                                                          help_text='Use `transactions` instead',
+                                                          version='2.25'),
+                                  transactions=results,
+                                  rc=0)
 
         settings = libdnf5.base.GoalJobSettings()
         try:
@@ -767,7 +796,11 @@ class Dnf5Module(YumDnf):
                 msg = "Failed to install some of the specified packages"
             self.module.fail_json(
                 msg=msg,
-                failures=failures,
+                failures=deprecate_value(failures,
+                                         msg="dnf result `failures` is deprecated",
+                                         help_text="Use `transaction_errors` instead.",
+                                         version="2.25"),
+                transaction_errors=failures,
                 rc=1,
             )
 
@@ -799,7 +832,11 @@ class Dnf5Module(YumDnf):
                 if result == libdnf5.base.Transaction.TransactionRunResult_ERROR_GPG_CHECK:
                     self.module.fail_json(
                         msg="Failed to validate GPG signatures: {}".format(",".join(transaction.get_gpg_signature_problems())),
-                        failures=[],
+                        failures=deprecate_value([],
+                                                 msg="dnf result `failures` is deprecated",
+                                                 help_text="Use `transaction_errors` instead.",
+                                                 version="2.25"),
+                        transaction_errors=[],
                         rc=1,
                     )
                 elif result != libdnf5.base.Transaction.TransactionRunResult_SUCCESS:
@@ -815,7 +852,11 @@ class Dnf5Module(YumDnf):
 
                     self.module.fail_json(
                         msg="Failed to install some of the specified packages",
-                        failures=failures,
+                        failures=deprecate_value(failures,
+                                                 msg="dnf result `failures` is deprecated",
+                                                 help_text="Use `transaction_errors` instead.",
+                                                 version="2.25"),
+                        transaction_errors=failures,
                         rc=1,
                     )
 
@@ -823,7 +864,11 @@ class Dnf5Module(YumDnf):
             msg = "Nothing to do"
 
         self.module.exit_json(
-            results=results,
+            results=deprecate_value(results,
+                                    msg='dnf result `results` is deprecated',
+                                    help_text='Use `transactions` instead',
+                                    version='2.25'),
+            transactions=results,
             changed=changed,
             msg=msg,
             rc=0,
@@ -840,7 +885,13 @@ def main():
     try:
         Dnf5Module(module).run()
     except LIBDNF5_ERRORS as e:
-        module.fail_json(msg=str(e), failures=[], rc=1)
+        module.fail_json(msg=str(e),
+                         failures=deprecate_value([],
+                                                  msg="dnf result `failures` is deprecated",
+                                                  help_text="Use `transaction_errors` instead.",
+                                                  version="2.25"),
+                         transaction_errors=[],
+                         rc=1)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -335,7 +335,7 @@ msg:
   type: str
   sample: "Nothing to do"
 results:
-  description: A list of the dnf transaction results (deprecated for removal in 2.25. Use transactions instead)
+  description: A list of the dnf transaction results (deprecated for removal in 2.25. Use RV(transactions) instead)
   returned: success
   type: list
   sample: ["Installed: lsof-4.94.0-4.fc37.x86_64"]
@@ -344,8 +344,9 @@ transactions:
   returned: success
   type: list
   sample: ["Installed: lsof-4.94.0-4.fc37.x86_64"]
+  version_added: 2.22
 failures:
-  description: A list of the dnf transaction failures (deprecated for removal in 2.25. Use transaction_errors instead)
+  description: A list of the dnf transaction failures (deprecated for removal in 2.25. Use RV(transaction_errors) instead)
   returned: failure
   type: list
   sample: ["Argument 'lsof' matches only excluded packages."]
@@ -354,6 +355,7 @@ transaction_errors:
   returned: failure
   type: list
   sample: ["Argument 'lsof' matches only excluded packages."]
+  version_added: 2.22
 rc:
   description: For compatibility, 0 for success, 1 for failure
   returned: always

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -10,6 +10,7 @@ import pathlib
 import ansible.constants as C
 from ansible.errors import AnsibleError
 from ansible._internal._datatag._tags import SourceWasEncrypted
+from ansible.module_utils.datatag import deprecate_value
 from ansible.module_utils.common.text.converters import to_native
 from ansible.plugins.action import ActionBase, VariableLayer
 from ansible.utils.vars import combine_vars
@@ -139,7 +140,11 @@ class ActionModule(ActionBase):
 
         if failed:
             result['failed'] = failed
-            result['message'] = err_msg
+            result['message'] = deprecate_value(err_msg,
+                                                msg="The return value `message` is deprecated",
+                                                version="2.25",
+                                                help_text="Use `msg` instead")
+            result['msg'] = err_msg
         elif self.hash_behaviour is not None and self.hash_behaviour != C.DEFAULT_HASH_BEHAVIOUR:
             merge_hashes = self.hash_behaviour == 'merge'
             existing_variables = {k: v for k, v in task_vars.items() if k in results}

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -51,8 +51,8 @@
 - assert:
     that:
       - dnf_result is success
-      - dnf_result.results|length > 0
-      - "dnf_result.results[0].startswith('Installed: ')"
+      - dnf_result.transactions|length > 0
+      - "dnf_result.transactions[0].startswith('Installed: ')"
 
 - name: install sos
   dnf:
@@ -88,7 +88,7 @@
   assert:
     that:
         - "'changed' in dnf_result"
-        - "'results' in dnf_result"
+        - "'transactions' in dnf_result"
 
 # INSTALL AGAIN
 - name: install sos again (check_mode)
@@ -101,7 +101,7 @@
 - assert:
     that:
       - dnf_result is not changed
-      - dnf_result.results|length == 0
+      - dnf_result.transactions|length == 0
 
 - name: install sos again
   dnf:
@@ -242,9 +242,9 @@
 - assert:
     that:
       - dnf_result is success
-      - dnf_result.results|length >= 2
-      - "dnf_result.results[0].startswith('Removed: ')"
-      - "dnf_result.results[1].startswith('Removed: ')"
+      - dnf_result.transactions|length >= 2
+      - "dnf_result.transactions[0].startswith('Removed: ')"
+      - "dnf_result.transactions[1].startswith('Removed: ')"
 
 - name: uninstall sos and dos2unix
   dnf:
@@ -290,7 +290,7 @@
   assert:
     that:
         - "'changed' in dnf_result"
-        - "'results' in dnf_result"
+        - "'transactions' in dnf_result"
 
 - name: uninstall sos in /
   dnf: name=sos installroot='/'
@@ -312,7 +312,7 @@
 - assert:
     that:
       - dnf_result is success
-      - "dnf_result.results[0].startswith('Downloaded: ')"
+      - "dnf_result.transactions[0].startswith('Downloaded: ')"
 
 - name: Test download_only
   dnf:
@@ -383,7 +383,7 @@
     that:
     - not dnf_result is failed
     - dnf_result is changed
-    - "'results' in dnf_result"
+    - "'transactions' in dnf_result"
     - dinginessentail_result.rc == 0
 
 - name: install the group again
@@ -420,7 +420,7 @@
   assert:
     that:
     - dnf_result is changed
-    - "'results' in dnf_result"
+    - "'transactions' in dnf_result"
     - landsidescalping_result.rc == 0
 
 - name: try to install the group again, with --check to check 'changed'
@@ -459,7 +459,7 @@
     that:
     - not dnf_result is failed
     - dnf_result is changed
-    - "'results' in dnf_result"
+    - "'transactions' in dnf_result"
 
 - dnf:
     name: "@Custom Group"
@@ -540,7 +540,7 @@
     that:
     - not dnf_result is failed
     - dnf_result is changed
-    - "'results' in dnf_result"
+    - "'transactions' in dnf_result"
     - landsidescalping_result.rc == 0
 
 - name: uninstall Custom Environment Group
@@ -572,8 +572,8 @@
   assert:
     that:
         - "dnf_result is failed"
-        - "'non-existent-rpm' in dnf_result['failures'][0]"
-        - "'No package non-existent-rpm available' in dnf_result['failures'][0]"
+        - "'non-existent-rpm' in dnf_result['transaction_errors'][0]"
+        - "'No package non-existent-rpm available' in dnf_result['transaction_errors'][0]"
         - "'Failed to install some of the specified packages' in dnf_result['msg']"
 
 - name: ensure sos isn't installed
@@ -635,8 +635,8 @@
     that:
         - "not dnf_result is changed"
         - "dnf_result is failed"
-        - dnf_result.failures | length > 0
-        - '"scriptlet failed, exit status 1" in dnf_result.failures[0]'
+        - dnf_result.transaction_errors | length > 0
+        - '"scriptlet failed, exit status 1" in dnf_result.transaction_errors[0]'
 
 # setup for testing installing an RPM from local file
 
@@ -699,7 +699,7 @@
   assert:
     that:
         - "'changed' in dnf_result"
-        - "'results' in dnf_result"
+        - "'transactions' in dnf_result"
 
 # Install RPM from url with update_only
 - name: install from url with update_only
@@ -721,7 +721,7 @@
   assert:
     that:
         - "'changed' in dnf_result"
-        - "'results' in dnf_result"
+        - "'transactions' in dnf_result"
 
 - name: Create a temp RPM file which does not contain nevra information
   file:

--- a/test/integration/targets/dnf/tasks/dnf_group_remove.yml
+++ b/test/integration/targets/dnf/tasks/dnf_group_remove.yml
@@ -23,7 +23,7 @@
   assert:
     that:
         - "'changed' in dnf_result"
-        - "'results' in dnf_result"
+        - "'transactions' in dnf_result"
 
 - name: remove the group
   dnf:
@@ -42,7 +42,7 @@
     that:
         - "'changed' in dnf_result"
         - "'msg' in dnf_result"
-        - "'results' in dnf_result"
+        - "'transactions' in dnf_result"
 
 - name: remove the group again
   dnf:
@@ -60,7 +60,7 @@
     that:
         - "'changed' in dnf_result"
         - "'msg' in dnf_result"
-        - "'results' in dnf_result"
+        - "'transactions' in dnf_result"
 
 - name: check mode remove the group again
   dnf:
@@ -78,7 +78,7 @@
   assert:
     that:
         - "'changed' in dnf_result"
-        - "'results' in dnf_result"
+        - "'transactions' in dnf_result"
 
 - name: install a group and a package to test
   dnf:
@@ -102,7 +102,7 @@
   assert:
     that:
         - "'changed' in dnf_result"
-        - "'results' in dnf_result"
+        - "'transactions' in dnf_result"
 
 - name: remove the group along with the package
   dnf:
@@ -120,7 +120,7 @@
     that:
         - "'changed' in dnf_result"
         - "'msg' in dnf_result"
-        - "'results' in dnf_result"
+        - "'transactions' in dnf_result"
 
 - name: check mode remove the group along with the package
   dnf:
@@ -138,4 +138,4 @@
   assert:
     that:
         - "'changed' in dnf_result"
-        - "'results' in dnf_result"
+        - "'transactions' in dnf_result"

--- a/test/integration/targets/dnf/tasks/dnfinstallroot.yml
+++ b/test/integration/targets/dnf/tasks/dnfinstallroot.yml
@@ -27,7 +27,7 @@
   assert:
     that:
         - "'changed' in dnf_result"
-        - "'results' in dnf_result"
+        - "'transactions' in dnf_result"
 
 - name: cleanup installroot
   file:

--- a/test/integration/targets/dnf/tasks/filters.yml
+++ b/test/integration/targets/dnf/tasks/filters.yml
@@ -31,10 +31,10 @@
     - assert:
         that:
           - update_no_filter is changed
-          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_no_filter.results'
-          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_no_filter.results'
-          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_no_filter.results'
-          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_no_filter.results'
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_no_filter.transactions'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_no_filter.transactions'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_no_filter.transactions'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_no_filter.transactions'
 
     - name: Install old versions of toaster and oven
       dnf:
@@ -58,10 +58,10 @@
     - assert:
         that:
           - update_security is changed
-          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_security.results'
-          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_security.results'
-          - '"Installed: oven-1.2.3.5-1.el8.noarch" not in update_security.results'
-          - '"Removed: oven-1.2.3.4-1.el8.noarch" not in update_security.results'
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_security.transactions'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_security.transactions'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" not in update_security.transactions'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" not in update_security.transactions'
 
     - name: Install old versions of toaster and oven
       dnf:
@@ -85,10 +85,10 @@
     - assert:
         that:
           - update_bugfix is changed
-          - '"Installed: toaster-1.2.3.5-1.el8.noarch" not in update_bugfix.results'
-          - '"Removed: toaster-1.2.3.4-1.el8.noarch" not in update_bugfix.results'
-          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_bugfix.results'
-          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_bugfix.results'
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" not in update_bugfix.transactions'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" not in update_bugfix.transactions'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_bugfix.transactions'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_bugfix.transactions'
 
     - name: Install old versions of toaster and oven
       dnf:
@@ -126,10 +126,10 @@
     - assert:
         that:
           - update_bugfix is changed
-          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_bugfix.results'
-          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_bugfix.results'
-          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_bugfix.results'
-          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_bugfix.results'
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_bugfix.transactions'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_bugfix.transactions'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_bugfix.transactions'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_bugfix.transactions'
 
     - name: Install old version of toaster again
       dnf:

--- a/test/integration/targets/dnf/tasks/filters_check_mode.yml
+++ b/test/integration/targets/dnf/tasks/filters_check_mode.yml
@@ -33,10 +33,10 @@
         that:
           - update_no_filter is changed
           - '"would have if not in check mode" in update_no_filter.msg'
-          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_no_filter.results'
-          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_no_filter.results'
-          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_no_filter.results'
-          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_no_filter.results'
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_no_filter.transactions'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_no_filter.transactions'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_no_filter.transactions'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_no_filter.transactions'
 
     - name: Ask for pending updates with security=true (check_mode)
       dnf:
@@ -54,10 +54,10 @@
         that:
           - update_security is changed
           - '"would have if not in check mode" in update_security.msg'
-          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_security.results'
-          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_security.results'
-          - '"Installed: oven-1.2.3.5-1.el8.noarch" not in update_security.results'
-          - '"Removed: oven-1.2.3.4-1.el8.noarch" not in update_security.results'
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_security.transactions'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_security.transactions'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" not in update_security.transactions'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" not in update_security.transactions'
 
     - name: Ask for pending updates with bugfix=true (check_mode)
       dnf:
@@ -75,10 +75,10 @@
         that:
           - update_bugfix is changed
           - '"would have if not in check mode" in update_bugfix.msg'
-          - '"Installed: toaster-1.2.3.5-1.el8.noarch" not in update_bugfix.results'
-          - '"Removed: toaster-1.2.3.4-1.el8.noarch" not in update_bugfix.results'
-          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_bugfix.results'
-          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_bugfix.results'
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" not in update_bugfix.transactions'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" not in update_bugfix.transactions'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_bugfix.transactions'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_bugfix.transactions'
 
     - name: Ask for pending updates with bugfix=true and security=true (check_mode)
       dnf:
@@ -97,10 +97,10 @@
         that:
           - update_bugfix is changed
           - '"would have if not in check mode" in update_bugfix.msg'
-          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_bugfix.results'
-          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_bugfix.results'
-          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_bugfix.results'
-          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_bugfix.results'
+          - '"Installed: toaster-1.2.3.5-1.el8.noarch" in update_bugfix.transactions'
+          - '"Removed: toaster-1.2.3.4-1.el8.noarch" in update_bugfix.transactions'
+          - '"Installed: oven-1.2.3.5-1.el8.noarch" in update_bugfix.transactions'
+          - '"Removed: oven-1.2.3.4-1.el8.noarch" in update_bugfix.transactions'
 
   always:
     - name: Remove installed packages

--- a/test/integration/targets/dnf/tasks/repo.yml
+++ b/test/integration/targets/dnf/tasks/repo.yml
@@ -18,7 +18,7 @@
     - name: Verify dnf module outputs
       assert:
         that:
-            - "'results' in dnf_result"
+            - "'transactions' in dnf_result"
 
     - shell: dnf history list | wc -l
       register: dnf_history_lines_before
@@ -88,7 +88,7 @@
     - name: Verify dnf module outputs
       assert:
         that:
-            - "'results' in dnf_result"
+            - "'transactions' in dnf_result"
     # ============================================================================
     - name: Update to the latest dinginessentail
       dnf:
@@ -109,7 +109,7 @@
     - name: Verify dnf module outputs
       assert:
         that:
-            - "'results' in dnf_result"
+            - "'transactions' in dnf_result"
     # ============================================================================
     - name: Install dinginessentail-1.0-1 from a file (higher version is already installed)
       dnf:
@@ -133,7 +133,7 @@
         that:
             - "'msg' in dnf_result"
             - "'rc' in dnf_result"
-            - "'results' in dnf_result"
+            - "'transactions' in dnf_result"
     # ============================================================================
     - name: Install dinginessentail-1.0-1 from a file (downgrade)
       dnf:
@@ -156,7 +156,7 @@
     - name: Verify dnf module outputs
       assert:
         that:
-            - "'results' in dnf_result"
+            - "'transactions' in dnf_result"
 
     - name: Remove dinginessentail
       dnf:
@@ -183,7 +183,7 @@
     - name: Verify dnf module outputs
       assert:
         that:
-            - "'results' in dnf_result"
+            - "'transactions' in dnf_result"
     # ============================================================================
     - name: Install dinginessentail-1.0-1 from a file again
       dnf:
@@ -222,7 +222,7 @@
     - name: Verify dnf module outputs
       assert:
         that:
-            - "'results' in dnf_result"
+            - "'transactions' in dnf_result"
     # ============================================================================
     - name: Install dinginessentail-1.0-2 from a file again
       dnf:
@@ -329,12 +329,12 @@
     - name: check that dnf returns nevra for backwards compat
       assert:
         that:
-          - '"envra" in list_out["results"][0]'
-          - '"nevra" in list_out["results"][0]'
+          - '"envra" in list_out["transactions"][0]'
+          - '"nevra" in list_out["transactions"][0]'
 
     - set_fact:
         passed: true
-      loop: "{{ list_out.results }}"
+      loop: "{{ list_out.transactions }}"
       when: item.yumstate == 'installed'
 
     - name: Test that there is yumstate=installed in the result
@@ -369,7 +369,7 @@
         that:
             - "'msg' in dnf_result"
             - "'rc' in dnf_result"
-            - "'results' in dnf_result"
+            - "'transactions' in dnf_result"
   always:
     - name: Clean up
       dnf:
@@ -414,7 +414,7 @@
         that:
             - "'msg' in dnf_result"
             - "'rc' in dnf_result"
-            - "'results' in dnf_result"
+            - "'transactions' in dnf_result"
   always:
     - name: Clean up
       dnf:
@@ -521,7 +521,7 @@
     - assert:
         that:
           - dnf_results is changed
-          - "'Installed: provides_foo_b' in dnf_results['results'][0]"
+          - "'Installed: provides_foo_b' in dnf_results['transactions'][0]"
   always:
     - name: Clean up
       dnf:
@@ -676,7 +676,7 @@
             - "dnf_result is changed"
             - "'msg' in dnf_result"
             - "'rc' in dnf_result"
-            - "'results' in dnf_result"
+            - "'transactions' in dnf_result"
   always:
     - name: Clean up
       dnf:

--- a/test/integration/targets/dnf/tasks/skip_broken_and_nobest.yml
+++ b/test/integration/targets/dnf/tasks/skip_broken_and_nobest.yml
@@ -51,7 +51,7 @@
         that:
           - skip_broken_res.msg == 'Nothing to do'
           - skip_broken_res.rc == 0
-          - skip_broken_res.results == []
+          - skip_broken_res.transactions == []
 
     - name: Remove all test packages
       dnf:
@@ -89,7 +89,7 @@
       assert:
         that:
           - skip_broken_res.rc == 0
-          - skip_broken_res.results|length == 2
+          - skip_broken_res.transactions|length == 2
           # FIXME: The following assertions have always been broken. Fix the code and/or test as needed.
           # - 'skip_broken_res.results|select("contains", "Installed: broken-a-1.2.4")|length > 0'
           # - 'skip_broken_res.results|select("contains", "Installed: broken-d-1.2.5")|length > 0'
@@ -132,7 +132,7 @@
       assert:
         that:
           - res is changed
-          - res.results|select("contains", pkg_state ~ " broken-a-1.2.3")|length > 0
+          - res.transactions|select("contains", pkg_state ~ " broken-a-1.2.3")|length > 0
 
     # Still case 2, but with broken package to test skip_broken
     # skip_broken: false
@@ -185,7 +185,7 @@
       assert:
         that:
           - res is changed
-          - res.results|select("contains", pkg_state ~ " broken-a-1.2.3")|length > 0
+          - res.transactions|select("contains", pkg_state ~ " broken-a-1.2.3")|length > 0
 
     # Case 3 still, with broken package and skip_broken tests like above.
     - name: Install an older known broken version of broken-a, allow_downgrade=true, skip_broken=false
@@ -272,7 +272,7 @@
     - assert:
         that:
           - nobest.rc == 0
-          - nobest.results == []
+          - nobest.transactions == []
 
     # Case 6: Current or older version already installed (no version specified
     # in our pkg_spec) and we're requesting present, not latest.

--- a/test/integration/targets/dnf/tasks/test_sos_removal.yml
+++ b/test/integration/targets/dnf/tasks/test_sos_removal.yml
@@ -16,5 +16,5 @@
       - sos_rm is successful
       - sos_rm is changed
       - |
-        sos_rm.results|select("contains", "Removed: sos-" ~ sos_version ~ "-" ~ sos_release) | length > 0
-      - sos_rm.results|length > 0
+        sos_rm.transactions|select("contains", "Removed: sos-" ~ sos_version ~ "-" ~ sos_release) | length > 0
+      - sos_rm.transactions|length > 0

--- a/test/integration/targets/include_vars/tasks/main.yml
+++ b/test/integration/targets/include_vars/tasks/main.yml
@@ -106,13 +106,13 @@
       - "invalid_ignore_files is failed"
       - "'option must be a list' in invalid_ignore_files.msg"
       - "non_existent_dir_results is failed"
-      - "'directory does not exist' in non_existent_dir_results.message"
+      - "'directory does not exist' in non_existent_dir_results.msg"
       - "invalid_option_results is failed"
       - "'is not a valid option' in invalid_option_results.msg"
       - "invalid_files_dir_results is failed"
       - "'these are incompatible' in invalid_files_dir_results.msg"
       - "non_file_dir_results is failed"
-      - "'is not a directory' in non_file_dir_results.message"
+      - "'is not a directory' in non_file_dir_results.msg"
       - "invalid_extensions_results is failed"
       - "'option must be a list' in invalid_extensions_results.msg"
 
@@ -186,7 +186,7 @@
 - name: verify that files without valid extensions are loaded
   assert:
     that:
-      - "'a valid extension' in include_with_unknown_file_extension.message"
+      - "'a valid extension' in include_with_unknown_file_extension.msg"
 
 - name: include var with raw params
   include_vars: >
@@ -209,7 +209,7 @@
 - name: Verify that file and raw_params provide correct error message to user
   assert:
     that:
-      - "'Could not find file' in include_with_non_existent_file.message"
+      - "'Could not find file' in include_with_non_existent_file.msg"
 
 - name: include var (FQCN) with raw params
   ansible.builtin.include_vars: >


### PR DESCRIPTION
##### SUMMARY

Deprecates several return values:

| module | return | reason |
| --- | --- | --- |
| dnf | failures | Undocumented + too close to `failed` |
| dnf | results  | Undocumented + `results` key is used for loop results |
| include_vars | message | The standard pattern for returning an error message is `msg` (https://github.com/ansible/ansible/pull/86526#discussion_r2776401895) |

Fixes #70003

##### ISSUE TYPE

- Bugfix Pull Request
