### PR TITLE
setup module, move fqdn and domain facts from platform category to fqdn

### DIFF
--- a/changelogs/fragments/fqdn_facts.yml
+++ b/changelogs/fragments/fqdn_facts.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+  - |
+    `fqdn` and `domain` facts have moved from `platform` category to `fqdn`.

--- a/lib/ansible/module_utils/facts/compat.py
+++ b/lib/ansible/module_utils/facts/compat.py
@@ -64,7 +64,7 @@ def ansible_facts(module, gather_subset=None):
     filter_spec = module.params.get('filter', '*')
 
     minimal_gather_subset = frozenset(['apparmor', 'caps', 'cmdline', 'date_time',
-                                       'distribution', 'dns', 'env', 'fips', 'local',
+                                       'distribution', 'dns', 'env', 'fips', 'fqdn', 'local',
                                        'lsb', 'pkg_mgr', 'platform', 'python', 'selinux',
                                        'service_mgr', 'ssh_pub_keys', 'user'])
 

--- a/lib/ansible/module_utils/facts/default_collectors.py
+++ b/lib/ansible/module_utils/facts/default_collectors.py
@@ -40,6 +40,7 @@ from ansible.module_utils.facts.system.chroot import ChrootFactCollector
 from ansible.module_utils.facts.system.cmdline import CmdLineFactCollector
 from ansible.module_utils.facts.system.distribution import DistributionFactCollector
 from ansible.module_utils.facts.system.date_time import DateTimeFactCollector
+from ansible.module_utils.facts.system.fqdn import FQDNFactCollector
 from ansible.module_utils.facts.system.env import EnvFactCollector
 from ansible.module_utils.facts.system.dns import DnsFactCollector
 from ansible.module_utils.facts.system.fips import FipsFactCollector
