### PR TITLE
fix: skip dataclasses._is_type patch on Python 3.15+

### DIFF
--- a/lib/ansible/module_utils/_internal/_patches/_dataclass_annotation_patch.py
+++ b/lib/ansible/module_utils/_internal/_patches/_dataclass_annotation_patch.py
@@ -23,6 +23,8 @@ class DataclassesIsTypePatch(CallablePatch):
 
     @classmethod
     def is_patch_needed(cls) -> bool:
+        if sys.version_info >= (3, 15):
+            return False
         @dataclasses.dataclass
         class CheckClassVar:
             # this is the broken case requiring patching: ClassVar dot-referenced from a module that is not `typing` is treated as an instance field


### PR DESCRIPTION
##### SUMMARY
Skip the `dataclasses._is_type` patch on Python 3.15+ since `_is_type` was
removed in CPython 3.15.0b1 (https://github.com/python/cpython/pull/140541).
This caused an `AttributeError` when running `gather_facts` on a host using
Python 3.15, as the patch target no longer exists.

Fixes #87081

##### ISSUE TYPE
- Bugfix Pull Request
