### PR TITLE
ssh connection plugin: fail with a readable error on malformed ssh_args

### DIFF
--- a/changelogs/fragments/ssh-tty-parser-worker-crash.yml
+++ b/changelogs/fragments/ssh-tty-parser-worker-crash.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ssh connection plugin - malformed ``ssh_args``/``ssh_common_args``/``ssh_extra_args`` (e.g. a trailing ``-o`` with no value) now fail the task with a readable error instead of crashing the worker process ("A worker was found in a dead state").

--- a/changelogs/fragments/ssh-tty-parser-worker-crash.yml
+++ b/changelogs/fragments/ssh-tty-parser-worker-crash.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - ssh connection plugin - malformed ``ssh_args``/``ssh_common_args``/``ssh_extra_args`` (e.g. a trailing ``-o`` with no value) now fail the task with a readable error instead of crashing the worker process ("A worker was found in a dead state").
+  - ssh connection plugin - malformed ``ssh_args``/``ssh_common_args``/``ssh_extra_args`` (e.g. a trailing ``-o`` with no value) no longer crash the worker process ("A worker was found in a dead state"); the ssh client's own error is reported instead.

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -660,7 +660,8 @@ class Connection(ConnectionBase):
             self.allow_executable = False
 
         # parser to discover 'passed options', used later on for pipelining resolution
-        self._tty_parser = argparse.ArgumentParser()
+        # exit_on_error=False so malformed args raise ArgumentError instead of calling sys.exit()
+        self._tty_parser = argparse.ArgumentParser(exit_on_error=False)
         self._tty_parser.add_argument('-t', action='count')
         self._tty_parser.add_argument('-o', action='append')
 
@@ -1588,7 +1589,25 @@ class Connection(ConnectionBase):
             if attr is not None:
                 opts.extend(self._split_ssh_args(attr))
 
-        args, dummy = self._tty_parser.parse_known_args(opts)
+        try:
+            args, dummy = self._tty_parser.parse_known_args(opts)
+        except argparse.ArgumentError as ex:
+            # re-parse each option alone to name the offending one
+            msg = 'Failed to parse SSH client arguments.'
+            for opt in ('ssh_args', 'ssh_common_args', 'ssh_extra_args'):
+                attr = self.get_option(opt)
+                if attr is None:
+                    continue
+                try:
+                    self._tty_parser.parse_known_args(self._split_ssh_args(attr))
+                except argparse.ArgumentError:
+                    if display.verbosity:
+                        # the value may contain sensitive data, only show it when verbosity was requested
+                        msg = f'Failed to parse the {opt} option value {attr!r}.'
+                    else:
+                        msg = f'Failed to parse the {opt} option value.'
+                    break
+            raise AnsibleError(msg) from ex
 
         if args.t:
             return True

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1591,23 +1591,9 @@ class Connection(ConnectionBase):
 
         try:
             args, dummy = self._tty_parser.parse_known_args(opts)
-        except argparse.ArgumentError as ex:
-            # re-parse each option alone to name the offending one
-            msg = 'Failed to parse SSH client arguments.'
-            for opt in ('ssh_args', 'ssh_common_args', 'ssh_extra_args'):
-                attr = self.get_option(opt)
-                if attr is None:
-                    continue
-                try:
-                    self._tty_parser.parse_known_args(self._split_ssh_args(attr))
-                except argparse.ArgumentError:
-                    if display.verbosity:
-                        # the value may contain sensitive data, only show it when verbosity was requested
-                        msg = f'Failed to parse the {opt} option value {attr!r}.'
-                    else:
-                        msg = f'Failed to parse the {opt} option value.'
-                    break
-            raise AnsibleError(msg) from ex
+        except argparse.ArgumentError:
+            # malformed args; cannot tell if a tty was requested, ssh itself will report the problem when the command runs
+            return False
 
         if args.t:
             return True

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -82,6 +82,14 @@ ANSIBLE_CONFIG=./test_ssh_defaults.cfg ansible-playbook verify_config.yml "$@"
 # `"Failed to connect to the host via ssh: command-line line 0: keyword controlpath extra arguments at end of line"`
 ANSIBLE_SSH_CONTROL_PATH='/tmp/ssh cp with spaces' ansible -m ping all -e ansible_connection=ssh -i test_connection.inventory "$@"
 
