### PR TITLE
module_utils.url: Add max_response_headers option

### DIFF
--- a/changelogs/fragments/urls-max-response-headers.yml
+++ b/changelogs/fragments/urls-max-response-headers.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - >-
+    module_utils.urls - Added ``max_response_headers`` option to ``Request``,
+    ``open_url``, ``UnixHTTPSConnection``, and ``UnixHTTPConnection`` to allow
+    overriding the default limit of 100 response headers (https://github.com/ansible/ansible/issues/82780).

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -40,6 +40,7 @@ import os
 import platform
 import re
 import socket
+import sys
 import tempfile
 import traceback
 import types  # pylint: disable=unused-import
@@ -233,8 +234,9 @@ if HAS_SSL:
         http.client.HTTPConnection.connect = _connect
 
     class UnixHTTPSConnection(http.client.HTTPSConnection):  # type: ignore[no-redef]
-        def __init__(self, unix_socket):
+        def __init__(self, unix_socket, max_response_headers=None):
             self._unix_socket = unix_socket
+            self._max_response_headers = max_response_headers
 
         def connect(self):
             # This method exists simply to ensure we monkeypatch
@@ -246,13 +248,16 @@ if HAS_SSL:
                 super().connect()
 
         def __call__(self, *args, **kwargs):
+            if self._max_response_headers is not None and sys.version_info >= (3, 15):
+                kwargs['max_response_headers'] = self._max_response_headers
             super().__init__(*args, **kwargs)
             return self
 
     class UnixHTTPSHandler(urllib.request.HTTPSHandler):  # type: ignore[no-redef]
-        def __init__(self, unix_socket, **kwargs):
+        def __init__(self, unix_socket, max_response_headers=None, **kwargs):
             super().__init__(**kwargs)
             self._unix_socket = unix_socket
+            self._max_response_headers = max_response_headers
 
         def https_open(self, req):
             kwargs = {}
@@ -262,7 +267,7 @@ if HAS_SSL:
             except AttributeError:
                 pass
             return self.do_open(
-                UnixHTTPSConnection(self._unix_socket),
+                UnixHTTPSConnection(self._unix_socket, max_response_headers=self._max_response_headers),
                 req,
                 context=self._context,
                 **kwargs
@@ -272,8 +277,9 @@ if HAS_SSL:
 class UnixHTTPConnection(http.client.HTTPConnection):
     """Handles http requests to a unix socket file"""
 
-    def __init__(self, unix_socket):
+    def __init__(self, unix_socket, max_response_headers=None):
         self._unix_socket = unix_socket
+        self._max_response_headers = max_response_headers
 
     def connect(self):
         self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -285,6 +291,8 @@ class UnixHTTPConnection(http.client.HTTPConnection):
             self.sock.settimeout(self.timeout)
 
     def __call__(self, *args, **kwargs):
+        if self._max_response_headers is not None and sys.version_info >= (3, 15):
+            kwargs['max_response_headers'] = self._max_response_headers
         super().__init__(*args, **kwargs)
         return self
 
@@ -292,12 +300,13 @@ class UnixHTTPConnection(http.client.HTTPConnection):
 class UnixHTTPHandler(urllib.request.HTTPHandler):
     """Handler for Unix urls"""
 
-    def __init__(self, unix_socket, **kwargs):
+    def __init__(self, unix_socket, max_response_headers=None, **kwargs):
         super().__init__(**kwargs)
         self._unix_socket = unix_socket
+        self._max_response_headers = max_response_headers
 
     def http_open(self, req):
-        return self.do_open(UnixHTTPConnection(self._unix_socket), req)
+        return self.do_open(UnixHTTPConnection(self._unix_socket, max_response_headers=self._max_response_headers), req)
 
 
 class ParseResultDottedDict(dict):
@@ -726,7 +735,7 @@ class Request:
                  url_username=None, url_password=None, http_agent=None, force_basic_auth=False,
                  follow_redirects='urllib2', client_cert=None, client_key=None, cookies=None, unix_socket=None,
                  ca_path=None, unredirected_headers=None, decompress=True, ciphers=None, use_netrc=True,
-                 context=None):
+                 context=None, max_response_headers=None):
         """This class works somewhat similarly to the ``Session`` class of from requests
         by defining a cookiejar that can be used across requests as well as cascaded defaults that
         can apply to repeated requests
@@ -766,6 +775,7 @@ class Request:
         self.ciphers = ciphers
         self.use_netrc = use_netrc
         self.context = context
+        self.max_response_headers = max_response_headers
         if isinstance(cookies, cookiejar.CookieJar):
             self.cookies = cookies
         else:
@@ -782,7 +792,7 @@ class Request:
              force_basic_auth=None, follow_redirects=None,
              client_cert=None, client_key=None, cookies=None, use_gssapi=False,
              unix_socket=None, ca_path=None, unredirected_headers=None, decompress=None,
-             ciphers=None, use_netrc=None, context=None):
+             ciphers=None, use_netrc=None, context=None, max_response_headers=None):
         """
         Sends a request via HTTP(S) or FTP using urllib (Python3)
 
@@ -854,11 +864,12 @@ class Request:
         ciphers = self._fallback(ciphers, self.ciphers)
         use_netrc = self._fallback(use_netrc, self.use_netrc)
         context = self._fallback(context, self.context)
+        max_response_headers = self._fallback(max_response_headers, self.max_response_headers)
 
         handlers = []
 
         if unix_socket:
