### PR TITLE
[stable-2.21] Handle missing trailing newline in keys

### DIFF
--- a/changelogs/fragments/87304-rpm_key-armor-trailing-newline.yml
+++ b/changelogs/fragments/87304-rpm_key-armor-trailing-newline.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - rpm_key - ensure a trailing newline is present on PGP armor data before
+    passing it to librpm for parsing, fixing failures on systems where
+    ``pgpParsePkts`` requires it (https://github.com/ansible/ansible/issues/87303).

--- a/lib/ansible/modules/rpm_key.py
+++ b/lib/ansible/modules/rpm_key.py
@@ -161,6 +161,9 @@ class LibRPM:
         pkt = ctypes.POINTER(ctypes.c_uint8)()
         pktlen = ctypes.c_size_t()
 
+        if not armor.endswith("\n"):
+            armor += "\n"
+
         armor_bytes = armor.encode()
         result = self._lib.pgpParsePkts(armor_bytes, ctypes.byref(pkt), ctypes.byref(pktlen))
 

--- a/test/integration/targets/rpm_key/tasks/rpm_key.yaml
+++ b/test/integration/targets/rpm_key/tasks/rpm_key.yaml
@@ -238,6 +238,42 @@
       - result is success
       - result is not changed
 
+# Test armor without trailing newline (https://github.com/ansible/ansible/issues/87303).
+# Note that this particular issue is very dependent on the version of librpm installed.
+# Tolerancy of a missing newline varies across older versions, but we add this specific
+# test to validate our handling of the missing trailing newline.
+- name: Remove all keys from key ring
+  shell: rpm -q gpg-pubkey | xargs rpm -e
+
+- name: Read test key content
+  slurp:
+    src: "{{ test_key_path }}"
+  register: test_key_content
+
+- name: Write key file without trailing newline
+  copy:
+    content: "{{ (test_key_content['content'] | b64decode).rstrip('\n') }}"
+    dest: "{{ remote_tmp_dir }}/key_no_newline.asc"
+    mode: "0644"
+
+- name: Verify key file has no trailing newline
+  shell: test "$(tail -c 1 {{ remote_tmp_dir }}/key_no_newline.asc)" != ""
+
+- name: Import key without trailing newline
+  rpm_key:
+    state: present
+    key: "{{ remote_tmp_dir }}/key_no_newline.asc"
+
+- name: Import key without trailing newline (idempotent)
+  rpm_key:
+    state: present
+    key: "{{ remote_tmp_dir }}/key_no_newline.asc"
+  register: no_newline_idempotence
+
+- name: Verify idempotence
+  assert:
+    that: no_newline_idempotence is not changed
+
 # Test PGPv6 keys
 - name: Test PGPv6 Keys
   block:


### PR DESCRIPTION
Backport of PR #87304

(cherry picked from commit 4e131d639aabd9d4cecd589dc046582921487a41)