### PR TITLE
[stable-2.21] Fix IndexError in free strategy when hosts become unreachable

### DIFF
--- a/changelogs/fragments/87027-free-strategy-indexerror.yml
+++ b/changelogs/fragments/87027-free-strategy-indexerror.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - free strategy - Fix ``IndexError`` when hosts become unreachable during playbook execution (https://github.com/ansible/ansible/issues/87027).

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -92,6 +92,11 @@ class StrategyModule(StrategyBase):
                 result = False
                 break
 
+            # Reset last_host if it's out of bounds for the current hosts_left
+            # This can happen when hosts become unreachable between iterations
+            if last_host >= len(hosts_left):
+                last_host = 0
+
             work_to_do = False        # assume we have no more work to do
             starting_host = last_host  # save current position so we know when we've looped back around and need to break
 

--- a/test/integration/targets/strategy_free/free_hosts
+++ b/test/integration/targets/strategy_free/free_hosts
@@ -1,0 +1,4 @@
+[local]
+host0 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"
+host1 ansible_connection=ssh ansible_host=127.0.0.1 ansible_port=1011  # IANA Reserved port
+host2 ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/test/integration/targets/strategy_free/free_index_error.yml
+++ b/test/integration/targets/strategy_free/free_index_error.yml
@@ -1,0 +1,11 @@
+---
+- hosts: host0, host1, host2
+  strategy: free
+  gather_facts: false
+  tasks:
+    - name: EXPECTED FAILURE - First ping
+      ping:
+      throttle: 2
+
+    - name: Second ping
+      ping:

--- a/test/integration/targets/strategy_free/runme.sh
+++ b/test/integration/targets/strategy_free/runme.sh
@@ -8,3 +8,9 @@ set +e
 result="$(ansible-playbook test_last_include_in_always.yml -i inventory "$@" 2>&1)"
 set -e
 grep -q "INCLUDED TASK EXECUTED" <<< "$result"
+
+set +e
+result="$(ansible-playbook free_index_error.yml -i free_hosts "$@" 2>&1)"
+set -e
+grep -q "\[host1\]: UNREACHABLE!" <<< "$result"
+! grep -q "IndexError: list index out of range" <<< "$result"


### PR DESCRIPTION
Backport of PR #87037

(cherry picked from commit 08a71d148e2b26e1e2b3102cd616d23650305741)