### PR TITLE
[stable-2.19] ansible-test - Replace FreeBSD 14.2 with 14.3 (#85561)

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -98,8 +98,8 @@ stages:
               test: rhel/10.1
             - name: FreeBSD 13.5
               test: freebsd/13.5
-            - name: FreeBSD 14.2
-              test: freebsd/14.2
+            - name: FreeBSD 14.3
+              test: freebsd/14.3
           groups:
             - 1
             - 2
@@ -114,8 +114,8 @@ stages:
               test: rhel/10.1
             - name: FreeBSD 13.5
               test: freebsd/13.5
-            - name: FreeBSD 14.2
-              test: freebsd/14.2
+            - name: FreeBSD 14.3
+              test: freebsd/14.3
           groups:
             - 3
             - 4

--- a/changelogs/fragments/ansible-test-freebsd-14.3.yml
+++ b/changelogs/fragments/ansible-test-freebsd-14.3.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ansible-test - Replace FreeBSD 14.2 with 14.3.

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -202,11 +202,11 @@
   stat:
     path: '{{ item }}'
   loop:
+    - '{{ cafile_path.stdout_lines|default(["/_i_dont_exist_ca.pem"])|first }}'
     - /etc/ssl/certs/ca-bundle.crt
     - /etc/ssl/certs/ca-certificates.crt
     - /var/lib/ca-certificates/ca-bundle.pem
     - /usr/local/share/certs/ca-root-nss.crt
-    - '{{ cafile_path.stdout_lines|default(["/_i_dont_exist_ca.pem"])|first }}'
     - /etc/ssl/cert.pem
   register: ca_bundle_candidates
 

--- a/test/lib/ansible_test/_data/completion/remote.txt
+++ b/test/lib/ansible_test/_data/completion/remote.txt
@@ -3,7 +3,7 @@ alpine become=doas_sudo provider=aws arch=x86_64
 fedora/41 python=3.13 become=sudo provider=aws arch=x86_64 alias=fedora/latest
 fedora become=sudo provider=aws arch=x86_64
 freebsd/13.5 python=3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64 alias=freebsd/13
-freebsd/14.2 python=3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64 alias=freebsd/14,freebsd/latest
+freebsd/14.3 python=3.11 python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64 alias=freebsd/14,freebsd/latest
 freebsd python_dir=/usr/local/bin become=su_sudo provider=aws arch=x86_64
 macos/15.3 python=3.13 python_dir=/usr/local/bin become=sudo provider=mac arch=aarch64 alias=macos/15,macos/latest
 macos python_dir=/usr/local/bin become=sudo provider=mac arch=aarch64

--- a/test/lib/ansible_test/_util/target/setup/bootstrap.sh
+++ b/test/lib/ansible_test/_util/target/setup/bootstrap.sh
@@ -190,7 +190,7 @@ bootstrap_remote_freebsd()
             13.5/3.11)
                 # defaults available
                 ;;
-            14.2/3.11)
+            14.3/3.11)
                 # defaults available
                 ;;
             *)


### PR DESCRIPTION
##### SUMMARY

ansible-test - Replace FreeBSD 14.2 with 14.3

Backport of https://github.com/ansible/ansible/pull/85561

(cherry picked from commit 58c9f480291060a98a49c18e86b10b200b0a009b)

##### ISSUE TYPE

Feature Pull Request
