### PR TITLE
[stable-2.16] winrm/psrp - apply no_log to stdout/stderr logs (#86919)

### DIFF
--- a/changelogs/fragments/winrm-psrp-nolog.yml
+++ b/changelogs/fragments/winrm-psrp-nolog.yml
@@ -1,0 +1,5 @@
+security_fixes:
+  - >-
+    winrm - Do not log raw stdout/stderr on verbosity 5 when task has ``no_log: true`` set
+  - >-
+    psrp - Do not log raw stdout/stderr on verbosity 5 when task has ``no_log: true`` set

--- a/lib/ansible/plugins/connection/psrp.py
+++ b/lib/ansible/plugins/connection/psrp.py
@@ -903,9 +903,14 @@ if ($read -gt 0) {
             stderr_list += self.host.ui.stderr
         stderr = u"\r\n".join([to_text(o) for o in stderr_list])
 
+        log_stdout = stdout
+        log_stderr = stderr
+        if self._play_context.no_log:
+            log_stdout = log_stderr = '<censored due to no log>'
+
         display.vvvvv("PSRP RC: %d" % rc, host=self._psrp_host)
-        display.vvvvv("PSRP STDOUT: %s" % stdout, host=self._psrp_host)
-        display.vvvvv("PSRP STDERR: %s" % stderr, host=self._psrp_host)
+        display.vvvvv(f"PSRP STDOUT: {log_stdout}", host=self._psrp_host)
+        display.vvvvv(f"PSRP STDERR: {log_stderr}", host=self._psrp_host)
 
         # reset the host back output back to defaults, needed if running
         # multiple pipelines on the same RunspacePool

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -657,11 +657,16 @@ class Connection(ConnectionBase):
             stdout = to_text(b_stdout)
             stderr = to_text(b_stderr)
 
+            log_stdout = stdout
+            log_stderr = stderr
+            if self._play_context.no_log:
+                log_stdout = log_stderr = '<censored due to no log>'
+
             if from_exec:
-                display.vvvvv('WINRM RESULT <Response code %d, out %r, err %r>' % (rc, stdout, stderr), host=self._winrm_host)
+                display.vvvvv(f'WINRM RESULT <Response code {rc}, out {log_stdout!r}, err {log_stderr!r}>', host=self._winrm_host)
             display.vvvvvv('WINRM RC %d' % rc, host=self._winrm_host)
-            display.vvvvvv('WINRM STDOUT %s' % stdout, host=self._winrm_host)
-            display.vvvvvv('WINRM STDERR %s' % stderr, host=self._winrm_host)
+            display.vvvvvv(f'WINRM STDOUT {log_stdout}', host=self._winrm_host)
+            display.vvvvvv(f'WINRM STDERR {log_stderr}', host=self._winrm_host)
 
             # This is done after logging so we can still see the raw stderr for
             # debugging purposes.


### PR DESCRIPTION
##### SUMMARY
Backport of https://github.com/ansible/ansible/pull/86919

(cherry picked from commit 49f1615157c54a119d0e51b4df0e7c410ec0e766)

##### ISSUE TYPE
- Bugfix Pull Request