### PR TITLE
module_utils.urls - do not raise when masking an unparsable url

### DIFF
--- a/changelogs/fragments/mask-url-unparsable-url.yml
+++ b/changelogs/fragments/mask-url-unparsable-url.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - module_utils.urls - ``mask_url`` no longer raises ``ValueError`` for a URL that ``urlparse`` rejects, such as one containing
+    an unterminated IPv6 literal.
+    ``fetch_url`` calls it before entering its exception handler, so modules including ``uri`` and ``get_url`` reported a traceback
+    instead of a clean failure for such a URL.
+    The userinfo of an unparsable URL is now masked on a best-effort basis so credentials are still not echoed back.

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -315,12 +315,23 @@ class ParseResultDottedDict(dict):
         return [self.get(k, None) for k in ('scheme', 'netloc', 'path', 'params', 'query', 'fragment')]
 
 
+_UNPARSABLE_USERINFO = re.compile(r'(?P<prefix>^[^:/?#]*://)[^/?#]*@')
+
+
 def mask_url(url: str) -> str:
     """
     Safely display a url by masking confidential data
     from a string or the result from urlparse/split
     """
-    if (parsed_url := urlparse(url)) and not parsed_url.username and not parsed_url.password:
+    try:
+        parsed_url = urlparse(url)
+    except ValueError:
+        # `urlparse` rejects some malformed URLs outright, such as one with an unterminated IPv6 literal.
+        # The authority cannot be parsed in that case, so mask any userinfo textually instead.
+        # Returning the value unchanged would risk echoing credentials back to the caller.
+        return _UNPARSABLE_USERINFO.sub(r'\g<prefix>****:****@', url)
+
+    if not parsed_url.username and not parsed_url.password:
         return url
 
     netloc: str

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -315,7 +315,28 @@ class ParseResultDottedDict(dict):
         return [self.get(k, None) for k in ('scheme', 'netloc', 'path', 'params', 'query', 'fragment')]
 
 
-_UNPARSABLE_USERINFO = re.compile(r'(?P<prefix>^[^:/?#]*://)[^/?#]*@')
+def _mask_unparsable_url(url: str) -> str:
+    """
+    Mask the userinfo of a url that `urlparse` refuses to parse, on a best-effort basis.
+
+    Only `/` is treated as ending the authority, since a malformed userinfo may contain any other
+    character. That can over-mask a url whose authority holds an `@` for some other reason, which is
+    preferred over risking a credential being echoed back to the caller.
+    """
+    before_authority, separator, remainder = url.partition('//')
+
+    if not separator:
+        return url  # no authority to hold a userinfo
+
+    authority, path_separator, path = remainder.partition('/')
+
+    if '@' not in authority:
+        return url
+
+    # `rpartition` matches how `urlparse` itself splits the userinfo from the host
+    host = authority.rpartition('@')[2]
+
+    return f'{before_authority}{separator}****:****@{host}{path_separator}{path}'
 
 
 def mask_url(url: str) -> str:
@@ -326,10 +347,10 @@ def mask_url(url: str) -> str:
     try:
         parsed_url = urlparse(url)
     except ValueError:
-        # `urlparse` rejects some malformed URLs outright, such as one with an unterminated IPv6 literal.
+        # `urlparse` rejects some malformed urls outright, such as one with an unterminated IPv6 literal.
         # The authority cannot be parsed in that case, so mask any userinfo textually instead.
         # Returning the value unchanged would risk echoing credentials back to the caller.
-        return _UNPARSABLE_USERINFO.sub(r'\g<prefix>****:****@', url)
+        return _mask_unparsable_url(url)
 
     if not parsed_url.username and not parsed_url.password:
         return url

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -158,6 +158,19 @@ def test_fetch_url_connectionerror(open_url_mock, fake_ansible_module):
     assert excinfo.value.kwargs['status'] == -1
 
 
