### PR TITLE
get_url: fail when checksum URL host or port differs from url

### DIFF
--- a/changelogs/fragments/get_url_checksum.yml
+++ b/changelogs/fragments/get_url_checksum.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - get_url - fail with error when the checksum URL host or port differs from ``url``.

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -49,7 +49,7 @@ import urllib.request
 from contextlib import contextmanager
 from functools import partial
 from http import cookiejar
-from urllib.parse import unquote, urlparse, urlunparse
+from urllib.parse import unquote, urlparse, urlunparse, urlsplit
 from urllib.request import BaseHandler
 
 try:
@@ -1656,3 +1656,28 @@ def fetch_file(module, url, data=None, headers=None, method=None,
 def get_user_agent():
     """Returns a user agent used by open_url"""
     return u"ansible-httpget"
+
+
+def url_host_port(url):
+    """Return normalized (hostname, port) for remote URLs, else None."""
+    parts = urlsplit(url)
+    default_ports = {'http': 80, 'https': 443, 'ftp': 21, 'ftps': 990}
+    if parts.scheme not in default_ports:
+        return None
+
+    hostname = parts.hostname or ''
+    port = parts.port
+    if port is None:
+        port = default_ports[parts.scheme]
+
+    return hostname, port
+
+
+def urls_have_different_host_port(url_a, url_b):
+    """Return True when two remote URLs target different host/port pairs."""
+    host_port_a = url_host_port(url_a)
+    host_port_b = url_host_port(url_b)
+    if host_port_a is None or host_port_b is None:
+        return False
+
+    return host_port_a != host_port_b

--- a/lib/ansible/modules/get_url.py
+++ b/lib/ansible/modules/get_url.py
@@ -101,6 +101,7 @@ options:
         the destination file is replaced with the newly downloaded file.
       - If the checksum URL requires username and password, O(url_username) and O(url_password) are used
         to download the checksum file.
+      - Module fails if the checksum URL host or port differs from the url parameter.
     type: str
     default: ''
     version_added: "2.0"
@@ -378,7 +379,7 @@ from urllib.parse import urlsplit
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import to_native
-from ansible.module_utils.urls import fetch_url, is_fetch_success, mask_url, url_argument_spec
+from ansible.module_utils.urls import fetch_url, is_fetch_success, mask_url, url_argument_spec, urls_have_different_host_port
 
 # ==============================================================
 # url handling
@@ -567,6 +568,11 @@ def main():
 
         if is_url(checksum):
             checksum_url = checksum
+            if urls_have_different_host_port(url, checksum_url):
+                module.fail_json(
+                    msg="The checksum URL host or port differs from the url parameter",
+                    **result,
+                )
             # download checksum file to checksum_tmpsrc
             checksum_tmpsrc, _dummy = url_get(module, checksum_url, dest, use_proxy, last_mod_time, force, timeout, headers, tmp_dest,
                                               unredirected_headers=unredirected_headers, ciphers=ciphers, use_netrc=use_netrc)

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -424,6 +424,14 @@
     path: "{{ remote_tmp_dir }}/27617.txt"
   register: stat_result_sha1
 
+- name: download src with sha1 checksum url with different host port
+  get_url:
+    url: 'http://localhost:{{ http_port }}/27617.txt'
+    dest: '{{ remote_tmp_dir }}'
+    checksum: 'sha1:http://localhost:9999/sha1sum.txt'
+  register: result_sha1_different_host_port
+  ignore_errors: true
+
 - name: download src with sha256 checksum url
   get_url:
     url: 'http://localhost:{{ http_port }}/27617.txt'
@@ -638,6 +646,8 @@
       - "stat_result_sha256_with_asterisk_86132.stat.exists == true"
       - result_sha256_86132_single_space is changed
       - "stat_result_sha256_86132_single_space.stat.exists == true"
+      - result_sha1_different_host_port is failed
+      - "result_sha1_different_host_port.msg == 'The checksum URL host or port differs from the url parameter'"
 
 - name: Test for incomplete data read (issue 85164)
   get_url:


### PR DESCRIPTION
##### SUMMARY

Prevent potential SSRF by rejecting checksum URLs that target a
different host or port than the download URL.

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/get_url_checksum.yml
lib/ansible/module_utils/urls.py
lib/ansible/modules/get_url.py
test/integration/targets/get_url/tasks/main.yml


