### PR TITLE
Surface Local RPC server startup exceptions

### DIFF
--- a/changelogs/fragments/87031-rpc-startup-exception.yml
+++ b/changelogs/fragments/87031-rpc-startup-exception.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-core - Surface the underlying Local RPC server startup exception instead of reporting a generic timeout when startup fails before the server signals readiness (https://github.com/ansible/ansible/issues/87031).

--- a/lib/ansible/_internal/_rpc_host.py
+++ b/lib/ansible/_internal/_rpc_host.py
@@ -45,10 +45,16 @@ class LocalNotAProcess(BaseProcess):
 
             # the only target this should see is _run_server
             # start cannot return until Server.serve_forever is called (our custom subclass sets the _server_ready event)
-            self._tpe.submit(self._target, *self._args, **self._kwargs)
+            _server_ready.clear()
+            server_future = self._tpe.submit(self._target, *self._args, **self._kwargs)
+            server_future.add_done_callback(lambda _future: _server_ready.set())
 
             if not _server_ready.wait(5):
                 raise TimeoutError("Local RPC server did not start.")
+
+            if server_future.done():
+                server_future.result()
+                raise RuntimeError("Local RPC server stopped during startup.")
         finally:
             signal.signal = original_signal  # always restore default signal impl
 

--- a/test/units/_internal/test_rpc_host.py
+++ b/test/units/_internal/test_rpc_host.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from ansible._internal import _rpc_host
+
+
+@pytest.fixture(autouse=True)
+def reset_server_ready() -> t.Iterator[None]:
+    _rpc_host._server_ready.clear()
+    yield
+    _rpc_host._server_ready.clear()
+
+
+def test_local_process_start_reraises_server_startup_exception() -> None:
+    expected = PermissionError("AF_UNIX sockets are blocked")
+
+    def fail_to_start() -> None:
+        raise expected
+
+    process = _rpc_host.LocalNotAProcess(target=fail_to_start, args=())
+
+    with pytest.raises(PermissionError, match="AF_UNIX sockets are blocked") as error:
+        process.start()
+
+    assert error.value is expected
+
+
+def test_local_process_start_rejects_server_exit_before_ready() -> None:
+    process = _rpc_host.LocalNotAProcess(target=lambda: None, args=())
+
+    with pytest.raises(RuntimeError, match="stopped during startup"):
+        process.start()


### PR DESCRIPTION
##### SUMMARY

Fixes #87031.

When the in-process Local RPC server fails before `LocalServer.serve_forever()` signals readiness, the server thread exits but `LocalNotAProcess.start()` previously waited for the full startup timeout and raised only `TimeoutError("Local RPC server did not start.")`.

This keeps the existing startup requirement intact, but wakes the startup wait when the server thread exits and re-raises the underlying exception. In sandboxed environments that block Unix-domain socket creation, users should now see the actual `PermissionError` instead of a misleading generic timeout.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

Validation run locally:

- `PYTHONPATH=lib:test/units test/results/.tmp/delegation/python3.14/bin/python -m pytest -q test/units/_internal/test_rpc_host.py`
- `python3.14 bin/ansible-test sanity -v --venv --test pep8 --test pylint lib/ansible/_internal/_rpc_host.py test/units/_internal/test_rpc_host.py`
- `python3.14 bin/ansible-test sanity -v --venv --test changelog changelogs/fragments/87031-rpc-startup-exception.yml`
- `git diff --check`