### PR TITLE
Docs: clarify mode inheritance for unarchive when mode not specified

### DIFF
--- a/lib/ansible/modules/unarchive.py
+++ b/lib/ansible/modules/unarchive.py
@@ -145,6 +145,12 @@ notes:
       are not touched. This is the same behavior as a normal archive extraction.
     - Existing files/directories in the destination which are not in the archive
       are ignored for purposes of deciding if the archive should be unpacked or not.
+    - When O(mode) is not specified, the permissions of extracted files are preserved
+      from the archive. For zip archives, the original permissions stored in the
+      zip file are used. For tar archives, the effective permissions depend on the
+      extraction flags and whether the extraction is performed as root (GNU tar
+      defaults to C(--same-permissions) for root and C(--no-same-permissions) for
+      ordinary users, where C(--no-same-permissions) applies the user's umask).
 seealso:
 - module: community.general.archive
 - module: community.general.iso_extract


### PR DESCRIPTION
## Problem

From docs about `mode` opts in archive we read:

> The permissions the resulting filesystem object should have.
> If `mode` is not specified and the destination filesystem object does not exist, the default umask on the system will be used when setting the mode for the newly created filesystem object.
> If `mode` is not specified and the destination filesystem object does exist, the mode of the existing filesystem object will be used.

But this description is not clear for `unarchive` because zip files can save original permissions. For example, `zipinfo` shows `rwxrwx---` etc., and after extraction those permissions are preserved even though `mode` was not specified and umask would suggest 775.

Need to add information that file permissions can be inherited from the archive if `mode` is not specified.

Fixes #82459

## Change

Adds a `notes` entry to `lib/ansible/modules/unarchive.py` DOCUMENTATION clarifying:

- When `mode` is not specified, permissions are preserved from the archive
- For zip archives, original permissions stored in the zip are used
- For tar archives, effective permissions depend on extraction flags and whether run as root (GNU tar defaults to `--same-permissions` for root and `--no-same-permissions` for ordinary users, where the latter applies umask)

Single-file docs-only change, no logic change.

## Why this approach

The `unarchive` module extends the common `files` doc fragment, so the generic `mode` description is not accurate for archive extraction. Adding a specific note to this module's docs is the minimal, correct location and preserves the fragment for other modules. The wording matches the tar manpage distinction raised in the issue comments (root vs non-root) and the zip behavior observed in the reproduction.

## Testing

```text
command: python -m py_compile lib/ansible/modules/unarchive.py
result: ok

command: git diff --check
result: clean

command: ansible-doc ansible.builtin.unarchive | grep -A5 "When mode is not specified"
result: shows new note with expected text
```

## Documentation and release impact

- [x] User-facing documentation updated
- [ ] Changelog needed — docs-only

## Review notes

- Follow-up: none
- Security: no

## AI disclosure

Muse Spark assisted in drafting the docs; changes reviewed and tested manually.
