### PR TITLE
exec_wrapper - fix failure when multiple pwsh/powershell.exe match on PATH

### DIFF
--- a/changelogs/fragments/87228-fix-exec-wrapper-multiple-pwsh-in-path.yml
+++ b/changelogs/fragments/87228-fix-exec-wrapper-multiple-pwsh-in-path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - exec_wrapper - fix a failure when multiple ``pwsh``/``powershell.exe`` executables match on PATH (e.g. both the 32-bit and 64-bit Windows PowerShell directories), which caused ``Get-Command`` to return an array and break the interpreter respawn logic (https://github.com/ansible/ansible/issues/87228).

--- a/lib/ansible/executor/powershell/exec_wrapper.ps1
+++ b/lib/ansible/executor/powershell/exec_wrapper.ps1
@@ -82,6 +82,7 @@ begin {
         $null = $PSBoundParameters.Remove('PwshPath')
 
         $targetPwsh = Get-Command -Name $PwshPath -CommandType Application -ErrorAction Ignore |
+            Select-Object -First 1 |
             ForEach-Object { [Path]::GetFullPath($_.Path) }
         if (-not $targetPwsh) {
             @{


### PR DESCRIPTION
##### SUMMARY

Fixes #87228.

`lib/ansible/executor/powershell/exec_wrapper.ps1` resolves the target PowerShell interpreter with:

```powershell
$targetPwsh = Get-Command -Name $PwshPath -CommandType Application -ErrorAction Ignore |
    ForEach-Object { [Path]::GetFullPath($_.Path) }
```

When `PATH` contains more than one matching executable (e.g. both `C:\Windows\System32\WindowsPowerShell\v1.0` and `C:\Windows\SysWOW64\WindowsPowerShell\v1.0`), `Get-Command` returns multiple results and `$targetPwsh` becomes an array instead of a single string. The rest of the script (`Get-Item -LiteralPath $targetPwsh`, `Split-Path -Path $targetPwsh`, etc.) assumes a single path and fails at runtime once it receives an array — this is exactly the failure reported in the issue when running any task against a Windows host with a 32-bit PowerShell directory on `PATH`.

This adds `Select-Object -First 1` right after `Get-Command`, so the pipeline always resolves to a single path, the same as the existing behavior when only one match is found.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/powershell/exec_wrapper.ps1

##### ADDITIONAL INFORMATION

I don't have a Windows host handy to reproduce the original PSRP/`win_ping` failure end-to-end, but the root cause is reproducible in isolation: piping a two-element collection through `ForEach-Object { [Path]::GetFullPath($_.Path) }` yields an array, and every subsequent use of `$targetPwsh` in this file (`Get-Item -LiteralPath`, `[Directory]::ResolveLinkTarget`, `Split-Path -Path`) expects a scalar string. `Select-Object -First 1` is the minimal fix that preserves existing single-match behavior while resolving the multi-match case.

This PR was written with the help of Claude Code (Claude Sonnet 5). I reviewed the change and traced through the surrounding script logic by hand to confirm the fix; I was not able to run this against a real Windows target in this environment (no Windows host / no working local PowerShell to exercise the respawn path), so please treat this as needing extra scrutiny in CI/review given the change touches a security/execution-relevant script.