### PR TITLE
Use errno symbol instead of hardcoded value in wait_for

### DIFF
--- a/changelogs/fragments/87087-wait_for-errno-constant.yml
+++ b/changelogs/fragments/87087-wait_for-errno-constant.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - wait_for - use ``errno.ENOENT`` symbolic constant instead of hardcoded value for improved code portability.

--- a/lib/ansible/modules/wait_for.py
+++ b/lib/ansible/modules/wait_for.py
@@ -581,7 +581,7 @@ def main():
                     os.stat(b_path)
                 except OSError as e:
                     # If anything except file not present, throw an error
-                    if e.errno != 2:
+                    if e.errno != errno.ENOENT:
                         elapsed = datetime.now(timezone.utc) - start
                         module.fail_json(msg=msg or "Failed to stat %s, %s" % (path, e.strerror), elapsed=elapsed.seconds)
                     # file doesn't exist yet, so continue


### PR DESCRIPTION
##### SUMMARY

Use errno symbol `ENOENT` instead of the hardcoded value of `2` in the `wait_for` module.

Fixes #87082 

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request
