### PR TITLE
Add `--fix` flag to trailing-newline sanity test

### DIFF
--- a/changelogs/fragments/trailing-newline-fix-implementation.yml
+++ b/changelogs/fragments/trailing-newline-fix-implementation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - ansible-test sanity trailing-newline - add support for ``--fix`` flag to automatically end files with a newline ``\n``.

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/aliases
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group3  # runs in the distro test containers
+shippable/generic/group1  # runs in the default test container
+context/controller
+destructive  # Creates/destroys stuff in lib/ansible/module_utils

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/aliases
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/aliases
@@ -1,4 +1,3 @@
 shippable/posix/group3  # runs in the distro test containers
 shippable/generic/group1  # runs in the default test container
 context/controller
-destructive  # Creates/destroys stuff in lib/ansible/module_utils

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
@@ -1,36 +1,39 @@
 #!/usr/bin/env bash
 
-set -eu
+set -eux
 
-# Navigate to project root
-cd ../../../../../../../../..
 
-TEST_DIR="lib/ansible/module_utils/newlinetests"
+SCRIPT_PATH=$(realpath "$ANSIBLE_TEST_ANSIBLE_LIB_ROOT/../../test/sanity/code-smell/trailing-newline.py")
+
+TEST_DIR=$(mktemp -d)
 RESULTS="$TEST_DIR/results.txt"
 HAS_NEWLINE="$TEST_DIR/has_newline.py"
 NO_NEWLINE="$TEST_DIR/no_newline.py"
 
 trap 'rm -rf "$TEST_DIR"' EXIT
 
-mkdir -p "$TEST_DIR"
 echo "# test" > "$HAS_NEWLINE"
 echo -n "# test" > "$NO_NEWLINE"
 
-set -x
+export ANSIBLE_TEST_FIX_MODE=0
 
-echo "Check successful test"
-ansible-test sanity --test trailing-newline "$HAS_NEWLINE" "${@}"
-
-echo "Check that sanity test fail"
-ansible-test sanity --test trailing-newline "$NO_NEWLINE" "${@}" > "$RESULTS" || true
+# Check that sanity fails NO_NEWLINE, and succeeds on HAS_NEWLINE
+python "$SCRIPT_PATH" "$HAS_NEWLINE" "$NO_NEWLINE" | tee "$RESULTS"  
 cat "$RESULTS"
-grep -q "ERROR: $NO_NEWLINE:0:0: text files should end with a newline character" "$RESULTS"
+! grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS"
+grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"
 
-echo "Attempt to fix"
-ansible-test sanity --test trailing-newline --fix "$NO_NEWLINE" "${@}" > "$RESULTS"
-grep -v "ERROR: $NO_NEWLINE:0:0: text files should end with a newline character" "$RESULTS"
+# Fix file, check no errors
+ANSIBLE_TEST_FIX_MODE=1 python "$SCRIPT_PATH" "$NO_NEWLINE" "$HAS_NEWLINE" | tee "$RESULTS"
+cat "$RESULTS"
+! grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"
+! grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS"
 
-echo "Check for success after fix"
-ansible-test sanity --test trailing-newline "$NO_NEWLINE" "${@}"
+# Check again for no errors after fix
+python "$SCRIPT_PATH" "$HAS_NEWLINE" "$NO_NEWLINE" | tee "$RESULTS"  
+cat "$RESULTS"
+! grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"
+! grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS"
+
 # Manual check for sanity (count newlines in last byte of file)
 [[ $(tail -c1 "$NO_NEWLINE" | wc -l) -gt 0 ]]

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
@@ -18,7 +18,9 @@ python "$SCRIPT_PATH" "$HAS_NEWLINE" "$NO_NEWLINE" | tee "$RESULTS"
 if grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS"; then
     exit 1
 fi
-grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"
+if ! grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"; then
+    exit 1
+fi
 
 # Fix file, check no errors
 ANSIBLE_TEST_FIX_MODE=1 python "$SCRIPT_PATH" "$NO_NEWLINE" "$HAS_NEWLINE" | tee "$RESULTS"
