### PR TITLE
Add roles_include play keyword for dynamic role inclusion

### DIFF
--- a/changelogs/fragments/roles_include-play-keyword.yml
+++ b/changelogs/fragments/roles_include-play-keyword.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - play - add a ``roles_include`` play keyword, the dynamic (``include_role``) counterpart to the
+    static ``roles`` keyword. Roles listed under ``roles_include`` are resolved at runtime, so a
+    role skipped by ``--tags`` is never loaded and its automatic argument-spec validation task is
+    never created.

--- a/lib/ansible/keyword_desc.yml
+++ b/lib/ansible/keyword_desc.yml
@@ -53,6 +53,7 @@ register: Name of variable that will contain task status and module return data.
 rescue: List of tasks in a :term:`block` that run if there is a task error in the main :term:`block` list.
 retries: "Number of retries before giving up in a :term:`until` loop. This setting is only used in combination with :term:`until`."
 roles: List of roles to be imported into the play
+roles_include: List of roles to be dynamically included (via include_role) into the play, the runtime-resolved counterpart to ``roles``.
 run_once: Boolean that will bypass the host loop, forcing the task to attempt to execute on the first host available and afterward apply any results and facts to all active hosts in the same batch.
 serial: Explicitly define how Ansible batches the execution of the current play on the play's target. See :ref:`rolling_update_batch_size`.
 strategy: Allows you to choose the strategy plugin to use for the play. See :ref:`strategy_plugins`.

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -74,6 +74,7 @@ class Play(Base, Taggable, CollectionSearch):
 
     # Role Attributes
     roles = NonInheritableFieldAttribute(isa='list', default=list, priority=90)
+    roles_include = NonInheritableFieldAttribute(isa='list', default=list, priority=90)
 
     # Block (Task) Lists Attributes
     handlers = NonInheritableFieldAttribute(isa='list', default=list, priority=-1)
@@ -231,6 +232,51 @@ class Play(Base, Taggable, CollectionSearch):
 
         return self.roles
 
+    def _load_roles_include(self, attr, ds):
+        """
+        Loads ``roles_include`` into a list of blocks, the dynamic counterpart to
+        the static ``roles`` keyword. Each entry uses the same syntax as ``roles``
+        (a bare role name or a mapping with a ``role`` key) but is desugared into an
+        ``include_role`` task, so roles are resolved at runtime rather than at parse
+        time. A role skipped by ``--tags`` is therefore never loaded, and its
+        automatic argument-spec validation task is never created.
+        """
+
+        if ds is None:
+            return []
+
+        if not isinstance(ds, list):
+            raise AnsibleParserError("roles_include must be a list of roles.", obj=self._ds)
+
+        return self._load(attr, [self._roles_include_task(entry) for entry in ds])
+
+    @staticmethod
+    def _roles_include_task(entry):
+        """Desugar a single ``roles_include`` entry into an ``include_role`` task ds."""
+        if isinstance(entry, str):
+            entry = {'role': entry}
+        if not isinstance(entry, dict) or 'role' not in entry:
+            raise AnsibleParserError(
+                "A roles_include entry must be a role name or a mapping with a 'role' key, "
+                "but got: %r" % (entry,)
+            )
+
+        task = {'include_role': {'name': entry['role']}}
+
+        # ``tags`` gate selection of the include itself (so ``--tags`` can skip the
+        # whole role) and, via ``apply``, propagate onto the role's own tasks.
+        tags = entry.get('tags')
+        if tags is not None:
+            task['include_role']['apply'] = {'tags': tags}
+            task['tags'] = tags
+
+        # Keywords that apply to the include task rather than the role lookup.
+        for key in ('when', 'vars', 'name'):
+            if key in entry:
+                task[key] = entry[key]
+
+        return task
+
     def _load_vars_prompt(self, attr, ds):
         # avoid circular dep
         from ansible.vars.manager import preprocess_vars
@@ -326,7 +372,7 @@ class Play(Base, Taggable, CollectionSearch):
             b.always = [flush_block]
             block_list.append(b)
 
-            tasks = self._compile_roles() + self.tasks
+            tasks = self._compile_roles() + self.roles_include + self.tasks
             b = Block(play=self)
             if tasks:
                 b.block = tasks
