### PR TITLE
Fix role argument spec validation ignoring tags

### DIFF
--- a/changelogs/fragments/82505-role-argspec-tags.yml
+++ b/changelogs/fragments/82505-role-argspec-tags.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Role argument spec validation - the implicit validation task now respects role tags instead of always running, matching the behavior of implicit fact gathering (https://github.com/ansible/ansible/issues/82505).
+  - Role argument spec validation - the implicit validation task no longer runs for roles that have no tasks selected by tags (https://github.com/ansible/ansible/issues/82505).

--- a/changelogs/fragments/82505-role-argspec-tags.yml
+++ b/changelogs/fragments/82505-role-argspec-tags.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Role argument spec validation - the implicit validation task now respects role tags instead of always running, matching the behavior of implicit fact gathering (https://github.com/ansible/ansible/issues/82505).

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -19,6 +19,7 @@ from ansible.errors import AnsibleError
 from ansible.executor.playbook_executor import PlaybookExecutor
 from ansible.module_utils.common.text.converters import to_bytes
 from ansible.playbook.block import Block
+from ansible.playbook.role import prune_orphaned_role_argspec_validation
 from ansible.plugins.loader import add_all_plugin_dirs
 from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.collection_loader._collection_finder import _get_collection_name_from_path, _get_collection_playbook_path
@@ -208,8 +209,12 @@ class PlaybookCLI(CLI):
                             return taskmsg
 
                         all_vars = variable_manager.get_vars(play=play)
+                        filtered_blocks = []
                         for block in play.compile():
                             block = block.filter_tagged_tasks(all_vars)
+                            if block.has_tasks():
+                                filtered_blocks.append(block)
+                        for block in prune_orphaned_role_argspec_validation(filtered_blocks, all_vars):
                             if not block.has_tasks():
                                 continue
                             taskmsg += _process_block(block)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -25,6 +25,7 @@ from ansible import constants as C
 from ansible.errors import AnsibleAssertionError
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.playbook.block import Block
+from ansible.playbook.role import prune_orphaned_role_argspec_validation
 from ansible.playbook.task import Task
 from ansible.utils.display import Display
 
@@ -201,8 +202,15 @@ class PlayIterator:
         # used for the lockstep mechanism in the linear strategy
         self.all_tasks = setup_block.get_tasks()
 
+        filtered_blocks = []
         for block in self._play.compile():
             new_block = block.filter_tagged_tasks(all_vars)
+            if new_block.has_tasks():
+                filtered_blocks.append(new_block)
+
+        # Role argspec validation uses tags: always so it survives filtering; drop it
+        # when the role has no remaining runnable tasks (see issue #82505).
+        for new_block in prune_orphaned_role_argspec_validation(filtered_blocks, all_vars):
             if new_block.has_tasks():
                 self._blocks.append(new_block)
                 self.all_tasks.extend(new_block.get_tasks())

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -38,6 +38,7 @@ from ansible.playbook.taggable import Taggable
 from ansible.plugins.loader import add_all_plugin_dirs
 from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.display import Display
+from ansible.utils.fqcn import add_internal_fqcns
 from ansible.utils.path import is_subpath
 from ansible.utils.vars import combine_vars
 
@@ -51,9 +52,11 @@ if _t.TYPE_CHECKING:
     from ansible.playbook.block import Block
     from ansible.playbook.play import Play
 
-__all__ = ['Role', 'hash_params']
+__all__ = ['Role', 'hash_params', 'prune_orphaned_role_argspec_validation']
 
 _display = Display()
+
+_VALIDATE_ARGUMENT_SPEC_ACTIONS = frozenset(add_internal_fqcns(('validate_argument_spec',)))
 
 
 def hash_params(params):
@@ -399,6 +402,9 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
                 },
             },
             'name': task_name,
+            # Survive tag filtering so we can decide post-filter whether the role
+            # still has work to do; orphaned validation is pruned afterwards.
+            'tags': ['always'],
         }
 
     def _load_role_yaml(self, subdir, main=None, allow_dir=False):
