### PR TITLE
doc(config): document supported server options under GALAXY_SERVER_LIST

### DIFF
--- a/changelogs/fragments/87425-doc-galaxy-server-options.yml
+++ b/changelogs/fragments/87425-doc-galaxy-server-options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - config - document supported server options (including ``validate_certs``, ``auth_url``, and ``client_id``) under ``GALAXY_SERVER_LIST`` (https://github.com/ansible/ansible/issues/87425).

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1494,6 +1494,7 @@ GALAXY_SERVER_LIST:
   description:
   - A list of Galaxy servers to use when installing a collection.
   - The value corresponds to the config ini header ``[galaxy_server.{{item}}]`` which defines the server details.
+  - Supported server configuration keys include ``url``, ``username``, ``password``, ``token``, ``auth_url``, ``validate_certs``, ``client_id``, ``client_secret``, and ``timeout``.
   - 'See :ref:`galaxy_server_config` for more details on how to define a Galaxy server.'
   - The order of servers in this list is used as the order in which a collection is resolved.
   - Setting this config option will ignore the :ref:`galaxy_server` config option.


### PR DESCRIPTION
### Summary
Document supported server configuration keys (including `validate_certs`, `auth_url`, `client_id`, `client_secret`, and `timeout`) under the `GALAXY_SERVER_LIST` description in `lib/ansible/config/base.yml`.

Fixes #87425

### Issue Type
Documentation Report

### Component Name
config, galaxy

### Ansible Version
devel (2.21+)