### PR TITLE
fix: preserve list merge semantics for equivalent dictionaries

### DIFF
--- a/changelogs/fragments/79293-combine-identical-list-merge.yml
+++ b/changelogs/fragments/79293-combine-identical-list-merge.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    combine filter - Preserve duplicate list entries when merging equivalent dictionaries with ``list_merge='append'`` or ``list_merge='prepend'``
+    (https://github.com/ansible/ansible/issues/79293).

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -102,9 +102,9 @@ def merge_hash(x, y, recursive=True, list_merge='replace'):
     _validate_mutable_mappings(x, y)
 
     # to speed things up: if x is empty or equal to y, return y
-    # (this `if` can be remove without impact on the function
+    # (this `if` can be removed without impact on the function
     #  except performance)
-    if x == {} or x == y:
+    if x == {} or (x == y and list_merge not in ('append', 'prepend')):
         return y.copy()
     if y == {}:
         return x

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -280,6 +280,7 @@
       # more advanced dict combination tests are done in the "merge_hash" function unit tests
       # but even though it's redundant with those unit tests, we do at least the most complicated example of the documentation here
       - "(default | combine(patch, recursive=True, list_merge='append_rp')) == result"
+      - "({'profile_list': ['test']} | combine({'profile_list': ['test']}, recursive=True, list_merge='append')) == {'profile_list': ['test', 'test']}"
       - combine_fail is failed
       - |
           "'recursive' and 'list_merge' are the only valid keyword arguments" is in combine_fail.msg

--- a/test/units/utils/test_vars.py
+++ b/test/units/utils/test_vars.py
@@ -279,6 +279,47 @@ class TestVariableUtils(unittest.TestCase):
         }
         self.assertEqual(merge_hash(low, high, True, 'prepend_rp'), expected)
 
+    def test_merge_hash_equal_dicts_with_list_append_and_prepend(self):
+        left_item = mock.MagicMock(name="left")
+        right_item = mock.MagicMock(name="right")
+        left_item.__eq__.return_value = True
+        low = {"list": [left_item]}
+        high = {"list": [right_item]}
+
+        self.assertEqual(low, high)
+        appended = merge_hash(low, high, list_merge='append')["list"]
+        prepended = merge_hash(low, high, list_merge='prepend')["list"]
+        self.assertEqual(len(appended), 2)
+        self.assertIs(appended[0], left_item)
+        self.assertIs(appended[1], right_item)
+        self.assertEqual(len(prepended), 2)
+        self.assertIs(prepended[0], right_item)
+        self.assertIs(prepended[1], left_item)
+
+    def test_merge_hash_equal_dicts_with_nested_list_append_and_prepend(self):
+        left_item = mock.MagicMock(name="left")
+        right_item = mock.MagicMock(name="right")
+        left_item.__eq__.return_value = True
+        low = {"nested": {"list": [left_item]}}
+        high = {"nested": {"list": [right_item]}}
+
+        self.assertEqual(low, high)
+        appended = merge_hash(low, high, list_merge='append')["nested"]["list"]
+        prepended = merge_hash(low, high, list_merge='prepend')["nested"]["list"]
+        self.assertEqual(len(appended), 2)
+        self.assertIs(appended[0], left_item)
+        self.assertIs(appended[1], right_item)
+        self.assertEqual(len(prepended), 2)
+        self.assertIs(prepended[0], right_item)
+        self.assertIs(prepended[1], left_item)
+
+    def test_merge_hash_equal_dicts_preserve_other_list_merge_modes(self):
+        value = {"list": [1, 1]}
+
+        for list_merge in ('replace', 'keep', 'append_rp', 'prepend_rp'):
+            with self.subTest(list_merge=list_merge):
+                self.assertEqual(merge_hash(value, value, list_merge=list_merge), value)
+
 
 def test_transform_to_native_types() -> None:
     """Verify that transform_to_native_types results in native types for both keys and values, with default redaction."""


### PR DESCRIPTION
##### SUMMARY

Restrict the equal-dictionary early return in `merge_hash()` so it remains active for merge modes where equal inputs cannot change the result, while allowing `append` and `prepend` to follow the existing per-key merge path. Keep the empty-dictionary shortcut and the existing behavior for `replace`, `keep`, `append_rp`, and `prepend_rp`; no new helper or public API is needed. Add focused unit regressions for equivalent dictionaries under both duplicate-preserving list modes, including recursive nested lists and the requested ordering, then exercise the same contract through the `combine` filter integration target.

`ansible.builtin.combine` delegates dictionary merging to `merge_hash()`, whose equality fast path currently returns a copy of the right-hand dictionary whenever both inputs compare equal. That shortcut is behavior-preserving for `replace`, `keep`, `append_rp`, and `prepend_rp`, but it incorrectly bypasses the duplicate-preserving semantics of `append` and `prepend`. As a result, combining equivalent dictionaries containing lists produces one copy of each list instead of concatenating the lists in the requested order. The supplied timeline contains two closed, unmerged attempts (#79312 and #87344); this plan supersedes them by limiting the production change to the invalid optimization and covering the public filter behavior as well as the utility function.

Fixes #79293

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

AI was used for assistance.
