### PR TITLE
validate fqcn from artifact metadata in get_direct_collection_fqcn

### DIFF
--- a/changelogs/fragments/validate-collection-name-from-artifact-metadata.yml
+++ b/changelogs/fragments/validate-collection-name-from-artifact-metadata.yml
@@ -1,0 +1,2 @@
+security_fixes:
+  - ansible-galaxy collection install - Validate the collection name read from an artifact's ``MANIFEST.json`` before using it to build the installation path, so a crafted ``namespace`` or ``name`` containing path separators or ``..`` can no longer redirect the install destination outside the collections directory.

--- a/changelogs/fragments/validate-collection-name-from-artifact-metadata.yml
+++ b/changelogs/fragments/validate-collection-name-from-artifact-metadata.yml
@@ -1,2 +1,2 @@
-security_fixes:
-  - ansible-galaxy collection install - Validate the collection name read from an artifact's ``MANIFEST.json`` before using it to build the installation path, so a crafted ``namespace`` or ``name`` containing path separators or ``..`` can no longer redirect the install destination outside the collections directory.
+bugfixes:
+  - ansible-galaxy collection install - validate the ``namespace`` and ``name`` read from an artifact's ``MANIFEST.json`` and fail with a clear error when they do not form a valid ``namespace.name``, instead of using the unvalidated value to build the installation path.

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -41,6 +41,7 @@ from ansible.module_utils.common.process import get_bin_path
 from ansible.module_utils.common.sentinel import Sentinel
 from ansible.module_utils.common.yaml import yaml_load
 from ansible.module_utils.urls import open_url
+from ansible.utils.collection_loader import AnsibleCollectionRef
 from ansible.utils.display import Display
 
 import ansible.constants as C
@@ -262,10 +263,17 @@ class ConcreteArtifactsManager:
             # NOTE: should it be something like "<virtual>"?
             return None
 
