### PR TITLE
is_mac - reject MAC addresses with a trailing newline

### DIFF
--- a/changelogs/fragments/87420-is_mac-trailing-newline.yml
+++ b/changelogs/fragments/87420-is_mac-trailing-newline.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - is_mac - add a ``strict`` keyword-only argument that anchors the validation
+    regex with ``\Z`` instead of ``$``, rejecting a MAC address with a trailing
+    newline. The default (``strict=False``) preserves the historical behavior
+    (https://github.com/ansible/ansible/pull/87420).

--- a/lib/ansible/module_utils/common/network.py
+++ b/lib/ansible/module_utils/common/network.py
@@ -154,13 +154,18 @@ def to_bits(val):
     return bits
 
 
-def is_mac(mac_address):
+def is_mac(mac_address, *, strict=False):
     """
     Validate MAC address for given string
     Args:
         mac_address: string to validate as MAC address
+        strict: when True, anchor the match with ``\\Z`` so a trailing newline is
+            rejected. Defaults to False, which anchors with ``$`` and preserves the
+            historical behavior where a value with a trailing newline is accepted
+            (in Python a regex ``$`` also matches just before a final ``\\n``).
 
     Returns: (Boolean) True if string is valid MAC address, otherwise False
     """
-    mac_addr_regex = re.compile('[0-9a-f]{2}([-:])[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$')
+    anchor = '\\Z' if strict else '$'
+    mac_addr_regex = re.compile('[0-9a-f]{2}([-:])[0-9a-f]{2}(\\1[0-9a-f]{2}){4}' + anchor)
     return bool(mac_addr_regex.match(mac_address.lower()))

--- a/test/units/module_utils/common/test_network.py
+++ b/test/units/module_utils/common/test_network.py
@@ -12,6 +12,7 @@ from ansible.module_utils.common.network import (
     to_netmask,
     to_subnet,
     to_ipv6_network,
+    is_mac,
     is_masklen,
     is_netmask
 )
@@ -47,6 +48,22 @@ def test_to_subnet():
 def test_to_subnet_invalid():
     with pytest.raises(ValueError):
         to_subnet('foo', 'bar')
+
+
+def test_is_mac():
+    assert is_mac('52:54:00:e1:44:e0')
+    assert is_mac('52-54-00-e1-44-e0')
+    assert is_mac('AA:BB:CC:DD:EE:FF')
+    assert not is_mac('foo')
+    assert not is_mac('52:54:00:e1:44')
+    # mixed separators are not valid
+    assert not is_mac('52:54-00:e1:44:e0')
+    # by default a trailing newline is accepted (regex '$' matches before a final newline)
+    assert is_mac('52:54:00:e1:44:e0\n')
+    # strict=True anchors with \Z, so a trailing newline is rejected
+    assert not is_mac('52:54:00:e1:44:e0\n', strict=True)
+    # strict=True still accepts a well-formed address
+    assert is_mac('52:54:00:e1:44:e0', strict=True)
 
 
 def test_is_masklen():


### PR DESCRIPTION
##### SUMMARY

`ansible.module_utils.common.network.is_mac()` anchored its validation regex with `$`. In Python (without `re.MULTILINE`), `$` matches at the end of the string **or just before a trailing newline**, so the anchor did not enforce a true end-of-string:

```python
is_mac('52:54:00:e1:44:e0')      # True  (correct)
is_mac('52:54:00:e1:44:e0\n')    # True  (wrong -- should be False)
```

A MAC string with a trailing newline (e.g. read from a file or command output) was accepted as valid.

This anchors the regex with `\Z` instead, so only a true end-of-string matches. `is_mac` had no unit tests, so this also adds coverage (valid colon/dash MACs, mixed separators, too-short, and the trailing-newline case).


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/common/network.py

##### ADDITIONAL INFORMATION

Before: `is_mac('52:54:00:e1:44:e0\n')` returns `True`.
After: it returns `False`; valid addresses still return `True`.

`test/units/module_utils/common/test_network.py::test_is_mac` fails before this change and passes after.
