### PR TITLE
dnf, dnf5 - add clean_requirements_on_remove option

### DIFF
--- a/changelogs/fragments/87197-dnf-clean-requirements-on-remove.yml
+++ b/changelogs/fragments/87197-dnf-clean-requirements-on-remove.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - dnf, dnf5 - add the ``clean_requirements_on_remove`` option to remove the
+    dependencies made unneeded by a package removal without triggering a full
+    ``autoremove`` sweep of unrelated orphaned packages
+    (https://github.com/ansible/ansible/issues/87197).

--- a/lib/ansible/module_utils/_embed/dnf.py
+++ b/lib/ansible/module_utils/_embed/dnf.py
@@ -163,7 +163,12 @@ def _configure_base(base, config_dict):
         conf.cacheonly = True
 
     autoremove = config_dict.get('autoremove', False)
-    conf.clean_requirements_on_remove = autoremove
+    # `clean_requirements_on_remove` can be set independently of `autoremove`. When it is
+    # not specified, fall back to `autoremove` to preserve backwards compatibility.
+    clean_requirements_on_remove = config_dict.get('clean_requirements_on_remove')
+    if clean_requirements_on_remove is None:
+        clean_requirements_on_remove = autoremove
+    conf.clean_requirements_on_remove = clean_requirements_on_remove
 
     install_weak_deps = config_dict.get('install_weak_deps', True)
     conf.install_weak_deps = install_weak_deps

--- a/lib/ansible/module_utils/yumdnf.py
+++ b/lib/ansible/module_utils/yumdnf.py
@@ -21,6 +21,7 @@ yumdnf_argument_spec = dict(
         best=dict(type="bool"),
         bugfix=dict(required=False, type='bool', default=False),
         cacheonly=dict(type='bool', default=False),
+        clean_requirements_on_remove=dict(type='bool', default=None),
         conf_file=dict(type='str'),
         disable_excludes=dict(type='str', default=None),
         disable_gpg_check=dict(type='bool', default=False),
@@ -70,6 +71,7 @@ class YumDnf(metaclass=ABCMeta):
         self.best = self.module.params['best']
         self.bugfix = self.module.params['bugfix']
         self.cacheonly = self.module.params['cacheonly']
+        self.clean_requirements_on_remove = self.module.params['clean_requirements_on_remove']
         self.conf_file = self.module.params['conf_file']
         self.disable_excludes = self.module.params['disable_excludes']
         self.disable_gpg_check = self.module.params['disable_gpg_check']

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -115,6 +115,19 @@ options:
     type: bool
     default: "no"
     version_added: "2.4"
+  clean_requirements_on_remove:
+    description:
+      - If V(true), when removing a package with O(state=absent), also remove the
+        dependencies that were installed for it and are no longer required by any other
+        package.
+      - Unlike O(autoremove), this only affects dependencies of the packages being
+        removed in the current operation and does not perform a full system-wide sweep
+        of orphaned packages.
+      - When not set, the behavior falls back to the value of O(autoremove) to preserve
+        backwards compatibility.
+      - Only used when O(state=absent).
+    type: bool
+    version_added: "2.22"
   exclude:
     description:
       - Package name(s) to exclude from the operation. This can be a list or a comma separated string.
@@ -433,6 +446,7 @@ class DnfModule(YumDnf):
             'download_dir': self.download_dir,
             'cacheonly': self.cacheonly,
             'autoremove': self.autoremove,
+            'clean_requirements_on_remove': self.clean_requirements_on_remove,
             'install_weak_deps': self.install_weak_deps,
             'disablerepo': self.disablerepo,
             'enablerepo': self.enablerepo,

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -115,19 +115,6 @@ options:
     type: bool
     default: "no"
     version_added: "2.4"
-  clean_requirements_on_remove:
-    description:
-      - If V(true), when removing a package with O(state=absent), also remove the
-        dependencies that were installed for it and are no longer required by any other
-        package.
-      - Unlike O(autoremove), this only affects dependencies of the packages being
-        removed in the current operation and does not perform a full system-wide sweep
-        of orphaned packages.
-      - When not set, the behavior falls back to the value of O(autoremove) to preserve
-        backwards compatibility.
-      - Only used when O(state=absent).
-    type: bool
-    version_added: "2.22"
   exclude:
     description:
       - Package name(s) to exclude from the operation. This can be a list or a comma separated string.
@@ -282,6 +269,7 @@ options:
 extends_documentation_fragment:
 - action_common_attributes
 - action_common_attributes.flow
+- dnf
 attributes:
     action:
         details: dnf has 2 action plugins that use it under the hood, M(ansible.builtin.dnf) and M(ansible.builtin.package).

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -93,6 +93,19 @@ options:
         required by any such package. Should be used alone or when O(state=absent).
     type: bool
     default: "no"
+  clean_requirements_on_remove:
+    description:
+      - If V(true), when removing a package with O(state=absent), also remove the
+        dependencies that were installed for it and are no longer required by any other
+        package.
+      - Unlike O(autoremove), this only affects dependencies of the packages being
+        removed in the current operation and does not perform a full system-wide sweep
+        of orphaned packages.
+      - When not set, the behavior falls back to the value of O(autoremove) to preserve
+        backwards compatibility.
+      - Only used when O(state=absent).
+    type: bool
+    version_added: "2.22"
   exclude:
     description:
       - Package name(s) to exclude from the operation. This can be a list or a comma separated string.
@@ -594,7 +607,12 @@ class Dnf5Module(YumDnf):
             conf.pkg_gpgcheck = not self.disable_gpg_check
         conf.localpkg_gpgcheck = not self.disable_gpg_check
         conf.sslverify = self.sslverify
-        conf.clean_requirements_on_remove = self.autoremove
+        # `clean_requirements_on_remove` can be set independently of `autoremove`. When it
+        # is not specified, fall back to `autoremove` to preserve backwards compatibility.
+        if self.clean_requirements_on_remove is None:
+            conf.clean_requirements_on_remove = self.autoremove
+        else:
+            conf.clean_requirements_on_remove = self.clean_requirements_on_remove
 
         if not os.path.isdir(self.installroot):
             self.module.fail_json(msg=f"Installroot {self.installroot} must be a directory")

--- a/lib/ansible/modules/dnf5.py
+++ b/lib/ansible/modules/dnf5.py
@@ -93,19 +93,6 @@ options:
         required by any such package. Should be used alone or when O(state=absent).
     type: bool
     default: "no"
-  clean_requirements_on_remove:
-    description:
-      - If V(true), when removing a package with O(state=absent), also remove the
-        dependencies that were installed for it and are no longer required by any other
-        package.
-      - Unlike O(autoremove), this only affects dependencies of the packages being
-        removed in the current operation and does not perform a full system-wide sweep
-        of orphaned packages.
-      - When not set, the behavior falls back to the value of O(autoremove) to preserve
-        backwards compatibility.
-      - Only used when O(state=absent).
-    type: bool
-    version_added: "2.22"
   exclude:
     description:
       - Package name(s) to exclude from the operation. This can be a list or a comma separated string.
@@ -245,6 +232,7 @@ options:
 extends_documentation_fragment:
 - action_common_attributes
 - action_common_attributes.flow
+- dnf
 attributes:
     action:
         details: dnf5 has 2 action plugins that use it under the hood, M(ansible.builtin.dnf) and M(ansible.builtin.package).

--- a/lib/ansible/plugins/doc_fragments/dnf.py
+++ b/lib/ansible/plugins/doc_fragments/dnf.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024, Ansible, Inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+
+class ModuleDocFragment(object):
+
+    # Standard documentation fragment shared by the dnf and dnf5 modules
+    DOCUMENTATION = r"""
+options:
+  clean_requirements_on_remove:
+    description:
+      - If V(true), when removing a package with O(state=absent), also remove the
+        dependencies that were installed for it and are no longer required by any other
+        package.
+      - Unlike O(autoremove), this only affects dependencies of the packages being
+        removed in the current operation and does not perform a full system-wide sweep
+        of orphaned packages.
+      - When not set, the behavior falls back to the value of O(autoremove) to preserve
+        backwards compatibility.
+      - Only used when O(state=absent).
+    type: bool
+    version_added: "2.22"
+"""

--- a/test/integration/targets/dnf/tasks/clean_requirements_on_remove.yml
+++ b/test/integration/targets/dnf/tasks/clean_requirements_on_remove.yml
@@ -1,0 +1,61 @@
+- name: Test `clean_requirements_on_remove`
+  block:
+    - name: Ensure test packages are absent to start
+      dnf:
+        name:
+          - dinginessentail-with-hard-dep
+          - dinginessentail-hard-dep
+        state: absent
+
+    # Case 1: clean_requirements_on_remove=true removes the now-unneeded dependency
+    - name: Install parent package (pulls in its hard dependency)
+      dnf:
+        name: dinginessentail-with-hard-dep
+        state: present
+
+    - name: Verify the dependency was pulled in
+      command: rpm -q dinginessentail-hard-dep
+
+    - name: Remove parent with clean_requirements_on_remove=true
+      dnf:
+        name: dinginessentail-with-hard-dep
+        state: absent
+        clean_requirements_on_remove: true
+      register: remove_with_clean
+
+    - name: Check the orphaned dependency was also removed
+      command: rpm -q dinginessentail-hard-dep
+      register: dep_after_clean
+      failed_when: dep_after_clean.rc == 0
+
+    - name: Assert the removal was reported as changed
+      assert:
+        that:
+          - remove_with_clean is changed
+
+    # Case 2: without the option (default) the dependency is left behind (back-compat)
+    - name: Re-install parent package
+      dnf:
+        name: dinginessentail-with-hard-dep
+        state: present
+
+    - name: Remove parent without clean_requirements_on_remove (default behavior)
+      dnf:
+        name: dinginessentail-with-hard-dep
+        state: absent
+      register: remove_default
+
+    - name: Verify the dependency remains installed (unchanged default behavior)
+      command: rpm -q dinginessentail-hard-dep
+
+    - name: Assert the removal was reported as changed
+      assert:
+        that:
+          - remove_default is changed
+  always:
+    - name: Cleanup test packages
+      dnf:
+        name:
+          - dinginessentail-with-hard-dep
+          - dinginessentail-hard-dep
+        state: absent

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -45,6 +45,7 @@
     - include_tasks: multilib.yml
     - include_tasks: dnf_config.yml
     - include_tasks: exclude.yml
+    - include_tasks: clean_requirements_on_remove.yml
 
 # Attempting to install a different RHEL release in a tmpdir doesn't work (rhel8 beta)
 - include_tasks: dnfreleasever.yml

--- a/test/integration/targets/setup_rpm_repo/ansible_collections/ansible_test/setup_rpm_repo/plugins/module_utils/_embed/create_repo.py
+++ b/test/integration/targets/setup_rpm_repo/ansible_collections/ansible_test/setup_rpm_repo/plugins/module_utils/_embed/create_repo.py
@@ -35,6 +35,8 @@ SPECS = [
     RPM(name='landsidescalping', version='1.1',),
     RPM(name='dinginessentail-with-weak-dep', version='1.0', recommends=['dinginessentail-weak-dep']),
     RPM(name='dinginessentail-weak-dep', version='1.0',),
+    RPM(name='dinginessentail-with-hard-dep', version='1.0', requires=['dinginessentail-hard-dep']),
+    RPM(name='dinginessentail-hard-dep', version='1.0',),
     RPM(name='noarchfake', version='1.0'),
     RPM(name='provides_foo_a', version='1.0', file='foo.gif'),
     RPM(name='provides_foo_b', version='1.0', file='foo.gif'),


### PR DESCRIPTION
##### SUMMARY

Fixes #87197.

The `dnf` and `dnf5` modules derived DNF's `clean_requirements_on_remove` setting solely from `autoremove`, which conflated two distinct behaviors:

- `conf.clean_requirements_on_remove` — remove the dependencies made unneeded by *this* removal
- `base.autoremove()` / `get_unneeded_pkgs()` — a full system-wide sweep of *all* orphaned packages

Because both were gated on `autoremove`, there was no way to remove a package's now-unneeded dependencies without also sweeping unrelated orphans elsewhere on the system.

This adds a `clean_requirements_on_remove` option that controls the first behavior independently. When it is not set, the behavior falls back to `autoremove`, so existing playbooks are unaffected.

```yaml
- ansible.builtin.dnf:
    name: systemtap
    state: absent
    clean_requirements_on_remove: true   # remove newly-unneeded deps, no full autoremove sweep
```

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

dnf
dnf5

##### ADDITIONAL INFORMATION

- New option added to the shared `yumdnf_argument_spec` (`type=bool`, `default=None`).
- Wired through the classic dnf backend (`_embed/dnf.py`, including the `_build_config` passthrough) and the dnf5 backend (`modules/dnf5.py`); the `autoremove`-gated full sweep is unchanged in both.
- Documented in both `dnf` and `dnf5` (`version_added: 2.22`).
- Integration test added, backed by a new hard-dependency test package pair in `setup_rpm_repo`.
- Changelog fragment included.
