### PR TITLE
powershell exec_wrapper: select first pwsh when multiple match

### DIFF
--- a/changelogs/fragments/powershell-exec-wrapper-select-first.yml
+++ b/changelogs/fragments/powershell-exec-wrapper-select-first.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - powershell exec_wrapper - fix handling when multiple pwsh executables match by selecting the first result (https://github.com/ansible/ansible/issues/87228).

--- a/lib/ansible/executor/powershell/exec_wrapper.ps1
+++ b/lib/ansible/executor/powershell/exec_wrapper.ps1
@@ -81,6 +81,14 @@ begin {
     if ($PwshPath) {
         $null = $PSBoundParameters.Remove('PwshPath')
 
+        if ($PwshPath -eq 'powershell') {
+            # The default shebang for PowerShell modules is #!powershell which
+            # on Windows means to use the builtin powershell. We hardcode the
+            # path to the known location for the current process arch's
+            # powershell.exe.
+            $PwshPath = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe'
+        }
+
         $targetPwsh = Get-Command -Name $PwshPath -CommandType Application -ErrorAction Ignore |
             Select-Object -First 1 |
             ForEach-Object { [Path]::GetFullPath($_.Path) }

--- a/lib/ansible/executor/powershell/exec_wrapper.ps1
+++ b/lib/ansible/executor/powershell/exec_wrapper.ps1
@@ -82,6 +82,7 @@ begin {
         $null = $PSBoundParameters.Remove('PwshPath')
 
         $targetPwsh = Get-Command -Name $PwshPath -CommandType Application -ErrorAction Ignore |
+            Select-Object -First 1 |
             ForEach-Object { [Path]::GetFullPath($_.Path) }
         if (-not $targetPwsh) {
             @{

--- a/lib/ansible/executor/powershell/exec_wrapper.ps1
+++ b/lib/ansible/executor/powershell/exec_wrapper.ps1
@@ -81,14 +81,6 @@ begin {
     if ($PwshPath) {
         $null = $PSBoundParameters.Remove('PwshPath')
 
-        if ($PwshPath -eq 'powershell') {
-            # The default shebang for PowerShell modules is #!powershell which
-            # on Windows means to use the builtin powershell. We hardcode the
-            # path to the known location for the current process arch's
-            # powershell.exe.
-            $PwshPath = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe'
-        }
-
         $targetPwsh = Get-Command -Name $PwshPath -CommandType Application -ErrorAction Ignore |
             Select-Object -First 1 |
             ForEach-Object { [Path]::GetFullPath($_.Path) }

--- a/test/integration/targets/powershell_exec_wrapper/library/get_info.ps1
+++ b/test/integration/targets/powershell_exec_wrapper/library/get_info.ps1
@@ -9,4 +9,5 @@ if (-not (Get-Variable -Name IsWindows -ErrorAction Ignore)) {
 @{
     current_time = [DateTime]::Now.ToFileTime()
     is_windows = $IsWindows
+    intptr_size = [IntPtr]::Size
 } | ConvertTo-Json -Compress

--- a/test/integration/targets/powershell_exec_wrapper/library/get_info.ps1
+++ b/test/integration/targets/powershell_exec_wrapper/library/get_info.ps1
@@ -9,5 +9,4 @@ if (-not (Get-Variable -Name IsWindows -ErrorAction Ignore)) {
 @{
     current_time = [DateTime]::Now.ToFileTime()
     is_windows = $IsWindows
-    intptr_size = [IntPtr]::Size
 } | ConvertTo-Json -Compress

--- a/test/integration/targets/powershell_exec_wrapper/tasks/windows.yml
+++ b/test/integration/targets/powershell_exec_wrapper/tasks/windows.yml
@@ -205,25 +205,11 @@
       New-ItemProperty @keyParams | Out-Null
 
 - block:
-  - name: Run module with 32-bit PowerShell in PATH with default interpreter
+  - name: Reset connection to ensure refreshed env vars
+    meta: reset_connection
+
+  - name: Test that multiple PATH entries continue to work
     get_info:
-    register: ps_home
-
-  - name: Assert PSHome is for 64-bit PowerShell
-    assert:
-      that:
-      - ps_home.intptr_size == 8
-
-  - name: Verify that ansible_pwsh_interpreter can still override it back to the 32-bit PowerShell
-    get_info:
-    vars:
-      ansible_pwsh_interpreter: C:\Windows\SysWow64\WindowsPowerShell\v1.0\powershell.exe
-    register: ps_home
-
-  - name: Assert PSHome is for 32-bit PowerShell
-    assert:
-      that:
-      - ps_home.intptr_size == 4
 
   always:
   # We use raw as we won't know if setting the PATH broke everything or not.
@@ -231,3 +217,6 @@
     raw: >-
       C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
       -EncodedCommand {{ reset_path_command | b64encode(encoding='utf-16-le')}}
+
+  - name: Reset connection to after resetting env vars
+    meta: reset_connection

--- a/test/integration/targets/powershell_exec_wrapper/tasks/windows.yml
+++ b/test/integration/targets/powershell_exec_wrapper/tasks/windows.yml
@@ -159,3 +159,75 @@
   failed_when: >-
     iso8601_date.value != '2040-10-27T14:30:00' or
     iso8601_date.value_type != 'System.String'
+
+# https://github.com/ansible/ansible/issues/87228
+- name: Prepend 32-bit PATH for interpreter check
+  ansible.windows.win_powershell:
+    script: |
+      $ErrorActionPreference = 'Stop'
+
+      $keyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
+      $sysWowPowerShell = 'C:\Windows\SysWow64\WindowsPowerShell\v1.0'
+
+      $key = Get-Item -LiteralPath $keyPath
+      $rawPath = $key.GetValue('PATH', '', 'DoNotExpandEnvironmentNames')
+      $key.Dispose()
+
+      [System.Management.Automation.Language.CodeGeneration]::EscapeSingleQuotedStringContent($rawPath)
+
+      $keyParams = @{
+          Path = $keyPath
+          Name = 'PATH'
+          Value = "$sysWowPowerShell;$rawPath"
+          PropertyType = 'ExpandString'
+          Force = $true
+          Confirm = $false
+      }
+      New-ItemProperty @keyParams | Out-Null
+  register: path_info
+
+- name: Set reset PowerShell script to restore PATH to original value
+  set_fact:
+    reset_path_command: |
+      $ErrorActionPreference = 'Stop'
+
+      $keyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment'
+      $rawPath = '{{ path_info.output[0] }}'
+
+      $keyParams = @{
+          Path = $keyPath
+          Name = 'PATH'
+          Value = $rawPath
+          PropertyType = 'ExpandString'
+          Force = $true
+          Confirm = $false
+      }
+      New-ItemProperty @keyParams | Out-Null
+
+- block:
+  - name: Run module with 32-bit PowerShell in PATH with default interpreter
+    get_info:
+    register: ps_home
+
+  - name: Assert PSHome is for 64-bit PowerShell
+    assert:
+      that:
+      - ps_home.intptr_size == 8
+
+  - name: Verify that ansible_pwsh_interpreter can still override it back to the 32-bit PowerShell
+    get_info:
+    vars:
+      ansible_pwsh_interpreter: C:\Windows\SysWow64\WindowsPowerShell\v1.0\powershell.exe
+    register: ps_home
+
+  - name: Assert PSHome is for 32-bit PowerShell
+    assert:
+      that:
+      - ps_home.intptr_size == 4
+
+  always:
+  # We use raw as we won't know if setting the PATH broke everything or not.
+  - name: Reset PATH back to the original value
+    raw: >-
+      C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+      -EncodedCommand {{ reset_path_command | b64encode(encoding='utf-16-le')}}


### PR DESCRIPTION
##### SUMMARY

Fix handling when Get-Command returns multiple pwsh executables by
selecting the first result before getting the full path.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

Fixes: https://github.com/ansible/ansible/issues/87228

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/powershell-exec-wrapper-select-first.yml
lib/ansible/executor/powershell/exec_wrapper.ps1


