### PR TITLE
Fix uncaught OverflowError in check_type_int for infinity strings

### DIFF
--- a/changelogs/fragments/check_type_int-inf.yml
+++ b/changelogs/fragments/check_type_int-inf.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - module_utils - ``check_type_int`` now raises the documented ``TypeError``
+    (instead of an uncaught ``OverflowError``) for the string values ``inf``,
+    ``-inf`` and ``Infinity``, which ``decimal.Decimal`` accepts but cannot be
+    converted to an ``int``.

--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -483,7 +483,7 @@ def check_type_int(value):
                 raise ValueError("Significant decimal part found")
             else:
                 value = int_value
-        except (decimal.DecimalException, TypeError, ValueError) as e:
+        except (ArithmeticError, TypeError, ValueError) as e:
             raise TypeError(f'"{value!r}" cannot be converted to an int') from e
     return value
 

--- a/test/units/module_utils/common/validation/test_check_type_int.py
+++ b/test/units/module_utils/common/validation/test_check_type_int.py
@@ -26,6 +26,10 @@ def test_check_type_int_fail():
         (b'1', 1),
         (3.14159, 3),
         'b',
+        'inf',
+        '-inf',
+        'Infinity',
+        'nan',
     )
     for case in test_cases:
         with pytest.raises(TypeError) as e:


### PR DESCRIPTION
##### SUMMARY

`check_type_int` is documented to raise `TypeError` for values it cannot convert to an int. Since the rewrite to `decimal.Decimal`, the string values `inf`, `-inf` and `Infinity` slip past that contract: `decimal.Decimal("inf")` succeeds, but `int(Decimal("Infinity"))` raises `OverflowError`, which is not in the caught tuple (`OverflowError` is an `ArithmeticError`, unrelated to `decimal.DecimalException`). So instead of the intended graceful `TypeError`, an uncaught `OverflowError` propagates.

```python
>>> from ansible.module_utils.common.validation import check_type_int
>>> check_type_int('inf')
OverflowError: cannot convert Infinity to integer      # expected: TypeError
>>> check_type_int('nan')
TypeError: "'nan'" cannot be converted to an int        # correct (inconsistent with inf)
```

Any module parameter with `type: int` (port, timeout, uid/gid, size, retries, …) that receives `inf`/`-inf`/`Infinity` — trivially reachable from a templated value, a var file or `--extra-vars` — aborts argument validation with an unhandled traceback instead of the normal "cannot be converted to an int" error.

##### Fix

Catch `ArithmeticError` (a superclass of both `decimal.DecimalException` and `OverflowError`) so the intended `TypeError` is raised. Adds regression cases for `inf`/`-inf`/`Infinity`/`nan`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module_utils/common/validation
