### PR TITLE
GetAddrInfoPatch: don't crash when the idna codec is missing

### DIFF
--- a/changelogs/fragments/86072-getaddrinfo-idna.yml
+++ b/changelogs/fragments/86072-getaddrinfo-idna.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "module_utils - importing modules no longer fails when the idna codec is missing; the standard library ``getaddrinfo`` is used instead (https://github.com/ansible/ansible/issues/86072)."
+  - "Ansible no longer fails to import when IDNA support is missing (https://github.com/ansible/ansible/issues/86072)."

--- a/changelogs/fragments/86072-getaddrinfo-idna.yml
+++ b/changelogs/fragments/86072-getaddrinfo-idna.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "module_utils - do not fail module import with ``LookupError: unknown encoding: idna`` when the idna codec is missing."

--- a/changelogs/fragments/86072-getaddrinfo-idna.yml
+++ b/changelogs/fragments/86072-getaddrinfo-idna.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "module_utils - do not fail module import with ``LookupError: unknown encoding: idna`` when the idna codec is missing."
+  - "module_utils - importing modules no longer fails when the idna codec is missing; the standard library ``getaddrinfo`` is used instead (https://github.com/ansible/ansible/issues/86072)."

--- a/lib/ansible/module_utils/_internal/_patches/_socket_patch.py
+++ b/lib/ansible/module_utils/_internal/_patches/_socket_patch.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import socket
 import typing as t
 
@@ -21,11 +20,14 @@ class GetAddrInfoPatch(CallablePatch):
 
     @classmethod
     def is_patch_needed(cls) -> bool:
-        with contextlib.suppress(OSError):
+        try:
             socket.getaddrinfo('127.0.0.1', _CustomInt(22))
+        except OSError:
+            return True
+        except LookupError:
             return False
 
-        return True
+        return False
 
     def __call__(self, host, port, *args, **kwargs) -> t.Any:
         if type(port) is not int and isinstance(port, int):  # pylint: disable=unidiomatic-typecheck

--- a/test/units/module_utils/_internal/_patches/test_socket_patch.py
+++ b/test/units/module_utils/_internal/_patches/test_socket_patch.py
@@ -3,9 +3,21 @@ from __future__ import annotations
 import socket
 
 from ansible.module_utils._internal._datatag._tags import Deprecated
+from ansible.module_utils._internal._patches._socket_patch import GetAddrInfoPatch
 
 
 def test_getaddrinfo() -> None:
     """Verify that `socket.getaddrinfo` works with a tagged port."""
     # DTFIX5: add additional args and validate output shape (ensure passthru is working)
     socket.getaddrinfo('localhost', Deprecated(msg='').tag(22))
+
+
+def test_is_patch_needed_when_idna_codec_missing(monkeypatch) -> None:
+    """Missing idna codec must not make the probe raise or apply the patch."""
+    def boom(*args, **kwargs):
+        raise LookupError('unknown encoding: idna')
+
+    monkeypatch.setattr(socket, 'getaddrinfo', boom)
+
+    assert GetAddrInfoPatch.is_patch_needed() is False
+    GetAddrInfoPatch.patch()


### PR DESCRIPTION
GetAddrInfoPatch.is_patch_needed() only swallowed OSError. Without the idna codec the probe raises LookupError and module import dies.

Catch LookupError and leave stdlib getaddrinfo. OSError still means the patch is needed.

Fixes #86072