### PR TITLE
module_utils.urls - mask a url whose password is blank

### DIFF
--- a/changelogs/fragments/mask-url-empty-password.yml
+++ b/changelogs/fragments/mask-url-empty-password.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - module_utils.urls - ``mask_url`` now masks the userinfo of a URL whose password is blank, such as
+    ``https://user:@example.com``.
+    The blank password made it take the username-only branch, whose substring replacement could not match the netloc, so the URL
+    was returned with the username still in the clear.

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -320,17 +320,20 @@ def mask_url(url: str) -> str:
     Safely display a url by masking confidential data
     from a string or the result from urlparse/split
     """
-    if (parsed_url := urlparse(url)) and not parsed_url.username and not parsed_url.password:
+    parsed_url = urlparse(url)
+
+    # `username`/`password` are only None when the netloc carries no userinfo at all.
+    # Either can be an empty string when the userinfo is present but blank, which still needs masking.
+    if parsed_url.username is None and parsed_url.password is None:
         return url
 
-    netloc: str
     mask = '****'
-    if parsed_url.password:
-        netloc = parsed_url.netloc.replace(f'{parsed_url.username}:{parsed_url.password}@', f'{mask}:{mask}@')
-    else:
-        netloc = parsed_url.netloc.replace(f'{parsed_url.username}@', f'{mask}@')
+    userinfo = mask if parsed_url.password is None else f'{mask}:{mask}'
+    # rebuild the netloc rather than substring-replacing the userinfo out of it,
+    # since a blank username or password leaves nothing reliable to match on
+    host = parsed_url.netloc.rpartition('@')[2]
 
-    return urlunparse(parsed_url._replace(netloc=netloc))
+    return urlunparse(parsed_url._replace(netloc=f'{userinfo}@{host}'))
 
 
 def generic_urlparse(parts):

--- a/test/units/module_utils/urls/test_mask_url.py
+++ b/test/units/module_utils/urls/test_mask_url.py
@@ -27,6 +27,14 @@ from ansible.module_utils.urls import mask_url
         ('ftps://secretuser:secretsecret@file.server/yolo.asc', ('file.server/yolo.asc')),
         ('redis://:secretpass@cache.internal:6379/0', ('cache.internal', '6379', 'redis')),
         ('amqp://:secretpw@rabbit.internal:5672/vhost', ('rabbit.internal', '5672', 'vhost')),
+        # a blank password still means userinfo is present, so it must be masked
+        ('https://secretuser:@hideme.com/index.html', ('hideme.com', 'index.html', '****')),
+        ('https://secretuser:@hideme.com:8443/index.html', ('hideme.com', '8443', '****')),
+        ('ftp://secretuser:@files.insecure/pub/file.txt', ('files.insecure', 'pub/file.txt', '****')),
+        # blank on both sides of the delimiter
+        ('https://:@hideme.com/index.html', ('hideme.com', 'index.html', '****')),
+        # a password containing '@' must not confuse host detection
+        ('https://secretuser:secret@pass@hideme.com/index.html', ('hideme.com', 'index.html', '****')),
     )
 )
 def test_mask_url(url, wanted):
@@ -36,3 +44,31 @@ def test_mask_url(url, wanted):
 
     for notmasked in wanted:
         assert notmasked in masked
+
+
+@pytest.mark.parametrize(
+    'url',
+    (
+        'https://nocreds.example.com/index.html',
+        'https://nocreds.example.com:8443/index.html?token=notuserinfo',
+        'http://nocreds.example.com',
+    )
+)
+def test_mask_url_without_userinfo_is_unchanged(url):
+    """A URL carrying no userinfo is returned untouched."""
+    assert mask_url(url) == url
+
+
+@pytest.mark.parametrize(
+    'url, expected',
+    (
+        ('https://secretuser@hideme.com/x', 'https://****@hideme.com/x'),
+        ('https://secretuser:secretpass@hideme.com/x', 'https://****:****@hideme.com/x'),
+        ('https://secretuser:@hideme.com/x', 'https://****:****@hideme.com/x'),
+        ('https://:secretpass@hideme.com/x', 'https://****:****@hideme.com/x'),
+        ('https://secretuser:secretpass@[::1]:8443/x', 'https://****:****@[::1]:8443/x'),
+    )
+)
+def test_mask_url_exact_output(url, expected):
+    """Everything except the userinfo survives masking intact."""
+    assert mask_url(url) == expected


### PR DESCRIPTION
Closes #87396.

## SUMMARY

`mask_url()` chooses its branch on the *truthiness* of `password` rather than on whether a password
delimiter is present. For `https://user:@example.com/p` the password is `''`, so the username-only
branch searches the netloc for `'user@'` -- which is not present, since the netloc is
`'user:@example.com'`. The replacement matches nothing and the URL is returned completely unmasked.

`mask_url()` is the single chokepoint that URL reporting was routed through by `24b1f6219e`, covering
`fetch_url`, `uri`, `get_url`, `apt_key`, `rpm_key`, the `url` lookup and the `unarchive` action. A
`user:@host` form -- what you get when a password variable templates to an empty string, and which some
services accept as token-in-username auth -- bypasses the mask and echoes the username into task
output, `-vvvv` logs and callback plugins. The secret itself is empty in this shape, so this is identity
disclosure rather than a password leak, but it defeats the function's stated guarantee.

The fix keys the branch off `is None` rather than truthiness, which distinguishes "absent" from "present
but empty", and rebuilds the netloc from `rpartition('@')` instead of substring-replacing the userinfo
out of it. That removes the substring-matching failure mode entirely and also handles a password
containing `@` correctly.

**Testing.** `test_mask_url.py` gains blank-password cases (with and without a port, and with both sides
of the delimiter blank), a password containing `@`, a test that a URL with no userinfo is returned
untouched, and exact-output assertions covering all five userinfo shapes including IPv6. 5 fail without
the source change.

## ISSUE TYPE

- Bugfix Pull Request
