### PR TITLE
genent: fail with error on platforms like Alpine when service is provided

### DIFF
--- a/changelogs/fragments/85568-getent-service-error.yml
+++ b/changelogs/fragments/85568-getent-service-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - getent - fail with error when service is provided on platforms using busybox like alpine (https://github.com/ansible/ansible/issues/85568).

--- a/lib/ansible/modules/getent.py
+++ b/lib/ansible/modules/getent.py
@@ -115,6 +115,7 @@ ansible_facts:
       type: list
 """
 
+import platform
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
 
@@ -147,6 +148,8 @@ def main():
         cmd = [getent_bin, database]
 
     if service is not None:
+        if platform.libc_ver()[0] not in ('glibc',):
+            module.fail_json(msg=f"Specifying service `{service}` not supported on this platform.")
         cmd.extend(['-s', service])
 
     if not split and split is not None:

--- a/test/integration/targets/getent/tasks/main.yml
+++ b/test/integration/targets/getent/tasks/main.yml
@@ -6,45 +6,58 @@
   shell: which getent
   failed_when: False
   register: getent_check
-##
-## getent
-##
-- block:
-    - name: run getent with specified service
-      getent:
-          database: passwd
-          key: root
-          service: files
-      register: getent_test0
-      when: ansible_system != 'FreeBSD' and ansible_distribution != 'Alpine'
 
-    - name: run getent w/o specified service (FreeBSD)
-      getent:
-          database: passwd
-          key: root
-      register: getent_test0
-      when: ansible_system == 'FreeBSD' or ansible_distribution == 'Alpine'
+- name: skip test on unsupported platforms
+  meta: end_play
+  when: getent_check.rc != 0
 
-    - debug: var=getent_test0
+- name: run getent with specified service
+  getent:
+      database: passwd
+      key: root
+      service: files
+  register: getent_test0
+  when: ansible_system != 'FreeBSD' and ansible_distribution != 'Alpine'
 
-    - name: validate results
-      assert:
-          that:
-              - 'getent_passwd is defined'
-              - 'getent_passwd.root is defined'
-              - 'getent_passwd.root|length == 6'
+- name: run getent w/o specified service (FreeBSD)
+  getent:
+      database: passwd
+      key: root
+  register: getent_test0
+  when: ansible_system == 'FreeBSD' or ansible_distribution == 'Alpine'
 
-    - name: run getent with invalid split value
-      getent:
-        database: group
-        split: ""
-      register: getent_test1
-      ignore_errors: True
+- name: validate results
+  assert:
+      that:
+          - 'getent_test0 is success'
+          - 'getent_passwd is defined'
+          - 'getent_passwd.root is defined'
+          - 'getent_passwd.root|length == 6'
 
-    - name: validate results
-      assert:
-        that:
+- name: run getent with invalid split value
+  getent:
+      database: group
+      split: ""
+  register: getent_test1
+  ignore_errors: True
+
+- name: validate results
+  assert:
+      that:
           - 'getent_test1 is failed'
           - 'getent_test1.msg is contains "Invalid split value. The value must be a non-empty string"'
 
-  when: getent_check.rc == 0
+- name: run getent with specified service on Alpine (expected failure)
+  getent:
+      database: passwd
+      service: files
+  register: getent_service_unsupported
+  ignore_errors: true
+  when: ansible_distribution == 'Alpine'
+
+- name: validate unsupported service result on Alpine (expected failure)
+  assert:
+      that:
+          - 'getent_service_unsupported is failed'
+          - 'getent_service_unsupported.msg is contains "Specifying service `files` not supported on this platform."'
+  when: ansible_distribution == 'Alpine'


### PR DESCRIPTION
##### SUMMARY

Fixes #85568 

When `getent` exists with rc=2 and no `key` was supplied, the module currently reports:

`One or more supplied key could not be found in the database.`

That message is misleading for service override failures such as `database=passwd service=files` on platforms where the service flag is unsupported. This change keeps the existing missing-key message when a key was supplied, but returns a more accurate service/platform message when no key was supplied.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

getent

#####  ADDITIONAL INFORMATION

Added unit coverage for the rc=2 service override path and for the existing missing-key path.