@@ -671,3 +677,149 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
             parent.set_loader(loader)
         for dep in self.get_direct_dependencies():
             dep.set_loader(loader)
+
+
+def _is_role_argspec_validation_task(task) -> bool:
+    """Return True if task is the implicit role argument-spec validation task."""
+    if task.action not in _VALIDATE_ARGUMENT_SPEC_ACTIONS:
+        return False
+    context = task.args.get('validate_args_context') if isinstance(task.args, Mapping) else None
+    return isinstance(context, Mapping) and context.get('type') == 'role'
+
+
+def _is_role_complete_task(task) -> bool:
+    """Return True if task is the implicit meta: role_complete marker."""
+    return (
+        task.action in C._ACTION_META
+        and isinstance(task.args, Mapping)
+        and task.args.get('_raw_params') == 'role_complete'
+    )
+
+
+def _role_had_user_tasks(role: Role) -> bool:
+    """True if the role originally contained any non-validation tasks."""
+    for block in role._task_blocks:
+        for task in block.get_tasks():
+            if not _is_role_argspec_validation_task(task):
+                return True
+    return False
+
+
+def _evaluate_tags_without_always(task, only_tags, skip_tags, all_vars) -> bool:
+    """Evaluate tags as if the task did not have the special ``always`` tag."""
+    saved_tags = task._tags
+    # Clear the task-local tags (``always``) so only inherited role/import tags apply.
+    task._tags = []
+    try:
+        return task.evaluate_tags(only_tags, skip_tags, all_vars)
+    finally:
+        task._tags = saved_tags
+
+
+def _walk_block_tasks(block, callback) -> None:
+    """Invoke callback for every Task in a block tree (including nested blocks)."""
+    from ansible.playbook.block import Block
+
+    def _walk(target):
+        for item in target:
+            if isinstance(item, Block):
+                _walk(item.block)
+                _walk(item.rescue)
+                _walk(item.always)
+            else:
+                callback(item)
+
+    _walk(block.block)
+    _walk(block.rescue)
+    _walk(block.always)
+
+
+def _remove_validation_tasks(block, roles_to_prune: set[int]):
+    """Return a copy of block without argspec validation for roles in roles_to_prune."""
+    from ansible.playbook.block import Block
+
+    def _filter_list(target):
+        filtered = []
+        for item in target:
+            if isinstance(item, Block):
+                new_child = _remove_validation_tasks(item, roles_to_prune)
+                if new_child.has_tasks():
+                    filtered.append(new_child)
+            else:
+                role = getattr(item, '_role', None)
+                if (
+                    role is not None
+                    and id(role) in roles_to_prune
+                    and _is_role_argspec_validation_task(item)
+                ):
+                    continue
+                filtered.append(item)
+        return filtered
+
+    new_block = block.copy(exclude_parent=True, exclude_tasks=True)
+    new_block._parent = block._parent
+    new_block.block = _filter_list(block.block)
+    new_block.rescue = _filter_list(block.rescue)
+    new_block.always = _filter_list(block.always)
+    return new_block
+
+
+def prune_orphaned_role_argspec_validation(blocks, all_vars):
+    """Drop role argspec validation when the role has no runnable tagged tasks.
+
+    The validation task is tagged ``always`` so it survives ``filter_tagged_tasks``.
+    After filtering, keep it only when:
+
+    * at least one non-validation, non-role_complete task from the same role remains, or
+    * the role had no user tasks to begin with (argspec-only) and the role/import tags
+      would select it without relying on ``always``.
+
+    This must consider tasks across all blocks from a role, not a single block, because
+    a surviving task may live in a different block than the validation task.
+    """
+    if not blocks:
+        return blocks
+
+    role_info: dict[int, dict] = {}
+
+    def _collect(task) -> None:
+        role = getattr(task, '_role', None)
+        if role is None:
+            return
+        info = role_info.setdefault(id(role), {
+            'role': role,
+            'validations': [],
+            'has_user_tasks': False,
+            'play': None,
+        })
+        if info['play'] is None and task._parent is not None:
+            info['play'] = task.get_play()
+        if _is_role_argspec_validation_task(task):
+            info['validations'].append(task)
+        elif not _is_role_complete_task(task):
+            info['has_user_tasks'] = True
+
+    for block in blocks:
+        _walk_block_tasks(block, _collect)
+
+    roles_to_prune: set[int] = set()
+    for role_id, info in role_info.items():
+        if not info['validations'] or info['has_user_tasks']:
+            continue
+
+        if _role_had_user_tasks(info['role']):
+            # All real tasks were filtered out; do not validate.
+            roles_to_prune.add(role_id)
+            continue
+
+        # ArgSpec-only role: honor inherited tags without the forced ``always``.
+        play = info['play'] or getattr(blocks[0], '_play', None)
+        only_tags = getattr(play, 'only_tags', None) or frozenset()
+        skip_tags = getattr(play, 'skip_tags', None) or frozenset()
+        if not _evaluate_tags_without_always(info['validations'][0], only_tags, skip_tags, all_vars):
+            roles_to_prune.add(role_id)
+
+    if not roles_to_prune:
+        return blocks
+
+    return [_remove_validation_tasks(block, roles_to_prune) for block in blocks]

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -399,7 +399,6 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
                 },
             },
             'name': task_name,
