### PR TITLE
Fix test compatibility with pytest >= 9.1

### DIFF
--- a/test/units/module_utils/basic/test_set_mode_if_different.py
+++ b/test/units/module_utils/basic/test_set_mode_if_different.py
@@ -151,7 +151,7 @@ def test_missing_lchmod_is_link(am, mock_stats, mocker, monkeypatch, check_mode)
     mocker.stopall()
 
 
-@pytest.mark.parametrize('stdin,',
+@pytest.mark.parametrize('stdin',
                          ({},),
                          indirect=['stdin'])
 def test_missing_lchmod_is_link_in_sticky_dir(am, mock_stats, mocker):


### PR DESCRIPTION
##### SUMMARY
Pytest 9.1 fixed parametrize to correctly unpack single-element tuple values when using a string argnames with a trailing comma (e.g. "arg,"), treating it like the tuple form ("arg",) (pytest-dev/pytest#719). This causes test_missing_lchmod_is_link_in_sticky_dir to fail because the trailing comma in @pytest.mark.parametrize('stdin,', ...) now makes pytest try to unpack {} as a sequence, finding 0 elements for 1 name.

Remove the spurious trailing comma from 'stdin,'.

Assisted-by: Claude Opus 4.6

##### ISSUE TYPE

- Test Pull Request
