### PR TITLE
Validate literal empty delegate_to values

### DIFF
--- a/changelogs/fragments/84332-empty-delegate-to.yml
+++ b/changelogs/fragments/84332-empty-delegate-to.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - delegation - reject a literal empty ``delegate_to`` value consistently with an empty value produced by templating (https://github.com/ansible/ansible/issues/84332).

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -520,16 +520,13 @@ class VariableManager:
         Not used directly be VariableManager, but used primarily within TaskExecutor
         """
         delegated_vars = {}
-        delegated_host_name = ...  # sentinel value distinct from empty/None, which are errors
 
-        if task.delegate_to:
-            try:
-                delegated_host_name = templar.template(task.delegate_to)
-            except AnsibleValueOmittedError:
-                pass
+        if task.delegate_to is None:
+            return delegated_vars, None
 
-        # bypass for unspecified value/omit
-        if delegated_host_name is ...:
+        try:
+            delegated_host_name = templar.template(task.delegate_to)
+        except AnsibleValueOmittedError:
             return delegated_vars, None
 
         if not delegated_host_name:

--- a/test/integration/targets/delegate_to/test_delegate_to.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to.yml
@@ -71,11 +71,19 @@
       ignore_errors: true
       register: d_empty
 
-    - name: Ensure previous 2 tests actually did what was expected
+    - name: Use literal empty to thwart delegation should fail
+      ping:
+      delegate_to: ""
+      when: false
+      ignore_errors: true
+      register: d_literal_empty
+
+    - name: Ensure previous tests actually did what was expected
       assert:
         that:
           - d_omitted is success
           - d_empty is failed
+          - d_literal_empty is failed
 
 - name: verify delegation with per host vars
   hosts: testhost6

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -18,12 +18,17 @@
 from __future__ import annotations
 
 import os
-
 import unittest
 from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible._internal._templating._engine import TemplateEngine
+from ansible.errors import AnsibleError
 from ansible.inventory.manager import InventoryManager
 from ansible.module_utils._internal._datatag import AnsibleTagHelper
 from ansible.playbook.play import Play
+from ansible.template import trust_as_template
 
 
 from units.mock.loader import DictDataLoader
@@ -165,3 +170,41 @@ class TestVariableManager(unittest.TestCase):
             task = blocks[2].block[0]
             res = v.get_vars(play=play1, task=task)
             self.assertEqual(res['role_var'], 'role_var_from_role2')
+
+
+@pytest.mark.parametrize(
+    ("delegate_to", "variables", "expected_hostname"),
+    [
+        pytest.param(None, {}, None, id="unspecified"),
+        pytest.param(trust_as_template("{{ omit }}"), {}, None, id="omit"),
+        pytest.param("delegate.example", {}, "delegate.example", id="valid-host"),
+    ],
+)
+def test_get_delegated_vars_and_hostname(delegate_to, variables, expected_hostname):
+    inventory = InventoryManager(loader=DictDataLoader({}))
+    variable_manager = VariableManager(loader=DictDataLoader({}), inventory=inventory)
+    task = MagicMock(delegate_to=delegate_to)
+
+    with patch.object(variable_manager, "get_vars", return_value={}):
+        delegated_vars, delegated_host_name = variable_manager.get_delegated_vars_and_hostname(TemplateEngine(variables=variables), task, {})
+
+    assert delegated_host_name == expected_hostname
+    if expected_hostname is None:
+        assert delegated_vars == {}
+    else:
+        assert delegated_vars["ansible_delegated_vars"][expected_hostname]["inventory_hostname"] is None
+
+
+@pytest.mark.parametrize(
+    ("delegate_to", "variables"),
+    [
+        pytest.param("", {}, id="literal-empty"),
+        pytest.param(trust_as_template("{{ delegate_host }}"), {"delegate_host": ""}, id="templated-empty"),
+    ],
+)
+def test_get_delegated_vars_and_hostname_rejects_empty(delegate_to, variables):
+    variable_manager = VariableManager(loader=DictDataLoader({}), inventory=InventoryManager(loader=DictDataLoader({})))
+    task = MagicMock(delegate_to=delegate_to)
+
+    with pytest.raises(AnsibleError, match="Empty hostname produced from delegate_to"):
+        variable_manager.get_delegated_vars_and_hostname(TemplateEngine(variables=variables), task, {})


### PR DESCRIPTION
##### SUMMARY

Make `delegate_to` distinguish an unspecified value from a specified literal empty string. Literal and templated empty values now follow the same validation path, while unspecified and `omit` values continue to disable delegation.

Fixes #84332

Tests cover unspecified, literal empty, templated empty, omit, and valid host values. The existing `delegate_to` integration target now verifies literal-empty parity at runtime.

Tested with:

- `ansible-test units -v --venv test/units/vars/test_variable_manager.py` (4,262 passed, 2 skipped, 25 xfailed; target selection expanded under this checkout).
- `ansible-test sanity -v --venv lib/ansible/vars/manager.py test/units/vars/test_variable_manager.py test/integration/targets/delegate_to/test_delegate_to.yml changelogs/fragments/84332-empty-delegate-to.yml` (passed).
- `ansible-test integration delegate_to -v --venv`: the changed runtime scenario passed (omit succeeded; templated and literal empty values failed; assertions passed). The broader target later stopped in the unrelated `verify_interpreter.yml` setup because its generated venv lacked `jinja2`.
- Regression proof against pre-fix production code: the literal-empty unit case fails because no `AnsibleError` is raised.

AI disclosure: OpenCode using gpt-5.6-sol assisted with implementation, tests, and PR preparation. The contribution was reviewed and verified by the submitter.

##### ISSUE TYPE

- Bugfix Pull Request