@@ -352,6 +398,7 @@ class Play(Base, Taggable, CollectionSearch):
         block_list.extend(self.pre_tasks)
         block_list.append(flush_block)
         block_list.extend(self._compile_roles())
+        block_list.extend(self.roles_include)
         block_list.extend(self.tasks)
         block_list.append(flush_block)
         block_list.extend(self.post_tasks)

--- a/test/integration/targets/roles_include/aliases
+++ b/test/integration/targets/roles_include/aliases
@@ -1,0 +1,2 @@
+shippable/posix/group5
+context/controller

--- a/test/integration/targets/roles_include/roles/db/meta/argument_specs.yml
+++ b/test/integration/targets/roles_include/roles/db/meta/argument_specs.yml
@@ -1,0 +1,11 @@
+---
+# A spec so that loading this role triggers the automatic, always-tagged
+# "Validating arguments against arg spec" task. The option has a default, so
+# validation always succeeds; the point is whether the validation runs at all.
+argument_specs:
+  main:
+    short_description: db role
+    options:
+      db_flag:
+        type: bool
+        default: true

--- a/test/integration/targets/roles_include/roles/db/tasks/main.yml
+++ b/test/integration/targets/roles_include/roles/db/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: db role task
+  debug:
+    msg: "DB"

--- a/test/integration/targets/roles_include/roles/web/tasks/main.yml
+++ b/test/integration/targets/roles_include/roles/web/tasks/main.yml
@@ -1,0 +1,3 @@
+- name: web role task
+  debug:
+    msg: "WEB"

--- a/test/integration/targets/roles_include/runme.sh
+++ b/test/integration/targets/roles_include/runme.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ARGSPEC="Validating arguments against arg spec 'main'"
+
+# A full run executes every role in roles_include.
+[ "$(ansible-playbook test_roles_include.yml -i ../../inventory "$@" | grep -c '"msg": "WEB"')" = "1" ]
+[ "$(ansible-playbook test_roles_include.yml -i ../../inventory "$@" | grep -c '"msg": "DB"')" = "1" ]
+
+# A tag-scoped run loads only the selected role. roles_include resolves roles
+# dynamically, so an unselected role is never loaded: its tasks do not run AND
+# its automatic argument-spec validation never happens.
+out="$(ansible-playbook test_roles_include.yml -i ../../inventory --tags web "$@")"
+[ "$(grep -c '"msg": "WEB"' <<<"$out")" = "1" ]
+[ "$(grep -c '"msg": "DB"' <<<"$out")" = "0" ]
+[ "$(grep -c "$ARGSPEC" <<<"$out")" = "0" ]
+
+# Contrast: the static roles: keyword still loads the unselected role under the
+# same filter, so its arg-spec validation (tagged 'always') runs regardless.
+out_static="$(ansible-playbook test_roles_static.yml -i ../../inventory --tags web "$@")"
+[ "$(grep -c '"msg": "WEB"' <<<"$out_static")" = "1" ]
+[ "$(grep -c '"msg": "DB"' <<<"$out_static")" = "0" ]
+[ "$(grep -c "$ARGSPEC" <<<"$out_static")" = "1" ]
+
+echo "roles_include integration tests passed"

--- a/test/integration/targets/roles_include/test_roles_include.yml
+++ b/test/integration/targets/roles_include/test_roles_include.yml
@@ -1,0 +1,6 @@
+- name: dynamic role inclusion via the roles_include keyword
+  hosts: testhost
+  gather_facts: false
+  roles_include:
+    - {role: web, tags: [web]}
+    - {role: db, tags: [db]}

--- a/test/integration/targets/roles_include/test_roles_static.yml
+++ b/test/integration/targets/roles_include/test_roles_static.yml
@@ -1,0 +1,9 @@
+# Same roles via the static roles: keyword, for contrast in runme.sh: under a
+# tag filter the unselected role is still loaded, so its always-tagged arg-spec
+# validation runs - the overhead roles_include avoids.
+- name: static role inclusion via the roles keyword
+  hosts: testhost
+  gather_facts: false
+  roles:
+    - {role: web, tags: [web]}
+    - {role: db, tags: [db]}

--- a/test/units/playbook/test_play.py
+++ b/test/units/playbook/test_play.py
@@ -161,6 +161,92 @@ def test_play_with_roles(mocker):
     assert isinstance(p.get_roles()[0], Role)
 
 
