### PR TITLE
Fix role path lookup resolving against CWD instead of playbook directory

### DIFF
--- a/changelogs/fragments/87100-role-search-path-cwd.yml
+++ b/changelogs/fragments/87100-role-search-path-cwd.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - role definition - fix path-based role lookup resolving relative to the process working directory
+    instead of the playbook directory when the role name looks like a path (https://github.com/ansible/ansible/issues/87100).

--- a/lib/ansible/playbook/role/definition.py
+++ b/lib/ansible/playbook/role/definition.py
@@ -187,8 +187,9 @@ class RoleDefinition(Base, Conditional, Taggable, CollectionSearch):
             if self._loader.path_exists(role_path):
                 return (role_name, role_path)
 
-        # if not found elsewhere try to extract path from name
-        role_path = unfrackpath(role_name)
+        # if not found elsewhere try to extract path from name, resolving relative
+        # to the playbook directory rather than the process CWD
+        role_path = unfrackpath(role_name, basedir=self._loader.get_basedir())
         if self._loader.path_exists(role_path):
             role_name = os.path.basename(role_name)
             return (role_name, role_path)


### PR DESCRIPTION
## Summary

Fixes #87100.

When a role name looks like a filesystem path (e.g. a relative path accidentally created with `ansible-galaxy role init blah` from the wrong working directory), the fallback `unfrackpath(role_name)` call at `lib/ansible/playbook/role/definition.py:191` passed `basedir=None`, which resolves to the **process CWD** rather than the playbook directory.

This meant a role could be found (and silently used) even though it lives in a completely unrelated directory where `ansible-playbook` was invoked from — undocumented, confusing, and inconsistent with all other role search paths.

### Change

Pass `basedir=self._loader.get_basedir()` so the path-based fallback resolves from the same playbook directory used by every other search path in `_load_role_path`.

```python
# before
role_path = unfrackpath(role_name)

# after
role_path = unfrackpath(role_name, basedir=self._loader.get_basedir())
```

## Test plan

- [ ] Manual reproduction with the repro script from issue #87100 confirms the role is no longer found from CWD when it should not be
- [ ] Existing role unit tests pass: `ansible-test units test/units/playbook/role/`
- [ ] Sanity: `ansible-test sanity lib/ansible/playbook/role/definition.py`

🤖 Generated with [Claude Code](https://claude.ai/code)