+def test_fetch_url_unparsable_url(open_url_mock, fake_ansible_module):
+    """A URL that `urlparse` rejects fails cleanly instead of escaping as a traceback."""
+    unparsable = 'https://secretuser:secretpass@[::1/index.html'
+    open_url_mock.side_effect = ValueError('Invalid IPv6 URL')
+
+    with pytest.raises(FailJson) as excinfo:
+        fetch_url(fake_ansible_module, unparsable)
+
+    assert excinfo.value.kwargs['msg'] == 'Invalid IPv6 URL'
+    assert excinfo.value.kwargs['status'] == -1
+    assert 'secret' not in excinfo.value.kwargs['url']
+
+
 def test_fetch_url_httperror(open_url_mock, fake_ansible_module):
     open_url_mock.side_effect = urllib.error.HTTPError(
         BASE_URL,

--- a/test/units/module_utils/urls/test_mask_url.py
+++ b/test/units/module_utils/urls/test_mask_url.py
@@ -27,6 +27,19 @@ from ansible.module_utils.urls import mask_url
         ('ftps://secretuser:secretsecret@file.server/yolo.asc', ('file.server/yolo.asc')),
         ('redis://:secretpass@cache.internal:6379/0', ('cache.internal', '6379', 'redis')),
         ('amqp://:secretpw@rabbit.internal:5672/vhost', ('rabbit.internal', '5672', 'vhost')),
+        # urls that `urlparse` rejects outright, so `mask_url` must mask them without parsing
+        ('https://secretuser:secretpass@[::1/index.html', ('https://', '[::1/index.html', '****:****@')),
+        ('https://secretuser@[::1/index.html', ('https://', '[::1/index.html', '****:****@')),
+        ('ftp://secretuser:secretpass@[fe80::1:8080/pub/file.txt', ('ftp://', 'pub/file.txt', '****:****@')),
+        ('https://:secretpass@::1]/index.html', ('https://', '::1]/index.html', '****:****@')),
+        ('https://secretuser:secretpass@[::1', ('https://', '[::1', '****:****@')),
+        # a scheme-relative url has no scheme to anchor on
+        ('//secretuser:secretpass@[::1/index.html', ('//', '[::1/index.html', '****:****@')),
+        # only `/` ends the authority, so a `?` or `#` cannot hide the userinfo
+        ('https://[::1secretuser:sec?retpass@host/index.html', ('https://', 'host/index.html', '****:****@')),
+        ('https://secretuser:secretpass@[::1#fragment', ('https://', '[::1', '****:****@', '#fragment')),
+        # the last `@` separates userinfo from host, matching how urlparse splits it
+        ('https://secretuser:secret@pass@[::1/index.html', ('https://', '[::1/index.html', '****:****@')),
     )
 )
 def test_mask_url(url, wanted):
@@ -38,32 +51,17 @@ def test_mask_url(url, wanted):
         assert notmasked in masked
 
 
-# `urlparse` raises ValueError for these, so `mask_url` must not propagate it to its callers.
-@pytest.mark.parametrize(
-    'url, wanted',
-    (
-        ('https://secretuser:secretpass@[::1/index.html', ('https://', '[::1/index.html', '****:****@')),
-        ('https://secretuser@[::1/index.html', ('https://', '[::1/index.html', '****:****@')),
-        ('ftp://secretuser:secretpass@[fe80::1:8080/pub/file.txt', ('ftp://', 'pub/file.txt', '****:****@')),
-    )
-)
-def test_mask_url_unparsable(url, wanted):
-    """An unparsable URL still has its userinfo masked, on a best-effort basis."""
-    masked = mask_url(url)
-    assert 'secret' not in masked
-
-    for notmasked in wanted:
-        assert notmasked in masked
-
-
 @pytest.mark.parametrize(
     'url',
     (
+        # `urlparse` rejects all of these, and none carries a userinfo, so each must survive intact
+        # in order to stay useful for diagnostics
         'https://[::1/index.html',
         'https://example.com]:443/index.html',
-        'https://[v1.fe80::a+en1]:8080/index.html',
+        'https://[fe80::1:8080/index.html',
+        '//[::1/index.html',
     )
 )
