### PR TITLE
unarchive: validate extra_opts to prevent command execution

### DIFF
--- a/changelogs/fragments/unarchive-extra-opts-validation.yml
+++ b/changelogs/fragments/unarchive-extra-opts-validation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - unarchive - validate ``extra_opts`` parameter to reject dangerous GNU tar options that could execute arbitrary commands.

--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -808,12 +808,27 @@ class TgzArchive(object):
         self.file_args = file_args
         self.opts = module.params['extra_opts']
         self.module = module
+
+        # Prefer gtar (GNU tar) as it supports the compression options -z, -j and -J
+        try:
+            self.cmd_path = get_bin_path('gtar')
+        except ValueError:
+            # Fallback to tar
+            try:
+                self.cmd_path = get_bin_path('tar')
+            except ValueError:
+                self.module.fail_json(msg="Unable to find required 'gtar' or 'tar' binary in the path")
+
+        self.tar_type = self._get_tar_type()
+        if self.tar_type == 'gnu':
+            try:
+                self._reject_dangerous_gnu_tar_extra_opts()
+            except ValueError as ex:
+                self.module.fail_json(msg=str(ex))
         if self.module.check_mode:
             self.module.exit_json(skipped=True, msg="remote module (%s) does not support check mode when using gtar" % self.module._name)
         self.excludes = [path.rstrip('/') for path in self.module.params['exclude']]
         self.include_files = self.module.params['include']
-        self.cmd_path = None
-        self.tar_type = None
         self.zipflag = '-z'
         self._files_in_archive = []
 
@@ -949,18 +964,6 @@ class TgzArchive(object):
         return dict(cmd=cmd, rc=rc, out=out, err=err)
 
     def can_handle_archive(self):
-        # Prefer gtar (GNU tar) as it supports the compression options -z, -j and -J
-        try:
-            self.cmd_path = get_bin_path('gtar')
-        except ValueError:
-            # Fallback to tar
-            try:
-                self.cmd_path = get_bin_path('tar')
-            except ValueError:
-                return False, "Unable to find required 'gtar' or 'tar' binary in the path"
-
-        self.tar_type = self._get_tar_type()
-
         if self.tar_type != 'gnu':
             return False, 'Command "%s" detected as tar type %s. GNU tar required.' % (self.cmd_path, self.tar_type)
 
@@ -972,6 +975,31 @@ class TgzArchive(object):
         # Errors and no files in archive assume that we weren't able to
         # properly unarchive it
         return False, 'Command "%s" found no files in archive. Empty archive files are not supported.' % self.cmd_path
+
+    def _reject_dangerous_gnu_tar_extra_opts(self):
+        """Reject GNU tar extra_opts that can execute arbitrary commands."""
+        dangerous_value_prefixes = (
+            '--checkpoint-action=exec=',
+            '--to-command=',
+            '--use-compress-program=',
+        )
+        dangerous_split_options = {
+            '--to-command',
+            '--use-compress-program',
+            '-I',
+        }
+
+        opts = iter(self.opts)
+        for opt in opts:
+            for prefix in dangerous_value_prefixes:
+                if opt.startswith(prefix):
+                    raise ValueError(f'Refusing unsafe tar extra option: {opt}')
+
+            next_opt = next(opts, None)
+            if next_opt:
+                if opt.startswith('--checkpoint-action') and next_opt.startswith('exec=') or \
+                   opt in dangerous_split_options:
+                    raise ValueError(f'Refusing unsafe tar extra option: {opt} {next_opt}')
 
 
 # Class to handle tar files that aren't compressed

--- a/test/units/modules/test_unarchive.py
+++ b/test/units/modules/test_unarchive.py
@@ -9,9 +9,43 @@ import pytest
 from ansible.modules.unarchive import ZipArchive, TgzArchive
 
 
+class FakeAnsibleModule:
+    def __init__(self):
+        self.params = {}
+        self.tmpdir = None
+        self.check_mode = False
+        self._name = 'unarchive'
+
+    def fail_json(self, **kwargs):
+        raise ValueError(kwargs.get('msg', ''))
+
+    def exit_json(self, **kwargs):
+        raise ValueError(kwargs.get('msg', ''))
+
+    def debug(self, msg):
+        pass
+
+    def run_command(self, cmd, **kwargs):
+        if '--version' in cmd:
+            return 0, 'tar (GNU tar) 1.34', ''
+        return 1, '', ''
+
+
 @pytest.fixture
 def fake_ansible_module():
