### PR TITLE
get_url: respect force=no for existing files

### DIFF
--- a/changelogs/fragments/64016-get-url-force-no.yml
+++ b/changelogs/fragments/64016-get-url-force-no.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - get_url - avoid downloading an existing destination when ``force`` is disabled and no checksum is provided (https://github.com/ansible/ansible/issues/64016).

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -604,10 +604,10 @@ def main():
             if checksum != destination_checksum:
                 checksum_mismatch = True
 
-        # Not forcing redownload, unless checksum does not match
-        if not force and checksum and not checksum_mismatch:
-            # Not forcing redownload, unless checksum does not match
-            # allow file attribute changes
+        # Do not download an existing file when force is disabled, unless its
+        # checksum does not match the requested checksum.
+        if not force and not checksum_mismatch:
+            # The file does not need downloading; allow file attribute changes.
             file_args = module.load_file_common_arguments(module.params, path=dest)
             result['changed'] = module.set_fs_attributes_if_different(file_args, False)
             if result['changed']:

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -294,10 +294,11 @@
       - result is not changed
       - result.msg == 'file already exists'
 
-- name: get a file that doesn't respond to If-Modified-Since without checksum
+- name: get a file that doesn't respond to If-Modified-Since without checksum when force is enabled
   get_url:
     url: 'https://{{ httpbin_host }}/get'
     dest: '{{ remote_tmp_dir }}/test'
+    force: yes
   register: result
 
 - name: Assert that we downloaded the file

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -229,6 +229,7 @@
   get_url:
     url: 'https://{{ httpbin_host }}/status/304'
     dest: '{{ remote_tmp_dir }}/test'
+    force: yes
   register: result
 
 - name: Assert that we get the appropriate status_code

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -281,17 +281,17 @@
     that:
       - result.msg == 'file already exists'
 
-- name: Get a file that already exists
+- name: Do not download a file that already exists when force is disabled
   get_url:
-    url: 'https://{{ httpbin_host }}/cache'
+    url: 'https://{{ httpbin_host }}/status/500'
     dest: '{{ remote_tmp_dir }}/test'
   register: result
 
-- name: Assert that we didn't re-download unnecessarily
+- name: Assert that an existing file was not downloaded
   assert:
     that:
       - result is not changed
-      - "'304' in result.msg"
+      - result.msg == 'file already exists'
 
 - name: get a file that doesn't respond to If-Modified-Since without checksum
   get_url:


### PR DESCRIPTION
Fixes #64016.

The `get_url` module now respects the documented `force: false` behavior when the destination already exists and no checksum is provided. A checksum mismatch still forces a download, preserving checksum validation behavior.

The integration regression test uses an HTTP 500 endpoint so the pre-fix code would attempt the request and fail, while the fixed code exits with `file already exists`. The existing 304-status regression test now opts into `force: yes` explicitly because it is testing conditional-download metadata. The changelog fragment records the user-visible bugfix.

Validation:
- `/opt/homebrew/bin/python3.14 bin/ansible-test sanity --local --changed --untracked --test validate-modules`
- `/opt/homebrew/bin/python3.14 bin/ansible-test units --local --python 3.14 --requirements test/units/modules/test_get_url.py` (8 passed)
- `python3 -m py_compile lib/ansible/modules/get_url.py`
- YAML parsing for the integration task and changelog fragment
- `git diff --check`

The integration target requires Ansible's container-backed `cloud/httptester` environment and was not run locally because Docker is unavailable here. Hosted CI is enabled for the draft PR.
