### PR TITLE
ansible-galaxy - don't version-compare virtual collections on reinstall

### DIFF
--- a/changelogs/fragments/81687-galaxy-git-version-reinstall.yml
+++ b/changelogs/fragments/81687-galaxy-git-version-reinstall.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - fix ``collection install`` crashing with ``Non integer values in LooseVersion`` when re-installing a ``git`` type requirement that has an explicit ``name`` and a non-SemVer ``version`` (a ``v``-prefixed tag, a branch, or ``HEAD``); virtual (SCM and subdirs) requirements are now consistently treated as unsatisfied during the already-installed check, matching the resolver, so they are always reinstalled instead of being version-compared against the installed copy (https://github.com/ansible/ansible/issues/81687).

--- a/lib/ansible/galaxy/collection/__init__.py
+++ b/lib/ansible/galaxy/collection/__init__.py
@@ -693,7 +693,7 @@ def install_collections(
         req
         for req in unsatisfied_requirements
         for exs in existing_collections
-        if req.fqcn == exs.fqcn and meets_requirements(exs.ver, req.ver)
+        if req.fqcn == exs.fqcn and not req.is_virtual and meets_requirements(exs.ver, req.ver)
     }
 
     if not unsatisfied_requirements and not upgrade:

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/reinstalling.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/reinstalling.yml
@@ -2,11 +2,45 @@
   command: 'ansible-galaxy collection install git+file://{{ test_repo_path }}/.git#/collection_1/'
   register: installed
 
+# https://github.com/ansible/ansible/issues/81687
+- name: Create a requirements file pinning the git collection by ref
+  copy:
+    dest: "{{ galaxy_dir }}/test_requirements.yml"
+    content: |
+      collections:
+        - name: ansible_test.collection_1
+          source: git+file://{{ test_repo_path }}/.git#/collection_1/
+          type: git
+          # the bug: shouldn't compare this value against non-virtual collections
+          version: HEAD
+
+- name: Rerun installing a collection with a dep using a requirements file
+  command: 'ansible-galaxy collection install -r {{ galaxy_dir }}/test_requirements.yml'
+  register: installed_again
+
+- name: Create a requirements file pinning the git collection by a v-prefixed tag
+  copy:
+    dest: "{{ galaxy_dir }}/test_requirements_tag.yml"
+    content: |
+      collections:
+        - name: ansible_test.collection_1
+          source: git+file://{{ test_repo_path }}/.git#/collection_1/
+          type: git
+          version: v1.0.0
+
+- name: Rerun installing a collection with a dep pinned to a v-prefixed tag
+  command: 'ansible-galaxy collection install -r {{ galaxy_dir }}/test_requirements_tag.yml'
+  register: installed_again_tag
+
 - name: SCM collections don't have a concrete artifact version so the collection should always be reinstalled
   assert:
     that:
-      - "'Created collection for ansible_test.collection_1' in installed.stdout"
-      - "'Created collection for ansible_test.collection_2' in installed.stdout"
+      - "'Created collection for ansible_test.collection_1' in item.stdout"
+      - "'Created collection for ansible_test.collection_2' in item.stdout"
+  loop:
+    - "{{ installed }}"
+    - "{{ installed_again }}"
+    - "{{ installed_again_tag }}"
 
 - name: The collection should also be reinstalled when --force flag is used
   command: 'ansible-galaxy collection install git+file://{{ test_repo_path }}/.git#/collection_1/ --force'
@@ -26,6 +60,14 @@
     that:
       - "'Created collection for ansible_test.collection_1' in installed.stdout"
       - "'Created collection for ansible_test.collection_2' in installed.stdout"
+
+- name: Remove requirements files
+  file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ galaxy_dir }}/test_requirements.yml"
+    - "{{ galaxy_dir }}/test_requirements_tag.yml"
 
 - include_tasks: ./empty_installed_collections.yml
   when: cleanup

--- a/test/integration/targets/ansible-galaxy-collection-scm/tasks/setup_multi_collection_repo.yml
+++ b/test/integration/targets/ansible-galaxy-collection-scm/tasks/setup_multi_collection_repo.yml
@@ -63,6 +63,8 @@
   loop:
     - git add ./
     - git commit -m 'add collections'
+    # tag consumed by reinstalling.yml's "version: v1.0.0" pin (issue #81687)
+    - git tag v1.0.0
 
 - name: Build the actual artifact for ansible_test.collection_1 for comparison
   command: "ansible-galaxy collection build ansible_test/collection_1 --output-path {{ galaxy_dir }}"


### PR DESCRIPTION
##### SUMMARY

`ansible-galaxy collection install -r requirements.yml` crashes with `Non integer values in LooseVersion (...)` when re-installing (without `--force`) a `type: git` collection requirement that is given with an explicit `name`, a `source`, and a non-SemVer `version` — a `v`-prefixed tag, a branch, or `HEAD`, all of which are documented-valid git `version:` values.

Fixes #81687 (duplicates: #83288, #78067).

**Root cause.** The "already installed" subtraction in `install_collections` (`lib/ansible/galaxy/collection/__init__.py`) version-compares each requirement against installed collections:

```python
if req.fqcn == exs.fqcn and meets_requirements(exs.ver, req.ver)
```

A git requirement supplied with an explicit `name` **and** `source` keeps a concrete `fqcn` (so it matches an installed copy) while still being virtual (`is_virtual == is_scm`), and its `version` string is kept verbatim as `req.ver`. So `meets_requirements('1.0.0', 'v1.0.0')` calls `SemanticVersion.from_loose_version(LooseVersion('v1.0.0'))` → `ValueError`. The `git+file://…` CLI form is unaffected: it yields a virtual requirement whose `fqcn` is `None`, so it never matches an installed copy. The dependency resolver's `Provider.is_satisfied_by` already avoids the crash by short-circuiting on `requirement.is_virtual` before calling `meets_requirements`; this subtraction just lacks the same guard.

**Fix.** Add `not req.is_virtual` to the subtraction, so virtual (SCM/subdirs) requirements are consistently treated as unsatisfied and always reinstalled — matching `is_satisfied_by` and the semantic the existing SCM reinstall test already asserts. This is @s-hertel's never-merged alternative commit [`a30b9948`](https://github.com/ansible/ansible/commit/a30b99487a4437923eb10855f0ae56616fb6a5d9) ("Consider virtual collections always unsatisfied").

**Why not #81691's approach.** The earlier fix mutated `req_name` inside `from_requirement_dict` and was closed over concern about unaudited side effects in that classmethod. This change stays out of `from_requirement_dict` entirely — one line at the crash site — and reuses #81691's integration test, extended with a `v`-prefixed tag case (`version: v1.0.0`) in addition to `version: HEAD`.

**Behavior change.** A `type: git` requirement with an explicit `name` + `source` + a SemVer-parsable `version` (e.g. `1.0.0`), which today short-circuits as satisfied, is now always reinstalled on repeat runs (noted in the changelog). No correctness change; only that narrow sub-case reinstalls where it previously skipped.

Reproduction verified on ansible-core 2.19.9 and 2.20.5 (fresh install succeeds; re-install without `--force` crashes): https://github.com/ansible/ansible/issues/81687#issuecomment-4991917935

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ansible-galaxy
