### PR TITLE
fix: strip non-JSON DNF plugin output from dnf helper stdout (#87366)

### DIFF
--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -464,6 +464,23 @@ class DnfModule(YumDnf):
 
         return interpreter
 
+
+    @staticmethod
+    def _extract_json_from_stdout(stdout):
+        """Extract JSON from stdout that may contain DNF plugin informational output."""
+        # DNF plugins (e.g. kpatch-dnf) may write informational text to stdout before
+        # the JSON response. Try to find the JSON portion by looking for the first '{'.
+        json_start = stdout.find('{')
+        if json_start > 0:
+            # Only strip leading non-JSON text; the JSON should be the last line(s)
+            candidate = stdout[json_start:]
+            try:
+                return json.loads(candidate)
+            except json.JSONDecodeError:
+                pass
+        # If no JSON found or extraction failed, let the original error handling take over
+        return json.loads(stdout)
+
     def _execute_dnf_script(self, command, config, params=None):
         """Execute the dnf module_utils script via subprocess with JSON RPC."""
         request = {'command': command, 'config': config}
@@ -484,7 +501,7 @@ class DnfModule(YumDnf):
             )
 
             if stdout:
-                return json.loads(stdout)
+                return self._extract_json_from_stdout(stdout)
             else:
                 return {
                     'failed': True,


### PR DESCRIPTION
## Description

When a DNF plugin (e.g. `kpatch-dnf`) writes informational output to stdout before the JSON response, the `_execute_dnf_script` method fails to parse the combined stdout as JSON.

### Problem

The DNF helper script outputs JSON to stdout, but DNF plugins may write informational text to stdout first. For example:



The current code calls `json.loads(stdout)` directly, which fails on the mixed output.

### Fix

Added `DnfModule._extract_json_from_stdout()` static method that:
1. Checks if the first `{` appears after leading non-JSON text
2. If so, attempts to parse the JSON from that position
3. Falls back to the original behavior if extraction fails

### Testing

- When stdout is pure JSON: behavior is unchanged
- When stdout has DNF plugin output before JSON: the JSON portion is extracted and parsed correctly
- When stdout has no JSON at all: falls through to the existing error handling

Fixes #87366