### PR TITLE
subelements filter - reject an empty accessor

### DIFF
--- a/changelogs/fragments/subelements-empty-accessor.yml
+++ b/changelogs/fragments/subelements-empty-accessor.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - subelements filter - an empty accessor such as ``{{ data | subelements([]) }}`` now reports a filter error instead of raising
+    ``UnboundLocalError``.
+    The error message for a key that does not point to a list referenced the inner loop variable, which is never bound when the
+    accessor is empty.

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -570,6 +570,10 @@ def subelements(obj, subelements, skip_missing=False):
     else:
         raise AnsibleTypeError('subelements must be a list or a string')
 
+    # An empty accessor would skip the loop below, leaving its `subelement` variable unbound for the error message.
+    if not subelement_list:
+        raise AnsibleFilterError('subelements must not be empty')
+
     results = []
 
     for element in element_list:

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -696,6 +696,12 @@
   ignore_errors: yes
   register: subelements_5
 
+- name: Verify subelements throws on empty subelements arg
+  set_fact:
+    foo: '{{subelements_demo | subelements([])}}'
+  ignore_errors: yes
+  register: subelements_6
+
 - name: Verify subelements
   assert:
     that:
@@ -703,6 +709,8 @@
       - '"obj must be a list of dicts or a nested dict" is in subelements_1.msg'
       - subelements_2 is failed
       - '"subelements must be a list or a string" is in subelements_2.msg'
+      - subelements_6 is failed
+      - '"subelements must not be empty" in subelements_6.msg'
       - 'subelements_demo|subelements("does not compute", skip_missing=True) == []'
       - subelements_3 is failed
       - '"could not find" in subelements_3.msg'

--- a/test/units/plugins/filter/test_core.py
+++ b/test/units/plugins/filter/test_core.py
@@ -8,8 +8,8 @@ import pytest
 
 from ansible._internal._datatag._tags import Origin
 from ansible.module_utils.common.text.converters import to_native
-from ansible.plugins.filter.core import to_bool, to_uuid
-from ansible.errors import AnsibleError
+from ansible.plugins.filter.core import subelements, to_bool, to_uuid
+from ansible.errors import AnsibleError, AnsibleFilterError, AnsibleTypeError
 from ansible.template import Templar, trust_as_template, is_trusted_as_template
 from ...test_utils.controller.display import emits_warnings
 
@@ -68,6 +68,36 @@ def test_from_yaml_trust(trust: bool) -> None:
 
     assert result == [dict(a='b')]
     assert is_trusted_as_template(result[0]['a']) is trust
+
+
+SUBELEMENTS_DEMO = [{'name': 'alice', 'groups': ['wheel'], 'authorized': ['/tmp/alice/onekey.pub']}]
+
+
+def test_subelements() -> None:
+    assert subelements(SUBELEMENTS_DEMO, 'groups') == [(SUBELEMENTS_DEMO[0], 'wheel')]
+
+
+def test_subelements_empty_accessor() -> None:
+    """An empty accessor reports a filter error rather than crashing on an unbound loop variable."""
+    with pytest.raises(AnsibleFilterError, match='subelements must not be empty'):
+        subelements(SUBELEMENTS_DEMO, [])
+
+
+def test_subelements_empty_accessor_on_empty_obj() -> None:
+    """The accessor is validated up front, so an empty obj does not mask the problem."""
+    with pytest.raises(AnsibleFilterError, match='subelements must not be empty'):
+        subelements([], [])
+
+
+def test_subelements_invalid_accessor_type() -> None:
+    with pytest.raises(AnsibleTypeError, match='subelements must be a list or a string'):
+        subelements(SUBELEMENTS_DEMO, 17)
+
+
+def test_subelements_value_not_a_list() -> None:
+    """The pre-existing error for a non-list target still names the offending key."""
+    with pytest.raises(AnsibleTypeError, match="should point to a list"):
+        subelements(SUBELEMENTS_DEMO, 'name')
 
 
 def test_from_yaml_origin() -> None:


### PR DESCRIPTION
Closes #87398.

## SUMMARY

`subelements` builds its "should point to a list" error message from `subelement`, the inner loop
variable. With an empty accessor the loop never runs, so the name is never bound, and since `values` is
still the element dict the `isinstance` check fails and the unbound reference is evaluated.
`{{ data | subelements([]) }}` therefore raises a raw `UnboundLocalError` with no indication that the
empty argument is at fault, where the surrounding code goes to some trouble to produce good diagnostics.

The fix validates the accessor up front and raises
`AnsibleFilterError('subelements must not be empty')`.

The guard is deliberately narrow. An accessor containing an empty *key* (`subelements('')`) already
produces a sensible `could not find '' key` message, so it is left alone rather than changing behaviour
beyond the reported defect.

**Testing.** Unit tests for the empty accessor, for an empty accessor combined with an empty `obj` (so
the up-front validation is what fires, not an incidental empty loop), for the invalid-accessor-type path,
and a regression assertion that the pre-existing "should point to a list" error still names the offending
key. Plus an integration case in `filter_core`. 2 fail without the source change.

## ISSUE TYPE

- Bugfix Pull Request
