### PR TITLE
async_wrapper - fix race condition and short timeout

### DIFF
--- a/changelogs/fragments/fix-short-timeout-async-wrapper.yml
+++ b/changelogs/fragments/fix-short-timeout-async-wrapper.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - parallel fact gathering - fix hang caused by corrupt async job files.
+minor_changes:
+  - parallel fact gathering - the async wrapper now considers the timeout when determining whether to kill the process running the module. Previously, a 5 second sleep occurred twice before checking if the job had remaining time.

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -301,17 +301,16 @@ def main():
                     remaining = remaining - step
                     notice("%s still running (%s)" % (sub_pid, remaining))
                     if remaining <= 0:
-                        # ensure we leave response in poll location
-                        res = {'msg': 'Timeout exceeded', 'failed': True, 'child_pid': sub_pid}
-                        global job_path
-                        job_path = job_path + ".wrapper"
-                        jwrite(res)
-
                         # actually kill it
                         notice("Timeout reached, now killing %s" % (sub_pid))
                         os.killpg(sub_pid, signal.SIGKILL)
                         notice("Sent kill to group %s " % sub_pid)
                         time.sleep(1)
+
+                        # ensure we leave response in poll location
+                        res = {'msg': 'Timeout exceeded', 'failed': True, 'child_pid': sub_pid}
+                        jwrite(res)
+
                         if not preserve_tmp:
                             shutil.rmtree(os.path.dirname(wrapped_module), True)
                         end(res)

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 
-import fcntl
 import json
 import shlex
 import shutil
@@ -119,20 +118,15 @@ def _filter_non_json_lines(data):
 
 def jwrite(info):
     jobfile = job_path + ".tmp"
-    with open(jobfile, "w") as tjob:
-        try:
-            fcntl.flock(tjob.fileno(), fcntl.LOCK_EX)
-        except OSError as ex:
-            notice(f'failed to acquire lock for {jobfile!r}: {ex}')
-            raise
-        try:
-            tjob.write(json.dumps(info))
-        except OSError as ex:
-            notice(f'failed to write to {jobfile!r}: {ex}')
-            raise
-        finally:
-            os.rename(jobfile, job_path)
-            fcntl.flock(tjob.fileno(), fcntl.LOCK_UN)
+    tjob = open(jobfile, "w")
+    try:
+        tjob.write(json.dumps(info))
+    except OSError as ex:
+        notice(f'failed to write to {jobfile!r}: {ex}')
+        raise
+    finally:
+        tjob.close()
+        os.rename(jobfile, job_path)
 
 
 def _run_module(jid, *module_args):
@@ -309,6 +303,8 @@ def main():
                     if remaining <= 0:
                         # ensure we leave response in poll location
                         res = {'msg': 'Timeout exceeded', 'failed': True, 'child_pid': sub_pid}
+                        global job_path
+                        job_path = job_path + ".wrapper"
                         jwrite(res)
 
                         # actually kill it

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 
+import fcntl
 import json
 import shlex
 import shutil
@@ -118,15 +119,20 @@ def _filter_non_json_lines(data):
 
 def jwrite(info):
     jobfile = job_path + ".tmp"
-    tjob = open(jobfile, "w")
-    try:
-        tjob.write(json.dumps(info))
-    except OSError as ex:
-        notice(f'failed to write to {jobfile!r}: {ex}')
-        raise
-    finally:
-        tjob.close()
-        os.rename(jobfile, job_path)
+    with open(jobfile, "w") as tjob:
+        try:
+            fcntl.flock(tjob.fileno(), fcntl.LOCK_EX)
+        except OSError as ex:
+            notice(f'failed to acquire lock for {jobfile!r}: {ex}')
+            raise
+        try:
+            tjob.write(json.dumps(info))
+        except OSError as ex:
+            notice(f'failed to write to {jobfile!r}: {ex}')
+            raise
+        finally:
+            os.rename(jobfile, job_path)
+            fcntl.flock(tjob.fileno(), fcntl.LOCK_UN)
 
 
 def _run_module(jid, *module_args):
@@ -291,11 +297,15 @@ def main():
                 os.setpgid(sub_pid, sub_pid)
 
                 notice("Start watching %s (%s)" % (sub_pid, remaining))
