### PR TITLE
user - do not follow a symlink at the ssh private key path

### DIFF
--- a/changelogs/fragments/87430-user-ssh-key-symlink.yml
+++ b/changelogs/fragments/87430-user-ssh-key-symlink.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - do not follow a symlink at the SSH private key path when ``force`` is set. ``ssh-keygen`` overwrote in place, so a symlink under the target user's control redirected the generated private key to wherever it pointed. The path is now removed first, as the public key path already was, and both are checked with ``os.path.lexists`` so a symlink whose target does not exist yet is caught too (https://github.com/ansible/ansible/issues/87430).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -1257,15 +1257,22 @@ class User(object):
             except OSError as e:
                 return (1, '', 'Failed to create %s: %s' % (ssh_dir, to_native(e)))
 
-        if os.path.exists(ssh_key_file):
+        # lexists, not exists: a symlink whose target does not exist yet is still
+        # a symlink ssh-keygen would follow, creating the key at its target.
+        if os.path.lexists(ssh_key_file):
             if self.force:
                 self.module.warn(f'Overwriting existing ssh key private file "{ssh_key_file}"')
+                # Remove it instead of letting ssh-keygen overwrite in place. The
+                # path is under the target user's control, so if it is a symlink
+                # ssh-keygen would follow it and write the private key wherever it
+                # points. This is what the public key below already does.
+                os.unlink(ssh_key_file)
                 overwrite = 'y'
             else:
                 self.module.warn(f'Found existing ssh key private file "{ssh_key_file}", no force, so skipping ssh-keygen generation')
                 return (None, 'Key already exists, use "force: yes" to overwrite', '')
 
-        if os.path.exists(pub_file):
+        if os.path.lexists(pub_file):
             if self.force:
                 self.module.warn(f'Overwriting existing ssh key public file "{pub_file}"')
                 os.unlink(pub_file)

--- a/test/integration/targets/user/tasks/ssh_keygen.yml
+++ b/test/integration/targets/user/tasks/ssh_keygen.yml
@@ -98,3 +98,50 @@
 
     - name: Ensure clean/non existing ansibulluser
       user: name=ansibulluser state=absent
+
+  - name: Ensure a private key symlink is not followed
+    block:
+    - name: flag file for test
+      tempfile:
+      register: privflagfile
+
+    - name: give the flag file known content
+      copy:
+        content: 'do not overwrite me'
+        dest: '{{ privflagfile.path }}'
+
+    - name: precreate .ssh
+      file: path={{home ~ '.ssh'}} state=directory
+
+    - name: setup private key linked to flag file
+      file: path={{home ~ ssh_key_file}} src={{privflagfile.path}} state=link
+
+    - name: Create user with ssh key, forcing overwrite
+      user:
+        name: ansibulluser
+        state: present
+        generate_ssh_key: yes
+        ssh_key_file: '{{ ssh_key_file }}'
+        force: true
+      register: user_force_priv
+
+    - stat: path={{home ~ ssh_key_file}}
+      register: check_priv
+
+    - slurp: path={{ privflagfile.path }}
+      register: flag_contents
+
+    - name: ensure the key replaced the link and its target was left alone
+      assert:
+        that:
+          - user_force_priv is success
+          - check_priv.stat.exists
+          - not check_priv.stat.islnk
+          - (flag_contents.content | b64decode) == 'do not overwrite me'
+    always:
+    - name: Clean up files
+      file: path={{ home ~ item }} state=absent
+      loop: '{{ key_files + [privflagfile.path] }}'
+
+    - name: Ensure clean/non existing ansibulluser
+      user: name=ansibulluser state=absent


### PR DESCRIPTION
##### SUMMARY

Fixes #87430.

When `force` is set, `ssh_key_gen` unlinks the **public** key path before generating, but not the **private** one — it answers `y` to `ssh-keygen`'s overwrite prompt instead:

```python
        if os.path.exists(ssh_key_file):
            if self.force:
                self.module.warn(...)
                overwrite = 'y'          # <- symlink stays in place
        if os.path.exists(pub_file):
            if self.force:
                self.module.warn(...)
                os.unlink(pub_file)      # <- symlink removed
```

`ssh-keygen` then opens the path and follows the symlink, writing the generated private key wherever it points. That path is inside the target user's home, so the user chooses the destination while the module runs as root.

##### The `lexists` part

Unlinking alone is not enough, which is the part worth flagging. `os.path.exists` follows the link, so a symlink whose target does not exist yet reports `False`, nothing is removed, and `ssh-keygen` creates the key at the target anyway.

I checked this by driving `User.ssh_key_gen` directly with a stubbed module object, on `devel` and on this branch:

| symlink target | `devel` | unlink only | `lexists` + unlink |
|---|---|---|---|
| existing file | overwritten | safe | safe |
| does not exist yet | created | **still created** | safe |

So both checks move to `os.path.lexists`. The public key path gets the same treatment, since it has the same hole for a dangling link.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/user.py`

##### ADDITIONAL INFORMATION

Behaviour without `force` also changes slightly, and I think in the right direction: a dangling symlink at either path is now reported as "already exists, use force" instead of being silently written through.

The new integration block mirrors the existing "Ensure we don't break on conflicts" block, which already tests exactly this for the public key — it links the key path at a flag file, forces generation, then asserts the link was replaced by a real file and the flag file's contents are untouched. I have not been able to run the integration target here (it needs a managed test host), so that block is checked for structure and YAML validity only; the behaviour it asserts is what I verified with the stub above and with `ssh-keygen` directly.

The issue is already public, so this is a public PR rather than a security report — happy to move it if you would prefer that.

Assisted-by: Claude (Opus 5)