### PR TITLE
Fix CI timeout by defining gather_timeout

### DIFF
--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -314,6 +314,7 @@
 - name: test 'hidden' async, gather_facts does internal on parallel true. Ensure it won't freeze in check_mode due to async_status not supporting it.
   gather_facts:
     parallel: true
+    gather_timeout: 10
   timeout: 60
   check_mode: true
   when: "ansible_facts['os_family'] != 'Darwin'"


### PR DESCRIPTION
##### SUMMARY

Update CI task parallel fact gathering test to define a reasonable `gather_timeout`. This is fallout from #87090, because I changed the implicit timeout from 10 seconds to 5, thinking it was internal. It seems FreeBSD can take longer than 5 seconds to run the service_facts module.

The underlying issue is that when no `gather_timeout` is provided, parallel fact gathering uses an undocumented, arbitrary value defined internally in the `async_wrapper`. I'm working on fixing this in #87223, and will make sure there's intentional test coverage.

##### ISSUE TYPE

- Test Pull Request
