### PR TITLE
Remove 'when' and 'tags' from _get_hash_dict for role deduplication in conditioned dependencies

### DIFF
--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -190,8 +190,6 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
                 'name': self.get_name(),
                 'path': self.get_role_path(),
                 'params': MappingProxyType(self.get_role_params()),
-                'when': self.when,
-                'tags': self.tags,
                 'from_files': MappingProxyType(self._from_files),
                 'vars': MappingProxyType(self.vars),
                 'from_include': self.from_include,


### PR DESCRIPTION
Removed 'when' and 'tags' from _get_hash_dict role attribute mapping

##### SUMMARY

Removed when and tags from the hash dict. These are execution modifiers (controlling when/whether a role runs), not part of role identity (controlling which role it is). Role deduplication should only consider name, path, parameters, vars, from_files, and from_include — matching Ansible's documented behavior that "Ansible does not execute a role within the play if it has already been executed."

Fixes #87024

##### ISSUE TYPE

- Bugfix Pull Request
