### PR TITLE
Separate powershell exec options with module JSON

### DIFF
--- a/lib/ansible/executor/powershell/async_watchdog.ps1
+++ b/lib/ansible/executor/powershell/async_watchdog.ps1
@@ -26,7 +26,14 @@ param (
 if (-not (Test-Path -LiteralPath $ResultPath)) {
     throw "async result file at '$ResultPath' does not exist"
 }
-$result = Get-Content -LiteralPath $ResultPath | ConvertFrom-Json | Convert-JsonObject
+$rawResult = Get-Content -LiteralPath $ResultPath | ConvertFrom-Json
+
+# We ensure the outer PSObject is a hashtable to make it easier to add/merge
+# additional keys.
+$result = @{}
+foreach ($prop in $rawResult.PSObject.Properties) {
+    $result[$prop.Name] = $prop.Value
+}
 
 # The intermediate script is used so that things are set up like it normally
 # is. The new Runspace is used to ensure we can stop it once the async time is
@@ -85,9 +92,11 @@ try {
 
         $trailingJunk = $moduleResultJson.Substring($endJsonChar + 1).Trim()
         $moduleResultJson = $moduleResultJson.Substring(0, $endJsonChar + 1)
-        $moduleResult = $moduleResultJson | ConvertFrom-Json | Convert-JsonObject
+        $moduleResult = $moduleResultJson | ConvertFrom-Json
         # TODO: check for conflicting keys
-        $result = $result + $moduleResult
+        foreach ($prop in $moduleResult.PSObject.Properties) {
+            $result[$prop.Name] = $prop.Value
+        }
 
         if ($trailingJunk) {
             if (-not $result.warnings) {

--- a/lib/ansible/executor/powershell/exec_wrapper.ps1
+++ b/lib/ansible/executor/powershell/exec_wrapper.ps1
@@ -25,7 +25,7 @@ param (
     $InputObject,
 
     [Parameter()]
-    [IDictionary]
+    [PSObject]
     $Manifest,
 
     [Parameter()]
@@ -182,7 +182,7 @@ begin {
         }
     }
 
-    # $Script:AnsibleManifest = @{}  # Defined in process/end.
+    # $Script:AnsibleManifest = [PSCustomObject]@{}  # Defined in process/end.
     $Script:AnsibleShouldConstrain = if ($PSVersionTable.PSVersion -lt '6.0' -or $IsWindows) {
         [SystemPolicy]::GetSystemLockdownPolicy() -eq 'Enforce'
     }
@@ -215,33 +215,6 @@ begin {
     $Script:AnsibleTempScripts = [List[string]]::new()
     $Script:AnsibleClrFacadeSet = $false
 
-    Function Convert-JsonObject {
-        param(
-            [Parameter(Mandatory, ValueFromPipeline)]
-            [AllowNull()]
-            [object]
-            $InputObject
-        )
-
-        process {
-            # Using the full type name is important as PSCustomObject is an
-            # alias for PSObject which all piped objects are.
-            if ($InputObject -is [System.Management.Automation.PSCustomObject]) {
-                $value = @{}
-                foreach ($prop in $InputObject.PSObject.Properties) {
-                    $value[$prop.Name] = Convert-JsonObject -InputObject $prop.Value
-                }
-                $value
-            }
-            elseif ($InputObject -is [Array]) {
-                , @($InputObject | Convert-JsonObject)
-            }
-            else {
-                $InputObject
-            }
-        }
-    }
-
     Function Get-AnsibleScript {
         [CmdletBinding()]
         param (
@@ -258,7 +231,7 @@ begin {
             $SkipHashCheck
         )
 
-        if (-not $Script:AnsibleManifest.scripts.Contains($Name)) {
+        if (-not $Script:AnsibleManifest.scripts.PSObject.Properties.Match($Name)) {
             $err = [ErrorRecord]::new(
                 [Exception]::new("Could not find the script '$Name'."),
                 "ScriptNotFound",
@@ -267,7 +240,7 @@ begin {
             $PSCmdlet.ThrowTerminatingError($err)
         }
 
-        $scriptInfo = $Script:AnsibleManifest.scripts[$Name]
+        $scriptInfo = $Script:AnsibleManifest.scripts.$Name
         $scriptBytes = [Convert]::FromBase64String($scriptInfo.script)
         $scriptContents = [Encoding]::UTF8.GetString($scriptBytes)
 
@@ -378,16 +351,18 @@ begin {
         $Script:AnsibleManifest.actions = @($newActions | Select-Object)
 
         $actionName = $action.name
-        $actionParams = $action.params
+        $actionParams = @{}
         $actionScript = Get-AnsibleScript -Name $actionName -IncludeScriptBlock
 
-        foreach ($kvp in $action.secure_params.GetEnumerator()) {
-            if (-not $kvp.Value) {
+        foreach ($prop in $action.params.PSObject.Properties) {
+            $actionParams[$prop.Name] = $prop.Value
+        }
+        foreach ($prop in $action.secure_params.PSObject.Properties) {
+            if (-not $prop.Value) {
                 continue
             }
 
-            $name = $kvp.Key
-            $actionParams.$name = $kvp.Value | ConvertTo-SecureString -AsPlainText -Force
+            $actionParams[$prop.Name] = $prop.Value | ConvertTo-SecureString -AsPlainText -Force
         }
 
         [PSCustomObject]@{
@@ -747,13 +722,7 @@ begin {
         else {
             # Otherwise the first part of the input is the manifest json with the
             # chance for extra data afterwards.
-            $jsonParams = @{}
-            if ($IsCoreCLR) {
-                # PowerShell 7 parses an ISO 8601 date string into a DateTime object. As we
-                # want to preserve the original string we tell it using the DateKind param.
-                $jsonParams.DateKind = 'String'
-            }
-            $jsonPipeline = { ConvertFrom-Json @jsonParams | Convert-JsonObject }.GetSteppablePipeline()
+            $jsonPipeline = { ConvertFrom-Json }.GetSteppablePipeline()
             $jsonPipeline.Begin($true)
         }
     }

--- a/lib/ansible/executor/powershell/module_manifest.py
+++ b/lib/ansible/executor/powershell/module_manifest.py
@@ -437,14 +437,13 @@ def _create_powershell_wrapper(
             else:
                 ps_deps.append(dep)
 
+        encoder = get_module_encoder(profile, Direction.CONTROLLER_TO_MODULE)
+        module_arg_json = json.dumps(module_args, cls=encoder)
+
         module_params |= {
-            'Variables': [
-                {
-                    'Name': 'complex_args',
-                    'Value': _prepare_module_args(module_args, profile),
-                    'Scope': 'Global',
-                },
-            ],
+            'ArgumentJSON': module_arg_json,
+            # FUTURE: Provide the profile to the module wrapper.
+            # 'ArgumentProfile': profile,
             'CSharpModules': cs_deps,
             'PowerShellModules': ps_deps,
             'ForModule': True,

--- a/lib/ansible/executor/powershell/module_wrapper.ps1
+++ b/lib/ansible/executor/powershell/module_wrapper.ps1
@@ -140,16 +140,17 @@ if ($ArgumentJSON) {
         # want to preserve the original string we tell it using the DateKind param.
         $jsonParams.DateKind = 'String'
     }
-    $parsedArgs = $ArgumentJSON | ConvertFrom-Json @jsonParams| Convert-JsonObject
+    $parsedArgs = $ArgumentJSON | ConvertFrom-Json @jsonParams | Convert-JsonObject
 
     # FUTURE: Deprecate complex_args and move parsing logic into module_utils.
     # Deprecation requires exec_wrapper warning system to be implemented. We
     # can use Set-PSBreakPoint to fire an action on variable reads.
-    $null = $ps.AddCommand("Set-Variable").AddParameters(@{
-        Name = 'complex_args'
-        Value = $parsedArgs
-        Scope = 'Global'
-    }).AddStatement()
+    $null = $ps.AddCommand("Set-Variable").AddParameters(
+        @{
+            Name = 'complex_args'
+            Value = $parsedArgs
+            Scope = 'Global'
+        }).AddStatement()
 }
 
 # env vars are process side so we can just set them here.

--- a/lib/ansible/executor/powershell/module_wrapper.ps1
+++ b/lib/ansible/executor/powershell/module_wrapper.ps1
@@ -15,12 +15,7 @@ param(
     $Script,
 
     [Parameter()]
-    [IDictionary[]]
-    [AllowEmptyCollection()]
-    $Variables = @(),
-
-    [Parameter()]
-    [IDictionary]
+    [PSObject]
     $Environment,
 
     [Parameter()]
@@ -38,9 +33,40 @@ param(
     $Breakpoints,
 
     [Parameter()]
+    [string]
+    $ArgumentJSON,
+
+    [Parameter()]
     [switch]
     $ForModule
 )
+
+Function Convert-JsonObject {
+    param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [AllowNull()]
+        [object]
+        $InputObject
+    )
+
+    process {
+        # Using the full type name is important as [PSCustomObject] is an
+        # alias for [PSObject] which all piped objects are.
+        if ($InputObject -is [System.Management.Automation.PSCustomObject]) {
+            $value = @{}
+            foreach ($prop in $InputObject.PSObject.Properties) {
+                $value[$prop.Name] = Convert-JsonObject -InputObject $prop.Value
+            }
+            $value
+        }
+        elseif ($InputObject -is [Array]) {
+            , @($InputObject | Convert-JsonObject)
+        }
+        else {
+            $InputObject
+        }
+    }
+}
 
 Function Write-AnsibleErrorDetail {
     [CmdletBinding()]
@@ -107,13 +133,28 @@ else {
     Set-WinPSDefaultFileEncoding
 }
 
-foreach ($variable in $Variables) {
-    $null = $ps.AddCommand("Set-Variable").AddParameters($variable).AddStatement()
+if ($ArgumentJSON) {
+    $jsonParams = @{}
+    if ($IsCoreCLR) {
+        # PowerShell 7 parses an ISO 8601 date string into a DateTime object. As we
+        # want to preserve the original string we tell it using the DateKind param.
+        $jsonParams.DateKind = 'String'
+    }
+    $parsedArgs = $ArgumentJSON | ConvertFrom-Json @jsonParams| Convert-JsonObject
+
+    # FUTURE: Deprecate complex_args and move parsing logic into module_utils.
+    # Deprecation requires exec_wrapper warning system to be implemented. We
+    # can use Set-PSBreakPoint to fire an action on variable reads.
+    $null = $ps.AddCommand("Set-Variable").AddParameters(@{
+        Name = 'complex_args'
+        Value = $parsedArgs
+        Scope = 'Global'
+    }).AddStatement()
 }
 
 # env vars are process side so we can just set them here.
-foreach ($env in $Environment.GetEnumerator()) {
-    [Environment]::SetEnvironmentVariable($env.Key, $env.Value)
+foreach ($env in $Environment.PSObject.Properties) {
+    [Environment]::SetEnvironmentVariable($env.Name, $env.Value)
 }
 
 # Redefine Write-Host to dump to output instead of failing, lots of scripts


### PR DESCRIPTION
##### SUMMARY
Separates the logic for parsing and processing the execution wrapper input manifest and the module argument options. This enables future work around module option secret registration, ability for modules to use custom serialization profiles like in Python and a better separation of manifest payloads for exec wrapper data set by us and module options set by end users.

The exec wrapper is not publicly exposed so we can go back to using the default output types of PSObject for dicts to avoid iterating of values recursively when we control the consumption.

Module argument options set to `$complex_args` will continue to use the existing conversion process with the goal of eventual deprecation and moving the responsibility for parsing the JSON to module utils or modules themselves.

As this change is internal and not user facing, no changelog is needed.

##### ISSUE TYPE
- Feature Pull Request