@@ -39,4 +41,6 @@ if grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESU
 fi
 
 # Manual check for sanity (count newlines in last byte of file)
-[[ $(tail -c1 "$NO_NEWLINE" | wc -l) -gt 0 ]]
+if [[ $(tail -c1 "$NO_NEWLINE" | wc -l) -eq 0 ]]; then
+    exit 1
+fi

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
@@ -3,14 +3,11 @@
 set -eux
 
 
-SCRIPT_PATH=$(realpath "$ANSIBLE_TEST_ANSIBLE_LIB_ROOT/../../test/sanity/code-smell/trailing-newline.py")
+SCRIPT_PATH="$ANSIBLE_TEST_ANSIBLE_LIB_ROOT/../../test/sanity/code-smell/trailing-newline.py"
 
-TEST_DIR=$(mktemp -d)
-RESULTS="$TEST_DIR/results.txt"
-HAS_NEWLINE="$TEST_DIR/has_newline.py"
-NO_NEWLINE="$TEST_DIR/no_newline.py"
-
-trap 'rm -rf "$TEST_DIR"' EXIT
+RESULTS="$OUTPUT_DIR/results.txt"
+HAS_NEWLINE="$OUTPUT_DIR/has_newline.py"
+NO_NEWLINE="$OUTPUT_DIR/no_newline.py"
 
 echo "# test" > "$HAS_NEWLINE"
 echo -n "# test" > "$NO_NEWLINE"

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
@@ -15,8 +15,6 @@ mkdir "$TEST_DIR"
 echo "# test" > "$HAS_NEWLINE"
 echo -n "# test" > "$NO_NEWLINE"
 
-trap 'rm -rf "$TEST_DIR"' EXIT
-
 export ANSIBLE_TEST_FIX_MODE=0
 
 # Check that sanity fails NO_NEWLINE, and succeeds on HAS_NEWLINE

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 
-set -e
+set -eux -o pipefail
+
 SCRIPT_PATH="$ANSIBLE_TEST_ANSIBLE_LIB_ROOT/../../test/sanity/code-smell/trailing-newline.py"
 
 RESULTS="$OUTPUT_DIR/trailing_newline_results.txt"

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
@@ -2,7 +2,6 @@
 
 
 set -e
-
 SCRIPT_PATH="$ANSIBLE_TEST_ANSIBLE_LIB_ROOT/../../test/sanity/code-smell/trailing-newline.py"
 
 RESULTS="$OUTPUT_DIR/trailing_newline_results.txt"

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
@@ -20,20 +20,20 @@ export ANSIBLE_TEST_FIX_MODE=0
 # Check that sanity fails NO_NEWLINE, and succeeds on HAS_NEWLINE
 python "$SCRIPT_PATH" "$HAS_NEWLINE" "$NO_NEWLINE" | tee "$RESULTS"  
 cat "$RESULTS"
-! grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS"
+! grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS" && exit 1
 grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"
 
 # Fix file, check no errors
 ANSIBLE_TEST_FIX_MODE=1 python "$SCRIPT_PATH" "$NO_NEWLINE" "$HAS_NEWLINE" | tee "$RESULTS"
 cat "$RESULTS"
-! grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"
-! grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS"
+! grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS" && exit 1
+! grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS" && exit 1
 
 # Check again for no errors after fix
 python "$SCRIPT_PATH" "$HAS_NEWLINE" "$NO_NEWLINE" | tee "$RESULTS"  
 cat "$RESULTS"
-! grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"
-! grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS"
+! grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS" && exit 1
+! grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS" && exit 1
 
 # Manual check for sanity (count newlines in last byte of file)
 [[ $(tail -c1 "$NO_NEWLINE" | wc -l) -gt 0 ]]

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
@@ -1,16 +1,13 @@
 #!/usr/bin/env bash
 
-set -eux
 
+set -e
 
 SCRIPT_PATH="$ANSIBLE_TEST_ANSIBLE_LIB_ROOT/../../test/sanity/code-smell/trailing-newline.py"
 