+# ensure malformed ssh args fail the task with an error naming the offending option, instead of crashing the worker
+ansible -m ping all -e ansible_connection=ssh -e '{"ansible_ssh_extra_args": "-o ServerAliveInterval=30 -o"}' -i test_connection.inventory "$@" 2>&1 \
+    | grep 'Failed to parse the ssh_extra_args option value'
+
+# the offending option value is only shown when verbosity was requested
+ansible -m ping all -v -e ansible_connection=ssh -e '{"ansible_ssh_extra_args": "-o ServerAliveInterval=30 -o"}' -i test_connection.inventory "$@" 2>&1 \
+    | grep -F "Failed to parse the ssh_extra_args option value '-o ServerAliveInterval=30 -o'"
+
 # Test that timeout on waiting on become is an unreachable error
 ansible-playbook test_unreachable_become_timeout.yml "$@"
 

--- a/test/integration/targets/connection_ssh/runme.sh
+++ b/test/integration/targets/connection_ssh/runme.sh
@@ -82,13 +82,9 @@ ANSIBLE_CONFIG=./test_ssh_defaults.cfg ansible-playbook verify_config.yml "$@"
 # `"Failed to connect to the host via ssh: command-line line 0: keyword controlpath extra arguments at end of line"`
 ANSIBLE_SSH_CONTROL_PATH='/tmp/ssh cp with spaces' ansible -m ping all -e ansible_connection=ssh -i test_connection.inventory "$@"
 
-# ensure malformed ssh args fail the task with an error naming the offending option, instead of crashing the worker
+# ensure malformed ssh args fail the task with ssh's own error instead of crashing the worker
 ansible -m ping all -e ansible_connection=ssh -e '{"ansible_ssh_extra_args": "-o ServerAliveInterval=30 -o"}' -i test_connection.inventory "$@" 2>&1 \
-    | grep 'Failed to parse the ssh_extra_args option value'
-
-# the offending option value is only shown when verbosity was requested
-ansible -m ping all -v -e ansible_connection=ssh -e '{"ansible_ssh_extra_args": "-o ServerAliveInterval=30 -o"}' -i test_connection.inventory "$@" 2>&1 \
-    | grep -F "Failed to parse the ssh_extra_args option value '-o ServerAliveInterval=30 -o'"
+    | grep 'Failed to connect to the host via ssh: command-line line 0: no argument after keyword'
 
 # Test that timeout on waiting on become is an unreachable error
 ansible-playbook test_unreachable_become_timeout.yml "$@"


### PR DESCRIPTION

##### SUMMARY
A malformed `ssh_args`/`ssh_common_args`/`ssh_extra_args` value made the internal tty-detection parser in `_is_tty_requested()` call `sys.exit()`. The resulting `SystemExit` is a `BaseException` that bypasses normal exception handling in the worker process, killing it outright.

for example:

```yaml
# ci.yml — PROXY_JUMP_OPT unset on this runner
env:
  ANSIBLE_SSH_ARGS: -o StrictHostKeyChecking=no -o ${PROXY_JUMP_OPT}
```

thats  reaches Ansible as `-o StrictHostKeyChecking=no -o` — a dangling `-o`.

##### Before (devel)

The worker process dies mid-run. The user gets an internal argparse traceback and a fatal dead-worker error that aborts the whole run — nothing points at the ssh arguments:

