### PR TITLE
fix: randomize_list bare except Exception silently swallows errors

### DIFF
--- a/changelogs/fragments/fix-randomize-list-bare-except.yml
+++ b/changelogs/fragments/fix-randomize-list-bare-except.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - randomize_list filter - fix bare ``except Exception`` that silently swallowed
+    all errors during list conversion and shuffling.
+    Only catch ``TypeError`` for non-iterable inputs.

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -305,13 +305,14 @@ def rand(environment, end, start=None, step=None, seed=None):
 def randomize_list(mylist, seed=None):
     try:
         mylist = list(mylist)
-        if seed:
-            r = Random(seed)
-            r.shuffle(mylist)
-        else:
-            shuffle(mylist)
-    except Exception:
-        pass
+    except TypeError:
+        return mylist
+
+    if seed:
+        r = Random(seed)
+        r.shuffle(mylist)
+    else:
+        shuffle(mylist)
     return mylist
 
 

--- a/test/units/plugins/filter/test_core.py
+++ b/test/units/plugins/filter/test_core.py
@@ -8,7 +8,7 @@ import pytest
 
 from ansible._internal._datatag._tags import Origin
 from ansible.module_utils.common.text.converters import to_native
-from ansible.plugins.filter.core import to_bool, to_uuid
+from ansible.plugins.filter.core import to_bool, to_uuid, randomize_list
 from ansible.errors import AnsibleError
 from ansible.template import Templar, trust_as_template, is_trusted_as_template
 from ...test_utils.controller.display import emits_warnings
@@ -87,3 +87,26 @@ def test_from_yaml_origin() -> None:
         assert origin.description == "a unit test"
         assert origin.line_num == 44  # source string origin plus two blank lines
         assert origin.col_num == 6
+
+
+def test_randomize_list():
+    """Verify randomize_list handles various input types correctly."""
+    # Non-iterable input should be returned as-is without error
+    assert randomize_list(42) == 42
+    assert randomize_list(None) is None
+
+    # String input should be converted to list and shuffled
+    result = randomize_list("abc", seed=42)
+    assert sorted(result) == ['a', 'b', 'c']
+
+    # Empty list returns empty
+    assert randomize_list([]) == []
+
+    # Single element list returns same element
+    assert randomize_list([1]) == [1]
+
+    # Deterministic output with seed
+    result1 = randomize_list([1, 2, 3, 4, 5], seed=42)
+    result2 = randomize_list([1, 2, 3, 4, 5], seed=42)
+    assert result1 == result2
+    assert sorted(result1) == [1, 2, 3, 4, 5]


### PR DESCRIPTION
##### SUMMARY

The `randomize_list` filter currently uses a bare `except Exception: pass` that silently swallows ALL exceptions during both list conversion and shuffling. This means:

- Non-iterable inputs silently return the original value instead of raising an informative error
- Unexpected errors during `shuffle()` (e.g., `MemoryError`) are silently discarded

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/plugins/filter/core.py` - `randomize_list` filter

##### Changes

- Replaced `except Exception: pass` with targeted `except TypeError` for non-iterable inputs
- Moved shuffling operations outside the try/except so unexpected errors propagate properly
- Added unit tests for `randomize_list` covering non-iterable inputs, deterministic output, and edge cases

##### ADDITIONAL INFORMATION

The existing behavior of returning non-iterable inputs unchanged is preserved (only `TypeError` is caught from `list()`). The fix ensures that genuine errors during shuffling — which should never occur under normal circumstances — are not silently discarded.
