### PR TITLE
systemd: ignore daemon actions for global scope

### DIFF
--- a/changelogs/fragments/87086-systemd-global-daemon-actions.yml
+++ b/changelogs/fragments/87086-systemd-global-daemon-actions.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - systemd - the module did not check if the daemon bus was relevant to the requested scope context.
+    The global scope does not use the bus, which lead to task failures. Explicitly disabling daemon
+    actions when in global scope mitigates this issue (https://github.com/ansible/ansible/pull/87086).

--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -51,12 +51,14 @@ options:
         description:
             - Run C(daemon-reload) before doing any other operations, to make sure systemd has read any changes.
             - When set to V(true), runs C(daemon-reload) even if the module does not start or stop anything.
+            - Ignored when C(scope) is set to V(global).
         type: bool
         default: no
         aliases: [ daemon-reload ]
     daemon_reexec:
         description:
             - Run daemon_reexec command before doing any other operations, the systemd manager will serialize the manager state.
+            - Ignored when C(scope) is set to V(global).
         type: bool
         default: no
         aliases: [ daemon-reexec ]
@@ -384,6 +386,11 @@ def main():
 
     if module.params['force']:
         systemctl += " --force"
+
+    # Bus is not available when using the global scope
+    if module.params['scope'] == 'global':
+        module.params['daemon_reload'] = False
+        module.params['daemon_reexec'] = False
 
     rc = 0
     out = err = ''


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->

The global scope does not use the system or session daemon bus when configuring user services. Attempting to call actions like daemon_reload and daemon_exec within a global scope errors out.

This is a QoL change intended to reduce incidental task failures:

```text
[ERROR]: Task failed: Module failed: failure 1 during daemon-reload: Failed to connect to bus: No such file or directory
```

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
