### PR TITLE
ansible-galaxy: Add per-server client_cert and client_key configurations for mTLS

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -660,6 +660,14 @@ class GalaxyCLI(CLI):
                 server_options['validate_certs'] = context.CLIARGS['resolved_validate_certs']
             validate_certs = server_options['validate_certs']
 
+            for cert_key in ('client_cert', 'client_key'):
+                cert_path = server_options.get(cert_key)
+                if cert_path and not os.path.exists(cert_path):
+                    raise AnsibleError(
+                        "Galaxy server '%s' has an invalid %s '%s': file does not exist"
+                        % (server_key, cert_key, cert_path)
+                    )
+
             # default case if no auth info is provided.
             server_options['token'] = None
 

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -43,6 +43,8 @@ GALAXY_SERVER_DEF = [
     ('client_id', False, 'str'),
     ('client_secret', False, 'str'),
     ('timeout', False, 'int'),
+    ('client_cert', False, 'path'),
+    ('client_key', False, 'path'),
 ]
 
 # config definition fields

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -261,6 +261,7 @@ class GalaxyAPI:
             clear_response_cache=False, no_cache=True,
             priority=float('inf'),
             timeout=60,
+            client_cert=None, client_key=None,
     ):
         self.galaxy = galaxy
         self.name = name
@@ -270,6 +271,8 @@ class GalaxyAPI:
         self.api_server = url
         self.validate_certs = validate_certs
         self.timeout = timeout
+        self.client_cert = client_cert
+        self.client_key = client_key
         self._available_api_versions = available_api_versions or {}
         self._priority = priority
         self._server_timeout = timeout
@@ -392,7 +395,8 @@ class GalaxyAPI:
         try:
             display.vvvv("Calling Galaxy at %s" % url)
             resp = open_url(to_native(url), data=args, validate_certs=self.validate_certs, headers=headers,
-                            method=method, timeout=self._server_timeout, http_agent=user_agent(), follow_redirects='safe')
+                            method=method, timeout=self._server_timeout, http_agent=user_agent(), follow_redirects='safe',
+                            client_cert=self.client_cert, client_key=self.client_key)
         except HTTPError as e:
             raise GalaxyError(e, error_context_msg)
         except Exception as ex:
@@ -452,7 +456,8 @@ class GalaxyAPI:
         args = urlencode({"github_token": github_token})
 
         try:
-            resp = open_url(url, data=args, validate_certs=self.validate_certs, method="POST", http_agent=user_agent(), timeout=self._server_timeout)
+            resp = open_url(url, data=args, validate_certs=self.validate_certs, method="POST", http_agent=user_agent(),
+                            timeout=self._server_timeout, client_cert=self.client_cert, client_key=self.client_key)
         except HTTPError as e:
             raise GalaxyError(e, 'Attempting to authenticate to galaxy')
         except Exception as ex:

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -154,6 +154,8 @@ class ConcreteArtifactsManager:
                 expected_hash=metadata.artifact_sha256,
                 validate_certs=api.validate_certs,
                 token=api.token,
+                client_cert=api.client_cert,
+                client_key=api.client_key,
             )  # type: bytes
         except URLError as err:
             raise AnsibleError(
@@ -482,8 +484,8 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
     backoff_iterator=generate_jittered_backoff(retries=6, delay_base=2, delay_threshold=40),
     should_retry_error=should_retry_error
 )
