### PR TITLE
Prevent dnf from printing to stdout during operation of dnf embed

### DIFF
--- a/changelogs/fragments/87366-dnf-plugin-stdout.yml
+++ b/changelogs/fragments/87366-dnf-plugin-stdout.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - dnf - Prevent dnf informational output written to stdout by a DNF plugin (such as ``kpatch-dnf``) from causing JSON parsing issues with the embedded DNF helper script (https://github.com/ansible/ansible/issues/87366).

--- a/lib/ansible/module_utils/_embed/dnf.py
+++ b/lib/ansible/module_utils/_embed/dnf.py
@@ -11,6 +11,8 @@
 #
 # Requires-Python: ">=3.6"
 
+import contextlib
+import io
 import json
 import os
 import sys
@@ -811,13 +813,16 @@ def main():
         list_command = params.get('list_command')
         if not list_command:
             _exit_json({'failed': True, 'msg': 'No list_command specified for list operation'})
-        result = list_items(config, list_command)
+        with contextlib.redirect_stdout(io.StringIO()):
+            result = list_items(config, list_command)
 
     elif command == 'ensure':
-        result = ensure(config, params)
+        with contextlib.redirect_stdout(io.StringIO()):
+            result = ensure(config, params)
 
     elif command == 'update-cache':
-        result = update_cache_only(config)
+        with contextlib.redirect_stdout(io.StringIO()):
+            result = update_cache_only(config)
 
     else:
         _exit_json({'failed': True, 'msg': f'Unknown command: {command}'})

--- a/lib/ansible/modules/dnf.py
+++ b/lib/ansible/modules/dnf.py
@@ -398,6 +398,7 @@ from ansible.module_utils.urls import fetch_file
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.respawn import get_env_with_pythonpath, probe_interpreters_for_module
 from ansible.module_utils.embed import EmbedManager
+from ansible.module_utils.json_utils import _filter_non_json_lines
 from ansible.module_utils.yumdnf import YumDnf, yumdnf_argument_spec
 
 
@@ -484,7 +485,7 @@ class DnfModule(YumDnf):
             )
 
             if stdout:
-                return json.loads(stdout)
+                return json.loads(_filter_non_json_lines(stdout))
             else:
                 return {
                     'failed': True,

--- a/test/integration/targets/dnf/files/noisy_dnf_plugin.py
+++ b/test/integration/targets/dnf/files/noisy_dnf_plugin.py
@@ -1,0 +1,14 @@
+"""Writes unsolicited output directly to stdout, similar to plugins such as
+kpatch-dnf, to verify that the ansible.builtin.dnf module does not fail to
+parse the JSON response produced by the embedded DNF helper script when a
+loaded DNF plugin also writes to stdout.
+"""
+
+import dnf
+
+
+class AnsibleTestNoisyPlugin(dnf.Plugin):
+    name = 'ansible_test_noisy'
+
+    def sack(self):
+        print('This is unsolicited stdout output from a test DNF plugin.')

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -45,6 +45,7 @@
     - include_tasks: multilib.yml
     - include_tasks: dnf_config.yml
     - include_tasks: exclude.yml
+    - include_tasks: noisy_plugin.yml
 
 # Attempting to install a different RHEL release in a tmpdir doesn't work (rhel8 beta)
 - include_tasks: dnfreleasever.yml

--- a/test/integration/targets/dnf/tasks/noisy_plugin.yml
+++ b/test/integration/targets/dnf/tasks/noisy_plugin.yml
@@ -1,0 +1,29 @@
+---
+- name: Determine the DNF plugin path
+  command: "{{ ansible_facts.python_interpreter | default('/usr/bin/python3') }} -c \"import dnf.const; print(dnf.const.PLUGINPATH)\""
+  register: dnf_plugin_path
+  changed_when: false
+
+- block:
+    - name: Install a DNF plugin that writes unsolicited output to stdout
+      copy:
+        src: noisy_dnf_plugin.py
+        dest: "{{ dnf_plugin_path.stdout }}/noisy_dnf_plugin.py"
+        mode: '0644'
+
+    - name: Run the dnf module while the noisy plugin is loaded
+      dnf:
+        name: sos
+        state: present
+      register: dnf_noisy_plugin_result
+
+    - name: Verify the module succeeded despite the plugin's stdout output
+      assert:
+        that:
+          - dnf_noisy_plugin_result is not failed
+          - "'results' in dnf_noisy_plugin_result"
+  always:
+    - name: Remove the noisy DNF plugin
+      file:
+        path: "{{ dnf_plugin_path.stdout }}/noisy_dnf_plugin.py"
+        state: absent

--- a/test/sanity/ignore.txt
+++ b/test/sanity/ignore.txt
@@ -277,6 +277,7 @@ test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:a
 test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:ansible-deprecated-date-not-permitted  # required to verify plugin against core
 test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:ansible-deprecated-unnecessary-collection-name  # required to verify plugin against core
 test/integration/targets/ansible-test-sanity-pylint/deprecated_thing.py pylint:ansible-deprecated-collection-name-not-permitted  # required to verify plugin against core
+test/integration/targets/dnf/files/noisy_dnf_plugin.py boilerplate  # annotations future bombs on Python 3.6
 test/integration/targets/lineinfile/files/testnoeof.txt trailing-newline  # Specifically testing EOF
 test/units/errors/fixtures/inputs/long_file.txt trailing-newline
 test/units/errors/fixtures/inputs/one_line_file.txt trailing-newline


### PR DESCRIPTION
##### SUMMARY

Prevent dnf from printing to stdout during operation of dnf embed. Fixes #87366

Without the fix:

```
TASK [dnf : Run the dnf module while the noisy plugin is loaded] ***************
[ERROR]: Task failed: Module failed: Failed to parse JSON from dnf script: Expecting value: line 1 column 1 (char 0). stdout: This is unsolicited stdout output from a test DNF plugin.
{"msg": "Nothing to do", "changed": false, "results": [], "rc": 0, "warnings": [], "failures": []}
Origin: /root/ansible/test/results/.tmp/integration/dnf-8kjzad7n-ÅÑŚÌβŁÈ/test/integration/targets/dnf/tasks/noisy_plugin.yml:14:7

12         mode: '0644'
13
14     - name: Run the dnf module while the noisy plugin is loaded
         ^ column 7

fatal: [testhost]: FAILED! => {"changed": false, "msg": "Failed to parse JSON from dnf script: Expecting value: line 1 column 1 (char 0). stdout: This is unsolicited stdout output from a test DNF plugin.\n{\"msg\": \"Nothing to do\", \"changed\": false, \"results\": [], \"rc\": 0, \"warnings\": [], \"failures\": []}", "rc": 1, "results": []}
```

##### ISSUE TYPE

- Bugfix Pull Request
