### PR TITLE
Include origin in error for invalid config choice

### DIFF
--- a/changelogs/fragments/invalid-config-choice-origin.yml
+++ b/changelogs/fragments/invalid-config-choice-origin.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- config - Include the origin in error message indicating an invalid choice in a configuration value

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -222,7 +222,7 @@ def _ensure_type(value: object, value_type: str | None, origin: str | None = Non
             # FIXME: define and document a pass-through value_type (None, 'raw', 'object', '', ...) and then deprecate acceptance of unknown types
             return value  # return non-str values of unknown value_type as-is
 
-    raise ValueError(f'Invalid value provided for {value_type!r}: {original_value!r}')
+    raise ValueError(f'Invalid value provided for {value_type!r}: {original_value!r}.')
 
 
 # FIXME: see if this can live in utils/path
@@ -701,8 +701,10 @@ class ConfigManager:
                     origin = 'default'
                     value = ensure_type(defs[config].get('default'), defs[config].get('type'), origin=origin, origin_ftype=origin_ftype)
                 else:
+                    value_type = defs[config].get('type')
                     raise AnsibleOptionsError(
-                        f'Config {_get_config_label(plugin_type, plugin_name, config)} from {origin!r} has an invalid value {value!r}.'
+                        f'Config {_get_config_label(plugin_type, plugin_name, config)} from {origin!r} has an invalid value.',
+                        help_text=f'Value must be of type {value_type!r}.',
                     ) from ex
 
             # deal with restricted values
@@ -728,7 +730,7 @@ class ConfigManager:
 
                     raise AnsibleOptionsError(
                         f'Config {_get_config_label(plugin_type, plugin_name, config)} from {origin!r} has an invalid value {value!r}.',
-                        help_text=f'Valid values are: {valid}'
+                        help_text=f'Valid values are: {valid}.',
                     )
 
             # deal with deprecation of the setting

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -701,7 +701,9 @@ class ConfigManager:
                     origin = 'default'
                     value = ensure_type(defs[config].get('default'), defs[config].get('type'), origin=origin, origin_ftype=origin_ftype)
                 else:
-                    raise AnsibleOptionsError(f'Config {_get_config_label(plugin_type, plugin_name, config)} from {origin!r} has an invalid value.') from ex
+                    raise AnsibleOptionsError(
+                        f'Config {_get_config_label(plugin_type, plugin_name, config)} from {origin!r} has an invalid value {value!r}.'
+                    ) from ex
 
             # deal with restricted values
             if value is not None and 'choices' in defs[config] and defs[config]['choices'] is not None:
@@ -725,7 +727,7 @@ class ConfigManager:
                         valid = defs[config]['choices']
 
                     raise AnsibleOptionsError(
-                        f'Config {_get_config_label(plugin_type, plugin_name, config)} from {origin!r} has an invalid value.',
+                        f'Config {_get_config_label(plugin_type, plugin_name, config)} from {origin!r} has an invalid value {value!r}.',
                         help_text=f'Valid values are: {valid}'
                     )
 

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -724,8 +724,10 @@ class ConfigManager:
                     else:
                         valid = defs[config]['choices']
 
-                    raise AnsibleOptionsError(f'Invalid value {value!r} for config {_get_config_label(plugin_type, plugin_name, config)}.',
-                                              help_text=f'Valid values are: {valid}')
+                    raise AnsibleOptionsError(
+                        f'Config {_get_config_label(plugin_type, plugin_name, config)} from {origin!r} has an invalid value.',
+                        help_text=f'Valid values are: {valid}'
+                    )
 
             # deal with deprecation of the setting
             if 'deprecated' in defs[config] and origin != 'default':

--- a/test/integration/targets/config/runme.sh
+++ b/test/integration/targets/config/runme.sh
@@ -8,6 +8,9 @@ ANSIBLE_TIMEOUT='' ansible -m ping testhost -i ../../inventory "$@"
 # env var is wrong type, this should be a fatal error pointing at the setting
 ANSIBLE_TIMEOUT='lola' ansible -m ping testhost -i ../../inventory "$@" 2>&1 | grep "Config 'DEFAULT_TIMEOUT' from 'env: ANSIBLE_TIMEOUT' has an invalid value"
 
+#env var is not in choices, this should be a fatail error pointing at the setting
+ANSIBLE_DISPLAY_TRACEBACK='lola' ansible-config dump 2>&1 | grep "Config 'DISPLAY_TRACEBACK' from 'env: ANSIBLE_DISPLAY_TRACEBACK' has an invalid value."
+
 # https://github.com/ansible/ansible/issues/69577
 ANSIBLE_REMOTE_TMP="$HOME/.ansible/directory_with_no_space"  ansible -m ping testhost -i ../../inventory "$@"
 

--- a/test/integration/targets/config/runme.sh
+++ b/test/integration/targets/config/runme.sh
@@ -8,7 +8,7 @@ ANSIBLE_TIMEOUT='' ansible -m ping testhost -i ../../inventory "$@"
 # env var is wrong type, this should be a fatal error pointing at the setting
 ANSIBLE_TIMEOUT='lola' ansible -m ping testhost -i ../../inventory "$@" 2>&1 | grep "Config 'DEFAULT_TIMEOUT' from 'env: ANSIBLE_TIMEOUT' has an invalid value"
 
-#env var is not in choices, this should be a fatail error pointing at the setting
+#env var is not in choices, this should be a fatal error pointing at the setting
 ANSIBLE_DISPLAY_TRACEBACK='lola' ansible-config dump 2>&1 | grep "Config 'DISPLAY_TRACEBACK' from 'env: ANSIBLE_DISPLAY_TRACEBACK' has an invalid value."
 
 # https://github.com/ansible/ansible/issues/69577

--- a/test/integration/targets/config/validation.yml
+++ b/test/integration/targets/config/validation.yml
@@ -13,7 +13,7 @@
       assert:
         that:
           - bad_input is failed
-          - '"Invalid value " in bad_input.msg'
+          - '"invalid value" in bad_input.msg'
 
     - name: test config option casting
       set_fact:

--- a/test/integration/targets/lookup_config/tasks/main.yml
+++ b/test/integration/targets/lookup_config/tasks/main.yml
@@ -108,7 +108,7 @@
       - lookup_config_4 is success
       - 'lookup4|length == 0'
       - lookup_config_5 is failed
-      - lookup_config_5.msg is contains "Invalid value 'boo'"
+      - lookup_config_5.msg is contains "invalid value 'boo'"
       - lookup_config_6 is failed
       - '"Invalid setting identifier" in lookup_config_6.msg'
       - lookup_config_7 is failed


### PR DESCRIPTION
##### SUMMARY

Include origin in error for invalid config choice

I've updated the exception to match the wording of the invalid type coercion error that happens earlier.

##### ISSUE TYPE

- Bugfix Pull Request