### PR TITLE
ansible-galaxy: add per-server client_cert/client_key for mTLS

### DIFF
--- a/changelogs/fragments/87236-galaxy-server-mtls.yml
+++ b/changelogs/fragments/87236-galaxy-server-mtls.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >-
+    ansible-galaxy - Add per-server ``client_cert`` and ``client_key`` options for mTLS authentication
+    to Galaxy servers (https://github.com/ansible/ansible/issues/87236).

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -660,6 +660,22 @@ class GalaxyCLI(CLI):
                 server_options['validate_certs'] = context.CLIARGS['resolved_validate_certs']
             validate_certs = server_options['validate_certs']
 
+            client_cert = server_options.get('client_cert')
+            client_key = server_options.get('client_key')
+            if client_key and not client_cert:
+                raise AnsibleError(
+                    "Galaxy server '%s' has client_key set without client_cert. "
+                    "Provide client_cert, or a combined PEM via client_cert alone."
+                    % server_key
+                )
+            for cert_key in ('client_cert', 'client_key'):
+                cert_path = server_options.get(cert_key)
+                if cert_path and not os.path.exists(cert_path):
+                    raise AnsibleError(
+                        "Galaxy server '%s' has an invalid %s '%s': file does not exist"
+                        % (server_key, cert_key, cert_path)
+                    )
+
             # default case if no auth info is provided.
             server_options['token'] = None
 
@@ -673,6 +689,8 @@ class GalaxyCLI(CLI):
                         validate_certs=validate_certs,
                         client_id=client_id,
                         client_secret=client_secret,
+                        client_cert=client_cert,
+                        client_key=client_key,
                     )
                 elif token_val:
                     # The galaxy v1 / github / django / 'Token'

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -43,6 +43,8 @@ GALAXY_SERVER_DEF = [
     ('client_id', False, 'str'),
     ('client_secret', False, 'str'),
     ('timeout', False, 'int'),
+    ('client_cert', False, 'path'),
+    ('client_key', False, 'path'),
 ]
 
 # config definition fields

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -261,6 +261,7 @@ class GalaxyAPI:
             clear_response_cache=False, no_cache=True,
             priority=float('inf'),
             timeout=60,
+            client_cert=None, client_key=None,
     ):
         self.galaxy = galaxy
         self.name = name
@@ -270,6 +271,8 @@ class GalaxyAPI:
         self.api_server = url
         self.validate_certs = validate_certs
         self.timeout = timeout
+        self.client_cert = client_cert
+        self.client_key = client_key
         self._available_api_versions = available_api_versions or {}
         self._priority = priority
         self._server_timeout = timeout
@@ -392,7 +395,8 @@ class GalaxyAPI:
         try:
             display.vvvv("Calling Galaxy at %s" % url)
             resp = open_url(to_native(url), data=args, validate_certs=self.validate_certs, headers=headers,
-                            method=method, timeout=self._server_timeout, http_agent=user_agent(), follow_redirects='safe')
+                            method=method, timeout=self._server_timeout, http_agent=user_agent(), follow_redirects='safe',
+                            client_cert=self.client_cert, client_key=self.client_key)
         except HTTPError as e:
             raise GalaxyError(e, error_context_msg)
         except Exception as ex:
@@ -452,7 +456,8 @@ class GalaxyAPI:
         args = urlencode({"github_token": github_token})
 
         try:
-            resp = open_url(url, data=args, validate_certs=self.validate_certs, method="POST", http_agent=user_agent(), timeout=self._server_timeout)
+            resp = open_url(url, data=args, validate_certs=self.validate_certs, method="POST", http_agent=user_agent(),
+                            timeout=self._server_timeout, client_cert=self.client_cert, client_key=self.client_key)
         except HTTPError as e:
             raise GalaxyError(e, 'Attempting to authenticate to galaxy')
         except Exception as ex:

--- a/lib/ansible/galaxy/collection/concrete_artifact_manager.py
+++ b/lib/ansible/galaxy/collection/concrete_artifact_manager.py
@@ -155,6 +155,8 @@ class ConcreteArtifactsManager:
                 expected_hash=metadata.artifact_sha256,
                 validate_certs=api.validate_certs,
                 token=api.token,
