### PR TITLE
Fix apt tests to work in ubuntu VM

### DIFF
--- a/test/integration/targets/apt/tasks/apt-multiarch.yml
+++ b/test/integration/targets/apt/tasks/apt-multiarch.yml
@@ -20,7 +20,7 @@
   include_vars: '{{ item }}'
   with_first_found:
   - files:
-    - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
+    - '{{ ansible_facts.distribution }}-{{ ansible_facts.distribution_major_version }}.yml'
     - 'default.yml'
     paths: '../vars'
 

--- a/test/integration/targets/apt/tasks/apt-multiarch.yml
+++ b/test/integration/targets/apt/tasks/apt-multiarch.yml
@@ -20,7 +20,7 @@
   include_vars: '{{ item }}'
   with_first_found:
   - files:
-    - '{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml'
+    - '{{ ansible_facts["distribution"] }}-{{ ansible_facts["distribution_major_version"] }}.yml'
     - 'default.yml'
     paths: '../vars'
 

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -1,69 +1,3 @@
-# UNINSTALL 'python3-apt'
-#  The `apt` module has the smarts to auto-install `python3-apt`.  To test, we
-#  will first uninstall `python3-apt`.
-- name: uninstall python3-apt with apt
-  apt:
-    pkg: python3-apt
-    state: absent
-    purge: yes
-  register: apt_result
-
-# In check mode, auto-install of `python3-apt` must fail
-- name: test fail uninstall hello without required apt deps in check mode
-  apt:
-    pkg: hello
-    state: absent
-    purge: yes
-  register: apt_result
-  check_mode: yes
-  ignore_errors: yes
-
-- name: verify fail uninstall hello without required apt deps in check mode
-  assert:
-    that:
-    - apt_result is failed
-    - '"If run normally this module can auto-install it" in apt_result.msg'
-
-- name: check with dpkg
-  shell: dpkg -s python3-apt
-  register: dpkg_result
-  ignore_errors: true
-
-- name: Test the auto_install_module_deps option
-  apt:
-    pkg: hello
-    auto_install_module_deps: false
-  register: r
-  ignore_errors: true
-
-- assert:
-    that:
-      - r is failed
-      - r.msg is contains("Could not import the python3-apt module")
-
-# UNINSTALL 'hello'
-#   With 'python-apt' uninstalled, the first call to 'apt' should install
-#   python-apt without updating the cache.
-- name: uninstall hello with apt and prevent updating the cache
-  apt:
-    pkg: hello
-    state: absent
-    purge: yes
-    update_cache: no
-  register: apt_result
-
-- name: check hello with dpkg
-  shell: dpkg-query -l hello
-  failed_when: False
-  register: dpkg_result
-
-- name: verify uninstall hello with apt and prevent updating the cache
-  assert:
-    that:
-    - "'changed' in apt_result"
-    - apt_result is not changed
-    - "dpkg_result.rc == 1"
-
 - name: Test installing fnmatch package
   apt:
     name:
@@ -88,7 +22,7 @@
 - name: Test update_cache 1 (check mode)
   apt:
     update_cache: true
-    cache_valid_time: 10
+    cache_valid_time: 0
   register: apt_update_cache_1_check_mode
   check_mode: true
 
@@ -118,32 +52,6 @@
       - apt_update_cache_1 is changed
       - apt_update_cache_2_check_mode is not changed
       - apt_update_cache_2 is not changed
-
-- name: uninstall apt bindings with apt again
-  apt:
-    pkg: [python-apt, python3-apt]
-    state: absent
-    purge: yes
-
-# UNINSTALL 'hello'
-#   With 'python-apt' uninstalled, the first call to 'apt' should install
-#   python-apt.
-- name: uninstall hello with apt
-  apt: pkg=hello state=absent purge=yes
-  register: apt_result
-  until: apt_result is success
-
-- name: check hello with dpkg
-  shell: dpkg-query -l hello
-  failed_when: False
-  register: dpkg_result
-
-- name: verify uninstallation of hello
-  assert:
-    that:
-    - "'changed' in apt_result"
-    - apt_result is not changed
-    - "dpkg_result.rc == 1"
 
 # UNINSTALL AGAIN
 - name: uninstall hello with apt
