### PR TITLE
test any_errors_fatal keyword using variable

### DIFF
--- a/changelogs/fragments/free-any_errors_fatal-eval.yml
+++ b/changelogs/fragments/free-any_errors_fatal-eval.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - free - fix warning about ``any_errors_fatal`` when it is a template that evaluates to ``False``.

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -179,7 +179,7 @@ class StrategyModule(StrategyBase):
                         else:
                             # handle step if needed, skip meta actions as they are used internally
                             if not self._step or self._take_step(task, host_name):
-                                if task.any_errors_fatal:
+                                if templar.template(task.any_errors_fatal):
                                     display.warning("Using any_errors_fatal with the free strategy is not supported, "
                                                     "as tasks are executed independently on each host")
                                 if isinstance(task, Handler):

--- a/test/integration/targets/any_errors_fatal/61025.yml
+++ b/test/integration/targets/any_errors_fatal/61025.yml
@@ -1,0 +1,12 @@
+- hosts: testhost,testhost2
+  gather_facts: false
+  any_errors_fatal: "{{ False }}"
+  tasks:
+    - name: EXPECTED FAILURE
+      fail:
+        msg: triggering a failure
+      when: "inventory_hostname == 'testhost'"
+
+    - name: Run on otherhost
+      debug:
+      failed_when: inventory_hostname == 'testhost'

--- a/test/integration/targets/any_errors_fatal/runme.sh
+++ b/test/integration/targets/any_errors_fatal/runme.sh
@@ -50,3 +50,6 @@ ansible-playbook -i inventory "$@" 80981.yml | tee out.txt
 
 ansible-playbook -i inventory "$@" 61025.yml | tee out.txt
 [ "$(grep -c 'Run on otherhost' out.txt)" -eq 1 ]
+
+ANSIBLE_STRATEGY=free ansible-playbook -i inventory "$@" 61025.yml 2>&1 | tee out.txt
+[ "$(grep -c 'Using any_errors_fatal with the free strategy is not supported' out.txt)" -eq 0 ]

--- a/test/integration/targets/any_errors_fatal/runme.sh
+++ b/test/integration/targets/any_errors_fatal/runme.sh
@@ -47,3 +47,6 @@ ansible-playbook -i inventory "$@" 80981.yml | tee out.txt
 [ "$(grep -c 'SHOULD NOT HAPPEN' out.txt)" -eq 0 ]
 [ "$(grep -c 'rescuedd' out.txt)" -eq 2 ]
 [ "$(grep -c 'recovered' out.txt)" -eq 2 ]
+
+ansible-playbook -i inventory "$@" 61025.yml | tee out.txt
+[ "$(grep -c 'Run on otherhost' out.txt)" -eq 1 ]


### PR DESCRIPTION
##### SUMMARY

This was fixed for `linear` in 64d74c975479df6d0d1b67acf7b8686ece97f787, but I don't see a test for it, so this adds one to prevent a regression.

I also updated free to evaluate `any_errors_fatal`, so it gives a warning when enabled.

Closes #61025

##### ISSUE TYPE

- Test Pull Request
- Bugfix Pull Request
