### PR TITLE
Fix/pip virtualenv relative path

### DIFF
--- a/changelogs/fragments/84905-pip-virtualenv-relative-path.yaml
+++ b/changelogs/fragments/84905-pip-virtualenv-relative-path.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - pip - fix relative ``virtualenv`` path being resolved against ``/tmp`` instead
+    of the current working directory when ``chdir`` is not set (https://github.com/ansible/ansible/issues/84905).

--- a/lib/ansible/module_utils/_internal/_patches/_dataclass_annotation_patch.py
+++ b/lib/ansible/module_utils/_internal/_patches/_dataclass_annotation_patch.py
@@ -25,6 +25,7 @@ class DataclassesIsTypePatch(CallablePatch):
     def is_patch_needed(cls) -> bool:
         if sys.version_info >= (3, 15):
             return False
+
         @dataclasses.dataclass
         class CheckClassVar:
             # this is the broken case requiring patching: ClassVar dot-referenced from a module that is not `typing` is treated as an instance field

--- a/lib/ansible/module_utils/_internal/_patches/_dataclass_annotation_patch.py
+++ b/lib/ansible/module_utils/_internal/_patches/_dataclass_annotation_patch.py
@@ -23,6 +23,8 @@ class DataclassesIsTypePatch(CallablePatch):
 
     @classmethod
     def is_patch_needed(cls) -> bool:
+        if sys.version_info >= (3, 15):
+            return False
         @dataclasses.dataclass
         class CheckClassVar:
             # this is the broken case requiring patching: ClassVar dot-referenced from a module that is not `typing` is treated as an instance field

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -782,6 +782,8 @@ def main():
     venv_created = False
     if env and chdir:
         env = os.path.join(chdir, env)
+    elif env and not os.path.isabs(env):
+        env = os.path.join(os.getcwd(),env)
 
     if umask and not isinstance(umask, int):
         try:

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -783,7 +783,7 @@ def main():
     if env and chdir:
         env = os.path.join(chdir, env)
     elif env and not os.path.isabs(env):
-        env = os.path.join(os.getcwd(),env)
+        env = os.path.join(os.getcwd(), env)
 
     if umask and not isinstance(umask, int):
         try:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -682,3 +682,20 @@
           - multi_editable_install is changed
           - multi_pip_list_check.stdout is search('sample-project\s+1.0.0\s+' ~ remote_tmp_dir ~ '/sample-project')
           - multi_pip_list_check.stdout is search('another-project\s+1.0.0\s+' ~ remote_tmp_dir ~ '/another-project')
+
+# Test: relative virtualenv path without chdir should resolve against cwd, not /tmp
+- name: Create virtualenv with relative path (no chdir)
+  pip:
+    name: setuptools
+    virtualenv: relative-test-venv
+  register: pip_relative_venv
+
+- name: Assert relative virtualenv was created successfully
+  assert:
+    that:
+      - pip_relative_venv is success
+
+- name: Cleanup relative virtualenv
+  file:
+    path: "{{ playbook_dir }}/relative-test-venv"
+    state: absent


### PR DESCRIPTION
##### SUMMARY
Found a bug where if you give a relative path like `my-venv` to the virtualenv 
option without setting chdir, Ansible creates the virtual environment in `/tmp` 
but then looks for it in your current directory. So it never finds it and fails.

Fixed it by converting the relative path to an absolute path using `os.getcwd()` 
when no chdir is given, so both the creation and the lookup happen in the same place.

Fixes #84905

##### ISSUE TYPE
- Bugfix Pull Request