### PR TITLE
apt_repository: Fix IndexError when validating short source lines

### DIFF
--- a/changelogs/fragments/apt_repository-validate-source-indexerror.yml
+++ b/changelogs/fragments/apt_repository-validate-source-indexerror.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - apt_repository - treat a source line whose type is valid but which has fewer
+    than two following fields (for example a bare ``deb``) as invalid instead of
+    raising an ``IndexError`` while parsing sources.list files.

--- a/lib/ansible/modules/apt_repository.py
+++ b/lib/ansible/modules/apt_repository.py
@@ -324,6 +324,9 @@ class SourcesList(object):
         else:
             remaining_parts = parts[1:]
 
+        if len(remaining_parts) < 2:
+            return False
+
         # According to `sources.list(5)` man pages, only four fields are mandatory:
         # * `Types` either `deb` or/and `deb-src`
         # * `URIs` to repositories holding valid APT structure (unclear if multiple are allowed)

--- a/test/units/modules/test_apt_repository.py
+++ b/test/units/modules/test_apt_repository.py
@@ -25,6 +25,11 @@ from ansible.modules.apt_repository import SourcesList
             True,
             id="comment_at_end_line"
         ),
+        pytest.param("deb", False, id="type_only"),
+        pytest.param("deb https://example.com/debian", False, id="uri_without_suite"),
+        pytest.param("deb [arch=amd64] https://example.com/debian", False, id="option_uri_without_suite"),
+        pytest.param("", False, id="empty_source"),
+        pytest.param("deb [arch=amd64 http://example.com/debian focal main", False, id="unclosed_option_bracket"),
     ]
 )
 def test_validate(line, expected):


### PR DESCRIPTION
##### SUMMARY

`SourcesList._validate_source` indexed `remaining_parts[1]` without a length check,
so a line with a valid type but fewer than two following fields (a bare `deb`, or
`deb <uri>` with no suite) raised `IndexError` instead of being rejected, aborting
the whole task.

##### ISSUE TYPE

- Bugfix Pull Request