### PR TITLE
test: fix passing a non-Collection iterable to pytest.parametrize

### DIFF
--- a/test/lib/ansible_test/_internal/commands/units/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/units/__init__.py
@@ -258,6 +258,7 @@ def command_units(args: UnitsConfig) -> None:
 
         if not data_context().content.collection:
             cmd.append('--durations=25')
+            cmd.append('--pythonwarnings=error:Passing a non-Collection iterable to parametrize is deprecated')
 
         plugins = []
 

--- a/test/units/executor/module_common/test_module_common.py
+++ b/test/units/executor/module_common/test_module_common.py
@@ -174,7 +174,7 @@ class TestDetectionRegexes:
     def test_detect_core_library_path_re(self, testcase, result):
         assert amc.CORE_LIBRARY_PATH_RE.search(testcase).group('path') == result
 
-    @pytest.mark.parametrize('testcase', (p[0] for p in COLLECTION_PATHS))
+    @pytest.mark.parametrize('testcase', [p[0] for p in COLLECTION_PATHS])
     def test_no_detect_core_library_path_re(self, testcase):
         assert not amc.CORE_LIBRARY_PATH_RE.search(testcase)
 
@@ -182,6 +182,6 @@ class TestDetectionRegexes:
     def test_detect_collection_path_re(self, testcase, result):
         assert amc.COLLECTION_PATH_RE.search(testcase).group('path') == result
 
-    @pytest.mark.parametrize('testcase', (p[0] for p in CORE_PATHS))
+    @pytest.mark.parametrize('testcase', [p[0] for p in CORE_PATHS])
     def test_no_detect_collection_path_re(self, testcase):
         assert not amc.COLLECTION_PATH_RE.search(testcase)

--- a/test/units/module_utils/basic/test_atomic_move.py
+++ b/test/units/module_utils/basic/test_atomic_move.py
@@ -72,7 +72,7 @@ def fake_stat(mocker):
     yield stat1
 
 
-@pytest.mark.parametrize('stdin, selinux', product([{}], (True, False)), indirect=['stdin'])
+@pytest.mark.parametrize('stdin, selinux', list(product([{}], (True, False))), indirect=['stdin'])
 def test_new_file(atomic_am, atomic_mocks, mocker, selinux):
     # test destination does not exist, login name = 'root', no environment, os.rename() succeeds
     mock_context = atomic_am.selinux_default_context.return_value
@@ -92,7 +92,7 @@ def test_new_file(atomic_am, atomic_mocks, mocker, selinux):
         assert not atomic_am.set_context_if_different.called
 
 
-@pytest.mark.parametrize('stdin, selinux', product([{}], (True, False)), indirect=['stdin'])
+@pytest.mark.parametrize('stdin, selinux', list(product([{}], (True, False))), indirect=['stdin'])
 def test_existing_file(atomic_am, atomic_mocks, fake_stat, mocker, selinux):
     # Test destination already present
     mock_context = atomic_am.selinux_context.return_value
@@ -190,7 +190,7 @@ def test_rename_perms_fail_temp_creation_fails(atomic_am, atomic_mocks, mocker, 
         atomic_am.atomic_move('/path/to/src', '/path/to/dest')
 
 
-@pytest.mark.parametrize('stdin, selinux', product([{}], (True, False)), indirect=['stdin'])
+@pytest.mark.parametrize('stdin, selinux', list(product([{}], (True, False))), indirect=['stdin'])
 def test_rename_perms_fail_temp_succeeds(atomic_am, atomic_mocks, fake_stat, mocker, selinux):
     """Test os.rename raising an error but fallback to using mkstemp works"""
     mock_context = atomic_am.selinux_default_context.return_value

--- a/test/units/module_utils/basic/test_exit_json.py
+++ b/test/units/module_utils/basic/test_exit_json.py
@@ -35,7 +35,7 @@ class TestAnsibleModuleExitJson:
          {'msg': 'message', 'datetime': DATETIME.isoformat(), 'invocation': EMPTY_INVOCATION}),
     )
 