@@ -216,7 +124,9 @@
 
 - name: check hello architecture
   shell: dpkg -s hello | grep Architecture | awk '{print $2}'
-  register: hello_architecture
+  register:
+    hello_deb_architecture: _task.result.stdout_lines | first | regex_replace('(amd64|arm64|i386)v[0-9]+$', '\1')
+    hello_architecture: _task.result.stdout_lines | last
 
 - name: uninstall hello with apt
   apt: pkg=hello state=absent purge=yes
@@ -404,12 +314,15 @@
     purge: yes
     update_cache: no
 
+- name: ensure hello deb is in apt cache for deb install test
+  command: apt-get install --download-only --reinstall -y hello
+
 - name: install deb file
-  apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ hello_architecture.stdout }}.deb"
+  apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ hello_architecture }}.deb"
   register: apt_initial
 
 - name: install deb file again
-  apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ hello_architecture.stdout }}.deb"
+  apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ hello_architecture }}.deb"
   register: apt_secondary
 
 - name: verify installation of hello
@@ -422,7 +335,7 @@
   apt: pkg=hello state=absent purge=yes
 
 - name: install deb file from URL
-  apt: "deb=https://ci-files.testing.ansible.com/test/integration/targets/apt/hello_{{ hello_old_version }}_{{ hello_architecture.stdout }}.deb"
+  apt: "deb=https://ci-files.testing.ansible.com/test/integration/targets/apt/hello_{{ hello_old_version }}_{{ hello_deb_architecture }}.deb"
   register: apt_url
 
 - name: verify installation of hello
@@ -434,7 +347,7 @@
   apt: pkg=hello state=absent purge=yes
 
 - name: force install of deb
-  apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ hello_architecture.stdout }}.deb" force=true
+  apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ hello_architecture }}.deb" force=true
   register: dpkg_force
 
 - name: verify installation of hello
@@ -608,7 +521,7 @@
 
 # https://github.com/ansible/ansible/issues/65325
 - name: Download and install old version of hello (to test allow_change_held_packages option)
-  apt: "deb=https://ci-files.testing.ansible.com/test/integration/targets/apt/hello_{{ hello_old_version }}_{{ hello_architecture.stdout }}.deb"
+  apt: "deb=https://ci-files.testing.ansible.com/test/integration/targets/apt/hello_{{ hello_old_version }}_{{ hello_deb_architecture }}.deb"
   notify:
     - remove package hello
 

--- a/test/integration/targets/apt/tasks/autoinstall-deps.yml
+++ b/test/integration/targets/apt/tasks/autoinstall-deps.yml
@@ -63,4 +63,3 @@
     - "'changed' in apt_result"
     - apt_result is not changed
     - "dpkg_result.rc == 1"
-

