### PR TITLE
[stable-2.21] config: Use correct key for inject_invocation

### DIFF
--- a/changelogs/fragments/inject_invocation.yml
+++ b/changelogs/fragments/inject_invocation.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - config - use correct key value for inject_invocation setting (https://github.com/ansible/ansible/issues/86999).

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1677,7 +1677,7 @@ INJECT_INVOCATION:
   env:
     - name: ANSIBLE_INJECT_INVOCATION
   ini:
-    - key: interpreter_python
+    - key: inject_invocation
       section: defaults
   vars:
     - name: ansible_inject_invocation


### PR DESCRIPTION
##### SUMMARY

* inject_invocation inadvertently used 'interpreter_python' key in config file instead 'inject_invocation'.

Fixes: #86999
(cherry picked from commit 09f1ac4)

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
