### PR TITLE
Fix bytes_to_human rendering a size at the unit boundary as 1024.00

### DIFF
--- a/changelogs/fragments/bytes_to_human-boundary.yml
+++ b/changelogs/fragments/bytes_to_human-boundary.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - bytes_to_human - a size one byte below a unit boundary is now rounded up to
+    the next unit (for example ``1073741823`` renders as ``1.00 GB`` instead of
+    ``1024.00 MB``), matching how the value reads after rounding to two decimals.

--- a/lib/ansible/module_utils/common/text/formatters.py
+++ b/lib/ansible/module_utils/common/text/formatters.py
@@ -121,6 +121,15 @@ def bytes_to_human(size, isbits=False, unit=None):
         if (unit is None and size >= limit) or unit is not None and unit.upper() == suffix[0]:
             break
 
+    # Rounding to 2 decimals can push the value to the next unit's boundary
+    # (e.g. 1 GiB - 1 byte is 1023.9999... MB, which renders as "1024.00 MB").
+    # Promote to the next-larger unit so it shows as "1.00 GB".
+    if unit is None and limit != 1 and round(size / limit, 2) >= 1024:
+        larger = min((v for v in SIZE_RANGES.values() if v > limit), default=None)
+        if larger is not None:
+            limit = larger
+            suffix = next(s for s, v in SIZE_RANGES.items() if v == larger)
+
     if limit != 1:
         suffix += base[0]
     else:

--- a/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
+++ b/test/units/module_utils/common/text/formatters/test_bytes_to_human.py
@@ -16,6 +16,8 @@ from ansible.module_utils.common.text.formatters import bytes_to_human
         (0.5, u'0.50 Bytes'),
         (0.54, u'0.54 Bytes'),
         (1024, u'1.00 KB'),
+        (1048575, u'1.00 MB'),
+        (1073741823, u'1.00 GB'),
         (1025, u'1.00 KB'),
         (1536, u'1.50 KB'),
         (1790, u'1.75 KB'),


### PR DESCRIPTION
##### SUMMARY

`bytes_to_human` picks the unit from the raw size (`size >= limit`) but then rounds the quotient to two decimals. A size one byte below a unit boundary rounds up to `1024.00` while the unit stays one step too low:

```python
>>> from ansible.module_utils.common.text.formatters import bytes_to_human
>>> bytes_to_human(1073741824 - 1)
'1024.00 MB'          # expected '1.00 GB'
>>> bytes_to_human(1048576 - 1)
'1024.00 KB'          # expected '1.00 MB'
```

`1024.00 MB` is not a value `bytes_to_human` should ever print. It shows up in any report/`debug`/template that renders a size fact (e.g. `human_readable`) for a value that happens to sit just under a power of 1024 — common for "round" disks and memory sizes.

##### Fix

After selecting the unit, if the value rounded to two decimals reaches the next unit's boundary, promote to that next unit (so it renders `1.00 GB`). Only affects the auto-unit path; an explicitly requested `unit=` is untouched. Adds boundary regression cases.

Note: negative sizes remain unchanged (out of scope for this fix).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/common/text/formatters
