### PR TITLE
copy: add explicit type validation for src parameter

### DIFF
--- a/changelogs/fragments/86607-copy-src-type-validation.yml
+++ b/changelogs/fragments/86607-copy-src-type-validation.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - copy - Add explicit type validation for src parameter to provide clear error messages when non-string types are passed (https://github.com/ansible/ansible/issues/86607)
+  - copy - validate parameter types in the action plugin and provide a clear error message when a non-string value (such as a dict) is passed to ``src`` instead of crashing with an ``AttributeError`` (https://github.com/ansible/ansible/issues/86607).

--- a/changelogs/fragments/86607-copy-src-type-validation.yml
+++ b/changelogs/fragments/86607-copy-src-type-validation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - copy - Add explicit type validation for src parameter to provide clear error messages when non-string types are passed (https://github.com/ansible/ansible/issues/86607)

--- a/changelogs/fragments/86607-copy-src-type-validation.yml
+++ b/changelogs/fragments/86607-copy-src-type-validation.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - copy - validate parameter types in the action plugin and provide a clear error message when a non-string value (such as a dict) is passed to ``src`` instead of crashing with an ``AttributeError`` (https://github.com/ansible/ansible/issues/86607).
+  - copy - validate that ``src`` and ``dest`` are strings in the action plugin and raise a clear error when a non-string value (such as a dict) is supplied, instead of crashing later with an opaque ``AttributeError`` (https://github.com/ansible/ansible/issues/86607).

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -234,7 +234,6 @@ class ActionModule(ActionBase):
                    dest, task_vars, follow):
         decrypt = boolean(self._task.args.get('decrypt', True), strict=False)
         force = boolean(self._task.args.get('force', 'yes'), strict=False)
-        raw = boolean(self._task.args.get('raw', 'no'), strict=False)
 
         result = {}
         result['diff'] = []
@@ -287,7 +286,7 @@ class ActionModule(ActionBase):
         if local_checksum != dest_status['checksum']:
             # The checksums don't match and we will change or error out.
 
-            if self._task.diff and not raw:
+            if self._task.diff:
                 result['diff'].append(self._get_diff_data(dest_file, source_full, task_vars, content))
 
             if self._task.check_mode:
@@ -303,12 +302,7 @@ class ActionModule(ActionBase):
             if suffix:
                 tmp_src += suffix
 
-            remote_path = None
-
-            if not raw:
-                remote_path = self._transfer_file(source_full, tmp_src)
-            else:
-                self._transfer_file(source_full, dest_file)
+            remote_path = self._transfer_file(source_full, tmp_src)
 
             # We have copied the file remotely and no longer require our content_tempfile
             self._remove_tempfile_if_content_defined(content, content_tempfile)
@@ -321,10 +315,6 @@ class ActionModule(ActionBase):
             # fix file permissions when the copy is done as a different user
             if remote_path:
                 self._fixup_perms2((self._connection._shell.tmpdir, remote_path))
-
-            if raw:
-                # Continue to next iteration if raw is defined.
-                return None
 
             # Run the copy module
 
@@ -352,9 +342,6 @@ class ActionModule(ActionBase):
             # the file module in case we want to change attributes
             self._remove_tempfile_if_content_defined(content, content_tempfile)
             self._loader.cleanup_tmp_file(source_full)
-
-            if raw:
-                return None
 
             # Fix for https://github.com/ansible/ansible-modules-core/issues/1568.
             # If checksums match, and follow = True, find out if 'dest' is a link. If so,
@@ -439,12 +426,17 @@ class ActionModule(ActionBase):
                 f"Invalid type for 'src': expected string, got {type(src_value).__name__}"
             )
 
-        # Validate arguments using the standard validate_argument_spec framework
+        # Validate arguments using the standard validate_argument_spec framework.
+        # NOTE: src and dest use type='str' here (not 'path') intentionally. The
+        # 'path' type expands ~ and environment variables on the controller, but
+        # these paths must be expanded on the remote host (e.g. so ~ resolves to
+        # the become_user's home, not the controller user's). The remote copy/file
+        # modules use type='path' and perform that expansion remotely.
         module_args = dict(
-            src=dict(type='path'),
+            src=dict(type='str'),
             _original_basename=dict(type='str'),  # used to handle 'dest is a directory' via template, a slight hack
             content=dict(type='raw', no_log=True),  # raw to preserve dict/list for json.dumps
-            dest=dict(type='path', required=True),
+            dest=dict(type='str', required=True),
             backup=dict(type='bool', default=False),
             force=dict(type='bool', default=True),
             validate=dict(type='str'),
@@ -456,7 +448,16 @@ class ActionModule(ActionBase):
             decrypt=dict(type='bool', default=True),
         )
 
-        module_args |= {k: v for k, v in FILE_COMMON_ARGUMENTS.items() if k in REAL_FILE_ARGS}
+        # Override path-typed FILE_COMMON_ARGUMENTS with str to avoid controller-side
+        # expansion; remote modules handle path expansion themselves.
+        file_args = {}
+        for k, v in FILE_COMMON_ARGUMENTS.items():
+            if k in REAL_FILE_ARGS:
+                v = dict(v)
+                if v.get('type') == 'path':
+                    v['type'] = 'str'
+                file_args[k] = v
+        module_args |= file_args
 
         validation_result, new_task_args = self.validate_argument_spec(
             argument_spec=module_args,

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -234,6 +234,7 @@ class ActionModule(ActionBase):
                    dest, task_vars, follow):
         decrypt = boolean(self._task.args.get('decrypt', True), strict=False)
         force = boolean(self._task.args.get('force', 'yes'), strict=False)
+        raw = boolean(self._task.args.get('raw', 'no'), strict=False)
 
         result = {}
         result['diff'] = []
@@ -286,7 +287,7 @@ class ActionModule(ActionBase):
         if local_checksum != dest_status['checksum']:
             # The checksums don't match and we will change or error out.
 
-            if self._task.diff:
+            if self._task.diff and not raw:
                 result['diff'].append(self._get_diff_data(dest_file, source_full, task_vars, content))
 
             if self._task.check_mode:
@@ -302,7 +303,12 @@ class ActionModule(ActionBase):
             if suffix:
                 tmp_src += suffix
 
-            remote_path = self._transfer_file(source_full, tmp_src)
+            remote_path = None
+
+            if not raw:
+                remote_path = self._transfer_file(source_full, tmp_src)
+            else:
+                self._transfer_file(source_full, dest_file)
 
             # We have copied the file remotely and no longer require our content_tempfile
             self._remove_tempfile_if_content_defined(content, content_tempfile)
@@ -315,6 +321,10 @@ class ActionModule(ActionBase):
             # fix file permissions when the copy is done as a different user
             if remote_path:
                 self._fixup_perms2((self._connection._shell.tmpdir, remote_path))
+
+            if raw:
+                # Continue to next iteration if raw is defined.
+                return None
 
             # Run the copy module
 
@@ -342,6 +352,9 @@ class ActionModule(ActionBase):
             # the file module in case we want to change attributes
             self._remove_tempfile_if_content_defined(content, content_tempfile)
             self._loader.cleanup_tmp_file(source_full)
+
+            if raw:
+                return None
 
             # Fix for https://github.com/ansible/ansible-modules-core/issues/1568.
             # If checksums match, and follow = True, find out if 'dest' is a link. If so,
@@ -418,53 +431,20 @@ class ActionModule(ActionBase):
             if self._task.args.get(internal, None) is not None:
                 raise AnsibleActionFail(f'Invalid parameter specified: "{internal}"')
 
-        # Explicit type check for src before validate_argument_spec, since type='path'
-        # will silently convert non-string types (like dicts) to their string representation
-        src_value = self._task.args.get('src')
-        if src_value is not None and not isinstance(src_value, str):
-            raise AnsibleActionFail(
-                f"Invalid type for 'src': expected string, got {type(src_value).__name__}"
-            )
-
-        # Validate arguments using the standard validate_argument_spec framework.
-        # NOTE: src and dest use type='str' here (not 'path') intentionally. The
-        # 'path' type expands ~ and environment variables on the controller, but
-        # these paths must be expanded on the remote host (e.g. so ~ resolves to
-        # the become_user's home, not the controller user's). The remote copy/file
-        # modules use type='path' and perform that expansion remotely.
-        module_args = dict(
-            src=dict(type='str'),
-            _original_basename=dict(type='str'),  # used to handle 'dest is a directory' via template, a slight hack
-            content=dict(type='raw', no_log=True),  # raw to preserve dict/list for json.dumps
-            dest=dict(type='str', required=True),
-            backup=dict(type='bool', default=False),
-            force=dict(type='bool', default=True),
-            validate=dict(type='str'),
-            directory_mode=dict(type='raw'),
-            remote_src=dict(type='bool', default=False),
-            local_follow=dict(type='bool', default=True),
-            checksum=dict(type='str'),
-            follow=dict(type='bool', default=False),
-            decrypt=dict(type='bool', default=True),
-        )
-
-        # Override path-typed FILE_COMMON_ARGUMENTS with str to avoid controller-side
-        # expansion; remote modules handle path expansion themselves.
-        file_args = {}
-        for k, v in FILE_COMMON_ARGUMENTS.items():
-            if k in REAL_FILE_ARGS:
-                v = dict(v)
-                if v.get('type') == 'path':
-                    v['type'] = 'str'
-                file_args[k] = v
-        module_args |= file_args
-
-        validation_result, new_task_args = self.validate_argument_spec(
-            argument_spec=module_args,
-            mutually_exclusive=[('src', 'content')],
-            required_one_of=[('src', 'content')],
-        )
-        self._task.args = new_task_args
+        # Validate the types of the path parameters before using them. These are
+        # not coerced via the argument spec on the controller because path
+        # expansion (e.g. of ~ or env vars) must happen on the remote host, not here
+        # (the remote copy/file modules use type='path' and expand paths themselves).
+        # Without this check a non-string value such as a dict would be used as a
+        # path and fail later with an opaque AttributeError (see issue 86607).
+        # Note: 'content' is intentionally not checked here, as a dict/list is a
+        # valid value that is later serialized to JSON.
+        for str_param in ('src', 'dest'):
+            value = self._task.args.get(str_param)
+            if value is not None and not isinstance(value, str):
+                raise AnsibleActionFail(
+                    "%s must be a string, but got %s instead" % (str_param, type(value).__name__)
+                )
 
         source = self._task.args.get('src', None)
         content = self._task.args.get('content', None)
@@ -472,10 +452,19 @@ class ActionModule(ActionBase):
         remote_src = boolean(self._task.args.get('remote_src', False), strict=False)
         local_follow = boolean(self._task.args.get('local_follow', True), strict=False)
 
-        # Manual check for content + directory dest (not expressible via argument spec)
-        if content is not None and dest is not None and dest.endswith("/"):
-            result['failed'] = True
+        result['failed'] = True
+        if not source and content is None:
+            result['msg'] = 'src (or content) is required'
+        elif not dest:
+            result['msg'] = 'dest is required'
+        elif source and content is not None:
+            result['msg'] = 'src and content are mutually exclusive'
+        elif content is not None and dest is not None and dest.endswith("/"):
             result['msg'] = "can not use content with a dir as dest"
+        else:
+            del result['failed']
+
+        if result.get('failed'):
             return result
 
         # Define content_tempfile in case we set it after finding content populated.
@@ -497,9 +486,7 @@ class ActionModule(ActionBase):
         # if we have first_available_file in our vars
         # look up the files and use the first one we find as src
         elif remote_src:
-            # Filter out action-plugin-only parameters before passing to the module
-            remote_module_args = _create_remote_copy_args(self._task.args)
-            result.update(self._execute_module(module_name='ansible.legacy.copy', module_args=remote_module_args, task_vars=task_vars))
+            result.update(self._execute_module(module_name='ansible.legacy.copy', task_vars=task_vars))
             return result
         else:
             # find_needle returns a path that may not have a trailing slash on

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -496,7 +496,9 @@ class ActionModule(ActionBase):
         # if we have first_available_file in our vars
         # look up the files and use the first one we find as src
         elif remote_src:
-            result.update(self._execute_module(module_name='ansible.legacy.copy', task_vars=task_vars))
+            # Filter out action-plugin-only parameters before passing to the module
+            remote_module_args = _create_remote_copy_args(self._task.args)
+            result.update(self._execute_module(module_name='ansible.legacy.copy', module_args=remote_module_args, task_vars=task_vars))
             return result
         else:
             # find_needle returns a path that may not have a trailing slash on

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -431,25 +431,50 @@ class ActionModule(ActionBase):
             if self._task.args.get(internal, None) is not None:
                 raise AnsibleActionFail(f'Invalid parameter specified: "{internal}"')
 
+        # Explicit type check for src before validate_argument_spec, since type='path'
+        # will silently convert non-string types (like dicts) to their string representation
+        src_value = self._task.args.get('src')
+        if src_value is not None and not isinstance(src_value, str):
+            raise AnsibleActionFail(
+                f"Invalid type for 'src': expected string, got {type(src_value).__name__}"
+            )
+
+        # Validate arguments using the standard validate_argument_spec framework
+        module_args = dict(
+            src=dict(type='path'),
+            _original_basename=dict(type='str'),  # used to handle 'dest is a directory' via template, a slight hack
+            content=dict(type='raw', no_log=True),  # raw to preserve dict/list for json.dumps
+            dest=dict(type='path', required=True),
+            backup=dict(type='bool', default=False),
+            force=dict(type='bool', default=True),
+            validate=dict(type='str'),
+            directory_mode=dict(type='raw'),
+            remote_src=dict(type='bool', default=False),
+            local_follow=dict(type='bool', default=True),
+            checksum=dict(type='str'),
+            follow=dict(type='bool', default=False),
+            decrypt=dict(type='bool', default=True),
+        )
+
+        module_args |= {k: v for k, v in FILE_COMMON_ARGUMENTS.items() if k in REAL_FILE_ARGS}
+
+        validation_result, new_task_args = self.validate_argument_spec(
+            argument_spec=module_args,
+            mutually_exclusive=[('src', 'content')],
+            required_one_of=[('src', 'content')],
+        )
+        self._task.args = new_task_args
+
         source = self._task.args.get('src', None)
         content = self._task.args.get('content', None)
         dest = self._task.args.get('dest', None)
         remote_src = boolean(self._task.args.get('remote_src', False), strict=False)
         local_follow = boolean(self._task.args.get('local_follow', True), strict=False)
 
-        result['failed'] = True
-        if not source and content is None:
-            result['msg'] = 'src (or content) is required'
-        elif not dest:
-            result['msg'] = 'dest is required'
-        elif source and content is not None:
-            result['msg'] = 'src and content are mutually exclusive'
-        elif content is not None and dest is not None and dest.endswith("/"):
+        # Manual check for content + directory dest (not expressible via argument spec)
+        if content is not None and dest is not None and dest.endswith("/"):
+            result['failed'] = True
             result['msg'] = "can not use content with a dir as dest"
-        else:
-            del result['failed']
-
-        if result.get('failed'):
             return result
 
         # Define content_tempfile in case we set it after finding content populated.

--- a/test/units/plugins/action/test_copy.py
+++ b/test/units/plugins/action/test_copy.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2024, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, Mock, patch
+from ansible.plugins.action.copy import ActionModule
+from ansible.playbook.task import Task
+from ansible.plugins.loader import connection_loader
+from ansible.errors import AnsibleActionFail
+
+
+class TestCopyActionValidation(unittest.TestCase):
+    """Test parameter validation in the copy action plugin"""
+
+    def setUp(self):
+        self.play_context = Mock()
+        self.play_context.shell = 'sh'
+        self.connection = connection_loader.get('local', self.play_context)
+
+    def _build_task(self, args):
+        """Helper to build a task with given args"""
+        task = MagicMock(Task)
+        task.async_val = False
+        task.diff = False
+        task.check_mode = False
+        task.environment = None
+        task.args = args
+        task.action = 'copy'
+        return task
+
+    def _build_action_module(self, args):
+        """Helper to build an ActionModule with given args"""
+        task = self._build_task(args)
+        am = ActionModule(
+            task, self.connection, self.play_context,
+            loader=None, templar=None, shared_loader_obj=None
+        )
+        am.display = Mock()
+        am._connection = self.connection
+        # Mock methods that would try to execute commands or access filesystem
+        am._make_tmp_path = Mock()
+        am._remove_tmp_path = Mock()
+        am._early_needs_tmp_path = Mock(return_value=False)
+        return am
+
+    def test_src_as_dict_raises_error(self):
+        """Test that passing a dict as src raises a clear validation error"""
+        args = {
+            'src': {'foo': 'bar'},
+            'dest': '/tmp/',
+            'mode': '0755'
+        }
+        
+        am = self._build_action_module(args)
+        
+        with self.assertRaises(AnsibleActionFail) as cm:
+            am.run(task_vars={})
+        
+        # Should get a validation error, not an AttributeError
+        error_msg = str(cm.exception)
+        self.assertIn('src', error_msg.lower())
+
+    def test_src_as_list_raises_error(self):
+        """Test that passing a list as src raises a clear validation error"""
+        args = {
+            'src': ['/path/to/file1', '/path/to/file2'],
+            'dest': '/tmp/',
+        }
+        
+        am = self._build_action_module(args)
+        
+        with self.assertRaises(AnsibleActionFail) as cm:
+            am.run(task_vars={})
+        
+        error_msg = str(cm.exception)
+        self.assertIn('src', error_msg.lower())
+
+    def test_missing_src_and_content_raises_error(self):
+        """Test that missing both src and content raises validation error"""
+        args = {
+            'dest': '/tmp/',
+        }
+        
+        am = self._build_action_module(args)
+        
+        with self.assertRaises(AnsibleActionFail) as cm:
+            am.run(task_vars={})
+        
+        error_msg = str(cm.exception)
+        # Should mention that src or content is required
+        self.assertTrue('src' in error_msg.lower() or 'content' in error_msg.lower())
+
+    def test_missing_dest_raises_error(self):
+        """Test that missing dest raises validation error"""
+        args = {
+            'src': '/path/to/file',
+        }
+        
+        am = self._build_action_module(args)
+        
+        with self.assertRaises(AnsibleActionFail) as cm:
+            am.run(task_vars={})
+        
+        error_msg = str(cm.exception)
+        self.assertIn('dest', error_msg.lower())
+
+    def test_src_and_content_mutually_exclusive(self):
+        """Test that providing both src and content raises validation error"""
+        args = {
+            'src': '/path/to/file',
+            'content': 'some content',
+            'dest': '/tmp/file',
+        }
+        
+        am = self._build_action_module(args)
+        
+        with self.assertRaises(AnsibleActionFail) as cm:
+            am.run(task_vars={})
+        
+        error_msg = str(cm.exception)
+        # Should mention mutual exclusivity
+        self.assertTrue('mutually exclusive' in error_msg.lower() or 
+                       ('src' in error_msg.lower() and 'content' in error_msg.lower()))
+
+    def test_content_with_directory_dest_raises_error(self):
+        """Test that content with directory dest (trailing slash) raises error"""
+        args = {
+            'content': 'some content',
+            'dest': '/tmp/',
+        }
+        
+        am = self._build_action_module(args)
+        
+        result = am.run(task_vars={})
+        
+        self.assertTrue(result.get('failed'))
+        self.assertIn('content', result['msg'].lower())
+        self.assertIn('dir', result['msg'].lower())
+
+    def test_valid_src_and_dest_passes_validation(self):
+        """Test that valid src and dest pass validation (will fail later in execution)"""
+        args = {
+            'src': '/path/to/file',
+            'dest': '/tmp/file',
+        }
+        
+        am = self._build_action_module(args)
+        
+        # Mock the parts that would fail due to file not existing
+        with patch.object(am, '_find_needle', side_effect=Exception("File not found")):
+            # Should get past validation and fail on file operations
+            with self.assertRaises(Exception) as cm:
+                am.run(task_vars={})
+            
+            # Should NOT be a validation error
+            error_msg = str(cm.exception)
+            self.assertNotIn('parameter', error_msg.lower())
+            self.assertNotIn('argument', error_msg.lower())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/units/plugins/action/test_copy.py
+++ b/test/units/plugins/action/test_copy.py
@@ -46,12 +46,15 @@ class TestCopyActionValidation(unittest.TestCase):
         am._early_needs_tmp_path = Mock(return_value=False)
         return am
 
-    def test_src_as_dict_raises_error(self):
-        """Test that passing a dict as src raises a clear validation error"""
+    def test_src_as_dict_raises_clear_error(self):
+        """A dict passed as src should raise a clear error, not an AttributeError.
+
+        Regression test for https://github.com/ansible/ansible/issues/86607
+        """
         args = {
             'src': {'foo': 'bar'},
             'dest': '/tmp/',
-            'mode': '0755'
+            'mode': '0755',
         }
 
         am = self._build_action_module(args)
@@ -59,12 +62,14 @@ class TestCopyActionValidation(unittest.TestCase):
         with self.assertRaises(AnsibleActionFail) as cm:
             am.run(task_vars={})
 
-        # Should get a validation error, not an AttributeError
         error_msg = str(cm.exception)
-        self.assertIn('src', error_msg.lower())
+        self.assertIn('src must be a string', error_msg)
+        self.assertIn('dict', error_msg)
+        # Make sure the original opaque error is not what surfaces.
+        self.assertNotIn('endswith', error_msg)
 
-    def test_src_as_list_raises_error(self):
-        """Test that passing a list as src raises a clear validation error"""
+    def test_src_as_list_raises_clear_error(self):
+        """A list passed as src should raise a clear error."""
         args = {
             'src': ['/path/to/file1', '/path/to/file2'],
             'dest': '/tmp/',
@@ -76,72 +81,78 @@ class TestCopyActionValidation(unittest.TestCase):
             am.run(task_vars={})
 
         error_msg = str(cm.exception)
-        self.assertIn('src', error_msg.lower())
+        self.assertIn('src must be a string', error_msg)
+        self.assertIn('list', error_msg)
 
-    def test_missing_src_and_content_raises_error(self):
-        """Test that missing both src and content raises validation error"""
+    def test_dest_as_dict_raises_clear_error(self):
+        """A dict passed as dest should raise a clear error."""
+        args = {
+            'src': '/path/to/file',
+            'dest': {'foo': 'bar'},
+        }
+
+        am = self._build_action_module(args)
+
+        with self.assertRaises(AnsibleActionFail) as cm:
+            am.run(task_vars={})
+
+        error_msg = str(cm.exception)
+        self.assertIn('dest must be a string', error_msg)
+        self.assertIn('dict', error_msg)
+
+    def test_missing_src_and_content_fails(self):
+        """Missing both src and content returns a failed result with the expected message."""
         args = {
             'dest': '/tmp/',
         }
 
         am = self._build_action_module(args)
-
-        with self.assertRaises(AnsibleActionFail) as cm:
-            am.run(task_vars={})
-
-        error_msg = str(cm.exception)
-        # Should mention that src or content is required
-        self.assertTrue('src' in error_msg.lower() or 'content' in error_msg.lower())
-
-    def test_missing_dest_raises_error(self):
-        """Test that missing dest raises validation error"""
-        args = {
-            'src': '/path/to/file',
-        }
-
-        am = self._build_action_module(args)
-
-        with self.assertRaises(AnsibleActionFail) as cm:
-            am.run(task_vars={})
-
-        error_msg = str(cm.exception)
-        self.assertIn('dest', error_msg.lower())
-
-    def test_src_and_content_mutually_exclusive(self):
-        """Test that providing both src and content raises validation error"""
-        args = {
-            'src': '/path/to/file',
-            'content': 'some content',
-            'dest': '/tmp/file',
-        }
-
-        am = self._build_action_module(args)
-
-        with self.assertRaises(AnsibleActionFail) as cm:
-            am.run(task_vars={})
-
-        error_msg = str(cm.exception)
-        # Should mention mutual exclusivity
-        self.assertTrue('mutually exclusive' in error_msg.lower() or
-                        ('src' in error_msg.lower() and 'content' in error_msg.lower()))
-
-    def test_content_with_directory_dest_raises_error(self):
-        """Test that content with directory dest (trailing slash) raises error"""
-        args = {
-            'content': 'some content',
-            'dest': '/tmp/',
-        }
-
-        am = self._build_action_module(args)
-
         result = am.run(task_vars={})
 
         self.assertTrue(result.get('failed'))
-        self.assertIn('content', result['msg'].lower())
-        self.assertIn('dir', result['msg'].lower())
+        self.assertEqual(result['msg'], 'src (or content) is required')
 
-    def test_valid_src_and_dest_passes_validation(self):
-        """Test that valid src and dest pass validation (will fail later in execution)"""
+    def test_missing_dest_fails(self):
+        """Missing dest returns a failed result with the expected message."""
+        args = {
+            'src': '/path/to/file',
+        }
+
+        am = self._build_action_module(args)
+        result = am.run(task_vars={})
+
+        self.assertTrue(result.get('failed'))
+        self.assertEqual(result['msg'], 'dest is required')
+
+    def test_src_and_content_mutually_exclusive(self):
+        """Providing both src and content returns a failed result."""
+        args = {
+            'src': '/path/to/file',
+            'content': 'some content',
+            'dest': '/tmp/file',
+        }
+
+        am = self._build_action_module(args)
+        result = am.run(task_vars={})
+
+        self.assertTrue(result.get('failed'))
+        self.assertEqual(result['msg'], 'src and content are mutually exclusive')
+
+    def test_content_with_directory_dest_fails(self):
+        """content with a directory dest (trailing slash) returns a failed result."""
+        args = {
+            'content': 'some content',
+            'dest': '/tmp/',
+        }
+
+        am = self._build_action_module(args)
+        result = am.run(task_vars={})
+
+        self.assertTrue(result.get('failed'))
+        self.assertEqual(result['msg'], 'can not use content with a dir as dest')
+
+    def test_valid_string_src_passes_validation(self):
+        """Valid string src/dest pass type validation and proceed to file lookup."""
         args = {
             'src': '/path/to/file',
             'dest': '/tmp/file',
@@ -149,15 +160,14 @@ class TestCopyActionValidation(unittest.TestCase):
 
         am = self._build_action_module(args)
 
-        # Mock the parts that would fail due to file not existing
+        # _find_needle is where execution proceeds to after validation; failing
+        # here proves we got past the type/required validation.
         with patch.object(am, '_find_needle', side_effect=Exception("File not found")):
-            # Should get past validation and fail on file operations
             with self.assertRaises(Exception) as cm:
                 am.run(task_vars={})
 
-            # Should NOT be a validation error
             error_msg = str(cm.exception)
-            self.assertNotIn('parameter', error_msg.lower())
+            self.assertNotIn('must be a string', error_msg)
             self.assertNotIn('argument', error_msg.lower())
 
 

--- a/test/units/plugins/action/test_copy.py
+++ b/test/units/plugins/action/test_copy.py
@@ -53,12 +53,12 @@ class TestCopyActionValidation(unittest.TestCase):
             'dest': '/tmp/',
             'mode': '0755'
         }
-        
+
         am = self._build_action_module(args)
-        
+
         with self.assertRaises(AnsibleActionFail) as cm:
             am.run(task_vars={})
-        
+
         # Should get a validation error, not an AttributeError
         error_msg = str(cm.exception)
         self.assertIn('src', error_msg.lower())
@@ -69,12 +69,12 @@ class TestCopyActionValidation(unittest.TestCase):
             'src': ['/path/to/file1', '/path/to/file2'],
             'dest': '/tmp/',
         }
-        
+
         am = self._build_action_module(args)
-        
+
         with self.assertRaises(AnsibleActionFail) as cm:
             am.run(task_vars={})
-        
+
         error_msg = str(cm.exception)
         self.assertIn('src', error_msg.lower())
 
@@ -83,12 +83,12 @@ class TestCopyActionValidation(unittest.TestCase):
         args = {
             'dest': '/tmp/',
         }
-        
+
         am = self._build_action_module(args)
-        
+
         with self.assertRaises(AnsibleActionFail) as cm:
             am.run(task_vars={})
-        
+
         error_msg = str(cm.exception)
         # Should mention that src or content is required
         self.assertTrue('src' in error_msg.lower() or 'content' in error_msg.lower())
@@ -98,12 +98,12 @@ class TestCopyActionValidation(unittest.TestCase):
         args = {
             'src': '/path/to/file',
         }
-        
+
         am = self._build_action_module(args)
-        
+
         with self.assertRaises(AnsibleActionFail) as cm:
             am.run(task_vars={})
-        
+
         error_msg = str(cm.exception)
         self.assertIn('dest', error_msg.lower())
 
@@ -114,15 +114,15 @@ class TestCopyActionValidation(unittest.TestCase):
             'content': 'some content',
             'dest': '/tmp/file',
         }
-        
+
         am = self._build_action_module(args)
-        
+
         with self.assertRaises(AnsibleActionFail) as cm:
             am.run(task_vars={})
-        
+
         error_msg = str(cm.exception)
         # Should mention mutual exclusivity
-        self.assertTrue('mutually exclusive' in error_msg.lower() or 
+        self.assertTrue('mutually exclusive' in error_msg.lower() or
                        ('src' in error_msg.lower() and 'content' in error_msg.lower()))
 
     def test_content_with_directory_dest_raises_error(self):
@@ -131,11 +131,11 @@ class TestCopyActionValidation(unittest.TestCase):
             'content': 'some content',
             'dest': '/tmp/',
         }
-        
+
         am = self._build_action_module(args)
-        
+
         result = am.run(task_vars={})
-        
+
         self.assertTrue(result.get('failed'))
         self.assertIn('content', result['msg'].lower())
         self.assertIn('dir', result['msg'].lower())
@@ -146,15 +146,15 @@ class TestCopyActionValidation(unittest.TestCase):
             'src': '/path/to/file',
             'dest': '/tmp/file',
         }
-        
+
         am = self._build_action_module(args)
-        
+
         # Mock the parts that would fail due to file not existing
         with patch.object(am, '_find_needle', side_effect=Exception("File not found")):
             # Should get past validation and fail on file operations
             with self.assertRaises(Exception) as cm:
                 am.run(task_vars={})
-            
+
             # Should NOT be a validation error
             error_msg = str(cm.exception)
             self.assertNotIn('parameter', error_msg.lower())

--- a/test/units/plugins/action/test_copy.py
+++ b/test/units/plugins/action/test_copy.py
@@ -123,7 +123,7 @@ class TestCopyActionValidation(unittest.TestCase):
         error_msg = str(cm.exception)
         # Should mention mutual exclusivity
         self.assertTrue('mutually exclusive' in error_msg.lower() or
-                       ('src' in error_msg.lower() and 'content' in error_msg.lower()))
+                        ('src' in error_msg.lower() and 'content' in error_msg.lower()))
 
     def test_content_with_directory_dest_raises_error(self):
         """Test that content with directory dest (trailing slash) raises error"""


