### PR TITLE
selinux_default_context: pass real st_mode to matchpathcon for existing paths

### DIFF
--- a/changelogs/fragments/87285-selinux-default-context-mode.yml
+++ b/changelogs/fragments/87285-selinux-default-context-mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - copy, template, and other file modules now resolve the correct SELinux context when multiple file-context rules apply to the same path (e.g. a regular file vs a symbolic link). selinux_default_context stats the existing path and passes its real mode to matchpathcon instead of always using the ``unknown`` mode (https://github.com/ansible/ansible/issues/87285).

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -643,6 +643,17 @@ class AnsibleModule(object):
         context = self.selinux_initial_context()
         if not self.selinux_enabled():
             return context
+        # matchpathcon() uses the mode argument to disambiguate between fcontext
+        # rules that target different file types for the same path (e.g. a regular
+        # file vs a symbolic link). A mode of 0 means "unknown" and causes libselinux
+        # to pick whichever rule sorts first rather than the one matching the actual
+        # file type, so files end up mislabeled. When the caller did not pass an
+        # explicit mode and the path already exists, stat it and pass the real mode.
+        if mode == 0:
+            try:
+                mode = os.lstat(to_bytes(path, errors='surrogate_or_strict')).st_mode
+            except OSError:
+                pass
         try:
             ret = selinux.matchpathcon(to_native(path, errors='surrogate_or_strict'), mode)
         except OSError:

--- a/test/units/module_utils/basic/test_selinux.py
+++ b/test/units/module_utils/basic/test_selinux.py
@@ -97,6 +97,45 @@ class TestSELinuxMU:
             selinux.matchpathcon.side_effect = OSError
             assert am.selinux_default_context(path='/foo/bar') == [None, None, None, None]
 
+    def test_selinux_default_context_passes_st_mode_for_existing_path(self):
+        # When the path exists and the caller omits mode, selinux_default_context must
+        # stat the path and forward the real st_mode to matchpathcon so that fcontext
+        # rules keyed on file type (regular file vs symlink, etc.) resolve correctly.
+        am = no_args_module(selinux_enabled=True, selinux_mls_enabled=True)
+
+        fake_stat = type('st', (), {'st_mode': 0o100644})()  # S_IFREG | 0644
+        with patch.object(basic, 'selinux', create=True) as selinux, \
+                patch('os.lstat', return_value=fake_stat) as lstat:
+            selinux.matchpathcon.return_value = [0, 'system_u:object_r:httpd_config_t:s0']
+            assert am.selinux_default_context(path='/etc/httpd/conf.d/test.conf') == \
+                ['system_u', 'object_r', 'httpd_config_t', 's0']
+            lstat.assert_called_once_with(b'/etc/httpd/conf.d/test.conf')
+            assert selinux.matchpathcon.call_args[0][1] == 0o100644
+
+    def test_selinux_default_context_keeps_mode_zero_for_missing_path(self):
+        # A non-existent path cannot be stat-ed; mode must stay 0 (unknown) so
+        # behaviour for files created fresh matches libselinux's default lookup.
+        am = no_args_module(selinux_enabled=True, selinux_mls_enabled=True)
+
+        with patch.object(basic, 'selinux', create=True) as selinux, \
+                patch('os.lstat', side_effect=OSError) as lstat:
+            selinux.matchpathcon.return_value = [0, 'system_u:object_r:etc_t:s0']
+            assert am.selinux_default_context(path='/nonexistent/path') == \
+                ['system_u', 'object_r', 'etc_t', 's0']
+            lstat.assert_called_once_with(b'/nonexistent/path')
+            assert selinux.matchpathcon.call_args[0][1] == 0
+
+    def test_selinux_default_context_respects_explicit_mode(self):
+        # An explicit mode argument must be forwarded as-is; the path must not be stat-ed.
+        am = no_args_module(selinux_enabled=True, selinux_mls_enabled=True)
+
+        with patch.object(basic, 'selinux', create=True) as selinux, \
+                patch('os.lstat', side_effect=AssertionError('should not stat when mode is explicit')) as lstat:
+            selinux.matchpathcon.return_value = [0, 'system_u:object_r:httpd_config_t:s0']
+            assert am.selinux_default_context(path='/foo/bar', mode=0o120644) == \
+                ['system_u', 'object_r', 'httpd_config_t', 's0']
+            assert selinux.matchpathcon.call_args[0][1] == 0o120644
+
     def test_selinux_context(self):
         # selinux unavailable
         with patch.object(basic, 'HAVE_SELINUX', False):


### PR DESCRIPTION
When a path matches several SELinux file-context rules that differ only by file type (the /etc/httpd tree is the common example: regular files get httpd_config_t while symbolic links get etc_t), copy/template and other file modules end up labelling the new file with the wrong context.

The root cause is in selinux_default_context() — it forwards mode=0 ("unknown") to matchpathcon(), so libselinux resolves the rule by sort order instead of by file type and the new file inherits whichever context happened to come first.

This change stats the path when it already exists and forwards the real st_mode to matchpathcon, letting the type-specific fcontext rule win. For fresh file creation the path does not exist yet, so mode stays 0 and behaviour is unchanged; an explicit mode argument continues to be forwarded as-is.

I added unit tests for the three cases: existing path (real mode forwarded), missing path (mode stays 0), and explicit mode (no stat, forwarded as-is). The existing selinux and atomic_move test suites still pass.

Fixes #87285