-def test_mask_url_unparsable_without_credentials(url):
-    """An unparsable URL with no userinfo is returned intact so it remains useful for diagnostics."""
+def test_mask_url_unparsable_without_userinfo(url):
+    """An unparsable url with no userinfo is returned unchanged."""
     assert mask_url(url) == url

--- a/test/units/module_utils/urls/test_mask_url.py
+++ b/test/units/module_utils/urls/test_mask_url.py
@@ -36,3 +36,34 @@ def test_mask_url(url, wanted):
 
     for notmasked in wanted:
         assert notmasked in masked
+
+
+# `urlparse` raises ValueError for these, so `mask_url` must not propagate it to its callers.
+@pytest.mark.parametrize(
+    'url, wanted',
+    (
+        ('https://secretuser:secretpass@[::1/index.html', ('https://', '[::1/index.html', '****:****@')),
+        ('https://secretuser@[::1/index.html', ('https://', '[::1/index.html', '****:****@')),
+        ('ftp://secretuser:secretpass@[fe80::1:8080/pub/file.txt', ('ftp://', 'pub/file.txt', '****:****@')),
+    )
+)
+def test_mask_url_unparsable(url, wanted):
+    """An unparsable URL still has its userinfo masked, on a best-effort basis."""
+    masked = mask_url(url)
+    assert 'secret' not in masked
+
+    for notmasked in wanted:
+        assert notmasked in masked
+
+
+@pytest.mark.parametrize(
+    'url',
+    (
+        'https://[::1/index.html',
+        'https://example.com]:443/index.html',
+        'https://[v1.fe80::a+en1]:8080/index.html',
+    )
+)
+def test_mask_url_unparsable_without_credentials(url):
+    """An unparsable URL with no userinfo is returned intact so it remains useful for diagnostics."""
+    assert mask_url(url) == url


### PR DESCRIPTION
Closes #87390.

## SUMMARY

`mask_url()` calls `urlparse()`, which raises `ValueError` for a URL it cannot parse, such as one
containing an unterminated IPv6 literal. `fetch_url()` calls `mask_url()` on the line immediately
before the `try` block whose `except (ConnectionError, ValueError)` clause exists to handle exactly
that, so the exception escapes as a traceback instead of becoming a clean `fail_json`. `uri` and
`get_url` call it in the same unguarded way.

For a user this means a malformed URL yields a Python traceback on stderr rather than a structured
`failed: true` result, which breaks `ignore_errors` and `rescue` handling and leaves the module output
unparseable by the controller.

This is a regression from `24b1f6219e` (#87361). Before that commit the same input produced
`{"url": ..., "status": -1, "failed": true, "msg": "Invalid IPv6 URL"}`.

**Approach.** `mask_url()` is a display helper, so this makes it total rather than moving the call
sites. `urlparse()` is wrapped and, on failure, the userinfo is masked textually instead:

```python
_UNPARSABLE_USERINFO = re.compile(r'(?P<prefix>^[^:/?#]*://)[^/?#]*@')
```

Returning the value unchanged was rejected because the authority cannot be parsed in that case, so
credentials could be echoed back to the caller, which is the very thing `24b1f6219e` set out to
prevent. Returning a bare placeholder was also rejected because it discards the URL the user needs in
order to diagnose the problem. The best-effort mask keeps both properties, so the reproducer now
returns

```json
{"url": "https://****:****@[::1/path", "status": -1, "failed": true, "msg": "Invalid IPv6 URL"}
```

**Testing.** `test_mask_url.py` gains cases asserting that an unparsable URL has its userinfo masked
and that one without userinfo is returned intact, following the file's existing convention of putting
`secret` in anything that must be masked and asserting `'secret' not in masked`. `test_fetch_url.py`
gains `test_fetch_url_unparsable_url`, which asserts the clean `fail_json` and that the reported URL
carries no credentials. All 7 new tests fail without the source change.

## ISSUE TYPE

- Bugfix Pull Request
