### PR TITLE
Fix child worker signal handler race condition

### DIFF
--- a/changelogs/fragments/86946-child-worker-signal-race.yml
+++ b/changelogs/fragments/86946-child-worker-signal-race.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- TaskQueueManager - fix ``AssertionError`` crash when a forked worker process
+  receives SIGTERM/SIGINT before replacing inherited parent signal handlers
+  (https://github.com/ansible/ansible/issues/86946).

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -189,12 +189,11 @@ class WorkerProcess(multiprocessing_context.Process):  # type: ignore[name-defin
         a try/except added in far-away code can cause a crashed child process
         to suddenly assume the role and prior state of its parent.
         """
-        # Set the queue on Display so calls to Display.display are proxied over the queue
-        display.set_queue(self._final_q)
-        self._detach()
-        # propagate signals
         signal.signal(signal.SIGINT, self._term)
         signal.signal(signal.SIGTERM, self._term)
+
+        display.set_queue(self._final_q)
+        self._detach()
 
         try:
             with _task.TaskContext.create(task=self._task, task_vars=self._task_vars, host_name=self._host.name):

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -145,6 +145,7 @@ class TaskQueueManager:
     RUN_UNKNOWN_ERROR = 255  # never leaves PlaybookExecutor.run, intentionally includes the bit value for 8
 
     _callback_dispatch_error_handler = ErrorHandler.from_config('_CALLBACK_DISPATCH_ERROR_BEHAVIOR')
+    _fork_handler_registered = False
 
     def __init__(
         self,
@@ -209,9 +210,21 @@ class TaskQueueManager:
         signal.signal(signal.SIGTERM, self._signal_handler)
         signal.signal(signal.SIGINT, self._signal_handler)
 
+        if not TaskQueueManager._fork_handler_registered:
+            os.register_at_fork(after_in_child=TaskQueueManager._reset_child_signals)
+            TaskQueueManager._fork_handler_registered = True
+
     def _initialize_processes(self, num: int) -> None:
         # mutable update to ensure the reference stays the same
         self._workers[:] = [None] * num
+
+    @staticmethod
+    def _reset_child_signals() -> None:
+        """``after_in_child`` fork callback that restores default signal
+        disposition before any child code runs, closing the race window
+        where an inherited parent handler could execute in the child."""
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     def _signal_handler(self, signum, frame) -> None:
         """
@@ -223,12 +236,20 @@ class TaskQueueManager:
         """
         signal.signal(signum, signal.SIG_DFL)
 
+        my_pid = os.getpid()
+
+        if any(w is not None and w.pid == my_pid for w in self._workers):
+            # Forked child received a signal before replacing the inherited
+            # parent handlers. Default disposition is now restored above;
+            # re-raise so the default handler terminates the child cleanly.
+            os.kill(my_pid, signum)
+            return
+
         for worker in self._workers:
             if worker is None or not worker.is_alive():
                 continue
             if worker.pid:
                 try:
-                    # notify workers
                     os.kill(worker.pid, signum)
                 except OSError as e:
                     if e.errno != errno.ESRCH:
@@ -239,12 +260,11 @@ class TaskQueueManager:
             # Defer to CLI handling
             raise KeyboardInterrupt()
 
-        pid = os.getpid()
         try:
-            os.kill(pid, signum)
+            os.kill(my_pid, signum)
         except OSError as e:
             signame = signal.strsignal(signum)
-            display.error(f'Unable to send {signame} to {pid}: {e}')
+            display.error(f'Unable to send {signame} to {my_pid}: {e}')
 
     def load_callbacks(self):
         """

--- a/test/units/executor/test_task_queue_manager.py
+++ b/test/units/executor/test_task_queue_manager.py
@@ -1,0 +1,157 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import signal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.executor.task_queue_manager import TaskQueueManager
+
+
+@pytest.fixture()
+def tqm():
+    with (
+        patch('ansible.executor.task_queue_manager.FinalQueue'),
+        patch('ansible.executor.task_queue_manager._rpc_host.LocalManager.shared_instance'),
+        patch('ansible.executor.task_queue_manager.context.CLIARGS', {}),
+    ):
+        return TaskQueueManager(
+            inventory=MagicMock(),
+            variable_manager=MagicMock(),
+            loader=MagicMock(),
+            passwords={},
+        )
+
+
+class TestSignalHandlerChildRaceDetection:
+    """Tests for the race condition where a forked child receives a signal
+    before it has replaced the inherited parent signal handlers."""
+
+    @pytest.mark.parametrize("signum", [signal.SIGTERM, signal.SIGINT])
+    def test_child_process_skips_worker_management(self, tqm, signum):
+        """When the handler runs in a child (os.getpid() matches a worker PID),
+        it must not call worker.is_alive() or attempt to signal other workers."""
+        mock_worker = MagicMock()
+        mock_worker.pid = 12345
+        tqm._workers = [mock_worker]
+
+        with (
+            patch('ansible.executor.task_queue_manager.os.getpid', return_value=12345),
+            patch('ansible.executor.task_queue_manager.os.kill') as mock_kill,
+            patch('ansible.executor.task_queue_manager.signal.signal'),
+        ):
+            tqm._signal_handler(signum, None)
+
+        mock_worker.is_alive.assert_not_called()
+        mock_kill.assert_called_once_with(12345, signum)
+
+    def test_child_race_skips_none_workers(self, tqm):
+        """None entries in the worker list must not cause errors during the
+        child-detection check."""
+        mock_worker = MagicMock()
+        mock_worker.pid = 42
+        tqm._workers = [None, mock_worker, None]
+
+        with (
+            patch('ansible.executor.task_queue_manager.os.getpid', return_value=42),
+            patch('ansible.executor.task_queue_manager.os.kill') as mock_kill,
+            patch('ansible.executor.task_queue_manager.signal.signal'),
+        ):
+            tqm._signal_handler(signal.SIGTERM, None)
+
+        mock_worker.is_alive.assert_not_called()
+        mock_kill.assert_called_once_with(42, signal.SIGTERM)
+
+
+class TestSignalHandlerNormalOperation:
+    """Tests for normal parent-process signal handling (no race condition)."""
+
+    def test_signals_alive_workers(self, tqm):
+        mock_worker = MagicMock()
+        mock_worker.pid = 12345
+        mock_worker.is_alive.return_value = True
+        tqm._workers = [mock_worker]
+
+        with (
+            patch('ansible.executor.task_queue_manager.os.getpid', return_value=99999),
+            patch('ansible.executor.task_queue_manager.os.kill') as mock_kill,
+            patch('ansible.executor.task_queue_manager.signal.signal'),
+        ):
+            tqm._signal_handler(signal.SIGTERM, None)
+
+        worker_calls = [c for c in mock_kill.call_args_list if c[0][0] == 12345]
+        assert len(worker_calls) == 1
+        assert worker_calls[0][0] == (12345, signal.SIGTERM)
+
+    def test_skips_dead_workers(self, tqm):
+        mock_worker = MagicMock()
+        mock_worker.pid = 12345
+        mock_worker.is_alive.return_value = False
+        tqm._workers = [mock_worker]
+
+        with (
+            patch('ansible.executor.task_queue_manager.os.getpid', return_value=99999),
+            patch('ansible.executor.task_queue_manager.os.kill') as mock_kill,
+            patch('ansible.executor.task_queue_manager.signal.signal'),
+        ):
+            tqm._signal_handler(signal.SIGTERM, None)
+
+        worker_calls = [c for c in mock_kill.call_args_list if c[0][0] == 12345]
+        assert len(worker_calls) == 0
+
+    def test_skips_none_workers(self, tqm):
+        mock_worker = MagicMock()
+        mock_worker.pid = 12345
+        mock_worker.is_alive.return_value = True
+        tqm._workers = [None, mock_worker, None]
+
+        with (
+            patch('ansible.executor.task_queue_manager.os.getpid', return_value=99999),
+            patch('ansible.executor.task_queue_manager.os.kill') as mock_kill,
+            patch('ansible.executor.task_queue_manager.signal.signal'),
+        ):
+            tqm._signal_handler(signal.SIGTERM, None)
+
+        worker_calls = [c for c in mock_kill.call_args_list if c[0][0] == 12345]
+        assert len(worker_calls) == 1
+
+    def test_sigint_raises_keyboard_interrupt(self, tqm):
+        mock_worker = MagicMock()
+        mock_worker.pid = 12345
+        mock_worker.is_alive.return_value = True
+        tqm._workers = [mock_worker]
+
+        with (
+            patch('ansible.executor.task_queue_manager.os.getpid', return_value=99999),
+            patch('ansible.executor.task_queue_manager.os.kill'),
+            patch('ansible.executor.task_queue_manager.signal.signal'),
+        ):
+            with pytest.raises(KeyboardInterrupt):
+                tqm._signal_handler(signal.SIGINT, None)
+
+
+class TestResetChildSignals:
+    def test_resets_sigterm_and_sigint(self):
+        with patch('ansible.executor.task_queue_manager.signal.signal') as mock_signal:
+            TaskQueueManager._reset_child_signals()
+
+        mock_signal.assert_any_call(signal.SIGTERM, signal.SIG_DFL)
+        mock_signal.assert_any_call(signal.SIGINT, signal.SIG_DFL)
+        assert mock_signal.call_count == 2


### PR DESCRIPTION
##### SUMMARY

Fix the race condition where a forked `WorkerProcess` receives SIGTERM/SIGINT before replacing the inherited parent signal handlers, causing an `AssertionError` in `worker.is_alive()`.

Three-layer fix:
- **`os.register_at_fork`** callback resets SIGTERM/SIGINT to `SIG_DFL` immediately after fork, before any child code runs
- **Reordered `WorkerProcess.run()`** so signal handler replacement is the first operation, before `_detach()` and display setup
- **Defensive PID guard in `_signal_handler`** detects when the handler is running in a child process and safely re-raises with the default handler

Fixes #86946

A previous attempt at this fix (#86948) was closed because it couldn't be tested without SunOS. This PR includes unit tests that verify the race condition handling via mocking, validated with `ansible-test units --docker default` across Python 3.13, 3.14, and 3.15.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`lib/ansible/executor/task_queue_manager.py`
`lib/ansible/executor/process/worker.py`