### PR TITLE
fix: Resolve chained hostvars template references

### DIFF
--- a/changelogs/fragments/17806-hostvars-recursive-templating.yml
+++ b/changelogs/fragments/17806-hostvars-recursive-templating.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - hostvars - resolve chained variable references that access ``hostvars`` (https://github.com/ansible/ansible/issues/17806)

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-import collections.abc as c
+import collections as _collections
 import typing as t
 
 from ansible.module_utils._internal import _datatag
@@ -32,7 +32,7 @@ if t.TYPE_CHECKING:
 __all__ = ['HostVars', 'HostVarsVars']
 
 
-class HostVars(c.Mapping):
+class HostVars(_collections.abc.Mapping):
     """A read-only wrapper to enable on-demand templating of a specific host's variables under that host's variable context."""
     def __init__(self, inventory: InventoryManager, variable_manager: VariableManager, loader: DataLoader) -> None:
         self._inventory = inventory
@@ -64,7 +64,7 @@ class HostVars(c.Mapping):
         if isinstance(data, _jinja_bits.Marker):
             return data
 
-        return HostVarsVars(data, loader=self._loader, host=key)
+        return HostVarsVars(data, loader=self._loader, host=key, hostvars=self)
 
     def __contains__(self, item: object) -> bool:
         # does not use inventory.hosts, so it can create localhost on demand
@@ -82,14 +82,15 @@ class HostVars(c.Mapping):
         return self
 
 
-class HostVarsVars(c.Mapping):
+class HostVarsVars(_collections.abc.Mapping):
     """A read-only view of a specific host's vars that will template on access under that host's variable context."""
 
-    def __init__(self, variables: dict[str, t.Any], loader: DataLoader | None, host: str) -> None:
+    def __init__(self, variables: dict[str, t.Any], loader: DataLoader | None, host: str, hostvars: HostVars | None = None) -> None:
         from ansible._internal._templating import _engine
 
         self._vars = variables
-        self._templar = _engine.TemplateEngine(variables=variables, loader=loader)
+        templar_variables = _collections.ChainMap({'hostvars': hostvars}, variables) if hostvars is not None else variables
+        self._templar = _engine.TemplateEngine(variables=templar_variables, loader=loader)
         self._host = host
 
     def __getitem__(self, key: str) -> t.Any:

--- a/test/integration/targets/var_templating/group_vars/all.yml
+++ b/test/integration/targets/var_templating/group_vars/all.yml
@@ -5,3 +5,7 @@ nested_x:
   value:
     x: 100
 nested_y: "{{ nested_x }}"
+test1: "{{ inventory_hostname }}"
+test3: '{{ hostvars["host1"].test1 }}'
+test4: "{{ hostvars[inventory_hostname].test1 }}"
+test6: "{{ test3 }}"

--- a/test/integration/targets/var_templating/task_vars_templating.yml
+++ b/test/integration/targets/var_templating/task_vars_templating.yml
@@ -34,6 +34,16 @@
           - y_1 == y_2
           - x_1 == y_1
 
+    - name: Verify hostvars templates use the referenced host's context
+      assert:
+        that:
+          - hostvars[inventory_hostname].test1 == inventory_hostname
+          - hostvars[inventory_hostname].test3 == 'host1'
+          - hostvars[inventory_hostname].test4 == inventory_hostname
+          - hostvars[inventory_hostname].test6 == 'host1'
+          - hostvars['missing'] is undefined
+          - hostvars[inventory_hostname].missing is undefined
+
     - debug:
         msg: "{{ hostvars['host1']['nested_x']['value'] }}"
       register: x_1


### PR DESCRIPTION
##### SUMMARY

Pass the existing `HostVars` mapping into `HostVarsVars` and expose it to that class's `TemplateEngine` as an additional templating variable without changing the raw variable collection to `include_hostvars=True` or mutating the tagged host-variable dictionary. Keep resolution lazy so cross-host lookups continue to use `HostVars.__getitem__`, preserve each referenced host's own variable context, and avoid eagerly materializing or recursively copying the complete inventory. Extend the existing `var_templating` integration fixture with direct, nested, cross-host, and chained hostvars values, then assert that the chained value resolves fully while the already-supported cases remain unchanged.

Ansible now templates ordinary and nested host variables lazily in the referenced host's context, but a chained expression still fails when one host variable resolves through another variable that itself references `hostvars`. `HostVars.raw_get()` deliberately asks `VariableManager` for variables with `include_hostvars=False`, and `HostVarsVars` builds its per-host `TemplateEngine` from that reduced mapping, so the second template pass reports that `hostvars` is undefined. The maintainer's current reproducer isolates the remaining case as `hostvars[current_host].test6`, where `test6` references `test3` and `test3` references `hostvars["l1"].test1`. The issue is therefore concrete and limited to preserving the root lazy hostvars mapping in the per-host templating context.

Fixes #17806

##### ISSUE TYPE

- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- Test Pull Request

AI was used for assistance.