-def _download_file(url, b_path, expected_hash, validate_certs, token=None, timeout=60):
-    # type: (str, bytes, t.Optional[str], bool, GalaxyToken, int) -> bytes
+def _download_file(url, b_path, expected_hash, validate_certs, token=None, timeout=60, client_cert=None, client_key=None):
+    # type: (str, bytes, t.Optional[str], bool, GalaxyToken, int, t.Optional[str], t.Optional[str]) -> bytes
     # ^ NOTE: used in download and verify_collections ^
     b_tarball_name = to_bytes(
         url.rsplit('/', 1)[1], errors='surrogate_or_strict',
@@ -505,7 +507,9 @@ def _download_file(url, b_path, expected_hash, validate_certs, token=None, timeo
         validate_certs=validate_certs,
         headers=None if token is None else token.headers(),
         unredirected_headers=['Authorization'], http_agent=user_agent(),
-        timeout=timeout
+        timeout=timeout,
+        client_cert=client_cert,
+        client_key=client_key,
     )
 
     with open(b_file_path, 'wb') as download_file:  # type: t.BinaryIO

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -1358,3 +1358,63 @@ def test_install_collection_with_roles(requirements_file, monkeypatch):
     assert mock_role_install.call_count == 0
 
     assert any(list('contains roles which will be ignored' in mock_call[1][0] for mock_call in mock_display.mock_calls))
+
+
+def _fake_server_options(**overrides):
+    """Return a minimal galaxy server options dict suitable for mocking get_plugin_options."""
+    opts = {
+        'url': 'https://example.com',
+        'auth_url': None,
+        'client_id': None,
+        'client_secret': None,
+        'token': None,
+        'username': None,
+        'password': None,
+        'validate_certs': True,
+        'timeout': 60,
+        'client_cert': None,
+        'client_key': None,
+    }
+    opts.update(overrides)
+    return opts
+
+
+def test_galaxy_server_client_cert_and_key_accepted_when_files_exist(monkeypatch, tmp_path):
+    cert = tmp_path / 'client.pem'
+    key = tmp_path / 'client.key'
+    cert.write_text('cert-data')
+    key.write_text('key-data')
+
+    monkeypatch.setattr(C, 'GALAXY_SERVER_LIST', ['myserver'])
+    monkeypatch.setattr(C.config, 'load_galaxy_server_defs', MagicMock())
+    monkeypatch.setattr(C.config, 'get_plugin_options',
+                        MagicMock(return_value=_fake_server_options(
+                            client_cert=str(cert), client_key=str(key))))
+    monkeypatch.setattr(GalaxyCLI, 'execute_install', MagicMock())
+
+    # Validation passes silently when both cert files exist.
+    GalaxyCLI(args=['ansible-galaxy', 'collection', 'install', 'namespace.collection']).run()
+
+
+def test_galaxy_server_client_cert_missing_file_raises_error(monkeypatch, tmp_path):
+    missing = str(tmp_path / 'nonexistent.pem')
+    monkeypatch.setattr(C, 'GALAXY_SERVER_LIST', ['myserver'])
+    monkeypatch.setattr(C.config, 'load_galaxy_server_defs', MagicMock())
+    monkeypatch.setattr(C.config, 'get_plugin_options',
+                        MagicMock(return_value=_fake_server_options(client_cert=missing)))
+
+    gc = GalaxyCLI(args=['ansible-galaxy', 'collection', 'install', 'namespace.collection'])
+    with pytest.raises(AnsibleError, match="invalid client_cert.*does not exist"):
+        gc.run()
+
+
+def test_galaxy_server_client_key_missing_file_raises_error(monkeypatch, tmp_path):
+    missing = str(tmp_path / 'nonexistent.key')
+    monkeypatch.setattr(C, 'GALAXY_SERVER_LIST', ['myserver'])
+    monkeypatch.setattr(C.config, 'load_galaxy_server_defs', MagicMock())
+    monkeypatch.setattr(C.config, 'get_plugin_options',
+                        MagicMock(return_value=_fake_server_options(client_key=missing)))
+
+    gc = GalaxyCLI(args=['ansible-galaxy', 'collection', 'install', 'namespace.collection'])
+    with pytest.raises(AnsibleError, match="invalid client_key.*does not exist"):
+        gc.run()

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -1299,3 +1299,47 @@ def test_cache_missing_results_raises_descriptive_error(mocker):
             cache=True,
             cache_key='/api/v1/roles/'
         )
