### PR TITLE
test: cover DataLoader None path arguments

### DIFF
--- a/changelogs/fragments/86056-dataloader-path-dwim-relative-stack-tests.yml
+++ b/changelogs/fragments/86056-dataloader-path-dwim-relative-stack-tests.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "DataLoader - Expand unit test coverage for ``path_dwim_relative_stack`` when ``dirname`` or ``source`` is ``None`` (https://github.com/ansible/ansible/issues/86056)."

--- a/test/units/parsing/test_dataloader.py
+++ b/test/units/parsing/test_dataloader.py
@@ -167,6 +167,18 @@ class TestPathDwimRelativeStackDataLoader(unittest.TestCase):
     def test_none(self):
         self.assertRaisesRegex(AnsibleFileNotFound, 'on the Ansible Controller', self._loader.path_dwim_relative_stack, None, None, None)
 
+    def test_none_dirname(self):
+        with tempfile.TemporaryDirectory() as temp_dir_path:
+            temp_dir = pathlib.Path(temp_dir_path)
+            source_path = temp_dir / 'source.yml'
+            source_path.touch()
+
+            self.assertEqual(self._loader.path_dwim_relative_stack([str(temp_dir)], None, source_path.name), str(source_path))
+
+    def test_none_source(self):
+        with pytest.raises(AnsibleFileNotFound, match='on the Ansible Controller'):
+            self._loader.path_dwim_relative_stack([], 'files', None)
+
     def test_empty_strings(self):
         self.assertEqual(self._loader.path_dwim_relative_stack('', '', ''), os.path.abspath('./') + '/')
 


### PR DESCRIPTION
##### SUMMARY

Add unit coverage for `DataLoader.path_dwim_relative_stack` when `dirname` is `None` and when `source` is `None`.

Fixes #86056

##### ISSUE TYPE

- Test Pull Request

##### COMPONENT NAME

lib/ansible/parsing/dataloader.py

##### ADDITIONAL INFORMATION

The tests use a real temporary file to verify a `None` dirname still resolves a source from the search stack, and verify a `None` source raises `AnsibleFileNotFound` with a configured dirname.

##### TESTING

- `bin/ansible-test units --python 3.13 test/units/parsing/test_dataloader.py`
- `bin/ansible-test units --python 3.13`
- `bin/ansible-test sanity --python 3.13 test/units/parsing/test_dataloader.py changelogs/fragments/86056-dataloader-path-dwim-relative-stack-tests.yml`
