### PR TITLE
file based cache plugins - do not promote a partially written cache file

### DIFF
--- a/changelogs/fragments/cache-abort-on-failed-dump.yml
+++ b/changelogs/fragments/cache-abort-on-failed-dump.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - file based cache plugins - a cache write that fails part way through no longer replaces the existing cache entry with a
+    partially written file.
+    Previously the error was only reported as a warning and the truncated temporary file was still renamed over the valid entry,
+    so a transient failure such as a full disk permanently destroyed the cached data for that key.

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -180,8 +180,13 @@ class BaseFileCacheModule(BaseCacheModule):
                 self._dump(value, tmpfile_path)
             except OSError as ex:
                 display.error_as_warning(f"Error in {self.plugin_name!r} cache plugin while trying to write to {tmpfile_path!r}.", exception=ex)
-            try:
+                # A failed dump can leave a partially written temp file behind, so do not promote it over `cachefile`.
+                # Returning here leaves any existing cache entry intact instead of replacing it with corrupt data.
+                return
+            finally:
                 os.close(tmpfile_handle)  # os.rename fails if handle is still open in WSL
+
+            try:
                 os.rename(tmpfile_path, cachefile)
                 os.chmod(cachefile, mode=S_IRWU_RG_RO)
             except OSError as ex:

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -18,6 +18,9 @@
 from __future__ import annotations
 
 
+import errno
+import os
+import pathlib
 import shutil
 import tempfile
 
@@ -147,6 +150,43 @@ class TestJsonFileCachePrefix(TestJsonFileCache):
         assert 'special_test' not in self.cache
         assert 'test' in self.cache
         assert self.cache['test'] == dict(b=2)
+
+
+class TestJsonFileCacheFailedWrite(unittest.TestCase):
+    """A cache write that fails part way through must not destroy the entry already on disk."""
+
+    def setUp(self):
+        self.cache_dir = tempfile.mkdtemp(prefix='ansible-plugins-cache-')
+        self.cache = cache_loader.get('jsonfile', _uri=self.cache_dir, _timeout=0, _prefix='ansible_facts')
+
+    def tearDown(self):
+        shutil.rmtree(self.cache_dir)
+
+    def test_failed_dump_keeps_existing_entry(self):
+        self.cache.set('host', {'ansible_os_family': 'RedHat'})
+        assert self.cache.get('host') == {'ansible_os_family': 'RedHat'}
+
+        def failing_dump(value, filepath):
+            # `_dump` implementations are not atomic, so a failure can leave a truncated file behind.
+            pathlib.Path(filepath).write_text('{"__payload__": "{\\"truncated')
+            raise OSError(errno.ENOSPC, 'No space left on device')
+
+        # bypass the schema-qualifying interposer to reach the file cache plugin itself
+        self.cache.__wrapped__._dump = failing_dump
+        self.cache.set('host', {'ansible_os_family': 'Debian'})
+
+        # a later run must still be able to read the previously cached facts
+        reader = cache_loader.get('jsonfile', _uri=self.cache_dir, _timeout=0, _prefix='ansible_facts')
+        assert reader.get('host') == {'ansible_os_family': 'RedHat'}
+
+    def test_failed_dump_leaves_no_temp_file(self):
+        def failing_dump(value, filepath):
+            raise OSError(errno.ENOSPC, 'No space left on device')
+
+        self.cache.__wrapped__._dump = failing_dump
+        self.cache.set('host', {'ansible_os_family': 'Debian'})
+
+        assert os.listdir(self.cache_dir) == []
 
 
 class TestCachePlugin(unittest.TestCase):


### PR DESCRIPTION
Closes #87391.


## SUMMARY

`BaseFileCacheModule.set()` writes to a temp file and renames it over the cache entry, a pattern whose
whole purpose is to make the update atomic. But a failing `_dump()` is only reported as a warning and
control falls straight through into the `os.rename()`, so a partially written temp file is promoted to
*the* cache file. `_dump()` is not atomic either -- the `jsonfile` implementation is
`Path(filepath).write_text(json.dumps(value))` -- so an `ENOSPC` part way through leaves truncated
bytes on disk.

The next run then reads that file, raises `The cache file ... was corrupt`, **deletes it**, and aborts
the play. A transient, fully recoverable write error is escalated into permanent loss of cached facts.

This adds an early `return` on dump failure so any existing entry is left intact, and moves the
`os.close()` of the temp handle into a `finally` so it is closed exactly once before any rename and is
not leaked on the new early-return path. The existing `finally` already unlinks the abandoned temp
file.

`get()`'s behaviour of deleting a file it cannot parse is deliberately left alone, to keep this change
scoped to the reported defect.

**Testing.** Two unit tests: one asserts the previously cached value is still readable by a fresh cache
instance after a failed write, the other that no temp file is left behind. Both fail without the source
change.

## ISSUE TYPE

- Bugfix Pull Request
