### PR TITLE
Docs: document valid color options for parsecolor

### DIFF
--- a/lib/ansible/utils/color.py
+++ b/lib/ansible/utils/color.py
@@ -53,7 +53,26 @@ if C.ANSIBLE_FORCE_COLOR:
 
 
 def parsecolor(color):
-    """SGR parameter string for the specified color name."""
+    """Return SGR parameter string for the specified color.
+
+    Valid color values are:
+
+    * Named colors from :data:`ansible.constants.COLOR_CODES`: ``black``,
+      ``bright gray``, ``blue``, ``white``, ``green``, ``bright blue``, ``cyan``,
+      ``bright green``, ``red``, ``bright cyan``, ``purple``, ``bright red``,
+      ``yellow``, ``bright purple``, ``dark gray``, ``bright yellow``, ``magenta``,
+      ``bright magenta``, ``normal``.
+    * 256-color palette: ``color0`` through ``color255`` (e.g. ``color196``
+      for bright red, ``color240`` for dark gray). See
+      https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit for the chart.
+    * RGB cube: ``rgb<red><green><blue>`` where each component is ``0``–``5``
+      (e.g. ``rgb500`` is red, ``rgb050`` is green, ``rgb005`` is blue,
+      ``rgb555`` is white). Maps to 256-color codes 16–231.
+    * Grayscale ramp: ``gray0`` through ``gray23`` (maps to 232–255).
+
+    :param color: color name or 256-color/RGB/gray specifier
+    :returns: SGR parameter string for use in ANSI escape sequences
+    """
     matches = re.match(r"color(?P<color>[0-9]+)"
                        r"|(?P<rgb>rgb(?P<red>[0-5])(?P<green>[0-5])(?P<blue>[0-5]))"
                        r"|gray(?P<gray>[0-9]+)", color)


### PR DESCRIPTION
## Problem

Other than the defaults listed for the `COLOR_*` variables, there are no definitions for what are valid choices for colors. Looking at `parsecolor()` in `lib/ansible/utils/color.py`, there appear to be ways to select colors aside from using predefined color names that appear to also be undocumented.

Having the list of pre-defined colors, and valid examples of how to use the alternate color methods would be useful when trying to modify output to suit custom display configurations and/or address accessibility needs.

Fixes #83633

## Change

Document the valid color values accepted by `parsecolor()` in `lib/ansible/utils/color.py`:

- Named colors from `ansible.constants.COLOR_CODES` (`black`, `bright gray`, `blue`, `white`, `green`, `bright blue`, `cyan`, `bright green`, `red`, `bright cyan`, `purple`, `bright red`, `yellow`, `bright purple`, `dark gray`, `bright yellow`, `magenta`, `bright magenta`, `normal`)
- 256-color palette: `color0` through `color255` (e.g. `color196` for bright red)
- RGB cube: `rgb<red><green><blue>` where each component is `0`–`5` (e.g. `rgb500` is red)
- Grayscale ramp: `gray0` through `gray23` (maps to 232–255)

Adds reference to the ANSI 256-color chart for further details. Single-file, docs-only change.

## Why this approach

Minimal docs-only change to the docstring that is the authoritative source for `parsecolor` behavior. No code or runtime change; the existing regex already supports these patterns, they were just undocumented. Matches the issue's component (`lib/ansible/utils/color.py`) and avoids touching generated docs.

## Testing

```text
command: uv run --project /tmp/ansible-l7-83633/repo python -c "from ansible.utils.color import parsecolor; print(parsecolor('red'), parsecolor('color196'), parsecolor('rgb500'), parsecolor('gray10'))"
result: 0;31 38;5;196 38;5;196 38;5;242 — all correct

command: git diff --check
result: clean

command: uv run --project /tmp/ansible-l7-83633/repo python -c "import ansible.utils.color; print('Valid color values' in ansible.utils.color.parsecolor.__doc__)"
result: True
```

## Documentation and release impact

- [x] User-facing documentation updated (docstring)
- [ ] Changelog needed — docs-only
- [x] No compatibility impact

## Review notes

- Known limitations: none
- Security/licensing: no new dependencies, GPL-3.0

## AI disclosure

Muse Spark assisted in drafting the docstring; all changes manually reviewed and tested. The contributor understands and can explain the submitted code.
