### PR TITLE
Fix FreeBSD tunnel CIDR netmask parsing

### DIFF
--- a/changelogs/fragments/44869-freebsd-tunnel-netmask.yml
+++ b/changelogs/fragments/44869-freebsd-tunnel-netmask.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup - use a FreeBSD point-to-point peer CIDR prefix to calculate the local IPv4 netmask (https://github.com/ansible/ansible/issues/44869).

--- a/lib/ansible/module_utils/facts/network/generic_bsd.py
+++ b/lib/ansible/module_utils/facts/network/generic_bsd.py
@@ -227,13 +227,13 @@ class GenericBsdIfconfigNetwork(Network):
                 netmask_idx = 3
 
             netmask = words[netmask_idx]
-            if words[2] == '-->' and '/' in netmask:
+            if '/' in netmask:
                 netmask_length = int(netmask.rsplit('/', 1)[1])
                 netmask_bin = (1 << 32) - (1 << 32 >> netmask_length)
                 netmask = socket.inet_ntoa(struct.pack('!L', netmask_bin))
             # deal with hex netmask
-            elif re.match('([0-9a-f]){8}$', netmask):
-                netmask = '0x' + words[netmask_idx]
+            if re.match('([0-9a-f]){8}$', netmask):
+                netmask = '0x' + netmask
 
             if netmask.startswith('0x'):
                 address['netmask'] = socket.inet_ntoa(struct.pack('!L', int(netmask, base=16)))

--- a/lib/ansible/module_utils/facts/network/generic_bsd.py
+++ b/lib/ansible/module_utils/facts/network/generic_bsd.py
@@ -226,11 +226,14 @@ class GenericBsdIfconfigNetwork(Network):
             except ValueError:
                 netmask_idx = 3
 
+            netmask = words[netmask_idx]
+            if words[2] == '-->' and '/' in netmask:
+                netmask_length = int(netmask.rsplit('/', 1)[1])
+                netmask_bin = (1 << 32) - (1 << 32 >> netmask_length)
+                netmask = socket.inet_ntoa(struct.pack('!L', netmask_bin))
             # deal with hex netmask
-            if re.match('([0-9a-f]){8}$', words[netmask_idx]):
+            elif re.match('([0-9a-f]){8}$', netmask):
                 netmask = '0x' + words[netmask_idx]
-            else:
-                netmask = words[netmask_idx]
 
             if netmask.startswith('0x'):
                 address['netmask'] = socket.inet_ntoa(struct.pack('!L', int(netmask, base=16)))

--- a/test/units/module_utils/facts/network/test_generic_bsd.py
+++ b/test/units/module_utils/facts/network/test_generic_bsd.py
@@ -193,7 +193,75 @@ def test_compare_old_new_ifconfig(mocker):
                 },
                 {'all_ipv4_addresses': ['10.109.188.206']},
             ),
-            id="ifconfig-output-2",
+            id="point-to-point-hex-netmask",
+        ),
+        pytest.param(
+            "inet 192.0.2.1 --> 192.0.2.2/24",
+            (
+                {
+                    'ipv4': [
+                        {
+                            'address': '192.0.2.1',
+                            'netmask': '255.255.255.0',
+                            'network': '192.0.2.0',
+                            'broadcast': '192.0.2.255',
+                        }
+                    ]
+                },
+                {'all_ipv4_addresses': ['192.0.2.1']},
+            ),
+            id="point-to-point-peer-cidr",
+        ),
+        pytest.param(
+            "inet 192.0.2.1 --> 192.0.2.2 netmask 255.255.255.0",
+            (
+                {
+                    'ipv4': [
+                        {
+                            'address': '192.0.2.1',
+                            'netmask': '255.255.255.0',
+                            'network': '192.0.2.0',
+                            'broadcast': '192.0.2.255',
+                        }
+                    ]
+                },
+                {'all_ipv4_addresses': ['192.0.2.1']},
+            ),
+            id="point-to-point-dotted-netmask",
+        ),
+        pytest.param(
+            "inet 192.0.2.1 --> 192.0.2.2/32",
+            (
+                {
+                    'ipv4': [
+                        {
+                            'address': '192.0.2.1',
+                            'netmask': '255.255.255.255',
+                            'network': '192.0.2.1',
+                            'broadcast': '192.0.2.1',
+                        }
+                    ]
+                },
+                {'all_ipv4_addresses': ['192.0.2.1']},
+            ),
+            id="point-to-point-peer-host-cidr",
+        ),
+        pytest.param(
+            "inet 192.0.2.1/24 broadcast 192.0.2.255 flags 0x0",
+            (
+                {
+                    'ipv4': [
+                        {
+                            'address': '192.0.2.1',
+                            'netmask': '255.255.255.0',
+                            'network': '192.0.2.0',
+                            'broadcast': '192.0.2.255',
+                        }
+                    ]
+                },
+                {'all_ipv4_addresses': ['192.0.2.1']},
+            ),
+            id="local-address-cidr",
         ),
     ],
 )

--- a/test/units/module_utils/facts/network/test_generic_bsd.py
+++ b/test/units/module_utils/facts/network/test_generic_bsd.py
@@ -230,6 +230,23 @@ def test_compare_old_new_ifconfig(mocker):
             id="point-to-point-dotted-netmask",
         ),
         pytest.param(
+            "inet 192.0.2.1 --> 192.0.2.2 netmask 0xffffff00",
+            (
+                {
+                    'ipv4': [
+                        {
+                            'address': '192.0.2.1',
+                            'netmask': '255.255.255.0',
+                            'network': '192.0.2.0',
+                            'broadcast': '192.0.2.255',
+                        }
+                    ]
+                },
+                {'all_ipv4_addresses': ['192.0.2.1']},
+            ),
+            id="point-to-point-explicit-hex-netmask",
+        ),
+        pytest.param(
             "inet 192.0.2.1 --> 192.0.2.2/32",
             (
                 {


### PR DESCRIPTION
##### SUMMARY

Fix FreeBSD point-to-point IPv4 fact parsing when `ifconfig` reports the CIDR prefix on the peer address, for example `inet 192.0.2.1 --> 192.0.2.2/24`. The parser now derives the local netmask from that prefix while preserving ordinary CIDR and explicit dotted or hexadecimal netmask forms.

Fixes #44869

Tests added for peer CIDR prefixes (`/24` and `/32`), explicit point-to-point netmasks, and ordinary local-address CIDR parsing.

Tested with:

- `ansible-test units -v --venv test/units/module_utils/facts/network/test_generic_bsd.py` (4,257 passed, 2 skipped, 25 xfailed; target selection expanded under this checkout).
- `ansible-test sanity -v --venv lib/ansible/module_utils/facts/network/generic_bsd.py test/units/module_utils/facts/network/test_generic_bsd.py changelogs/fragments/44869-freebsd-tunnel-netmask.yml` (passed).
- Regression proof against pre-fix production code: peer CIDR cases fail with `OSError: illegal IP address string passed to inet_aton`.

AI disclosure: OpenCode using gpt-5.6-sol assisted with implementation, tests, and PR preparation. The contribution was reviewed and verified by the submitter.

##### ISSUE TYPE

- Bugfix Pull Request