### PR TITLE
Fix galaxy install over collection symlink

### DIFF
--- a/changelogs/fragments/81350-galaxy-install-symlink.yml
+++ b/changelogs/fragments/81350-galaxy-install-symlink.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - replace an existing collection symlink when force installing a collection.

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -1511,7 +1511,9 @@ def install(collection, path, artifacts_manager):  # FIXME: mv to dataclasses?
         format(coll=to_text(collection), path=collection_path),
     )
 
-    if os.path.exists(b_collection_path):
+    if os.path.islink(b_collection_path):
+        os.unlink(b_collection_path)
+    elif os.path.exists(b_collection_path):
         shutil.rmtree(b_collection_path)
 
     if collection.is_dir:

--- a/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
+++ b/test/integration/targets/ansible-galaxy-collection/tasks/install.yml
@@ -868,6 +868,42 @@
     - install_symlink_actual.results[5].stat.islnk
     - install_symlink_actual.results[5].stat.lnk_target == '../REÅDMÈ.md'
 
+- name: create existing collection replacement target for force install over symlink - {{ test_id }}
+  file:
+    path: '{{ galaxy_dir }}/scratch/symlink-force-target'
+    state: directory
+
+- name: replace installed collection path with symlink before force install - {{ test_id }}
+  file:
+    path: '{{ galaxy_dir }}/ansible_collections/symlink/symlink'
+    src: '{{ galaxy_dir }}/scratch/symlink-force-target'
+    state: link
+    force: true
+
+- name: force install collection over existing symlink - {{ test_id }}
+  command: ansible-galaxy collection install symlink.symlink -s '{{ test_name }}' --force {{ galaxy_verbosity }}
+  environment:
+    ANSIBLE_COLLECTIONS_PATH: '{{ galaxy_dir }}/ansible_collections'
+  register: install_symlink_force
+
+- name: get result of force install collection over existing symlink - {{ test_id }}
+  stat:
+    path: '{{ galaxy_dir }}/ansible_collections/symlink/symlink'
+  register: install_symlink_force_actual
+
+- name: get result of force installed collection manifest - {{ test_id }}
+  stat:
+    path: '{{ galaxy_dir }}/ansible_collections/symlink/symlink/MANIFEST.json'
+  register: install_symlink_force_manifest
+
+- name: assert force install collection over existing symlink - {{ test_id }}
+  assert:
+    that:
+    - '"Installing ''symlink.symlink:1.0.0'' to" in install_symlink_force.stdout'
+    - install_symlink_force_actual.stat.isdir
+    - not install_symlink_force_actual.stat.islnk
+    - install_symlink_force_manifest.stat.isreg
+
 
 # Testing an install from source to check that symlinks to directories
 # are preserved (see issue https://github.com/ansible/ansible/issues/78442)


### PR DESCRIPTION
##### SUMMARY

When force installing a collection, replace an existing collection symlink before extracting the new collection. This preserves the existing directory replacement path while avoiding `shutil.rmtree()` on a symbolic link.

Fixes #81350

##### ISSUE TYPE

- Bugfix Pull Request

##### TESTS

```text
ansible-test units -v --venv --requirements test/units/galaxy/test_collection_install.py --num-workers 1
ansible-test sanity -v --venv --requirements --test changelog lib/ansible/galaxy/collection/__init__.py test/units/galaxy/test_collection_install.py changelogs/fragments/81350-galaxy-install-symlink.yml
```
