### PR TITLE
[stable-2.21] Add deprecation status to the tree and oneline callback DOCUMENTATION

### DIFF
--- a/changelogs/fragments/fix-tree-and-oneline-callback-deprecation.yml
+++ b/changelogs/fragments/fix-tree-and-oneline-callback-deprecation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Add deprecation status to the tree and oneline callback DOCUMENTATION. (https://github.com/ansible/ansible/issues/87020)

--- a/lib/ansible/config/ansible_builtin_runtime.yml
+++ b/lib/ansible/config/ansible_builtin_runtime.yml
@@ -9140,6 +9140,14 @@ plugin_routing:
     mongodb:
       redirect: community.mongodb.mongodb
   callback:
+    tree:
+      deprecation:
+        removal_version: "2.23"
+        warning_text: "Use another callback plugin, or vendor and/or move the tree callback to a collection."
+    oneline:
+      deprecation:
+        removal_version: "2.23"
+        warning_text: "Use another callback plugin, or vendor and/or move the oneline callback to a collection."
     actionable:
       redirect: community.general.actionable
     cgroup_memory_recap:

--- a/lib/ansible/plugins/callback/oneline.py
+++ b/lib/ansible/plugins/callback/oneline.py
@@ -11,13 +11,16 @@ DOCUMENTATION = """
     version_added: historical
     description:
         - This is the output callback used by the C(-o)/C(--one-line) command line option.
+    deprecated:
+      why: The P(ansible.builtin.oneline#callback) callback is no longer recommended due to long term instability.
+      alternatives: Use a stable callback with test coverage, or consider vendoring and/or adding this plugin to a collection.
+      removed_in: "2.23"
 """
 
 from ansible import constants as C
 from ansible.plugins.callback import CallbackBase
 from ansible.template import Templar
 from ansible.executor.task_result import CallbackTaskResult
-from ansible.module_utils._internal import _deprecator
 
 
 class CallbackModule(CallbackBase):
@@ -30,15 +33,6 @@ class CallbackModule(CallbackBase):
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'stdout'
     CALLBACK_NAME = 'oneline'
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self._display.deprecated(  # pylint: disable=ansible-deprecated-unnecessary-collection-name
-            msg='The oneline callback plugin is deprecated.',
-            version='2.23',
-            deprecator=_deprecator.ANSIBLE_CORE_DEPRECATOR,  # entire plugin being removed; this improves the messaging
-        )
 
     def _command_generic_msg(self, hostname, result, caption):
         stdout = result.get('stdout', '').replace('\n', '\\n').replace('\r', '\\r')

--- a/lib/ansible/plugins/callback/tree.py
+++ b/lib/ansible/plugins/callback/tree.py
@@ -25,6 +25,10 @@ DOCUMENTATION = """
     description:
         - "This callback is used by the Ansible (adhoc) command line option C(-t|--tree)."
         - This produces a JSON dump of events in a directory, a file for each host, the directory used MUST be passed as a command line option.
+    deprecated:
+      why: The P(ansible.builtin.tree#callback) callback is no longer recommended due to long term instability.
+      alternatives: Use a stable callback with test coverage, or consider vendoring and/or moving this plugin to a collection.
+      removed_in: "2.23"
 """
 
 import os
@@ -34,7 +38,6 @@ from ansible.executor.task_result import CallbackTaskResult
 from ansible.module_utils.common.text.converters import to_bytes
 from ansible.plugins.callback import CallbackBase
 from ansible.utils.path import makedirs_safe, unfrackpath
-from ansible.module_utils._internal import _deprecator
 
 
 class CallbackModule(CallbackBase):
@@ -46,15 +49,6 @@ class CallbackModule(CallbackBase):
     CALLBACK_TYPE = 'aggregate'
     CALLBACK_NAME = 'tree'
     CALLBACK_NEEDS_ENABLED = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self._display.deprecated(  # pylint: disable=ansible-deprecated-unnecessary-collection-name
-            msg='The tree callback plugin is deprecated.',
-            version='2.23',
-            deprecator=_deprecator.ANSIBLE_CORE_DEPRECATOR,  # entire plugin being removed; this improves the messaging
-        )
 
     def set_options(self, task_keys=None, var_options=None, direct=None):
         """ override to set self.tree """


### PR DESCRIPTION
##### SUMMARY

Backport of #87072

Also move the runtime deprecation warning to the runtime metadata

(cherry picked from commit 6c75a50d5e9058822644f7627e9aacc0b010d287)

##### ISSUE TYPE

- Docs Pull Request
