### PR TITLE
Clarify copy recursive diff support

### DIFF
--- a/lib/ansible/modules/copy.py
+++ b/lib/ansible/modules/copy.py
@@ -146,7 +146,8 @@ attributes:
   check_mode:
     support: full
   diff_mode:
-    support: full
+    details: Content diffs are shown for regular file copies. Recursive copies can report changed files without showing content diffs.
+    support: partial
   platform:
     platforms: posix
   safe_file_operations:


### PR DESCRIPTION
##### SUMMARY
Clarify that `ansible.builtin.copy` has partial diff mode support because recursive copies can report changed files without showing per-file content diffs.

This addresses the documentation side of #86856: the module currently declares `diff_mode` as `full`, while recursive copies do not provide content diffs.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
copy

##### ADDITIONAL INFORMATION
Validation run locally:

- `git diff --check`
- `python -m py_compile lib/ansible/modules/copy.py`

I also attempted `ansible-test sanity --test validate-modules lib/ansible/modules/copy.py`, but on this Windows environment the ansible-test stub failed before running checks with `OSError: [WinError 87]` from `os.get_blocking()`.
