### PR TITLE
deb822_repository: add update_cache option

### DIFF
--- a/changelogs/fragments/deb822_repository-update-cache.yml
+++ b/changelogs/fragments/deb822_repository-update-cache.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - deb822_repository - add ``update_cache`` option to run the equivalent of ``apt-get update``
+    after the repository or its signing key changed, matching ``apt_repository``. It defaults
+    to ``false`` to preserve the module's previous behaviour.

--- a/lib/ansible/modules/deb822_repository.py
+++ b/lib/ansible/modules/deb822_repository.py
@@ -11,8 +11,8 @@ description:
 - 'Add and remove deb822 formatted repositories in Debian based distributions.'
 module: deb822_repository
 notes:
-- This module will not automatically update caches, call the M(ansible.builtin.apt) module based
-  on the changed state.
+- By default this module will not update caches. Either set O(update_cache=true), or call
+  the M(ansible.builtin.apt) module based on the changed state.
 options:
     allow_downgrade_to_insecure:
         description:
@@ -150,6 +150,16 @@ options:
         description:
         - Which types of packages to look for from a given source; either
           binary V(deb) or source code V(deb-src).
+    update_cache:
+        description:
+        - Run the equivalent of C(apt-get update) after a change to the
+          repository or its signing key.
+        - Nothing is run when the module reports no change, or in check mode.
+        - Defaults to V(false), unlike M(ansible.builtin.apt_repository),
+          to preserve the behaviour of earlier versions of this module.
+        type: bool
+        default: false
+        version_added: '2.22'
     uris:
         description:
         - The URIs must specify the base of the Debian distribution archive,
@@ -216,6 +226,16 @@ EXAMPLES = """
     components: stable
     architectures: amd64
     signed_by: https://download.example.com/linux/ubuntu/gpg
+
+- name: Add repo and update the apt cache when the repo changed
+  deb822_repository:
+    name: example
+    types: deb
+    uris: https://download.example.com/linux/ubuntu
+    suites: '{{ ansible_distribution_release }}'
+    components: stable
+    signed_by: https://download.example.com/linux/ubuntu/gpg
+    update_cache: true
 """
 
 RETURN = """
@@ -385,6 +405,13 @@ def write_signed_by_key(module, v, slug):
     return changed, filename, None
 
 
+def update_apt_cache(module):
+    apt_get_path = module.get_bin_path('apt-get', required=True)
+    rc, stdout, stderr = module.run_command([apt_get_path, 'update'])
+    if rc != 0:
+        module.fail_json(msg=f"Failed to update apt cache: '{stderr.strip() or stdout.strip()}'")
+
+
 def install_python_debian(module, deb_pkg_name):
 
     if not module.check_mode:
@@ -503,6 +530,10 @@ def main():
                 ],
                 'default': 'present',
             },
+            'update_cache': {
+                'type': 'bool',
+                'default': False,
+            },
         },
         mutually_exclusive=[
             ['exclude', 'include']
@@ -569,6 +600,7 @@ def main():
     # popped non-deb822 args
     mode = params.pop('mode')
     state = params.pop('state')
+    update_cache = params.pop('update_cache')
     params.pop('install_python_debian')
 
     name = params['name']
@@ -599,6 +631,8 @@ def main():
                 if not check_mode:
                     os.unlink(signed_by_filename)
                 changed = True
+        if changed and update_cache and not check_mode:
+            update_apt_cache(module)
         module.exit_json(
             repo=None,
             changed=changed,
@@ -644,6 +678,9 @@ def main():
         changed |= True
 
     changed |= module.set_mode_if_different(sources_filename, mode, False)
+
+    if changed and update_cache and not check_mode:
+        update_apt_cache(module)
 
     module.exit_json(
         repo=repo,

--- a/test/integration/targets/deb822_repository/tasks/test.yml
+++ b/test/integration/targets/deb822_repository/tasks/test.yml
@@ -241,3 +241,60 @@
 - assert:
     that:
       - ansible_test_http_agent is changed
+
+# The setup_deb_repo dependency builds a local repo at /tmp/repo (not added,
+# install_repo=false) carrying the dummy package 'foobar'. Its visibility in
+# apt-cache proves the module refreshed the cache itself.
+- name: Add local repo with update_cache
+  deb822_repository:
+    name: ansible-test-update-cache
+    uris: file:///tmp/repo
+    suites: stable
+    components: main
+    architectures: all
+    trusted: true
+    update_cache: true
+  register: update_cache_add
+
+- name: Query foobar package after add
+  command: apt-cache policy foobar
+  register: update_cache_policy_after_add
+
+- name: Add local repo with update_cache idempotency
+  deb822_repository:
+    name: ansible-test-update-cache
+    uris: file:///tmp/repo
+    suites: stable
+    components: main
+    architectures: all
+    trusted: true
+    update_cache: true
+  register: update_cache_idem
+
+- assert:
+    that:
+      - update_cache_add is changed
+      # update_cache must not leak into the repository definition
+      - >
+        'Update-Cache' not in update_cache_add.repo
+      # apt-cache prints file: URIs with the empty authority collapsed
+      - >
+        'file:/tmp/repo' in update_cache_policy_after_add.stdout
+      - update_cache_idem is not changed
+
+- name: Remove local repo with update_cache
+  deb822_repository:
+    name: ansible-test-update-cache
+    state: absent
+    update_cache: true
+  register: update_cache_remove
+
+- name: Query foobar package after remove
+  command: apt-cache policy foobar
+  register: update_cache_policy_after_remove
+
+- assert:
+    that:
+      - update_cache_remove is changed
+      - >
+        'file:/tmp/repo' not in update_cache_policy_after_remove.stdout


### PR DESCRIPTION
##### SUMMARY

Adds an opt-in `update_cache` option to `deb822_repository` that runs the equivalent of `apt-get update` after the repository definition or its signing key actually changed — the same semantics as `apt_repository`, whose cache refresh only fires on change.

Details:

- Defaults to `false` to preserve the module's existing behaviour, following the precedent set by `install_python_debian` (#85487), whose `apt_repository` counterpart also defaults to true. Happy to flip the default if parity is preferred.
- Never runs when the module reports no change, and never in check mode.
- The option is popped from `params` alongside `mode`/`state` so it cannot leak into the rendered `.sources` file (the failure mode `install_python_debian` had in #86395); the integration tests assert this.
- The docs note "This module will not automatically update caches…" is reworded to mention the new option.
- Integration tests reuse the local repository built by the existing `setup_deb_repo` dependency: adding it with `update_cache: true` asserts the dummy `foobar` package becomes visible to `apt-cache policy` (proving the module itself refreshed the cache), plus idempotency, removal, and the no-leak check.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

deb822_repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)