### PR TITLE
Docs: Clarify copy module's owner and group parameters

### DIFF
--- a/changelogs/fragments/84732-copy-module-doc.yml
+++ b/changelogs/fragments/84732-copy-module-doc.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - copy - Clarify that owner and group do not preserve previous ownership by default (https://github.com/ansible/ansible/issues/84732).

--- a/lib/ansible/plugins/doc_fragments/files.py
+++ b/lib/ansible/plugins/doc_fragments/files.py
@@ -34,8 +34,7 @@ options:
   owner:
     description:
     - Name of the user that should own the filesystem object, as would be fed to C(chown).
-    - When left unspecified, it uses the current user unless you are root, in which
-      case it can preserve the previous ownership.
+    - When left unspecified, it uses the current user.
     - Specifying a numeric username (for example, "1000") will be assumed to be a user ID (UID) and not a username.
       To prevent confusion, avoid using purely numeric usernames.
 
@@ -43,8 +42,7 @@ options:
   group:
     description:
     - Name of the group that should own the filesystem object, as would be fed to C(chown).
-    - When left unspecified, it uses the current group of the current user unless you are root,
-      in which case it can preserve the previous ownership.
+    - When left unspecified, it uses the current group of the current user.
     - Specifying a numeric group name (for example, "1000") will be assumed to be a group ID (GID) and not a group name.
       To prevent confusion, avoid using purely numeric group names.
     type: str


### PR DESCRIPTION
##### SUMMARY

This PR fixes #84732 by clarifying the default behavior of the `owner` and `group` parameters in the `copy` module. The documentation previously stated that when running as root, the previous ownership would be preserved if these options were left unspecified, but this is inaccurate. The updated documentation correctly reflects that they default to the current user and group.

##### ISSUE TYPE

- Docs Pull Request