### PR TITLE
[stable-2.20] Increase async timeout from 1s to 5s in async integration tests

### DIFF
--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -284,7 +284,7 @@
 - name: Test that async has stdin
   command: >
     {{ ansible_python_interpreter|default('/usr/bin/python') }} -c 'import os; os.fdopen(os.dup(0), "r")'
-  async: 1
+  async: 5
   poll: 1
 
 - name: run async poll callback test playbook


### PR DESCRIPTION
Backport of PR #87309

(cherry picked from commit 64508ba2a5e6e9e962b2c163f87ecbcd0eabef62)