-    @pytest.mark.parametrize('args, expected, stdin', ((a, e, {}) for a, e in DATA), indirect=['stdin'])
+    @pytest.mark.parametrize('args, expected, stdin', [(a, e, {}) for a, e in DATA], indirect=['stdin'])
     def test_exit_json_exits(self, am, capfd, args, expected):
         with pytest.raises(SystemExit) as ctx:
             am.exit_json(**args)
@@ -46,7 +46,7 @@ class TestAnsibleModuleExitJson:
         assert return_val == expected
 
     @pytest.mark.parametrize('args, expected, stdin',
-                             ((a, e, {}) for a, e in DATA if 'msg' in a),
+                             [(a, e, {}) for a, e in DATA if 'msg' in a],
                              indirect=['stdin'])
     def test_fail_json_exits(self, am, capfd, args, expected):
         with pytest.raises(SystemExit) as ctx:
@@ -132,8 +132,8 @@ class TestAnsibleModuleExitValuesRemoved:
     )
 
     @pytest.mark.parametrize('am, stdin, return_val, expected',
-                             (({'username': {}, 'password': {'no_log': True}, 'token': {'no_log': True}}, s, r, e)
-                              for s, r, e in DATA),
+                             [({'username': {}, 'password': {'no_log': True}, 'token': {'no_log': True}}, s, r, e)
+                              for s, r, e in DATA],
                              indirect=['am', 'stdin'])
     def test_exit_json_removes_values(self, am, capfd, return_val, expected):
         with pytest.raises(SystemExit):
@@ -143,8 +143,8 @@ class TestAnsibleModuleExitValuesRemoved:
         assert json.loads(out) == expected
 
     @pytest.mark.parametrize('am, stdin, return_val, expected',
-                             (({'username': {}, 'password': {'no_log': True}, 'token': {'no_log': True}}, s, r, e)
-                              for s, r, e in DATA),
+                             [({'username': {}, 'password': {'no_log': True}, 'token': {'no_log': True}}, s, r, e)
+                              for s, r, e in DATA],
                              indirect=['am', 'stdin'])
     def test_fail_json_removes_values(self, am, capfd, return_val, expected):
         expected['failed'] = True

--- a/test/units/module_utils/basic/test_get_file_attributes.py
+++ b/test/units/module_utils/basic/test_get_file_attributes.py
@@ -53,7 +53,7 @@ NO_VERSION_DATA = (
 )
 
 
-@pytest.mark.parametrize('stdin, data', product(({},), DATA), indirect=['stdin'])
+@pytest.mark.parametrize('stdin, data', list(product(({},), DATA)), indirect=['stdin'])
 def test_get_file_attributes(am, stdin, mocker, data):
     # Test #18731
     mocker.patch.object(AnsibleModule, 'get_bin_path', return_value=(0, '/usr/bin/lsattr', ''))
@@ -63,7 +63,7 @@ def test_get_file_attributes(am, stdin, mocker, data):
         assert key in result and result[key] == value
 
 
-@pytest.mark.parametrize('stdin, data', product(({},), NO_VERSION_DATA), indirect=['stdin'])
+@pytest.mark.parametrize('stdin, data', list(product(({},), NO_VERSION_DATA)), indirect=['stdin'])
 def test_get_file_attributes_no_version(am, stdin, mocker, data):
     # Test #18731
     mocker.patch.object(AnsibleModule, 'get_bin_path', return_value=(0, '/usr/bin/lsattr', ''))

--- a/test/units/module_utils/basic/test_log.py
+++ b/test/units/module_utils/basic/test_log.py
@@ -16,7 +16,7 @@ class TestAnsibleModuleLogSmokeTest:
     DATA = DATA + [d.encode('utf-8') for d in DATA]
     DATA += [b'non-utf8 :\xff: test']
 
-    @pytest.mark.parametrize('msg, stdin', ((m, {}) for m in DATA), indirect=['stdin'])
+    @pytest.mark.parametrize('msg, stdin', [(m, {}) for m in DATA], indirect=['stdin'])
     def test_smoketest_syslog(self, am, mocker, msg):
         # These talk to the live daemons on the system.  Need to do this to
         # show that what we send doesn't cause an issue once it gets to the