+                client_cert=api.client_cert,
+                client_key=api.client_key,
             )  # type: bytes
         except URLError as err:
             raise AnsibleError(
@@ -483,8 +485,8 @@ def _extract_collection_from_git(repo_url, coll_ver, b_path):
     backoff_iterator=generate_jittered_backoff(retries=6, delay_base=2, delay_threshold=40),
     should_retry_error=should_retry_error
 )
-def _download_file(url, b_path, expected_hash, validate_certs, token=None, timeout=60):
-    # type: (str, bytes, t.Optional[str], bool, GalaxyToken, int) -> bytes
+def _download_file(url, b_path, expected_hash, validate_certs, token=None, timeout=60, client_cert=None, client_key=None):
+    # type: (str, bytes, t.Optional[str], bool, GalaxyToken, int, t.Optional[str], t.Optional[str]) -> bytes
     # ^ NOTE: used in download and verify_collections ^
     b_tarball_name = to_bytes(
         url.rsplit('/', 1)[1], errors='surrogate_or_strict',
@@ -506,7 +508,9 @@ def _download_file(url, b_path, expected_hash, validate_certs, token=None, timeo
         validate_certs=validate_certs,
         headers=None if token is None else token.headers(),
         unredirected_headers=['Authorization'], http_agent=user_agent(),
-        timeout=timeout
+        timeout=timeout,
+        client_cert=client_cert,
+        client_key=client_key,
     )
 
     with open(b_file_path, 'wb') as download_file:  # type: t.BinaryIO

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -217,17 +217,34 @@ class GalaxyRole(object):
         if role_data:
 
             # first grab the file and save it to a temp location
+            from_github = False
             if self.download_url is not None:
                 archive_url = self.download_url
             elif "github_user" in role_data and "github_repo" in role_data:
                 archive_url = 'https://github.com/%s/%s/archive/%s.tar.gz' % (role_data["github_user"], role_data["github_repo"], self.version)
+                from_github = True
             else:
                 archive_url = self.src
 
             display.display("- downloading role from %s" % archive_url)
 
+            # Only attach per-server mTLS credentials for non-GitHub downloads so
+            # private client certificates are not presented to github.com.
+            client_cert = None
+            client_key = None
+            if not from_github:
+                client_cert = getattr(self.api, 'client_cert', None)
+                client_key = getattr(self.api, 'client_key', None)
+
             try:
-                url_file = open_url(archive_url, validate_certs=self._validate_certs, http_agent=user_agent(), timeout=60)
+                url_file = open_url(
+                    archive_url,
+                    validate_certs=self._validate_certs,
+                    http_agent=user_agent(),
+                    timeout=60,
+                    client_cert=client_cert,
+                    client_key=client_key,
+                )
                 temp_file = tempfile.NamedTemporaryFile(delete=False)
                 data = url_file.read()
                 while data:

--- a/lib/ansible/galaxy/token.py
+++ b/lib/ansible/galaxy/token.py
@@ -48,7 +48,16 @@ class KeycloakToken(object):
 
     token_type = 'Bearer'
 
-    def __init__(self, access_token=None, auth_url=None, validate_certs=True, client_id=None, client_secret=None):
+    def __init__(
+        self,
+        access_token=None,
+        auth_url=None,
+        validate_certs=True,
+        client_id=None,
+        client_secret=None,
+        client_cert=None,
+        client_key=None,
+    ):
         self.access_token = access_token
         self.auth_url = auth_url
         self._token = None
@@ -57,6 +66,8 @@ class KeycloakToken(object):
         if self.client_id is None:
             self.client_id = 'cloud-services'
         self.client_secret = client_secret
+        self.client_cert = client_cert
+        self.client_key = client_key
         self._expiration = None
 
     def _form_payload(self):
@@ -88,11 +99,15 @@ class KeycloakToken(object):
 
         display.vvv(f'Authenticating via {self.auth_url}')
         try:
-            resp = open_url(to_native(self.auth_url),
-                            data=payload,
-                            validate_certs=self.validate_certs,
-                            method='POST',
-                            http_agent=user_agent())
+            resp = open_url(
+                to_native(self.auth_url),
+                data=payload,
+                validate_certs=self.validate_certs,
+                method='POST',
+                http_agent=user_agent(),
+                client_cert=self.client_cert,
+                client_key=self.client_key,
+            )
         except HTTPError as e:
             raise GalaxyError(e, 'Unable to get access token')
         display.vvv('Authentication successful')

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -1369,3 +1369,78 @@ def test_install_collection_with_roles(requirements_file, monkeypatch):
     assert mock_role_install.call_count == 0
 
     assert any(list('contains roles which will be ignored' in mock_call[1][0] for mock_call in mock_display.mock_calls))
+
+
+def _fake_server_options(**overrides):
+    """Return a minimal galaxy server options dict suitable for mocking get_plugin_options."""
+    opts = {
+        'url': 'https://example.com',
+        'auth_url': None,
+        'client_id': None,
+        'client_secret': None,
+        'token': None,
+        'username': None,
+        'password': None,
+        'validate_certs': True,
+        'timeout': 60,
+        'client_cert': None,
+        'client_key': None,
+    }
+    opts.update(overrides)
+    return opts
+
+
+def test_galaxy_server_client_cert_and_key_accepted_when_files_exist(monkeypatch, tmp_path):
+    cert = tmp_path / 'client.pem'
+    key = tmp_path / 'client.key'
+    cert.write_text('cert-data')
+    key.write_text('key-data')
+
+    monkeypatch.setattr(C, 'GALAXY_SERVER_LIST', ['myserver'])
+    monkeypatch.setattr(C.config, 'load_galaxy_server_defs', MagicMock())
+    monkeypatch.setattr(C.config, 'get_plugin_options',
+                        MagicMock(return_value=_fake_server_options(
+                            client_cert=str(cert), client_key=str(key))))
+    monkeypatch.setattr(GalaxyCLI, 'execute_install', MagicMock())
+
+    GalaxyCLI(args=['ansible-galaxy', 'collection', 'install', 'namespace.collection']).run()
+
+
+def test_galaxy_server_client_cert_missing_file_raises_error(monkeypatch, tmp_path):
+    missing = str(tmp_path / 'nonexistent.pem')
+    monkeypatch.setattr(C, 'GALAXY_SERVER_LIST', ['myserver'])
+    monkeypatch.setattr(C.config, 'load_galaxy_server_defs', MagicMock())
+    monkeypatch.setattr(C.config, 'get_plugin_options',
+                        MagicMock(return_value=_fake_server_options(client_cert=missing)))
+
+    gc = GalaxyCLI(args=['ansible-galaxy', 'collection', 'install', 'namespace.collection'])
+    with pytest.raises(AnsibleError, match="invalid client_cert.*does not exist"):
+        gc.run()
+
+
+def test_galaxy_server_client_key_missing_file_raises_error(monkeypatch, tmp_path):
+    cert = tmp_path / 'client.pem'
+    cert.write_text('cert-data')
+    missing = str(tmp_path / 'nonexistent.key')
+    monkeypatch.setattr(C, 'GALAXY_SERVER_LIST', ['myserver'])
+    monkeypatch.setattr(C.config, 'load_galaxy_server_defs', MagicMock())
+    monkeypatch.setattr(C.config, 'get_plugin_options',
+                        MagicMock(return_value=_fake_server_options(
+                            client_cert=str(cert), client_key=missing)))
+
+    gc = GalaxyCLI(args=['ansible-galaxy', 'collection', 'install', 'namespace.collection'])
+    with pytest.raises(AnsibleError, match="invalid client_key.*does not exist"):
+        gc.run()
+
+
+def test_galaxy_server_client_key_without_cert_raises_error(monkeypatch, tmp_path):
+    key = tmp_path / 'client.key'
+    key.write_text('key-data')
+    monkeypatch.setattr(C, 'GALAXY_SERVER_LIST', ['myserver'])
+    monkeypatch.setattr(C.config, 'load_galaxy_server_defs', MagicMock())
+    monkeypatch.setattr(C.config, 'get_plugin_options',
+                        MagicMock(return_value=_fake_server_options(client_key=str(key))))
+
+    gc = GalaxyCLI(args=['ansible-galaxy', 'collection', 'install', 'namespace.collection'])
+    with pytest.raises(AnsibleError, match="client_key set without client_cert"):
+        gc.run()

--- a/test/units/galaxy/test_api.py
+++ b/test/units/galaxy/test_api.py
@@ -1299,3 +1299,47 @@ def test_cache_missing_results_raises_descriptive_error(mocker):
             cache=True,
             cache_key='/api/v1/roles/'
         )
