### PR TITLE
[stable-2.21] Install runc on fedora if installing docker (#87229)

### DIFF
--- a/test/integration/targets/ansible-test-container/runme.py
+++ b/test/integration/targets/ansible-test-container/runme.py
@@ -1007,6 +1007,9 @@ class DnfBootstrapper(Bootstrapper):
         if cls.install_docker():
             packages.append('moby-engine')
 
+        if cls.install_docker() and os_release.id == 'fedora':
+            packages.append('runc')
+
         if os_release.id == 'rhel':
             # As of the release of RHEL 9.1, installing podman on RHEL 9.0 results in a non-fatal error at install time:
             #


### PR DESCRIPTION
(cherry picked from commit 1e511b5)

Co-authored-by: sivel / Matt Martz <matt@sivel.net>