### PR TITLE
Re-enable Azure core-ci credential provider test

### DIFF
--- a/test/integration/targets/ansible-test-cloud-azure/aliases
+++ b/test/integration/targets/ansible-test-cloud-azure/aliases
@@ -1,4 +1,3 @@
 cloud/azure
 shippable/generic/group1
 context/controller
-disabled/yes  # Azure credential provisioner pool broken in Core CI (likely SP policy)


### PR DESCRIPTION
##### SUMMARY
Attempting to re-enable/see what might still be broken with the Azure core-ci integration tests.

##### ISSUE TYPE
- Test Pull Request
