### PR TITLE
decode url path before basename in get_response_filename

### DIFF
--- a/changelogs/fragments/uri-response-filename-traversal.yml
+++ b/changelogs/fragments/uri-response-filename-traversal.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - uri - decode the URL path before deriving the destination filename in
+    ``get_response_filename`` so percent-encoded path separators cannot place
+    the downloaded file outside a ``dest`` directory.

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -344,9 +344,7 @@ def get_response_filename(response):
     else:
         url = response.geturl()
         path = urlparse(url)[2]
-        filename = os.path.basename(path.rstrip('/')) or None
-        if filename:
-            filename = unquote(filename)
+        filename = os.path.basename(unquote(path).rstrip('/')) or None
 
     return filename
 

--- a/test/units/module_utils/urls/test_urls.py
+++ b/test/units/module_utils/urls/test_urls.py
@@ -4,7 +4,35 @@
 
 from __future__ import annotations
 
+from email.message import Message
+
 from ansible.module_utils import urls
+
+
+class _FakeResponse:
+    def __init__(self, url, content_disposition=None):
+        self._url = url
+        self.headers = Message()
+        if content_disposition is not None:
+            self.headers['content-disposition'] = content_disposition
+
+    def geturl(self):
+        return self._url
+
+
+def test_get_response_filename_from_content_disposition():
+    resp = _FakeResponse('http://ansible.com/', 'attachment; filename="report.tar.gz"')
+    assert urls.get_response_filename(resp) == 'report.tar.gz'
+
+
+def test_get_response_filename_from_url_path():
+    resp = _FakeResponse('http://ansible.com/files/data%20set.txt')
+    assert urls.get_response_filename(resp) == 'data set.txt'
+
+
+def test_get_response_filename_strips_encoded_traversal():
+    resp = _FakeResponse('http://ansible.com/a/%2e%2e%2f%2e%2e%2fetc%2fpasswd')
+    assert urls.get_response_filename(resp) == 'passwd'
 
 
 def test_basic_auth_header():


### PR DESCRIPTION
##### SUMMARY

1. when `uri` downloads into a directory `dest`, the destination filename comes from the response url path via `get_response_filename` in `module_utils/urls.py`.
2. `os.path.basename` ran before `unquote`, so a percent-encoded separator like `%2f` survived basename and then decoded into `../`, so the written body could land outside `dest` (e.g. url path `/a/%2e%2e%2f%2e%2e%2fetc%2fpasswd` produced the filename `../../etc/passwd`).

Decode the path before basename so directory components are stripped. Added unit tests covering the content-disposition path, a normal url path, and the encoded-traversal case.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/urls.py
