### PR TITLE
[stable-2.21] Fix broken callback dispatch on skipped meta tasks (#86977)

### DIFF
--- a/changelogs/fragments/meta_skipped_callback_args.yml
+++ b/changelogs/fragments/meta_skipped_callback_args.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - meta pseudo-action - Fixed callback args passed to ``v2_runner_on_skipped`` when any ``meta`` action was skipped by a ``when`` condition; added test coverage.
+    A previous regression caused the callback dispatch to be omitted and a warning issued.

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -1016,10 +1016,12 @@ class StrategyBase:
         else:
             display.vv(f"META: {header}")
 
-        if skipped:
-            self._tqm.send_callback('v2_runner_on_skipped', target_host, task, utr)
+        htr = HostTaskResult(host=target_host, task=task, utr=utr)
 
-        return [HostTaskResult(host=target_host, task=task, utr=utr)]
+        if skipped:
+            self._tqm.send_callback('v2_runner_on_skipped', htr)
+
+        return [htr]
 
     def _get_cached_role(self, task, play):
         return play._get_cached_role(task._role)

--- a/test/integration/targets/meta_tasks/runme.sh
+++ b/test/integration/targets/meta_tasks/runme.sh
@@ -40,8 +40,10 @@ done
 
 # test end_play meta task
 for test_strategy in linear free; do
-  out="$(ansible-playbook test_end_play.yml -i inventory.yml -e test_strategy=$test_strategy -vv "$@")"
+  # $@ omitted to avoid additional verbosity, which will line-break and indent the JSON output we need to check
+  out="$(ansible-playbook test_end_play.yml -i inventory.yml -e test_strategy=$test_strategy -vv)"
 
+  grep -q "skipping:.*end_play conditional evaluated to False, continuing play" <<< "$out"
   grep -q "META: ending play" <<< "$out"
   grep -qv 'Failed to end using end_play' <<< "$out"
 

--- a/test/integration/targets/meta_tasks/test_end_play.yml
+++ b/test/integration/targets/meta_tasks/test_end_play.yml
@@ -3,6 +3,10 @@
   gather_facts: no
   strategy: "{{ test_strategy | default('linear') }}"
   tasks:
+    - name: Skipped end_play
+      meta: end_play
+      when: false
+
     - debug:
         msg: "Testing end_play on host {{ inventory_hostname }}"
 


### PR DESCRIPTION
* Fix broken callback dispatch on skipped meta tasks
(cherry picked from commit cb535cf)

Co-authored-by: Matt Davis <6775756+nitzmahone@users.noreply.github.com>