### PR TITLE
ImmutableDict - compare contents rather than hashes

### DIFF
--- a/changelogs/fragments/immutabledict-eq-contents.yml
+++ b/changelogs/fragments/immutabledict-eq-contents.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - module_utils.common.collections - ``ImmutableDict`` equality now compares contents instead of hashes.
+    An ``ImmutableDict`` previously compared equal to any object with a colliding hash, including a ``frozenset`` of its own items,
+    while comparing unequal to a ``dict`` with the same contents because a ``dict`` is unhashable.
+    Contents are now also comparable when a value makes the ``ImmutableDict`` unhashable.

--- a/lib/ansible/module_utils/common/collections.py
+++ b/lib/ansible/module_utils/common/collections.py
@@ -40,13 +40,13 @@ class ImmutableDict(_c.Hashable, _c.Mapping[_KT, _VT], _t.Generic[_KT, _VT]):
         return hash(frozenset(self.items()))
 
     def __eq__(self, other: object) -> bool:
-        try:
-            if self.__hash__() == hash(other):
-                return True
-        except TypeError:
-            pass
+        # Compare contents rather than hashes. Comparing hashes made an ImmutableDict equal to any object with a
+        # colliding hash -- including a frozenset of its own items -- while making it unequal to an equal mapping,
+        # since a mapping is generally unhashable.
+        if isinstance(other, _c.Mapping):
+            return dict(self._store) == dict(other)
 
-        return False
+        return NotImplemented
 
     def __repr__(self) -> str:
         return 'ImmutableDict({0})'.format(repr(self._store))

--- a/test/units/module_utils/common/test_collections.py
+++ b/test/units/module_utils/common/test_collections.py
@@ -147,6 +147,48 @@ class TestImmutableDict:
         expected_repr = "ImmutableDict({0})".format(initial_data_repr)
         assert actual_repr == expected_repr
 
+    def test_eq_immutabledict(self):
+        assert ImmutableDict(a=1, b=2) == ImmutableDict(a=1, b=2)
+        assert ImmutableDict(a=1, b=2) != ImmutableDict(a=1, b=3)
+        assert ImmutableDict(a=1, b=2) != ImmutableDict(a=1)
+
+    def test_eq_mapping(self):
+        """An ImmutableDict equals any mapping with the same contents."""
+        assert ImmutableDict(a=1, b=2) == {'a': 1, 'b': 2}
+        assert {'a': 1, 'b': 2} == ImmutableDict(a=1, b=2)
+        assert ImmutableDict(a=1, b=2) != {'a': 1, 'b': 3}
+        assert {'a': 1} != ImmutableDict(a=1, b=2)
+
+    def test_eq_not_a_mapping(self):
+        """A non-mapping is never equal, even when its hash collides with the ImmutableDict's."""
+        imdict = ImmutableDict(a=1, b=2)
+
+        # a frozenset of the items hashes identically, since __hash__ is defined as hash(frozenset(self.items()))
+        items = frozenset(imdict.items())
+        assert hash(imdict) == hash(items)
+        assert imdict != items
+        assert items != imdict
+
+        assert imdict != ('a', 1)
+        assert imdict != 'a=1,b=2'
+        assert imdict != 42
+        assert imdict != [('a', 1), ('b', 2)]
+
+    def test_eq_unhashable_values(self):
+        """Contents are comparable even when they make the ImmutableDict unhashable."""
+        assert ImmutableDict(a=[1, 2]) == ImmutableDict(a=[1, 2])
+        assert ImmutableDict(a=[1, 2]) == {'a': [1, 2]}
+        assert ImmutableDict(a=[1, 2]) != ImmutableDict(a=[1, 3])
+
+    def test_hash_eq_consistency(self):
+        """Equal, hashable ImmutableDicts hash equally, so they collapse in a set."""
+        first = ImmutableDict(a=1, b=2)
+        second = ImmutableDict(b=2, a=1)
+
+        assert first == second
+        assert hash(first) == hash(second)
+        assert len({first, second}) == 1
+
 
 class TestOrderedSet:
     def test_init_empty(self):


### PR DESCRIPTION
Closes #87397.

## SUMMARY

`ImmutableDict.__eq__` is defined as hash equality. Two consequences follow directly: it compares equal
to a `frozenset` of its own items, by construction rather than coincidence, since `__hash__` is
`hash(frozenset(self.items()))`; and it compares *unequal* to a `dict` with the same contents, because
`hash(dict)` raises `TypeError` and the handler falls through to `return False`. `ImmutableDict`
registers as a `collections.abc.Mapping`, so that second behaviour breaks the expectation that equal
mappings compare equal.

`ImmutableDict` backs `ansible.context.CLIARGS`, so `CLIARGS == {'verbosity': 3, ...}` -- the natural way
to assert on CLI state -- is always `False` and silently sends code down the wrong branch.

The fix compares contents for mappings and returns `NotImplemented` otherwise, letting the reflected
operand try and yielding `False` when neither side knows how to compare. `__hash__` is unchanged and
remains consistent with the new `__eq__` for mapping comparisons. Being non-hash-based costs nothing
here, since the contents are already required to be hashable; as a bonus, contents are now comparable
even when a value makes the `ImmutableDict` unhashable. Returning `NotImplemented` from `__eq__` is
already the pattern used by `OrderedSet` in this same file, so mypy is satisfied.

This is an observable behaviour change, hence the changelog fragment. `test_context_objects.py`, which
compares `ImmutableDict` values via `_make_immutable`, still passes.

**Testing.** Five unit tests: equality between `ImmutableDict`s, equality with an equal mapping in both
directions, inequality against non-mappings including the colliding `frozenset` (asserting the hashes are
in fact equal, so the test would catch a regression to hash comparison), comparability with unhashable
values, and hash/eq consistency via set collapsing. 3 fail without the source change.

## ISSUE TYPE

- Bugfix Pull Request
