### PR TITLE
Add timeout to pause with prompts

### DIFF
--- a/changelogs/fragments/30116-pause-timeout-seconds.yml
+++ b/changelogs/fragments/30116-pause-timeout-seconds.yml
@@ -1,8 +1,8 @@
 minor_changes:
-  - pause - add ``timeout_seconds`` parameter that allows an interactive prompt to accept
+  - "pause - add ``timeout_seconds`` parameter that allows an interactive prompt to accept
     user input while enforcing a hard deadline, and ``timeout_action`` parameter (``continue``
     or ``abort``) that controls what happens when the deadline expires.
     When ``timeout_seconds`` is set, ``timed_out`` is always present in the result (``false``
     when the user responds in time, ``true`` when the timer fires); ``timeout_action: abort``
     raises a fatal error, while the default ``timeout_action: continue`` resumes the play
-    with an empty ``user_input`` (https://github.com/ansible/ansible/issues/30116).
+    with an empty ``user_input`` (https://github.com/ansible/ansible/issues/30116)."

--- a/changelogs/fragments/30116-pause-timeout-seconds.yml
+++ b/changelogs/fragments/30116-pause-timeout-seconds.yml
@@ -1,0 +1,8 @@
+minor_changes:
+  - pause - add ``timeout_seconds`` parameter that allows an interactive prompt to accept
+    user input while enforcing a hard deadline, and ``timeout_action`` parameter (``continue``
+    or ``abort``) that controls what happens when the deadline expires.
+    When ``timeout_seconds`` is set, ``timed_out`` is always present in the result (``false``
+    when the user responds in time, ``true`` when the timer fires); ``timeout_action: abort``
+    raises a fatal error, while the default ``timeout_action: continue`` resumes the play
+    with an empty ``user_input`` (https://github.com/ansible/ansible/issues/30116).

--- a/lib/ansible/modules/pause.py
+++ b/lib/ansible/modules/pause.py
@@ -35,14 +35,33 @@ options:
     description:
       - Controls whether or not keyboard input is shown when typing.
       - Only has effect if neither O(seconds) nor O(minutes) are set.
+        When O(timeout_seconds) is used, input is always echoed regardless of this setting.
     type: bool
     default: 'yes'
     version_added: 2.5
+  timeout_seconds:
+    description:
+      - Maximum number of seconds to wait for user input at an interactive prompt.
+      - When the timeout expires with no input, the action specified by O(timeout_action) is taken.
+      - User input is still accepted and returned during the countdown, unlike O(seconds) and O(minutes) which discard all key presses.
+      - Mutually exclusive with O(seconds) and O(minutes).
+    type: int
+    version_added: "2.22"
+  timeout_action:
+    description:
+      - The action to take when O(timeout_seconds) elapses before the user presses Enter.
+      - V(continue) resumes playbook execution with an empty RV(user_input).
+      - V(abort) raises a fatal error and stops the playbook run.
+      - Only meaningful when O(timeout_seconds) is set.
+    type: str
+    choices: ['continue', 'abort']
+    default: 'continue'
+    version_added: "2.22"
 author: "Tim Bielawa (@tbielawa)"
 extends_documentation_fragment:
-  -  action_common_attributes
-  -  action_common_attributes.conn
-  -  action_common_attributes.flow
+  - action_common_attributes
+  - action_common_attributes.conn
+  - action_common_attributes.flow
 attributes:
     action:
         support: full
@@ -64,7 +83,8 @@ attributes:
         platforms: all
 notes:
       - Starting in 2.2, if you specify 0 or negative for minutes or seconds, it will wait for 1 second, previously it would wait indefinitely.
-      - User input is not captured or echoed, regardless of echo setting, when minutes or seconds is specified.
+      - User input is not captured or echoed, regardless of echo setting, when O(minutes) or O(seconds) is specified.
+        This does not apply to O(timeout_seconds), where input is always captured and echoed.
 """
 
 EXAMPLES = """
@@ -83,14 +103,30 @@ EXAMPLES = """
   ansible.builtin.pause:
     prompt: "Enter a secret"
     echo: no
+
+- name: Pause for user input with a 30-second timeout, continuing automatically on expiry
+  ansible.builtin.pause:
+    prompt: "Enter the target hostname (auto-continues in 30s)"
+    timeout_seconds: 30
+
+- name: Pause for user input with a 60-second timeout, aborting the run on expiry
+  ansible.builtin.pause:
+    prompt: "Confirm deployment target (abort if no answer in 60s)"
+    timeout_seconds: 60
+    timeout_action: abort
 """
 
 RETURN = """
 user_input:
-  description: User input from interactive console
-  returned: if no waiting time set
+  description: User input from interactive console. Empty string when O(timeout_seconds) elapses with no input.
+  returned: when neither O(seconds) nor O(minutes) is specified, or when O(timeout_seconds) is used
   type: str
   sample: Example user input
+timed_out:
+  description: Whether the prompt timed out before the user pressed Enter.
+  returned: when O(timeout_seconds) is set
+  type: bool
+  sample: false
 start:
   description: Time when started pausing
   returned: always

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -46,9 +46,13 @@ class ActionModule(ActionBase):
                 'minutes': {'type': int},  # Don't break backwards compat, allow floats, by using int callable
                 'seconds': {'type': int},  # Don't break backwards compat, allow floats, by using int callable
                 'prompt': {'type': 'str'},
+                'timeout_seconds': {'type': 'int'},
+                'timeout_action': {'type': 'str', 'default': 'continue', 'choices': ['continue', 'abort']},
             },
             mutually_exclusive=(
                 ('minutes', 'seconds'),
+                ('minutes', 'timeout_seconds'),
+                ('seconds', 'timeout_seconds'),
             ),
         )
 
@@ -57,6 +61,8 @@ class ActionModule(ActionBase):
         seconds = None
         echo = new_module_args['echo']
         echo_prompt = ''
+        timeout_seconds = new_module_args['timeout_seconds']
+        timeout_action = new_module_args['timeout_action']
         result.update(dict(
             changed=False,
             rc=0,
@@ -68,8 +74,9 @@ class ActionModule(ActionBase):
             echo=echo
         ))
 
-        # Add a note saying the output is hidden if echo is disabled
-        if not echo:
+        # Add a note saying the output is hidden if echo is disabled.
+        # timeout_seconds always echoes input, so the suffix is suppressed in that path.
+        if not echo and new_module_args['timeout_seconds'] is None:
             echo_prompt = ' (output is hidden)'
 
         if new_module_args['prompt']:
@@ -89,7 +96,7 @@ class ActionModule(ActionBase):
 
         start = time.time()
         result['start'] = to_text(datetime.datetime.now())
-        result['user_input'] = b''
+        result['user_input'] = ''
 
         default_input_complete = None
         if seconds is not None:
@@ -109,23 +116,46 @@ class ActionModule(ActionBase):
             # don't complete on LF/CR; we expect a timeout/interrupt and ignore user input when a pause duration is specified
             default_input_complete = tuple()
 
-        # Only echo input if no timeout is specified
+        # Only echo input if no timed countdown is specified (seconds/minutes path).
+        # timeout_seconds always echoes input regardless of the echo task arg.
         echo = seconds is None and echo
 
+        # user_input is bytes here because prompt_until returns bytes; to_text() at line 176
+        # converts it to str before it reaches the result dict.
         user_input = b''
-        try:
-            _user_input = display.prompt_until(prompt, private=not echo, seconds=seconds, complete_input=default_input_complete)
-        except AnsiblePromptInterrupt:
-            user_input = None
-        except AnsiblePromptNoninteractive:
-            if seconds is None:
-                display.warning("Not waiting for response to prompt as stdin is not interactive")
-            else:
-                # wait specified duration
-                time.sleep(seconds)
-        else:
-            if seconds is None:
+        timed_out = False
+        if timeout_seconds is not None:
+            # Hard-deadline interactive prompt: accept user input and return it, expiring after timeout_seconds.
+            if timeout_seconds < 1:
+                timeout_seconds = 1
+            try:
+                _prompt_start = time.time()
+                # timeout_seconds always echoes input (private=False), regardless of the echo task arg.
+                _user_input = display.prompt_until(prompt, private=False, seconds=timeout_seconds)
+                # Disambiguate empty-input-on-timeout from the user pressing Enter immediately:
+                # both return b'', but a genuine timeout takes at least timeout_seconds to elapse.
+                if _user_input == b'' and (time.time() - _prompt_start) >= timeout_seconds:
+                    timed_out = True
                 user_input = _user_input
+            except AnsiblePromptInterrupt:
+                user_input = None
+            except AnsiblePromptNoninteractive:
+                display.warning("Not waiting for response to prompt as stdin is not interactive")
+        else:
+            try:
+                _user_input = display.prompt_until(prompt, private=not echo, seconds=seconds, complete_input=default_input_complete)
+            except AnsiblePromptInterrupt:
+                user_input = None
+            except AnsiblePromptNoninteractive:
+                if seconds is None:
+                    display.warning("Not waiting for response to prompt as stdin is not interactive")
+                else:
+                    # wait specified duration
+                    time.sleep(seconds)
+            else:
+                if seconds is None:
+                    user_input = _user_input
+
         # user interrupt
         if user_input is None:
             prompt = "Press 'C' to continue the play or 'A' to abort \r"
@@ -133,6 +163,11 @@ class ActionModule(ActionBase):
                 user_input = display.prompt_until(prompt, private=not echo, interrupt_input=(b'a',), complete_input=(b'c',))
             except AnsiblePromptInterrupt:
                 raise AnsibleError('user requested abort!')
+            # timed_out is False here: an interrupt means the user was present, not that the timer fired.
+
+        # Abort the play if the timeout fired and the task is configured to abort.
+        if timed_out and timeout_action == 'abort':
+            raise AnsibleError('Timed out waiting for user input after %d seconds' % timeout_seconds)
 
         duration = time.time() - start
         result['stop'] = to_text(datetime.datetime.now())
@@ -144,4 +179,6 @@ class ActionModule(ActionBase):
             duration = round(duration, 2)
         result['stdout'] = "Paused for %s %s" % (duration, duration_unit)
         result['user_input'] = to_text(user_input, errors='surrogate_or_strict')
+        if timeout_seconds is not None:
+            result['timed_out'] = timed_out
         return result

--- a/test/integration/targets/pause/pause-10.yml
+++ b/test/integration/targets/pause/pause-10.yml
@@ -1,0 +1,22 @@
+- name: Test pause module with timeout_seconds and timeout_action=abort - abort on expiry
+  hosts: localhost
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: Prompt that will abort on timeout (this task is expected to fail)
+      pause:
+        prompt: Enter a value or the play will abort
+        timeout_seconds: 2
+        timeout_action: abort
+      register: abort_pause
+      ignore_errors: yes
+
+    - name: Verify the task failed with a timeout message
+      assert:
+        that:
+          - abort_pause is failed
+          - "'Timed out waiting for user input' in abort_pause.msg"
+
+    - debug:
+        msg: Task after abort pause

--- a/test/integration/targets/pause/pause-11.yml
+++ b/test/integration/targets/pause/pause-11.yml
@@ -1,0 +1,14 @@
+- name: Test pause module with timeout_seconds - ctrl+c handling
+  hosts: localhost
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: Prompt with a long timeout (used for ctrl+c tests)
+      pause:
+        prompt: Enter a value with timeout
+        timeout_seconds: 30
+      register: timeout_pause
+
+    - debug:
+        msg: Task after pause

--- a/test/integration/targets/pause/pause-7.yml
+++ b/test/integration/targets/pause/pause-7.yml
@@ -1,0 +1,20 @@
+- name: Test pause module with timeout_seconds - user answers in time
+  hosts: localhost
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: Prompt with a long timeout (user will answer before expiry)
+      pause:
+        prompt: Enter a value with timeout
+        timeout_seconds: 30
+      register: timeout_pause
+
+    - name: Verify timed_out is False when user answered
+      assert:
+        that:
+          - timeout_pause.timed_out is false
+          - timeout_pause.user_input == 'hello timeout'
+
+    - debug:
+        msg: Task after pause

--- a/test/integration/targets/pause/pause-8.yml
+++ b/test/integration/targets/pause/pause-8.yml
@@ -1,0 +1,20 @@
+- name: Test pause module with timeout_seconds - timeout fires with no input
+  hosts: localhost
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: Prompt that will time out (very short deadline, no input sent)
+      pause:
+        prompt: Enter a value or wait for timeout
+        timeout_seconds: 2
+      register: timeout_pause
+
+    - name: Verify timed_out is True and user_input is empty
+      assert:
+        that:
+          - timeout_pause.timed_out is true
+          - timeout_pause.user_input == ''
+
+    - debug:
+        msg: Task after timeout pause

--- a/test/integration/targets/pause/pause-9.yml
+++ b/test/integration/targets/pause/pause-9.yml
@@ -1,0 +1,20 @@
+- name: Test pause module with timeout_seconds - user presses Enter immediately (not a timeout)
+  hosts: localhost
+  become: no
+  gather_facts: no
+
+  tasks:
+    - name: Prompt with long timeout, user presses Enter immediately
+      pause:
+        prompt: Press Enter to continue
+        timeout_seconds: 30
+      register: enter_pause
+
+    - name: Verify timed_out is False when user pressed Enter with empty input
+      assert:
+        that:
+          - enter_pause.timed_out is false
+          - enter_pause.user_input == ''
+
+    - debug:
+        msg: Task after enter pause

--- a/test/integration/targets/pause/test-pause.py
+++ b/test/integration/targets/pause/test-pause.py
@@ -306,3 +306,130 @@ pause_test.expect(r"\(ctrl\+C then 'C' = continue early, ctrl\+C then 'A' = abor
 pause_test.send('\r')
 pause_test.expect(pexpect.EOF)
 pause_test.close()
+
+
+# -- timeout_seconds: timeout fires with no input (timed_out=True) --
+
+playbook = 'pause-8.yml'
+
+# Case 1 - Wait for the 2-second deadline to expire (send nothing)
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=15,
+    env=os.environ
+)
+
+pause_test.logfile = sys.stdout.buffer
+pause_test.expect(r'Enter a value or wait for timeout:')
+# Do not send any input; let the 2-second timeout fire naturally
+pause_test.expect('Task after timeout pause', timeout=15)
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+assert pause_test.exitstatus == 0
+
+
+# -- timeout_seconds: user answers before expiry (timed_out=False) --
+
+playbook = 'pause-7.yml'
+
+# Case 1 - User sends input before the 30-second deadline
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=15,
+    env=os.environ
+)
+
+pause_test.logfile = sys.stdout.buffer
+pause_test.expect(r'Enter a value with timeout:')
+pause_test.send('hello timeout')
+pause_test.send('\r')
+pause_test.expect('Task after pause', timeout=10)
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+assert pause_test.exitstatus == 0
+
+
+# -- timeout_seconds: user presses Enter immediately (empty input, timed_out=False) --
+
+playbook = 'pause-9.yml'
+
+# Case 1 - User presses Enter right away; this must NOT set timed_out=True
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = sys.stdout.buffer
+pause_test.expect(r'Press Enter to continue:')
+pause_test.send('\r')
+pause_test.expect('Task after enter pause', timeout=10)
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+assert pause_test.exitstatus == 0
+
+
+# -- timeout_seconds + timeout_action=abort: abort on expiry --
+
+playbook = 'pause-10.yml'
+
+# Case 1 - Let the 2-second deadline fire; the ignored error is caught and asserted in the playbook.
+# ignore_errors: yes on the pause task catches the AnsibleError raised by the action plugin,
+# allowing the subsequent assert and debug tasks to run and the play to exit 0.
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=[playbook] + args,
+    timeout=15,
+    env=os.environ
+)
+
+pause_test.logfile = sys.stdout.buffer
+pause_test.expect(r'Enter a value or the play will abort:')
+# Do not send any input; let the timeout fire
+pause_test.expect('Task after abort pause', timeout=15)
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+assert pause_test.exitstatus == 0
+
+
+# -- timeout_seconds: Ctrl+C then Continue --
+
+# Case 1 - Ctrl+C during timeout_seconds prompt, then press C to continue
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=['pause-11.yml'] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = sys.stdout.buffer
+pause_test.expect(r'Enter a value with timeout:')
+pause_test.send('\x03')
+pause_test.expect("Press 'C' to continue the play or 'A' to abort")
+pause_test.send('C')
+pause_test.expect('Task after pause')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+assert pause_test.exitstatus == 0
+
+
+# Case 2 - Ctrl+C during timeout_seconds prompt, then press A to abort
+pause_test = pexpect.spawn(
+    'ansible-playbook',
+    args=['pause-11.yml'] + args,
+    timeout=10,
+    env=os.environ
+)
+
+pause_test.logfile = sys.stdout.buffer
+pause_test.expect(r'Enter a value with timeout:')
+pause_test.send('\x03')
+pause_test.expect("Press 'C' to continue the play or 'A' to abort")
+pause_test.send('A')
+pause_test.expect('user requested abort!')
+pause_test.expect(pexpect.EOF)
+pause_test.close()
+assert pause_test.exitstatus != 0

--- a/test/units/plugins/action/test_pause.py
+++ b/test/units/plugins/action/test_pause.py
@@ -203,7 +203,6 @@ def test_timeout_seconds_echo_false_does_not_append_hidden_suffix(mocker, action
     assert prompt_mock.call_args.kwargs.get('private') is False
 
 
-
 @pytest.mark.parametrize('task_args', [{'seconds': 10, 'timeout_seconds': 5}], indirect=True)
 def test_seconds_and_timeout_seconds_mutually_exclusive(mocker, action_plugin):
     """seconds and timeout_seconds must not be used together."""

--- a/test/units/plugins/action/test_pause.py
+++ b/test/units/plugins/action/test_pause.py
@@ -1,0 +1,224 @@
+# Copyright (c) 2026 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Tests for the pause action plugin."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ansible.errors import AnsibleActionFail, AnsibleError, AnsiblePromptInterrupt, AnsiblePromptNoninteractive
+from ansible.playbook.task import Task
+from ansible.plugins.action.pause import ActionModule as PauseAction
+
+
+@pytest.fixture
+def task_args(request):
+    """Return playbook task args."""
+    return getattr(request, 'param', {})
+
+
+@pytest.fixture
+def module_task(task_args):
+    """Construct a task object for pause."""
+    task = MagicMock(spec=Task)
+    task.action = 'pause'
+    task.args = task_args
+    task.async_val = False
+    task.check_mode = False
+    task.diff = False
+    task.get_name.return_value = 'pause'
+    return task
+
+
+@pytest.fixture
+def play_context():
+    """Construct a play context."""
+    ctx = MagicMock()
+    ctx.check_mode = False
+    return ctx
+
+
+@pytest.fixture
+def action_plugin(play_context, module_task):
+    """Initialize a pause action plugin with a fully mocked connection."""
+    connection = MagicMock()
+    return PauseAction(
+        module_task,
+        connection,
+        play_context,
+        loader=None,
+        templar=None,
+        shared_loader_obj=None,
+    )
+
+
+@pytest.mark.parametrize('task_args', [{'timeout_seconds': 30}], indirect=True)
+def test_timeout_seconds_continue_on_expiry(mocker, action_plugin):
+    """When timeout_seconds fires with no input, timed_out=True and user_input is empty (continue mode)."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    mocker.patch('ansible.plugins.action.pause.display.prompt_until', return_value=b'')
+    # Simulate elapsed time >= timeout_seconds so the empty return is treated as a real timeout,
+    # not as the user pressing Enter immediately.
+    # Call order in run(): (1) start=time.time(), (2) _prompt_start=time.time(),
+    # (3) time.time()-_prompt_start [timeout check], (4) duration=time.time()-start.
+    mocker.patch('ansible.plugins.action.pause.time.time', side_effect=[0.0, 0.0, 31.0, 32.0])
+
+    result = action_plugin.run(task_vars={})
+
+    assert result['timed_out'] is True
+    assert result['user_input'] == ''
+    assert 'failed' not in result or not result['failed']
+
+
+@pytest.mark.parametrize('task_args', [{'timeout_seconds': 30}], indirect=True)
+def test_timeout_seconds_user_responds_in_time(mocker, action_plugin):
+    """When the user enters text before timeout_seconds, timed_out=False."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    mocker.patch('ansible.plugins.action.pause.display.prompt_until', return_value=b'my answer')
+
+    result = action_plugin.run(task_vars={})
+
+    assert result['timed_out'] is False
+    assert result['user_input'] == 'my answer'
+    assert 'failed' not in result or not result['failed']
+
+
+@pytest.mark.parametrize('task_args', [{'timeout_seconds': 30, 'timeout_action': 'abort'}], indirect=True)
+def test_timeout_seconds_abort_on_expiry(mocker, action_plugin):
+    """When timeout fires and timeout_action=abort, an AnsibleError is raised."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    mocker.patch('ansible.plugins.action.pause.display.prompt_until', return_value=b'')
+    # Simulate elapsed time >= timeout_seconds so the empty return is treated as a real timeout.
+    # Call order in run(): (1) start=time.time(), (2) _prompt_start=time.time(),
+    # (3) time.time()-_prompt_start [timeout check]. AnsibleError is raised before call (4).
+    mocker.patch('ansible.plugins.action.pause.time.time', side_effect=[0.0, 0.0, 31.0])
+
+    with pytest.raises(AnsibleError, match='Timed out waiting for user input'):
+        action_plugin.run(task_vars={})
+
+
+@pytest.mark.parametrize('task_args', [{'timeout_seconds': 30, 'timeout_action': 'abort'}], indirect=True)
+def test_timeout_seconds_abort_not_triggered_when_input_given(mocker, action_plugin):
+    """When the user answers before timeout, abort action is NOT triggered even when timeout_action=abort."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    mocker.patch('ansible.plugins.action.pause.display.prompt_until', return_value=b'hello')
+
+    result = action_plugin.run(task_vars={})
+
+    assert result['timed_out'] is False
+    assert result['user_input'] == 'hello'
+    assert 'failed' not in result or not result['failed']
+
+
+@pytest.mark.parametrize('task_args', [{'timeout_seconds': 0}], indirect=True)
+def test_timeout_seconds_minimum_one(mocker, action_plugin):
+    """timeout_seconds below 1 is clamped to 1."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    prompt_mock = mocker.patch('ansible.plugins.action.pause.display.prompt_until', return_value=b'answer')
+
+    action_plugin.run(task_vars={})
+
+    # The call should have used seconds=1 (clamped), not 0
+    call_kwargs = prompt_mock.call_args
+    assert call_kwargs.kwargs['seconds'] == 1
+
+
+@pytest.mark.parametrize('task_args', [{'timeout_seconds': 30}], indirect=True)
+def test_timeout_seconds_noninteractive_warns(mocker, action_plugin):
+    """In non-interactive mode, a warning is emitted and no error is raised."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    warn_mock = mocker.patch('ansible.plugins.action.pause.display.warning')
+    mocker.patch(
+        'ansible.plugins.action.pause.display.prompt_until',
+        side_effect=AnsiblePromptNoninteractive('not a tty'),
+    )
+
+    result = action_plugin.run(task_vars={})
+
+    warn_mock.assert_called_once()
+    assert 'failed' not in result or not result['failed']
+
+
+@pytest.mark.parametrize('task_args', [{'timeout_seconds': 30}], indirect=True)
+def test_timeout_seconds_ctrl_c_then_continue(mocker, action_plugin):
+    """Ctrl+C during a timeout_seconds prompt leads to the C/A sub-prompt; 'c' continues the play."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    mocker.patch(
+        'ansible.plugins.action.pause.display.prompt_until',
+        side_effect=[AnsiblePromptInterrupt('interrupt'), b''],
+    )
+
+    result = action_plugin.run(task_vars={})
+
+    assert 'failed' not in result or not result['failed']
+
+
+@pytest.mark.parametrize('task_args', [{'timeout_seconds': 30}], indirect=True)
+def test_timeout_seconds_ctrl_c_then_abort(mocker, action_plugin):
+    """Ctrl+C during a timeout_seconds prompt, then 'a' at sub-prompt aborts the run."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    mocker.patch(
+        'ansible.plugins.action.pause.display.prompt_until',
+        side_effect=[AnsiblePromptInterrupt('interrupt'), AnsiblePromptInterrupt('abort')],
+    )
+
+    with pytest.raises(AnsibleError, match='user requested abort'):
+        action_plugin.run(task_vars={})
+
+
+@pytest.mark.parametrize('task_args', [{'timeout_seconds': 30}], indirect=True)
+def test_timeout_seconds_present_in_result(mocker, action_plugin):
+    """timed_out key is always included in result when timeout_seconds is specified."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    mocker.patch('ansible.plugins.action.pause.display.prompt_until', return_value=b'hi')
+
+    result = action_plugin.run(task_vars={})
+
+    assert 'timed_out' in result
+
+
+@pytest.mark.parametrize('task_args', [{}], indirect=True)
+def test_no_timeout_timed_out_absent_from_result(mocker, action_plugin):
+    """timed_out key must NOT appear in result when timeout_seconds is not specified."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    mocker.patch('ansible.plugins.action.pause.display.prompt_until', return_value=b'hi')
+
+    result = action_plugin.run(task_vars={})
+
+    assert 'timed_out' not in result
+
+
+@pytest.mark.parametrize('task_args', [{'timeout_seconds': 30, 'echo': False, 'prompt': 'My prompt'}], indirect=True)
+def test_timeout_seconds_echo_false_does_not_append_hidden_suffix(mocker, action_plugin):
+    """echo: false combined with timeout_seconds must not add '(output is hidden)' to the prompt.
+    timeout_seconds always echoes input (private=False), so the suffix would be misleading."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    prompt_mock = mocker.patch('ansible.plugins.action.pause.display.prompt_until', return_value=b'answer')
+
+    action_plugin.run(task_vars={})
+
+    called_prompt = prompt_mock.call_args.args[0]
+    assert '(output is hidden)' not in called_prompt
+    assert prompt_mock.call_args.kwargs.get('private') is False
+
+
+
+@pytest.mark.parametrize('task_args', [{'seconds': 10, 'timeout_seconds': 5}], indirect=True)
+def test_seconds_and_timeout_seconds_mutually_exclusive(mocker, action_plugin):
+    """seconds and timeout_seconds must not be used together."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    mocker.patch('ansible.plugins.action.pause.display.prompt_until', return_value=b'')
+
+    with pytest.raises(AnsibleActionFail, match='mutually exclusive'):
+        action_plugin.run(task_vars={})
+
+
+@pytest.mark.parametrize('task_args', [{'minutes': 1, 'timeout_seconds': 5}], indirect=True)
+def test_minutes_and_timeout_seconds_mutually_exclusive(mocker, action_plugin):
+    """minutes and timeout_seconds must not be used together."""
+    mocker.patch('ansible.plugins.action.pause.display.display')
+    mocker.patch('ansible.plugins.action.pause.display.prompt_until', return_value=b'')
+
+    with pytest.raises(AnsibleActionFail, match='mutually exclusive'):
+        action_plugin.run(task_vars={})


### PR DESCRIPTION


##### SUMMARY

While developing an Ansible playbook, I would like to have a task conditionally run based on a user input. However, if the user does not reply within a given amount I would like the playbook to just exit without executing the conditional action. I was surprised to learn that there was not a good way to do this within Ansible. Specifically, within pause if the minutes or seconds parameters have been set, any user inputs are ignored. I believe vars_prompt also does not work since I would like the user input to be collected after templating a message.
This limitation has existed for some time as #30116 is from 2017. Reading through the comments it seems to me that @tbielawa proposed a reasonable solution. I have worked to implement the solution as they described it. 
> So specifically, are you requesting that if the default prompt mechanism is used, one without seconds or minutes set, you want that to expire after a set period of time? I think that kind of functionality would require (at least) two new parameters in the module
> - timeout_seconds (int) - The number of seconds to wait on a non-timed prompt before the action given in timeout_action is taken.
> - timeout_action (string one of continue or abort) - The action to take on pause tasks after timeout_seconds has passed and no seconds or minutes parameters are set. continue will automatically resume the run, abort will stop the entire operation. Mutually exclusive with the seconds and minutes parameters.

Fixes #30116 

Development aided by IBM Bob 2.0

##### ISSUE TYPE

- Feature Pull Request
