### PR TITLE
ssh - pass sudoable=False for sftp/scp file transfers

### DIFF
--- a/changelogs/fragments/87272-ssh-sudoable-file-transfer.yml
+++ b/changelogs/fragments/87272-ssh-sudoable-file-transfer.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ssh connection plugin - file transfers (sftp/scp) no longer guess whether privilege escalation applies by searching for the ``ssh_executable`` string inside the command; escalation state is now determined explicitly, fixing hangs when the executable path appeared in sftp/scp arguments (https://github.com/ansible/ansible/issues/87272).

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -1160,12 +1160,12 @@ class Connection(ConnectionBase):
             'awaiting_prompt', 'awaiting_escalation', 'ready_to_send', 'awaiting_exit'
         ]
 
-        # Are we requesting privilege escalation? Right now, we may be invoked
-        # to execute sftp/scp with sudoable=True, but we can request escalation
-        # only when using ssh. Otherwise, we can send initial data straight away.
+        # Are we requesting privilege escalation? Callers that cannot escalate
+        # (e.g. sftp/scp file transfers) must pass sudoable=False. Otherwise,
+        # we can send initial data straight away.
 
         state = states.index('ready_to_send')
-        if to_bytes(self.get_option('ssh_executable')) in cmd and sudoable:
+        if sudoable:
             prompt = getattr(self.become, 'prompt', None)
             if prompt:
                 # We're requesting escalation with a password, so we have to
@@ -1425,7 +1425,7 @@ class Connection(ConnectionBase):
                     cmd = self._build_command(self.get_option('sftp_executable'), method, to_bytes(host))
                     in_data = f"{sftp_action} {shlex.quote(in_path)} {shlex.quote(out_path)}\n"
                     in_data = to_bytes(in_data, nonstring='passthru')
-                    (returncode, stdout, stderr) = self._bare_run(cmd, in_data, checkrc=False)
+                    (returncode, stdout, stderr) = self._bare_run(cmd, in_data, sudoable=False, checkrc=False)
                 case 'scp':
                     scp = self.get_option('scp_executable')
                     if sftp_action == 'get':
@@ -1433,7 +1433,7 @@ class Connection(ConnectionBase):
                     else:
                         cmd = self._build_command(scp, method, in_path, f'{host}:{self._shell.quote(out_path)}')
                     in_data = None
-                    (returncode, stdout, stderr) = self._bare_run(cmd, in_data, checkrc=False)
+                    (returncode, stdout, stderr) = self._bare_run(cmd, in_data, sudoable=False, checkrc=False)
                 case 'piped':
                     if sftp_action == 'get':
                         # we pass sudoable=False to disable pty allocation, which

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -218,19 +218,19 @@ class TestConnectionBaseClass(unittest.TestCase):
         # Test when SFTP works
         expected_in_data = b' '.join((b'put', to_bytes(shlex.quote('/path/to/in/file')), to_bytes(shlex.quote('/path/to/dest/file')))) + b'\n'
         conn.put_file('/path/to/in/file', '/path/to/dest/file')
-        conn._bare_run.assert_called_with('some command to run', expected_in_data, checkrc=False)
+        conn._bare_run.assert_called_with('some command to run', expected_in_data, sudoable=False, checkrc=False)
 
         # Test filenames with unicode
         expected_in_data = b' '.join((b'put',
                                       to_bytes(shlex.quote('/path/to/in/file/with/unicode-fö〩')),
                                       to_bytes(shlex.quote('/path/to/dest/file/with/unicode-fö〩')))) + b'\n'
         conn.put_file(u'/path/to/in/file/with/unicode-fö〩', u'/path/to/dest/file/with/unicode-fö〩')
-        conn._bare_run.assert_called_with('some command to run', expected_in_data, checkrc=False)
+        conn._bare_run.assert_called_with('some command to run', expected_in_data, sudoable=False, checkrc=False)
 
         # Test when SFTP doesn't work but SCP does
         conn._bare_run.side_effect = [(1, 'stdout', 'some errors'), (0, '', '')]
         conn.put_file('/path/to/in/file', '/path/to/dest/file')
-        conn._bare_run.assert_called_with('some command to run', None, checkrc=False)
+        conn._bare_run.assert_called_with('some command to run', None, sudoable=False, checkrc=False)
         conn._bare_run.side_effect = None
 
         # Test that a non-zero rc raises an error
@@ -270,12 +270,12 @@ class TestConnectionBaseClass(unittest.TestCase):
         expected_in_data = b' '.join((b'get', to_bytes(shlex.quote('/path/to/in/file')), to_bytes(shlex.quote('/path/to/dest/file')))) + b'\n'
         conn.set_options({})
         conn.fetch_file('/path/to/in/file', '/path/to/dest/file')
-        conn._bare_run.assert_called_with('some command to run', expected_in_data, checkrc=False)
+        conn._bare_run.assert_called_with('some command to run', expected_in_data, sudoable=False, checkrc=False)
 
         # Test when SFTP doesn't work but SCP does
         conn._bare_run.side_effect = [(1, 'stdout', 'some errors'), (0, '', '')]
         conn.fetch_file('/path/to/in/file', '/path/to/dest/file')
-        conn._bare_run.assert_called_with('some command to run', None, checkrc=False)
+        conn._bare_run.assert_called_with('some command to run', None, sudoable=False, checkrc=False)
         conn._bare_run.side_effect = None
 
         # Test when filename is unicode
@@ -283,7 +283,7 @@ class TestConnectionBaseClass(unittest.TestCase):
                                       to_bytes(shlex.quote('/path/to/in/file/with/unicode-fö〩')),
                                       to_bytes(shlex.quote('/path/to/dest/file/with/unicode-fö〩')))) + b'\n'
         conn.fetch_file(u'/path/to/in/file/with/unicode-fö〩', u'/path/to/dest/file/with/unicode-fö〩')
-        conn._bare_run.assert_called_with('some command to run', expected_in_data, checkrc=False)
+        conn._bare_run.assert_called_with('some command to run', expected_in_data, sudoable=False, checkrc=False)
         conn._bare_run.side_effect = None
 
         # Test that a non-zero rc raises an error


### PR DESCRIPTION
##### SUMMARY

Fixes #87272

The `_bare_run()` state machine decided whether privilege escalation may occur by searching for the `ssh_executable` string anywhere inside the command bytes:

```python
if to_bytes(self.get_option('ssh_executable')) in cmd and sudoable:
```

This heuristic existed to distinguish real ssh invocations from sftp/scp file transfers, since the transfer call sites in `_file_transport_command()` left `sudoable` at its default of `True`.

If the `ssh_executable` path happened to appear anywhere in an sftp/scp command (e.g. the same wrapper script passed via `sftp_extra_args = "-S <path>"`), the transfer wrongly entered the escalation state machine and hung until `Timeout waiting for privilege escalation prompt`.

This PR passes `sudoable=False` explicitly at the sftp/scp call sites (file transfers can never request escalation) and trusts the `sudoable` flag alone in `_bare_run()`, instead of guessing from the command text. The `piped` transfer method and `exec_command()` already pass `sudoable` explicitly, so no other call sites are affected.

Unit test assertions for `put_file`/`fetch_file` are updated to expect the explicit `sudoable=False`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ssh