### PR TITLE
Remove empty bullet point in autogenerated Jinja2 filter/test synopsis

### DIFF
--- a/changelogs/fragments/ansible-doc-jinja2-synopsis.yml
+++ b/changelogs/fragments/ansible-doc-jinja2-synopsis.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- >-
+  ``ansible-doc -t filter|test <plugin>`` - remove empty bullet point from the description.

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -892,7 +892,6 @@ class DocCLI(CLI, RoleMixin):
                     short_description=desc,
                     description=[
                         desc,
-                        '',
                         f"This is the Jinja builtin {plugin_type} plugin {short_name!r}.",
                         f"See: U(https://jinja.palletsprojects.com/en/stable/templates/#jinja-{plugin_type}s.{short_name})",
                     ],


### PR DESCRIPTION
##### SUMMARY

The empty bullet point looks like broken documentation https://docs.ansible.com/projects/ansible/latest/collections/ansible/builtin/map_filter.html#synopsis.

I think this is a positive/neutral change for ansible-doc because the description format is more consistent between our own plugins (where descriptions are typically a list of non-empty strings), and the Jinja2 plugin descriptions.

Related #87324.

##### ISSUE TYPE

- Bugfix Pull Request