@@ -42,7 +42,7 @@ class TestAnsibleModuleLogSyslog:
         (b'non-utf8 :\xff: test', b'non-utf8 :\xff: test'.decode('utf-8', 'replace')),
     ]
 
-    @pytest.mark.parametrize('no_log, stdin', (product((True, False), [{}])), indirect=['stdin'])
+    @pytest.mark.parametrize('no_log, stdin', list(product((True, False), [{}])), indirect=['stdin'])
     def test_no_log(self, am, mocker, no_log):
         """Test that when no_log is set, logging does not occur"""
         mock_syslog = mocker.patch('syslog.syslog', autospec=True)
@@ -55,7 +55,7 @@ class TestAnsibleModuleLogSyslog:
             mock_syslog.assert_called_once_with(syslog.LOG_INFO, 'unittest no_log')
 
     @pytest.mark.parametrize('msg, param, stdin',
-                             ((m, p, {}) for m, p in OUTPUT_DATA),
+                             [(m, p, {}) for m, p in OUTPUT_DATA],
                              indirect=['stdin'])
     def test_output_matches(self, am, mocker, msg, param):
         """Check that log messages are sent correctly"""

--- a/test/units/module_utils/basic/test_run_command.py
+++ b/test/units/module_utils/basic/test_run_command.py
@@ -127,8 +127,8 @@ class TestRunCommandArgs:
     )
 
     @pytest.mark.parametrize('cmd, expected, shell, stdin',
-                             ((arg, cmd_str if sh else cmd_lst, sh, {})
-                              for (arg, cmd_lst, cmd_str), sh in product(ARGS_DATA, (True, False))),
+                             [(arg, cmd_str if sh else cmd_lst, sh, {})
+                              for (arg, cmd_lst, cmd_str), sh in product(ARGS_DATA, (True, False))],
                              indirect=['stdin'])
     def test_args(self, cmd, expected, shell, rc_am):
         rc_am.run_command(cmd, use_unsafe_shell=shell)

--- a/test/units/module_utils/basic/test_set_mode_if_different.py
+++ b/test/units/module_utils/basic/test_set_mode_if_different.py
@@ -46,7 +46,7 @@ def mock_lchmod(mocker):
 
 
 @pytest.mark.parametrize('previous_changes, check_mode, exists, stdin',
-                         product((True, False), (True, False), (True, False), ({},)),
+                         list(product((True, False), (True, False), (True, False), ({},))),
                          indirect=['stdin'])
 def test_no_mode_given_returns_previous_changes(am, mock_stats, mock_lchmod, mocker, previous_changes, check_mode, exists):
     am.check_mode = check_mode
