### PR TITLE
user: Warn if move_home is true and home dir does not exist

### DIFF
--- a/changelogs/fragments/user_local_user.yml
+++ b/changelogs/fragments/user_local_user.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - user - warn if move_home is true and home directory does not exist (https://github.com/ansible/ansible/issues/37398).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -126,8 +126,7 @@ options:
         description:
             - "If set to V(true) when used with O(home), attempt to move the user's old home
               directory to the specified directory if it isn't there already and the old home exists."
-            - If O(local) is set to V(true), this option will be ignored if the home directory does not exist.
-            - If the current home directory does not exist the new home directory will not be created.
+            - If O(local) is set to V(true), this option will be ignored if the currenthome directory does not exist.
         type: bool
         default: no
     system:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -126,7 +126,7 @@ options:
         description:
             - "If set to V(true) when used with O(home), attempt to move the user's old home
               directory to the specified directory if it isn't there already and the old home exists."
-            - If O(local) is set to V(true), this option will be ignored if the currenthome directory does not exist.
+            - If O(local) is set to V(true), this option will be ignored if the current home directory does not exist.
         type: bool
         default: no
     system:

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -126,6 +126,8 @@ options:
         description:
             - "If set to V(true) when used with O(home), attempt to move the user's old home
               directory to the specified directory if it isn't there already and the old home exists."
+            - If O(local) is set to V(true), this option will be ignored if the home directory does not exist.
+            - If the current home directory does not exist the new home directory will not be created.
         type: bool
         default: no
     system:
@@ -978,11 +980,15 @@ class User(object):
             cmd.append('-c')
             cmd.append(self.comment)
 
-        if self.home is not None and info[5] != self.home:
+        existing_home = info[5]
+        if self.home is not None and existing_home != self.home:
             cmd.append('-d')
             cmd.append(self.home)
             if self.move_home:
-                cmd.append('-m')
+                if self.local and not os.path.exists(existing_home):
+                    self.module.warn("Ignoring move_home since home directory %s does not exist, but local is true" % existing_home)
+                else:
+                    cmd.append('-m')
 
         if self.shell is not None and info[6] != self.shell:
             cmd.append('-s')

--- a/test/integration/targets/user/tasks/test_local.yml
+++ b/test/integration/targets/user/tasks/test_local.yml
@@ -232,3 +232,40 @@
         force: yes
         remove: yes
         local: yes
+
+- name: Test move_home for local users
+  block:
+    - name: Create local_ansibulluser
+      user:
+        name: local_ansibulluser
+        state: present
+        local: yes
+        createhome: false
+      register: local_user_test_8
+
+    - name: Move home for local_ansibulluser
+      user:
+        name: local_ansibulluser
+        state: present
+        local: yes
+        move_home: true
+        home: /home/local_ansibulluser_move_home
+        createhome: true
+      register: local_user_test_9
+
+    - name: Check if warnings were displayed properly
+      assert:
+        that:
+          - local_user_test_8.changed
+          - local_user_test_9.changed
+          - local_user_test_9.warnings is defined
+          - local_user_test_9.warnings[0] is search("Ignoring move_home since")
+
+  always:
+    - name: Clean up local_ansibulluser
+      user:
+        name: local_ansibulluser
+        state: absent
+        force: yes
+        remove: yes
+        local: yes

--- a/test/integration/targets/user/tasks/test_local.yml
+++ b/test/integration/targets/user/tasks/test_local.yml
@@ -234,6 +234,7 @@
         local: yes
 
 - name: Test move_home for local users
+  when: ansible_facts.system in ['Linux']
   block:
     - name: Create local_ansibulluser
       user:


### PR DESCRIPTION
##### SUMMARY

* While modifying the user with lusermod command, warn user
  if home directory does not exists and move_home is set to
  true.

Fixes: #37398

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/user_local_user.yml
lib/ansible/modules/user.py
test/integration/targets/user/tasks/test_local.yml