+
+                if remaining != 0 and step >= remaining:
+                    step = remaining / 2
+
                 time.sleep(step)
+
                 while os.waitpid(sub_pid, os.WNOHANG) == (0, 0):
-                    notice("%s still running (%s)" % (sub_pid, remaining))
-                    time.sleep(step)
                     remaining = remaining - step
+                    notice("%s still running (%s)" % (sub_pid, remaining))
                     if remaining <= 0:
                         # ensure we leave response in poll location
                         res = {'msg': 'Timeout exceeded', 'failed': True, 'child_pid': sub_pid}
@@ -309,6 +319,8 @@ def main():
                         if not preserve_tmp:
                             shutil.rmtree(os.path.dirname(wrapped_module), True)
                         end(res)
+
+                    time.sleep(step)
                 notice("Done in kid B.")
                 if not preserve_tmp:
                     shutil.rmtree(os.path.dirname(wrapped_module), True)

--- a/test/integration/targets/gathering_facts/library/slow
+++ b/test/integration/targets/gathering_facts/library/slow
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-sleep 10
+sleep 3
 
 echo '{
     "changed": false,

--- a/test/integration/targets/gathering_facts/runme.sh
+++ b/test/integration/targets/gathering_facts/runme.sh
@@ -15,7 +15,7 @@ ANSIBLE_GATHERING=smart ansible-playbook test_run_once.yml -i inventory -v "$@"
 ansible-playbook test_prevent_injection.yml -i inventory -v "$@"
 
 # ensure fact merging is working properly
-ansible-playbook verify_merge_facts.yml -v "$@" -e 'ansible_facts_parallel: False'
+ansible-playbook verify_merge_facts.yml -v "$@" -e 'ansible_facts_parallel=False'
 
 # ensure we dont clobber facts in loop
 ansible-playbook prevent_clobbering.yml -v "$@"
@@ -36,10 +36,10 @@ ansible-playbook test_module_defaults.yml "$@" --tags templating
 ANSIBLE_FACTS_MODULES='ansible.legacy.slow' ansible -m gather_facts localhost --playbook-dir ./ "$@"
 
 # test that gather_facts will timeout parallel modules that dont support gather_timeout when using gather_Timeout
-ANSIBLE_FACTS_MODULES='ansible.legacy.slow' ansible -m gather_facts localhost --playbook-dir ./ -a 'gather_timeout=1 parallel=true' "$@" 2>&1 |grep 'Timeout exceeded'
+ANSIBLE_FACTS_MODULES='ansible.legacy.slow' ANSIBLE_TASK_TIMEOUT=5 ansible -m gather_facts localhost --playbook-dir ./ -a 'gather_timeout=1 parallel=true' "$@" 2>&1 |grep 'Timeout exceeded'
 
 # test that gather_facts parallel w/o timing out
-ANSIBLE_FACTS_MODULES='ansible.legacy.slow' ansible -m gather_facts localhost --playbook-dir ./ -a 'gather_timeout=30 parallel=true' "$@" 2>&1 |grep -v 'Timeout exceeded'
+ANSIBLE_FACTS_MODULES='ansible.legacy.slow' ansible -m gather_facts localhost --playbook-dir ./ -a 'gather_timeout=10 parallel=true' "$@" 2>&1 |grep 'Timeout exceeded' && exit 1
 
 
 # test parallelism


### PR DESCRIPTION
##### SUMMARY

Fix race condition writing async job file and remove the hardcoded 2 x 5s pauses before detecting a timeout.

This bug causes https://github.com/ansible/ansible/issues/84074#issuecomment-4659620093 and the first error in https://github.com/ansible/ansible/issues/84074#issuecomment-4521011172.

While fixing that, I noticed couple issues with the gathering_facts integration test:
- `-e 'ansible_facts_parallel: False'` results in the extra vars `{'_raw_params': 'ansible_facts_parallel: False'}`
- `grep -v 'Timeout exceeded'` succeeds if there are other lines to match when the timeout occurs

ci_complete

##### ISSUE TYPE

- Bugfix Pull Request
- Test Pull Request