### PR TITLE
Handle missing AZP git metadata

### DIFF
--- a/changelogs/fragments/87052-azp-env-show-no-git.yml
+++ b/changelogs/fragments/87052-azp-env-show-no-git.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - In Azure Pipelines, gracefully disable change detection when git metadata is unavailable instead of failing while resolving merge-parent commits (https://github.com/ansible/ansible/issues/87052).

--- a/test/lib/ansible_test/_internal/ci/azp.py
+++ b/test/lib/ansible_test/_internal/ci/azp.py
@@ -190,6 +190,8 @@ class AzurePipelinesChanges:
         self.org = self.org_uri.strip('/').split('/')[-1]
         self.is_pr = self.pr_branch_name is not None
 
+        commits = None
+
         if self.is_pr:
             # HEAD is a merge commit of the PR branch into the target branch
             # HEAD^1 is HEAD of the target branch (first parent of merge commit)
@@ -202,24 +204,34 @@ class AzurePipelinesChanges:
             commits = self.get_successful_merge_run_commits()
 
             self.branch = self.source_branch_name
-            self.base_commit = self.get_last_successful_commit(commits)
+            self.base_commit = None
             self.commit = 'HEAD'
 
-        self.commit = self.git.run_git(['rev-parse', self.commit]).strip()
+        try:
+            if commits:
+                self.base_commit = self.get_last_successful_commit(commits)
 
-        if self.base_commit:
-            self.base_commit = self.git.run_git(['rev-parse', self.base_commit]).strip()
+            self.commit = self.git.run_git(['rev-parse', self.commit]).strip()
 
-            # <commit>...<commit>
-            # This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.
-            # see: https://git-scm.com/docs/git-diff
-            dot_range = '%s...%s' % (self.base_commit, self.commit)
+            if self.base_commit:
+                self.base_commit = self.git.run_git(['rev-parse', self.base_commit]).strip()
 
-            self.paths = sorted(self.git.get_diff_names([dot_range]))
-            self.diff = self.git.get_diff([dot_range])
-        else:
+                # <commit>...<commit>
+                # This form is to view the changes on the branch containing and up to the second <commit>, starting at a common ancestor of both <commit>.
+                # see: https://git-scm.com/docs/git-diff
+                dot_range = '%s...%s' % (self.base_commit, self.commit)
+
+                self.paths = sorted(self.git.get_diff_names([dot_range]))
+                self.diff = self.git.get_diff([dot_range])
+            else:
+                self.paths = None  # act as though change detection not enabled, do not filter targets
+                self.diff = []
+        except ApplicationError as ex:
+            self.base_commit = ''
+            self.commit = ''
             self.paths = None  # act as though change detection not enabled, do not filter targets
             self.diff = []
+            display.warning(f'Cannot determine changes. All tests will be executed. Reason: {ex}')
 
     def get_successful_merge_run_commits(self) -> set[str]:
         """

--- a/test/units/ansible_test/_internal/ci/test_azp.py
+++ b/test/units/ansible_test/_internal/ci/test_azp.py
@@ -12,7 +12,7 @@ if t.TYPE_CHECKING:
     from ansible_test._internal.ci.azp import AzurePipelinesChanges
 
 
-def create_azure_pipelines_changes(mocker: pytest_mock.MockerFixture) -> AzurePipelinesChanges:
+def create_azure_pipelines_changes(mocker: pytest_mock.MockerFixture, *, pull_request: bool = False) -> AzurePipelinesChanges:
     """Prepare an AzurePipelinesChanges instance for testing."""
     from ansible_test._internal.ci.azp import AzurePipelinesChanges
     from ansible_test._internal.config import CommonConfig
@@ -36,6 +36,13 @@ def create_azure_pipelines_changes(mocker: pytest_mock.MockerFixture) -> AzurePi
         BUILD_SOURCEBRANCH='devel',
         BUILD_SOURCEBRANCHNAME='devel',
     )
+
+    if pull_request:
+        env.update(
+            BUILD_SOURCEBRANCH='refs/pull/1/merge',
+            BUILD_SOURCEBRANCHNAME='merge',
+            SYSTEM_PULLREQUEST_TARGETBRANCH='devel',
+        )
 
     mocker.patch.dict(os.environ, env, clear=True)
 
@@ -94,3 +101,42 @@ def test_get_successful_merge_run_commits(
         patched_warning.assert_not_called()
 
     assert spy_get_successful_merge_run_commits.spy_return == (expected_commits or set())
+
+
+def test_pull_request_without_git_metadata_runs_all_tests(mocker: pytest_mock.MockerFixture) -> None:
+    """Verify AZP pull requests degrade gracefully when git metadata is unavailable."""
+    from ansible_test._internal.git import Git
+    from ansible_test._internal.util import SubprocessError, display
+
+    patched_run_git = mocker.patch.object(
+        Git,
+        'run_git',
+        side_effect=SubprocessError(
+            ['git', 'rev-parse', 'HEAD^2'],
+            status=128,
+            stderr='fatal: not a git repository',
+        ),
+    )
+    patched_get_diff_names = mocker.patch.object(Git, 'get_diff_names')
+    patched_get_diff = mocker.patch.object(Git, 'get_diff')
+    patched_warning = mocker.patch.object(display, 'warning')
+
+    changes = create_azure_pipelines_changes(mocker, pull_request=True)
+
+    assert changes.is_pr is True
+    assert changes.branch == 'devel'
+    assert changes.base_commit == ''
+    assert changes.commit == ''
+    assert changes.paths is None
+    assert changes.diff == []
+
+    patched_run_git.assert_called_once_with(['rev-parse', 'HEAD^2'])
+    patched_get_diff_names.assert_not_called()
+    patched_get_diff.assert_not_called()
+
+    patched_warning.assert_called_once()
+    warning = patched_warning.call_args.args[0]
+
+    assert warning.startswith('Cannot determine changes. All tests will be executed. Reason: Command "git rev-parse')
+    assert 'HEAD^2' in warning
+    assert 'not a git repository' in warning


### PR DESCRIPTION
##### SUMMARY
Handle Azure Pipelines change detection failures when git metadata is unavailable, such as checkout copies without a `.git` directory. Instead of aborting while resolving `HEAD^2`, ansible-test now warns and disables target filtering so commands like `ansible-test env --show` can continue.

Fixes #87052

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
Local verification:
- `PYTHONPATH=test/lib:lib test/results/.tmp/delegation/python3.12/bin/python -m pytest -q -c test/lib/ansible_test/_data/pytest/config/default.ini test/units/ansible_test/_internal/ci/test_azp.py`
- `ansible-test units -v --venv test/units/ansible_test/_internal/ci/test_azp.py`
- `ansible-test sanity -v --venv --test compile test/lib/ansible_test/_internal/ci/azp.py test/units/ansible_test/_internal/ci/test_azp.py`
- `ansible-test sanity -v --venv --test pep8 test/lib/ansible_test/_internal/ci/azp.py test/units/ansible_test/_internal/ci/test_azp.py changelogs/fragments/87052-azp-env-show-no-git.yml`
- `ansible-test sanity -v --venv --test changelog changelogs/fragments/87052-azp-env-show-no-git.yml`
- `git diff --check`