### PR TITLE
Add ansible-galaxy role download

### DIFF
--- a/changelogs/fragments/86116-galaxy-role-download.yml
+++ b/changelogs/fragments/86116-galaxy-role-download.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ansible-galaxy - add the ``role download`` command for creating role archives and offline-install requirements files (https://github.com/ansible/ansible/issues/86116).

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -47,7 +47,7 @@ from ansible.galaxy.collection.concrete_artifact_manager import (
 from ansible.galaxy.collection.gpg import GPG_ERROR_MAP
 from ansible.galaxy.dependency_resolution.dataclasses import Requirement
 
-from ansible.galaxy.role import GalaxyRole
+from ansible.galaxy.role import GalaxyRole, download_roles
 from ansible.galaxy.token import BasicAuthToken, GalaxyToken, KeycloakToken, NoTokenSentinel
 from ansible.module_utils.ansible_release import __version__ as ansible_version
 from ansible.module_utils.common.collections import is_iterable
@@ -313,6 +313,24 @@ class GalaxyCLI(CLI):
 
         self.add_info_options(role_parser, parents=[common, roles_path, offline])
         self.add_install_options(role_parser, parents=[common, force, roles_path])
+        self.add_download_role_options(role_parser, parents=[common])
+
+    def add_download_role_options(self, parser, parents=None):
+        download_parser = parser.add_parser(
+            'download',
+            parents=parents,
+            help='Download roles as tarballs for an offline install.',
+        )
+        download_parser.set_defaults(func=self.execute_download_role)
+
+        download_parser.add_argument('args', help='Role(s)', metavar='role', nargs='*')
+        download_parser.add_argument('-r', '--requirements-file', dest='requirements',
+                                     help='A file containing a list of roles to be downloaded.')
+        download_parser.add_argument('-p', '--download-path', dest='download_path',
+                                     default='./roles',
+                                     help='The directory to download the roles to.')
+        download_parser.add_argument('-i', '--ignore-errors', dest='ignore_errors', action='store_true', default=False,
+                                     help='Ignore errors and continue with the next specified role.')
 
     def add_download_options(self, parser, parents=None):
         download_parser = parser.add_parser('download', parents=parents,
@@ -1055,6 +1073,40 @@ class GalaxyCLI(CLI):
             context.CLIARGS['allow_pre_release'],
             artifacts_manager=artifacts_manager,
         )
+
+        return 0
+
+    def execute_download_role(self):
+        """Download roles as tarballs for an offline install."""
+        role_inputs = context.CLIARGS['args']
+        requirements_file = context.CLIARGS['requirements']
+
+        if role_inputs and requirements_file:
+            raise AnsibleError('The positional role arg and --requirements-file are mutually exclusive.')
+        if not role_inputs and not requirements_file:
+            raise AnsibleError('You must specify a role name or a requirements file.')
+
+        if requirements_file:
+            requirements_file = GalaxyCLI._resolve_path(requirements_file)
+            if not (requirements_file.endswith('.yaml') or requirements_file.endswith('.yml')):
+                raise AnsibleError('Invalid role requirements file, it must end with a .yml or .yaml extension')
+
+            requirements = self._parse_requirements_file(requirements_file)
+            roles = requirements['roles']
+            if requirements['collections']:
+                display.vvv("The requirements file '%s' contains collections which will be ignored." % requirements_file)
+        else:
+            roles = [
+                GalaxyRole(self.galaxy, self.lazy_role_api, **RoleRequirement.role_yaml_parse(role_input))
+                for role_input in role_inputs
+            ]
+
+        download_path = GalaxyCLI._resolve_path(context.CLIARGS['download_path'])
+        b_download_path = to_bytes(download_path, errors='surrogate_or_strict')
+        if not os.path.exists(b_download_path):
+            os.makedirs(b_download_path)
+
+        download_roles(roles, download_path, context.CLIARGS['ignore_errors'])
 
         return 0
 

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -28,13 +28,13 @@ import tarfile
 import tempfile
 
 from collections.abc import MutableSequence
-from shutil import rmtree
+from shutil import copyfile, rmtree
 
 from ansible import context
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.galaxy.api import GalaxyAPI
 from ansible.galaxy.user_agent import user_agent
-from ansible.module_utils.common.text.converters import to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.common.yaml import yaml_dump, yaml_load
 from ansible.module_utils.compat.version import LooseVersion
 from ansible.module_utils.urls import open_url
@@ -240,7 +240,8 @@ class GalaxyRole(object):
 
         return False
 
-    def install(self):
+    def _get_archive_file(self):
+        """Return a local archive containing the role."""
 
         if self.scm:
             # create tar file from scm url
@@ -300,6 +301,39 @@ class GalaxyRole(object):
         else:
             raise AnsibleError("No valid role data found")
 
+        return tmp_file
+
+    def download(self, output_path):
+        """Download the role archive to the specified output path."""
+        tmp_file = self._get_archive_file()
+        if not tmp_file:
+            return False
+
+        if not tarfile.is_tarfile(tmp_file):
+            raise AnsibleError('the downloaded file does not appear to be a valid tar archive.')
+
+        if os.path.isfile(self.src):
+            archive_name = os.path.basename(self.src)
+        else:
+            role_name = self.name.replace('/', '-').replace('\\', '-')
+            role_version = to_text(self.version or 'master').replace('/', '-').replace('\\', '-')
+            archive_name = f'{role_name}-{role_version}.tar.gz'
+
+        archive_path = os.path.join(output_path, archive_name)
+        try:
+            copyfile(tmp_file, archive_path)
+        finally:
+            if not (self.src and os.path.isfile(self.src)):
+                try:
+                    os.unlink(tmp_file)
+                except OSError as ex:
+                    display.error_as_warning(f'Unable to remove tmp file {tmp_file!r}.', exception=ex)
+
+        return archive_path
+
+    def install(self):
+
+        tmp_file = self._get_archive_file()
         if tmp_file:
 
             display.debug("installing from %s" % tmp_file)
@@ -447,3 +481,38 @@ class GalaxyRole(object):
             raise AnsibleParserError(f"Expected role dependencies to be a list. Role {self} has meta/requirements.yml {self._requirements}")
 
         return self._requirements
+
+
+def download_roles(roles, output_path, ignore_errors):
+    """Download role archives and write an offline-install requirements file."""
+    requirements = []
+
+    for role in roles:
+        display.display("Downloading role '%s' to '%s'" % (role, output_path))
+        try:
+            archive_path = role.download(output_path)
+        except AnsibleError as ex:
+            display.warning("Role '%s' was not downloaded successfully: %s" % (role.name, to_text(ex)))
+            if not ignore_errors:
+                raise
+            continue
+
+        if not archive_path:
+            display.warning("Role '%s' was not downloaded successfully." % role.name)
+            if not ignore_errors:
+                raise AnsibleError('Failed to download role %s.' % role.name)
+            continue
+
+        requirement = {
+            'name': role.name,
+            'src': os.path.basename(archive_path),
+        }
+        if role.version:
+            requirement['version'] = role.version
+        requirements.append(requirement)
+        display.display("Role '%s' was downloaded successfully" % role)
+
+    requirements_path = os.path.join(output_path, 'requirements.yml')
+    display.display("Writing requirements.yml file of downloaded roles to '%s'" % requirements_path)
+    with open(requirements_path, mode='wb') as req_fd:
+        req_fd.write(to_bytes(yaml_dump({'roles': requirements}), errors='surrogate_or_strict'))

--- a/test/integration/targets/ansible-galaxy-role/tasks/main.yml
+++ b/test/integration/targets/ansible-galaxy-role/tasks/main.yml
@@ -57,6 +57,44 @@
 - name: Uninstall valid role
   command: ansible-galaxy role remove valid-testrole
 
+- name: Download a role archive from a direct role specification
+  command: >-
+    ansible-galaxy role download {{ remote_tmp_dir }}/valid-role.tar,,direct-download-role
+    --download-path {{ remote_tmp_dir }}/role-download-direct
+
+- name: Install the directly downloaded role archive offline
+  command: ansible-galaxy role install -r requirements.yml --roles-path '{{ remote_tmp_dir }}/roles-direct'
+  args:
+    chdir: '{{ remote_tmp_dir }}/role-download-direct'
+
+- name: Verify the directly downloaded role was installed
+  stat:
+    path: '{{ remote_tmp_dir }}/roles-direct/direct-download-role/tasks/main.yml'
+  register: direct_download_role
+
+- assert:
+    that:
+    - direct_download_role.stat.exists
+
+- name: Download a role archive from a requirements file
+  command: >-
+    ansible-galaxy role download -r valid-requirements.yml
+    --download-path {{ remote_tmp_dir }}/role-download-requirements
+
+- name: Install the requirements-downloaded role archive offline
+  command: ansible-galaxy role install -r requirements.yml --roles-path '{{ remote_tmp_dir }}/roles-requirements'
+  args:
+    chdir: '{{ remote_tmp_dir }}/role-download-requirements'
+
+- name: Verify the requirements-downloaded role was installed
+  stat:
+    path: '{{ remote_tmp_dir }}/roles-requirements/valid-testrole/tasks/main.yml'
+  register: requirements_download_role
+
+- assert:
+    that:
+    - requirements_download_role.stat.exists
+
 - name: Install invalid role
   command: ansible-galaxy install -r invalid-requirements.yml
   ignore_errors: yes

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -1070,6 +1070,41 @@ def test_collection_install_custom_server(collection_install):
     assert mock_install.call_args[0][2][0].validate_certs is True
 
 
+def test_role_download_with_name(monkeypatch, tmp_path):
+    mock_download = MagicMock()
+    monkeypatch.setattr(ansible.cli.galaxy, 'download_roles', mock_download)
+
+    download_path = to_text(tmp_path / 'roles')
+    GalaxyCLI(args=['ansible-galaxy', 'role', 'download', 'namespace.role', '-p', download_path]).run()
+
+    assert mock_download.call_count == 1
+    roles, actual_download_path, ignore_errors = mock_download.call_args.args
+    assert len(roles) == 1
+    assert roles[0].name == 'namespace.role'
+    assert actual_download_path == download_path
+    assert ignore_errors is False
+
+
+@pytest.mark.parametrize('requirements_file', ["""
+roles:
+- name: namespace.role
+  src: namespace.role
+"""], indirect=True)
+def test_role_download_with_requirements_file(monkeypatch, requirements_file, tmp_path):
+    mock_download = MagicMock()
+    monkeypatch.setattr(ansible.cli.galaxy, 'download_roles', mock_download)
+
+    download_path = to_text(tmp_path / 'roles')
+    GalaxyCLI(args=['ansible-galaxy', 'role', 'download', '-r', requirements_file, '-p', download_path]).run()
+
+    assert mock_download.call_count == 1
+    roles, actual_download_path, ignore_errors = mock_download.call_args.args
+    assert len(roles) == 1
+    assert roles[0].name == 'namespace.role'
+    assert actual_download_path == download_path
+    assert ignore_errors is False
+
+
 @pytest.fixture()
 def requirements_file(request, tmp_path_factory):
     content = request.param

--- a/test/units/galaxy/test_role_install.py
+++ b/test/units/galaxy/test_role_install.py
@@ -10,6 +10,8 @@ import os
 import functools
 import pytest
 import tempfile
+import tarfile
+import yaml
 
 from io import StringIO
 from ansible import context
@@ -166,3 +168,24 @@ def test_role_download_url_default_version(init_mock_temp_file, mocker, galaxy_s
 
     assert mock_role_download_api.call_count == 1
     assert mock_role_download_api.mock_calls[0][1][0] == 'http://localhost:8080/test_owner/test_role/0.0.2.tar.gz'
+
+
+def test_role_download_local_archive(tmp_path, galaxy_server):
+    source_archive = tmp_path / 'test-role.tar'
+    output_path = tmp_path / 'download'
+    output_path.mkdir()
+
+    with tarfile.open(source_archive, 'w'):
+        pass
+
+    galaxy_role = role.GalaxyRole(Galaxy(), galaxy_server, 'test-role', src=to_text(source_archive))
+    downloaded_archive = galaxy_role.download(to_text(output_path))
+
+    assert downloaded_archive == to_text(output_path / 'test-role.tar')
+    assert (output_path / 'test-role.tar').read_bytes() == source_archive.read_bytes()
+
+    role.download_roles([galaxy_role], to_text(output_path), ignore_errors=False)
+
+    assert yaml.safe_load((output_path / 'requirements.yml').read_text()) == {
+        'roles': [{'name': 'test-role', 'src': 'test-role.tar'}],
+    }


### PR DESCRIPTION
##### SUMMARY

Add `ansible-galaxy role download` to download role archives and write a portable `requirements.yml` for offline `ansible-galaxy role install -r requirements.yml`.

Fixes #86116

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

lib/ansible/cli/galaxy.py
lib/ansible/galaxy/role.py
test/integration/targets/ansible-galaxy-role/
test/units/cli/test_galaxy.py
test/units/galaxy/test_role_install.py

##### ADDITIONAL INFORMATION

Tests:
- `ansible-test integration ansible-galaxy-role --venv -v`
- Focused role-download unit tests
- Changed-file PEP 8 and pylint checks