### PR TITLE
fix handling run_once failures

### DIFF
--- a/changelogs/fragments/fix-block-rescue.yml
+++ b/changelogs/fragments/fix-block-rescue.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - free strategy - now ignores ``run_once`` when processing task failures instead of marking other hosts in the batch as failed. (https://github.com/ansible/ansible/issues/80737)
+   - Fix an issue where rescued hosts were excluded from subsequent plays when ``any_errors_fatal`` was set. (https://github.com/ansible/ansible/issues/84117)
+  - Hosts failed indirectly by ``any_errors_fatal``/``run_once`` now increment the ``failed`` or ``rescued`` stat in the ``PLAY RECAP``.
+  - Hosts failed indirectly by ``run_once`` now execute ``rescue``/``always`` tasks. (https://github.com/ansible/ansible/issues/87308)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -168,12 +168,6 @@ def debug_closure(func):
                 if next_action.result == NextAction.REDO:
                     # rollback host state
                     self._tqm.clear_failed_hosts()
-                    if task.run_once and iterator._play.strategy in add_internal_fqcns(('linear',)) and result.utr.failed:
-                        for host_name, state in prev_host_states.items():
-                            if host_name == host.name:
-                                continue
-                            iterator.set_state_for_host(host_name, state)
-                            iterator._play._removed_hosts.remove(host_name)
                     iterator.set_state_for_host(host.name, prev_host_state)
                     for attr, what in status_to_stats_map:
                         if getattr(result.utr, attr):
@@ -562,13 +556,7 @@ class StrategyBase:
                     state_when_failed = iterator.get_state_for_host(original_host.name)
                     display.debug("marking %s as failed" % original_host.name)
 
-                    if original_task.run_once:
-                        # if we're using run_once, we have to fail every host here
-                        for h in self._inventory.get_hosts(iterator._play.hosts):
-                            if h.name not in self._tqm._unreachable_hosts:
-                                iterator.mark_host_failed(h)
-                    else:
-                        iterator.mark_host_failed(original_host)
+                    iterator.mark_host_failed(original_host)
 
                     state, dummy = iterator.get_next_task_for_host(original_host, peek=True)
 

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -141,6 +141,8 @@ class StrategyModule(StrategyBase):
                     templar = TemplateEngine(loader=self._loader, variables=task_vars)
                     display.debug("done getting variables")
 
+                    initial_host_state = iterator.get_state_for_host(host.name)
+
                     # test to see if the task across all hosts points to an action plugin which
                     # sets BYPASS_HOST_LOOP to true, or if it has run_once enabled. If so, we
                     # will only send this task to the first host in the list.
@@ -354,8 +356,14 @@ class StrategyModule(StrategyBase):
                 if mark_hosts_failed and (failed_hosts or unreachable_hosts):
                     for host in hosts_left:
                         if host.name not in failed_hosts:
-                            self._tqm._failed_hosts[host.name] = True
                             iterator.mark_host_failed(host)
+
+                            if iterator.is_any_block_rescuing(initial_host_state) and host.name not in unreachable_hosts:
+                                self._tqm._stats.increment('rescued', host.name)
+                            else:
+                                self._tqm._failed_hosts[host.name] = True
+                                self._tqm._stats.increment('failures', host.name)
+
                 display.debug("done checking for any_errors_fatal")
 
                 display.debug("checking for max_fail_percentage")

--- a/test/integration/targets/any_errors_fatal/runme.sh
+++ b/test/integration/targets/any_errors_fatal/runme.sh
@@ -36,6 +36,9 @@ set -e
 
 ansible-playbook -i inventory "$@" 31543.yml | tee out.txt
 [ "$(grep -c 'SHOULD NOT HAPPEN' out.txt)" -eq 0 ]
+# Check play recap includes failed for both hosts
+grep 'testhost.*ok=1.*failed=1.*skipped=0' out.txt
+grep 'testhost2.*ok=1.*failed=1.*skipped=1' out.txt
 
 ansible-playbook -i inventory "$@" 36308.yml | tee out.txt
 [ "$(grep -c 'handler1 ran' out.txt)" -eq 1 ]
@@ -47,3 +50,7 @@ ansible-playbook -i inventory "$@" 80981.yml | tee out.txt
 [ "$(grep -c 'SHOULD NOT HAPPEN' out.txt)" -eq 0 ]
 [ "$(grep -c 'rescuedd' out.txt)" -eq 2 ]
 [ "$(grep -c 'recovered' out.txt)" -eq 2 ]
+
+# Check play recap includes rescued for both hosts
+grep 'testhost.*ok=2.*skipped=0.*rescued=1' out.txt
+grep 'testhost2.*ok=2.*skipped=1.*rescued=1' out.txt

--- a/test/integration/targets/strategy_free/runme.sh
+++ b/test/integration/targets/strategy_free/runme.sh
@@ -13,4 +13,9 @@ set +e
 result="$(ansible-playbook free_index_error.yml -i free_hosts "$@" 2>&1)"
 set -e
 grep -q "\[host1\]: UNREACHABLE!" <<< "$result"
-! grep -q "IndexError: list index out of range" <<< "$result"
+if grep -q "IndexError: list index out of range" <<< "$result"; then
+    exit 1
+fi
+
+result="$(ansible-playbook test_run_once_noop.yml -i free_hosts "$@" 2>&1)"
+grep "Using run_once with the free strategy is not currently supported." <<< "$result"

--- a/test/integration/targets/strategy_free/test_run_once_noop.yml
+++ b/test/integration/targets/strategy_free/test_run_once_noop.yml
@@ -1,0 +1,11 @@
+- hosts: host0,host1,host2
+  gather_facts: no
+  strategy: free
+  tasks:
+    - block:
+        - fail:
+          when: inventory_hostname == "host0"
+          run_once: True
+      rescue:
+        - assert:
+            that: inventory_hostname == "host0"

--- a/test/integration/targets/strategy_linear/runme.sh
+++ b/test/integration/targets/strategy_linear/runme.sh
@@ -7,3 +7,14 @@ ansible-playbook test_include_file_noop.yml -i inventory "$@"
 ansible-playbook task_action_templating.yml -i inventory "$@"
 
 ansible-playbook task_templated_run_once.yml -i inventory "$@"
+
+ansible-playbook test_run_once_rescue.yml -i inventory "$@" | tee out.txt
+
+# test number of actual tasks executed
+test "$(grep -c '"task [1-4] testhost"' out.txt)" == 4
+test "$(grep -c '"task [1-4] testhost2"' out.txt)" == 1
+grep '"task 4 testhost2"' out.txt
+
+# test play recap agrees
+grep 'testhost.*ok=2.*rescued=2' out.txt
+grep 'testhost2.*ok=1.*rescued=2' out.txt

--- a/test/integration/targets/strategy_linear/test_run_once_rescue.yml
+++ b/test/integration/targets/strategy_linear/test_run_once_rescue.yml
@@ -1,0 +1,28 @@
+- hosts: testhost,testhost2
+  gather_facts: no
+  strategy: linear
+  tasks:
+    - name: Test run_once set on a block
+      run_once: True
+      block:
+        - name: EXPECTED FAILURE
+          fail:
+            msg: "task 1 {{ inventory_hostname }}"
+      rescue:
+        - debug:
+            msg: "task 2 {{ inventory_hostname }}"
+          failed_when: inventory_hostname != 'testhost'
+
+- hosts: testhost,testhost2
+  gather_facts: no
+  strategy: linear
+  tasks:
+    - name: Test run_once set within a block
+      block:
+        - name: EXPECTED FAILURE
+          fail:
+            msg: "task 3 {{ inventory_hostname }}"
+          run_once: True
+      rescue:
+        - debug:
+            msg: "task 4 {{ inventory_hostname }}"


### PR DESCRIPTION
##### SUMMARY

Hosts failed via `run_once` task failures are marked failed twice (first in the strategy base, and then again in the linear strategy), preventing any more tasks from executing.

Since the strategy base is marking hosts as failed for `run_once`, this also caused a bug with the free strategy, since `run_once` should have no effect.

Fixes #87308
Fixes #83292
Fixes #80737
Fixes #84117
Closes #87320
Closes #87363

##### ISSUE TYPE

- Bugfix Pull Request
