### PR TITLE
Bump maximum version of setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 77.0.3, <= 80.3.1"]  # lower bound to support license/license-files (PEP 639), upper bound for latest version tested at release
+requires = ["setuptools >= 77.0.3, <= 84.0.0"]  # lower bound to support license/license-files (PEP 639), upper bound for latest version tested at release
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
##### SUMMARY

Bump the maximum supported version of setuptools to minimise the risk of dependency hell for folks installing ansible-core

Current pinning is only there because it's the last version that was tested against at the time (#85103), not because something broke

##### ISSUE TYPE

- Feature Pull Request
