### PR TITLE
Fix regression in file.get_state() with non-directory parent

### DIFF
--- a/changelogs/fragments/87289-file-get-state-notadirectory.yml
+++ b/changelogs/fragments/87289-file-get-state-notadirectory.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - file - treat a path whose parent component is not a directory as ``absent`` in ``get_state()`` instead of raising ``NotADirectoryError`` (https://github.com/ansible/ansible/pull/87289).
+  - file - fail with a clear error message when a path's parent component is not a directory, instead of raising an unhandled ``NotADirectoryError`` (https://github.com/ansible/ansible/pull/87289).

--- a/changelogs/fragments/87289-file-get-state-notadirectory.yml
+++ b/changelogs/fragments/87289-file-get-state-notadirectory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - file - treat a path whose parent component is not a directory as ``absent`` in ``get_state()`` instead of raising ``NotADirectoryError`` (https://github.com/ansible/ansible/pull/87289).

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -320,6 +320,9 @@ def get_state(path):
         st = os.lstat(b_path)
     except FileNotFoundError:
         return 'absent'
+    except NotADirectoryError:
+        # a parent component of the path is not a directory, so the path cannot exist
+        return 'absent'
     except PermissionError:
         module.warn(f"Insufficient permissions to access {to_native(b_path)}. Treating as absent")
         return 'absent'

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -320,9 +320,12 @@ def get_state(path):
         st = os.lstat(b_path)
     except FileNotFoundError:
         return 'absent'
-    except NotADirectoryError:
-        # a parent component of the path is not a directory, so the path cannot exist
-        return 'absent'
+    except NotADirectoryError as e:
+        module.fail_json(
+            msg=f"Invalid path {b_path}. A parent of the path is not a directory",
+            path=b_path,
+            exception=e
+        )
     except PermissionError:
         module.warn(f"Insufficient permissions to access {to_native(b_path)}. Treating as absent")
         return 'absent'

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -89,6 +89,23 @@
       - ghost_file_result.state == 'absent'
       - "'cannot continue' in ghost_file_result.msg"
 
+- name: create a regular file to use as a non-directory parent
+  file:
+    path: '{{ remote_tmp_dir_test }}/notadir'
+    state: touch
+
+- name: Target a path whose parent component is not a directory
+  file:
+    path: '{{ remote_tmp_dir_test }}/notadir/child'
+  ignore_errors: yes
+  register: notadir_result
+
+- name: Validate path-under-file is treated as absent, not a traceback
+  assert:
+    that:
+      - notadir_result is failed
+      - notadir_result.state == 'absent'
+
 - name: verify that we are checking an absent file
   file: path={{remote_tmp_dir_test}}/bar.txt state=absent
   register: file2_result

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -100,11 +100,11 @@
   ignore_errors: yes
   register: notadir_result
 
-- name: Validate path-under-file is treated as absent, not a traceback
+- name: Validate path-under-file fails with a clear error, not a traceback
   assert:
     that:
       - notadir_result is failed
-      - notadir_result.state == 'absent'
+      - "'parent of the path is not a directory' in notadir_result.msg"
 
 - name: verify that we are checking an absent file
   file: path={{remote_tmp_dir_test}}/bar.txt state=absent


### PR DESCRIPTION
##### SUMMARY

PR #86608 rewrote `get_state()` in the `file` module to catch only `FileNotFoundError` and `PermissionError`. 

As a result, when invoking the function with a path whose parent component is not a directory (which is not a real thing in practice) now raises an uncaught `NotADirectoryError` exception instead of being treated as `absent`. 

It is unclear if this is the intended behavior or a real regression, but it is a change in behavior from the previous implementation. This PR restores this part of the previous behavior by catching `NotADirectoryError` and returning `absent`.

I realize that "a path whose parent component is not a directory" is a weird use-case (and it will never exist in practice), but this issue can trigger in unexpected circumstances when not being careful with the module logic.

I have hit this issue while working with the `dev-sec/ansible-collection-hardening` repo, as reported here: https://github.com/dev-sec/ansible-collection-hardening/pull/963 The collection relies on the previous behavior of `get_state()` not raising an exception to continue working nicely.

It is totally possible that this should be fixed in the downstream module logic instead.

##### ISSUE TYPE

- Bugfix Pull Request

##### ADDITIONAL INFORMATION

##### Reproduction

Take this script:

```python
# check_get_state.py
import os
import sys

sys.path.insert(0, os.path.join(os.path.dirname(__file__), "lib"))

import ansible.modules.file as file_module

class FakeModule:
    def warn(self, msg):
        print(f"WARN: {msg}")
file_module.module = FakeModule()

path = "/dev/null/foobar"  # parent component (/dev/null) is not a directory
state = file_module.get_state(path)
print(f"get_state({path!r}) -> {state!r}")
```

The regression can be pinned to #86608 by running the script against the merge commit and its parent (`36e318dfe9` is the squash-merge of #86608):

```console
# state right before #86608 was merged -> 'absent'
$ git checkout 36e318dfe9~1
$ python3 check_get_state.py
get_state('/dev/null/foobar') -> 'absent'

# state right after #86608 was merged -> traceback
$ git checkout 36e318dfe9
$ python3 check_get_state.py
NotADirectoryError: [Errno 20] Not a directory: b'/dev/null/foobar'

# current devel still has the bug -> traceback
$ git checkout devel
$ python3 check_get_state.py
NotADirectoryError: [Errno 20] Not a directory: b'/dev/null/foobar'

# this branch restores the previous behavior -> 'absent'
$ git checkout fix-file-get-state-notadirectory
$ python3 check_get_state.py
get_state('/dev/null/foobar') -> 'absent'
```
