### PR TITLE
camel_dict_to_snake_dict - honour ignore_list at every depth

### DIFF
--- a/changelogs/fragments/camel-dict-ignore-list-recursion.yml
+++ b/changelogs/fragments/camel-dict-ignore-list-recursion.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - module_utils.common.dict_transformations - ``camel_dict_to_snake_dict`` now honours ``ignore_list`` at every depth, including
+    for dicts nested inside lists.
+    Previously the argument was dropped on each recursive call, so only top level keys were protected and case-sensitive keys in a
+    nested sub-tree such as ``Tags`` were still converted.

--- a/lib/ansible/module_utils/common/dict_transformations.py
+++ b/lib/ansible/module_utils/common/dict_transformations.py
@@ -22,7 +22,8 @@ def camel_dict_to_snake_dict(camel_dict, reversible=False, ignore_list=()):
 
     ignore_list is used to avoid converting a sub-tree of a dict. This is
     particularly important for tags, where keys are case-sensitive. We convert
-    the 'Tags' key but nothing below.
+    the 'Tags' key but nothing below. It applies at every depth, including to
+    dicts nested inside lists.
     """
 
     def value_is_list(camel_list):
@@ -30,7 +31,7 @@ def camel_dict_to_snake_dict(camel_dict, reversible=False, ignore_list=()):
         checked_list = []
         for item in camel_list:
             if isinstance(item, dict):
-                checked_list.append(camel_dict_to_snake_dict(item, reversible))
+                checked_list.append(camel_dict_to_snake_dict(item, reversible, ignore_list))
             elif isinstance(item, list):
                 checked_list.append(value_is_list(item))
             else:
@@ -41,7 +42,7 @@ def camel_dict_to_snake_dict(camel_dict, reversible=False, ignore_list=()):
     snake_dict = {}
     for k, v in camel_dict.items():
         if isinstance(v, dict) and k not in ignore_list:
-            snake_dict[_camel_to_snake(k, reversible=reversible)] = camel_dict_to_snake_dict(v, reversible)
+            snake_dict[_camel_to_snake(k, reversible=reversible)] = camel_dict_to_snake_dict(v, reversible, ignore_list)
         elif isinstance(v, list) and k not in ignore_list:
             snake_dict[_camel_to_snake(k, reversible=reversible)] = value_is_list(v)
         else:

--- a/test/units/module_utils/common/test_dict_transformations.py
+++ b/test/units/module_utils/common/test_dict_transformations.py
@@ -66,6 +66,36 @@ class TestCaseCamelDictToSnakeDict:
         assert snake_dict['hello'] == dict(one='one', two='two')
         assert snake_dict['world'] == dict(Three='three', Four='four')
 
+    def test_ignore_list_nested_in_dict(self):
+        """An ignored key is honoured at any depth, not just at the top level."""
+        camel_dict = dict(Instance=dict(InstanceId='i-123', Tags=dict(MyKey='v', AnotherKey='v')))
+        snake_dict = camel_dict_to_snake_dict(camel_dict, ignore_list=('Tags',))
+        assert snake_dict['instance']['instance_id'] == 'i-123'
+        assert snake_dict['instance']['tags'] == dict(MyKey='v', AnotherKey='v')
+
+    def test_ignore_list_nested_in_list(self):
+        """An ignored key is honoured for dicts reached through a list."""
+        camel_dict = dict(Instances=[dict(InstanceId='i-123', Tags=dict(MyKey='v'))])
+        snake_dict = camel_dict_to_snake_dict(camel_dict, ignore_list=('Tags',))
+        assert snake_dict['instances'][0]['instance_id'] == 'i-123'
+        assert snake_dict['instances'][0]['tags'] == dict(MyKey='v')
+
+    def test_ignore_list_deeply_nested(self):
+        """An ignored key is honoured through alternating dict and list nesting."""
+        camel_dict = dict(Reservations=[dict(Instances=[dict(Tags=dict(CamelKey='v'), BlockDevices=[dict(DeviceName='xvda')])])])
+        snake_dict = camel_dict_to_snake_dict(camel_dict, ignore_list=('Tags',))
+        instance = snake_dict['reservations'][0]['instances'][0]
+        assert instance['tags'] == dict(CamelKey='v')
+        # keys outside the ignored sub-tree are still converted at that depth
+        assert instance['block_devices'][0]['device_name'] == 'xvda'
+
+    def test_ignore_list_multiple_keys(self):
+        camel_dict = dict(Outer=dict(Tags=dict(AKey='a'), Metadata=dict(BKey='b'), Other=dict(CKey='c')))
+        snake_dict = camel_dict_to_snake_dict(camel_dict, ignore_list=('Tags', 'Metadata'))
+        assert snake_dict['outer']['tags'] == dict(AKey='a')
+        assert snake_dict['outer']['metadata'] == dict(BKey='b')
+        assert snake_dict['outer']['other'] == dict(c_key='c')
+
 
 class TestCaseDictMerge:
     def test_dict_merge(self):


### PR DESCRIPTION
Closes #87394.

## SUMMARY

`camel_dict_to_snake_dict()`'s docstring says `ignore_list` exists to avoid converting a sub-tree,
"particularly important for tags, where keys are case-sensitive". But the argument is dropped on both
recursive call sites, so the guard only ever fires at depth 0. A nested `Tags` block -- the
overwhelmingly common shape, e.g. `{'Reservations': [{'Instances': [{'Tags': {...}}]}]}` -- comes back
with mangled keys.

This is the public `module_utils` helper that cloud collections use to normalise API responses, and AWS
tag keys are case-sensitive, so a module comparing desired against reported tags sees a spurious
difference. It corrupts data silently rather than failing.

The fix threads `ignore_list` through both recursive paths, including into dicts reached via lists.

**Testing.** Four unit tests cover nesting in a dict, nesting in a list, alternating dict/list nesting,
and multiple ignored keys, including an assertion that keys *outside* the ignored sub-tree are still
converted at that depth. All four fail without the source change.

Because collections may have grown to depend on the shallow behaviour, this carries a changelog
fragment.

## ISSUE TYPE

- Bugfix Pull Request
