### PR TITLE
merge_hash - always return a new dictionary

### DIFF
--- a/changelogs/fragments/merge-hash-return-new-dict.yml
+++ b/changelogs/fragments/merge-hash-return-new-dict.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - "``merge_hash`` now always returns a new dictionary, as documented.
+    Previously it returned the first operand itself when the second was empty, so callers that modified the result -- including
+    users of ``combine_vars`` and the ``combine`` filter -- could modify the dictionary they passed in."

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -94,6 +94,11 @@ def merge_hash(x, y, recursive=True, list_merge='replace'):
     Return a new dictionary result of the merges of y into x,
     so that keys from y take precedence over keys from x.
     (x and y aren't modified)
+
+    The returned dictionary is always a new top-level dictionary, so adding or removing keys on it never
+    affects x or y.
+    Nested containers may still be shared with x and y, so callers must not mutate values reached through
+    the result.
     """
     if list_merge not in ('replace', 'keep', 'append', 'prepend', 'append_rp', 'prepend_rp'):
         raise AnsibleError("merge_hash: 'list_merge' argument can only be equal to 'replace', 'keep', 'append', 'prepend', 'append_rp' or 'prepend_rp'")
@@ -107,7 +112,8 @@ def merge_hash(x, y, recursive=True, list_merge='replace'):
     if x == {} or x == y:
         return y.copy()
     if y == {}:
-        return x
+        # a copy, so the caller never receives the dictionary it passed in
+        return x.copy()
 
     # in the following we will copy elements from y to x, but
     # we don't want to modify x, so we create a copy of it

--- a/test/units/utils/test_vars.py
+++ b/test/units/utils/test_vars.py
@@ -113,6 +113,44 @@ class TestVariableUtils(unittest.TestCase):
         }
     }
 
+    def test_merge_hash_returns_new_dict(self):
+        """merge_hash must never hand back one of the dictionaries it was given."""
+        # every combination of empty/non-empty and equal/unequal operands hits a different early return
+        for x, y in (
+            ({'a': 1}, {}),                    # y empty
+            ({}, {'a': 1}),                    # x empty
+            ({'a': 1}, {'a': 1}),              # x == y
+            ({'a': 1}, {'b': 2}),              # general merge
+            ({}, {}),                          # both empty
+        ):
+            original_x = x.copy()
+            original_y = y.copy()
+
+            result = merge_hash(x, y)
+
+            self.assertIsNot(result, x, f'result is the x operand for {x=} {y=}')
+            self.assertIsNot(result, y, f'result is the y operand for {x=} {y=}')
+
+            # adding a key to the result must not leak into either operand
+            result['injected_by_test'] = True
+            self.assertEqual(x, original_x, f'x was modified for {x=} {y=}')
+            self.assertEqual(y, original_y, f'y was modified for {x=} {y=}')
+
+    def test_combine_vars_returns_new_dict(self):
+        """combine_vars inherits the guarantee from merge_hash under both hash behaviours."""
+        for behaviour in ('merge', 'replace'):
+            with mock.patch('ansible.constants.DEFAULT_HASH_BEHAVIOUR', behaviour):
+                a = {'a': 1}
+                b = {}
+
+                result = combine_vars(a, b)
+
+                self.assertIsNot(result, a, f'result is the a operand for {behaviour=}')
+                self.assertIsNot(result, b, f'result is the b operand for {behaviour=}')
+
+                result['injected_by_test'] = True
+                self.assertEqual(a, {'a': 1}, f'a was modified for {behaviour=}')
+
     def test_merge_hash_simple(self):
         for test in self.combine_vars_merge_data:
             self.assertEqual(merge_hash(test['a'], test['b']), test['result'])


### PR DESCRIPTION
Closes #87393.

## SUMMARY

`merge_hash()` documents that it returns a new dictionary and that "x and y aren't modified", but when
`y` is empty it returns `x` itself. Callers that treat the result as their own copy can therefore
modify the dictionary they passed in. This reaches user-facing code through `combine_vars()` and the
`combine` filter, where `{{ dict_a | combine({}) }}` returns `dict_a` itself.

The fix returns `x.copy()`.

The docstring is also amended to state the guarantee precisely: the top-level dictionary is always new,
but nested containers may be shared with either operand, so callers must not mutate values reached
through the result. The shallow copy is a deliberate performance trade-off that is relied on widely, so
this documents the real contract rather than switching to `deepcopy` and changing the cost of every
variable merge.

Note `VariableManager._combine_and_track` already carries an `if new_data == {}: return data` guard, so
core's own hot path happened to sidestep this, which is why it stayed latent.

**Testing.** `test_merge_hash_returns_new_dict` covers all five early-return and general paths (`y`
empty, `x` empty, `x == y`, general merge, both empty), asserting the result is neither operand and
that writing to it leaves both untouched. `test_combine_vars_returns_new_dict` covers the same through
`combine_vars` under both hash behaviours. Both fail without the source change.

## ISSUE TYPE

- Bugfix Pull Request
