### PR TITLE
interpreter discovery - name the delegated host in discovery messages

### DIFF
--- a/changelogs/fragments/87298-interpreter-discovery-delegated-host.yml
+++ b/changelogs/fragments/87298-interpreter-discovery-delegated-host.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - interpreter discovery - discovery messages named the inventory host
+    instead of the delegated host when a task used ``delegate_to``. They now
+    name the host the interpreter was actually discovered on
+    (https://github.com/ansible/ansible/issues/87310).

--- a/lib/ansible/executor/interpreter_discovery.py
+++ b/lib/ansible/executor/interpreter_discovery.py
@@ -25,7 +25,7 @@ class InterpreterDiscoveryRequiredError(Exception):
 
 def discover_interpreter(action, interpreter_name, discovery_mode, task_vars):
     """Probe the target host for a Python interpreter from the `INTERPRETER_PYTHON_FALLBACK` list, returning the first found or `/usr/bin/python3` if none."""
-    host = task_vars.get('inventory_hostname', 'unknown')
+    host = action._task.delegate_to or task_vars.get('inventory_hostname', 'unknown')
     res = None
     found_interpreters = [_FALLBACK_INTERPRETER]  # fallback value
     is_silent = discovery_mode.endswith('_silent')


### PR DESCRIPTION
##### SUMMARY

Use the delegated host name in interpreter discovery messages when a task uses `delegate_to`. Previously these messages named the inventory host, reporting a host as using an interpreter that does not exist on it.

The same value is used for the `-vvv` `Attempting python interpreter discovery` line, which was mislabeled in the same way and is fixed by the same change.

Before, with play host `ubuntu22` (python3.10) and a task delegated to `debian12` (python3.11):

```
TASK [Task delegated to debian12]
[WARNING]: Host 'ubuntu22' is using the discovered Python interpreter at '/usr/bin/python3.11'
changed: [ubuntu22 -> debian12]

TASK [Task on the play host]
[WARNING]: Host 'ubuntu22' is using the discovered Python interpreter at '/usr/bin/python3.10'
changed: [ubuntu22]
```

The same host is reported with two different interpreters a few lines apart, and the first report is wrong.

After:

```
TASK [Task delegated to debian12]
[WARNING]: Host 'debian12' is using the discovered Python interpreter at '/usr/bin/python3.11'
changed: [ubuntu22 -> debian12]
```

`ansible_delegated_vars[<delegate>]['inventory_hostname']` is set to the play host in `vars/manager.py`, and that structure is read by user playbooks, so I did not change it. Only the message construction is adjusted.


Happy to add an integration test if you'd like one.


Fixes #87298

##### ISSUE TYPE

- Bugfix Pull Request