-            handlers.append(UnixHTTPHandler(unix_socket))
+            handlers.append(UnixHTTPHandler(unix_socket, max_response_headers=max_response_headers))
 
         url, auth_headers, auth_handlers = _configure_auth(url, url_username, url_password, use_gssapi, force_basic_auth, use_netrc)
         headers.update(auth_headers)
@@ -877,7 +888,7 @@ class Request:
                 client_key=client_key,
             )
         if unix_socket:
-            ssl_handler = UnixHTTPSHandler(unix_socket=unix_socket, context=context)
+            ssl_handler = UnixHTTPSHandler(unix_socket=unix_socket, max_response_headers=max_response_headers, context=context)
         else:
             ssl_handler = urllib.request.HTTPSHandler(context=context)
         handlers.append(ssl_handler)
@@ -1005,7 +1016,8 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
              force_basic_auth=False, follow_redirects='urllib2',
              client_cert=None, client_key=None, cookies=None,
              use_gssapi=False, unix_socket=None, ca_path=None,
-             unredirected_headers=None, decompress=True, ciphers=None, use_netrc=True):
+             unredirected_headers=None, decompress=True, ciphers=None, use_netrc=True,
+             max_response_headers=None):
     """
     Sends a request via HTTP(S) or FTP using urllib (Python3)
 
@@ -1018,7 +1030,8 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
                           force_basic_auth=force_basic_auth, follow_redirects=follow_redirects,
                           client_cert=client_cert, client_key=client_key, cookies=cookies,
                           use_gssapi=use_gssapi, unix_socket=unix_socket, ca_path=ca_path,
-                          unredirected_headers=unredirected_headers, decompress=decompress, ciphers=ciphers, use_netrc=use_netrc)
+                          unredirected_headers=unredirected_headers, decompress=decompress, ciphers=ciphers, use_netrc=use_netrc,
+                          max_response_headers=max_response_headers)
 
 
 # deprecated: description='TypedDict Required/NotRequired' python_version='3.11'

--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -10,7 +10,8 @@ import urllib.request
 import http.client
 
 from ansible.module_utils.urls import (Request, open_url, cookiejar,
-                                       UnixHTTPHandler, UnixHTTPSConnection)
+                                       UnixHTTPHandler, UnixHTTPSConnection,
+                                       UnixHTTPSHandler)
 from ansible.module_utils.urls import HTTPRedirectHandler
 
 import pytest
@@ -54,6 +55,7 @@ def test_Request_fallback(urlopen_mock, install_opener_mock, mocker):
         ca_path=pem,
         ciphers=['ECDHE-RSA-AES128-SHA256'],
         use_netrc=True,
+        max_response_headers=200,
     )
     fallback_mock = mocker.spy(request, '_fallback')
 
@@ -79,10 +81,11 @@ def test_Request_fallback(urlopen_mock, install_opener_mock, mocker):
         call(None, ['ECDHE-RSA-AES128-SHA256']),  # ciphers
         call(None, True),  # use_netrc
         call(None, None),  # context
+        call(None, 200),  # max_response_headers
     ]
     fallback_mock.assert_has_calls(calls)
 
-    assert fallback_mock.call_count == 19  # All but headers use fallback
+    assert fallback_mock.call_count == 20  # All but headers use fallback
 
     args = urlopen_mock.call_args[0]
     assert args[1] is None  # data, this is handled in the Request not urlopen
@@ -160,6 +163,30 @@ def test_Request_open_https_unix_socket(urlopen_mock, install_opener_mock, mocke
     args = do_open.call_args[0]
     cls = args[0]
     assert isinstance(cls, UnixHTTPSConnection)
+
+
+def test_Request_open_unix_socket_max_response_headers(urlopen_mock, install_opener_mock, mocker):
+    do_open = mocker.patch.object(urllib.request.HTTPSHandler, 'do_open')
+
+    r = Request().open('GET', 'https://ansible.com/', unix_socket='/foo/bar/baz.sock', max_response_headers=200)
+
+    opener = install_opener_mock.call_args[0][0]
+    handlers = opener.handlers
+
+    https_handler = None
+    for handler in handlers:
+        if isinstance(handler, UnixHTTPSHandler):
+            https_handler = handler
+            break
+
+    assert https_handler is not None
+    assert https_handler._max_response_headers == 200
+
+    https_handler.https_open(None)
+    args = do_open.call_args[0]
+    conn = args[0]
+    assert isinstance(conn, UnixHTTPSConnection)
+    assert conn._max_response_headers == 200
 
 
 def test_Request_open_ftp(urlopen_mock, install_opener_mock, mocker):
@@ -444,4 +471,4 @@ def test_open_url(urlopen_mock, install_opener_mock, mocker):
                                      force_basic_auth=False, follow_redirects='urllib2',
                                      client_cert=None, client_key=None, cookies=None, use_gssapi=False,
                                      unix_socket=None, ca_path=None, unredirected_headers=None, decompress=True,
-                                     ciphers=None, use_netrc=True)
+                                     ciphers=None, use_netrc=True, max_response_headers=None)


### PR DESCRIPTION
##### SUMMARY

Plumb the Python 3.15 max_response_headers parameter through
UnixHTTPSConnection, UnixHTTPConnection, their handlers, Request,
and open_url so callers can override the default 100-header limit.

Fixes: #82780

Assisted-by: Claude Opus 4.6 (Anthropic)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Co-Authored-By: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/urls-max-response-headers.yml
lib/ansible/module_utils/urls.py
test/units/module_utils/urls/test_Request.py


