### PR TITLE
strip credential headers on cross-origin redirect in HTTPRedirectHandler

### DIFF
--- a/changelogs/fragments/urls-redirect-strip-credentials.yml
+++ b/changelogs/fragments/urls-redirect-strip-credentials.yml
@@ -1,0 +1,4 @@
+security_fixes:
+  - >-
+    ansible.module_utils.urls - strip ``Authorization``, ``Cookie`` and ``Proxy-Authorization`` headers when an HTTP
+    redirect crosses to a different origin (scheme, host or port) so credentials are not sent to an unrelated host.

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -460,6 +460,16 @@ class HTTPRedirectHandler(urllib.request.HTTPRedirectHandler):
             if code == 301 and method == 'POST':
                 method = 'GET'
 
+        # Strip credential-bearing headers when the redirect crosses to a
+        # different origin (scheme, host or port), otherwise a redirect to an
+        # attacker-controlled location leaks the caller's credentials.
+        old_origin = urlparse(req.get_full_url())
+        new_origin = urlparse(newurl)
+        if (old_origin.scheme, old_origin.hostname, old_origin.port) != \
+                (new_origin.scheme, new_origin.hostname, new_origin.port):
+            req_headers = {k: v for k, v in req_headers.items()
+                           if k.lower() not in ('authorization', 'cookie', 'proxy-authorization')}
+
         return urllib.request.Request(
             newurl,
             data=data,

--- a/test/units/module_utils/urls/test_RedirectHandlerFactory.py
+++ b/test/units/module_utils/urls/test_RedirectHandlerFactory.py
@@ -82,6 +82,54 @@ def test_redir_headers_removal(urllib_req, request_body, mocker):
                                      unverifiable=True)
 
 
+def test_redir_strips_credentials_cross_origin(urllib_req, request_body, mocker):
+    req_mock = mocker.patch('ansible.module_utils.urls.urllib.request.Request')
+    handler = HTTPRedirectHandler('all')
+    inst = handler()
+
+    urllib_req.headers = {
+        'Authorization': 'Basic Zm9vOmJhcg==',
+        'Cookie': 'session=secret',
+        'Proxy-Authorization': 'Basic Zm9vOmJhcg==',
+        'Foo': 'bar',
+    }
+
+    inst.redirect_request(urllib_req, request_body, 301, '301 Moved Permanently', {}, 'https://evil.example/')
+    req_mock.assert_called_once_with('https://evil.example/', data=None, headers={'Foo': 'bar'}, method='GET',
+                                     origin_req_host='ansible.com', unverifiable=True)
+
+
+def test_redir_strips_credentials_scheme_downgrade(urllib_req, request_body, mocker):
+    req_mock = mocker.patch('ansible.module_utils.urls.urllib.request.Request')
+    handler = HTTPRedirectHandler('all')
+    inst = handler()
+
+    urllib_req.headers = {
+        'Authorization': 'Basic Zm9vOmJhcg==',
+        'Foo': 'bar',
+    }
+
+    inst.redirect_request(urllib_req, request_body, 301, '301 Moved Permanently', {}, 'http://ansible.com/')
+    req_mock.assert_called_once_with('http://ansible.com/', data=None, headers={'Foo': 'bar'}, method='GET',
+                                     origin_req_host='ansible.com', unverifiable=True)
+
+
+def test_redir_keeps_credentials_same_origin(urllib_req, request_body, mocker):
+    req_mock = mocker.patch('ansible.module_utils.urls.urllib.request.Request')
+    handler = HTTPRedirectHandler('all')
+    inst = handler()
+
+    urllib_req.headers = {
+        'Authorization': 'Basic Zm9vOmJhcg==',
+        'Foo': 'bar',
+    }
+
+    inst.redirect_request(urllib_req, request_body, 301, '301 Moved Permanently', {}, 'https://ansible.com/other')
+    req_mock.assert_called_once_with('https://ansible.com/other', data=None,
+                                     headers={'Authorization': 'Basic Zm9vOmJhcg==', 'Foo': 'bar'}, method='GET',
+                                     origin_req_host='ansible.com', unverifiable=True)
+
+
 def test_redir_url_spaces(urllib_req, request_body, mocker):
     req_mock = mocker.patch('ansible.module_utils.urls.urllib.request.Request')
     handler = HTTPRedirectHandler('all')


### PR DESCRIPTION
1. `redirect_request` hands the original request headers to the `Location` target, so `Authorization`, `Cookie` and `Proxy-Authorization` ride along even when the redirect lands on a different host.
2. a malicious server (or an open redirect on the host the caller trusts) can therefore bounce the request to any origin and read the caller's credentials.

Compares the original and new origin and drops those three headers when scheme/host/port differ, which also covers an https to http downgrade on the same host. Same-origin redirects are untouched.

What happens today: a request to `https://trusted/` carrying basic-auth that 302s to `https://attacker/` sends the `Authorization` header straight to `attacker`. Added unit tests for the cross-host case, the scheme downgrade, and the same-origin case where the headers should still be kept.
