### PR TITLE
Improve diff-support

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1504,30 +1504,29 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
                     diff['before_header'] = destination
                     diff['before'] = to_text(dest_contents)
 
-            if source_file:
-                st = os.stat(source)
-                if C.MAX_FILE_SIZE_FOR_DIFF > 0 and st[stat.ST_SIZE] > C.MAX_FILE_SIZE_FOR_DIFF:
-                    diff['src_larger'] = C.MAX_FILE_SIZE_FOR_DIFF
-                else:
-                    display.debug("Reading local copy of the file %s" % source)
-                    try:
-                        with open(source, 'rb') as src:
-                            src_contents = src.read()
-                    except Exception as e:
-                        raise AnsibleError("Unexpected error while reading source (%s) for diff: %s " % (source, to_native(e)))
-
-                    if b"\x00" in src_contents:
-                        diff['src_binary'] = 1
-                    else:
-                        if content:
-                            diff['after_header'] = destination
-                        else:
-                            diff['after_header'] = source
-                        diff['after'] = to_text(src_contents)
+            st = os.stat(source)
+            if C.MAX_FILE_SIZE_FOR_DIFF > 0 and st[stat.ST_SIZE] > C.MAX_FILE_SIZE_FOR_DIFF:
+                diff['src_larger'] = C.MAX_FILE_SIZE_FOR_DIFF
             else:
-                display.debug(u"source of file passed in")
-                diff['after_header'] = u'dynamically generated'
-                diff['after'] = source
+                display.debug("Reading local copy of the file %s" % source)
+                try:
+                    with open(source, 'rb') as src:
+                        src_contents = src.read()
+                except Exception as e:
+                    raise AnsibleError("Unexpected error while reading source (%s) for diff: %s " % (source, to_native(e)))
+
+                if b"\x00" in src_contents:
+                    diff['src_binary'] = 1
+                elif source_file:
+                    if content:
+                        diff['after_header'] = destination
+                    else:
+                        diff['after_header'] = source
+                    diff['after'] = to_text(src_contents)
+                else:
+                    display.debug(u"source of file passed in")
+                    diff['after_header'] = u'dynamically generated'
+                    diff['after'] = to_text(src_contents)
 
         if self._task.no_log:
             if 'before' in diff:

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -288,7 +288,7 @@ class ActionModule(ActionBase):
             # The checksums don't match and we will change or error out.
 
             if self._task.diff and not raw:
-                result['diff'].append(self._get_diff_data(dest_file, source_full, task_vars, content is None))
+                result['diff'].append(self._get_diff_data(dest_file, source_full, task_vars, content, content is None))
 
             if self._task.check_mode:
                 self._remove_tempfile_if_content_defined(content, content_tempfile)

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -288,7 +288,7 @@ class ActionModule(ActionBase):
             # The checksums don't match and we will change or error out.
 
             if self._task.diff and not raw:
-                result['diff'].append(self._get_diff_data(dest_file, source_full, task_vars, content))
+                result['diff'].append(self._get_diff_data(dest_file, source_full, task_vars, content is None))
 
             if self._task.check_mode:
                 self._remove_tempfile_if_content_defined(content, content_tempfile)

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -106,7 +106,7 @@
         that:
           - 'diff_output.diff[0].before == ""'
           - '"Ansible managed" in diff_output.diff[0].after'
-          - '"file.txt" in diff_output.diff[0].after_header'
+          - 'diff_output.diff[0].after_header == "dynamically generated"'
 
     - name: tests with remote_src and non files
       import_tasks: src_remote_file_is_not_file.yml


### PR DESCRIPTION
##### SUMMARY
Fix reporting "dynamically generated" content rather than reporting a temporary file, as it was intended

I found this issue when implementing Windows diff support.

Please backport this to earlier versions to fix the diff output when using `content` parameter.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE
- Bugfix Pull Request