-    return FakeAnsibleModule()
+    m = FakeAnsibleModule()
+    m.params = {
+        "extra_opts": [],
+        "exclude": [],
+        "include": [],
+        "io_buffer_size": 65536,
+    }
+    return m
+
+
+@pytest.fixture
+def gnu_tar_environment(mocker):
+    mocker.patch("ansible.modules.unarchive.get_bin_path", return_value="/bin/tar")
 
 
 def max_zip_timestamp():
@@ -22,10 +56,39 @@ def max_zip_timestamp():
         return time.mktime(time.struct_time((2038, 1, 1, 0, 0, 0, 0, 0, 0)))
 
 
-class FakeAnsibleModule:
-    def __init__(self):
-        self.params = {}
-        self.tmpdir = None
+@pytest.mark.parametrize('extra_opts', [
+    [],
+    ['--transform', 's/^xxx/yyy/'],
+])
+def test_reject_dangerous_gnu_tar_extra_opts_allows_safe_options(gnu_tar_environment, fake_ansible_module, extra_opts):
+    fake_ansible_module.params['extra_opts'] = extra_opts
+    TgzArchive(
+        src="",
+        b_dest="",
+        file_args="",
+        module=fake_ansible_module,
+    )
+
+
+@pytest.mark.parametrize('extra_opts, expected_msg', [
+    (['--checkpoint-action=exec=id'], 'Refusing unsafe tar extra option: --checkpoint-action=exec=id'),
+    (['--checkpoint-action', 'exec=id'], 'Refusing unsafe tar extra option: --checkpoint-action exec=id'),
+    (['--to-command=/bin/sh'], 'Refusing unsafe tar extra option: --to-command=/bin/sh'),
+    (['--to-command', '/bin/sh'], 'Refusing unsafe tar extra option: --to-command /bin/sh'),
+    (['--use-compress-program=/bin/sh'], 'Refusing unsafe tar extra option: --use-compress-program=/bin/sh'),
+    (['--use-compress-program', '/bin/sh'], 'Refusing unsafe tar extra option: --use-compress-program /bin/sh'),
+    (['-I', '/bin/sh'], 'Refusing unsafe tar extra option: -I /bin/sh'),
+])
+def test_reject_dangerous_gnu_tar_extra_opts(gnu_tar_environment, fake_ansible_module, extra_opts, expected_msg):
+    fake_ansible_module.params['extra_opts'] = extra_opts
+    with pytest.raises(ValueError) as exc_info:
+        TgzArchive(
+            src="",
+            b_dest="",
+            file_args="",
+            module=fake_ansible_module,
+        )
+    assert str(exc_info.value) == expected_msg
 
 
 class TestCaseZipArchive:
@@ -111,22 +174,34 @@ class TestCaseTgzArchive:
     def test_no_tar_binary(self, mocker, fake_ansible_module):
         mocker.patch("ansible.modules.unarchive.get_bin_path", side_effect=ValueError)
         fake_ansible_module.params = {
-            "extra_opts": "",
-            "exclude": "",
-            "include": "",
+            "extra_opts": [],
+            "exclude": [],
+            "include": [],
             "io_buffer_size": 65536,
         }
         fake_ansible_module.check_mode = False
 
-        t = TgzArchive(
-            src="",
-            b_dest="",
-            file_args="",
-            module=fake_ansible_module,
-        )
-        can_handle, reason = t.can_handle_archive()
+        with pytest.raises(ValueError, match='Unable to find required'):
+            TgzArchive(
+                src="",
+                b_dest="",
+                file_args="",
+                module=fake_ansible_module,
+            )
 
-        assert can_handle is False
-        assert 'Unable to find required' in reason
-        assert t.cmd_path is None
-        assert t.tar_type is None
+    def test_rejects_dangerous_extra_opts(self, gnu_tar_environment, fake_ansible_module):
+        fake_ansible_module.params = {
+            "extra_opts": ['--checkpoint-action=exec=id'],
+            "exclude": [],
+            "include": [],
+            "io_buffer_size": 65536,
+        }
+        fake_ansible_module.check_mode = False
+
+        with pytest.raises(ValueError, match='Refusing unsafe tar extra option'):
+            TgzArchive(
+                src="",
+                b_dest="",
+                file_args="",
+                module=fake_ansible_module,
+            )


### PR DESCRIPTION
##### SUMMARY

Add validation for the extra_opts parameter in TgzArchive to reject
dangerous GNU tar options that could be used to execute arbitrary
commands. The validation blocks options like --checkpoint-action=exec,
--to-command, --use-compress-program, and -I when they would allow
command execution.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/unarchive-extra-opts-validation.yml
lib/ansible/modules/unarchive.py
test/units/modules/test_unarchive.py


