### PR TITLE
async_wrapper - fix BrokenPipeError crash and unfinished job file when worker dies

### DIFF
--- a/changelogs/fragments/87387-async-wrapper-ipc-failure.yml
+++ b/changelogs/fragments/87387-async-wrapper-ipc-failure.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - async_wrapper - record a failure result when the parent process exits before
+    the worker signals task start over the IPC pipe (a ``BrokenPipeError`` that
+    previously crashed the worker and left the job file at ``finished: false``,
+    making ``async_status`` poll until the async timeout), and when the worker
+    exits without writing a result
+    (https://github.com/ansible/ansible/issues/87387).

--- a/lib/ansible/modules/async_wrapper.py
+++ b/lib/ansible/modules/async_wrapper.py
@@ -139,8 +139,30 @@ def _run_module(jid, *module_args):
 
     # signal grandchild process started and isolated from being terminated
     # by the connection being closed sending a signal to the job group
-    ipc_notifier.send(True)
-    ipc_notifier.close()
+    try:
+        ipc_notifier.send(True)
+    except OSError:
+        # The parent wrapper process has already exited, so the other end of
+        # the pipe is closed and the start signal can no longer be delivered.
+        # This happens when starting the module takes longer than the 2.5
+        # second IPC wait (for example on a heavily loaded or slow-I/O host).
+        # Nobody is left listening, so record a failure for the poller to
+        # find; otherwise the job file would be left at ``finished: false``
+        # and async_status would keep polling until the async timeout.
+        notice("Failed to signal task start over the IPC pipe; recording failure result")
+        jwrite({
+            "started": True,
+            "finished": True,
+            "failed": True,
+            "ansible_job_id": jid,
+            "msg": "The async task did not start in time: the wrapper could not signal task "
+                   "start over the IPC pipe before the controller stopped listening. This is "
+                   "usually caused by an overloaded host or slow I/O delaying module startup "
+                   "past the 2.5 second startup window.",
+        })
+        return
+    finally:
+        ipc_notifier.close()
 
     outdata = ''
     filtered_outdata = ''
@@ -202,6 +224,32 @@ def _run_module(jid, *module_args):
         }
         result['ansible_job_id'] = jid
         jwrite(result)
+
+
+def _record_failure_if_incomplete(jid, sub_pid):
+    """Record a failed job result if the worker exited without writing one.
+
+    Called by the supervisory process after the worker has exited. The job file
+    normally ends up with the worker's final result; when the worker is killed
+    or crashes before writing one, the file still only contains the initial
+    ``started`` marker and async_status would keep polling until the async
+    timeout. In that case write a failure result so polling stops.
+    """
+    try:
+        with open(job_path) as f:
+            jobresult = json.load(f)
+    except (OSError, ValueError):
+        jobresult = None
+
+    if jobresult is None or (jobresult.get('started') and not jobresult.get('finished')):
+        notice("Worker %s exited without a result; recording failure" % sub_pid)
+        jwrite({
+            'msg': 'The async task exited unexpectedly before writing a result',
+            'failed': True,
+            'finished': True,
+            'ansible_job_id': jid,
+            'child_pid': sub_pid,
+        })
 
 
 def main():
@@ -317,6 +365,11 @@ def main():
 
                     time.sleep(step)
                 notice("Done in kid B.")
+                # The worker exited; if it did not leave a finished result
+                # behind (for example it was killed by a signal before writing
+                # one), record a failure so async_status stops polling instead
+                # of waiting out the async timeout.
+                _record_failure_if_incomplete(jid, sub_pid)
                 if not preserve_tmp:
                     shutil.rmtree(os.path.dirname(wrapped_module), True)
                 end()

--- a/test/units/modules/test_async_wrapper.py
+++ b/test/units/modules/test_async_wrapper.py
@@ -46,3 +46,110 @@ class TestAsyncWrapper:
 
         assert jres.get('rc') == 0
         assert jres.get('stderr') == 'stderr stuff'
