### PR TITLE
systemd_service: add glob support for state

### DIFF
--- a/changelogs/fragments/87365-systemd-glob-pattern-support.yml
+++ b/changelogs/fragments/87365-systemd-glob-pattern-support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - systemd_service - allow glob patterns in the ``name`` option for ``state`` operations, enabling actions on multiple matching units at once. This is useful for managing instantiated template services such as ``app@*.service`` (https://github.com/ansible/ansible/issues/87365).

--- a/lib/ansible/modules/systemd_service.py
+++ b/lib/ansible/modules/systemd_service.py
@@ -22,6 +22,10 @@ options:
             - Name of the unit. This parameter takes the name of exactly one unit to work with.
             - When no extension is given, it is implied to a C(.service) as systemd.
             - When using in a chroot environment you always need to specify the name of the unit with the extension. For example, C(crond.service).
+            - Glob patterns (C(*), C(?), C([)) may be used with O(state) to act on multiple matching units.
+              This is useful for instantiated template services such as C(app@*.service).
+              When using glob patterns, the O(enabled) and O(masked) options are not supported,
+              and the task always reports changed since idempotency checks are skipped.
         type: str
         aliases: [ service, unit ]
     state:
@@ -92,7 +96,7 @@ attributes:
 notes:
     - O(state), O(enabled), O(masked) requires O(name).
     - Before 2.4 you always required O(name).
-    - Globs are not supported in name, in other words, C(postgres*.service).
+    - Glob patterns in O(name) are supported for O(state) operations but not with O(enabled) or O(masked).
     - The service names might vary by specific OS/distribution.
     - The order of execution when having multiple properties is to first enable/disable, then mask/unmask and then deal with the service state.
       It has been reported that C(systemctl) can behave differently depending on the order of operations if you do the same manually.
@@ -149,6 +153,16 @@ EXAMPLES = """
     scope: user
   environment:
     XDG_RUNTIME_DIR: "/run/user/{{ myuid }}"
+
+- name: Restart all instances of a template service
+  ansible.builtin.systemd_service:
+    name: 'app@*.service'
+    state: restarted
+
+- name: Stop all instances of a template service
+  ansible.builtin.systemd_service:
+    name: 'app@*.service'
+    state: stopped
 """
 
 RETURN = """
@@ -363,10 +377,6 @@ def main():
     )
 
     unit = module.params['name']
-    if unit is not None:
-        for globpattern in (r"*", r"?", r"["):
-            if globpattern in unit:
-                module.fail_json(msg="This module does not currently support using glob patterns, found '%s' in service name: %s" % (globpattern, unit))
 
     systemctl = module.get_bin_path('systemctl', True)
 
@@ -411,7 +421,32 @@ def main():
             else:
                 module.fail_json(msg='failure %d during daemon-reexec: %s' % (rc, err))
 
-    if unit:
+    is_glob = unit is not None and any(c in unit for c in ('*', '?', '['))
+
+    if is_glob:
+        if module.params['enabled'] is not None:
+            module.fail_json(msg="Glob patterns in service name are not supported with the 'enabled' option.")
+        if module.params['masked'] is not None:
+            module.fail_json(msg="Glob patterns in service name are not supported with the 'masked' option.")
+
+        if module.params['state'] is not None:
+            result['state'] = module.params['state']
+
+            if module.params['state'] == 'started':
+                action = 'start'
+            elif module.params['state'] == 'stopped':
+                action = 'stop'
+            else:
+                action = module.params['state'][:-2]
+                result['state'] = 'started'
+
+            result['changed'] = True
+            if not module.check_mode:
+                (rc, out, err) = module.run_command("%s --all %s '%s'" % (systemctl, action, unit))
+                if rc != 0:
+                    module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, err))
+
+    elif unit:
         found = False
         is_initd = sysv_exists(unit)
         is_systemd = False

--- a/test/integration/targets/systemd/tasks/main.yml
+++ b/test/integration/targets/systemd/tasks/main.yml
@@ -119,6 +119,7 @@
       - systemd_enable_ssh_2 is not changed
 
 - import_tasks: test_unit_template.yml
+- import_tasks: test_glob_pattern.yml
 - import_tasks: test_indirect_service.yml
 - import_tasks: test_enabled_runtime.yml
 - import_tasks: test_systemd_version.yml

--- a/test/integration/targets/systemd/tasks/test_glob_pattern.yml
+++ b/test/integration/targets/systemd/tasks/test_glob_pattern.yml
@@ -1,0 +1,158 @@
+# Test glob pattern support for systemd_service module
+
+- name: Start sleeper@200 for glob test
+  systemd:
+    name: sleeper@200.service
+    state: started
+  register: glob_setup_200
+
+- name: Start sleeper@201 for glob test
+  systemd:
+    name: sleeper@201.service
+    state: started
+  register: glob_setup_201
+
+- assert:
+    that:
+      - glob_setup_200 is success
+      - glob_setup_201 is success
+
+# Test restarting with glob pattern
+- name: Restart all sleeper instances using glob pattern
+  systemd:
+    name: 'sleeper@*.service'
+    state: restarted
+  register: glob_restart
+
+- assert:
+    that:
+      - glob_restart is changed
+      - glob_restart is success
+      - glob_restart.state == 'started'
+
+# Test check mode with glob pattern
+- name: Restart all sleeper instances using glob pattern (check mode)
+  systemd:
+    name: 'sleeper@*.service'
+    state: restarted
+  register: glob_restart_check
+  check_mode: true
+
+- assert:
+    that:
+      - glob_restart_check is changed
+      - glob_restart_check is success
+
+# Test stopping with glob pattern
+- name: Stop all sleeper instances using glob pattern
+  systemd:
+    name: 'sleeper@*.service'
+    state: stopped
+  register: glob_stop
+
+- assert:
+    that:
+      - glob_stop is changed
+      - glob_stop is success
+      - glob_stop.state == 'stopped'
+
+# Verify services actually stopped
+- name: Check sleeper@200 is stopped
+  systemd:
+    name: sleeper@200.service
+    state: stopped
+  register: verify_200_stopped
+
+- name: Check sleeper@201 is stopped
+  systemd:
+    name: sleeper@201.service
+    state: stopped
+  register: verify_201_stopped
+
+- assert:
+    that:
+      - verify_200_stopped is not changed
+      - verify_201_stopped is not changed
+
+# Test ? glob pattern
+- name: Restart sleeper instances matching ? pattern
+  systemd:
+    name: 'sleeper@20?.service'
+    state: restarted
+  register: glob_question
+
+- assert:
+    that:
+      - glob_question is changed
+      - glob_question is success
+      - glob_question.state == 'started'
+
+# Test [...] bracket glob pattern
+- name: Stop sleeper instances matching bracket pattern
+  systemd:
+    name: 'sleeper@20[01].service'
+    state: stopped
+  register: glob_bracket
+
+- assert:
+    that:
+      - glob_bracket is changed
+      - glob_bracket is success
+      - glob_bracket.state == 'stopped'
+
+# Verify bracket pattern actually stopped both instances
+- name: Check sleeper@200 is stopped after bracket glob
+  systemd:
+    name: sleeper@200.service
+    state: stopped
+  register: verify_200_bracket
+
+- name: Check sleeper@201 is stopped after bracket glob
+  systemd:
+    name: sleeper@201.service
+    state: stopped
+  register: verify_201_bracket
+
+- assert:
+    that:
+      - verify_200_bracket is not changed
+      - verify_201_bracket is not changed
+
+# Test that enabled with glob fails
+- name: Try to enable with glob pattern (should fail)
+  systemd:
+    name: 'sleeper@*.service'
+    enabled: true
+  register: glob_enable
+  ignore_errors: true
+
+- assert:
+    that:
+      - glob_enable is failed
+      - glob_enable.msg is search('enabled')
+
+# Test that masked with glob fails
+- name: Try to mask with glob pattern (should fail)
+  systemd:
+    name: 'sleeper@*.service'
+    masked: true
+  register: glob_mask
+  ignore_errors: true
+
+- assert:
+    that:
+      - glob_mask is failed
+      - glob_mask.msg is search('masked')
+
+# Cleanup
+- name: Stop sleeper@200
+  systemd:
+    name: sleeper@200.service
+    state: stopped
+  ignore_errors: true
+
+- name: Stop sleeper@201
+  systemd:
+    name: sleeper@201.service
+    state: stopped
+  ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

Assisted-by: Claude Code (claude.ai/code)

Allow glob patterns (`*`, `?`, `[`) in the `name` option for `state` operations,
enabling actions on multiple matching units at once.
Useful for instantiated template services where instance names are not known ahead of
time.

Fixes #87365

##### ISSUE TYPE

- Feature Pull Request