### PR TITLE
subelements: raise an error for empty subelements

### DIFF
--- a/changelogs/fragments/subelements.yml
+++ b/changelogs/fragments/subelements.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - subelements - raise an error when an empty subelements is provided (https://github.com/ansible/ansible/issues/87398).

--- a/changelogs/fragments/subelements.yml
+++ b/changelogs/fragments/subelements.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-    - subelements - raise an error when an empty subelements is provided (https://github.com/ansible/ansible/issues/87398).
+    - subelements - fix error message when an empty subelements is provided (https://github.com/ansible/ansible/issues/87398).

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -564,7 +564,7 @@ def subelements(obj, subelement_obj, skip_missing=False):
         raise AnsibleFilterError('obj must be a list of dicts or a nested dict')
 
     if isinstance(subelement_obj, list):
-        subelement_list = subelements[:]
+        subelement_list = subelement_obj[:]
     elif isinstance(subelement_obj, str):
         subelement_list = subelement_obj.split('.')
     else:

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -563,15 +563,15 @@ def subelements(obj, subelements, skip_missing=False):
     else:
         raise AnsibleFilterError('obj must be a list of dicts or a nested dict')
 
+    if not subelements:
+        raise AnsibleFilterError('subelements must not be empty')
+
     if isinstance(subelements, list):
         subelement_list = subelements[:]
     elif isinstance(subelements, str):
         subelement_list = subelements.split('.')
     else:
         raise AnsibleTypeError('subelements must be a list or a string')
-
-    if not subelement_list:
-        raise AnsibleFilterError('subelements must not be empty')
 
     results = []
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -590,7 +590,6 @@ def subelements(obj, subelements, skip_missing=False):
             else:
                 raise AnsibleTypeError("The subelement is empty")
 
-
         for value in values:
             results.append((element, value))
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -547,7 +547,7 @@ def flatten(mylist, levels=None, skip_nulls=True):
     return ret
 
 
-def subelements(obj, subelements, skip_missing=False):
+def subelements(obj, subelement_obj, skip_missing=False):
     """Accepts a dict or list of dicts, and a dotted accessor and produces a product
     of the element and the results of the dotted accessor
 
@@ -563,12 +563,12 @@ def subelements(obj, subelements, skip_missing=False):
     else:
         raise AnsibleFilterError('obj must be a list of dicts or a nested dict')
 
-    if isinstance(subelements, list):
+    if isinstance(subelement_obj, list):
         subelement_list = subelements[:]
-    elif isinstance(subelements, str):
-        subelement_list = subelements.split('.')
+    elif isinstance(subelement_obj, str):
+        subelement_list = subelement_obj.split('.')
     else:
-        raise AnsibleTypeError('subelements must be a list or a string')
+        raise AnsibleTypeError('subelements must be a list or a string, got {type(subelement_obj)}')
 
     results = []
 
@@ -581,14 +581,15 @@ def subelements(obj, subelements, skip_missing=False):
                 if skip_missing:
                     values = []
                     break
-                raise AnsibleFilterError("could not find %r key in iterated item %r" % (subelement, values))
+                raise AnsibleFilterError(f"could not find {subelement!r} key in iterated item {values!r}")
             except TypeError as ex:
-                raise AnsibleTypeError("the key '%s' should point to a dictionary, got '%s'" % (subelement, values)) from ex
+                raise AnsibleTypeError(f"the key {subelement!r} should point to a dictionary, got {values!r}") from ex
         if not isinstance(values, list):
             if subelement_list:
-                raise AnsibleTypeError("the key %r should point to a list, got %r" % (subelement, values))
+                raise AnsibleTypeError(f"the key {subelement!r} should point to a list, got {values!r}")
             else:
-                raise AnsibleTypeError("The subelement is empty")
+                raise AnsibleTypeError(f"Subelements in the object must be a list, got {type(values)}."
+                                       "A list cannot be extracted, because subelements is empty.")
 
         for value in values:
             results.append((element, value))

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -570,6 +570,9 @@ def subelements(obj, subelements, skip_missing=False):
     else:
         raise AnsibleTypeError('subelements must be a list or a string')
 
+    if not subelement_list:
+        raise AnsibleFilterError('subelements must not be empty')
+
     results = []
 
     for element in element_list:

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -568,7 +568,7 @@ def subelements(obj, subelement_obj, skip_missing=False):
     elif isinstance(subelement_obj, str):
         subelement_list = subelement_obj.split('.')
     else:
-        raise AnsibleTypeError('subelements must be a list or a string, got {type(subelement_obj)}')
+        raise AnsibleTypeError(f'subelements must be a list or a string, got {type(subelement_obj)}')
 
     results = []
 
@@ -588,7 +588,7 @@ def subelements(obj, subelement_obj, skip_missing=False):
             if subelement_list:
                 raise AnsibleTypeError(f"the key {subelement!r} should point to a list, got {values!r}")
             else:
-                raise AnsibleTypeError(f"Subelements in the object must be a list, got {type(values)}."
+                raise AnsibleTypeError(f"Subelements in the object must be a list, got {type(values)}. "
                                        "A list cannot be extracted, because subelements is empty.")
 
         for value in values:

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -563,9 +563,6 @@ def subelements(obj, subelements, skip_missing=False):
     else:
         raise AnsibleFilterError('obj must be a list of dicts or a nested dict')
 
-    if not subelements:
-        raise AnsibleFilterError('subelements must not be empty')
-
     if isinstance(subelements, list):
         subelement_list = subelements[:]
     elif isinstance(subelements, str):
@@ -586,9 +583,13 @@ def subelements(obj, subelements, skip_missing=False):
                     break
                 raise AnsibleFilterError("could not find %r key in iterated item %r" % (subelement, values))
             except TypeError as ex:
-                raise AnsibleTypeError("the key %s should point to a dictionary, got '%s'" % (subelement, values)) from ex
+                raise AnsibleTypeError("the key '%s' should point to a dictionary, got '%s'" % (subelement, values)) from ex
         if not isinstance(values, list):
-            raise AnsibleTypeError("the key %r should point to a list, got %r" % (subelement, values))
+            if subelement_list:
+                raise AnsibleTypeError("the key %r should point to a list, got %r" % (subelement, values))
+            else:
+                raise AnsibleTypeError("The subelement is empty")
+
 
         for value in values:
             results.append((element, value))

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -708,12 +708,6 @@
   ignore_errors: yes
   register: subelements_7
 
-- name: Verify subelements throws on empty obj
-  set_fact:
-    foo: '{{[] | subelements("groups")}}'
-  ignore_errors: yes
-  register: subelements_8
-
 - name: Verify subelements
   assert:
     that:
@@ -731,10 +725,10 @@
       - 'subelements_demo|subelements("groups") == [({"name": "alice", "groups": ["wheel"], "authorized": ["/tmp/alice/onekey.pub"]}, "wheel")]'
       - 'subelements_demo|subelements(["groups"]) == [({"name": "alice", "groups": ["wheel"], "authorized": ["/tmp/alice/onekey.pub"]}, "wheel")]'
       - subelements_6 is failed
-      - '"subelements must not be empty" in subelements_6.msg'
+      - '"The subelement is empty" in subelements_6.msg'
       - subelements_7 is failed
-      - '"subelements must not be empty" in subelements_7.msg'
-      - not subelements_8.failed
+      - '"could not find" in subelements_7.msg'
+      - '[] | subelements("groups") == []'
 
 - name: Verify dict2items throws on non-Mapping
   set_fact:

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -696,6 +696,12 @@
   ignore_errors: yes
   register: subelements_5
 
+- name: Verify subelements throws on empty list
+  set_fact:
+    foo: '{{subelements_demo | subelements([])}}'
+  ignore_errors: yes
+  register: subelements_6
+
 - name: Verify subelements
   assert:
     that:
@@ -712,7 +718,8 @@
       - '"should point to a dictionary" in subelements_5.msg'
       - 'subelements_demo|subelements("groups") == [({"name": "alice", "groups": ["wheel"], "authorized": ["/tmp/alice/onekey.pub"]}, "wheel")]'
       - 'subelements_demo|subelements(["groups"]) == [({"name": "alice", "groups": ["wheel"], "authorized": ["/tmp/alice/onekey.pub"]}, "wheel")]'
-
+      - subelements_6 is failed
+      - '"subelements must not be empty" in subelements_6.msg'
 
 - name: Verify dict2items throws on non-Mapping
   set_fact:

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -725,7 +725,7 @@
       - 'subelements_demo|subelements("groups") == [({"name": "alice", "groups": ["wheel"], "authorized": ["/tmp/alice/onekey.pub"]}, "wheel")]'
       - 'subelements_demo|subelements(["groups"]) == [({"name": "alice", "groups": ["wheel"], "authorized": ["/tmp/alice/onekey.pub"]}, "wheel")]'
       - subelements_6 is failed
-      - '"The subelement is empty" in subelements_6.msg'
+      - '"subelements is empty" in subelements_6.msg'
       - subelements_7 is failed
       - '"could not find" in subelements_7.msg'
       - '[] | subelements("groups") == []'

--- a/test/integration/targets/filter_core/tasks/main.yml
+++ b/test/integration/targets/filter_core/tasks/main.yml
@@ -702,6 +702,18 @@
   ignore_errors: yes
   register: subelements_6
 
+- name: Verify subelements throws on empty subelements
+  set_fact:
+    foo: '{{subelements_demo | subelements("")}}'
+  ignore_errors: yes
+  register: subelements_7
+
+- name: Verify subelements throws on empty obj
+  set_fact:
+    foo: '{{[] | subelements("groups")}}'
+  ignore_errors: yes
+  register: subelements_8
+
 - name: Verify subelements
   assert:
     that:
@@ -720,6 +732,9 @@
       - 'subelements_demo|subelements(["groups"]) == [({"name": "alice", "groups": ["wheel"], "authorized": ["/tmp/alice/onekey.pub"]}, "wheel")]'
       - subelements_6 is failed
       - '"subelements must not be empty" in subelements_6.msg'
+      - subelements_7 is failed
+      - '"subelements must not be empty" in subelements_7.msg'
+      - not subelements_8.failed
 
 - name: Verify dict2items throws on non-Mapping
   set_fact:


### PR DESCRIPTION
##### SUMMARY

* Instead of raising UnboundError exception, fail with appropriate
  error for empty subelements.

Fixes: #87398

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/subelements.yml
lib/ansible/plugins/filter/core.py
test/integration/targets/filter_core/tasks/main.yml


