### PR TITLE
module_utils.urls: skip unreadable CA cert dirs instead of aborting

### DIFF
--- a/changelogs/fragments/87260-galaxy-ca-certs-permission-denied.yml
+++ b/changelogs/fragments/87260-galaxy-ca-certs-permission-denied.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_utils.urls - Skip CA cert paths that exist but cannot be read (e.g. an inaccessible ``/etc/ansible`` symlink) instead of failing with a permission error. This could prevent ``ansible-galaxy`` from installing collections on hosts where a standard CA search path was present but not readable by the current user (https://github.com/ansible/ansible/issues/87260).

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -584,7 +584,16 @@ def get_ca_certs(cafile=None, capath=None):
         if not path or path == default_capath or not os.path.isdir(path):
             continue
 
-        for f in os.listdir(path):
+        try:
+            entries = os.listdir(path)
+        except OSError:
+            # The path may exist (so isdir() is True) but be unreadable, e.g.
+            # /etc/ansible symlinked to a directory the current user cannot
+            # access. Skipping it matches the handling of unreadable files
+            # below and avoids aborting the whole CA scan.
+            continue
+
+        for f in entries:
             full_path = os.path.join(path, f)
             if os.path.isfile(full_path) and os.path.splitext(f)[1] in {'.pem', '.cer', '.crt'}:
                 try:

--- a/test/units/module_utils/urls/test_urls.py
+++ b/test/units/module_utils/urls/test_urls.py
@@ -27,3 +27,33 @@ def test_unix_socket_patch_httpconnection_connect(mocker):
     with urls.unix_socket_patch_httpconnection_connect():
         conn.connect()
     assert unix_conn.call_count == 1
+
+
+def test_get_ca_certs_skips_unreadable_directories(mocker):
+    """A CA search path that exists but cannot be read should be skipped
+    rather than aborting the whole scan.
+
+    ``get_ca_certs`` builds a fixed search set that includes ``/etc/ansible``.
+    If that path exists but is unreadable, ``os.listdir`` raised
+    ``PermissionError`` instead of being skipped like the per-file ``OSError``
+    handling already does, which broke ``ansible-galaxy`` installs on hosts
+    where ``/etc/ansible`` is an inaccessible symlink
+    (https://github.com/ansible/ansible/issues/87260).
+    """
+    # The real isdir/listdir may not touch /etc/ansible on every CI host, so
+    # force the fallback path to look like an existing-but-unreadable directory.
+    mocker.patch.object(
+        urls.os.path,
+        'isdir',
+        side_effect=lambda p: True if str(p) == '/etc/ansible' else mocker.DEFAULT,
+    )
+    mocker.patch.object(
+        urls.os,
+        'listdir',
+        side_effect=lambda p: (_ for _ in ()).throw(PermissionError(13, 'Permission denied', str(p))) if str(p) == '/etc/ansible' else mocker.DEFAULT,
+    )
+
+    # Must not raise: the PermissionError from listdir('/etc/ansible') is caught.
+    data, paths_checked = urls.get_ca_certs()
+    assert isinstance(data, (bytes, bytearray))
+    assert '/etc/ansible' in paths_checked


### PR DESCRIPTION
get_ca_certs() scans a fixed set of CA search paths including /etc/ansible. When such a path exists (so os.path.isdir() returns True) but the current user cannot read it, os.listdir() raises PermissionError and propagates out of get_ca_certs(), which breaks ansible-galaxy collection installs (and any open_url consumer) on hosts where /etc/ansible is an inaccessible symlink or otherwise unreadable directory, as reported in #87260.

The per-file open() already had a try/except OSError guard, but the listdir() call that enumerates candidate cert files did not. This wraps listdir() in the same OSError guard so unreadable directories are skipped, consistent with the existing handling of unreadable individual files.

Adds a unit test (test_get_ca_certs_skips_unreadable_directories) reproducing the regression: it forces /etc/ansible to look like an existing-but-unreadable directory and asserts that get_ca_certs() returns normally instead of raising PermissionError. I verified the test fails on the previous code (PermissionError) and passes with the fix.

Fixes #87260