### PR TITLE
integration test unarchive: Only install language pack on Ubuntu

### DIFF
--- a/test/integration/targets/unarchive/tasks/test_different_language_var.yml
+++ b/test/integration/targets/unarchive/tasks/test_different_language_var.yml
@@ -1,10 +1,11 @@
 - name: test non-ascii with different LANGUAGE
   when: ansible_os_family == 'Debian'
   block:
-    - name: install fr language pack
+    - name: install fr language pack on Ubuntu
       apt:
         name: language-pack-fr
         state: present
+      when: ansible_facts.distribution == 'Ubuntu'
 
     - name: create our unarchive destination
       file:


### PR DESCRIPTION
##### SUMMARY

The language packs are an Ubuntu-specific packaging. On Debian systems (and derivatives) these packages don't exist and the language files are installed by default with the package (as confirmed with `apt-file search tar.mo`)

##### ISSUE TYPE
- Test Pull Request