-TEST_DIR="$OUTPUT_DIR/trailing_newline_sanity_test"
-RESULTS="$TEST_DIR/results.txt"
-HAS_NEWLINE="$TEST_DIR/has_newline.py"
-NO_NEWLINE="$TEST_DIR/no_newline.py"
-
-mkdir "$TEST_DIR"
+RESULTS="$OUTPUT_DIR/trailing_newline_results.txt"
+HAS_NEWLINE="$OUTPUT_DIR/has_newline.py"
+NO_NEWLINE="$OUTPUT_DIR/no_newline.py"
 
 echo "# test" > "$HAS_NEWLINE"
 echo -n "# test" > "$NO_NEWLINE"
@@ -19,7 +16,6 @@ export ANSIBLE_TEST_FIX_MODE=0
 
 # Check that sanity fails NO_NEWLINE, and succeeds on HAS_NEWLINE
 python "$SCRIPT_PATH" "$HAS_NEWLINE" "$NO_NEWLINE" | tee "$RESULTS"
-cat "$RESULTS"
 if grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS"; then
     exit 1
 fi
@@ -27,7 +23,6 @@ grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"
 
 # Fix file, check no errors
 ANSIBLE_TEST_FIX_MODE=1 python "$SCRIPT_PATH" "$NO_NEWLINE" "$HAS_NEWLINE" | tee "$RESULTS"
-cat "$RESULTS"
 if grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"; then
     exit 1
 fi
@@ -37,7 +32,6 @@ fi
 
 # Check again for no errors after fix
 python "$SCRIPT_PATH" "$HAS_NEWLINE" "$NO_NEWLINE" | tee "$RESULTS"
-cat "$RESULTS"
 if grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"; then
     exit 1
 fi

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
@@ -18,22 +18,32 @@ echo -n "# test" > "$NO_NEWLINE"
 export ANSIBLE_TEST_FIX_MODE=0
 
 # Check that sanity fails NO_NEWLINE, and succeeds on HAS_NEWLINE
-python "$SCRIPT_PATH" "$HAS_NEWLINE" "$NO_NEWLINE" | tee "$RESULTS"  
+python "$SCRIPT_PATH" "$HAS_NEWLINE" "$NO_NEWLINE" | tee "$RESULTS"
 cat "$RESULTS"
-! grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS" && exit 1
+if grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS"; then
+    exit 1
+fi
 grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"
 
 # Fix file, check no errors
 ANSIBLE_TEST_FIX_MODE=1 python "$SCRIPT_PATH" "$NO_NEWLINE" "$HAS_NEWLINE" | tee "$RESULTS"
 cat "$RESULTS"
-! grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS" && exit 1
-! grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS" && exit 1
+if grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"; then
+    exit 1
+fi
+if grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS"; then
+    exit 1
+fi
 
 # Check again for no errors after fix
-python "$SCRIPT_PATH" "$HAS_NEWLINE" "$NO_NEWLINE" | tee "$RESULTS"  
+python "$SCRIPT_PATH" "$HAS_NEWLINE" "$NO_NEWLINE" | tee "$RESULTS"
 cat "$RESULTS"
-! grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS" && exit 1
-! grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS" && exit 1
+if grep -q "$NO_NEWLINE: text files should end with a newline character" "$RESULTS"; then
+    exit 1
+fi
+if grep -q "$HAS_NEWLINE: text files should end with a newline character" "$RESULTS"; then
+    exit 1
+fi
 
 # Manual check for sanity (count newlines in last byte of file)
 [[ $(tail -c1 "$NO_NEWLINE" | wc -l) -gt 0 ]]

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
@@ -5,12 +5,17 @@ set -eux
 
 SCRIPT_PATH="$ANSIBLE_TEST_ANSIBLE_LIB_ROOT/../../test/sanity/code-smell/trailing-newline.py"
 
