### PR TITLE
Reject non-contiguous netmasks in is_netmask

### DIFF
--- a/changelogs/fragments/87235-is_netmask-contiguous.yml
+++ b/changelogs/fragments/87235-is_netmask-contiguous.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - module_utils - ``is_netmask`` now rejects non-contiguous netmasks such as
+    ``255.255.0.255``, where each octet is individually valid but the mask is not
+    a contiguous run of network bits followed by host bits
+    (https://github.com/ansible/ansible/pull/87235).

--- a/lib/ansible/module_utils/common/network.py
+++ b/lib/ansible/module_utils/common/network.py
@@ -25,11 +25,11 @@ def is_netmask(val):
     for part in parts:
         try:
             octet = int(part)
-            if octet not in VALID_MASKS:
-                raise ValueError
-            mask = (mask << 8) | octet
         except ValueError:
             return False
+        if octet not in VALID_MASKS:
+            return False
+        mask = (mask << 8) | octet
     inverted = mask ^ 0xFFFFFFFF
     return inverted & (inverted + 1) == 0
 

--- a/lib/ansible/module_utils/common/network.py
+++ b/lib/ansible/module_utils/common/network.py
@@ -21,22 +21,6 @@ def is_netmask(val):
     parts = str(val).split('.')
     if not len(parts) == 4:
         return False
-    for part in parts:
-        try:
-            if int(part) not in VALID_MASKS:
-                raise ValueError
-        except ValueError:
-            return False
-    # The individually valid octets must also form a contiguous run of
-    # network bits (all 1s followed by all 0s), e.g. 255.255.0.255 is not a
-    # valid netmask even though every octet is in VALID_MASKS.
-    mask = 0
-    for part in parts:
-        mask = (mask << 8) | int(part)
-    inverted = mask ^ 0xFFFFFFFF
-    parts = str(val).split('.')
-    if not len(parts) == 4:
-        return False
     mask = 0
     for part in parts:
         try:

--- a/lib/ansible/module_utils/common/network.py
+++ b/lib/ansible/module_utils/common/network.py
@@ -27,7 +27,14 @@ def is_netmask(val):
                 raise ValueError
         except ValueError:
             return False
-    return True
+    # The individually valid octets must also form a contiguous run of
+    # network bits (all 1s followed by all 0s), e.g. 255.255.0.255 is not a
+    # valid netmask even though every octet is in VALID_MASKS.
+    mask = 0
+    for part in parts:
+        mask = (mask << 8) | int(part)
+    inverted = mask ^ 0xFFFFFFFF
+    return inverted & (inverted + 1) == 0
 
 
 def is_masklen(val):

--- a/lib/ansible/module_utils/common/network.py
+++ b/lib/ansible/module_utils/common/network.py
@@ -34,6 +34,19 @@ def is_netmask(val):
     for part in parts:
         mask = (mask << 8) | int(part)
     inverted = mask ^ 0xFFFFFFFF
+    parts = str(val).split('.')
+    if not len(parts) == 4:
+        return False
+    mask = 0
+    for part in parts:
+        try:
+            octet = int(part)
+            if octet not in VALID_MASKS:
+                raise ValueError
+            mask = (mask << 8) | octet
+        except ValueError:
+            return False
+    inverted = mask ^ 0xFFFFFFFF
     return inverted & (inverted + 1) == 0
 
 

--- a/test/units/module_utils/common/test_network.py
+++ b/test/units/module_utils/common/test_network.py
@@ -67,6 +67,11 @@ def test_is_netmask():
     assert not is_netmask('254.255.255.0')
     assert not is_netmask('0.255.0.0')
     assert not is_netmask('0.0.0.255')
+    # inet_aton-style legacy forms must stay rejected (they break to_masklen)
+    assert not is_netmask('0xffffff00')
+    assert not is_netmask('0377.0377.0377.0')
+    assert not is_netmask('4294967040')
+    assert not is_netmask('255.255.0')
 
 
 def test_to_ipv6_network():

--- a/test/units/module_utils/common/test_network.py
+++ b/test/units/module_utils/common/test_network.py
@@ -57,8 +57,16 @@ def test_is_masklen():
 
 def test_is_netmask():
     assert is_netmask('255.255.255.255')
+    assert is_netmask('0.0.0.0')
+    assert is_netmask('255.255.255.0')
+    assert is_netmask('255.255.254.0')
     assert not is_netmask(24)
     assert not is_netmask('foo')
+    # individually valid octets that are not a contiguous mask
+    assert not is_netmask('255.255.0.255')
+    assert not is_netmask('254.255.255.0')
+    assert not is_netmask('0.255.0.0')
+    assert not is_netmask('0.0.0.255')
 
 
 def test_to_ipv6_network():


### PR DESCRIPTION
##### SUMMARY

`is_netmask` (in `module_utils/common/network.py`) only validates each octet against `VALID_MASKS` independently and never checks that the octets form a **contiguous** run of network bits. As a result, masks whose octets are each individually valid but which are not contiguous are wrongly reported as valid:

```python
>>> from ansible.module_utils.common.network import is_netmask, to_subnet
>>> is_netmask('255.255.0.255')   # True  (should be False)
>>> is_netmask('254.255.255.0')   # True  (should be False)
>>> is_netmask('0.255.0.0')       # True  (should be False)
>>> to_subnet('10.20.30.40', '255.255.0.255')  # '10.20.0.40/24'  (nonsensical)
```

A valid IPv4 netmask must be a contiguous block of `1` bits followed by `0` bits. This PR assembles the four octets into the 32-bit mask and verifies that shape (`inverted & (inverted + 1) == 0`), so non-contiguous masks are now correctly rejected while all genuine netmasks (`0.0.0.0` … `255.255.255.255`, `255.255.254.0`, etc.) still pass. No new imports are added.

Unit tests for `is_netmask` are extended with valid and non-contiguous cases (the new non-contiguous assertions fail without this change).

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

module_utils/common/network.py
