### PR TITLE
Increase async timeout from 1s to 5s in async integration tests

### DIFF
--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -287,7 +287,7 @@
 - name: Test that async has stdin
   command: >
     {{ ansible_python_interpreter|default('/usr/bin/python') }} -c 'import os; os.fdopen(os.dup(0), "r")'
-  async: 1
+  async: 5
   poll: 1
 
 - name: run async poll callback test playbook


### PR DESCRIPTION
##### SUMMARY

This playbook task has been seen to fail in CI due to a timeout. Bump the async timeout value to match the minimum within other tasks of the same playbook, from 1s to 5s.

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Test Pull Request