-RESULTS="$OUTPUT_DIR/results.txt"
-HAS_NEWLINE="$OUTPUT_DIR/has_newline.py"
-NO_NEWLINE="$OUTPUT_DIR/no_newline.py"
+TEST_DIR="$OUTPUT_DIR/trailing_newline_sanity_test"
+RESULTS="$TEST_DIR/results.txt"
+HAS_NEWLINE="$TEST_DIR/has_newline.py"
+NO_NEWLINE="$TEST_DIR/no_newline.py"
+
+mkdir "$TEST_DIR"
 
 echo "# test" > "$HAS_NEWLINE"
 echo -n "# test" > "$NO_NEWLINE"
+
+trap 'rm -rf "$TEST_DIR"' EXIT
 
 export ANSIBLE_TEST_FIX_MODE=0
 

--- a/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
+++ b/test/integration/targets/ansible-test-sanity-trailing-newline/runme.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Navigate to project root
+cd ../../../../../../../../..
+
+TEST_DIR="lib/ansible/module_utils/newlinetests"
+RESULTS="$TEST_DIR/results.txt"
+HAS_NEWLINE="$TEST_DIR/has_newline.py"
+NO_NEWLINE="$TEST_DIR/no_newline.py"
+
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+mkdir -p "$TEST_DIR"
+echo "# test" > "$HAS_NEWLINE"
+echo -n "# test" > "$NO_NEWLINE"
+
+set -x
+
+echo "Check successful test"
+ansible-test sanity --test trailing-newline "$HAS_NEWLINE" "${@}"
+
+echo "Check that sanity test fail"
+ansible-test sanity --test trailing-newline "$NO_NEWLINE" "${@}" > "$RESULTS" || true
+cat "$RESULTS"
+grep -q "ERROR: $NO_NEWLINE:0:0: text files should end with a newline character" "$RESULTS"
+
+echo "Attempt to fix"
+ansible-test sanity --test trailing-newline --fix "$NO_NEWLINE" "${@}" > "$RESULTS"
+grep -v "ERROR: $NO_NEWLINE:0:0: text files should end with a newline character" "$RESULTS"
+
+echo "Check for success after fix"
+ansible-test sanity --test trailing-newline "$NO_NEWLINE" "${@}"
+# Manual check for sanity (count newlines in last byte of file)
+[[ $(tail -c1 "$NO_NEWLINE" | wc -l) -gt 0 ]]

--- a/test/integration/targets/ansible-test-sanity/fix_filtering.sh
+++ b/test/integration/targets/ansible-test-sanity/fix_filtering.sh
@@ -4,7 +4,7 @@ echo "Testing that ansible-test sanity actually ignores files when passed with t
 TESTFILE="./no_trailing_newline.txt"
 RESULTFILE="$OUTPUT_DIR/fix_filter_results.txt"
 
-trap "echo -n 'no trailing newline' > $TESTFILE" EXIT
+trap 'echo -n "no trailing newline" > $TESTFILE' EXIT
 
 ansible-test sanity --test trailing-newline --fix &> "$RESULTFILE"
 

--- a/test/integration/targets/ansible-test-sanity/fix_filtering.sh
+++ b/test/integration/targets/ansible-test-sanity/fix_filtering.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+echo "Testing that ansible-test sanity actually ignores files when passed with the --fix flag"
+
+TESTFILE="./no_trailing_newline.txt"
+RESULTFILE="$OUTPUT_DIR/fix_filter_results.txt"
+
+trap "echo -n 'no trailing newline' > $TESTFILE" EXIT
+
+ansible-test sanity --test trailing-newline --fix &> "$RESULTFILE"
+
+# No error
+if grep -q "ERROR: test/sanity/ignore.txt.*Ignoring 'test/integration/targets/ansible-test-sanity/no_trailing_newline.txt' is unnecessary" "$RESULTFILE"; then
+	exit 1
+fi
+
+# no_trailing_newline.txt is in ignore.txt and it should not have been fixed
+if [[ $(tail -c1 "no_trailing_newline.txt" | wc -l) -eq 1 ]]; then
+	exit 1
+fi

