### PR TITLE
pip: resolve virtualenv path when chdir is relative

### DIFF
--- a/changelogs/fragments/81522-pip-virtualenv-relative-chdir.yml
+++ b/changelogs/fragments/81522-pip-virtualenv-relative-chdir.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - pip - resolve relative virtualenv paths when used with chdir (https://github.com/ansible/ansible/issues/81522).
+  - pip - resolve relative virtualenv paths consistently, including when used with chdir (https://github.com/ansible/ansible/issues/81522, https://github.com/ansible/ansible/issues/84905).

--- a/changelogs/fragments/81522-pip-virtualenv-relative-chdir.yml
+++ b/changelogs/fragments/81522-pip-virtualenv-relative-chdir.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - pip - resolve relative virtualenv paths when used with chdir (https://github.com/ansible/ansible/issues/81522).

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -780,8 +780,10 @@ def main():
     editable = module.params['editable']
 
     venv_created = False
-    if env and chdir:
-        env = os.path.join(chdir, env)
+    if env:
+        if chdir:
+            env = os.path.join(chdir, env)
+        env = os.path.abspath(env)
 
     if umask and not isinstance(umask, int):
         try:

--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -38,6 +38,7 @@ options:
         If the virtualenv does not exist, it will be created before installing
         packages. The optional O(virtualenv_site_packages), O(virtualenv_command),
         and O(virtualenv_python) options affect the creation of the virtualenv.
+      - When O(chdir) is set, a relative path is resolved relative to O(chdir).
     type: path
   virtualenv_site_packages:
     description:
@@ -87,6 +88,7 @@ options:
   chdir:
     description:
       - cd into this directory before running the command.
+      - When O(virtualenv) is a relative path, it is resolved relative to O(chdir).
     type: path
     version_added: "1.3"
   executable:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -707,3 +707,27 @@
     that:
       - pip_relative_chdir_virtualenv is successful
       - pip_relative_chdir_virtualenv.virtualenv is search('/checkout-dir/venv$')
+
+# https://github.com/ansible/ansible/issues/84905
+- name: remove stale relative virtualenv without chdir
+  file:
+    state: absent
+    path: relative-test-venv
+
+- name: create virtualenv with relative path and no chdir
+  pip:
+    name: setuptools
+    virtualenv: relative-test-venv
+    state: present
+  register: pip_relative_venv_no_chdir
+
+- name: assert relative virtualenv without chdir succeeds
+  assert:
+    that:
+      - pip_relative_venv_no_chdir is successful
+      - pip_relative_venv_no_chdir.virtualenv is search('/relative-test-venv$')
+
+- name: cleanup relative virtualenv without chdir
+  file:
+    state: absent
+    path: "{{ pip_relative_venv_no_chdir.virtualenv }}"

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -684,29 +684,30 @@
           - multi_pip_list_check.stdout is search('another-project\s+1.0.0\s+' ~ remote_tmp_dir ~ '/another-project')
 
 # https://github.com/ansible/ansible/issues/81522
-- name: create checkout-dir for relative chdir virtualenv test
-  file:
-    state: directory
-    path: checkout-dir
+- block:
+  - name: create checkout-dir for relative chdir virtualenv test
+    file:
+      state: directory
+      path: checkout-dir
 
-- name: remove stale virtualenv from relative chdir test
-  file:
-    state: absent
-    path: checkout-dir/venv
+  - name: create virtualenv when chdir is a relative path
+    pip:
+      chdir: checkout-dir
+      name: setuptools
+      virtualenv: venv
+      state: present
+    register: pip_relative_chdir_virtualenv
 
-- name: create virtualenv when chdir is a relative path
-  pip:
-    chdir: checkout-dir
-    name: setuptools
-    virtualenv: venv
-    state: present
-  register: pip_relative_chdir_virtualenv
-
-- name: assert relative chdir resolves virtualenv path correctly
-  assert:
-    that:
-      - pip_relative_chdir_virtualenv is successful
-      - pip_relative_chdir_virtualenv.virtualenv is search('/checkout-dir/venv$')
+  - name: assert relative chdir resolves virtualenv path correctly
+    assert:
+      that:
+        - pip_relative_chdir_virtualenv is successful
+        - pip_relative_chdir_virtualenv.virtualenv is search('/checkout-dir/venv$')
+  always:
+  - name: remove stale virtualenv from relative chdir test
+    file:
+      state: absent
+      path: "{{ pip_relative_chdir_virtualenv.virtualenv | default('checkout-dir') }}"
 
 # https://github.com/ansible/ansible/issues/84905
 - block:

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -682,3 +682,28 @@
           - multi_editable_install is changed
           - multi_pip_list_check.stdout is search('sample-project\s+1.0.0\s+' ~ remote_tmp_dir ~ '/sample-project')
           - multi_pip_list_check.stdout is search('another-project\s+1.0.0\s+' ~ remote_tmp_dir ~ '/another-project')
+
+# https://github.com/ansible/ansible/issues/81522
+- name: create checkout-dir for relative chdir virtualenv test
+  file:
+    state: directory
+    path: checkout-dir
+
+- name: remove stale virtualenv from relative chdir test
+  file:
+    state: absent
+    path: checkout-dir/venv
+
+- name: create virtualenv when chdir is a relative path
+  pip:
+    chdir: checkout-dir
+    name: setuptools
+    virtualenv: venv
+    state: present
+  register: pip_relative_chdir_virtualenv
+
+- name: assert relative chdir resolves virtualenv path correctly
+  assert:
+    that:
+      - pip_relative_chdir_virtualenv is successful
+      - pip_relative_chdir_virtualenv.virtualenv is search('/checkout-dir/venv$')

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -709,25 +709,26 @@
       - pip_relative_chdir_virtualenv.virtualenv is search('/checkout-dir/venv$')
 
 # https://github.com/ansible/ansible/issues/84905
-- name: remove stale relative virtualenv without chdir
-  file:
-    state: absent
-    path: relative-test-venv
+- block:
+  - name: remove stale relative virtualenv without chdir
+    file:
+      state: absent
+      path: relative-test-venv
 
-- name: create virtualenv with relative path and no chdir
-  pip:
-    name: setuptools
-    virtualenv: relative-test-venv
-    state: present
-  register: pip_relative_venv_no_chdir
+  - name: create virtualenv with relative path and no chdir
+    pip:
+      name: setuptools
+      virtualenv: relative-test-venv
+      state: present
+    register: pip_relative_venv_no_chdir
 
-- name: assert relative virtualenv without chdir succeeds
-  assert:
-    that:
-      - pip_relative_venv_no_chdir is successful
-      - pip_relative_venv_no_chdir.virtualenv is search('/relative-test-venv$')
-
-- name: cleanup relative virtualenv without chdir
-  file:
-    state: absent
-    path: "{{ pip_relative_venv_no_chdir.virtualenv }}"
+  - name: assert relative virtualenv without chdir succeeds
+    assert:
+      that:
+        - pip_relative_venv_no_chdir is successful
+        - pip_relative_venv_no_chdir.virtualenv is search('/relative-test-venv$')
+  always:
+  - name: cleanup relative virtualenv without chdir
+    file:
+      state: absent
+      path: "{{ pip_relative_venv_no_chdir.virtualenv | default('relative-test-venv') }}"


### PR DESCRIPTION
## Summary

When `virtualenv` is set, join it with `chdir` when both are provided, then normalize the path with `os.path.abspath`. That keeps create and lookup on the same absolute path for relative `chdir` (#81522) and for a relative `virtualenv` with no `chdir` (#84905).

Also documents that a relative `virtualenv` is resolved relative to `chdir` when both are set.

Fixes #81522
Fixes #84905

Supersedes #87175 (that PR was auto-closed when the branch was force-pushed to add a verified signature).

## Test plan

- [x] Integration test for relative `chdir` with `virtualenv: venv` (#81522)
- [x] Integration test for relative `virtualenv` with no `chdir` (#84905)
- [ ] `ansible-test` pip integration on CI