### PR TITLE
fix async task timeout error message

### DIFF
--- a/changelogs/fragments/fix-async-timeout-msg.yml
+++ b/changelogs/fragments/fix-async-timeout-msg.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - async - fix error message when the async task did not complete within the requested time.

--- a/lib/ansible/_internal/_task.py
+++ b/lib/ansible/_internal/_task.py
@@ -832,7 +832,7 @@ class UnifiedTaskResult:
 
     ansible_facts: dict[str, t.Any] | None = dataclasses.field(default=None, metadata=import_export())
     async_result: dict[str, t.Any] | None = dataclasses.field(default=None, metadata=export_only())
-    ansible_parsed: bool | None = None  # formerly _ansible_parsed
+    ansible_parsed: bool | None = dataclasses.field(default=None, metadata=import_export(destination=Destination.NOT_CALLBACK))  # formerly _ansible_parsed
     exception: _messages.ErrorSummary | None = dataclasses.field(default=None, metadata=import_export())
     finished: bool | None = dataclasses.field(default=None, metadata=import_export())
     msg: object | None = dataclasses.field(default=None, metadata=import_export())

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -736,7 +736,7 @@ class TaskExecutor:
                 async_failed_utr.failed = True
                 async_failed_utr.async_result = async_utr.as_result_dict()
 
-                if async_failed_utr.ansible_parsed:
+                if async_failed_utr.async_result.pop("ansible_parsed", None):
                     async_failed_utr.msg = "async task did not complete within the requested time - %ss" % self._task.async_val
                 else:
                     async_failed_utr.msg = "async task produced unparsable results"

--- a/test/integration/targets/async_fail/tasks/main.yml
+++ b/test/integration/targets/async_fail/tasks/main.yml
@@ -47,3 +47,15 @@
     that:
       - no_jid is failed
       - no_jid.msg == "No job id was returned by the async task"
+
+- name: run slow action with async timeout
+  command: sleep 3
+  async: 1
+  poll: 1
+  register: timeout_jid
+  ignore_errors: yes
+
+- assert:
+    that:
+      - timeout_jid is failed
+      - timeout_jid.msg == "async task did not complete within the requested time - 1s"


### PR DESCRIPTION
##### SUMMARY

While fixing #87090, I noticed that async tasks report the result as unparsable when a timeout occurs.

##### ISSUE TYPE

- Bugfix Pull Request
