### PR TITLE
Fix ansible_connection mutation between loop items

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -242,8 +242,10 @@ class TaskExecutor:
 
                     self._final_q.send_callback('v2_runner_item_on_ok', self._host, self._task, utr)
 
-            # update the connection value on the original task to reflect the resolved value
-            self._update_task_connection()
+        # Update the original task only after the loop is complete. Each loop
+        # item uses a task copy; mutating the original between items changes the
+        # connection magic vars seen by subsequent iterations.
+        self._update_task_connection()
 
         if last_loop_task:
             # FUTURE: hide this in Task/LoopContext once they're fully implemented

--- a/test/integration/targets/loop-connection/main.yml
+++ b/test/integration/targets/loop-connection/main.yml
@@ -31,3 +31,16 @@
       that:
       - connected_test.results[0].stderr == "ran - 1"
       - connected_test.results[1].stderr == "ran - 2"
+
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+  - name: test loop preserves declared ansible_connection
+    assert:
+      that:
+      - ansible_connection == "local"
+    loop:
+    - 1
+    - 2
+    - 3


### PR DESCRIPTION
##### SUMMARY
Fixes #87062.

In ansible-core 2.21, loop item execution updated the original task connection after each item. That changed the next item's connection magic vars from the declared short name, such as `local`, to the resolved FQCN, such as `ansible.builtin.local`.

This keeps the per-item task copy behavior for callback reporting, but defers updating the original task connection until the loop is complete. The final task callback still receives the resolved connection name.

##### ISSUE TYPE
- Bugfix Pull Request

##### TESTS
- `PYTHONPATH=lib python3 ./bin/ansible-playbook -i localhost, /tmp/.../play.yml`
- `PYTHONPATH=lib python3 bin/ansible-test integration loop-connection --local --color no`
- `PYTHONPATH=lib python3 bin/ansible-test integration callback_results --local --color no`
- `git diff --check`