### PR TITLE
fix: copy facts dict before caching to prevent cross-host variable aliasing

### DIFF
--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -581,7 +581,7 @@ class VariableManager:
             host_cache = self._fact_cache.get(host)
         except KeyError:
             # We get to set this as new
-            host_cache = facts
+            host_cache = dict(facts)  # copy to avoid aliasing shared facts dicts across hosts
         else:
             if not isinstance(host_cache, MutableMapping):
                 raise TypeError('The object retrieved for {0} must be a MutableMapping but was'
@@ -605,7 +605,7 @@ class VariableManager:
         try:
             self._nonpersistent_fact_cache[host] |= facts
         except KeyError:
-            self._nonpersistent_fact_cache[host] = facts
+            self._nonpersistent_fact_cache[host] = dict(facts)  # copy to avoid aliasing shared facts dicts across hosts
 
     def set_host_variable(self, host, varname, value):
         """


### PR DESCRIPTION
## Fix ansible_facts cross-host aliasing via register_host_variables

When `set_host_facts()` creates a new cache entry for a host (KeyError branch), it stores the caller's `facts` dict reference directly via `host_cache = facts`. If the strategy's `_process_pending_results` fans out the same `register_host_variables[CACHEABLE_FACT]` dict to multiple target hosts (via the `for target_host in potentially_delegated_host_list` loop), all those hosts share the same dict object.

On subsequent `set_host_facts()` calls for any of those hosts, the in-place merge `host_cache |= facts` mutates the shared object, contaminating every other host's cached facts.

**Fix**: copy the `facts` dict before storing it in the cache in both `set_host_facts()` and `set_nonpersistent_facts()`, preventing aliasing.

### Related Issue
Closes #87415

### Impact
- Only affects tasks where `register_host_variables` is called with the same dict reference for multiple hosts (run_once, delegate_facts, or parallel result processing)
- The implicit `ansible_facts` mechanism (CACHEABLE_FACT layer) is most affected; the `register:` workaround avoids this path entirely
