### PR TITLE
fix(ansible): deepcopy facts before caching to prevent cross-host leak

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -40,7 +40,7 @@ from ansible.template import Templar
 from ansible.utils.collection_loader import AnsibleCollectionConfig
 from ansible.utils.display import Display
 from ansible.utils.vars import combine_vars
-from ansible.vars.clean import namespace_facts
+from ansible.vars.clean import module_response_deepcopy, namespace_facts
 from ansible.vars.manager import _clean_and_deprecate_top_level_facts, _INJECT_FACTS
 from ansible._internal._errors import _task_timeout
 from ansible._internal import _task
@@ -555,7 +555,7 @@ class TaskExecutor:
 
             if utr.ansible_facts and _task.VariableLayer.CACHEABLE_FACT not in utr.pending_changes.register_host_variables:
                 # For backward compatibility, if the action provided ansible_facts, use that as the CACHEABLE_FACT layer if the action did not provide one.
-                utr.pending_changes.register_host_variables[_task.VariableLayer.CACHEABLE_FACT] = utr.ansible_facts
+                utr.pending_changes.register_host_variables[_task.VariableLayer.CACHEABLE_FACT] = module_response_deepcopy(utr.ansible_facts)
 
             # Variable layers should be reflected on task vars in the same way they will be handled by variable manager.
             # What occurs below is a partial re-implementation of variable manager, and thus does not fully reflect its behavior.

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -37,7 +37,7 @@ from ansible._internal._templating._engine import TemplateEngine
 from ansible.plugins.loader import cache_loader
 from ansible.utils.display import Display
 from ansible.utils.vars import combine_vars, load_extra_vars, load_options_vars
-from ansible.vars.clean import namespace_facts, clean_facts
+from ansible.vars.clean import clean_facts, module_response_deepcopy, namespace_facts
 from ansible.vars.hostvars import HostVars
 from ansible.vars.plugins import get_vars_from_inventory_sources, get_vars_from_path
 from ansible.vars.reserved import warn_if_reserved
@@ -581,13 +581,13 @@ class VariableManager:
             host_cache = self._fact_cache.get(host)
         except KeyError:
             # We get to set this as new
-            host_cache = facts
+            host_cache = module_response_deepcopy(facts)
         else:
             if not isinstance(host_cache, MutableMapping):
                 raise TypeError('The object retrieved for {0} must be a MutableMapping but was'
                                 ' a {1}'.format(host, type(host_cache)))
             # Update the existing facts
-            host_cache |= facts
+            host_cache |= module_response_deepcopy(facts)
 
         # Save the facts back to the backing store
         self._fact_cache.set(host, host_cache)


### PR DESCRIPTION
Bug: VariableManager.set_host_facts merges cached host facts with shallow dict union at lib/ansible/vars/manager.py:590. Nested dicts and lists are shared by reference, so mutating the incoming facts after caching leaks one host setup result onto another cached host.

Fix: Wrap facts in module_response_deepcopy before merge and before initial cache assignment. Same protection added at lib/ansible/executor/task_executor.py where pending cacheable facts are registered. Uses existing clean.module_response_deepcopy helper which handles dict and list recursion without full copy.deepcopy overhead.

Evidence: Reproduction shows shallow host_cache |= facts leaks nested mutation (MUTATED and appended 999 propagate into cache). After fix both cases are protected. py_compile passes on both files. Change is two imports plus three deepcopy wrappers, no behavior change for scalar facts.