### PR TITLE
jsonfile cache plugin - tolerate an unset prefix in keys() and flush()

### DIFF
--- a/changelogs/fragments/cache-prefix-default.yml
+++ b/changelogs/fragments/cache-prefix-default.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - jsonfile cache plugin - ``keys()`` and ``flush()`` no longer raise ``TypeError`` when ``fact_caching_prefix`` is unset.
+    The ``_prefix`` option had no default, so it resolved to ``None`` and only some of the code paths that use it guarded against
+    that.

--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -133,13 +133,14 @@ class BaseFileCacheModule(BaseCacheModule):
                     raise AnsibleError(f"'{self.plugin_name!r}' cache, configured path ({self._cache_dir}) does not have necessary permissions (rwx),"
                                        " disabling plugin")
 
+    def _get_prefix(self) -> str:
+        """Return the configured file name prefix, which is optional and may be unset."""
+        return self.get_option('_prefix') or ''
+
     def _get_cache_file_name(self, key: str) -> str:
         if key not in self._files:
             safe = self._sanitize_key(key)  # use key or filesystem safe hash of key
-            prefix = self.get_option('_prefix')
-            if not prefix:
-                prefix = ''
-            self._files[key] = os.path.join(self._cache_dir, prefix + safe)
+            self._files[key] = os.path.join(self._cache_dir, self._get_prefix() + safe)
         return self._files[key]
 
     def get(self, key):
@@ -218,7 +219,7 @@ class BaseFileCacheModule(BaseCacheModule):
         # When using a prefix we must remove it from the key name before
         # checking the expiry and returning it to the caller. Keys that do not
         # share the same prefix cannot be fetched from the cache.
-        prefix = self.get_option('_prefix')
+        prefix = self._get_prefix()
         prefix_length = len(prefix)
         keys = []
         for k in os.listdir(self._cache_dir):

--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -23,12 +23,14 @@ DOCUMENTATION = """
             section: defaults
         type: path
       _prefix:
+        default: ''
         description: User defined prefix to use when creating the JSON files
         env:
           - name: ANSIBLE_CACHE_PLUGIN_PREFIX
         ini:
           - key: fact_caching_prefix
             section: defaults
+        type: str
       _timeout:
         default: 86400
         description: Expiration timeout for the cache plugin data

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 
+import os
 import shutil
 import tempfile
 
@@ -147,6 +148,40 @@ class TestJsonFileCachePrefix(TestJsonFileCache):
         assert 'special_test' not in self.cache
         assert 'test' in self.cache
         assert self.cache['test'] == dict(b=2)
+
+
+class TestJsonFileCacheUnsetPrefix(unittest.TestCase):
+    """The prefix is an optional option, so every code path must tolerate it being unset."""
+
+    def setUp(self):
+        self.cache_dir = tempfile.mkdtemp(prefix='ansible-plugins-cache-')
+        # no _prefix passed, so the plugin's own option default applies
+        self.cache = cache_loader.get('jsonfile', _uri=self.cache_dir, _timeout=0)
+
+    def tearDown(self):
+        shutil.rmtree(self.cache_dir)
+
+    def test_prefix_default_is_a_string(self):
+        assert self.cache.__wrapped__._get_prefix() == ''
+
+    def test_keys_with_unset_prefix(self):
+        self.cache.set('host_a', {'a': 1})
+        self.cache.set('host_b', {'b': 2})
+
+        assert sorted(self.cache.keys()) == ['host_a', 'host_b']
+
+    def test_contains_and_get_with_unset_prefix(self):
+        self.cache.set('host_a', {'a': 1})
+
+        assert self.cache.contains('host_a')
+        assert self.cache.get('host_a') == {'a': 1}
+
+    def test_flush_with_unset_prefix(self):
+        self.cache.set('host_a', {'a': 1})
+        self.cache.__wrapped__.flush()
+
+        assert self.cache.keys() == []
+        assert os.listdir(self.cache_dir) == []
 
 
 class TestCachePlugin(unittest.TestCase):


### PR DESCRIPTION
Closes #87395.

## SUMMARY

`_get_cache_file_name()` guards against a falsy `_prefix` with `if not prefix: prefix = ''`, but
`keys()` three methods down calls `len(prefix)` directly. The `jsonfile` plugin declares `_prefix` with
no `default`, so it resolves to `None` whenever `fact_caching_prefix` is unset -- the default state for
a `jsonfile` fact cache, where only `fact_caching_connection` is required. `flush()` calls `keys()` and
inherits the crash.

`set()` and `get()` work, so the cache looks healthy and only enumeration and flushing fail, with an
opaque `TypeError`.

For accuracy about reachability: core's own `--flush-cache` path does *not* hit this, because
`CLI._flush_cache` clears per-host facts via `variable_manager.clear_facts()`; and the inventory cache
path is safe because its `cache_prefix` does have a default. It is reachable by any code that enumerates
or flushes a file-backed fact cache, which is the documented way to drive a cache plugin, and
`keys()`/`flush()` are `@abstractmethod`s on the public `BaseCacheModule` API.

The fix adds a `_get_prefix()` helper used by both call sites so they cannot drift apart again, and gives
the `jsonfile` `_prefix` option an explicit `default: ''` and `type: str`.

**Testing.** Four unit tests against a cache constructed without `_prefix`: the option default is a
string, `keys()` round-trips both entries, `contains()`/`get()` still work, and `flush()` empties both
the cache and the directory. Three fail without the source change.

## ISSUE TYPE

- Bugfix Pull Request