-            'tags': ['always'],
         }
 
     def _load_role_yaml(self, subdir, main=None, allow_dir=False):

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -49,8 +49,11 @@ from ansible.utils.vars import combine_vars
 #       * https://stackoverflow.com/q/39740632/199513
 #       * https://peps.python.org/pep-0484/#forward-references
 if _t.TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ansible.playbook.block import Block
     from ansible.playbook.play import Play
+    from ansible.playbook.task import Task
 
 __all__ = ['Role', 'hash_params', 'prune_orphaned_role_argspec_validation']
 
@@ -679,7 +682,7 @@ class Role(Base, Conditional, Taggable, CollectionSearch, Delegatable):
             dep.set_loader(loader)
 
 
-def _is_role_argspec_validation_task(task) -> bool:
+def _is_role_argspec_validation_task(task: Task) -> bool:
     """Return True if task is the implicit role argument-spec validation task."""
     if task.action not in _VALIDATE_ARGUMENT_SPEC_ACTIONS:
         return False
@@ -687,7 +690,7 @@ def _is_role_argspec_validation_task(task) -> bool:
     return isinstance(context, Mapping) and context.get('type') == 'role'
 
 
-def _is_role_complete_task(task) -> bool:
+def _is_role_complete_task(task: Task) -> bool:
     """Return True if task is the implicit meta: role_complete marker."""
     return (
         task.action in C._ACTION_META
@@ -705,7 +708,12 @@ def _role_had_user_tasks(role: Role) -> bool:
     return False
 
 
-def _evaluate_tags_without_always(task, only_tags, skip_tags, all_vars) -> bool:
+def _evaluate_tags_without_always(
+    task: Task,
+    only_tags: _t.AbstractSet[str],
+    skip_tags: _t.AbstractSet[str],
+    all_vars: dict[str, _t.Any],
+) -> bool:
     """Evaluate tags as if the task did not have the special ``always`` tag."""
     saved_tags = task._tags
     # Clear the task-local tags (``always``) so only inherited role/import tags apply.
@@ -716,7 +724,7 @@ def _evaluate_tags_without_always(task, only_tags, skip_tags, all_vars) -> bool:
         task._tags = saved_tags
 
 
-def _walk_block_tasks(block, callback) -> None:
+def _walk_block_tasks(block: Block, callback: Callable[[Task], None]) -> None:
     """Invoke callback for every Task in a block tree (including nested blocks)."""
     from ansible.playbook.block import Block
 
@@ -734,7 +742,7 @@ def _walk_block_tasks(block, callback) -> None:
     _walk(block.always)
 
 
-def _remove_validation_tasks(block, roles_to_prune: set[int]):
+def _remove_validation_tasks(block: Block, roles_to_prune: set[int]) -> Block:
     """Return a copy of block without argspec validation for roles in roles_to_prune."""
     from ansible.playbook.block import Block
 
@@ -764,7 +772,10 @@ def _remove_validation_tasks(block, roles_to_prune: set[int]):
     return new_block
 
 
-def prune_orphaned_role_argspec_validation(blocks, all_vars):
+def prune_orphaned_role_argspec_validation(
+    blocks: Sequence[Block],
+    all_vars: dict[str, _t.Any],
+) -> Sequence[Block]:
     """Drop role argspec validation when the role has no runnable tagged tasks.
 
     The validation task is tagged ``always`` so it survives ``filter_tagged_tasks``.
@@ -782,7 +793,7 @@ def prune_orphaned_role_argspec_validation(blocks, all_vars):
 
     role_info: dict[int, dict] = {}
 
-    def _collect(task) -> None:
+    def _collect(task: Task) -> None:
         role = getattr(task, '_role', None)
         if role is None:
             return

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -773,9 +773,9 @@ def _remove_validation_tasks(block: Block, roles_to_prune: set[int]) -> Block:
 
 
 def prune_orphaned_role_argspec_validation(
-    blocks: Sequence[Block],
+    blocks: list[Block],
     all_vars: dict[str, _t.Any],
-) -> Sequence[Block]:
+) -> list[Block]:
     """Drop role argspec validation when the role has no runnable tagged tasks.
 
     The validation task is tagged ``always`` so it survives ``filter_tagged_tasks``.

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -36,6 +36,7 @@ from ansible._internal import _task
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.playbook.handler import Handler
 from ansible.playbook.included_file import IncludedFile
+from ansible.playbook.role import prune_orphaned_role_argspec_validation
 from ansible.plugins.loader import action_loader
 from ansible.plugins.strategy import StrategyBase
 from ansible._internal._templating._engine import TemplateEngine
@@ -275,11 +276,15 @@ class StrategyModule(StrategyBase):
                             self._tqm._stats.increment('ok', host.name)
                         self._tqm.send_callback('v2_playbook_on_include', included_file)
 
+                    filtered_blocks = []
                     for new_block in new_blocks:
                         if is_handler:
                             for task in new_block.block:
                                 task.notified_hosts = included_file._hosts[:]
                             final_block = new_block
+                            for host in hosts_left:
+                                if host in included_file._hosts:
+                                    all_blocks[host].append(final_block)
                         else:
                             task_vars = self._variable_manager.get_vars(
                                 play=iterator._play,
@@ -287,10 +292,16 @@ class StrategyModule(StrategyBase):
                                 _hosts=self._hosts_cache,
                                 _hosts_all=self._hosts_cache_all,
                             )
-                            final_block = new_block.filter_tagged_tasks(task_vars)
-                        for host in hosts_left:
-                            if host in included_file._hosts:
-                                all_blocks[host].append(final_block)
+                            filtered_blocks.append((new_block.filter_tagged_tasks(task_vars), task_vars))
+
+                    if not is_handler:
+                        # new_blocks from one include share tag filtering vars from the include
+                        blocks_only = [b for b, _v in filtered_blocks]
+                        task_vars = filtered_blocks[0][1] if filtered_blocks else {}
+                        for final_block in prune_orphaned_role_argspec_validation(blocks_only, task_vars):
+                            for host in hosts_left:
+                                if host in included_file._hosts:
+                                    all_blocks[host].append(final_block)
                     display.debug("done collecting new blocks for %s" % included_file)
 
                 for host in failed_includes_hosts:

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -34,6 +34,7 @@ from ansible._internal import _task
 from ansible.errors import AnsibleError, AnsibleAssertionError, AnsibleParserError, AnsibleValueOmittedError, AnsibleUndefinedVariable
 from ansible.playbook.handler import Handler
 from ansible.playbook.included_file import IncludedFile
+from ansible.playbook.role import prune_orphaned_role_argspec_validation
 from ansible.plugins.action import ActionBase
 from ansible.plugins.loader import action_loader
 from ansible.plugins.strategy import StrategyBase
@@ -278,11 +279,12 @@ class StrategyModule(StrategyBase):
                             iterator.handlers = [h for b in iterator._play.handlers for h in b.block]
 
                             display.debug("iterating over new_blocks loaded from include file")
+                            filtered_blocks = []
                             for new_block in new_blocks:
                                 if is_handler:
                                     for task in new_block.block:
                                         task.notified_hosts = included_file._hosts[:]
-                                    final_block = new_block
+                                    filtered_blocks.append(new_block)
                                 else:
                                     task_vars = self._variable_manager.get_vars(
                                         play=iterator._play,
@@ -291,9 +293,19 @@ class StrategyModule(StrategyBase):
                                         _hosts_all=self._hosts_cache_all,
                                     )
                                     display.debug("filtering new block on tags")
-                                    final_block = new_block.filter_tagged_tasks(task_vars)
+                                    filtered_blocks.append(new_block.filter_tagged_tasks(task_vars))
                                     display.debug("done filtering new block on tags")
 
+                            if not is_handler and filtered_blocks:
+                                task_vars = self._variable_manager.get_vars(
+                                    play=iterator._play,
+                                    task=filtered_blocks[0].get_first_parent_include(),
+                                    _hosts=self._hosts_cache,
+                                    _hosts_all=self._hosts_cache_all,
+                                )
+                                filtered_blocks = prune_orphaned_role_argspec_validation(filtered_blocks, task_vars)
+
+                            for final_block in filtered_blocks:
                                 included_tasks.extend(final_block.get_tasks())
 
                                 for host in hosts_left:

--- a/test/integration/targets/roles_arg_spec/roles/mixed_tags/meta/argument_specs.yml
+++ b/test/integration/targets/roles_arg_spec/roles/mixed_tags/meta/argument_specs.yml
@@ -1,0 +1,7 @@
+argument_specs:
+    main:
+        short_description: Main entry point for mixed_tags role.
+        options:
+            mixed_str:
+                type: "str"
+                required: true

--- a/test/integration/targets/roles_arg_spec/roles/mixed_tags/tasks/main.yml
+++ b/test/integration/targets/roles_arg_spec/roles/mixed_tags/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- debug:
+    msg: "untagged task in mixed_tags with {{ mixed_str }}"
+
+- debug:
+    msg: "bar-tagged task in mixed_tags with {{ mixed_str }}"
+  tags:
+    - bar

--- a/test/integration/targets/roles_arg_spec/runme.sh
+++ b/test/integration/targets/roles_arg_spec/runme.sh
@@ -27,8 +27,10 @@ test $? -ne 0
 set -e
 
 VALIDATION_TASK="Validating arguments against arg spec 'main' - Main entry point for role A."
+MIXED_VALIDATION="Validating arguments against arg spec 'main' - Main entry point for mixed_tags role."
+EMPTY_VALIDATION="Validating arguments against arg spec 'main' - Main entry point for role role_with_no_tasks."
 
-# Test that a role's validation task respects tags like any other role task.
+# Tagged import_role: validation runs only for roles that still have work to do.
 
 # When running with --tags foo, only the foo-tagged role should validate.
 output=$(ansible-playbook test_tags.yml -i ../../inventory "$@" --tags foo)
@@ -45,3 +47,26 @@ test "$(echo "$output" | grep -c "$VALIDATION_TASK")" = 2
 # Without any tag filter, all roles validate.
 output=$(ansible-playbook test_tags.yml -i ../../inventory "$@")
 test "$(echo "$output" | grep -c "$VALIDATION_TASK")" = 3
+
+# Mixed role/task tags (mkrizek): role tagged foo, task tagged bar.
+# --tags bar still executes a role task, so validation must run for both invocations.
+output=$(ansible-playbook test_tags_mixed.yml -i ../../inventory "$@" --tags bar)
+test "$(echo "$output" | grep -c "$MIXED_VALIDATION")" = 2
+echo "$output" | grep -q "bar-tagged task in mixed_tags"
+
+# --skip-tags bar leaves the untagged role task runnable, so validation must still run.
+output=$(ansible-playbook test_tags_mixed.yml -i ../../inventory "$@" --skip-tags bar)
+test "$(echo "$output" | grep -c "$MIXED_VALIDATION")" = 2
+echo "$output" | grep -q "untagged task in mixed_tags"
+test "$(echo "$output" | grep -c "bar-tagged task in mixed_tags")" = 0
+
+# Fully skipped role (no matching tags) should not validate.
+output=$(ansible-playbook test_tags_mixed.yml -i ../../inventory "$@" --tags unrelated)
+test "$(echo "$output" | grep -c "$MIXED_VALIDATION")" = 0
+
+# Empty (argspec-only) role: matching tags validate; non-matching do not.
+output=$(ansible-playbook test_tags_empty_role.yml -i ../../inventory "$@" --tags empty_role)
+test "$(echo "$output" | grep -c "$EMPTY_VALIDATION")" = 1
+
+output=$(ansible-playbook test_tags_empty_role.yml -i ../../inventory "$@" --tags nomatch)
+test "$(echo "$output" | grep -c "$EMPTY_VALIDATION")" = 0

--- a/test/integration/targets/roles_arg_spec/runme.sh
+++ b/test/integration/targets/roles_arg_spec/runme.sh
@@ -26,7 +26,22 @@ ansible-playbook test_play_level_role_fails.yml -i ../../inventory "$@"
 test $? -ne 0
 set -e
 
-# Test the validation task is tagged with 'always' by specifying an unused tag.
-# The task is tagged with 'foo' but we use 'bar' in the call below and expect
-# the validation task to run anyway since it is tagged 'always'.
-ansible-playbook test_tags.yml -i ../../inventory "$@" --tags bar | grep "a : Validating arguments against arg spec 'main' - Main entry point for role A."
+VALIDATION_TASK="Validating arguments against arg spec 'main' - Main entry point for role A."
+
+# Test that a role's validation task respects tags like any other role task.
+
+# When running with --tags foo, only the foo-tagged role should validate.
+output=$(ansible-playbook test_tags.yml -i ../../inventory "$@" --tags foo)
+test "$(echo "$output" | grep -c "$VALIDATION_TASK")" = 1
+
+# When running with a tag that matches no role, nothing validates.
+output=$(ansible-playbook test_tags.yml -i ../../inventory "$@" --tags bar)
+test "$(echo "$output" | grep -c "$VALIDATION_TASK")" = 0
+
+# When running with --skip-tags on a role's tag, that role's validation is skipped.
+output=$(ansible-playbook test_tags.yml -i ../../inventory "$@" --skip-tags foo)
+test "$(echo "$output" | grep -c "$VALIDATION_TASK")" = 2
+
+# Without any tag filter, all roles validate.
+output=$(ansible-playbook test_tags.yml -i ../../inventory "$@")
+test "$(echo "$output" | grep -c "$VALIDATION_TASK")" = 3

--- a/test/integration/targets/roles_arg_spec/test_tags.yml
+++ b/test/integration/targets/roles_arg_spec/test_tags.yml
@@ -1,11 +1,34 @@
 ---
+# Test 1: Tagged role with matching tag - validation should run
 - hosts: localhost
   gather_facts: false
   tasks:
-      - name: "Tag test #1"
+      - name: "Tagged role with matching tag"
         import_role:
             name: a
         vars:
-            a_str: "tag test #1"
+            a_str: "tagged role matching"
         tags:
             - foo
+
+# Test 2: Tagged role with non-matching tag - validation should NOT run
+- hosts: localhost
+  gather_facts: false
+  tasks:
+      - name: "Tagged role with non-matching tag"
+        import_role:
+            name: a
+        vars:
+            a_str: "tagged role non-matching"
+        tags:
+            - baz
+
+# Test 3: Untagged role - validation runs only when no tag filter is active
+- hosts: localhost
+  gather_facts: false
+  tasks:
+      - name: "Untagged role"
+        import_role:
+            name: a
+        vars:
+            a_str: "untagged role"

--- a/test/integration/targets/roles_arg_spec/test_tags_empty_role.yml
+++ b/test/integration/targets/roles_arg_spec/test_tags_empty_role.yml
@@ -1,0 +1,13 @@
+---
+# ArgSpec-only role (no tasks). Validation should follow role/import tags
+# without the forced always behavior.
+- hosts: localhost
+  gather_facts: false
+  roles:
+    - role: role_with_no_tasks
+      tags: empty_role
+      a_str: "empty role matching"
+
+    - role: role_with_no_tasks
+      tags: other_empty
+      a_str: "empty role non-matching"

--- a/test/integration/targets/roles_arg_spec/test_tags_mixed.yml
+++ b/test/integration/targets/roles_arg_spec/test_tags_mixed.yml
@@ -1,0 +1,21 @@
+---
+# Role tagged foo with an inner task tagged bar (mkrizek's review case).
+# --tags bar must still run validation because a role task executes.
+- hosts: localhost
+  gather_facts: false
+  roles:
+    - role: mixed_tags
+      tags: foo
+      mixed_str: "roles keyword mixed tags"
+
+# Same scenario via import_role.
+- hosts: localhost
+  gather_facts: false
+  tasks:
+      - name: "import_role with role-level tags and mixed task tags"
+        import_role:
+            name: mixed_tags
+        vars:
+            mixed_str: "import_role mixed tags"
+        tags:
+            - foo


### PR DESCRIPTION
##### SUMMARY

The implicit "Validating arguments against arg spec" task was hardcoded with `tags: ['always']`, so it ran even when tag filtering skipped every task in the role. Users running `--tags foo` would see validation (and possible failures) for unrelated roles.

Simply removing `always` (or copying only the role's tags onto the validation task) is not correct: a role tagged `foo` can still execute a task tagged `bar` under `--tags bar`, and validation must still run in that case. There is also no static tag set that handles both `--tags` and `--skip-tags` correctly when sibling tasks have different tags (see discussion on #82505 / #82670).

This PR keeps the validation task tagged `always` so it survives `filter_tagged_tasks`, then **prunes it after filtering** unless the role still has runnable work:

- If any non-validation, non-`meta: role_complete` task from the role remains → keep validation (covers mixed role/task tags).
- If the role had tasks but all were filtered out → drop validation (fixes #82505).
- If the role is argspec-only (no tasks) → keep validation only when inherited role/import tags would select it without relying on `always`.

The prune runs across all filtered blocks for a role (validation and surviving tasks may live in different blocks) and is hooked from `PlayIterator`, `include_role` handling in the linear/free strategies, and `--list-tasks`.

Fixes #82505
Closes #82670

Also resolves the downstream issue reported at https://github.com/redhat-cop/infra.aap_configuration/issues/1351

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`lib/ansible/playbook/role/__init__.py`

##### ADDITIONAL INFORMATION

**Behavior:**

| Scenario | Before | After |
|---|---|---|
| Role tagged `foo`, run `--tags foo` | Validation runs | Validation runs |
| Role tagged `foo`, no matching tasks, run `--tags bar` | **Validation runs (bug)** | Validation skipped |
| Role tagged `foo`, task tagged `bar`, run `--tags bar` | Validation runs | Validation runs |
| Role tagged `foo`, untagged + `bar` tasks, `--skip-tags bar` | Validation runs | Validation runs |
| Untagged role, run `--tags bar` | **Validation runs (bug)** | Validation skipped |
| ArgSpec-only role tagged `foo`, `--tags foo` / `--tags bar` | always / always | runs / skipped |

**Tests added** in `roles_arg_spec`:
- import_role tag filtering (fully skipped roles)
- mixed role/task tags via `roles:` and `import_role` (mkrizek's case + `--skip-tags`)
- empty/argspec-only roles