### PR TITLE
ansible-vault: tolerate EPERM when restoring ownership on edit/rekey

### DIFF
--- a/changelogs/fragments/ansible-vault-edit-chown-eperm.yml
+++ b/changelogs/fragments/ansible-vault-edit-chown-eperm.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-vault - fix ``ansible-vault edit`` and ``ansible-vault rekey`` failing with a permissions error when file ownership cannot be restored, such as when an unprivileged user edits a file whose group they are not a member of (e.g. files created in ``/tmp`` on macOS inherit the ``wheel`` group) (https://github.com/ansible/ansible/issues/11544).

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import errno
 import fcntl
 import functools
 import os
@@ -981,7 +982,13 @@ class VaultEditor:
 
         # preserve permissions
         os.chmod(filename, prev.st_mode)
-        os.chown(filename, prev.st_uid, prev.st_gid)
+        try:
+            os.chown(filename, prev.st_uid, prev.st_gid)
+        except OSError as ex:
+            # unprivileged users cannot restore ownership to a group they are not a member of,
+            # such as when the file was created in a directory with BSD group inheritance (e.g. /tmp on macOS)
+            if ex.errno != errno.EPERM:
+                raise
 
         display.vvvvv(u'Rekeyed file "%s" (decrypted with vault id "%s") was encrypted with new vault-id "%s" and vault secret %s' %
                       (to_text(filename), to_text(vault_id_used), to_text(new_vault_id), to_text(new_vault_secret)))
@@ -1093,7 +1100,13 @@ class VaultEditor:
         if prev is not None:
             # TODO: selinux, ACLs, xattr?
             os.chmod(dest, prev.st_mode)
-            os.chown(dest, prev.st_uid, prev.st_gid)
+            try:
+                os.chown(dest, prev.st_uid, prev.st_gid)
+            except OSError as ex:
+                # unprivileged users cannot restore ownership to a group they are not a member of,
+                # such as when the file was created in a directory with BSD group inheritance (e.g. /tmp on macOS)
+                if ex.errno != errno.EPERM:
+                    raise
 
     def _editor_shell_command(self, filename):
         env_editor = C.config.get_config_value('EDITOR')

--- a/test/integration/targets/ansible-vault/runme.sh
+++ b/test/integration/targets/ansible-vault/runme.sh
@@ -628,3 +628,41 @@ out=$(diff salted_test1 salted_test2)
 # should be diff
 out=$(diff salted_test1 salted_test3 || true)
 [ "${out}" != "" ]
+
+# https://github.com/ansible/ansible/issues/11544
+# ansible-vault edit/rekey must tolerate EPERM when restoring the file's group ownership,
+# e.g. an unprivileged user editing a vaulted file whose group they are not a member of
+# (files created in /tmp on macOS inherit the directory's group through BSD group inheritance).
+# root normally holds CAP_CHOWN and cannot get EPERM from chown, so drop that capability
+# with setpriv to reproduce the unprivileged condition.
+if [ "$(id -u)" -eq 0 ] && command -v setpriv > /dev/null 2>&1 && command -v groupadd > /dev/null 2>&1; then
+    EPERM_GROUP="vault_eperm_test"
+    groupadd "${EPERM_GROUP}" || true
+
+    # sanity: the group restore below can only return EPERM if we are not a member of the group
+    if id -Gn | tr ' ' '\n' | grep -qxF "${EPERM_GROUP}"; then
+        echo "cannot test EPERM tolerance: current user is a member of ${EPERM_GROUP}"
+        exit 1
+    fi
+
+    TEST_FILE_EPERM="${MYTMPDIR}/test_file_eperm"
+    echo "This is a test file for edit and rekey without CAP_CHOWN" > "${TEST_FILE_EPERM}"
+    ansible-vault encrypt "$@" --vault-password-file vault-password "${TEST_FILE_EPERM}"
+    chgrp "${EPERM_GROUP}" "${TEST_FILE_EPERM}"
+
+    # edit rewrites the file and then restores its previous ownership; without CAP_CHOWN the
+    # group restore returns EPERM, which must be tolerated rather than fail the edit
+    EDITOR=./faux-editor.py setpriv --bounding-set=-chown ansible-vault edit "$@" --vault-password-file vault-password "${TEST_FILE_EPERM}"
+    ansible-vault view "$@" --vault-password-file vault-password "${TEST_FILE_EPERM}" | grep 'faux editor added'
+
+    # rekey restores ownership through its own chown call; the tolerated EPERM above left the
+    # file's group as the default one, so re-apply the test group to make the rekey restore a
+    # real group change again
+    chgrp "${EPERM_GROUP}" "${TEST_FILE_EPERM}"
+    EPERM_NEW_PASSWORD="${MYTMPDIR}/eperm-new-vault-password"
+    echo "new-password-for-eperm-test" > "${EPERM_NEW_PASSWORD}"
+    setpriv --bounding-set=-chown ansible-vault rekey "$@" --vault-password-file vault-password --new-vault-password-file "${EPERM_NEW_PASSWORD}" "${TEST_FILE_EPERM}"
+    ansible-vault view "$@" --vault-password-file "${EPERM_NEW_PASSWORD}" "${TEST_FILE_EPERM}" | grep 'faux editor added'
+
+    groupdel "${EPERM_GROUP}" || true
+fi


### PR DESCRIPTION
##### SUMMARY

`ansible-vault edit` and `ansible-vault rekey` restore the file's previous ownership with `os.chown()` after rewriting the vaulted file (`VaultEditor.shuffle_files()` and `VaultEditor.rekey_file()`). An unprivileged user cannot chown a file to a group they are not a member of, so both commands crash with `PermissionError: [Errno 1] Operation not permitted` whenever the vaulted file's group is not one of the user's groups.

This is easy to hit on macOS (and other BSD-semantics filesystems), where files inherit the group of their parent directory — e.g. any file created in `/tmp` gets group `wheel`:

```console
$ cd /tmp
$ echo 'secret: value' > secrets.yml     # group is now 'wheel' via BSD group inheritance
$ ansible-vault encrypt secrets.yml
$ ansible-vault edit secrets.yml
ERROR! Unexpected Exception: [Errno 1] Operation not permitted: '/tmp/secrets.yml'
```

The same traceback has been reported against `shuffle_files()` in #11544 (comment from 2018-05-15).

(`edit` hits this naturally in such directories because `shuffle_files()` moves a temp file in from `~/.ansible/tmp`, making the group-restore a real change; `rekey` hits it whenever the file's group differs from its parent directory's, e.g. a vaulted file moved in from elsewhere.)

This change wraps both `os.chown()` calls in `try/except OSError` and ignores `errno.EPERM` only; any other error still propagates. This matches the existing behavior of `AnsibleModule.preserved_copy()` and `AnsibleModule.atomic_move()` in `lib/ansible/module_utils/basic.py`, which guard their ownership-restore chown calls with the identical `errno.EPERM` check. (If #83482 — which replaces this logic with `atomic_move` — ever lands, it would subsume this fix; until then the crash is user-facing on every macOS install.)

Includes an integration test in `test/integration/targets/ansible-vault/runme.sh` (per review). CI runs as root, which holds `CAP_CHOWN` and cannot receive EPERM from chown, so the test drops that capability with `setpriv --bounding-set=-chown` to reproduce the unprivileged condition: it edits and then rekeys a vaulted file whose group the process is not a member of (re-applying the group before rekey, since the tolerated EPERM on edit leaves the file with the default group). Both operations crash without the fix and pass with it; plus a changelog fragment.

Related: #11544

##### ISSUE TYPE

- Bugfix Pull Request
