### PR TITLE
fix: propagate rescued status to all hosts when run_once rescue succeeds

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -579,17 +579,35 @@ class StrategyBase:
                     # we save the failed task in a special var for use
                     # within the rescue/always
                     if iterator.is_any_block_rescuing(state_when_failed):
-                        self._tqm._stats.increment('rescued', original_host.name)
+                        if original_task.run_once:
+                            # When run_once, failure was propagated to all hosts,
+                            # so rescue should also be propagated to all hosts.
+                            for h in self._inventory.get_hosts(iterator._play.hosts):
+                                if h.name not in self._tqm._unreachable_hosts:
+                                    self._tqm._stats.increment('rescued', h.name)
+                                    try:
+                                        iterator._play._removed_hosts.remove(h.name)
+                                    except ValueError:
+                                        pass
+                                    self._variable_manager.set_nonpersistent_facts(
+                                        h.name,
+                                        dict(
+                                            ansible_failed_task=original_task.dump_attrs(),
+                                            ansible_failed_result=task_result.utr.as_result_dict(),
+                                        ),
+                                    )
+                        else:
+                            self._tqm._stats.increment('rescued', original_host.name)
 
-                        iterator._play._removed_hosts.remove(original_host.name)
+                            iterator._play._removed_hosts.remove(original_host.name)
 
-                        self._variable_manager.set_nonpersistent_facts(
-                            original_host.name,
-                            dict(
-                                ansible_failed_task=original_task.dump_attrs(),
-                                ansible_failed_result=task_result.utr.as_result_dict(),
-                            ),
-                        )
+                            self._variable_manager.set_nonpersistent_facts(
+                                original_host.name,
+                                dict(
+                                    ansible_failed_task=original_task.dump_attrs(),
+                                    ansible_failed_result=task_result.utr.as_result_dict(),
+                                ),
+                            )
                     else:
                         self._tqm._stats.increment('failures', original_host.name)
                 else:


### PR DESCRIPTION
## Description

When a block with `run_once: true` fails, the failure is propagated to all hosts via `mark_host_failed()`. However, when the `rescue:` block succeeds, only the single host that ran the block was being marked as rescued. This is inconsistent — the rescued status should be propagated to all hosts, just like the failure was.

## Fix

When `run_once: true` and the block is being rescued, this PR propagates the rescued status, `_removed_hosts` removal, and `ansible_failed_task`/`ansible_failed_result` variables to all hosts in the play, matching the existing behavior for failure propagation.

## How to reproduce

```yaml
- name: Testing Playbook
  hosts: all
  gather_facts: false

  tasks:
    - name: Check that some prerequisite is met
      run_once: true
      block:
        - name: Fail one host
          ansible.builtin.fail:

      rescue:
        - name: Recover that host
          ansible.builtin.debug:
            msg: "I'm okay!"
```

Before the fix: only host1 shows rescued=1 in the play recap.
After the fix: all hosts show rescued=1.

## Related issue

Fixes #87308