### PR TITLE
Fix mask_url to also mask password-only URLs

### DIFF
--- a/changelogs/fragments/mask_url-password-auth.yml
+++ b/changelogs/fragments/mask_url-password-auth.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - module_utils - ``mask_url`` now masks the password in URLs that contain a
+    password but no username, such as ``redis://:password@host``, instead of
+    returning them unmasked.

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -320,7 +320,7 @@ def mask_url(url: str) -> str:
     Safely display a url by masking confidential data
     from a string or the result from urlparse/split
     """
-    if (parsed_url := urlparse(url)) and not parsed_url.username:
+    if (parsed_url := urlparse(url)) and not parsed_url.username and not parsed_url.password:
         return url
 
     netloc: str

--- a/test/units/module_utils/urls/test_mask_url.py
+++ b/test/units/module_utils/urls/test_mask_url.py
@@ -25,6 +25,8 @@ from ansible.module_utils.urls import mask_url
         ('ftps://secretuser:secretpass@file.secure/yolo.asc', ('yolo.asc', 'file.secure')),
         ('ftps://file.server/yolo.asc', ('yolo.asc')),
         ('ftps://secretuser:secretsecret@file.server/yolo.asc', ('file.server/yolo.asc')),
+        ('redis://:secretpass@cache.internal:6379/0', ('cache.internal', '6379', 'redis')),
+        ('amqp://:secretpw@rabbit.internal:5672/vhost', ('rabbit.internal', '5672', 'vhost')),
     )
 )
 def test_mask_url(url, wanted):


### PR DESCRIPTION
##### SUMMARY

`mask_url` returned URLs unchanged when they had a password but no username, such
as `redis://:password@host` or `amqp://:password@broker`, leaving the password in
the clear. The early return only checked for a username, extend it to also check
for a password so these URLs get masked.

##### ISSUE TYPE

- Bugfix Pull Request