### PR TITLE
regex_replace - report the real match count when mandatory_count is n…

### DIFF
--- a/changelogs/fragments/regex-replace-mandatory-count-msg.yml
+++ b/changelogs/fragments/regex-replace-mandatory-count-msg.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - regex_replace filter - the error raised when ``mandatory_count`` is not met now reports how many substitutions were actually
+    made.
+    It previously reported the value of the ``count`` argument, which defaults to ``0``, so the message usually claimed the pattern
+    matched zero times.

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -181,7 +181,7 @@ def regex_replace(value='', pattern='', replacement='', ignorecase=False, multil
     (output, subs) = _re.subn(replacement, value, count=count)
     if mandatory_count and mandatory_count != subs:
         raise AnsibleFilterError("'%s' should match %d times, but matches %d times in '%s'"
-                                 % (pattern, mandatory_count, count, value))
+                                 % (pattern, mandatory_count, subs, value))
     return output
 
 

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -415,6 +415,19 @@
     that:
       - "incorrect_mandatory_count is failed"
       - "' times, but matches ' in incorrect_mandatory_count.msg"
+      # the reported number is the substitutions actually made, not the value of `count`
+      - "'should match 1 times, but matches 2 times' in incorrect_mandatory_count.msg"
+
+- name: Verify regex_replace reports the real match count when count is also set
+  debug:
+    msg: "{{ 'aaa'|regex_replace('a', 'b', mandatory_count=1, count=2) }}"
+  ignore_errors: yes
+  register: mandatory_count_with_count
+
+- assert:
+    that:
+      - "mandatory_count_with_count is failed"
+      - "'should match 1 times, but matches 2 times' in mandatory_count_with_count.msg"
 
 - name: Verify case-insensitive regex_findall
   assert:

--- a/test/units/plugins/filter/test_core.py
+++ b/test/units/plugins/filter/test_core.py
@@ -8,8 +8,8 @@ import pytest
 
 from ansible._internal._datatag._tags import Origin
 from ansible.module_utils.common.text.converters import to_native
-from ansible.plugins.filter.core import to_bool, to_uuid
-from ansible.errors import AnsibleError
+from ansible.plugins.filter.core import regex_replace, to_bool, to_uuid
+from ansible.errors import AnsibleError, AnsibleFilterError
 from ansible.template import Templar, trust_as_template, is_trusted_as_template
 from ...test_utils.controller.display import emits_warnings
 
@@ -68,6 +68,30 @@ def test_from_yaml_trust(trust: bool) -> None:
 
     assert result == [dict(a='b')]
     assert is_trusted_as_template(result[0]['a']) is trust
+
+
+def test_regex_replace_mandatory_count_met() -> None:
+    assert regex_replace('foo=bar=baz', '=', ':', mandatory_count=2) == 'foo:bar:baz'
+
+
+@pytest.mark.parametrize(
+    'value, pattern, kwargs, expected_subs',
+    (
+        # `count` defaults to 0 (unlimited), so the reported number must come from the substitutions actually made
+        ('aaa', 'a', dict(mandatory_count=1), 3),
+        ('foo=bar=baz', '=', dict(mandatory_count=1), 2),
+        ('aaa', 'a', dict(mandatory_count=2, count=3), 3),
+        # no match at all
+        ('foo', 'z', dict(mandatory_count=1), 0),
+    )
+)
+def test_regex_replace_mandatory_count_reports_actual_subs(value, pattern, kwargs, expected_subs) -> None:
+    """The error message reports how many substitutions were made, not the value of `count`."""
+    with pytest.raises(AnsibleFilterError) as exc_info:
+        regex_replace(value, pattern, ':', **kwargs)
+
+    assert f'but matches {expected_subs} times' in str(exc_info.value)
+    assert f"should match {kwargs['mandatory_count']} times" in str(exc_info.value)
 
 
 def test_from_yaml_origin() -> None:


### PR DESCRIPTION
Closes #87399.

## SUMMARY

`re.subn()` returns the substitution count in `subs`, but the `mandatory_count` error formats `count` --
the *maximum substitutions* argument, which defaults to `0` -- into the "but matches %d times" slot. So
`regex_replace('aaa', 'a', 'b', mandatory_count=1)` reports that the pattern matched 0 times when it
matched three, leading the reader to conclude the regex is wrong when the assertion is what needs
adjusting.

The bug is easy to miss because supplying `count` explicitly can make the message look right by
coincidence. The existing integration test only asserts that the substring `' times, but matches '` is
present, never the number, so CI could not see it.

One-character fix, `count` to `subs`.

**Testing.** A parametrised unit test over four cases, including one where `count` is set (so the number
cannot pass by coincidence) and one where the pattern does not match at all, plus a tightened integration
assertion that now checks the reported number rather than only the surrounding text. 2 fail without the
source change.

## ISSUE TYPE

- Bugfix Pull Request
