### PR TITLE
Fix typo in free.py: 'do do' → 'do'

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -226,7 +226,7 @@ class TaskExecutor:
                     try:
                         utr.set_break_when_result(self._task._resolve_conditional(self._task.loop_control.break_when, task_ctx.task_vars))
                     except AnsibleError as ex:
-                        # RPFIX-5: UX: This this bypasses AnsibleTaskError handling, resulting in less information than a normal task failure.
+                        # RPFIX-5: UX: This bypasses AnsibleTaskError handling, resulting in less information than a normal task failure.
                         utr.set_break_when_result(ex)
 
                 self._update_task_connection()

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -109,7 +109,7 @@ class StrategyModule(StrategyBase):
                 host_name = host.get_name()
 
                 # peek at the next task for the host, to see if there's
-                # anything to do do for this host
+                # anything to do for this host
                 (state, task) = iterator.get_next_task_for_host(host, peek=True)
                 display.debug("free host state: %s" % state, host=host_name)
                 display.debug("free host task: %s" % task, host=host_name)


### PR DESCRIPTION
Fixes a duplicate word typo in `lib/ansible/plugins/strategy/free.py`.