@@ -60,7 +60,7 @@ def test_no_mode_given_returns_previous_changes(am, mock_stats, mock_lchmod, moc
 
 
 @pytest.mark.parametrize('mode, check_mode, stdin',
-                         product(SYNONYMS_0660, (True, False), ({},)),
+                         list(product(SYNONYMS_0660, (True, False), ({},))),
                          indirect=['stdin'])
 def test_mode_changed_to_0660(am, mock_stats, mocker, mode, check_mode):
     # Note: This is for checking that all the different ways of specifying
@@ -79,7 +79,7 @@ def test_mode_changed_to_0660(am, mock_stats, mocker, mode, check_mode):
 
 
 @pytest.mark.parametrize('mode, check_mode, stdin',
-                         product(SYNONYMS_0660, (True, False), ({},)),
+                         list(product(SYNONYMS_0660, (True, False), ({},))),
                          indirect=['stdin'])
 def test_mode_unchanged_when_already_0660(am, mock_stats, mocker, mode, check_mode):
     # Note: This is for checking that all the different ways of specifying
@@ -94,7 +94,7 @@ def test_mode_unchanged_when_already_0660(am, mock_stats, mocker, mode, check_mo
     assert not m_lchmod.called
 
 
-@pytest.mark.parametrize('mode, stdin', product(SYNONYMS_0660, ({},)), indirect=['stdin'])
+@pytest.mark.parametrize('mode, stdin', list(product(SYNONYMS_0660, ({},))), indirect=['stdin'])
 def test_mode_changed_to_0660_check_mode_no_file(am, mocker, mode):
     am.check_mode = True
     mocker.patch('os.path.exists', return_value=False)
@@ -102,7 +102,7 @@ def test_mode_changed_to_0660_check_mode_no_file(am, mocker, mode):
 
 
 @pytest.mark.parametrize('check_mode, stdin',
-                         product((True, False), ({},)),
+                         list(product((True, False), ({},))),
                          indirect=['stdin'])
 def test_missing_lchmod_is_not_link(am, mock_stats, mocker, monkeypatch, check_mode):
     """Some platforms have lchmod (*BSD) others do not (Linux)"""
@@ -125,7 +125,7 @@ def test_missing_lchmod_is_not_link(am, mock_stats, mocker, monkeypatch, check_m
 
 
 @pytest.mark.parametrize('check_mode, stdin',
-                         product((True, False), ({},)),
+                         list(product((True, False), ({},))),
                          indirect=['stdin'])
 def test_missing_lchmod_is_link(am, mock_stats, mocker, monkeypatch, check_mode):
     """Some platforms have lchmod (*BSD) others do not (Linux)"""

--- a/test/units/module_utils/basic/test_tmpdir.py
+++ b/test/units/module_utils/basic/test_tmpdir.py
@@ -56,7 +56,7 @@ class TestAnsibleModuleTmpDir:
         ),
     )
 
-    @pytest.mark.parametrize('args, expected, stat_exists', ((s, e, t) for s, t, e in DATA))
+    @pytest.mark.parametrize('args, expected, stat_exists', [(s, e, t) for s, t, e in DATA])
     def test_tmpdir_property(self, monkeypatch, args, expected, stat_exists):
         makedirs = {'called': False}
 

--- a/test/units/module_utils/common/arg_spec/test_aliases.py
+++ b/test/units/module_utils/common/arg_spec/test_aliases.py
@@ -88,7 +88,7 @@ ALIAS_TEST_CASES_INVALID: list[tuple[str, dict, dict, dict, str]] = [
 
 @pytest.mark.parametrize(
     ('arg_spec', 'parameters', 'expected', 'deprecation', 'warning'),
-    ((i[1:]) for i in ALIAS_TEST_CASES),
+    [i[1:] for i in ALIAS_TEST_CASES],
     ids=[i[0] for i in ALIAS_TEST_CASES]
 )
 def test_aliases(arg_spec, parameters, expected, deprecation, warning):
@@ -117,7 +117,7 @@ def test_aliases(arg_spec, parameters, expected, deprecation, warning):
 
 @pytest.mark.parametrize(
     ('arg_spec', 'parameters', 'expected', 'error'),
-    ((i[1:]) for i in ALIAS_TEST_CASES_INVALID),
+    [i[1:] for i in ALIAS_TEST_CASES_INVALID],
     ids=[i[0] for i in ALIAS_TEST_CASES_INVALID]
 )
 def test_aliases_invalid(arg_spec, parameters, expected, error):

--- a/test/units/module_utils/common/arg_spec/test_validate_invalid.py
+++ b/test/units/module_utils/common/arg_spec/test_validate_invalid.py
@@ -112,7 +112,7 @@ INVALID_SPECS = [
 
 @pytest.mark.parametrize(
     ('arg_spec', 'parameters', 'expected', 'unsupported', 'error'),
-    (i[1:] for i in INVALID_SPECS),
+    [i[1:] for i in INVALID_SPECS],
     ids=[i[0] for i in INVALID_SPECS]
 )
 def test_invalid_spec(arg_spec, parameters, expected, unsupported, error):

--- a/test/units/module_utils/common/arg_spec/test_validate_valid.py
+++ b/test/units/module_utils/common/arg_spec/test_validate_valid.py
@@ -314,7 +314,7 @@ VALID_SPECS = [
 
 @pytest.mark.parametrize(
     ('arg_spec', 'parameters', 'expected', 'valid_params'),
-    (i[1:] for i in VALID_SPECS),
+    [i[1:] for i in VALID_SPECS],
     ids=[i[0] for i in VALID_SPECS]
 )
 def test_valid_spec(arg_spec, parameters, expected, valid_params, mocker):

--- a/test/units/module_utils/common/text/converters/test_to_str.py
+++ b/test/units/module_utils/common/text/converters/test_to_str.py
@@ -23,25 +23,43 @@ VALID_STRINGS = (
 )
 
 
-@pytest.mark.parametrize('in_string, encoding, expected',
-                         itertools.chain(((d[0], d[2], d[1]) for d in VALID_STRINGS),
-                                         ((d[1], d[2], d[1]) for d in VALID_STRINGS)))
+@pytest.mark.parametrize(
+    'in_string, encoding, expected',
+    list(
+        itertools.chain(
+            ((d[0], d[2], d[1]) for d in VALID_STRINGS),
+            ((d[1], d[2], d[1]) for d in VALID_STRINGS)
+        )
+    )
+)
 def test_to_text(in_string, encoding, expected):
     """test happy path of decoding to text"""
     assert to_text(in_string, encoding) == expected
 
 
-@pytest.mark.parametrize('in_string, encoding, expected',
-                         itertools.chain(((d[0], d[2], d[0]) for d in VALID_STRINGS),
-                                         ((d[1], d[2], d[0]) for d in VALID_STRINGS)))
+@pytest.mark.parametrize(
+    'in_string, encoding, expected',
+    list(
+        itertools.chain(
+            ((d[0], d[2], d[0]) for d in VALID_STRINGS),
+            ((d[1], d[2], d[0]) for d in VALID_STRINGS)
+        )
+    )
+)
 def test_to_bytes(in_string, encoding, expected):
     """test happy path of encoding to bytes"""
     assert to_bytes(in_string, encoding) == expected
 
 
-@pytest.mark.parametrize('in_string, encoding, expected',
-                         itertools.chain(((d[0], d[2], d[1]) for d in VALID_STRINGS),
-                                         ((d[1], d[2], d[1]) for d in VALID_STRINGS)))
+@pytest.mark.parametrize(
+    'in_string, encoding, expected',
+    list(
+        itertools.chain(
+            ((d[0], d[2], d[1]) for d in VALID_STRINGS),
+            ((d[1], d[2], d[1]) for d in VALID_STRINGS)
+        )
+    )
+)
 def test_to_native(in_string, encoding, expected):
     """test happy path of encoding to native strings"""
     assert to_native(in_string, encoding) == expected

--- a/test/units/module_utils/facts/system/distribution/test_distribution_version.py
+++ b/test/units/module_utils/facts/system/distribution/test_distribution_version.py
@@ -23,7 +23,7 @@ for datafile in glob.glob(os.path.join(os.path.dirname(__file__), 'fixtures/*.js
         TESTSETS.append(json.loads(f.read()))
 
 
-@pytest.mark.parametrize("stdin, testcase", product([{}], TESTSETS), ids=lambda x: x.get('name'), indirect=['stdin'])
+@pytest.mark.parametrize("stdin, testcase", list(product([{}], TESTSETS)), ids=lambda x: x.get('name'), indirect=['stdin'])
 def test_distribution_version(am, mocker, testcase):
     """tests the distribution parsing code of the Facts class
 

--- a/test/units/modules/test_copy.py
+++ b/test/units/modules/test_copy.py
@@ -97,28 +97,28 @@ ONE_DIR_DATA: tuple[tuple[str, tuple[str, list[str]] | None, tuple[str, list[str
 ONE_DIR_DATA += tuple(item[:3] for item in TWO_DIRS_DATA)
 
 
-@pytest.mark.parametrize('directory, expected', ((d[0], d[4]) for d in THREE_DIRS_DATA))
+@pytest.mark.parametrize('directory, expected', [(d[0], d[4]) for d in THREE_DIRS_DATA])
 @pytest.mark.xfail(reason='broken test and/or code, original test missing assert', strict=False)
 def test_split_pre_existing_dir_three_levels_exist(directory, expected):
     with unittest.mock.patch('os.path.exists', side_effect=[True, True, True]):
         assert split_pre_existing_dir(directory) == expected
 
 
-@pytest.mark.parametrize('directory, expected', ((d[0], d[3]) for d in TWO_DIRS_DATA))
+@pytest.mark.parametrize('directory, expected', [(d[0], d[3]) for d in TWO_DIRS_DATA])
 @pytest.mark.xfail(reason='broken test and/or code, original test missing assert', strict=False)
 def test_split_pre_existing_dir_two_levels_exist(directory, expected):
     with unittest.mock.patch('os.path.exists', side_effect=[True, True, False]):
         assert split_pre_existing_dir(directory) == expected
 
 
-@pytest.mark.parametrize('directory, expected', ((d[0], d[2]) for d in ONE_DIR_DATA))
+@pytest.mark.parametrize('directory, expected', [(d[0], d[2]) for d in ONE_DIR_DATA])
 @pytest.mark.xfail(reason='broken test and/or code, original test missing assert', strict=False)
 def test_split_pre_existing_dir_one_level_exists(directory, expected):
     with unittest.mock.patch('os.path.exists', side_effect=[True, False, False]):
         assert split_pre_existing_dir(directory) == expected
 
 
-@pytest.mark.parametrize('directory', (d[0] for d in ONE_DIR_DATA if d[1] is None))
+@pytest.mark.parametrize('directory', [d[0] for d in ONE_DIR_DATA if d[1] is None])
 def test_split_pre_existing_dir_root_does_not_exist(directory):
     with unittest.mock.patch('os.path.exists', return_value=False):
         with pytest.raises(AnsibleModuleError) as excinfo:
@@ -126,7 +126,7 @@ def test_split_pre_existing_dir_root_does_not_exist(directory):
     assert excinfo.value.results['msg'].startswith("The '/' directory doesn't exist on this machine.")
 
 
-@pytest.mark.parametrize('directory, expected', ((d[0], d[1]) for d in ONE_DIR_DATA if not d[0].startswith('/')))
+@pytest.mark.parametrize('directory, expected', [(d[0], d[1]) for d in ONE_DIR_DATA if not d[0].startswith('/')])
 @pytest.mark.xfail(reason='broken test and/or code, original test missing assert', strict=False)
 def test_split_pre_existing_dir_working_dir_exists(directory, expected):
     with unittest.mock.patch('os.path.exists', return_value=False):

--- a/test/units/plugins/connection/test_psrp.py
+++ b/test/units/plugins/connection/test_psrp.py
@@ -191,8 +191,7 @@ class TestConnectionPSRP(object):
         ),
     )
 
-    @pytest.mark.parametrize('options, expected',
-                             ((o, e) for o, e in OPTIONS_DATA))
+    @pytest.mark.parametrize('options, expected', list(OPTIONS_DATA))
     def test_set_options(self, options, expected):
         pc = PlayContext()
 

--- a/test/units/plugins/connection/test_winrm.py
+++ b/test/units/plugins/connection/test_winrm.py
@@ -199,7 +199,7 @@ class TestConnectionWinRM(object):
     )
 
     @pytest.mark.parametrize('options, direct, expected, kerb',
-                             ((o, d, e, k) for o, d, e, k in OPTIONS_DATA))
+                             list(OPTIONS_DATA))
     def test_set_options(self, options, direct, expected, kerb):
         winrm.HAVE_KERBEROS = kerb
 


### PR DESCRIPTION
##### SUMMARY

* Passing a non-Collection iterable to parametrize is deprecated, let us fix it.

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE



- Test Pull Request

##### COMPONENT NAME
test/units/executor/module_common/test_module_common.py
test/units/module_utils/basic/test_atomic_move.py
test/units/module_utils/basic/test_exit_json.py
test/units/module_utils/basic/test_get_file_attributes.py
test/units/module_utils/basic/test_log.py
test/units/module_utils/basic/test_run_command.py
test/units/module_utils/basic/test_set_mode_if_different.py
test/units/module_utils/basic/test_tmpdir.py
test/units/module_utils/common/arg_spec/test_aliases.py
test/units/module_utils/common/arg_spec/test_validate_invalid.py
test/units/module_utils/common/arg_spec/test_validate_valid.py
test/units/module_utils/common/text/converters/test_to_str.py
test/units/module_utils/facts/system/distribution/test_distribution_version.py
test/units/modules/test_copy.py
test/units/plugins/connection/test_psrp.py
test/units/plugins/connection/test_winrm.py


