### PR TITLE
Fix delegated host label missing ansible_host after first loop item

### DIFF
--- a/changelogs/fragments/87358-delegate-to-loop-host-label.yml
+++ b/changelogs/fragments/87358-delegate-to-loop-host-label.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "callback plugins - fix displaying the delegated host's ``ansible_host`` address for all loop items, not just the first (https://github.com/ansible/ansible/issues/87358)."

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -744,12 +744,15 @@ class ConfigManager:
 
         return value, origin
 
-    def initialize_plugin_configuration_definitions(self, plugin_type, name, defs):
+    def initialize_plugin_configuration_definitions(self, plugin_type, name, defs, fqcn=None):
 
         if plugin_type not in self._plugins:
             self._plugins[plugin_type] = {}
 
         self._plugins[plugin_type][name] = defs
+
+        if fqcn and fqcn != name:
+            self._plugins[plugin_type][fqcn] = defs
 
     def _get_ini_config_value(self, config_file: str, section: str, option: str) -> t.Any:
         """

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -526,7 +526,7 @@ class PluginLoader:
         paths_with_context = self._get_paths_with_context(subdirs=subdirs)
         return [path_with_context.path for path_with_context in paths_with_context]
 
-    def _load_config_defs(self, name, module, path):
+    def _load_config_defs(self, name, module, path, fqcn=None):
         """ Reads plugin docs to find configuration setting definitions, to push to config manager for later use """
 
         # plugins w/o class name don't support config
@@ -550,7 +550,7 @@ class PluginLoader:
                     add_fragments(dstring, path, fragment_loader=fragment_loader, is_module=(type_name == 'module'), section='DOCUMENTATION')
 
                     if 'options' in dstring and isinstance(dstring['options'], dict):
-                        C.config.initialize_plugin_configuration_definitions(type_name, name, dstring['options'])
+                        C.config.initialize_plugin_configuration_definitions(type_name, name, dstring['options'], fqcn=fqcn)
                         display.debug('Loaded config def from plugin (%s/%s)' % (type_name, name))
 
     def add_directory(self, directory, with_subdir=False):
@@ -1076,7 +1076,7 @@ class PluginLoader:
             self._module_cache[path] = self._load_module_source(python_module_name=plugin_load_context._python_module_name, path=path)
             found_in_cache = False
 
-        self._load_config_defs(resolved_type_name, self._module_cache[path], path)
+        self._load_config_defs(resolved_type_name, self._module_cache[path], path, fqcn=fq_name)
 
         obj = getattr(self._module_cache[path], self.class_name)
 
@@ -1243,7 +1243,7 @@ class PluginLoader:
             else:
                 module = self._module_cache[path]
 
-            self._load_config_defs(basename, module, path)
+            self._load_config_defs(basename, module, path, fqcn=fqcn)
 
             try:
                 obj = getattr(module, self.class_name)

--- a/test/integration/targets/delegate_to/delegate_loop_label.yml
+++ b/test/integration/targets/delegate_to/delegate_loop_label.yml
@@ -1,0 +1,10 @@
+- name: Test that delegate_to shows ansible_host for all loop items
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Delegated task in a loop with multiple hosts
+      ansible.builtin.debug:
+        msg: test
+      delegate_to: "{{ item }}"
+      loop: "{{ groups['targets'] }}"

--- a/test/integration/targets/delegate_to/delegate_loop_label_inventory
+++ b/test/integration/targets/delegate_to/delegate_loop_label_inventory
@@ -1,0 +1,3 @@
+[targets]
+hosta ansible_host=127.0.0.3
+hostb ansible_host=127.0.0.4

--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -60,6 +60,13 @@ if grep '{{ hostip }}' out; then
   exit 1
 fi
 
+# ensure delegate_to shows ansible_host for all loop items (not just the first)
+ANSIBLE_TIMEOUT=3 ansible-playbook delegate_loop_label.yml -i delegate_loop_label_inventory -v | tee out
+if ! grep 'hosta(127.0.0.3)' out || ! grep 'hostb(127.0.0.4)' out; then
+  echo 'Callback did not display ansible_host for all delegated hosts in a loop.'
+  exit 1
+fi
+
 ansible-playbook has_hostvars.yml -i inventory -v "$@"
 
 # test ansible_x_interpreter


### PR DESCRIPTION
##### SUMMARY

When `delegate_to` is used in a loop, the callback host label showed the delegated host's `ansible_host` address (e.g., `hosta(192.0.2.1)`) only for the first loop item. Subsequent items displayed just the hostname without the address (e.g., `hostb`).

**Root cause:** After the first loop iteration, `_update_task_connection()` propagates the connection's FQCN (e.g., `ansible.builtin.ssh`) back to `self._task.connection`. On the next iteration, `current_connection` becomes the FQCN, but `C.config.get_plugin_options_from_var()` only recognizes the short plugin name (`ssh`). This caused the `ansible_host` lookup to fail, leaving the address out of `callback_delegated_vars_subset`.

**Fix:** Use `self._connection._load_name` (the short name) instead of `current_connection` when calling `get_plugin_options_from_var()`, matching the pattern already used in `ConnectionBase.update_vars()`.

Fixes #87358

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

executor / callback