+def _include_role_tasks(blocks):
+    """Collect every IncludeRole task found in a compiled list of blocks."""
+    from ansible.playbook.role_include import IncludeRole
+
+    found = []
+    for block in blocks:
+        for task in block.block + block.rescue + block.always:
+            if isinstance(task, IncludeRole):
+                found.append(task)
+    return found
+
+
+def test_play_with_roles_include():
+    p = Play.load(dict(
+        name="test play",
+        hosts=['foo'],
+        gather_facts=False,
+        roles_include=[dict(role='foo', tags=['foo'])],
+    ))
+
+    blocks = p.compile()
+    assert all(isinstance(block, Block) for block in blocks)
+
+    # roles_include is dynamic: the role is not statically compiled, so it does
+    # not appear in the play's static roles list at parse time.
+    assert p.get_roles() == []
+
+    includes = _include_role_tasks(blocks)
+    assert len(includes) == 1
+    ir = includes[0]
+    assert ir._role_name == 'foo'
+    # tags gate selection of the include itself, and propagate to the role's
+    # own tasks via apply.
+    assert 'foo' in ir.tags
+    assert ir.args['apply']['tags'] == ['foo']
+
+
+def test_play_with_roles_include_bare_string():
+    p = Play.load(dict(
+        name="test play",
+        hosts=['foo'],
+        gather_facts=False,
+        roles_include=['foo'],
+    ))
+
+    includes = _include_role_tasks(p.compile())
+    assert len(includes) == 1
+    assert includes[0]._role_name == 'foo'
+
+
+def test_play_with_roles_include_runs_before_tasks():
+    p = Play.load(dict(
+        name="test play",
+        hosts=['foo'],
+        gather_facts=False,
+        roles_include=['foo'],
+        tasks=[dict(action='shell echo "hello world"')],
+    ))
+
+    blocks = p.compile()
+    include_idx = next(i for i, b in enumerate(blocks) if _include_role_tasks([b]))
+    task_idx = next(
+        i for i, b in enumerate(blocks)
+        for t in b.block if getattr(t, 'action', None) == 'shell'
+    )
+    assert include_idx < task_idx
+
+
+@pytest.mark.parametrize(
+    'value',
+    (
+        'foo',                       # not a list
+        [dict(notrole='foo')],       # mapping without a 'role' key
+        [42],                        # neither a string nor a mapping
+    ),
+)
+def test_play_with_invalid_roles_include(value):
+    with pytest.raises(AnsibleParserError):
+        Play.load(dict(
+            name="test play",
+            hosts=['foo'],
+            gather_facts=False,
+            roles_include=value,
+        ))
+
+
 def test_play_compile():
     p = Play.load(dict(
         name="test play",


### PR DESCRIPTION
##### SUMMARY

The play level has a static role keyword (roles:, compiled at parse time, equivalent to import_role) but no dynamic counterpart. This adds roles_include:, the runtime-resolved sibling of roles:, completing the static/dynamic matrix alongside import_role/include_role and import_tasks/include_tasks.

Each roles_include entry uses the same syntax as roles (a bare role name or a mapping with a role key) and is desugared into an include_role task, so roles are resolved at runtime. A per-entry tags value gates selection of the include itself and, via apply, propagates onto the role's own tasks.

Because roles listed under roles_include are loaded dynamically, a role skipped by --tags is never loaded at all, so its automatically generated, always-tagged argument-spec validation task is never created. With static roles: that validation runs for every role on every tag-scoped invocation, even when the role's own tasks are skipped (https://github.com/ansible/ansible/issues/82505). Dynamic resolution also allows templated role names at the play level.

roles_include is declared as a NonInheritableFieldAttribute on Play and compiled into the play's block list in the same slot as roles: (after pre_tasks/static roles, before tasks); the existing IncludeRole and strategy machinery handles the runtime expansion, handler registration, and apply semantics.

Includes keyword documentation, a changelog fragment, unit tests for parsing and compilation, and an integration target that demonstrates the argument-spec validation is skipped for unselected roles.

The pr is so I can have the clean readability of roles: but with added speed of runs when targeting specific roles with --tags.

As an example in my tests selecting a single role tag using role: with 10+ roles all with arg specs ansible took 17s and with this change ( done via a monkeypatch not a core change) the run took 11s.

##### ISSUE TYPE

- Feature Pull Request

