### PR TITLE
fix: Reject literal empty delegate_to hostnames

### DIFF
--- a/changelogs/fragments/84332-delegate-to-empty-host.yml
+++ b/changelogs/fragments/84332-delegate-to-empty-host.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - delegate_to - reject a literal empty hostname consistently with a template
+    that resolves to an empty hostname (https://github.com/ansible/ansible/issues/84332).

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -522,7 +522,7 @@ class VariableManager:
         delegated_vars = {}
         delegated_host_name = ...  # sentinel value distinct from empty/None, which are errors
 
-        if task.delegate_to:
+        if task.delegate_to is not None:
             try:
                 delegated_host_name = templar.template(task.delegate_to)
             except AnsibleValueOmittedError:

--- a/test/integration/targets/delegate_to/test_delegate_to.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to.yml
@@ -62,20 +62,30 @@
       delegate_to: "{{ jenkins_install_key_on|default(omit) }}"
       register: d_omitted
 
+    - name: Use literal empty delegation should fail
+      ping:
+      delegate_to: ""
+      when: false
+      ignore_errors: true
+      register: d_literal_empty
+
     - name: Use empty to thwart delegation should fail
       ping:
       delegate_to: "{{ jenkins_install_key_on }}"
-      when: jenkins_install_key_on != ""
+      when: false
       vars:
         jenkins_install_key_on: ''
       ignore_errors: true
       register: d_empty
 
-    - name: Ensure previous 2 tests actually did what was expected
+    - name: Ensure delegation validation behaved as expected
       assert:
         that:
           - d_omitted is success
+          - d_literal_empty is failed
+          - d_literal_empty.msg is contains('Empty hostname produced from delegate_to')
           - d_empty is failed
+          - d_empty.msg is contains('Empty hostname produced from delegate_to')
 
 - name: verify delegation with per host vars
   hosts: testhost6


### PR DESCRIPTION
##### SUMMARY

Adjust the existing delegation-resolution branch in `lib/ansible/vars/manager.py` so an explicitly supplied empty string reaches the same empty-host validation as an empty templated result, while absent and omitted values continue to resolve to no delegation. Keep validation in the existing `VariableManager`/`TaskExecutor` execution path so delegated variables remain available during conditional evaluation and no test-only abstraction is introduced. Extend `test/integration/targets/delegate_to/test_delegate_to.yml` beside its current templated-empty and `omit` cases to prove literal and templated empty values fail consistently while omission succeeds.

`VariableManager.get_delegated_vars_and_hostname()` rejects a `delegate_to` expression that templates to an empty hostname, but treats a literal empty string as though delegation were unspecified. This produces inconsistent results for semantically equivalent task keywords and lets `delegate_to: ""` bypass the existing empty-host validation. Maintainers confirmed that delegation must still be resolved before a task's `when` expression because delegated variables can participate in that conditional. The accepted scope is therefore to reject the literal empty value, not to defer delegation until after conditional evaluation.

Fixes #84332

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

AI was used for assistance.
