### PR TITLE
get_lvm_facts: Warn on duplicate VGs & LVs

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -880,12 +880,21 @@ class LinuxHardware(Hardware):
 
         if os.getuid() == 0:
             lvm_util_options = '--noheadings --nosuffix --units g --separator ,'
+            duplicate_vgs = 0
+            duplicate_lvs = 0
 
             # vgs fields: VG #PV #LV #SN Attr VSize VFree
             vgs = {}
             rc, vg_lines, err = self.module.run_command('%s %s' % (vgs_cmd, lvm_util_options))
             for vg_line in vg_lines.splitlines():
                 items = vg_line.strip().split(',')
+                vg_name = items[0]
+                if vg_name in vgs:
+                    duplicate_vgs += 1
+                    self.module.debug(
+                        "Duplicate LVM volume group name '%s' encountered while gathering LVM facts; "
+                        "overwriting existing ansible_facts['lvm']['vgs'] entry with line: %s" % (vg_name, vg_line)
+                    )
                 vgs[items[0]] = {
                     'size_g': items[-2],
                     'free_g': items[-1],
@@ -906,6 +915,12 @@ class LinuxHardware(Hardware):
                     lv_name = items[0]
                     # The LV name is only unique per VG, so the top level fact lvs can be misleading.
                     # TODO: deprecate lvs in favor of vgs
+                    if lv_name in lvs:
+                        duplicate_lvs += 1
+                        self.module.debug(
+                            "Duplicate LVM logical volume name '%s' encountered while gathering LVM facts; "
+                            "overwriting existing ansible_facts['lvm']['lvs'] entry with line: %s" % (lv_name, lv_line)
+                        )
                     lvs[lv_name] = {'size_g': items[3], 'vg': vg_name}
                     try:
                         vgs[vg_name]['lvs'][lv_name] = {'size_g': items[3]}
@@ -926,6 +941,13 @@ class LinuxHardware(Hardware):
                         'size_g': items[4],
                         'free_g': items[5],
                         'vg': items[1]}
+
+            if duplicate_vgs or duplicate_lvs:
+                self.module.warn(
+                    "Duplicate LVM names were encountered while gathering LVM facts; "
+                    "overwrites applied: vgs=%d, lvs=%d."
+                    % (duplicate_vgs, duplicate_lvs)
+                )
 
             lvm_facts['lvm'] = {'lvs': lvs, 'vgs': vgs, 'pvs': pvs}
 

--- a/test/units/module_utils/facts/hardware/test_linux.py
+++ b/test/units/module_utils/facts/hardware/test_linux.py
@@ -195,3 +195,50 @@ class TestFactsLinuxHardwareGetMountFacts(unittest.TestCase):
         lh = linux.LinuxHardware(module=module, load_on_init=False)
         sg_inq_serial = lh._get_sg_inq_serial('/usr/bin/sg_inq', 'nvme0n1')
         self.assertEqual(sg_inq_serial, None)
+
+
+class TestFactsLinuxHardwareGetLvmFacts(unittest.TestCase):
+
+    @patch('ansible.module_utils.facts.hardware.linux.os.getuid', return_value=0)
+    def test_get_lvm_facts_duplicate_names_debug_and_single_warning(self, mock_getuid):
+        module = Mock()
+        module.get_bin_path = Mock(side_effect=lambda path: path)
+        module.run_command = Mock(side_effect=[
+            (
+                0,
+                'vg0,1,2,0,wz--n-,10.00,5.00\n'
+                'vg0,1,2,0,wz--n-,20.00,10.00\n'
+                'vg1,1,1,0,wz--n-,30.00,15.00',
+                '',
+            ),
+            (
+                0,
+                'lv0,vg0,-wi-a-----,1.00,,,,,\n'
+                'lv0,vg1,-wi-a-----,2.00,,,,,',
+                '',
+            ),
+            (0, '', ''),
+        ])
+        lh = linux.LinuxHardware(module=module, load_on_init=False)
+
+        lvm_facts = lh.get_lvm_facts()
+
+        self.assertEqual(lvm_facts['lvm']['vgs']['vg0']['size_g'], '20.00')
+        self.assertEqual(lvm_facts['lvm']['lvs']['lv0']['size_g'], '2.00')
+        self.assertEqual(lvm_facts['lvm']['lvs']['lv0']['vg'], 'vg1')
+        self.assertEqual(lvm_facts['lvm']['vgs']['vg0']['lvs']['lv0']['size_g'], '1.00')
+        self.assertEqual(lvm_facts['lvm']['vgs']['vg1']['lvs']['lv0']['size_g'], '2.00')
+        self.assertEqual(module.warn.call_count, 1)
+        module.warn.assert_called_with(
+            "Duplicate LVM names were encountered while gathering LVM facts; "
+            "overwrites applied: vgs=1, lvs=1."
+        )
+        self.assertEqual(module.debug.call_count, 2)
+        module.debug.assert_any_call(
+            "Duplicate LVM volume group name 'vg0' encountered while gathering LVM facts; "
+            "overwriting existing ansible_facts['lvm']['vgs'] entry with line: vg0,1,2,0,wz--n-,20.00,10.00"
+        )
+        module.debug.assert_any_call(
+            "Duplicate LVM logical volume name 'lv0' encountered while gathering LVM facts; "
+            "overwriting existing ansible_facts['lvm']['lvs'] entry with line: lv0,vg1,-wi-a-----,2.00,,,,,"
+        )


### PR DESCRIPTION
##### SUMMARY

LinuxHardware.get_lvm_facts() silently overwrites data for:

- VGs, if multiple VGs with the same name exist across PVs
- LVs, if multiple LVs with the same name exist across VGs

This change does not change this behavior,
it does add a WARN log if this overwrite happened during fact collection.

See also previous discussions in https://forum.ansible.com/t/lvm-facts-dont-include-all-lvs-and-vgs/45914
and issue #71041

##### ISSUE TYPE

- Bugfix Pull Request
