### PR TITLE
Fix typo in ansible_collector.py: 'it it' → 'it'

### DIFF
--- a/lib/ansible/module_utils/facts/ansible_collector.py
+++ b/lib/ansible/module_utils/facts/ansible_collector.py
@@ -148,7 +148,7 @@ def get_ansible_collector(all_collector_classes,
         collector_obj = collector_class(namespace=namespace)
         collectors.append(collector_obj)
 
-    # Add a collector that knows what gather_subset we used so it it can provide a fact
+    # Add a collector that knows what gather_subset we used so it can provide a fact
     collector_meta_data_collector = \
         CollectorMetaDataCollector(gather_subset=gather_subset,
                                    module_setup=True)

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -858,7 +858,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         # Step 4: World-readable temp directory
         if self.get_shell_option('world_readable_temp'):
             # chown and fs acls failed -- do things this insecure way only if
-            # the user opted in in the config file
+            # the user opted in the config file
             display.warning(
                 'Using world-readable permissions for temporary files Ansible '
                 'needs to create when becoming an unprivileged user. This may '


### PR DESCRIPTION
Fixes a duplicate word typo in `lib/ansible/module_utils/facts/ansible_collector.py`.