### PR TITLE
pip: fix always changed in check mode with virtualenv and requirements

### DIFF
--- a/lib/ansible/modules/pip.py
+++ b/lib/ansible/modules/pip.py
@@ -878,8 +878,41 @@ def main():
             module.exit_json(changed=False)
 
         if module.check_mode:
-            if extra_args or requirements or state == 'latest' or not name:
+            if extra_args or state == 'latest' or not name:
                 module.exit_json(changed=True)
+            if requirements:
+                # Fix for #62826: don't always report changed for requirements in check_mode
+                # Check if virtualenv would be created and if requirements already satisfied
+                # If virtualenv doesn't exist, it would be created -> changed
+                if env and not os.path.exists(os.path.join(env, 'bin', 'activate')):
+                    module.exit_json(changed=True)
+                # Check if packages from requirements file are already installed
+                try:
+                    with open(requirements, 'r') as f:
+                        req_packages = [line.strip() for line in f if line.strip() and not line.strip().startswith('#')]
+                    # Filter out options like --find-links, -i, etc.
+                    req_packages = [p for p in req_packages if not p.startswith('-')]
+                    if not req_packages:
+                        module.exit_json(changed=False)
+                    # Get current installed packages
+                    pkg_cmd_r, out_r, err_r = _get_packages(module, pip, chdir)
+                    out += out_r
+                    err += err_r
+                    pkg_list_r = [p for p in out_r.split('\n') if not p.startswith('You are using') and not p.startswith('You should consider') and p]
+                    # Check each requirement
+                    changed_r = False
+                    for req in req_packages:
+                        # Handle version specifiers and extras
+                        pkg = Package(req)
+                        # Use _is_present to check
+                        is_present = _is_present(module, pkg, pkg_list_r, pkg_cmd_r)
+                        if (state == 'present' and not is_present) or (state == 'absent' and is_present):
+                            changed_r = True
+                            break
+                    module.exit_json(changed=changed_r, cmd=pkg_cmd_r, stdout=out, stderr=err)
+                except Exception:
+                    # Fallback to always changed if we can't determine
+                    module.exit_json(changed=True)
 
             pkg_cmd, out_pip, err_pip = _get_packages(module, pip, chdir)
 


### PR DESCRIPTION
Fixes #62826

## Problem

The pip module will always be `changed` when using a virtualenv and when running in check mode, even when the virtualenv already exists and requirements are already satisfied.

This is caused by the check-mode handling:

```python
if extra_args or requirements or state == 'latest' or not name:
    module.exit_json(changed=True)
```

which unconditionally reports `changed=True` for any `requirements` file, without checking if the virtualenv would actually be created or if the packages are already installed.

Repro: create virtualenv with `ansible==2.8.5` via `pip: requirements: ... virtualenv: ...`, run again with `--check` → reports `changed: [127.0.0.1]` but should be `ok`.

## Change

- In `lib/ansible/modules/pip.py:main()` check-mode handling — remove `requirements` from the unconditional `changed=True` shortcut; handle `requirements` explicitly:
  - If `env` and `env/bin/activate` does not exist → `changed=True` (would create)
  - Else read `requirements` file, filter comments/options, get current `pip freeze` via `_get_packages`, build `Package` objects, and use `_is_present` to check each requirement. Only report `changed=True` if a package would actually be installed/removed (matching the non-check-mode `freeze_before != freeze_after` logic)
  - Fallback to `changed=True` on exception

Keep unrelated cleanup out of this PR.

## Why this approach

Matches the non-check-mode logic that compares freeze before/after, and reuses existing helpers (`_get_packages`, `_is_present`, `Package`). For check mode without actually running pip install, we simulate by checking if each requirement is already present. If virtualenv already exists and all requirements are satisfied, check mode now correctly reports `ok`.

## Testing

```text
command: python3 -m py_compile lib/ansible/modules/pip.py
result: ok

command: git diff --check
result: clean

command: manual (virtualenv already created with ansible==2.8.5, then --check)
result: second run now reports ok (was changed before)
```

## Documentation and release impact

- [x] User-facing behavior fixed (check mode idempotency)
- [x] Changelog/release note needed: bug fix
- [ ] Migration or compatibility note needed
- [ ] No documentation impact

## Review notes

- Known limitations: none beyond requirements file parsing (ignores `-` options)
- Follow-up issue, if any: none
- Security/licensing considerations: none
