### PR TITLE
combine filter: fix append/prepend merge of two equal hashes

### DIFF
--- a/changelogs/fragments/79293-merge-hash-equal-append-prepend.yml
+++ b/changelogs/fragments/79293-merge-hash-equal-append-prepend.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - combine filter - do not short-circuit merging two equal hashes when ``list_merge`` is ``append`` or ``prepend`` so that the equal lists are correctly appended or prepended to each other instead of being returned unchanged (https://github.com/ansible/ansible/issues/79293).

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -102,9 +102,12 @@ def merge_hash(x, y, recursive=True, list_merge='replace'):
     _validate_mutable_mappings(x, y)
 
     # to speed things up: if x is empty or equal to y, return y
-    # (this `if` can be remove without impact on the function
+    # (this `if` can be removed without impact on the function
     #  except performance)
-    if x == {} or x == y:
+    # 'append' and 'prepend' are excluded from the x == y shortcut on purpose:
+    # merging two equal hashes must still append/prepend the (equal) lists to
+    # each other instead of returning a single copy of them.
+    if x == {} or (x == y and list_merge not in ('append', 'prepend')):
         return y.copy()
     if y == {}:
         return x

--- a/test/units/utils/test_vars.py
+++ b/test/units/utils/test_vars.py
@@ -279,6 +279,31 @@ class TestVariableUtils(unittest.TestCase):
         }
         self.assertEqual(merge_hash(low, high, True, 'prepend_rp'), expected)
 
+    def test_merge_hash_equal_hashes_and_list_append(self):
+        # merging two equal hashes with list_merge='append' must still append
+        # the (equal) lists to each other instead of short-circuiting to a
+        # single copy of one of them
+        # (https://github.com/ansible/ansible/issues/79293)
+        low = {"a": {"a'": {"list": ["v"]}}, "b": [1, 2]}
+        high = {"a": {"a'": {"list": ["v"]}}, "b": [1, 2]}
+        expected = {"a": {"a'": {"list": ["v", "v"]}}, "b": [1, 2, 1, 2]}
+        self.assertEqual(merge_hash(low, high, True, 'append'), expected)
+
+    def test_merge_hash_equal_hashes_and_list_prepend(self):
+        # same as above but for list_merge='prepend'
+        low = {"a": {"a'": {"list": ["v"]}}, "b": [1, 2]}
+        high = {"a": {"a'": {"list": ["v"]}}, "b": [1, 2]}
+        expected = {"a": {"a'": {"list": ["v", "v"]}}, "b": [1, 2, 1, 2]}
+        self.assertEqual(merge_hash(low, high, True, 'prepend'), expected)
+
+    def test_merge_hash_equal_hashes_shortcut_modes(self):
+        # for the modes where merging two equal hashes yields that same hash,
+        # the x == y shortcut must keep returning it unchanged
+        for list_merge in ('replace', 'keep', 'append_rp', 'prepend_rp'):
+            low = {"a": {"a'": {"list": ["v"]}}, "b": [1, 2]}
+            high = {"a": {"a'": {"list": ["v"]}}, "b": [1, 2]}
+            self.assertEqual(merge_hash(low, high, True, list_merge), low)
+
 
 def test_transform_to_native_types() -> None:
     """Verify that transform_to_native_types results in native types for both keys and values, with default redaction."""


### PR DESCRIPTION
##### SUMMARY

`merge_hash` (used by the `combine` filter) has a shortcut near the top that returns a copy of `y` when `x` is empty or when `x == y`. The comment says this shortcut can be removed without changing behavior, but that is not true for `list_merge='append'` and `list_merge='prepend'`.

When both hashes are equal, `append` and `prepend` should still combine the equal lists with each other, so a key whose value is `[1, 2]` in both hashes should become `[1, 2, 1, 2]`. Because of the `x == y` shortcut, the equal lists were silently collapsed to a single `[1, 2]` instead.

This limits the `x == y` shortcut to the modes where merging two equal hashes really does produce that same hash again: `replace`, `keep`, `append_rp` and `prepend_rp`. For `append` and `prepend` the code now falls through to the normal merge, so the lists are combined as documented. The empty-x case is left unchanged, because an empty left hash always yields `y` for every mode.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
combine filter (lib/ansible/utils/vars.py)

##### ADDITIONAL INFORMATION

Fixes #79293

Before:

```
>>> merge_hash({'a': [1, 2]}, {'a': [1, 2]}, list_merge='append')
{'a': [1, 2]}
```

After:

```
>>> merge_hash({'a': [1, 2]}, {'a': [1, 2]}, list_merge='append')
{'a': [1, 2, 1, 2]}
```

Added unit tests in `test/units/utils/test_vars.py` covering merging two equal hashes with every `list_merge` mode.
