### PR TITLE
Add DataLoader path_dwim_relative_stack None coverage

### DIFF
--- a/test/units/parsing/test_dataloader.py
+++ b/test/units/parsing/test_dataloader.py
@@ -173,6 +173,26 @@ class TestPathDwimRelativeStackDataLoader(unittest.TestCase):
     def test_empty_lists(self):
         self.assertEqual(self._loader.path_dwim_relative_stack([], '', '~/'), os.path.expanduser('~'))
 
+    def test_none_dirname_finds_source_from_basedir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = 'included.yml'
+            expected = os.path.join(tmpdir, source)
+            pathlib.Path(expected).touch()
+            self._loader.set_basedir(tmpdir)
+
+            self.assertEqual(self._loader.path_dwim_relative_stack([], None, source), expected)
+
+    def test_none_source_warns_and_raises(self):
+        with emits_warnings('Invalid request to find a file that matches a "null" value'):
+            self.assertRaisesRegex(
+                AnsibleFileNotFound,
+                'on the Ansible Controller',
+                self._loader.path_dwim_relative_stack,
+                [],
+                'tasks',
+                None,
+            )
+
     def test_all_slash(self):
         self.assertEqual(self._loader.path_dwim_relative_stack('/', '/', '/'), '/')
 


### PR DESCRIPTION
##### SUMMARY
Expand unit test coverage for `DataLoader.path_dwim_relative_stack()` around `None` values, covering:

- `dirname=None` while resolving a source from the loader basedir
- `source=None` warning and `AnsibleFileNotFound` behavior

Closes #86056.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
lib/ansible/parsing/dataloader.py

##### ADDITIONAL INFORMATION
Local validation:

- `git diff --check`
- `py -3.14 -m py_compile test/units/parsing/test_dataloader.py lib/ansible/parsing/dataloader.py`

I attempted to run `py -3.14 -m pytest test/units/parsing/test_dataloader.py -q` locally, but test collection fails on Windows before running the tests because `ansible.parsing.vault` imports POSIX-only `fcntl`.
