### PR TITLE
find - treat mode as a minimum set of permissions when exact_mode is false

### DIFF
--- a/changelogs/fragments/find-exact-mode-minimum-set.yml
+++ b/changelogs/fragments/find-exact-mode-minimum-set.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - find - ``exact_mode=false`` now treats ``mode`` as a minimum set of permissions, as documented, so every requested permission
+    bit must be present on a file for it to match.
+    Previously a file matched when any single requested bit was present, so ``mode=0700`` with ``exact_mode=false`` also matched
+    a file with mode ``0400``.

--- a/lib/ansible/modules/find.py
+++ b/lib/ansible/modules/find.py
@@ -420,7 +420,9 @@ def mode_filter(st, mode, exact, module):
     if exact:
         return st_mode == mode
 
-    return bool(st_mode & mode)
+    # An inexact match treats `mode` as a minimum set of permissions, so every requested bit must be present.
+    # Testing `st_mode & mode` alone matches when only one of the requested bits overlaps.
+    return st_mode & mode == mode
 
 
 def statinfo(st):

--- a/test/integration/targets/find/tasks/mode.yml
+++ b/test/integration/targets/find/tasks/mode.yml
@@ -58,6 +58,30 @@
     exact_mode: false
   register: other_readable_symbolic
 
+- name: multi-bit mask, all user permissions octal
+  find:
+    path: '{{ remote_tmp_dir_test }}'
+    pattern: 'mode_*'
+    mode: '0700'
+    exact_mode: false
+  register: user_rwx_octal
+
+- name: multi-bit mask, all user permissions symbolic
+  find:
+    path: '{{ remote_tmp_dir_test }}'
+    pattern: 'mode_*'
+    mode: 'u=rwx'
+    exact_mode: false
+  register: user_rwx_symbolic
+
+- name: multi-bit mask, user and other read-write octal
+  find:
+    path: '{{ remote_tmp_dir_test }}'
+    pattern: 'mode_*'
+    mode: '0606'
+    exact_mode: false
+  register: user_other_rw_octal
+
 - assert:
     that:
       - exact_mode_0644.files == exact_mode_0644_symbolic.files
@@ -66,3 +90,13 @@
       - user_readable_octal.files|map(attribute='path')|map('basename')|sort == ['mode_0400', 'mode_0444', 'mode_0644', 'mode_0666', 'mode_0700']
       - other_readable_octal.files == other_readable_symbolic.files
       - other_readable_octal.files|map(attribute='path')|map('basename')|sort == ['mode_0444', 'mode_0644', 'mode_0666']
+
+# A mask with more than one bit set is a minimum set of permissions: every requested bit must be present.
+# Fixtures are mode_0644, mode_0444, mode_0400, mode_0700 and mode_0666.
+- assert:
+    that:
+      # only mode_0700 has all of u=rwx; 0400/0444/0644/0666 each overlap but do not satisfy the full set
+      - user_rwx_octal.files == user_rwx_symbolic.files
+      - user_rwx_octal.files|map(attribute='path')|map('basename')|sort == ['mode_0700']
+      # only mode_0666 has both u=rw and o=rw; mode_0644 overlaps on u=rw and o=r only
+      - user_other_rw_octal.files|map(attribute='path')|map('basename')|sort == ['mode_0666']

--- a/test/units/modules/test_find.py
+++ b/test/units/modules/test_find.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+import os
+import stat
+
+import pytest
+
+from ansible.modules.find import mode_filter
+
+
+class FakeStat:
+    """Stands in for the result of os.lstat, which mode_filter only reads st_mode from."""
+
+    def __init__(self, mode: int) -> None:
+        self.st_mode = stat.S_IFREG | mode
+
+
+@pytest.mark.parametrize(
+    'file_mode, wanted, expected',
+    (
+        # an exact match compares the full permission set
+        (0o644, '0644', True),
+        (0o644, '0645', False),
+        (0o700, '0700', True),
+        (0o600, '0700', False),
+    )
+)
+def test_mode_filter_exact(file_mode, wanted, expected):
+    assert mode_filter(FakeStat(file_mode), wanted, True, None) is expected
+
+
+@pytest.mark.parametrize(
+    'file_mode, wanted, expected',
+    (
+        # a single-bit mask matches whenever that bit is present
+        (0o400, '0400', True),
+        (0o444, '0400', True),
+        (0o644, '0400', True),
+        (0o200, '0400', False),
+        (0o444, '0004', True),
+        (0o440, '0004', False),
+        # a multi-bit mask is a *minimum* set: every requested bit must be present
+        (0o700, '0700', True),
+        (0o750, '0700', True),
+        (0o400, '0700', False),
+        (0o600, '0700', False),
+        (0o644, '0700', False),
+        (0o666, '0606', True),
+        (0o644, '0606', False),
+        (0o777, '0644', True),
+        (0o444, '0644', False),
+    )
+)
+def test_mode_filter_minimum_set(file_mode, wanted, expected):
+    """With exact_mode=false the mode is a minimum set of permissions, not a set of alternatives."""
+    assert mode_filter(FakeStat(file_mode), wanted, False, None) is expected
+
+
+def test_mode_filter_no_mode():
+    assert mode_filter(FakeStat(0o644), None, True, None) is True
+    assert mode_filter(FakeStat(0o644), '', False, None) is True
+
+
+def test_mode_filter_ignores_file_type_bits():
+    """Only the permission bits participate in the comparison."""
+    st = FakeStat(0o644)
+    assert st.st_mode & stat.S_IFREG
+    assert mode_filter(st, '0644', True, None) is True
+
+
+@pytest.mark.parametrize('file_mode, wanted, expected', ((0o700, 'u=rwx', True), (0o600, 'u=rwx', False)))
+def test_mode_filter_symbolic(file_mode, wanted, expected, set_module_args):
+    """A symbolic mode is resolved to octal before the comparison."""
+    set_module_args({'paths': [os.sep]})
+
+    from ansible.module_utils.basic import AnsibleModule
+
+    module = AnsibleModule(argument_spec={'paths': {'type': 'list', 'required': True, 'elements': 'path'}})
+
+    assert mode_filter(FakeStat(file_mode), wanted, False, module) is expected


### PR DESCRIPTION
Closes #87392.

## SUMMARY

`exact_mode` is documented as restricting matching to exact matches "and not as a minimum set of
permissions to match", so `exact_mode: false` should mean the file has *at least* the requested bits.
`mode_filter()` implemented it as `bool(st_mode & mode)`, which is true when a *single* bit overlaps.

Every multi-bit mask therefore over-matches, and it fails worst for the auditing use case the option
exists for: `mode: '0700', exact_mode: false` matches a `0444` read-only file, and
`mode: '0777', exact_mode: false` matches every file with any permission bit set. The error is always
in the direction of extra matches, so downstream tasks acting on `find`'s results operate on files the
author never intended to touch.

The fix is `st_mode & mode == mode`. Single-bit masks are unaffected, which is why this went
unnoticed: the existing integration tests only use `0400` and `0004`, where "any bit" and "all bits"
coincide. Both of those existing assertions were re-verified against the patched function and still
hold.

This is a behaviour change for anyone relying on the over-matching, hence the changelog fragment.

**Testing.** Adds `test/units/modules/test_find.py` (new file, 23 cases covering the exact,
minimum-set, symbolic and no-mode paths) and multi-bit integration cases to `find/tasks/mode.yml`
asserting that `mode: '0700'` matches only `mode_0700` and `mode: '0606'` matches only `mode_0666`.
6 of the new unit cases fail without the source change.

## ISSUE TYPE

- Bugfix Pull Request
