### PR TITLE
interpreter_discovery: name the delegated host in warning/debug messages

### DIFF
--- a/changelogs/fragments/87298-interpreter-discovery-delegated-host.yml
+++ b/changelogs/fragments/87298-interpreter-discovery-delegated-host.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - interpreter_discovery - fix warning and debug messages to name the delegated host when ``delegate_to`` is used, instead of the original inventory host (https://github.com/ansible/ansible/issues/87298)

--- a/lib/ansible/executor/interpreter_discovery.py
+++ b/lib/ansible/executor/interpreter_discovery.py
@@ -25,7 +25,12 @@ class InterpreterDiscoveryRequiredError(Exception):
 
 def discover_interpreter(action, interpreter_name, discovery_mode, task_vars):
     """Probe the target host for a Python interpreter from the `INTERPRETER_PYTHON_FALLBACK` list, returning the first found or `/usr/bin/python3` if none."""
-    host = task_vars.get('inventory_hostname', 'unknown')
+    # When a task is delegated, the discovery probe runs against the delegated
+    # host, but task_vars['inventory_hostname'] still names the original play
+    # host (see VariableManager.get_delegated_vars_and_hostname). Use the
+    # delegated host name so warning/debug messages match the probed target.
+    delegate_to = getattr(getattr(action, '_task', None), 'delegate_to', None)
+    host = delegate_to or task_vars.get('inventory_hostname', 'unknown')
     res = None
     found_interpreters = [_FALLBACK_INTERPRETER]  # fallback value
     is_silent = discovery_mode.endswith('_silent')

--- a/test/units/executor/test_interpreter_discovery.py
+++ b/test/units/executor/test_interpreter_discovery.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from unittest import mock
+
+from ansible.executor import interpreter_discovery
+
+
+def test_discover_interpreter_uses_delegated_host_for_warning():
+    """When the task uses delegate_to, display messages should name the delegated host."""
+    action = mock.MagicMock()
+    action._task.delegate_to = "delegated.example"
+
+    task_vars = {"inventory_hostname": "playhost.example"}
+
+    real_display = interpreter_discovery.display
+
+    captured_warnings = []
+
+    with mock.patch.object(real_display, "warning", side_effect=lambda msg, **kw: captured_warnings.append(msg)), \
+         mock.patch.object(real_display, "vvv") as vvv_mock, \
+         mock.patch.object(real_display, "debug"), \
+         mock.patch.object(interpreter_discovery.C.config, "get_config_value", return_value=["/usr/bin/python3"]):
+        action._low_level_execute_command.return_value = {
+            "stdout": "FOUND\n/usr/bin/python3.42\nENDFOUND",
+            "stderr": "",
+        }
+
+        result = interpreter_discovery.discover_interpreter(
+            action=action,
+            interpreter_name="python",
+            discovery_mode="auto",
+            task_vars=task_vars,
+        )
+
+    assert result == "/usr/bin/python3.42"
+
+    # The vvv "Attempting discovery" message should name the delegated host.
+    vvv_call = vvv_mock.call_args
+    assert vvv_call.kwargs["host"] == "delegated.example"
+
+    # The warning should also name the delegated host, not inventory_hostname.
+    assert any("delegated.example" in m for m in captured_warnings), captured_warnings
+    assert not any("playhost.example" in m for m in captured_warnings), captured_warnings
+
+
+def test_discover_interpreter_uses_inventory_host_without_delegation():
+    """Without delegate_to, display messages should name the inventory host as before."""
+    action = mock.MagicMock()
+    action._task.delegate_to = None
+
+    task_vars = {"inventory_hostname": "playhost.example"}
+
+    real_display = interpreter_discovery.display
+
+    captured_warnings = []
+
+    with mock.patch.object(real_display, "warning", side_effect=lambda msg, **kw: captured_warnings.append(msg)), \
+         mock.patch.object(real_display, "vvv") as vvv_mock, \
+         mock.patch.object(real_display, "debug"), \
+         mock.patch.object(interpreter_discovery.C.config, "get_config_value", return_value=["/usr/bin/python3"]):
+        action._low_level_execute_command.return_value = {
+            "stdout": "FOUND\n/usr/bin/python3.99\nENDFOUND",
+            "stderr": "",
+        }
+
+        result = interpreter_discovery.discover_interpreter(
+            action=action,
+            interpreter_name="python",
+            discovery_mode="auto",
+            task_vars=task_vars,
+        )
+
+    assert result == "/usr/bin/python3.99"
+
+    vvv_call = vvv_mock.call_args
+    assert vvv_call.kwargs["host"] == "playhost.example"
+
+    assert any("playhost.example" in m for m in captured_warnings), captured_warnings


### PR DESCRIPTION
When a task uses delegate_to, the interpreter discovery probe actually runs against the delegated host, but the display messages (warning, vvv, debug) all used task_vars["inventory_hostname"], which still points at the original play host. The net effect is that users see a message like "Host 'ubuntu-22.example' is using the discovered Python interpreter at ..." that names the wrong machine, which is confusing when the delegated host is on a different OS and the interpreter path does not even exist on the named host.

This reads action._task.delegate_to and uses it as the host name when delegation is active, falling back to inventory_hostname otherwise. Two unit tests cover both the delegated and non-delegated code paths.

Fixes #87298
