### PR TITLE
Disable dnf-latest integration tests

### DIFF
--- a/test/integration/targets/dnf-latest/aliases
+++ b/test/integration/targets/dnf-latest/aliases
@@ -2,3 +2,4 @@ context/target
 destructive
 shippable/posix/group7
 needs/target/dnf
+disabled  # fedora 41 support for dnf-nightly removed


### PR DESCRIPTION
##### SUMMARY

Disable dnf-latest integration tests

Fedora 41 has been removed from dnf-nightly builds

##### ISSUE TYPE

- Test Pull Request
