### PR TITLE
[stable-2.20] 🧪 Pin Codecov CLI uploader env for Python 3.13

### DIFF
--- a/.azure-pipelines/scripts/dependencies/codecov.txt
+++ b/.azure-pipelines/scripts/dependencies/codecov.txt
@@ -4,15 +4,14 @@
 #
 #    pip-compile --allow-unsafe --annotation-style=line --output-file=codecov.txt --strip-extras codecov.in
 #
-certifi==2025.8.3         # via requests, sentry-sdk
-charset-normalizer==3.4.3  # via requests
+certifi==2026.5.20        # via requests, sentry-sdk
+charset-normalizer==3.4.7  # via requests
 click==8.2.1              # via codecov-cli
-codecov-cli==11.2.3       # via -r codecov.in
-idna==3.10                # via requests
-ijson==3.4.0              # via codecov-cli
-pyyaml==6.0.2             # via codecov-cli
-requests==2.32.5          # via responses
-responses==0.21.0         # via codecov-cli
-sentry-sdk==2.38.0        # via codecov-cli
-test-results-parser==0.5.4  # via codecov-cli
-urllib3==2.5.0            # via requests, responses, sentry-sdk
+codecov-cli==11.2.8       # via -r codecov.in
+idna==3.16                # via requests
+ijson==3.5.0              # via codecov-cli
+pyyaml==6.0.3             # via codecov-cli
+requests==2.34.2          # via codecov-cli
+sentry-sdk==2.61.0        # via codecov-cli
+test-results-parser==0.6.1  # via codecov-cli
+urllib3==2.7.0            # via requests, sentry-sdk


### PR DESCRIPTION
PR #87041

PR #87010 bumped the container used in CI for uploading the coverage measurements to Codecov and its runtime now uses Python 3.13.

The previously set `.azure-pipelines/scripts/dependencies/codecov.txt` pip constraints used to lock down the transitive dependencies in that environment were of older versions and `test-results-parser==0.5.4` caused pip to trigger building this dependency from an sdist due to the latest platform-specific wheel available for that version being tagged for Python 3.12.

The new container does not have enough of the build toolchain and the build fails being unable to find the `cc` linker [[1]].

This patch mass-upgrades the transitive dependencies in said deptree to newer versions that also ship platform-specific wheels for Python 3.13 and 3.14.

[1]: https://dev.azure.com/ansible/ansible/_build/results?buildId=181432&view=logs&j=d7668ad9-d7bb-5ae4-c14f-5061b89e467d&s=44856301-4c0b-5572-5f50-eb8e385c84fd&t=7f884d87-6a36-516f-9067-af4cf77c020d&l=93

ci_coverage
ci_complete
(cherry picked from commit d25ac06)

##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
SSIA.
<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Maintenance Pull Request
- Test Pull Request