+
+
+def test_mtls_attributes_stored_on_init():
+    api = GalaxyAPI(None, "test", "https://galaxy.ansible.com/api/",
+                    client_cert='/path/to/client.pem', client_key='/path/to/client.key')
+    assert api.client_cert == '/path/to/client.pem'
+    assert api.client_key == '/path/to/client.key'
+
+
+def test_mtls_attributes_default_to_none_when_not_provided():
+    api = GalaxyAPI(None, "test", "https://galaxy.ansible.com/api/")
+    assert api.client_cert is None
+    assert api.client_key is None
+
+
+def test_mtls_client_cert_and_key_passed_to_open_url(monkeypatch):
+    mock_open = MagicMock(return_value=StringIO(u'{"results":[]}'))
+    monkeypatch.setattr(galaxy_api, 'open_url', mock_open)
+
+    api = GalaxyAPI(None, "test", "https://galaxy.ansible.com/api/",
+                    client_cert='/path/to/client.pem', client_key='/path/to/client.key')
+    api._available_api_versions = {'v1': 'v1/'}
+    api._call_galaxy('https://galaxy.ansible.com/api/v1/roles/')
+
+    kwargs = mock_open.call_args[1]
+    assert kwargs['client_cert'] == '/path/to/client.pem'
+    assert kwargs['client_key'] == '/path/to/client.key'
+
+
+def test_mtls_client_cert_and_key_passed_to_authenticate(monkeypatch):
+    mock_open = MagicMock(side_effect=[
+        StringIO(u'{"available_versions":{"v1":"v1/"}}'),
+        StringIO(u'{"token":"my_token"}'),
+    ])
+    monkeypatch.setattr(galaxy_api, 'open_url', mock_open)
+
+    api = GalaxyAPI(None, "test", "https://galaxy.ansible.com/api/",
+                    client_cert='/path/to/client.pem', client_key='/path/to/client.key')
+    api.authenticate("github_token")
+
+    # The second call is the authenticate POST to /api/v1/tokens/.
+    authenticate_kwargs = mock_open.call_args_list[1][1]
+    assert authenticate_kwargs['client_cert'] == '/path/to/client.pem'
+    assert authenticate_kwargs['client_key'] == '/path/to/client.key'