--- a/test/integration/targets/ansible-test-sanity/no_trailing_newline.txt
+++ b/test/integration/targets/ansible-test-sanity/no_trailing_newline.txt
@@ -1,0 +1,1 @@
+no trailing newline

--- a/test/integration/targets/ansible-test-sanity/runme.sh
+++ b/test/integration/targets/ansible-test-sanity/runme.sh
@@ -2,6 +2,8 @@
 
 set -eux
 
+source ./fix_filtering.sh
+
 ansible-test sanity --color --allow-disabled -e "${@}"
 
 set +x

--- a/test/lib/ansible_test/_internal/commands/sanity/__init__.py
+++ b/test/lib/ansible_test/_internal/commands/sanity/__init__.py
@@ -235,6 +235,7 @@ def command_sanity(args: SanityConfig) -> None:
 
                 usable_targets = sorted(test.filter_targets_by_version(args, list(usable_targets), version))
                 usable_targets = settings.filter_skipped_targets(usable_targets)
+                usable_targets = settings.filter_ignored_targets(usable_targets) if args.fix else usable_targets
                 sanity_targets = SanityTargets(tuple(all_targets), tuple(usable_targets))
 
                 test_needed = bool(usable_targets or test.no_targets or args.prime_venvs)
@@ -563,6 +564,10 @@ class SanityIgnoreProcessor:
     def filter_skipped_targets(self, targets: list[TestTarget]) -> list[TestTarget]:
         """Return the given targets, with any skipped paths filtered out."""
         return sorted(target for target in targets if target.path not in self.skip_entries)
+
+    def filter_ignored_targets(self, targets: list[TestTarget]) -> list[TestTarget]:
+        """Return the given targets, with any ignored paths filtered out."""
+        return sorted(target for target in targets if target.path not in self.ignore_entries)
 
     def process_errors(self, errors: list[SanityMessage], paths: list[str]) -> list[SanityMessage]:
         """Return the given errors filtered for ignores and with any settings related errors included."""

--- a/test/sanity/code-smell/trailing-newline.py
+++ b/test/sanity/code-smell/trailing-newline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sys
 import os
 
+
 def main():
     """Main entry point."""
     fix_mode = bool(int(os.environ['ANSIBLE_TEST_FIX_MODE']))

--- a/test/sanity/code-smell/trailing-newline.py
+++ b/test/sanity/code-smell/trailing-newline.py
@@ -3,19 +3,23 @@
 from __future__ import annotations
 
 import sys
-
+import os
 
 def main():
     """Main entry point."""
+    fix_mode = bool(int(os.environ['ANSIBLE_TEST_FIX_MODE']))
     for path in sys.argv[1:] or sys.stdin.read().splitlines():
-        with open(path, 'rb') as path_fd:
+        with open(path, 'ab+') as path_fd:
             try:
                 path_fd.seek(-1, 2)  # End of the file minus one byte
             except OSError as e:  # catch empty files
                 continue
             last_char = path_fd.read(1)
             if last_char != b'\n':
-                print(f'{path}: text files should end with a newline character "\\n"')
+                if fix_mode:
+                    path_fd.write(b'\n')
+                else:
+                    print(f'{path}: text files should end with a newline character "\\n"')
 
 
 if __name__ == '__main__':

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -282,3 +282,4 @@ test/units/errors/fixtures/inputs/long_file.txt trailing-newline
 test/units/errors/fixtures/inputs/one_line_file.txt trailing-newline
 test/units/errors/fixtures/inputs/short_file_missing_trailing_newline.txt trailing-newline
 .github/RELEASE_NAMES.txt release-names  # TODO: 2.21
+test/integration/targets/ansible-test-sanity/no_trailing_newline.txt trailing-newline  # Using trailing-newline test to check ignore filtering when used with --fix


### PR DESCRIPTION
##### SUMMARY

Adds a flag `--fix` to the trailing-newline sanity test to support automatically healing this issue.

Also adds an integration test for this sanity test.

##### ISSUE TYPE

- Test Pull Request
