### PR TITLE
[stable-2.21] Fix CVE-2026-11332 - prevent role requirements from configuring git

### DIFF
--- a/changelogs/fragments/fix-cloning-malformed-role-requirements.yml
+++ b/changelogs/fragments/fix-cloning-malformed-role-requirements.yml
@@ -1,0 +1,2 @@
+security_fixes:
+  - ansible-galaxy install - Ensure role requirements are passed as positional arguments to :command:`git clone`. Previously, a malicious role author could inject arbitrary git configuration in role dependencies. (CVE-2026-11332)

--- a/lib/ansible/utils/galaxy.py
+++ b/lib/ansible/utils/galaxy.py
@@ -72,7 +72,7 @@ def scm_archive_resource(src, scm='git', name=None, version='HEAD', keep_scm_met
         elif scm == 'hg':
             clone_cmd.append('--insecure')
 
-    clone_cmd.extend([src, name])
+    clone_cmd.extend(['--', src, name])
 
     run_scm_cmd(clone_cmd, tempdir)
 

--- a/test/integration/targets/ansible-galaxy-role/tasks/git-config-injection.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/git-config-injection.yml
@@ -23,19 +23,24 @@
     - name: Attempt to install invalid role requirements
       command: ansible-galaxy install -r {{ remote_tmp_dir }}/invalid-requirements.yml --ignore-errors
       register: result
+      environment:
+        ANSIBLE_NOCOLOR: True
+        ANSIBLE_FORCE_COLOR: False
 
     - name: Validate git core.sshCommand did not run
       stat:
         path: "{{ remote_tmp_dir }}/role_exe"
-      failed_when: _task.result.stat.exists
+      register: stat_result
+      failed_when: stat_result.stat.exists
 
     - name: Verify the invalid field is treated as a single positional argument (repo or dest)
       assert:
         that:
-          - result.stderr is search(error1)
-          - result.stderr is search(error2)
-          - (result.stderr | regex_findall("git clone") | length) == (result.stderr | regex_findall("git clone --") | length) == 2
+          - stderr is search(error1)
+          - stderr is search(error2)
+          - (stderr | regex_findall("git clone") | length) == (stderr | regex_findall("git clone --") | length) == 2
       vars:
+        stderr: "{{ result.stderr | regex_replace('\\n', ' ') }}"
         error1: "repository '{{ invalid_git_opts }}' does not exist"
         error2: "Cloning into '{{ invalid_git_opts }}'"
 

--- a/test/integration/targets/ansible-galaxy-role/tasks/git-config-injection.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/git-config-injection.yml
@@ -1,0 +1,47 @@
+- vars:
+    invalid_git_opts: '-ccore.sshCommand=sh -c "id > {{ remote_tmp_dir }}/role_exe"'
+    # use SSH protocol to test core.sshCommand is not configured
+    dummy_repo: git@github.com:ansible/nosuchrepo.git
+  block:
+    - name: Ensure git is installed
+      package:
+        name: git
+      when: ansible_distribution not in ["MacOSX", "Alpine"]
+      register: git_install
+
+    - name: Create invalid requirements file
+      copy:
+        dest: "{{ remote_tmp_dir }}/invalid-requirements.yml"
+        content: |
+          - src: {{ invalid_git_opts }}
+            scm: git
+            name: {{ dummy_repo }}
+          - src: {{ dummy_repo }}
+            scm: git
+            name: {{ invalid_git_opts }}
+
+    - name: Attempt to install invalid role requirements
+      command: ansible-galaxy install -r {{ remote_tmp_dir }}/invalid-requirements.yml --ignore-errors
+      register: result
+
+    - name: Validate git core.sshCommand did not run
+      stat:
+        path: "{{ remote_tmp_dir }}/role_exe"
+      failed_when: _task.result.stat.exists
+
+    - name: Verify the invalid field is treated as a single positional argument (repo or dest)
+      assert:
+        that:
+          - result.stderr is search(error1)
+          - result.stderr is search(error2)
+          - (result.stderr | regex_findall("git clone") | length) == (result.stderr | regex_findall("git clone --") | length) == 2
+      vars:
+        error1: "repository '{{ invalid_git_opts }}' does not exist"
+        error2: "Cloning into '{{ invalid_git_opts }}'"
+
+  always:
+    - name: Uninstall git if it was installed
+      package:
+        name: git
+        state: absent
+      when: git_install is changed | default(false)

--- a/test/integration/targets/ansible-galaxy-role/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/main.yml
@@ -70,3 +70,4 @@
 
 - import_tasks: dir-traversal.yml
 - import_tasks: valid-role-symlinks.yml
+- import_tasks: git-config-injection.yml


### PR DESCRIPTION
##### SUMMARY

Backport #87070 and #87085

* Pass malformed role requirements as positional arguments to prevent arbitrary git configuration

* Add test coverage, checking for specific errors and that git clone is always followed by --

(cherry picked from commit edee59aa15abcc74d920bb3e9c3835ab8db05a2f)

##### ISSUE TYPE

- Bugfix Pull Request
