### PR TITLE
meta: clarify what refresh_inventory reloads

### DIFF
--- a/lib/ansible/modules/meta.py
+++ b/lib/ansible/modules/meta.py
@@ -26,12 +26,6 @@ options:
           Ansible cannot know this and has no way of refreshing it (you can disable the cache or, if available for your specific inventory
           datasource (for example P(amazon.aws.aws_ec2#inventory)), you can use an inventory plugin instead of an inventory script).
           This is mainly useful when additional hosts are created and users wish to use them instead of using the M(ansible.builtin.add_host) module.
-        - Variable plugins are not part of inventory and handle caching independently of V(refresh_inventory).
-          V(refresh_inventory) will only reload variable plugins that perform no caching and are configured to run after inventory is parsed
-          instead of per task.
-          The default variable plugin P(ansible.builtin.host_group_vars#vars) caches applicable paths and file content, so creating, modifying, or removing
-          C(host_vars) and C(group_vars) files mid-play for hosts or groups that have already been targeted has no effect on the current or any
-          subsequent plays.
         - Note that neither V(refresh_inventory) nor the M(ansible.builtin.add_host) add hosts to the hosts the current play iterates over.
           However, if needed, you can explicitly delegate tasks to new hosts with C(delegate_to). Generally,
           C(delegate_to) can be used against hosts regardless of whether they are in the inventory or not, as long as
@@ -85,6 +79,12 @@ attributes:
 notes:
     - V(clear_facts) will remove the persistent facts from M(ansible.builtin.set_fact) using O(ansible.builtin.set_fact#module:cacheable=True),
       but not the current host variable it creates for the current run.
+    - Variable plugins are not part of inventory and handle execution and caching independently of V(refresh_inventory).
+      V(refresh_inventory) does not invalidate variable plugin caches. Whether later variable resolution sees updated variable plugin data depends
+      on the plugin's stage and caching behavior.
+    - The default variable plugin P(ansible.builtin.host_group_vars#vars) caches applicable paths and file content, so creating, modifying, or removing
+      C(host_vars) and C(group_vars) files mid-play for hosts or groups that have already been targeted has no effect on the current or any
+      subsequent plays. Use M(ansible.builtin.include_vars) to load variable files modified during playbook execution.
     - Skipping M(ansible.builtin.meta) tasks with tags is not supported before Ansible 2.11.
 seealso:
 - module: ansible.builtin.assert

--- a/lib/ansible/modules/meta.py
+++ b/lib/ansible/modules/meta.py
@@ -20,11 +20,18 @@ options:
         - This module takes a free form command, as a string. There is not an actual option named "free form".  See the examples!
         - V(flush_handlers) makes Ansible run any handler tasks which have thus far been notified. Ansible inserts these tasks internally at certain
           points to implicitly trigger handler runs (after pre/post tasks, the final role execution, and the main tasks section of your plays).
-        - V(refresh_inventory) (added in Ansible 2.0) forces the reload of the inventory, which in the case of dynamic inventory scripts means they will be
-          re-executed. If the dynamic inventory script is using a cache, Ansible cannot know this and has no way of refreshing it (you can disable the cache
-          or, if available for your specific inventory datasource (for example P(amazon.aws.aws_ec2#inventory)), you can use the an inventory plugin instead
-          of an inventory script). This is mainly useful when additional hosts are created and users wish to use them instead of using the
-          M(ansible.builtin.add_host) module.
+        - V(refresh_inventory) (added in Ansible 2.0) reloads inventory sources and the host and group structure based on those sources.
+          It also preserves dynamic hosts created by M(ansible.builtin.add_host) and dynamic groups created by M(ansible.builtin.group_by).
+          In the case of dynamic inventory scripts this means they will be re-executed. If the dynamic inventory script is using a cache,
+          Ansible cannot know this and has no way of refreshing it (you can disable the cache or, if available for your specific inventory
+          datasource (for example P(amazon.aws.aws_ec2#inventory)), you can use an inventory plugin instead of an inventory script).
+          This is mainly useful when additional hosts are created and users wish to use them instead of using the M(ansible.builtin.add_host) module.
+        - Variable plugins are not part of inventory and handle caching independently of V(refresh_inventory).
+          V(refresh_inventory) will only reload variable plugins that perform no caching and are configured to run after inventory is parsed
+          instead of per task.
+          The default variable plugin P(ansible.builtin.host_group_vars#vars) caches applicable paths and file content, so creating, modifying, or removing
+          C(host_vars) and C(group_vars) files mid-play for hosts or groups that have already been targeted has no effect on the current or any
+          subsequent plays.
         - Note that neither V(refresh_inventory) nor the M(ansible.builtin.add_host) add hosts to the hosts the current play iterates over.
           However, if needed, you can explicitly delegate tasks to new hosts with C(delegate_to). Generally,
           C(delegate_to) can be used against hosts regardless of whether they are in the inventory or not, as long as

--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -25,12 +25,13 @@ DOCUMENTATION = """
         - Enabled in configuration
     description:
         - Loads YAML vars into corresponding groups/hosts in group_vars/ and host_vars/ directories.
-        - Caches applicable paths and file content, so creating, modifying, or removing C(host_vars) and C(group_vars) files mid-play
-          for hosts or groups that have already been targeted has no effect on the current or any subsequent plays.
         - Files are restricted by extension to one of .yaml, .json, .yml or no extension.
         - Hidden (starting with '.') and backup (ending with '~') files and directories are ignored.
         - Only applies to inventory sources that are existing paths.
         - Starting in 2.10, this plugin requires enabling and is enabled by default.
+    notes:
+        - This plugin caches applicable paths and file content, so creating, modifying, or removing C(host_vars) and C(group_vars) files mid-play
+          for hosts or groups that have already been targeted has no effect on the current or any subsequent plays.
     options:
       stage:
         ini:

--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -25,6 +25,8 @@ DOCUMENTATION = """
         - Enabled in configuration
     description:
         - Loads YAML vars into corresponding groups/hosts in group_vars/ and host_vars/ directories.
+        - Caches applicable paths and file content, so creating, modifying, or removing C(host_vars) and C(group_vars) files mid-play
+          for hosts or groups that have already been targeted has no effect on the current or any subsequent plays.
         - Files are restricted by extension to one of .yaml, .json, .yml or no extension.
         - Hidden (starting with '.') and backup (ending with '~') files and directories are ignored.
         - Only applies to inventory sources that are existing paths.


### PR DESCRIPTION
##### SUMMARY

Clarify the documentation for `ansible.builtin.meta: refresh_inventory`.

The updated text explains that `refresh_inventory` reloads inventory sources and the host/group structure based on those sources, restores dynamic hosts from `add_host`, and restores dynamic groups from `group_by`.

It also clarifies that `refresh_inventory` does not reload variables already loaded for the current play, including `host_vars` and `group_vars` files, and points users to `include_vars` when they need to reload variable files modified during playbook execution.

Fixes #87161

##### ISSUE TYPE

- Docs Pull Request