+
+
+def test_mtls_attributes_stored_on_init():
+    api = GalaxyAPI(None, "test", "https://galaxy.ansible.com/api/",
+                    client_cert='/path/to/client.pem', client_key='/path/to/client.key')
+    assert api.client_cert == '/path/to/client.pem'
+    assert api.client_key == '/path/to/client.key'
+
+
+def test_mtls_attributes_default_to_none_when_not_provided():
+    api = GalaxyAPI(None, "test", "https://galaxy.ansible.com/api/")
+    assert api.client_cert is None
+    assert api.client_key is None
+
+
+def test_mtls_client_cert_and_key_passed_to_open_url(monkeypatch):
+    mock_open = MagicMock(return_value=StringIO(u'{"results":[]}'))
+    monkeypatch.setattr(galaxy_api, 'open_url', mock_open)
+
+    api = GalaxyAPI(None, "test", "https://galaxy.ansible.com/api/",
+                    client_cert='/path/to/client.pem', client_key='/path/to/client.key')
+    api._available_api_versions = {'v1': 'v1/'}
+    api._call_galaxy('https://galaxy.ansible.com/api/v1/roles/')
+
+    kwargs = mock_open.call_args[1]
+    assert kwargs['client_cert'] == '/path/to/client.pem'
+    assert kwargs['client_key'] == '/path/to/client.key'
+
+
+def test_mtls_client_cert_and_key_passed_to_authenticate(monkeypatch):
+    mock_open = MagicMock(side_effect=[
+        StringIO(u'{"available_versions":{"v1":"v1/"}}'),
+        StringIO(u'{"token":"my_token"}'),
+    ])
+    monkeypatch.setattr(galaxy_api, 'open_url', mock_open)
+
+    api = GalaxyAPI(None, "test", "https://galaxy.ansible.com/api/",
+                    client_cert='/path/to/client.pem', client_key='/path/to/client.key')
+    api.authenticate("github_token")
+
+    # The second call is the authenticate POST to /api/v1/tokens/.
+    authenticate_kwargs = mock_open.call_args_list[1][1]
+    assert authenticate_kwargs['client_cert'] == '/path/to/client.pem'
+    assert authenticate_kwargs['client_key'] == '/path/to/client.key'

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -941,6 +941,24 @@ def test_download_file_hash_mismatch(tmp_path_factory, monkeypatch):
         collection._download_file('http://google.com/file', temp_dir, 'bad', True)
 
 
+def test_download_file_mtls_client_cert_and_key(tmp_path_factory, monkeypatch):
+    temp_dir = to_bytes(tmp_path_factory.mktemp('test-mtls'))
+
+    data = b"\x00\x01\x02\x03"
+    mock_open = MagicMock()
+    mock_open.return_value = BytesIO(data)
+    monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
+
+    collection._download_file(
+        'http://example.com/ns-col-1.0.0.tar.gz', temp_dir, None, True,
+        client_cert='/path/client.pem', client_key='/path/client.key',
+    )
+
+    call_kwargs = mock_open.call_args[1]
+    assert call_kwargs['client_cert'] == '/path/client.pem'
+    assert call_kwargs['client_key'] == '/path/client.key'
+
+
 def test_extract_tar_file_invalid_hash(tmp_tarfile):
     temp_dir, tfile, filename, dummy = tmp_tarfile
 


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
This Pull Request implements mutual TLS (mTLS) client certificate support configured per Galaxy server.

**Rationale & Design Decisions:**
- Introduced `client_cert` and `client_key` configuration parameters under the `[galaxy_server.<name>]` section in `ansible.cfg`.
- Enabled the corresponding environment variables: `ANSIBLE_GALAXY_SERVER_<name>_CLIENT_CERT` and `ANSIBLE_GALAXY_SERVER_<name>_CLIENT_KEY`.
- By scoping these settings per server, we ensure that client certificates are only transmitted to the specific private endpoints requiring mTLS, rather than globally.
- The parsed paths are passed to the internal HTTP connection logic during role and collection downloads.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->
Fixes #87236


##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request