### PR TITLE
Add check_mode parameter to ActionBase._execute_module() for action plugins

### DIFF
--- a/changelogs/fragments/87071-action-plugin-execute-module-check-mode.yml
+++ b/changelogs/fragments/87071-action-plugin-execute-module-check-mode.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - action plugins - ``ActionBase._execute_module()`` now accepts an optional ``check_mode`` parameter
+    to override the task's check mode for a specific module execution. This avoids the fragile
+    workaround of temporarily mutating ``self._task.check_mode``
+    (https://github.com/ansible/ansible/issues/87071).

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1024,10 +1024,11 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
             data = re.sub(r'^((\r)?\n)?BECOME-SUCCESS.*(\r)?\n', '', data)
         return data
 
-    def _update_module_args(self, module_name, module_args, task_vars, ignore_unknown_opts: bool = False):
+    def _update_module_args(self, module_name, module_args, task_vars, ignore_unknown_opts: bool = False, check_mode: bool | None = None):
 
         # set check mode in the module arguments, if required
-        if self._task.check_mode:
+        effective_check_mode = self._task.check_mode if check_mode is None else check_mode
+        if effective_check_mode:
             if not self._supports_check_mode:
                 raise AnsibleError("check mode is not supported for this operation")
             module_args['_ansible_check_mode'] = True
@@ -1099,9 +1100,17 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         delete_remote_tmp: bool | None = None,
         wrap_async: bool = False,
         ignore_unknown_opts: bool = False,
+        check_mode: bool | None = None,
     ) -> dict[str, object]:
         """
         Transfer and run a module along with its arguments.
+
+        :kwarg check_mode: Override check mode for this module execution.
+            ``None`` (default) inherits check mode from the task. ``True``
+            forces check mode on, ``False`` forces it off. This is useful
+            when an action plugin needs to execute a module that gathers
+            information without modifying state, even when the task is
+            running in check mode.
         """
         if tmp is not None:
             display.warning('_execute_module no longer honors the tmp parameter. Action plugins'
@@ -1139,7 +1148,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         if module_args is None:
             module_args = self._task.args
 
-        self._update_module_args(module_name, module_args, task_vars, ignore_unknown_opts=ignore_unknown_opts)
+        self._update_module_args(module_name, module_args, task_vars, ignore_unknown_opts=ignore_unknown_opts, check_mode=check_mode)
 
         remove_async_dir = None
         if wrap_async or self._task.async_val:

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -1024,7 +1024,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
             data = re.sub(r'^((\r)?\n)?BECOME-SUCCESS.*(\r)?\n', '', data)
         return data
 
-    def _update_module_args(self, module_name, module_args, task_vars, ignore_unknown_opts: bool = False, check_mode: bool | None = None):
+    def _update_module_args(self, module_name, module_args, task_vars, ignore_unknown_opts: bool = False, *, check_mode: bool | None = None):
 
         # set check mode in the module arguments, if required
         effective_check_mode = self._task.check_mode if check_mode is None else check_mode
@@ -1100,6 +1100,7 @@ class ActionBase(ABC, _AnsiblePluginInfoMixin):
         delete_remote_tmp: bool | None = None,
         wrap_async: bool = False,
         ignore_unknown_opts: bool = False,
+        *,
         check_mode: bool | None = None,
     ) -> dict[str, object]:
         """

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -775,3 +775,53 @@ class TestActionBaseParseReturnedData(unittest.TestCase):
         res = action_base._parse_returned_data(returned_data, 'legacy')
         self.assertTrue(res.ansible_facts)
         self.assertIn('ansible_blip', res.ansible_facts)
+
+
+class TestUpdateModuleArgsCheckMode(unittest.TestCase):
+
+    def _make_action(self, task_check_mode=False):
+        action_base = _action_base()
+        mock_task = MagicMock()
+        mock_task.check_mode = task_check_mode
+        mock_task.no_log = False
+        mock_task.diff = False
+        mock_task.delegate_to = None
+        mock_task.environment = []
+        action_base._task = mock_task
+        return action_base
+
+    def test_inherits_task_check_mode_true(self):
+        action = self._make_action(task_check_mode=True)
+        module_args = {}
+        action._update_module_args('test_module', module_args, {})
+        self.assertTrue(module_args['_ansible_check_mode'])
+
+    def test_inherits_task_check_mode_false(self):
+        action = self._make_action(task_check_mode=False)
+        module_args = {}
+        action._update_module_args('test_module', module_args, {})
+        self.assertFalse(module_args['_ansible_check_mode'])
+
+    def test_override_check_mode_false_when_task_is_check(self):
+        action = self._make_action(task_check_mode=True)
+        module_args = {}
+        action._update_module_args('test_module', module_args, {}, check_mode=False)
+        self.assertFalse(module_args['_ansible_check_mode'])
+
+    def test_override_check_mode_true_when_task_is_not_check(self):
+        action = self._make_action(task_check_mode=False)
+        module_args = {}
+        action._update_module_args('test_module', module_args, {}, check_mode=True)
+        self.assertTrue(module_args['_ansible_check_mode'])
+
+    def test_override_none_inherits_from_task(self):
+        action = self._make_action(task_check_mode=True)
+        module_args = {}
+        action._update_module_args('test_module', module_args, {}, check_mode=None)
+        self.assertTrue(module_args['_ansible_check_mode'])
+
+    def test_override_does_not_mutate_task(self):
+        action = self._make_action(task_check_mode=True)
+        module_args = {}
+        action._update_module_args('test_module', module_args, {}, check_mode=False)
+        self.assertTrue(action._task.check_mode)


### PR DESCRIPTION
##### SUMMARY

Allow action plugins to override check mode for individual `_execute_module()` calls
without mutating shared task state. This adds an optional `check_mode` parameter
(`None`/`True`/`False`) that scopes the override to a single module invocation.

Fixes #87071

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

action plugins

##### ADDITIONAL INFORMATION

Action plugins that need to call read-only modules (e.g., `ansible.builtin.command`
running `skopeo inspect`) during check mode previously had to temporarily mutate
`self._task.check_mode`, which is fragile if an exception occurs between setting
and restoring it.

Now they can pass `check_mode=False` directly:

```python
result = self._execute_module(
    module_name='ansible.builtin.command',
    module_args=dict(_raw_params='skopeo inspect ...'),
    task_vars=task_vars,
    check_mode=False,
)
```

This is also useful for collection modules like `community.routeros.command` or
`community.docker.docker_container_exec` where `_low_level_execute_command()` is
not a viable alternative since those modules have their own transport/protocol logic.

**Changes:**
- Added optional `check_mode` parameter to `_execute_module()` and `_update_module_args()`
- `None` (default) preserves existing behavior (inherits from task)
- `True`/`False` explicitly overrides for that specific call
- Added unit tests covering all override scenarios
- Added changelog fragment