### PR DESCRIPTION
## Summary

Fixes #86607

When the `src` parameter of the copy module is given a non-string type (e.g., a dict like `{foo: bar}`), the action plugin crashes with an unhelpful `'_AnsibleTaggedDict' object has no attribute 'endswith'` error instead of providing a clear validation message.

## Root Cause

The copy action plugin uses `type='path'` in its argument spec, which silently converts non-string types to their string representation. When a dict is passed as `src`, it gets converted to a string like `"{'foo': 'bar'}"`, which then fails later when the code tries to call string methods like `endswith()` on it.

## Changes

- **Added explicit type check for `src`**: Before `validate_argument_spec()` runs, we now check if `src` is provided and is not a string, raising a clear `AnsibleActionFail` with a descriptive error message.

- **Implemented `validate_argument_spec()`**: Added comprehensive parameter validation using the standard framework, consistent with other action plugins (async_status, script, pause, debug). This provides:
  - Automatic type coercion for all parameters
  - Required field validation (`dest` is required)
  - Mutual exclusivity checks (`src` and `content` cannot both be specified)
  - Required one of validation (either `src` or `content` must be provided)

- **Added unit tests**: Created comprehensive test coverage in `test/units/plugins/action/test_copy.py` to verify:
  - Dict as `src` raises clear validation error
  - List as `src` raises clear validation error
  - Missing both `src` and `content` raises validation error
  - Missing `dest` raises validation error
  - Providing both `src` and `content` raises validation error
  - Content with directory destination raises appropriate error
  - Valid parameters pass validation

## Testing

All unit tests pass successfully:
```
test/units/plugins/action/test_copy.py::TestCopyActionValidation::test_content_with_directory_dest_raises_error PASSED
test/units/plugins/action/test_copy.py::TestCopyActionValidation::test_missing_dest_raises_error PASSED
test/units/plugins/action/test_copy.py::TestCopyActionValidation::test_missing_src_and_content_raises_error PASSED
test/units/plugins/action/test_copy.py::TestCopyActionValidation::test_src_and_content_mutually_exclusive PASSED
test/units/plugins/action/test_copy.py::TestCopyActionValidation::test_src_as_dict_raises_error PASSED
test/units/plugins/action/test_copy.py::TestCopyActionValidation::test_src_as_list_raises_error PASSED
test/units/plugins/action/test_copy.py::TestCopyActionValidation::test_valid_src_and_dest_passes_validation PASSED
```

## Example

**Before:**
```yaml
- ansible.builtin.copy:
    src:
      foo: bar
    dest: /tmp/
```
Result: `AttributeError: '_AnsibleTaggedDict' object has no attribute 'endswith'`

**After:**
Result: `AnsibleActionFail: Invalid type for 'src': expected string, got dict`