### PR TITLE
service_facts - correct documentation of the status values reported for systemd

### DIFF
--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -89,8 +89,13 @@ ansible_facts:
           sample: running
         status:
           description:
-          - State of the service.
-          - Either V(enabled), V(disabled), V(static), V(indirect) or V(unknown).
+          - Status of the service.
+          - For systemd this is the unit file state reported by C(systemctl list-unit-files) when the service has a unit file.
+          - Otherwise it is the active state reported by C(systemctl list-units), and a detected bad state takes precedence.
+          - 'Unit file states include: V(enabled), V(disabled), V(static), V(indirect), V(masked) and V(generated).'
+          - 'Active and bad states include: V(active), V(inactive), V(failed), V(masked) and V(not-found).'
+          - For RedHat/SUSE flavored sysvinit and for OpenBSD this is V(enabled) or V(disabled).
+          - Depending on the used init system additional statuses might be returned.
           returned: systemd systems or RedHat/SUSE flavored sysvinit/upstart or OpenBSD
           type: str
           sample: enabled


### PR DESCRIPTION
##### SUMMARY

The RETURN documentation for the `status` key of `service_facts` was inaccurate and incomplete for systemd. It listed only `enabled`, `disabled`, `static`, `indirect` or `unknown`, but `SystemctlScanService` actually derives `status` from the systemd unit file state via `systemctl list-unit-files` (`enabled`, `disabled`, `static`, `indirect`, `masked`, `generated`, ...), falling back to the active state from `systemctl list-units` (`active`, `inactive`, ...) for a service without a unit file, with bad states (`failed`, `masked`, `not-found`) taking precedence.

This updates the `status` description to reflect the real values and how they are determined, while keeping the RedHat/SUSE sysvinit and OpenBSD cases (covered by the same `returned:` clause) correct. Documentation-only change; no functional change and no changelog fragment.

##### ISSUE TYPE
- Documentation Pull Request

##### COMPONENT NAME
service_facts

Fixes #84500
