### PR TITLE
fix(exec_wrapper): select first powershell match when PATH has multiple entries

### DIFF
--- a/changelogs/fragments/powershell-exec-wrapper-multiple-path.yml
+++ b/changelogs/fragments/powershell-exec-wrapper-multiple-path.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - >-
+    powershell exec_wrapper - Select only the first match when resolving the
+    PowerShell interpreter so that multiple ``powershell.exe`` entries in PATH
+    (for example System32 and SysWOW64) no longer produce an array that breaks
+    the rest of the script.

--- a/lib/ansible/executor/powershell/exec_wrapper.ps1
+++ b/lib/ansible/executor/powershell/exec_wrapper.ps1
@@ -82,7 +82,8 @@ begin {
         $null = $PSBoundParameters.Remove('PwshPath')
 
         $targetPwsh = Get-Command -Name $PwshPath -CommandType Application -ErrorAction Ignore |
-            ForEach-Object { [Path]::GetFullPath($_.Path) }
+            ForEach-Object { [Path]::GetFullPath($_.Path) } |
+            Select-Object -First 1
         if (-not $targetPwsh) {
             @{
                 failed = $true


### PR DESCRIPTION
When multiple powershell.exe entries are on PATH (for example C:\Windows\System32\WindowsPowerShell\v1.0 and C:\Windows\SysWOW64\WindowsPowerShell\v1.0), Get-Command returns several Application results and $targetPwsh ends up as an array instead of a single path. The rest of exec_wrapper.ps1 treats $targetPwsh as a scalar, so the script fails at runtime. This adds Select-Object -First 1 to the pipeline so only the first match is kept, keeping the variable a single string as the downstream code expects.

Fixes #87228.

Assisted-by: Hermes Agent (AI coding assistant). I reviewed and tested the change myself.