-        return '.'.join((  # type: ignore[type-var]
+        fqcn = '.'.join((  # type: ignore[type-var]
             self._get_direct_collection_namespace(collection),  # type: ignore[arg-type]
             self._get_direct_collection_name(collection),
         ))
+        if not AnsibleCollectionRef.is_valid_collection_name(fqcn):
+            raise AnsibleError(
+                "Collection metadata at '%s' specifies an invalid collection name '%s'. The namespace and name "
+                "must be in the format <namespace>.<name> and contain characters from [a-zA-Z0-9_] only."
+                % (to_native(collection.src), fqcn)
+            )
+        return fqcn
 
     def get_direct_collection_version(self, collection):
         # type: (Collection) -> str

--- a/test/integration/targets/ansible-galaxy-collection/files/build_bad_name_tar.py
+++ b/test/integration/targets/ansible-galaxy-collection/files/build_bad_name_tar.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import sys
+import tarfile
+
+from ansible.module_utils.common.file import S_IRWXU_RXG_RXO
+
+manifest = {
+    'collection_info': {
+        'namespace': 'ns',
+        'name': '../../../../outside',
+        'version': '1.0.0',
+        'dependencies': {},
+    },
+    'file_manifest_file': {
+        'name': 'FILES.json',
+        'ftype': 'file',
+        'chksum_type': 'sha256',
+        'chksum_sha256': None,
+        'format': 1
+    },
+    'format': 1,
+}
+
+files = {
+    'files': [
+        {
+            'name': '.',
+            'ftype': 'dir',
+            'chksum_type': None,
+            'chksum_sha256': None,
+            'format': 1,
+        },
+    ],
+    'format': 1,
+}
+
+
+def add_file(tar_file, filename, b_content):
+    tar_info = tarfile.TarInfo(filename)
+    tar_info.size = len(b_content)
+    tar_info.mode = S_IRWXU_RXG_RXO
+    tar_file.addfile(tarinfo=tar_info, fileobj=io.BytesIO(b_content))
+
+
+collection_tar = os.path.join(sys.argv[1], 'badname-test-1.0.0.tar.gz')
+with tarfile.open(collection_tar, mode='w:gz') as tar_file:
+    b_files = json.dumps(files).encode('utf-8')
+    b_files_hash = hashlib.sha256()
+    b_files_hash.update(b_files)
+    manifest['file_manifest_file']['chksum_sha256'] = b_files_hash.hexdigest()
+
+    add_file(tar_file, 'MANIFEST.json', json.dumps(manifest).encode('utf-8'))
+    add_file(tar_file, 'FILES.json', b_files)

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -317,25 +317,21 @@
     that:
     - not fail_bad_tar_actual.stat.exists
 
-- name: setup tarball with a path traversal collection name - {{ test_id }}
+- name: setup tarball with an invalid collection name in its metadata - {{ test_id }}
   script: build_bad_name_tar.py {{ galaxy_dir | quote }}
 
-- name: fail to install a collection whose metadata name escapes the collection path - {{ test_id }}
+- name: try to install a collection whose metadata declares an invalid name - {{ test_id }}
   command: ansible-galaxy collection install '{{ galaxy_dir }}/badname-test-1.0.0.tar.gz' {{ galaxy_verbosity }}
   register: fail_bad_name
-  failed_when: fail_bad_name.rc != 1 and "invalid collection name" not in fail_bad_name.stderr
+  failed_when: false
   environment:
     ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
 
-- name: get result of failed collection install with a path traversal name - {{ test_id }}
-  stat:
-    path: '{{ galaxy_dir }}/outside'
-  register: fail_bad_name_actual
-
-- name: assert collection with a path traversal name was rejected before any path was built - {{ test_id }}
+- name: assert the invalid collection name was rejected with a clear error - {{ test_id }}
   assert:
     that:
-    - not fail_bad_name_actual.stat.exists
+    - fail_bad_name.rc != 0
+    - "'invalid collection name' in fail_bad_name.stderr"
 
 - name: install a collection from a URI - {{ test_id }}
   command: ansible-galaxy collection install {{ amanda }}/artifacts/namespace4-name-1.0.0.tar.gz {{ galaxy_verbosity }}

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -317,6 +317,26 @@
     that:
     - not fail_bad_tar_actual.stat.exists
 
+- name: setup tarball with a path traversal collection name - {{ test_id }}
+  script: build_bad_name_tar.py {{ galaxy_dir | quote }}
+
+- name: fail to install a collection whose metadata name escapes the collection path - {{ test_id }}
+  command: ansible-galaxy collection install '{{ galaxy_dir }}/badname-test-1.0.0.tar.gz' {{ galaxy_verbosity }}
+  register: fail_bad_name
+  failed_when: fail_bad_name.rc != 1 and "invalid collection name" not in fail_bad_name.stderr
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
+
+- name: get result of failed collection install with a path traversal name - {{ test_id }}
+  stat:
+    path: '{{ galaxy_dir }}/outside'
+  register: fail_bad_name_actual
+
+- name: assert collection with a path traversal name was rejected before any path was built - {{ test_id }}
+  assert:
+    that:
+    - not fail_bad_name_actual.stat.exists
+
 - name: install a collection from a URI - {{ test_id }}
   command: ansible-galaxy collection install {{ amanda }}/artifacts/namespace4-name-1.0.0.tar.gz {{ galaxy_verbosity }}
   register: install_uri

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -434,6 +434,42 @@ def test_build_requirement_from_tar_invalid_manifest(tmp_path_factory):
         Requirement.from_requirement_dict({'name': to_text(tar_path)}, concrete_artifact_cm)
 
 
+@pytest.mark.parametrize('namespace,name', [
+    ('ns', '../../../../tmp/evil'),
+    ('ns', '/tmp/evil'),
+    ('../../etc', 'evil'),
+    ('ns', 'has-a-dash'),
+])
+def test_build_requirement_from_tar_invalid_collection_name(namespace, name, tmp_path_factory):
+    test_dir = to_bytes(tmp_path_factory.mktemp('test-ÅÑŚÌβŁÈ Collections Input'))
+
+    json_data = to_bytes(json.dumps(
+        {
+            'collection_info': {
+                'namespace': namespace,
+                'name': name,
+                'version': '1.0.0',
+                'dependencies': {},
+            },
+            'format': 1,
+        }
+    ))
+
+    tar_path = os.path.join(test_dir, b'ansible-collections.tar.gz')
+    with tarfile.open(tar_path, 'w:gz') as tfile:
+        b_io = BytesIO(json_data)
+        tar_info = tarfile.TarInfo('MANIFEST.json')
+        tar_info.size = len(json_data)
+        tar_info.mode = S_IRWU_RG_RO
+        tfile.addfile(tarinfo=tar_info, fileobj=b_io)
+
+    concrete_artifact_cm = collection.concrete_artifact_manager.ConcreteArtifactsManager(test_dir, validate_certs=False)
+
+    expected = "invalid collection name"
+    with pytest.raises(AnsibleError, match=expected):
+        Requirement.from_requirement_dict({'name': to_text(tar_path)}, concrete_artifact_cm)
+
+
 def test_build_requirement_from_name(galaxy_server, monkeypatch, tmp_path_factory):
     mock_get_versions = MagicMock()
     mock_get_versions.return_value = ['2.1.9', '2.1.10']


### PR DESCRIPTION
##### SUMMARY

spotted while auditing the ansible-galaxy install path handling: `get_direct_collection_fqcn` takes `namespace` and `name` straight from a collection artifact's `MANIFEST.json` (or a source `galaxy.yml`) and they become the install destination in `install()` via `os.path.join(path, collection.namespace, collection.name)`, so a crafted `name` like `/tmp/x` (absolute, resets the join) or a `namespace`/`name` containing `..` redirects the install path outside the collections directory where `install()` then `shutil.rmtree()`s it and extracts the artifact; validate the resolved fqcn with `is_valid_collection_name` at the point it is read from metadata so malformed names are rejected before any path is built.

##### ISSUE TYPE

- Bugfix Pull Request