### PR TITLE
fix(exec_wrapper): select first powershell.exe match when PATH contains multiple entries

### DIFF
--- a/changelogs/fragments/87228-exec-wrapper-multiple-powershell.yml
+++ b/changelogs/fragments/87228-exec-wrapper-multiple-powershell.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - powershell exec_wrapper - handle multiple powershell.exe entries found in PATH by selecting the first match instead of producing an array that broke downstream path resolution (https://github.com/ansible/ansible/issues/87228).

--- a/lib/ansible/executor/powershell/exec_wrapper.ps1
+++ b/lib/ansible/executor/powershell/exec_wrapper.ps1
@@ -81,7 +81,12 @@ begin {
     if ($PwshPath) {
         $null = $PSBoundParameters.Remove('PwshPath')
 
+        # Select the first match so $targetPwsh stays a single string even when
+        # multiple powershell.exe entries are reachable through PATH (e.g. both
+        # System32 and SysWOW64 WindowsPowerShell directories). Without this,
+        # Get-Command returns an array and the downstream path operations fail.
         $targetPwsh = Get-Command -Name $PwshPath -CommandType Application -ErrorAction Ignore |
+            Select-Object -First 1 |
             ForEach-Object { [Path]::GetFullPath($_.Path) }
         if (-not $targetPwsh) {
             @{


### PR DESCRIPTION
When multiple powershell.exe entries are reachable through PATH (e.g. both System32 and SysWOW64 WindowsPowerShell directories on a stock Windows Server), Get-Command returns one ApplicationInfo per match. The existing pipeline feeds all of them through ForEach-Object, so $targetPwsh ends up as a string array rather than a single path. Every downstream operation then fails because ResolveLinkTarget, Split-Path, Get-Item, the $PSHome comparison, and the respawn call all assume a scalar string.

The fix is to Select-Object -First 1 before the ForEach-Object so only the first match is resolved to a full path. The not-found branch (-not $targetPwsh) still behaves correctly since Select-Object emits nothing when Get-Command finds no applications.

I went with the first match rather than trying to be clever about which one is "correct" because Get-Command already honors PATH ordering, so the first result is the same interpreter a plain powershell.exe invocation would launch. Reported in #87228.