### PR TITLE
ssh connection plugin: fail with a readable error on invalid RequestTTY

### DIFF
--- a/changelogs/fragments/ssh-requesttty-missing-value.yml
+++ b/changelogs/fragments/ssh-requesttty-missing-value.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ssh connection plugin - ``RequestTTY`` parsing in tty detection now matches OpenSSH - a missing, empty, or unsupported value in ``ssh_args``/``ssh_common_args``/``ssh_extra_args`` fails the task with a readable error instead of an unhandled ``IndexError`` or being silently ignored, and ``true`` is now recognized as an alias for ``yes``.

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1600,7 +1600,13 @@ class Connection(ConnectionBase):
                 val = arg.split(maxsplit=1)
 
             if val[0].lower().strip() == 'requesttty':
-                if val[1].lower().strip() in ('yes', 'force'):
+                if len(val) < 2 or not val[1].strip():
+                    raise AnsibleError(f'Invalid SSH option {arg!r}: missing value')
+                value = val[1].lower().strip()
+                # valid values per multistate_requesttty in OpenSSH readconf.c
+                if value not in ('yes', 'true', 'force', 'no', 'false', 'auto'):
+                    raise AnsibleError(f'Invalid SSH option {arg!r}: unsupported value')
+                if value in ('yes', 'true', 'force'):
                     return True
 
         return False

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -70,6 +70,29 @@ class TestConnectionBaseClass(unittest.TestCase):
         res, stdout, stderr = conn.exec_command('ssh')
         res, stdout, stderr = conn.exec_command('ssh', 'this is some data')
 
+    def test_plugins_connection_ssh__is_tty_requested_requesttty(self):
+        pc = PlayContext()
+        conn = connection_loader.get('ssh', pc)
+
+        cases = (
+            ('-o RequestTTY', AnsibleError),
+            ('-o RequestTTY=', AnsibleError),
+            ('-o RequestTTY=unsupported-value', AnsibleError),
+            ('-o RequestTTY=true', True),
+            ('-o RequestTTY=force', True),
+            ('-o RequestTTY=no', False),
+            ('-o RequestTTY=auto', False),
+        )
+        for ssh_args, expected in cases:
+            with self.subTest(ssh_args=ssh_args):
+                options = {'ssh_args': ssh_args, 'ssh_common_args': '', 'ssh_extra_args': ''}
+                conn.get_option = MagicMock(side_effect=options.get)
+                if expected is AnsibleError:
+                    with self.assertRaises(AnsibleError):
+                        conn._is_tty_requested()
+                else:
+                    self.assertEqual(conn._is_tty_requested(), expected)
+
     def test_plugins_connection_ssh__examine_output(self):
         pc = PlayContext()
         become_success_token = b'BECOME-SUCCESS-abcdefghijklmnopqrstuvxyz'


### PR DESCRIPTION
##### SUMMARY

A `RequestTTY` option in `ssh_args`/`ssh_common_args`/`ssh_extra_args` with a missing value raised an unhandled `IndexError`, while an empty or unsupported value was silently parsed as "no tty requested". 

OpenSSH rejects all of these fatally at startup, so raise `AnsibleError` naming the offending option instead. The supported value set (`yes`, `true`, `force`, `no`, `false`, `auto`) mirrors `multistate_requesttty` in OpenSSH `readconf.c`.

##### Before (devel)

```console
$ ANSIBLE_SSH_ARGS="-o RequestTTY" ansible all -i 'somehost,' -m ping
[ERROR]: Task failed: list index out of range
```

##### After (this PR)

```console
$ ANSIBLE_SSH_ARGS="-o RequestTTY" ansible all -i 'somehost,' -m ping
[ERROR]: Task failed: Invalid SSH option 'RequestTTY': missing value
```

| input | result |
|---|---|
| `-o RequestTTY` / `-o RequestTTY=` | `AnsibleError: Invalid SSH option ...: missing value` |
| `-o RequestTTY=<junk>` | `AnsibleError: Invalid SSH option ...: unsupported value` |
| `-o RequestTTY=yes/true/force` | tty detected |
| `-o RequestTTY=no/false/auto` | no tty, no error |

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/plugins/connection/ssh.py
