### PR TITLE
ansible-galaxy: add support for version: "latest" in requirements

### DIFF
--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -401,7 +401,7 @@ class CollectionDependencyProvider(AbstractProvider):
         if (
                 requirement.is_virtual or
                 candidate.is_virtual or
-                requirement.ver == '*'
+                requirement.ver in ('*', 'latest')
         ):
             return True
 

--- a/lib/ansible/galaxy/dependency_resolution/versioning.py
+++ b/lib/ansible/galaxy/dependency_resolution/versioning.py
@@ -52,7 +52,7 @@ def meets_requirements(version: str, requirements: str) -> bool:
             requirement = req
             op = operator.eq
 
-        if requirement == '*' or version == '*':
+        if requirement in ('*', 'latest') or version in ('*', 'latest'):
             continue
 
         if not op(


### PR DESCRIPTION
##### SUMMARY

Adds `"latest"` as a valid version specifier in collection requirements files. When specified, the resolver picks the highest non-pre-release version available.

Complements [pulp/pulp_ansible#2563](https://github.com/pulp/pulp_ansible/pull/2563) so `version: "latest"` works consistently across `ansible-galaxy` and Pulp sync.

##### WHAT CHANGED

- `versioning.py` - `meets_requirements()` treats `"latest"` like `"*"` to skip semver comparison
- `providers.py` - `is_satisfied_by()` treats `"latest"` like `"*"` to accept any candidate

The resolver already sorts candidates newest-first and filters pre-releases, so `"latest"` naturally resolves to the highest stable version.

Related: [AAP-50432](https://redhat.atlassian.net/browse/AAP-50432)

Assisted-by: Claude Code, model: claude-opus-4-6 <noreply@anthropic.com>