--- a/test/units/galaxy/test_collection.py
+++ b/test/units/galaxy/test_collection.py
@@ -960,6 +960,24 @@ def test_download_file_hash_mismatch(tmp_path_factory: pytest.TempPathFactory, m
         collection._download_file('http://google.com/file', temp_dir, 'bad', True)
 
 
+def test_download_file_mtls_client_cert_and_key(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    temp_dir = to_bytes(tmp_path_factory.mktemp('test-mtls'))
+
+    data = b"\x00\x01\x02\x03"
+    mock_open = MagicMock()
+    mock_open.return_value = MockHTTPResponses([(data, len(data))])
+    monkeypatch.setattr(collection.concrete_artifact_manager, 'open_url', mock_open)
+
+    collection._download_file(
+        'http://example.com/ns-col-1.0.0.tar.gz', temp_dir, None, True,
+        client_cert='/path/client.pem', client_key='/path/client.key',
+    )
+
+    call_kwargs = mock_open.call_args[1]
+    assert call_kwargs['client_cert'] == '/path/client.pem'
+    assert call_kwargs['client_key'] == '/path/client.key'
+
+
 def test_download_file_incomplete_read(
     tmp_path_factory: pytest.TempPathFactory,
     monkeypatch: pytest.MonkeyPatch

--- a/test/units/galaxy/test_role_install.py
+++ b/test/units/galaxy/test_role_install.py
@@ -166,3 +166,43 @@ def test_role_download_url_default_version(init_mock_temp_file, mocker, galaxy_s
 
     assert mock_role_download_api.call_count == 1
     assert mock_role_download_api.mock_calls[0][1][0] == 'http://localhost:8080/test_owner/test_role/0.0.2.tar.gz'
+
+
+def test_role_download_url_passes_mtls_client_cert(init_mock_temp_file, mocker, galaxy_server, mock_role_download_api, monkeypatch):
+    galaxy_server.client_cert = '/path/client.pem'
+    galaxy_server.client_key = '/path/client.key'
+
+    mock_api = mocker.MagicMock()
+    mock_api.side_effect = [
+        StringIO(u'{"available_versions":{"v1":"v1/"}}'),
+        StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
+        StringIO(u'{"results":[{"name": "0.0.1","download_url":"http://localhost:8080/test_owner/test_role/0.0.1.tar.gz"}]}'),
+    ]
+    monkeypatch.setattr(api, 'open_url', mock_api)
+
+    role.GalaxyRole(Galaxy(), galaxy_server, 'test_owner.test_role', version="0.0.1").install()
+
+    assert mock_role_download_api.call_count == 1
+    kwargs = mock_role_download_api.call_args[1]
+    assert kwargs['client_cert'] == '/path/client.pem'
+    assert kwargs['client_key'] == '/path/client.key'
+
+
+def test_role_download_github_does_not_pass_mtls_client_cert(init_mock_temp_file, mocker, galaxy_server, mock_role_download_api, monkeypatch):
+    galaxy_server.client_cert = '/path/client.pem'
+    galaxy_server.client_key = '/path/client.key'
+
+    mock_api = mocker.MagicMock()
+    mock_api.side_effect = [
+        StringIO(u'{"available_versions":{"v1":"v1/"}}'),
+        StringIO(u'{"results":[{"id":"123","github_user":"test_owner","github_repo": "test_role"}]}'),
+        StringIO(u'{"results":[{"name": "0.0.1"}]}'),
+    ]
+    monkeypatch.setattr(api, 'open_url', mock_api)
+
+    role.GalaxyRole(Galaxy(), galaxy_server, 'test_owner.test_role', version="0.0.1").install()
+
+    assert mock_role_download_api.call_count == 1
+    kwargs = mock_role_download_api.call_args[1]
+    assert kwargs.get('client_cert') is None
+    assert kwargs.get('client_key') is None

--- a/test/units/galaxy/test_token.py
+++ b/test/units/galaxy/test_token.py
@@ -95,3 +95,24 @@ def test_token_from_file_missing(b_token_file):
 @pytest.mark.parametrize('b_token_file', ['file'], indirect=True)
 def test_token_none(b_token_file):
     assert GalaxyToken(token=NoTokenSentinel).get() is None
+
+
+def test_keycloak_token_passes_mtls_client_cert_and_key(monkeypatch):
+    from io import StringIO
+
+    from ansible.galaxy.token import KeycloakToken
+
+    mock_open = MagicMock(return_value=StringIO('{"access_token":"tok","expires_in":3600,"token_type":"Bearer"}'))
+    monkeypatch.setattr('ansible.galaxy.token.open_url', mock_open)
+
+    token = KeycloakToken(
+        access_token='refresh',
+        auth_url='https://sso.example.com/token',
+        client_cert='/path/client.pem',
+        client_key='/path/client.key',
+    )
+    assert token.get() == 'tok'
+
+    kwargs = mock_open.call_args[1]
+    assert kwargs['client_cert'] == '/path/client.pem'
+    assert kwargs['client_key'] == '/path/client.key'


### PR DESCRIPTION
## Summary

- Add per-Galaxy-server `client_cert` / `client_key` config (and matching `ANSIBLE_GALAXY_SERVER_<name>_CLIENT_CERT` / `_CLIENT_KEY` env vars) for mTLS auth to private hubs.
- Pass client certificates through Galaxy API calls, collection downloads, role artifact downloads (not GitHub archives), and Keycloak token exchange.
- Validate cert/key paths at startup and reject `client_key` without `client_cert`.

Fixes #87236

## Test plan

- [x] Unit tests for config validation (missing files, key without cert)
- [x] Unit tests that `GalaxyAPI` / `_download_file` / `KeycloakToken` pass cert kwargs to `open_url`
- [x] Unit tests that role downloads use mTLS for Galaxy `download_url` and omit it for GitHub archives
- [ ] CI green on Azure Pipelines
