### PR TITLE
Add `ansible_distribution_cpe_name()` to get `CPE_NAME`

### DIFF
--- a/changelogs/fragments/distribution-cpe-name-fact.yml
+++ b/changelogs/fragments/distribution-cpe-name-fact.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - distribution facts - add the ``ansible_distribution_cpe_name`` fact, exposing the ``CPE_NAME`` published in the os-release file when the distribution provides one.

--- a/lib/ansible/module_utils/common/sys_info.py
+++ b/lib/ansible/module_utils/common/sys_info.py
@@ -108,6 +108,19 @@ def get_distribution_codename():
     return codename
 
 
+def get_distribution_cpe_name():
+    """
+    Return the CPE (Common Platform Enumeration) name for this OS distribution
+    as published in the ``CPE_NAME`` field of the os-release file, or None if
+    it is not available (the field is unset or there is no os-release file).
+
+    This reads the os-release file directly (via the bundled ``distro`` library)
+    so it works for any OS that ships one, including non-Linux systems such as
+    FreeBSD and Solaris.
+    """
+    return distro.os_release_info().get('cpe_name') or None
+
+
 def get_platform_subclass(cls):
     """
     Finds a subclass implementing desired functionality on the platform the code is running on

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -11,7 +11,7 @@ import re
 import typing as t
 
 from ansible.module_utils.common.sys_info import get_distribution, get_distribution_version, \
-    get_distribution_codename
+    get_distribution_codename, get_distribution_cpe_name
 from ansible.module_utils.facts.utils import get_file_content, get_file_lines
 from ansible.module_utils.facts.collector import BaseFactCollector
 
@@ -631,6 +631,9 @@ class Distribution(object):
         # look for an os family alias for the 'distribution', if there isn't one, use 'distribution'
         distribution_facts['os_family'] = self.OS_FAMILY.get(distro, None) or distro
 
+        # CPE name as published in the os-release file (when the distro provides one)
+        distribution_facts['distribution_cpe_name'] = get_distribution_cpe_name()
+
         return distribution_facts
 
     def get_distribution_AIX(self):
@@ -768,6 +771,7 @@ class DistributionFactCollector(BaseFactCollector):
     _fact_ids = set(['distribution_version',
                      'distribution_release',
                      'distribution_major_version',
+                     'distribution_cpe_name',
                      'os_family'])  # type: t.Set[str]
 
     def collect(self, module=None, collected_facts=None):

--- a/lib/ansible/modules/setup.py
+++ b/lib/ansible/modules/setup.py
@@ -18,7 +18,7 @@ options:
             - "If supplied, restrict the additional facts collected to the given subset.
               Possible values: V(all), V(all_ipv4_addresses), V(all_ipv6_addresses), V(apparmor), V(architecture),
               V(caps), V(chroot),V(cmdline), V(date_time), V(default_ipv4), V(default_ipv6), V(devices),
-              V(distribution), V(distribution_major_version), V(distribution_release), V(distribution_version),
+              V(distribution), V(distribution_cpe_name), V(distribution_major_version), V(distribution_release), V(distribution_version),
               V(dns), V(effective_group_ids), V(effective_user_id), V(env), V(facter), V(fips), V(hardware),
               V(interfaces), V(is_chroot), V(iscsi), V(kernel), V(local), V(lsb), V(machine), V(machine_id),
               V(mounts), V(network), V(ohai), V(os_family), V(pkg_mgr), V(platform), V(processor), V(processor_cores),

--- a/test/integration/targets/gathering_facts/test_gathering_facts.yml
+++ b/test/integration/targets/gathering_facts/test_gathering_facts.yml
@@ -26,6 +26,8 @@
             # these are true for linux, but maybe not for other os
           - 'ansible_system|default("UNDEF") != "UNDEF"'
           - 'ansible_distribution|default("UNDEF") != "UNDEF"'
+            # always emitted by the distribution collector (null when the distro has no CPE_NAME)
+          - 'ansible_distribution_cpe_name is defined'
             # we dont really require these but they are in the min set
             # - 'ansible_virtualization_role|default("UNDEF") == "UNDEF"'
             # - 'ansible_user_id|default("UNDEF") == "UNDEF"'

--- a/test/units/module_utils/facts/system/distribution/fixtures/almalinux_8_3_beta.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/almalinux_8_3_beta.json
@@ -43,6 +43,7 @@
         "Purple Manul"
     ],
     "result": {
+        "distribution_cpe_name": "cpe:/o:almalinux:almalinux:8.3:beta",
         "distribution": "AlmaLinux",
         "distribution_version": "8.3",
         "distribution_release": "Purple Manul",

--- a/test/units/module_utils/facts/system/distribution/fixtures/amazon_linux_2.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/amazon_linux_2.json
@@ -10,6 +10,7 @@
     },
     "name": "Amazon 2",
     "result": {
+        "distribution_cpe_name": "cpe:2.3:o:amazon:amazon_linux:2",
         "distribution_release": "NA",
         "distribution": "Amazon",
         "distribution_major_version": "2",

--- a/test/units/module_utils/facts/system/distribution/fixtures/amazon_linux_2016.03.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/amazon_linux_2016.03.json
@@ -2,6 +2,7 @@
     "name": "Amazon 2016.03",
     "platform.release": "4.14.94-73.73.amzn1.x86_64",
     "result": {
+        "distribution_cpe_name": "cpe:/o:amazon:linux:2016.03:ga",
         "distribution_release": "NA",
         "distribution": "Amazon",
         "distribution_major_version": "2016",

--- a/test/units/module_utils/facts/system/distribution/fixtures/amazon_linux_2018.03.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/amazon_linux_2018.03.json
@@ -2,6 +2,7 @@
     "name": "Amazon 2018.03",
     "platform.release": "4.14.94-73.73.amzn1.x86_64",
     "result": {
+        "distribution_cpe_name": "cpe:/o:amazon:linux:2018.03:ga",
         "distribution_release": "NA",
         "distribution": "Amazon",
         "distribution_major_version": "2018",

--- a/test/units/module_utils/facts/system/distribution/fixtures/centos_8_1.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/centos_8_1.json
@@ -44,6 +44,7 @@
         "Core"
     ],
     "result": {
+        "distribution_cpe_name": "cpe:/o:centos:centos:8",
         "distribution": "CentOS",
         "distribution_version": "8.1",
         "distribution_release": "Core",

--- a/test/units/module_utils/facts/system/distribution/fixtures/centos_stream_8.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/centos_stream_8.json
@@ -36,6 +36,7 @@
         ""
     ],
     "result": {
+        "distribution_cpe_name": "cpe:/o:centos:centos:8",
         "distribution": "CentOS",
         "distribution_version": "8",
         "distribution_release": "Stream",

--- a/test/units/module_utils/facts/system/distribution/fixtures/eurolinux_8.5.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/eurolinux_8.5.json
@@ -36,6 +36,7 @@
         "Tirana"
     ],
     "result": {
+        "distribution_cpe_name": "cpe:/o:eurolinux:eurolinux:8",
         "distribution": "EuroLinux",
         "distribution_version": "8.5",
         "distribution_release": "Tirana",

--- a/test/units/module_utils/facts/system/distribution/fixtures/fedora_31.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/fedora_31.json
@@ -46,6 +46,7 @@
     },
     "platform.dist": ["fedora", "31", ""],
     "result": {
+        "distribution_cpe_name": "cpe:/o:fedoraproject:fedora:31",
         "distribution": "Fedora",
         "distribution_version": "31",
         "distribution_release": "",

--- a/test/units/module_utils/facts/system/distribution/fixtures/flatcar_3139.2.0.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/flatcar_3139.2.0.json
@@ -33,6 +33,7 @@
         ""
     ],
     "result": {
+        "distribution_cpe_name": "cpe:2.3:o:flatcar-linux:flatcar_linux:3139.2.0:*:*:*:*:*:*:*",
         "distribution": "Flatcar",
         "distribution_version": "3139.2.0",
         "distribution_release": "NA",

--- a/test/units/module_utils/facts/system/distribution/fixtures/opensuse_leap_15.1.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/opensuse_leap_15.1.json
@@ -27,6 +27,7 @@
     },
     "platform.dist": ["opensuse-leap", "15.1", ""],
     "result": {
+        "distribution_cpe_name": "cpe:/o:opensuse:leap:15.1",
         "distribution": "openSUSE Leap",
         "distribution_version": "15.1",
         "distribution_release": "1",

--- a/test/units/module_utils/facts/system/distribution/fixtures/redhat_7.7.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/redhat_7.7.json
@@ -34,6 +34,7 @@
     },
     "platform.dist": ["rhel", "7.7", "Maipo"],
     "result": {
+        "distribution_cpe_name": "cpe:/o:redhat:enterprise_linux:7.7:GA:server",
         "distribution": "RedHat",
         "distribution_version": "7.7",
         "distribution_release": "Maipo",

--- a/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/rockylinux_8_3.json
@@ -36,6 +36,7 @@
         ""
     ],
     "result": {
+        "distribution_cpe_name": "cpe:/o:rocky:rocky:8",
         "distribution": "Rocky",
         "distribution_version": "8.3",
         "distribution_release": "NA",

--- a/test/units/module_utils/facts/system/distribution/fixtures/sles_15_6.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/sles_15_6.json
@@ -28,6 +28,7 @@
         ""
     ],
     "result": {
+        "distribution_cpe_name": "cpe:/o:suse:sles:15:sp6",
         "distribution": "SLES",
         "distribution_version": "15.6",
         "distribution_release": "6",

--- a/test/units/module_utils/facts/system/distribution/fixtures/sles_16_0.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/sles_16_0.json
@@ -35,6 +35,7 @@
         ""
     ],
     "result": {
+        "distribution_cpe_name": "cpe:/o:suse:sles:16:16.0",
         "distribution": "SLES",
         "distribution_version": "16.0",
         "distribution_release": "0",

--- a/test/units/module_utils/facts/system/distribution/fixtures/sles_sap_15_6.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/sles_sap_15_6.json
@@ -28,6 +28,7 @@
         ""
     ],
     "result": {
+        "distribution_cpe_name": "cpe:/o:suse:sles:15:sp6",
         "distribution": "SLES_SAP",
         "distribution_version": "15.6",
         "distribution_release": "6",

--- a/test/units/module_utils/facts/system/distribution/fixtures/sles_sap_16_0.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/sles_sap_16_0.json
@@ -35,6 +35,7 @@
         ""
     ],
     "result": {
+        "distribution_cpe_name": "cpe:/o:suse:sles:16:16.0",
         "distribution": "SLES_SAP",
         "distribution_version": "16.0",
         "distribution_release": "0",

--- a/test/units/module_utils/facts/system/distribution/fixtures/solaris_11.4.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/solaris_11.4.json
@@ -26,6 +26,7 @@
     },
     "platform.system": "SunOS",
     "result": {
+        "distribution_cpe_name": "cpe:/o:oracle:solaris:11:4",
         "distribution_release": "Oracle Solaris 11.4 SPARC",
         "distribution": "Solaris",
         "os_family": "Solaris",

--- a/test/units/module_utils/facts/system/distribution/fixtures/tencentos_3_1.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/tencentos_3_1.json
@@ -40,6 +40,7 @@
         "Final"
     ],
     "result": {
+        "distribution_cpe_name": "cpe:/o:tencentos:tencentos:3",
         "distribution": "TencentOS",
         "distribution_version": "3.1",
         "distribution_release": "Final",

--- a/test/units/module_utils/facts/system/distribution/fixtures/truenas_12.0rc1.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/truenas_12.0rc1.json
@@ -28,6 +28,7 @@
         ""
     ],
     "result": {
+        "distribution_cpe_name": "cpe:/o:freebsd:freebsd:12.2",
         "distribution": "FreeBSD",
         "distribution_version": "12.2",
         "distribution_release": "12.2-PRERELEASE",

--- a/test/units/module_utils/facts/system/distribution/fixtures/univention_corporate_server_5.2.json
+++ b/test/units/module_utils/facts/system/distribution/fixtures/univention_corporate_server_5.2.json
@@ -41,6 +41,7 @@
         "bookworm"
     ],
     "result": {
+        "distribution_cpe_name": "cpe:/o:univention:univention_corporate_server:5.2",
         "distribution": "Univention Corporate Server",
         "distribution_version": "5.2",
         "distribution_release": "bookworm",


### PR DESCRIPTION
##### SUMMARY

Adds a new `ansible_distribution_cpe_name()` function that provides with the `CPE_NAME` of an operating system that has this field populated.

The `distro` library already parses this via `os_release_info()` but it's value was discarded for some reason.

Tests have also been patched/modified to ensure that the behaviour is in line with the expectations.

##### ISSUE TYPE

- Feature Pull Request