### PR TITLE
ansible-test sanity: add docs URLs as `url` attribute to `<testsuite>` elements in JUnit XML output

### DIFF
--- a/changelogs/fragments/87220-junit-url.yml
+++ b/changelogs/fragments/87220-junit-url.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "ansible-test sanity - when using ``--junit`` to write JUnit XML files, add documentation URLs to ``<testsuite>`` elements as ``url`` attribute
+     (https://github.com/ansible/ansible/pull/87220)."

--- a/lib/ansible/utils/_junit_xml.py
+++ b/lib/ansible/utils/_junit_xml.py
@@ -144,6 +144,8 @@ class TestSuite:
     system_out: str | None = None
     system_err: str | None = None
 
+    url: str | None = None
+
     def __post_init__(self):
         if self.timestamp and self.timestamp.tzinfo != datetime.timezone.utc:
             raise ValueError(f'timestamp.tzinfo must be {datetime.timezone.utc!r}')
@@ -189,6 +191,7 @@ class TestSuite:
             name=self.name,
             package=self.package,
             skipped=self.skipped,
+            url=self.url,
             tests=self.tests,
             time=self.time,
             timestamp=self.timestamp.replace(tzinfo=None).isoformat(timespec='seconds') if self.timestamp else None,

--- a/test/lib/ansible_test/_internal/test.py
+++ b/test/lib/ansible_test/_internal/test.py
@@ -108,13 +108,14 @@ class TestResult:
 
         return name
 
-    def save_junit(self, args: TestConfig, test_case: junit_xml.TestCase) -> None:
+    def save_junit(self, args: TestConfig, test_case: junit_xml.TestCase, *, url: str | None = None) -> None:
         """Save the given test case results to disk as JUnit XML."""
         suites = junit_xml.TestSuites(
             suites=[
                 junit_xml.TestSuite(
                     name='ansible-test',
                     cases=[test_case],
+                    url=url,
                     timestamp=datetime.datetime.now(tz=datetime.timezone.utc),
                 ),
             ],
@@ -278,6 +279,7 @@ class TestFailure(TestResult):
         """Write results to a junit XML file."""
         title = self.format_title()
         output = self.format_block()
+        doc_url = self.find_docs()
 
         test_case = junit_xml.TestCase(
             classname=self.command,
@@ -290,7 +292,7 @@ class TestFailure(TestResult):
             ],
         )
 
-        self.save_junit(args, test_case)
+        self.save_junit(args, test_case, url=doc_url)
 
     def write_bot(self, args: TestConfig) -> None:
         """Write results to a file for ansibullbot to consume."""


### PR DESCRIPTION
##### SUMMARY
The `url` elements were available in [junit-xml](https://pypi.org/project/junit-xml/) ([source](https://github.com/kyrus/python-junit-xml/blob/4bd08a272f059998cedf9b7779f944d49eba13a6/junit_xml/__init__.py#L150)), from which the Ansible code was inspired (see https://github.com/ansible/ansible/pull/75605/changes).

This allows to extract all information that is part of the bot JSONs also from the JUnit XML files written by `ansible-test sanity --junit`, which makes it easier for other tools (like antsibull-nox) to process machine-readable ansible-test output.

Ref: https://github.com/ansible-community/antsibull-nox/issues/226

##### ISSUE TYPE

- Feature Pull Request
- Test Pull Request