@@ -117,6 +118,7 @@ _general = [
     CmdLineFactCollector,
     DateTimeFactCollector,
     EnvFactCollector,
+    FQDNFactCollector,
     LoadAvgFactCollector,
     SshPubKeyFactCollector,
     UserFactCollector,

--- a/lib/ansible/module_utils/facts/system/fqdn.py
+++ b/lib/ansible/module_utils/facts/system/fqdn.py
@@ -1,0 +1,39 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import socket
+
+from ansible.module_utils.facts.collector import BaseFactCollector
+
+
+class FQDNFactCollector(BaseFactCollector):
+    name = 'fqdn'
+    _fact_ids = {
+        'domain',
+        'fqdn',
+    }
+
+    def collect(self, module=None, collected_facts=None):
+        fqdn_facts = {}
+
+        # NOTE: socket.getfqdn() calls gethostbyaddr(socket.gethostname()),
+        # which can be slow to return if the name does not resolve correctly.
+        # On macOS if the name ends with .local then "local network privacy"
+        # policies may be applied.
+        fqdn_facts['fqdn'] = socket.getfqdn()
+        fqdn_facts['domain'] = '.'.join(fqdn_facts['fqdn'].split('.')[1:])
+        return fqdn_facts

--- a/lib/ansible/module_utils/facts/system/platform.py
+++ b/lib/ansible/module_utils/facts/system/platform.py
@@ -16,7 +16,6 @@
 from __future__ import annotations
 
 import re
-import socket
 import platform
 import typing as t
 
@@ -49,11 +48,8 @@ class PlatformFactCollector(BaseFactCollector):
 
         platform_facts['python_version'] = platform.python_version()
 
-        platform_facts['fqdn'] = socket.getfqdn()
         platform_facts['hostname'] = platform.node().split('.')[0]
         platform_facts['nodename'] = platform.node()
-
-        platform_facts['domain'] = '.'.join(platform_facts['fqdn'].split('.')[1:])
 
         arch_bits = platform.architecture()[0]
 

--- a/lib/ansible/modules/hostname.py
+++ b/lib/ansible/modules/hostname.py
@@ -874,11 +874,14 @@ def main():
 
     # NOTE: socket.getfqdn() calls gethostbyaddr(socket.gethostname()), which can be
     # slow to return if the name does not resolve correctly.
+    # On macOS if the name ends with .local then "local network privacy"
+    # policies may be applied.
+    fqdn = socket.getfqdn()
     kw = dict(changed=changed, name=name,
               ansible_facts=dict(ansible_hostname=name.split('.')[0],
                                  ansible_nodename=name,
-                                 ansible_fqdn=socket.getfqdn(),
-                                 ansible_domain='.'.join(socket.getfqdn().split('.')[1:])))
+                                 ansible_fqdn=fqdn,
+                                 ansible_domain='.'.join(fqdn.split('.')[1:])))
 
     if changed:
         kw['diff'] = {'after': 'hostname = ' + name + '\n',

--- a/lib/ansible/modules/setup.py
+++ b/lib/ansible/modules/setup.py
@@ -19,7 +19,7 @@ options:
               Possible values: V(all), V(all_ipv4_addresses), V(all_ipv6_addresses), V(apparmor), V(architecture),
               V(caps), V(chroot),V(cmdline), V(date_time), V(default_ipv4), V(default_ipv6), V(devices),
               V(distribution), V(distribution_cpe_name), V(distribution_major_version), V(distribution_release), V(distribution_version),
-              V(dns), V(effective_group_ids), V(effective_user_id), V(env), V(facter), V(fips), V(hardware),
+              V(dns), V(effective_group_ids), V(effective_user_id), V(env), V(facter), V(fips), V(fqdn), V(hardware),
               V(interfaces), V(is_chroot), V(iscsi), V(kernel), V(local), V(lsb), V(machine), V(machine_id),
               V(mounts), V(network), V(ohai), V(os_family), V(pkg_mgr), V(platform), V(processor), V(processor_cores),
               V(processor_count), V(python), V(python_version), V(real_user_id), V(selinux), V(service_mgr),
@@ -199,7 +199,7 @@ def main():
     # TODO: decide what '!all' means, I lean towards making it mean none, but likely needs
     #       some tweaking on how gather_subset operations are performed
     minimal_gather_subset = frozenset(['apparmor', 'caps', 'cmdline', 'date_time',
-                                       'distribution', 'dns', 'env', 'fips', 'local',
+                                       'distribution', 'dns', 'env', 'fips', 'fqdn', 'local',
                                        'lsb', 'pkg_mgr', 'platform', 'python', 'selinux',
                                        'service_mgr', 'ssh_pub_keys', 'user'])
 


### PR DESCRIPTION
A call to `socket.getfqdn()` can block for many seconds, depending on how DNS resolution is configured and/or OS level policies such as macOS "local network privacy" - which has been observed to delay the response by 70 seconds.

This change allows gathering "platform" facts without "fqdn" & "domain" facts. For backward compatibility the minimal set (`gather_subset=!all`) still includes "fqdn" & "domain". However anyone using `gather_subset=!all,!min,platform` will need to update to `gather_subset=!all,!min,platform,fqdn` if they rely on them (hence I've marked it as a breaking change).

##### SUMMARY

The platform category no longer includes "fqdn" or "domain"
```sh
➜  ansible git:(fqdn-facts) .venv/bin/ansible localhost -m setup -a 'gather_subset=!all,!min,platform' 
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_architecture": "arm64",
        "ansible_hostname": "kintha",
        "ansible_kernel": "25.6.0",
        "ansible_kernel_version": "Darwin Kernel Version 25.6.0: Sat Jul 11 15:26:21 PDT 2026; root:xnu-12377.161.13~4/RELEASE_ARM64_T6000",
        "ansible_machine": "arm64",
        "ansible_nodename": "kintha",
        "ansible_python_version": "3.15.0rc1",
        "ansible_system": "Darwin",
        "ansible_userspace_bits": "64",
        "gather_subset": [
            "!all",
            "!min",
            "platform"
        ],
        "module_setup": true
    },
    "changed": false
}
```

They now reside in the new "fqdn" category.
```sh
➜  ansible git:(fqdn-facts) .venv/bin/ansible localhost -m setup -a 'gather_subset=!all,!min,fqdn'    
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_domain": "",
        "ansible_fqdn": "kintha",
        "gather_subset": [
            "!all",
            "!min",
            "fqdn"
        ],
        "module_setup": true
    },
    "changed": false
}
```

The minimal set still gathers them
```sh
➜  ansible git:(fqdn-facts) .venv/bin/ansible localhost -m setup -a 'gather_subset=!all'          
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code and can become unstable at any point.
localhost | SUCCESS => {
    "ansible_facts": {
...
        "ansible_domain": "",
...
        "ansible_fqdn": "kintha",
...
        "gather_subset": [
            "!all"
        ],
        "module_setup": true
    },
    "changed": false
}
```
##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Feature Pull Request

I encountered the macOS delay running tests on the GitHub Actions macOS 15 runner, with hostnames such as "sat12-bq161-39e35cbe-a85a-4f28-831d-60a90ab94fbd-66F08D814687.local". The macOS local network privacy behaviour is described in Apple Technote TN3179

> Certain DNS operations also require local network access. The following table lists some common cases:
> 
> | Operation | Required |
> | -- | -- |
> | Resolving a local DNS name | yes |
> | Resolving a non-local DNS name with the system resolver | no |
> 
> This check applies to a wide variety of APIs including dnssd, <net_db.h>, and any APIs that use them.
> In this context, a local DNS name is one ending with .local (or .local.), per RFC 6762.
>
> -- https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy#DNS-operations

This PR is a follow on to https://github.com/mitogen-hq/mitogen/pull/1551, in the hope it's of use to the wider Ansible user base.
