### PR TITLE
file: fix relative path link replacement

### DIFF
--- a/changelogs/fragments/86146-file-relative-link-temp-path.yml
+++ b/changelogs/fragments/86146-file-relative-link-temp-path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - file - fix relative destination path handling when atomically replacing symlinks and hardlinks.

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -1013,6 +1013,10 @@ def main():
             appears_binary = execute_diff_peek(to_bytes(path, errors='surrogate_or_strict'))
             module.exit_json(path=path, changed=False, appears_binary=appears_binary)
 
+        if state in ('link', 'hard'):
+            path = to_native(os.path.abspath(to_bytes(path, errors='surrogate_or_strict')), errors='surrogate_or_strict')
+            module.params['path'] = path
+
         if state == 'file':
             result = ensure_file_attributes(path, follow, timestamps)
         elif state == 'directory':

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -962,6 +962,51 @@
 
 # END #55971
 
+# Regression test for https://github.com/ansible/ansible/issues/86146
+- block:
+  - name: Create relative hardlink source file
+    copy:
+      content: "relative hardlink source"
+      dest: relative_hardlink_source
+
+  - name: Create existing relative hardlink destination file
+    copy:
+      content: "existing hardlink destination"
+      dest: relative_hardlink_dest
+
+  - name: Replace existing relative file with hardlink
+    file:
+      src: relative_hardlink_source
+      dest: relative_hardlink_dest
+      state: hard
+      force: true
+    register: replace_relative_file_with_hardlink
+
+  - name: Stat relative hardlink source
+    stat:
+      path: relative_hardlink_source
+    register: relative_hardlink_source_stat
+
+  - name: Stat replaced relative hardlink destination
+    stat:
+      path: relative_hardlink_dest
+    register: relative_hardlink_dest_stat
+
+  - name: Ensure existing file was replaced with relative hardlink
+    assert:
+      that:
+        - replace_relative_file_with_hardlink is changed
+        - relative_hardlink_source_stat.stat.inode == relative_hardlink_dest_stat.stat.inode
+
+  always:
+    - name: Remove relative hardlink test files
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - relative_hardlink_source
+        - relative_hardlink_dest
+
 - name: Regression test for https://github.com/ansible/ansible/issues/57573
   block:
     - name: Create directory

--- a/test/integration/targets/file/tasks/state_link.yml
+++ b/test/integration/targets/file/tasks/state_link.yml
@@ -500,3 +500,49 @@
     - dest_is_existing_file_force is changed
     - dest_is_existing_file_force_stat.stat.exists
     - dest_is_existing_file_force_stat.stat.islnk
+
+# Regression test for https://github.com/ansible/ansible/issues/86146
+- name: Test replacing existing relative destination with symlink
+  block:
+    - name: Create relative target file
+      copy:
+        content: "relative target file"
+        dest: relative_target_file
+
+    - name: Create existing file at relative destination
+      copy:
+        content: "existing destination file"
+        dest: relative_link
+
+    - name: Replace existing relative file with symlink
+      file:
+        path: relative_link
+        src: relative_target_file
+        state: link
+        force: true
+        follow: false
+      register: replace_relative_file_with_link
+
+    - name: Stat replaced relative symlink
+      stat:
+        path: relative_link
+        follow: false
+      register: replaced_relative_link
+
+    - name: Ensure existing file was replaced with relative symlink
+      assert:
+        that:
+          - replace_relative_file_with_link is changed
+          - replaced_relative_link.stat.exists
+          - replaced_relative_link.stat.islnk
+          - replaced_relative_link.stat.lnk_target == 'relative_target_file'
+
+  always:
+    - name: Remove relative symlink test files
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - relative_link
+        - relative_target_file
+# End Test #86146


### PR DESCRIPTION
##### SUMMARY

Fixes #86146.

The file module built temp replacement paths with `os.path.sep.join()`. When replacing a symlink or hardlink whose destination is an implicit relative path, `os.path.dirname()` returns an empty value, which caused the temp path to be created at the filesystem root. Use `os.path.abspath()` so empty dirname handling is correct.

##### ISSUE TYPE

- Bugfix Pull Request

##### TESTING

- `python3 -m py_compile lib/ansible/modules/file.py`
- `git diff --check`
- `./bin/ansible-test integration -v --docker ubuntu2404 file`
- `./bin/ansible-test sanity -v --docker default lib/ansible/modules/file.py test/integration/targets/file/tasks/main.yml test/integration/targets/file/tasks/state_link.yml changelogs/fragments/86146-file-relative-link-temp-path.yml`