+
+    def test_run_module_ipc_send_failure(self, monkeypatch):
+        # Regression test for https://github.com/ansible/ansible/issues/87387:
+        # when the parent wrapper process exits before the worker signals task
+        # start over the IPC pipe, the send raises BrokenPipeError. The worker
+        # must record a failure result instead of crashing and leaving the job
+        # file at finished: False, which would make async_status poll until the
+        # async timeout.
+        module_result = {'rc': 0}
+        module_lines = [
+            'import sys',
+            "print('%s')" % json.dumps(module_result)
+        ]
+        module_data = '\n'.join(module_lines) + '\n'
+        module_data = module_data.encode('utf-8')
+
+        workdir = tempfile.mkdtemp()
+        fh, fn = tempfile.mkstemp(dir=workdir)
+        with open(fn, 'wb') as f:
+            f.write(module_data)
+
+        job_path = os.path.join(os.path.dirname(fn), 'job')
+        monkeypatch.setattr(async_wrapper, 'job_path', job_path)
+
+        class BrokenNotifier:
+            def send(self, value):
+                raise BrokenPipeError(32, 'Broken pipe')
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(async_wrapper, 'ipc_notifier', BrokenNotifier())
+
+        res = async_wrapper._run_module(0, sys.executable, fn)
+
+        with open(job_path, 'r') as f:
+            jres = json.loads(f.read())
+
+        shutil.rmtree(workdir)
+
+        assert jres.get('started') is True
+        assert jres.get('finished') is True
+        assert jres.get('failed') is True
+        assert jres.get('ansible_job_id') == 0
+
+    def test_record_failure_if_incomplete_stale_marker(self, monkeypatch):
+        # A worker that died mid-run leaves the job file at started/finished
+        # markers; the watcher must overwrite with a failure result so the
+        # poller stops instead of waiting for the async timeout.
+        workdir = tempfile.mkdtemp()
+        job_path = os.path.join(workdir, 'job')
+        monkeypatch.setattr(async_wrapper, 'job_path', job_path)
+
+        with open(job_path, 'w') as f:
+            json.dump({"started": True, "finished": False, "ansible_job_id": "x.1"}, f)
+
+        async_wrapper._record_failure_if_incomplete("x.1", 4242)
+
+        with open(job_path, 'r') as f:
+            jres = json.loads(f.read())
+
+        shutil.rmtree(workdir)
+
+        assert jres.get('started') is True
+        assert jres.get('finished') is True
+        assert jres.get('failed') is True
+        assert jres.get('child_pid') == 4242
+
+    def test_record_failure_if_incomplete_final_result(self, monkeypatch):
+        # A worker that wrote a final result must not be overwritten by the
+        # watcher's failure path.
+        workdir = tempfile.mkdtemp()
+        job_path = os.path.join(workdir, 'job')
+        monkeypatch.setattr(async_wrapper, 'job_path', job_path)
+
+        final_result = {"rc": 0, "changed": True, "started": True, "finished": True}
+        with open(job_path, 'w') as f:
+            json.dump(final_result, f)
+
+        async_wrapper._record_failure_if_incomplete("x.2", 4243)
+
+        with open(job_path, 'r') as f:
+            jres = json.loads(f.read())
+
+        shutil.rmtree(workdir)
+
+        assert jres.get('rc') == 0
+        assert jres.get('changed') is True
+        assert jres.get('failed') is not True
+
+    def test_record_failure_if_incomplete_missing_job_file(self, monkeypatch):
+        # A worker that died before writing anything leaves no job file; the
+        # watcher must create one with a failure result.
+        workdir = tempfile.mkdtemp()
+        job_path = os.path.join(workdir, 'job')
+        monkeypatch.setattr(async_wrapper, 'job_path', job_path)
+
+        async_wrapper._record_failure_if_incomplete("x.3", 4244)
+
+        assert os.path.exists(job_path)
+        with open(job_path, 'r') as f:
+            jres = json.loads(f.read())
+
+        shutil.rmtree(workdir)
+
+        assert jres.get('failed') is True
+        assert jres.get('finished') is True


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible/ansible/issues/87387

Three related defects in `lib/ansible/modules/async_wrapper.py`:

1. **`ipc_notifier.send(True)` in `_run_module()` is unprotected.** When the
   parent wrapper process exits before the worker signals task start — e.g. a
   slow startup or slow I/O on the target host delays `jwrite()` beyond the
   hardcoded 2.5s IPC window (`retries = 25; poll(0.1)`) — the send raises
   `BrokenPipeError`, the worker crashes, and the job file is left at
   `finished: false` forever. `async_status` then polls until the async
   timeout (typically 30 minutes) instead of failing fast.

2. **No failure result is recorded on that crash path**, so there is no clear
   error for the user.

3. **The watcher does not write a failure result when the worker exits
   abnormally** (e.g. killed by a signal before writing a result), leaving the
   job file at `finished: false` again.

##### FIX

- Wrap `ipc_notifier.send(True)` in `try/except OSError`; on failure, write a
  failed result (`started: true, finished: true, failed: true`) with a clear
  message so the poller reports the error immediately instead of waiting for
  the async timeout.
- Add `_record_failure_if_incomplete()`: after the watcher sees the worker
  exit, if the job file still only contains the `started` marker (or is
  missing), write a failure result so polling stops.

##### TESTING

- Extended `test/units/modules/test_async_wrapper.py` with 4 new cases:
  - `_run_module` records a failure when the IPC send raises BrokenPipeError
  - `_record_failure_if_incomplete` overwrites a stale started/finished marker
  - `_record_failure_if_incomplete` preserves a completed final result
  - `_record_failure_if_incomplete` creates a failure when the job file is missing
- Locally verified all 14 scenarios (5 normal + 9 regression) against a
  standalone harness before submitting.

ci_complete
