### PR TITLE
user: fix Alpine move_home ordering

### DIFF
--- a/changelogs/fragments/87044-user-alpine-move-home-ordering.yml
+++ b/changelogs/fragments/87044-user-alpine-move-home-ordering.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - fix ``move_home`` on BusyBox/Alpine to move existing home contents before rewriting ``/etc/passwd`` (https://github.com/ansible/ansible/pull/87044).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3309,6 +3309,20 @@ class BusyBox(User):
                 if rc is not None and rc != 0:
                     self.module.fail_json(name=self.name, msg=err, rc=rc)
 
+        # Move the home before rewriting /etc/passwd so usermod can still
+        # locate the current home directory contents.
+        if self.move_home and self.home is not None and user_info[5] != self.home:
+            usermod_bin = self.module.get_bin_path('usermod')
+            if usermod_bin is not None:
+                cmd = [usermod_bin, '-d', self.home, '-m', self.name]
+                rc, out, err = self.execute_command(cmd)
+                if rc is not None and rc != 0:
+                    self.module.fail_json(name=self.name, msg=err, rc=rc)
+
+                user_info = self.user_info()
+            else:
+                self.module.warn("usermod command not found, skipping home directory move")
+
         # Manage user settings
         uid = user_info[2]
         if self.uid is not None:
@@ -3346,16 +3360,6 @@ class BusyBox(User):
                 self.module.backup_local(self.PASSWORDFILE)
                 self.module.atomic_move(tmpfile, self.PASSWORDFILE)
 
-        # Manage home directory
-        if self.move_home:
-            usermod_bin = self.module.get_bin_path('usermod')
-            if usermod_bin is not None:
-                cmd = [usermod_bin, '-d', self.home, '-m', self.name]
-                rc, out, err = self.execute_command(cmd)
-                if rc is not None and rc != 0:
-                    self.module.fail_json(name=self.name, msg=err, rc=rc)
-            else:
-                self.module.warn("usermod command not found, skipping home directory move")
         return rc, out, err
 
 

--- a/test/integration/targets/user/tasks/test_modify_user_home.yml
+++ b/test/integration/targets/user/tasks/test_modify_user_home.yml
@@ -14,6 +14,14 @@
         home: /tmp/ansibulluser
         state: present
 
+    - name: Create sentinel file in the old home directory
+      copy:
+        content: sentinel
+        dest: /tmp/ansibulluser/sentinel
+        owner: ansibulluser
+        group: ansibulluser
+        mode: '0644'
+
     - name: Move user home directory
       user:
         name: ansibulluser
@@ -26,18 +34,38 @@
         path: /tmp/ansibulluser-moved
       register: user_home_directory
 
+    - name: Stat sentinel file in the new home directory
+      stat:
+        path: /tmp/ansibulluser-moved/sentinel
+      register: moved_sentinel_file
+
+    - name: Stat sentinel file in the old home directory
+      stat:
+        path: /tmp/ansibulluser/sentinel
+      register: old_sentinel_file
+
     - name: Check if user home directory is moved
       assert:
         that:
           - user_home_directory.stat.exists
           - user_home_directory.stat.isdir
           - user_home_directory.stat.pw_name == 'ansibulluser'
+          - moved_sentinel_file.stat.exists
+          - not old_sentinel_file.stat.exists
 
   always:
     - name: Remove user home directory
       user:
         name: ansibulluser
         state: absent
+
+    - name: Remove old and new home directories
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /tmp/ansibulluser
+        - /tmp/ansibulluser-moved
 
     - name: Remove package
       command: apk del shadow


### PR DESCRIPTION
## Summary
- move the BusyBox/Alpine `move_home` call ahead of the manual `/etc/passwd` rewrite
- add a regression test that checks an existing file is moved into the new home directory
- clean up both home directory paths in the Alpine integration test

## Why
The Alpine `move_home` support added in #86810 updates `/etc/passwd` before calling `usermod -d ... -m`.

On BusyBox systems we rewrite `/etc/passwd` directly, so that ordering leaves `usermod` seeing the new home path as the current one already. When that happens, the module can report success while leaving the old home contents behind.

The updated test creates a sentinel file in the original home directory and verifies that it ends up under the new home path after `move_home: yes`.

## Testing
- `python3 -m py_compile lib/ansible/modules/user.py`
- `python3 ./bin/ansible-test sanity --venv --python 3.14 --requirements --test compile --test pep8 --test validate-modules --test yamllint lib/ansible/modules/user.py test/integration/targets/user/tasks/test_modify_user_home.yml`