--- a/test/integration/targets/apt/tasks/autoinstall-deps.yml
+++ b/test/integration/targets/apt/tasks/autoinstall-deps.yml
@@ -1,0 +1,66 @@
+# UNINSTALL 'python3-apt'
+#  The `apt` module has the smarts to auto-install `python3-apt`.  To test, we
+#  will first uninstall `python3-apt`.
+- name: uninstall python3-apt with apt
+  apt:
+    pkg: python3-apt
+    state: absent
+    purge: yes
+  register: apt_result
+
+# In check mode, auto-install of `python3-apt` must fail
+- name: test fail uninstall hello without required apt deps in check mode
+  apt:
+    pkg: hello
+    state: absent
+    purge: yes
+  register: apt_result
+  check_mode: yes
+  ignore_errors: yes
+
+- name: verify fail uninstall hello without required apt deps in check mode
+  assert:
+    that:
+    - apt_result is failed
+    - '"If run normally this module can auto-install it" in apt_result.msg'
+
+- name: check with dpkg
+  shell: dpkg -s python3-apt
+  register: dpkg_result
+  ignore_errors: true
+
+- name: Test the auto_install_module_deps option
+  apt:
+    pkg: hello
+    auto_install_module_deps: false
+  register: r
+  ignore_errors: true
+
+- assert:
+    that:
+      - r is failed
+      - r.msg is contains("Could not import the python3-apt module")
+
+# UNINSTALL 'hello'
+#   With 'python-apt' uninstalled, the first call to 'apt' should install
+#   python-apt without updating the cache.
+- name: uninstall hello with apt and prevent updating the cache
+  apt:
+    pkg: hello
+    state: absent
+    purge: yes
+    update_cache: no
+  register: apt_result
+
+- name: check hello with dpkg
+  shell: dpkg-query -l hello
+  failed_when: False
+  register: dpkg_result
+
+- name: verify uninstall hello with apt and prevent updating the cache
+  assert:
+    that:
+    - "'changed' in apt_result"
+    - apt_result is not changed
+    - "dpkg_result.rc == 1"
+

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: skip test on unsupported platforms
   meta: end_play
-  when: ansible_distribution not in ('Ubuntu', 'Debian')
+  when: ansible_facts["distribution"] not in ('Ubuntu', 'Debian')
 
 - block:
   - import_tasks: 'apt.yml'

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -6,7 +6,6 @@
   when: ansible_distribution not in ('Ubuntu', 'Debian')
 
 - block:
-
   - import_tasks: 'apt.yml'
 
   - import_tasks: 'apt_deb_depend.yml'

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: skip test on unsupported platforms
   meta: end_play
-  when: ansible_facts["distribution"] not in ('Ubuntu', 'Debian')
+  when: ansible_facts.distribution not in ('Ubuntu', 'Debian')
 
 - block:
   - import_tasks: 'apt.yml'

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -29,7 +29,7 @@
           name: "{{ repodir }}"
           state: absent
 
-  - name: Test python3-apt auto instalation
+  - name: Test python3-apt auto installation
     block:
       - name: Remove packages that depend on python3-apt
         command:

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -6,6 +6,7 @@
   when: ansible_distribution not in ('Ubuntu', 'Debian')
 
 - block:
+
   - import_tasks: 'apt.yml'
 
   - import_tasks: 'apt_deb_depend.yml'
@@ -28,6 +29,23 @@
           name: "{{ repodir }}"
           state: absent
 
+  - name: Test python3-apt auto instalation
+    block:
+      - name: Remove packages that depend on python3-apt
+        command:
+          cmd: apt remove shim-signed -y --allow-remove-essential
+        register: remove_depending
+      - import_tasks: 'autoinstall-deps.yml'
+    always:
+      - name: Reinstall shim-signed
+        apt:
+          name: shim-signed
+          state: present
+          update_cache: no
+        when: not_installed_msg not in remove_depending.stdout
+        vars:
+          not_installed_msg: "Package 'shim-signed' is not installed"
+  
   always:
     - name: Check if the target is managed by ansible-test
       stat:


### PR DESCRIPTION
##### SUMMARY

Fixes the apt integration tests so that they work on `--remote ubuntu/latest` instead of just on docker. (also clears up an integration test)

3 issues fixed:

 - Removes `shim-signed` which depends on `python3-apt` so that `python3-apt` can be removed to test auto install logic.
 - Fixes package architecture resolution.  Docker container only has `arm64` for the `hello` package, but the container provides an `Architecture-Variant: arm64v3`.  This creates an issue for the remote url which does not support the architecture variant.
 - Fixes the use of `ansible_foo` in favor of `ansible_facts["foo"]`

##### ISSUE TYPE

- Test Pull Request
