### PR TITLE
Fix role lookup from ansible-playbook cwd

### DIFF
--- a/changelogs/fragments/87100-role-cwd-lookup.yml
+++ b/changelogs/fragments/87100-role-cwd-lookup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - roles - prevent bare role names from being resolved from the current working directory of the ``ansible-playbook`` process.

--- a/lib/ansible/playbook/role/definition.py
+++ b/lib/ansible/playbook/role/definition.py
@@ -38,6 +38,19 @@ __all__ = ['RoleDefinition']
 display = Display()
 
 
+def _is_role_path(role_name):
+    """Return True when a role name was provided as an explicit filesystem path."""
+    expanded_role_name = os.path.expanduser(os.path.expandvars(role_name))
+    path_separators = {os.path.sep, os.path.altsep, '/'}
+    path_separators.discard(None)
+
+    return (
+        expanded_role_name in (os.path.curdir, os.path.pardir) or
+        os.path.isabs(expanded_role_name) or
+        any(separator in expanded_role_name for separator in path_separators)
+    )
+
+
 class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
 
     role = NonInheritableFieldAttribute(isa='string')
@@ -188,10 +201,11 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
                 return (role_name, role_path)
 
         # if not found elsewhere try to extract path from name
-        role_path = unfrackpath(role_name)
-        if self._loader.path_exists(role_path):
-            role_name = os.path.basename(role_name)
-            return (role_name, role_path)
+        if _is_role_path(role_name):
+            role_path = unfrackpath(role_name)
+            if self._loader.path_exists(role_path):
+                role_name = os.path.basename(role_name)
+                return (role_name, role_path)
 
         searches = (self._collection_list or []) + role_search_paths
 

--- a/test/integration/targets/roles/cwd_role_lookup.yml
+++ b/test/integration/targets/roles/cwd_role_lookup.yml
@@ -1,0 +1,4 @@
+- hosts: testhost
+  gather_facts: false
+  roles:
+    - testrole

--- a/test/integration/targets/roles/runme.sh
+++ b/test/integration/targets/roles/runme.sh
@@ -40,6 +40,24 @@ done
 # ensure subdir contained to role in tasks_from is valid
 ansible-playbook test_subdirs.yml -i ../../inventory "$@"
 
+# ensure bare role names are not resolved from the ansible-playbook working directory
+target_dir="$(pwd)"
+cwd_role_lookup_dir="$(mktemp -d)"
+trap 'rm -rf "${cwd_role_lookup_dir}"' EXIT
+mkdir -p "${cwd_role_lookup_dir}/cwd/testrole/tasks"
+cat > "${cwd_role_lookup_dir}/cwd/testrole/tasks/main.yml" << EOF
+- ansible.builtin.debug:
+    msg: this should not load from cwd
+EOF
+(
+  cd "${cwd_role_lookup_dir}/cwd"
+  ansible-playbook "${target_dir}/cwd_role_lookup.yml" -i "${target_dir}/../../inventory" > "${cwd_role_lookup_dir}/cwd_role_lookup_output.log" 2>&1
+) && {
+  echo "Test failed for cwd_role_lookup.yml, playbook unexpectedly found role from cwd."
+  exit 1
+}
+grep "role 'testrole' was not found" "${cwd_role_lookup_dir}/cwd_role_lookup_output.log" > /dev/null
+
 # ensure vars scope is correct
 ansible-playbook vars_scope.yml -i ../../inventory "$@"
 

--- a/test/units/playbook/role/test_role.py
+++ b/test/units/playbook/role/test_role.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 
 from collections.abc import Container
 
+import os
 import pytest
 
 import unittest
 from unittest.mock import patch, MagicMock
 
-from ansible.errors import AnsibleParserError
+from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.playbook.block import Block
 
 from units.mock.loader import DictDataLoader
@@ -152,6 +153,47 @@ class TestHashParams(unittest.TestCase):
         for key in params_dict:
             self.assertTrue(key in params_dict)
             self.assertIn(key, params_dict)
+
+
+def _make_role_loader(playbook_dir, role_dir):
+    loader = DictDataLoader({
+        os.path.join(role_dir, 'tasks', 'main.yml'): """
+        - debug:
+            msg: should not load from cwd
+        """,
+    })
+    loader.get_basedir = lambda: str(playbook_dir)
+    return loader
+
+
+def test_bare_role_name_is_not_resolved_from_cwd(tmp_path, monkeypatch):
+    playbook_dir = tmp_path / 'playbooks'
+    cwd_role_dir = tmp_path / 'cwd' / 'testrole'
+    playbook_dir.mkdir()
+    cwd_role_dir.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path / 'cwd')
+
+    mock_play = MagicMock()
+    mock_play.role_cache = {}
+
+    with pytest.raises(AnsibleError, match="The role 'testrole' was not found in:"):
+        RoleInclude.load('testrole', play=mock_play, loader=_make_role_loader(playbook_dir, str(cwd_role_dir)))
+
+
+def test_explicit_role_path_is_resolved_from_cwd(tmp_path, monkeypatch):
+    playbook_dir = tmp_path / 'playbooks'
+    cwd_role_dir = tmp_path / 'cwd' / 'testrole'
+    playbook_dir.mkdir()
+    cwd_role_dir.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path / 'cwd')
+
+    mock_play = MagicMock()
+    mock_play.role_cache = {}
+
+    role_include = RoleInclude.load(os.path.join('.', 'testrole'), play=mock_play, loader=_make_role_loader(playbook_dir, str(cwd_role_dir)))
+
+    assert role_include.role == 'testrole'
+    assert role_include.get_role_path() == os.path.realpath(cwd_role_dir)
 
 
 class TestRole(unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY

Fixes #87100.

Bare role names were incorrectly falling through to `unfrackpath(role_name)`, which made them resolve relative to the current working directory of the `ansible-playbook` process. This allowed misplaced roles to be found from CWD even though CWD is not part of the documented role search path.

This change only allows the final filesystem fallback for explicit path-like role names, preserving `./role`, `../role`, absolute paths, `~`, and env-var-expanded paths.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

RoleDefinition

##### TESTING

- Added unit coverage for bare role names not resolving from CWD.
- Added unit coverage that explicit path-like role names still resolve.
- Added integration coverage under the `roles` target for the reported CWD lookup case.

Local checks run:
- `git diff --check`
- Python compile check for touched Python files
- Focused regression harness confirming the reported behavior is fixed

Full `ansible-test` should be run in CI or a POSIX dev environment:
- `ansible-test units -v --docker default test/units/playbook/role/test_role.py`
- `ansible-test integration -v --docker ubuntu2404 roles`