### PR TITLE
Mark integration test iptables as needs/root

### DIFF
--- a/test/integration/targets/iptables/aliases
+++ b/test/integration/targets/iptables/aliases
@@ -1,3 +1,4 @@
+needs/root
 shippable/posix/group2
 skip/freebsd
 skip/macos


### PR DESCRIPTION
It installs packages and runs iptables.

##### SUMMARY

Similar to #84487. In downstream Debian we run the tests without this marking as unprivileged user, where it fails.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Test Pull Request
