### PR TITLE
ansible-galaxy: provide clearer error when collection does not exist

### DIFF
--- a/changelogs/fragments/87271-galaxy-collection-not-found-error.yml
+++ b/changelogs/fragments/87271-galaxy-collection-not-found-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ansible-galaxy - provide a clearer error message when a requested collection does not exist on any configured Galaxy server, instead of a misleading dependency resolution error (https://github.com/ansible/ansible/issues/87271).

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -248,6 +248,7 @@ class CollectionDependencyProvider(AbstractProvider):
             and not coll_versions
             and first_req.type == 'galaxy'
             and not first_req.is_concrete_artifact
+            and all(r._parent is None for r in requirements)
         ):
             server_names = ', '.join(
                 api.api_server for api in self._api_proxy._apis

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -250,6 +250,12 @@ class CollectionDependencyProvider(AbstractProvider):
             and not first_req.is_concrete_artifact
             and all(r._parent is None for r in requirements)
         ):
+            # coll_versions is fetched directly from the Galaxy API and is not
+            # filtered by pre-release status (that filtering happens later,
+            # per-candidate, below). An empty coll_versions here therefore
+            # means no versions of any kind -- including pre-releases --
+            # exist for this collection on any configured server, so the
+            # generic pre-release hint would not be applicable/helpful.
             server_names = ', '.join(
                 api.api_server for api in self._api_proxy._apis
             ) or 'the configured Galaxy server(s)'

--- a/lib/ansible/galaxy/dependency_resolution/providers.py
+++ b/lib/ansible/galaxy/dependency_resolution/providers.py
@@ -18,6 +18,7 @@ if t.TYPE_CHECKING:
 
     from resolvelib.structs import RequirementInformation
 
+from ansible.errors import AnsibleError
 from ansible.galaxy.collection.gpg import get_signature_from_source
 from ansible.galaxy.dependency_resolution.dataclasses import (
     Candidate,
@@ -241,6 +242,19 @@ class CollectionDependencyProvider(AbstractProvider):
                 ) from exc
             # Unexpected error from a Galaxy server
             raise
+
+        if (
+            not preinstalled_candidates
+            and not coll_versions
+            and first_req.type == 'galaxy'
+            and not first_req.is_concrete_artifact
+        ):
+            server_names = ', '.join(
+                api.api_server for api in self._api_proxy._apis
+            ) or 'the configured Galaxy server(s)'
+            raise AnsibleError(
+                f"Collection '{fqcn}' does not exist on {server_names}."
+            )
 
         if first_req.is_concrete_artifact:
             # FIXME: do we assume that all the following artifacts are also concrete?

--- a/test/units/galaxy/test_collection_install.py
+++ b/test/units/galaxy/test_collection_install.py
@@ -579,7 +579,7 @@ def test_build_requirement_from_name_missing(galaxy_server, monkeypatch, tmp_pat
         ['namespace.collection'], None, artifacts_manager=concrete_artifact_cm
     )['collections']
 
-    expected = "Failed to resolve the requested dependencies map. Could not satisfy the following requirements:\n* namespace.collection:* (direct request)"
+    expected = "Collection 'namespace.collection' does not exist on"
     with pytest.raises(AnsibleError, match=re.escape(expected)):
         collection._resolve_depenency_map(requirements, [galaxy_server, galaxy_server], concrete_artifact_cm, None, False, True, False, False, False)
 


### PR DESCRIPTION
When installing a collection that doesn't exist on any configured Galaxy server, ansible-galaxy showed a confusing dependency resolution error suggesting --pre, instead of clearly stating the collection was not found.

This PR adds an explicit check in the dependency resolver: if a galaxy-type requirement has no available versions on any configured server, a clear AnsibleError is raised stating the collection does not exist, instead of falling through to the generic resolution-conflict message.

Fixes #87271

ISSUE TYPE
Bugfix Pull Request
COMPONENT NAME

lib/ansible/galaxy/dependency_resolution/providers.py

ADDITIONAL INFORMATION

Before:

[ERROR]: Failed to resolve the requested dependencies map. Could not satisfy the following requirements:
* foo.bar:* (direct request)
Hint: Pre-releases hosted on Galaxy or Automation Hub are not installed by default...

After:

[ERROR]: Collection 'foo.bar' does not exist on https://galaxy.ansible.com/api/