### PR TITLE
fix: Honor explicit apt versions with high pin priorities

### DIFF
--- a/changelogs/fragments/85147-apt-high-pin-priority.yml
+++ b/changelogs/fragments/85147-apt-high-pin-priority.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - apt - honor an explicitly requested package version when a higher-priority APT pin selects another version (https://github.com/ansible/ansible/issues/85147).

--- a/lib/ansible/modules/apt.py
+++ b/lib/ansible/modules/apt.py
@@ -220,7 +220,7 @@ notes:
      Since there are no warnings and prompts before installing, we disallow this. Use an explicit fnmatch pattern if you want wildcarding).
    - When used with a C(loop:) each package will be processed individually, it is much more efficient to pass the list directly to the O(name) option.
    - When O(default_release) is used, an implicit priority of 990 is used. This is the same behavior as C(apt-get -t).
-   - When an exact version is specified, an implicit priority of 1001 is used.
+   - When a specific version is specified, the available matching version takes precedence over pin priorities.
    - If the interpreter can't import C(python3-apt) the module will check for it in system-owned interpreters as well.
      If the dependency can't be found, depending on the value of O(auto_install_module_deps) the module will attempt to install it.
      If the dependency is found or installed, the module will be respawned under the correct interpreter.
@@ -503,6 +503,14 @@ def package_version_compare(version, other_version):
 
 
 def package_best_match(pkgname, version_cmp, version, release, cache):
+    pkg = cache[pkgname]
+    if version_cmp == "=":
+        best_match = None
+        for pkgver in pkg.version_list:
+            if fnmatch.fnmatch(pkgver.ver_str, version) and (best_match is None or package_version_compare(pkgver.ver_str, best_match) > 0):
+                best_match = pkgver.ver_str
+        return best_match
+
     policy = apt_pkg.Policy(cache)
 
     policy.read_pinfile(apt_pkg.config.find_file("Dir::Etc::preferences"))
@@ -511,18 +519,8 @@ def package_best_match(pkgname, version_cmp, version, release, cache):
     if release:
         # 990 is the priority used in `apt-get -t`
         policy.create_pin('Release', pkgname, release, 990)
-    if version_cmp == "=":
-        # Installing a specific version from command line overrides all pinning
-        # We don't mimic this exactly, but instead set a priority which is higher than all APT built-in pin priorities.
-        policy.create_pin('Version', pkgname, version, 1001)
-    pkg = cache[pkgname]
     pkgver = policy.get_candidate_ver(pkg)
     if not pkgver:
-        return None
-    # Check if the available version matches the requested version
-    if version_cmp == "=" and not fnmatch.fnmatch(pkgver.ver_str, version):
-        # Even though we put in a pin policy, it can be ignored if there is no
-        # possible candidate.
         return None
     if version_cmp == ">=" and not apt_pkg.version_compare(pkgver.ver_str, version) >= 0:
         return None

--- a/test/integration/targets/apt/tasks/repo.yml
+++ b/test/integration/targets/apt/tasks/repo.yml
@@ -181,6 +181,42 @@
         - item.item.3 is not string or "Inst foo [1.0.0] (" + item.item.3 + " localhost [all])" in item.stdout_lines
     loop: '{{ apt_result.results }}'
 
+  - name: Uninstall foo before testing high pin priorities
+    apt:
+      name: foo
+      state: absent
+
+  - name: Pin all foo versions above the former exact-version priority
+    copy:
+      content: |-
+        Package: foo
+        Pin: version *
+        Pin-Priority: 1002
+      dest: /etc/apt/preferences.d/foo
+
+  - name: Run high priority pinning version test matrix
+    apt:
+      name: foo{{ item.0 }}
+      state: latest
+    check_mode: true
+    ignore_errors: true
+    register: apt_result
+    loop:
+      # [filter, expected] # expected=False to assert an error
+      - ["=1.0.0", "1.0.0"]
+      - ["=1.0.*", "1.0.1"]
+      - ["", "2.0.1"]
+      - [">=1.0.0", "2.0.1"]
+      - ["=99", False]
+
+  - name: Validate high priority pinning version test matrix
+    assert:
+      that:
+        - (item.item.1 != False) or (item.item.1 == False and item is failed)
+        - (item.item.1 is string) == (item.stdout is defined)
+        - item.item.1 is not string or "(" + item.item.1 + " localhost [all])" in item.stdout
+    loop: '{{ apt_result.results }}'
+
   always:
     - name: Uninstall foo
       apt:


### PR DESCRIPTION
##### SUMMARY

Update exact-version resolution in `lib/ansible/modules/apt.py` so an available version matching the explicit specifier is selected independently of ordinary policy pin priority; retain policy candidate selection for unversioned and `>=` requests and preserve the module's documented version-wildcard behavior. Keep the selection and its existing caller in the same production module rather than introducing a test-only seam, and revise the module note that currently promises an implicit priority of 1001 so the documentation describes the actual precedence rule. Extend the existing repository/pinning matrix in `test/integration/targets/apt/tasks/repo.yml` with priorities above 1001 and assert the requested older version is selected while invalid requests and non-exact policy behavior remain unchanged.

The apt module's `package_best_match()` currently models an explicit `name=version` request by adding a version pin with priority 1001 and then asking APT policy for the candidate. A user preference with priority 1002 or higher can still win, causing the requested version to be rejected as unavailable even though the same explicit version installs through the apt command line. The reporter supplied a Debian reproduction, and a maintainer confirmed both the behavior and the hard-coded priority as the likely cause. The existing apt integration repository already provides several versions of a synthetic `foo` package, so the regression can be covered in the production module path.

Fixes #85147

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

AI was used for assistance.
