### PR TITLE
Recognize password failures for BusyBox su

### DIFF
--- a/changelogs/fragments/ansible-test-managed-alpine-sudo.yml
+++ b/changelogs/fragments/ansible-test-managed-alpine-sudo.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-test - Allow root to use sudo on managed Alpine instances.

--- a/changelogs/fragments/su-fail-messages.yml
+++ b/changelogs/fragments/su-fail-messages.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - su become plugin - Add recognition of password failure for BusyBox version of ``su``.

--- a/lib/ansible/plugins/become/su.py
+++ b/lib/ansible/plugins/become/su.py
@@ -104,7 +104,10 @@ class BecomeModule(BecomeBase):
     pipelining = False
 
     # messages for detecting prompted password issues
-    fail = ('Authentication failure',)
+    fail = (
+        'Authentication failure',
+        'incorrect password',  # BusyBox
+    )
 
     SU_PROMPT_LOCALIZATIONS = [
         'Password',

--- a/test/integration/targets/setup_test_user/handlers/main.yml
+++ b/test/integration/targets/setup_test_user/handlers/main.yml
@@ -5,3 +5,8 @@
     remove: yes
     force: yes
   loop: "{{ delete_users }}"
+
+- name: delete test user sudoers file
+  file:
+    path: '{{ sudoers_path ~ ".d/" ~ test_user_name }}'
+    state: absent

--- a/test/integration/targets/setup_test_user/tasks/sudo_config.yml
+++ b/test/integration/targets/setup_test_user/tasks/sudo_config.yml
@@ -12,3 +12,4 @@
       {{ test_user_name }}  ALL=(ALL)  {{"NOPASSWD: " if test_user_allow_sudo == "nopasswd" else ""}} ALL
     mode: '0440'
     dest: '{{ sudoers_path ~ ".d/" ~ test_user_name }}'
+  notify: delete test user sudoers file

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -230,6 +230,9 @@ bootstrap_remote_alpine()
         && break
         retry_or_fail
     done
+
+    # Allow root to use sudo to facilitate become testing as is done in other test environments.
+    echo "root ALL=(ALL) ALL" > /etc/sudoers.d/root
 }
 
 bootstrap_remote_fedora()


### PR DESCRIPTION
##### SUMMARY

Recognize password failures for BusyBox su.

Also allow root to use sudo on managed Alpine VMs in ansible-test.

##### ISSUE TYPE

Bugfix Pull Request