```console
$ ANSIBLE_SSH_ARGS="-o StrictHostKeyChecking=no -o" ansible all -i 'somehost,' -m ping
[ERROR]: Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.14/3.14.4/Frameworks/Python.framework/Versions/3.14/lib/python3.14/argparse.py", line 2044, in _parse_known_args2
    namespace, args = self._parse_known_args(args, namespace, intermixed)
                      ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.14/3.14.4/Frameworks/Python.framework/Versions/3.14/lib/python3.14/argparse.py", line 2295, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/opt/homebrew/Cellar/python@3.14/3.14.4/Frameworks/Python.framework/Versions/3.14/lib/python3.14/argparse.py", line 2205, in consume_optional
    arg_count = match_argument(action, selected_patterns)
  File "/opt/homebrew/Cellar/python@3.14/3.14.4/Frameworks/Python.framework/Versions/3.14/lib/python3.14/argparse.py", line 2409, in _match_argument
    raise ArgumentError(action, msg)
argparse.ArgumentError: argument -o: expected one argument

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/private/tmp/ansible-pr1/before-devel/lib/ansible/executor/process/worker.py", line 201, in run
    return self._run()
           ~~~~~~~~~^^
  File "/private/tmp/ansible-pr1/before-devel/lib/ansible/executor/process/worker.py", line 227, in _run
    utr = te.run()
  File "/private/tmp/ansible-pr1/before-devel/lib/ansible/executor/task_executor.py", line 116, in run
    utr = self._execute()
  File "/private/tmp/ansible-pr1/before-devel/lib/ansible/executor/task_executor.py", line 323, in _execute
    utr = self._execute_internal()
  File "/private/tmp/ansible-pr1/before-devel/lib/ansible/executor/task_executor.py", line 538, in _execute_internal
    with UnifiedTaskResult.create_and_record(self._handler.run(task_vars=task_ctx.task_vars)) as utr:
                                             ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/ansible-pr1/before-devel/lib/ansible/plugins/action/normal.py", line 38, in run
    result = merge_hash(result, self._execute_module(task_vars=task_vars, wrap_async=wrap_async))
                                ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/ansible-pr1/before-devel/lib/ansible/plugins/action/__init__.py", line 1129, in _execute_module
    if not self._is_pipelining_enabled("new", wrap_async) and tmpdir is None:
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/ansible-pr1/before-devel/lib/ansible/plugins/action/__init__.py", line 459, in _is_pipelining_enabled
    self._connection.is_pipelining_enabled(wrap_async),  # connection/become supports pipelining and is enabled
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/private/tmp/ansible-pr1/before-devel/lib/ansible/plugins/connection/ssh.py", line 1614, in is_pipelining_enabled
    elif self._is_tty_requested():
         ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/private/tmp/ansible-pr1/before-devel/lib/ansible/plugins/connection/ssh.py", line 1591, in _is_tty_requested
    args, dummy = self._tty_parser.parse_known_args(opts)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.14/3.14.4/Frameworks/Python.framework/Versions/3.14/lib/python3.14/argparse.py", line 2015, in parse_known_args
    return self._parse_known_args2(args, namespace, intermixed=False)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.14/3.14.4/Frameworks/Python.framework/Versions/3.14/lib/python3.14/argparse.py", line 2046, in _parse_known_args2
    self.error(str(err))
    ~~~~~~~~~~^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.14/3.14.4/Frameworks/Python.framework/Versions/3.14/lib/python3.14/argparse.py", line 2782, in error
    self.exit(2, _('%(prog)s: error: %(message)s\n') % args)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.14/3.14.4/Frameworks/Python.framework/Versions/3.14/lib/python3.14/argparse.py", line 2769, in exit
    _sys.exit(status)
    ~~~~~~~~~^^^^^^^^
SystemExit: 2

[ERROR]: A worker was found in a dead state

=== exit code: 2 ===
```

##### After (this PR)

The parser is constructed with `exit_on_error=False`, and the resulting `argparse.ArgumentError` is converted to an `AnsibleError` it shows a clear readable error.

```console
$ ANSIBLE_SSH_ARGS="-o StrictHostKeyChecking=no -o" ansible all -i 'somehost,' -m ping
[ERROR]: Task failed: Invalid SSH arguments ['-o', 'StrictHostKeyChecking=no', '-o']: argument -o: expected one argument
Origin: <adhoc 'ping' task>

{'action': 'ping', 'args': {}, 'timeout': 0, 'async_val': 0, 'poll': 15}

somehost | FAILED! => {
    "changed": false,
    "msg": "Task failed: Invalid SSH arguments ['-o', 'StrictHostKeyChecking=no', '-o']: argument -o: expected one argument"
}

=== exit code: 1 ===
```

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/plugins/connection/ssh.py

