### PR TITLE
user: handle removal of password minimum age in shadow-utils 4.20

### DIFF
--- a/changelogs/fragments/87428-user-chage-mindays.yml
+++ b/changelogs/fragments/87428-user-chage-mindays.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - user - fail explicitly with a descriptive error message when C(password_expire_min) is used on
+    systems where C(chage) does not support C(-m/--mindays), and emit a warning on supported systems
+    noting that minimum password age was removed in upstream shadow-utils 4.20
+    (https://github.com/ansible/ansible/issues/87428).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -263,7 +263,15 @@ options:
     password_expire_min:
         description:
             - Minimum number of days between password change.
-            - Supported on Linux only.
+            - Supported on Linux systems where the underlying C(chage) utility supports C(-m/--mindays).
+            - On systems where C(chage -m) is supported, a warning is emitted noting that the feature has
+              been removed in upstream shadow-utils 4.20+.
+            - On systems where the underlying C(chage) utility does not support C(-m/--mindays)
+              (for example, shadow-utils 4.20 and later), using this parameter will result in a
+              task failure with a descriptive error message.
+              The C(chage -m) option and C(PASS_MIN_DAYS) in C(login.defs) were removed by the
+              shadow-utils project as a security measure with no replacement.
+              See U(https://github.com/shadow-maint/shadow/pull/1482).
         type: int
         version_added: "2.11"
     password_expire_warn:
@@ -904,6 +912,27 @@ class User(object):
 
         return False
 
+    def _chage_supports_mindays(self):
+        # check if this version of chage supports -m / --mindays
+        # shadow-utils 4.20+ removed this option as a security measure
+        command_name = 'chage'
+        chage_path = self.module.get_bin_path(command_name, True)
+
+        if not os.access(chage_path, os.X_OK):
+            return False
+
+        cmd = [chage_path, '--help']
+        (rc, data1, data2) = self.execute_command(cmd, obey_checkmode=False)
+        helpout = data1 + data2
+
+        # check if -m / --mindays is listed in the help output
+        lines = to_native(helpout).split('\n')
+        for line in lines:
+            if re.search(r'(-m\b|--mindays\b)', line):
+                return True
+
+        return False
+
     def modify_user_usermod(self):
 
         if self.local:
@@ -1169,6 +1198,22 @@ class User(object):
         return info
 
     def set_password_expire(self):
+        if self.password_expire_min is not None:
+            if not self._chage_supports_mindays():
+                self.module.fail_json(
+                    msg=(
+                        "password_expire_min is not supported on this system. "
+                        "The underlying chage utility does not support "
+                        "-m/--mindays."
+                    )
+                )
+            else:
+                self.module.warn(
+                    "password_expire_min has been removed in upstream shadow-utils 4.20+ "
+                    "(chage -m / PASS_MIN_DAYS) and will not be supported once the "
+                    "system shadow-utils package is upgraded."
+                )
+
         min_needs_change = self.password_expire_min is not None
         max_needs_change = self.password_expire_max is not None
         warn_needs_change = self.password_expire_warn is not None

--- a/test/integration/targets/user/tasks/test_expires_min_max.yml
+++ b/test/integration/targets/user/tasks/test_expires_min_max.yml
@@ -1,19 +1,110 @@
 # https://github.com/ansible/ansible/issues/68775
-- name: Test setting maximum expiration
+# https://github.com/ansible/ansible/issues/87428
+- name: Test password expiration min/max settings
   when: ansible_facts.os_family in ['RedHat', 'Debian']
   block:
-    - name: create user
+    - name: create user for min/max expiration tests
       user:
         name: ansibulluser
         state: present
 
+    # Non-mutating capability probe: inspect chage --help for -m/--mindays support.
+    # shadow-utils 4.20+ removed chage -m as a security measure (https://github.com/shadow-maint/shadow/pull/1482).
+    - name: probe chage -m/--mindays support via --help
+      command: chage --help
+      register: chage_help_probe
+      failed_when: false
+      changed_when: false
+
+    - name: set fact indicating whether chage supports -m/--mindays
+      set_fact:
+        chage_mindays_supported: "{{ (chage_help_probe.stdout + chage_help_probe.stderr) is search('(-m\\b|--mindays\\b)') }}"
+
+    # ----------------------------------------------------------------
+    # Branch A: systems where chage -m is supported (shadow-utils < 4.20)
+    # ----------------------------------------------------------------
+    - name: test password_expire_min on systems supporting chage -m
+      when: chage_mindays_supported | bool
+      block:
+        - name: add minimum expire date for password
+          user:
+            name: ansibulluser
+            password_expire_min: 5
+          register: pass_min_2_0
+
+        - name: again add minimum expire date for password (idempotency)
+          user:
+            name: ansibulluser
+            password_expire_min: 5
+          register: pass_min_2_1
+
+        - name: validate result for minimum expire date
+          assert:
+            that:
+              - pass_min_2_0 is changed
+              - pass_min_2_1 is not changed
+              - pass_min_2_0.warnings is defined
+              - "'password_expire_min has been removed in upstream shadow-utils 4.20+' in pass_min_2_0.warnings[0]"
+
+        - name: get shadow data for ansibulluser
+          getent:
+            database: shadow
+            key: ansibulluser
+
+        - name: ensure minimum password age was set properly in shadow
+          assert:
+            that:
+              - ansible_facts.getent_shadow['ansibulluser'][2] == '5'
+
+        - name: set min and max at the same time (also verifies assigning 0 works)
+          user:
+            name: ansibulluser
+            password_expire_min: 0
+            password_expire_max: 0
+
+        - name: get shadow data after setting both min and max to 0
+          getent:
+            database: shadow
+            key: ansibulluser
+
+        - name: ensure min and max were both set to 0
+          assert:
+            that:
+              - ansible_facts.getent_shadow['ansibulluser'][2] == '0'
+              - ansible_facts.getent_shadow['ansibulluser'][3] == '0'
+
+    # ----------------------------------------------------------------
+    # Branch B: systems where chage -m has been removed (shadow-utils >= 4.20)
+    # Verify that Ansible produces a clear, explicit failure rather than a
+    # silent success or a confusing chage error.
+    # ----------------------------------------------------------------
+    - name: test password_expire_min produces explicit failure when chage -m is unsupported
+      when: not (chage_mindays_supported | bool)
+      block:
+        - name: attempt to set password_expire_min (expected to fail)
+          user:
+            name: ansibulluser
+            password_expire_min: 5
+          register: pass_min_unsupported
+          failed_when: false
+
+        - name: assert that the task failed with a descriptive error
+          assert:
+            that:
+              - pass_min_unsupported is failed
+              - "'password_expire_min is not supported on this system' in pass_min_unsupported.msg"
+
+    # ----------------------------------------------------------------
+    # password_expire_max: tested independently, supported in all environments.
+    # shadow-utils 4.20 deprecated -M but did NOT remove it yet.
+    # ----------------------------------------------------------------
     - name: add maximum expire date for password
       user:
         name: ansibulluser
         password_expire_max: 10
       register: pass_max_1_0
 
-    - name: again add maximum expire date for password
+    - name: again add maximum expire date for password (idempotency)
       user:
         name: ansibulluser
         password_expire_max: 10
@@ -25,49 +116,12 @@
           - pass_max_1_0 is changed
           - pass_max_1_1 is not changed
 
-    - name: add minimum expire date for password
-      user:
-        name: ansibulluser
-        password_expire_min: 5
-      register: pass_min_2_0
-
-    - name: again add minimum expire date for password
-      user:
-        name: ansibulluser
-        password_expire_min: 5
-      register: pass_min_2_1
-
-    - name: validate result for minimum expire date
-      assert:
-        that:
-          - pass_min_2_0 is changed
-          - pass_min_2_1 is not changed
-
-    - name: Get shadow data for ansibulluser
+    - name: get shadow data after setting password_expire_max
       getent:
         database: shadow
         key: ansibulluser
 
-    - name: Ensure password expiration was set properly
+    - name: ensure maximum password age was set properly in shadow
       assert:
         that:
-          - ansible_facts.getent_shadow['ansibulluser'][2] == '5'
           - ansible_facts.getent_shadow['ansibulluser'][3] == '10'
-
-    - name: Set min and max at the same time
-      user:
-        name: ansibulluser
-        # also checks that assigning 0 works
-        password_expire_min: 0
-        password_expire_max: 0
-
-    - name: Get shadow data for ansibulluser
-      getent:
-        database: shadow
-        key: ansibulluser
-
-    - name: Ensure password expiration was set properly
-      assert:
-        that:
-          - ansible_facts.getent_shadow['ansibulluser'][2] == '0'
-          - ansible_facts.getent_shadow['ansibulluser'][3] == '0'

--- a/test/sanity/code-smell/codespell/ignore-words.txt
+++ b/test/sanity/code-smell/codespell/ignore-words.txt
@@ -1,2 +1,3 @@
 afile  # commonly used variable name for "a file"
 astroid  # pylint's astroid
+chage  # command name for changing user password expiry information


### PR DESCRIPTION
### Summary
Fixes #87428

In `shadow-utils` 4.20 ("Ibores"), `chage -m` / `--mindays`, `passwd -n`, and `PASS_MIN_DAYS` were removed without replacement as a security measure (see https://github.com/shadow-maint/shadow/pull/1482).

This PR:
1. Implements a capability check `_chage_supports_mindays()` using non-mutating `chage --help` inspection (following the existing convention in `_check_usermod_append()`).
2. Fails explicitly with a clear, descriptive error message when `password_expire_min` is invoked on a system where `chage` lacks `-m/--mindays` support.
3. Emits a deprecation warning on systems where `chage -m` is still supported, alerting users of the upstream removal before their system utilities are upgraded.
4. Preserves existing behavior on systems running older `shadow-utils`.
5. Updates the parameter documentation in `user.py`.
6. Updates integration test `test_expires_min_max.yml` with dual-branch coverage for both supported (testing success and warning) and unsupported (testing explicit failure) systems, while testing `password_expire_max` independently in all environments.
7. Adds `chage` to sanity codespell ignore words.
8. Adds a changelog fragment.

### Issue Type
- Bugfix Pull Request

### Component Name
`ansible.builtin.user`

### Additional Information
The other expiration parameters (`password_expire_max`, `password_expire_warn`, `password_expire_account_disable`) remain functional in `shadow-utils` 4.20 despite being deprecated upstream, and are left untouched in this PR.
