### PR TITLE
fix: reconcile rescued include_role failures

### DIFF
--- a/changelogs/fragments/86721-include-role-rescue.yml
+++ b/changelogs/fragments/86721-include-role-rescue.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    include_role - Reconcile rescued role-loading failures with normal task failure handling so they do not remain in
+    failure statistics or prevent the host from running later plays (https://github.com/ansible/ansible/issues/86721).

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -527,6 +527,56 @@ class StrategyBase:
         except queue.Empty:
             pass
 
+    def _process_failed_result(self, iterator: PlayIterator, task_result: HostTaskResult) -> None:
+        """Update play state and statistics for a failed task result."""
+        original_host = task_result.host
+        original_task = task_result.task
+        ignore_errors = task_result.utr.ignore_errors
+
+        if not ignore_errors:
+            # save the current state before failing it for later inspection
+            state_when_failed = iterator.get_state_for_host(original_host.name)
+            display.debug("marking %s as failed" % original_host.name)
+
+            if original_task.run_once:
+                # if we're using run_once, we have to fail every host here
+                for host in self._inventory.get_hosts(iterator._play.hosts):
+                    if host.name not in self._tqm._unreachable_hosts:
+                        iterator.mark_host_failed(host)
+            else:
+                iterator.mark_host_failed(original_host)
+
+            state, dummy = iterator.get_next_task_for_host(original_host, peek=True)
+
+            if iterator.is_failed(original_host) and state and state.run_state == IteratingStates.COMPLETE:
+                self._tqm._failed_hosts[original_host.name] = True
+
+            # if we're iterating on the rescue portion of a block then
+            # we save the failed task in a special var for use
+            # within the rescue/always
+            if iterator.is_any_block_rescuing(state_when_failed):
+                self._tqm._stats.increment('rescued', original_host.name)
+
+                iterator._play._removed_hosts.remove(original_host.name)
+
+                self._variable_manager.set_nonpersistent_facts(
+                    original_host.name,
+                    dict(
+                        ansible_failed_task=original_task.dump_attrs(),
+                        ansible_failed_result=task_result.utr.as_result_dict(),
+                    ),
+                )
+            else:
+                self._tqm._stats.increment('failures', original_host.name)
+        else:
+            self._tqm._stats.increment('ok', original_host.name)
+            self._tqm._stats.increment('ignored', original_host.name)
+
+            if task_result.utr.changed:
+                self._tqm._stats.increment('changed', original_host.name)
+
+        self._tqm.send_callback('v2_runner_on_failed', task_result, ignore_errors=ignore_errors)
+
     @debug_closure
     def _process_pending_results(self, iterator: PlayIterator, one_pass: bool = False, max_passes: int | None = None) -> list[HostTaskResult]:
         """
@@ -555,51 +605,7 @@ class StrategyBase:
 
             if task_result.utr.failed:
                 role_ran = True
-                ignore_errors = task_result.utr.ignore_errors
-
-                if not ignore_errors:
-                    # save the current state before failing it for later inspection
-                    state_when_failed = iterator.get_state_for_host(original_host.name)
-                    display.debug("marking %s as failed" % original_host.name)
-
-                    if original_task.run_once:
-                        # if we're using run_once, we have to fail every host here
-                        for h in self._inventory.get_hosts(iterator._play.hosts):
-                            if h.name not in self._tqm._unreachable_hosts:
-                                iterator.mark_host_failed(h)
-                    else:
-                        iterator.mark_host_failed(original_host)
-
-                    state, dummy = iterator.get_next_task_for_host(original_host, peek=True)
-
-                    if iterator.is_failed(original_host) and state and state.run_state == IteratingStates.COMPLETE:
-                        self._tqm._failed_hosts[original_host.name] = True
-
-                    # if we're iterating on the rescue portion of a block then
-                    # we save the failed task in a special var for use
-                    # within the rescue/always
-                    if iterator.is_any_block_rescuing(state_when_failed):
-                        self._tqm._stats.increment('rescued', original_host.name)
-
-                        iterator._play._removed_hosts.remove(original_host.name)
-
-                        self._variable_manager.set_nonpersistent_facts(
-                            original_host.name,
-                            dict(
-                                ansible_failed_task=original_task.dump_attrs(),
-                                ansible_failed_result=task_result.utr.as_result_dict(),
-                            ),
-                        )
-                    else:
-                        self._tqm._stats.increment('failures', original_host.name)
-                else:
-                    self._tqm._stats.increment('ok', original_host.name)
-                    self._tqm._stats.increment('ignored', original_host.name)
-
-                    if task_result.utr.changed:
-                        self._tqm._stats.increment('changed', original_host.name)
-
-                self._tqm.send_callback('v2_runner_on_failed', task_result, ignore_errors=ignore_errors)
+                self._process_failed_result(iterator, task_result)
             elif task_result.utr.unreachable:
                 if not task_result.utr.ignore_unreachable:
                     self._tqm._unreachable_hosts[original_host.name] = True

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -226,7 +226,6 @@ class StrategyModule(StrategyBase):
 
             if len(included_files) > 0:
                 all_blocks = dict((host, []) for host in hosts_left)
-                failed_includes_hosts = set()
                 for included_file in included_files:
                     display.debug("collecting new blocks for %s" % included_file)
                     is_handler = False
@@ -261,9 +260,7 @@ class StrategyModule(StrategyBase):
                             r.utr.exception = utr.exception
                             r.utr.msg = utr.msg
 
-                            self._tqm._stats.increment('failures', r.host.name)
-                            self._tqm.send_callback('v2_runner_on_failed', r)
-                            failed_includes_hosts.add(r.host)
+                            self._process_failed_result(iterator, r)
                         continue
                     else:
                         # since we skip incrementing the stats when the task result is
@@ -289,10 +286,6 @@ class StrategyModule(StrategyBase):
                             if host in included_file._hosts:
                                 all_blocks[host].append(final_block)
                     display.debug("done collecting new blocks for %s" % included_file)
-
-                for host in failed_includes_hosts:
-                    self._tqm._failed_hosts[host.name] = True
-                    iterator.mark_host_failed(host)
 
                 display.debug("adding all collected blocks from %d included file(s) to iterator" % len(included_files))
                 for host in hosts_left:

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -249,7 +249,6 @@ class StrategyModule(StrategyBase):
                     all_blocks = dict((host, []) for host in hosts_left)
                     display.debug("done generating all_blocks data")
                     included_tasks = []
-                    failed_includes_hosts = set()
                     for included_file in included_files:
                         display.debug("processing included file: %s" % included_file._filename)
                         is_handler = False
@@ -309,19 +308,13 @@ class StrategyModule(StrategyBase):
                                 r.utr.exception = utr.exception
                                 r.utr.msg = utr.msg
 
-                                self._tqm._stats.increment('failures', r.host.name)
-                                self._tqm.send_callback('v2_runner_on_failed', r)
-                                failed_includes_hosts.add(r.host)
+                                self._process_failed_result(iterator, r)
                         else:
                             # since we skip incrementing the stats when the task result is
                             # first processed, we do so now for each host in the list
                             for host in included_file._hosts:
                                 self._tqm._stats.increment('ok', host.name)
                             self._tqm.send_callback('v2_playbook_on_include', included_file)
-
-                    for host in failed_includes_hosts:
-                        self._tqm._failed_hosts[host.name] = True
-                        iterator.mark_host_failed(host)
 
                     # finally go through all of the hosts and append the
                     # accumulated blocks to their list of tasks

--- a/test/integration/targets/includes/include_role_error_handling.yml
+++ b/test/integration/targets/includes/include_role_error_handling.yml
@@ -1,37 +1,68 @@
-- hosts: localhost
+- name: Test include_role error handling
+  hosts: localhost
   gather_facts: false
+  strategy: "{{ strategy | default('linear') }}"
+  vars:
+    error_type: missing_role
+    rescue_1: false
+    rescue_2: false
   tasks:
-    - name: test missing role rescue
-      vars:
-        rescue_1: false
+    - name: Test missing role rescue
+      when: error_type == 'missing_role'
       block:
         - name: Include a role that doesn't exist
           include_role:
             name: missing_role
-            rescuable: '{{ rescueme | default(omit) }}'
-
+            rescuable: "{{ rescueme | default(omit) }}"
       rescue:
-        - set_fact: 
-              rescue_1: true
-      always:
-        - assert:
+        - name: Rescue missing role include
+          ansible.builtin.set_fact:
+            rescue_1: true
+        - name: Verify missing role failure details
+          ansible.builtin.assert:
             that:
-              - rescue_1 == rescueme|default(True)
+              - ansible_failed_task.name == "Include a role that doesn't exist"
+              - ansible_failed_result.failed
 
-    - name: Test _from rescue
-      vars:
-        rescue_2: false
+    - name: Test tasks_from rescue
+      when: error_type == 'missing_tasks_from'
       block:
         - name: Include a task file that doesn't exist, but role exists
           include_role:
             name: include_roles
             tasks_from: missing_task_list
-            rescuable: '{{ rescueme | default(omit) }}'
-
+            rescuable: "{{ rescueme | default(omit) }}"
       rescue:
-        - set_fact: 
-              rescue_2: true
-      always:
-        - assert:
+        - name: Rescue missing tasks_from include
+          ansible.builtin.set_fact:
+            rescue_2: true
+        - name: Verify missing tasks_from failure details
+          ansible.builtin.assert:
             that:
-              - rescue_2 == rescueme|default(True)
+              - ansible_failed_task.name == "Include a task file that doesn't exist, but role exists"
+              - ansible_failed_result.failed
+
+    - name: Include a missing role outside a rescuing block
+      when: error_type == 'unrescued'
+      include_role:
+        name: missing_role
+
+    - name: Continue after include_role error handling
+      ansible.builtin.set_fact:
+        continued_after_rescue: true
+
+- name: Verify host state in a later play
+  hosts: localhost
+  gather_facts: false
+  strategy: "{{ strategy | default('linear') }}"
+  vars:
+    error_type: missing_role
+    rescue_1: false
+    rescue_2: false
+  tasks:
+    - name: Verify host is available in later play
+      ansible.builtin.assert:
+        that:
+          - continued_after_rescue
+          - rescue_1 == (error_type == 'missing_role')
+          - rescue_2 == (error_type == 'missing_tasks_from')

--- a/test/integration/targets/includes/runme.sh
+++ b/test/integration/targets/includes/runme.sh
@@ -19,12 +19,43 @@ ansible-playbook includes_loop_rescue.yml --extra-vars strategy=free "$@"
 
 ansible-playbook includes_from_dedup.yml -i ../../inventory "$@"
 
-# test 'rescueable' default (true)
-ansible-playbook include_role_error_handling.yml "$@"
-# test 'rescueable' explicit true 
+# test 'rescuable' default (true) with each strategy
+for strategy in linear free; do
+    output="$(ansible-playbook include_role_error_handling.yml "$@" -e "strategy=${strategy}")"
+    grep -q 'Rescue missing role include' <<< "$output"
+    grep -q 'Continue after include_role error handling' <<< "$output"
+    grep -q 'Verify host is available in later play' <<< "$output"
+    grep -q 'failed=0' <<< "$output"
+    grep -q 'rescued=1' <<< "$output"
+done
+
+# test 'rescuable' explicit true
 ansible-playbook include_role_error_handling.yml "$@" -e '{"rescueme": true}'
-# test 'rescueable' explicit false 
-[[ $(ansible-playbook include_role_error_handling.yml "$@" -e '{"rescueme": false}') != 0 ]]
+
+# test missing tasks_from failure state
+output="$(ansible-playbook include_role_error_handling.yml "$@" -e error_type=missing_tasks_from)"
+grep -q 'Verify missing tasks_from failure details' <<< "$output"
+grep -q 'Verify host is available in later play' <<< "$output"
+grep -q 'failed=0' <<< "$output"
+grep -q 'rescued=1' <<< "$output"
+
+# test 'rescuable' explicit false
+if ansible-playbook include_role_error_handling.yml "$@" -e '{"rescueme": false}'; then
+    exit 1
+fi
+
+# test an include failure outside a rescuing block
+set +e
+output="$(ansible-playbook include_role_error_handling.yml "$@" -e error_type=unrescued 2>&1)"
+rc=$?
+set -e
+test "$rc" -ne 0
+grep -q 'localhost.*FAILED!' <<< "$output"
+grep -q 'failed=1' <<< "$output"
+grep -q 'rescued=0' <<< "$output"
+if grep -q 'Continue after include_role error handling' <<< "$output" || grep -q 'Verify host is available in later play' <<< "$output"; then
+    exit 1
+fi
 # ensure imports are not rescuable
 [[ $(ansible-playbook import_no_rescue.yml "$@") != 0 ]]
 


### PR DESCRIPTION
##### SUMMARY

Extract the ordinary failed-result state transition and accounting from `StrategyBase._process_pending_results` into a shared production path that can also process an include-load exception without repeating pending-queue bookkeeping. Have both the linear and free include expansion paths convert the caught `AnsibleError` into the existing include result and pass it through that shared path, so block state, `ansible_failed_task`/`ansible_failed_result`, rescue statistics, callbacks, removed-host state, and terminal failed-host tracking follow the same rules as worker-returned task failures. Remove the strategy-specific unconditional failure-stat increments and failed-host assignments, while continuing to re-raise `AnsibleParserError` so `rescuable: false` remains fatal.

A missing role discovered while expanding a dynamic `include_role` is explicitly rescuable by default, and the enclosing block's rescue tasks do run. However, the linear and free strategies currently handle that controller-side load exception outside `_process_pending_results`, directly incrementing failure statistics and retaining the host in the task queue manager's failed-host set. The resulting state is internally inconsistent: work can continue in the current play, while the final recap still reports a failure and a later play can silently omit the host. The issue is verified and the thread identifies this divergent result-processing path as the root cause.

Fixes #86721

##### ISSUE TYPE

- Bugfix Pull Request

AI was used for assistance.
