### PR TITLE
Fix run_once host variable fanout isolation

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import cmd
+import copy
 import functools
 import os
 import pprint
@@ -674,16 +675,16 @@ class StrategyBase:
                             match variable_layer:
                                 case _task.VariableLayer.REGISTER_VARS:
                                     for target_host in original_host_list:
-                                        self._variable_manager.set_nonpersistent_facts(target_host, variables)
+                                        self._variable_manager.set_nonpersistent_facts(target_host, copy.deepcopy(variables))
                                 case _task.VariableLayer.CACHEABLE_FACT:
                                     for target_host in potentially_delegated_host_list:
-                                        self._variable_manager.set_host_facts(target_host, variables)
+                                        self._variable_manager.set_host_facts(target_host, copy.deepcopy(variables))
                                 case _task.VariableLayer.EPHEMERAL_FACT:
                                     for target_host in potentially_delegated_host_list:
-                                        self._variable_manager.set_nonpersistent_facts(target_host, variables)
+                                        self._variable_manager.set_nonpersistent_facts(target_host, copy.deepcopy(variables))
                                 case _task.VariableLayer.INCLUDE_VARS:
                                     for target_host in potentially_delegated_host_list:
-                                        for var_name, var_value in variables.items():
+                                        for var_name, var_value in copy.deepcopy(variables).items():
                                             self._variable_manager.set_host_variable(target_host, var_name, var_value)
                                 case _:
                                     raise NotImplementedError(f"Unsupported variable layer: {variable_layer}")

--- a/test/units/plugins/strategy/test_linear.py
+++ b/test/units/plugins/strategy/test_linear.py
@@ -4,20 +4,71 @@
 from __future__ import annotations
 
 
+from collections import deque
 import unittest
 from unittest.mock import patch, MagicMock
 
 from ansible.executor.play_iterator import PlayIterator
 from ansible.playbook import Playbook
 from ansible.playbook.play_context import PlayContext
+from ansible.plugins.strategy import StrategyBase
 from ansible.plugins.strategy.linear import StrategyModule
 from ansible.executor.task_queue_manager import TaskQueueManager
+from ansible.inventory.host import Host
+from ansible._internal import _task
 
 from units.mock.loader import DictDataLoader
 from units.mock.path import mock_unfrackpath_noop
 
 
 class TestStrategyLinear(unittest.TestCase):
+
+    def test_run_once_registered_host_variables_are_isolated_per_host(self):
+        strategy = StrategyBase.__new__(StrategyBase)
+        strategy._results_lock = MagicMock()
+        strategy._results = deque()
+        strategy._pending_results = 1
+        strategy._blocked_hosts = {}
+        strategy._queued_task_cache = {('host00', 'task-uuid'): dict(task_vars={}, play_context=MagicMock())}
+        strategy._hosts_cache = ['host00', 'host01']
+        strategy._diff = False
+        strategy.debugger_active = False
+        strategy._inventory = MagicMock()
+        strategy._inventory.get_hosts.return_value = [Host('host00'), Host('host01')]
+        strategy._process_rpc_queue = MagicMock()
+        strategy._tqm = MagicMock()
+        strategy._tqm._unreachable_hosts = {}
+        strategy._tqm._failed_hosts = {}
+        strategy._tqm._stats = MagicMock()
+        strategy._tqm.send_callback = MagicMock()
+        strategy._variable_manager = MagicMock()
+
+        task = MagicMock()
+        task.run_once = True
+        task.loop = None
+        task.delegate_to = None
+        task.delegate_facts = False
+        task._uuid = 'task-uuid'
+        task.debugger = 'never'
+
+        utr = _task.UnifiedTaskResult(is_module=False)
+        shared_facts = {'nested': {'marker': 'before'}}
+        utr.pending_changes.register_host_variables[_task.VariableLayer.EPHEMERAL_FACT] = shared_facts
+
+        strategy._results.append(_task.HostTaskResult(host=Host('host00'), task=task, utr=utr))
+
+        iterator = MagicMock()
+        iterator.host_states = {}
+
+        strategy._process_pending_results(iterator)
+
+        first_call, second_call = strategy._variable_manager.set_nonpersistent_facts.call_args_list
+        first_facts = first_call.args[1]
+        second_facts = second_call.args[1]
+
+        first_facts['nested']['marker'] = 'after'
+
+        self.assertEqual(second_facts['nested']['marker'], 'before')
 
     @patch('ansible.playbook.role.definition.unfrackpath', mock_unfrackpath_noop)
     def test_noop(self):


### PR DESCRIPTION
##### SUMMARY
Fixes #87148.

When a run_once task registers host variables, the strategy fan-out applied the same nested data object to every host in the batch. Later mutations to one host's variables could therefore leak into other hosts. This change deep-copies registered host variable data for each fan-out target before storing it.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
Added a regression test that processes a run_once result with nested registered host variables for two hosts, mutates the first host's applied data, and verifies the second host's data remains unchanged.

##### TESTS
- PYTHONPATH=lib:test pytest -q test/units/plugins/strategy/test_linear.py
- python -m py_compile lib/ansible/plugins/strategy/__init__.py test/units/plugins/strategy/test_linear.py
- git diff --check