### PR TITLE
WIP remove ansible_parsed from module results

### DIFF
--- a/changelogs/fragments/remove-ansible_parsed-from-task-return.yml
+++ b/changelogs/fragments/remove-ansible_parsed-from-task-return.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Remove internal ``ansible_parsed`` key from module task results.

--- a/lib/ansible/_internal/_task.py
+++ b/lib/ansible/_internal/_task.py
@@ -470,6 +470,7 @@ class Destination(enum.Enum):
     CALLBACK = enum.auto()
     NOT_CALLBACK = enum.auto()
     ANY = enum.auto()
+    INTERNAL = enum.auto()
 
 
 @dataclasses.dataclass(kw_only=True, frozen=True, slots=True)
@@ -832,7 +833,7 @@ class UnifiedTaskResult:
 
     ansible_facts: dict[str, t.Any] | None = dataclasses.field(default=None, metadata=import_export())
     async_result: dict[str, t.Any] | None = dataclasses.field(default=None, metadata=export_only())
-    ansible_parsed: bool | None = dataclasses.field(default=None, metadata=import_export(destination=Destination.NOT_CALLBACK))  # formerly _ansible_parsed
+    ansible_parsed: bool | None = dataclasses.field(default=None, metadata=import_export(source=Source.ACTION, destination=Destination.INTERNAL))  # formerly _ansible_parsed
     exception: _messages.ErrorSummary | None = dataclasses.field(default=None, metadata=import_export())
     finished: bool | None = dataclasses.field(default=None, metadata=import_export())
     msg: object | None = dataclasses.field(default=None, metadata=import_export())
@@ -919,6 +920,7 @@ class UnifiedTaskResult:
                 metadata.destination is Destination.ANY
                 or ((for_round_trip or for_callback) and metadata.destination is Destination.CALLBACK)
                 or ((for_round_trip or not for_callback) and metadata.destination is Destination.NOT_CALLBACK)
+                or (for_round_trip and metadata.destination is Destination.INTERNAL)
             ):
                 key = metadata.key or dc_field.name
                 field_name = key if hasattr(cls, key) else dc_field.name  # properties matching the exported key take precedence over the field during export

--- a/lib/ansible/_internal/_task.py
+++ b/lib/ansible/_internal/_task.py
@@ -833,7 +833,9 @@ class UnifiedTaskResult:
 
     ansible_facts: dict[str, t.Any] | None = dataclasses.field(default=None, metadata=import_export())
     async_result: dict[str, t.Any] | None = dataclasses.field(default=None, metadata=export_only())
-    ansible_parsed: bool | None = dataclasses.field(default=None, metadata=import_export(source=Source.ACTION, destination=Destination.INTERNAL))  # formerly _ansible_parsed
+    ansible_parsed: bool | None = dataclasses.field(
+        default=None, metadata=import_export(source=Source.ACTION, destination=Destination.INTERNAL)
+    )  # formerly _ansible_parsed
     exception: _messages.ErrorSummary | None = dataclasses.field(default=None, metadata=import_export())
     finished: bool | None = dataclasses.field(default=None, metadata=import_export())
     msg: object | None = dataclasses.field(default=None, metadata=import_export())

--- a/lib/ansible/_internal/_task.py
+++ b/lib/ansible/_internal/_task.py
@@ -922,7 +922,7 @@ class UnifiedTaskResult:
                 metadata.destination is Destination.ANY
                 or ((for_round_trip or for_callback) and metadata.destination is Destination.CALLBACK)
                 or ((for_round_trip or not for_callback) and metadata.destination is Destination.NOT_CALLBACK)
-                or (for_round_trip and metadata.destination is Destination.INTERNAL)
+                or (for_round_trip and not for_callback and metadata.destination is Destination.INTERNAL)
             ):
                 key = metadata.key or dc_field.name
                 field_name = key if hasattr(cls, key) else dc_field.name  # properties matching the exported key take precedence over the field during export

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -736,7 +736,7 @@ class TaskExecutor:
                 async_failed_utr.failed = True
                 async_failed_utr.async_result = async_utr.as_result_dict()
 
-                if async_failed_utr.async_result.pop("ansible_parsed", None):
+                if async_utr.ansible_parsed:
                     async_failed_utr.msg = "async task did not complete within the requested time - %ss" % self._task.async_val
                 else:
                     async_failed_utr.msg = "async task produced unparsable results"

--- a/test/integration/targets/async_fail/tasks/main.yml
+++ b/test/integration/targets/async_fail/tasks/main.yml
@@ -59,3 +59,4 @@
     that:
       - timeout_jid is failed
       - timeout_jid.msg == "async task did not complete within the requested time - 1s"
+      - timeout_jid.ansible_parsed is undefined

--- a/test/integration/targets/tasks/playbook.yml
+++ b/test/integration/targets/tasks/playbook.yml
@@ -5,6 +5,12 @@
     - name: "Task name with undefined variable: {{ not_defined }}"
       debug:
         msg: Hello
+      register: action_result
+
+    - name: validated expected action result keys
+      assert:
+        that:
+          - action_result.keys() | sort == ["changed", "failed", "msg"]
 
     # ensure we properly test for an action name, not a task name when checking for a meta task
     - name: "meta"
@@ -32,6 +38,7 @@
         that:
           - action_with_raise is failed
           - action_with_raise.msg is match "Task failed. I am an exception from an action"
+          - action_with_raise.keys() | sort == ["changed", "exception", "failed", "msg"]
 
     - name: validate error handling for actions that directly set `exception` in result dict
       action_that_fails:
@@ -43,3 +50,11 @@
         that:
           - action_with_result_fail is failed
           - action_with_result_fail.msg is match "sorry, it broke"
+
+    - name: validate expected module result keys
+      ping:
+      register: module_result
+
+    - assert:
+        that:
+          - module_result.keys() | sort == ["changed", "failed", "ping"]


### PR DESCRIPTION
##### SUMMARY

Fix a bug introduced in #87138 that broke windows tests by adding a new key https://github.com/ansible-collections/ansible.windows/pull/932.

ansible_parsed is set in the action plugin, so I added a destination that is only allowed when returning action results so it's accessible in the TaskExecutor but not included in the task result at all.

##### ISSUE TYPE

- Bugfix Pull Request
