### PR TITLE
mount_facts: strip blkid UUID lookup output

### DIFF
--- a/changelogs/fragments/mount-facts-strip-blkid-output.yml
+++ b/changelogs/fragments/mount-facts-strip-blkid-output.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - mount_facts - Strip whitespace from ``blkid`` UUID lookup output so static mounts can be filtered by resolved device paths.

--- a/lib/ansible/modules/mount_facts.py
+++ b/lib/ansible/modules/mount_facts.py
@@ -245,7 +245,7 @@ def get_device_by_uuid(module: AnsibleModule, uuid : str) -> str | None:
         cmd = [blkid_binary, "--uuid", uuid]
         with suppress(subprocess.CalledProcessError):
             blkid_output = handle_timeout(module)(subprocess.check_output)(cmd, text=True, timeout=module.params["timeout"])
-    return blkid_output
+    return blkid_output.strip() if blkid_output else None
 
 
 @functools.lru_cache(maxsize=None)

--- a/test/integration/targets/mount_facts/tasks/main.yml
+++ b/test/integration/targets/mount_facts/tasks/main.yml
@@ -180,6 +180,51 @@
           - static.ansible_facts.mount_points.values() | list | map(attribute='uuid') | unique | length > 0
       when: ansible_os_family not in ("Darwin", "FreeBSD")
 
+    - name: Find a resolvable UUID entry in fstab (Linux)
+      shell: "awk '!/^[[:space:]]*#/ && $1 ~ /^UUID=/ { print; exit }' /etc/fstab"
+      register: uuid_fstab_entry
+      changed_when: false
+      when: ansible_system == "Linux"
+
+    - name: Resolve the UUID fstab device (Linux)
+      command: "blkid --uuid {{ uuid_fstab_entry.stdout.split()[0].split('=', 1)[1] }}"
+      register: uuid_fstab_device
+      changed_when: false
+      failed_when: false
+      when:
+        - ansible_system == "Linux"
+        - uuid_fstab_entry.stdout | trim
+
+    - name: Test filtering a static UUID mount by its resolved device (Linux)
+      block:
+        - name: Create a temporary fstab source with the UUID entry
+          copy:
+            dest: "{{ remote_tmp_dir }}/mount_facts_uuid_fstab"
+            content: "{{ uuid_fstab_entry.stdout }}\n"
+
+        - name: Collect the UUID mount with an exact device filter
+          mount_facts:
+            sources:
+              - "{{ remote_tmp_dir }}/mount_facts_uuid_fstab"
+            devices:
+              - "{{ uuid_fstab_device.stdout | trim }}"
+          register: uuid_filtered
+
+        - name: Verify the UUID mount passed the device filter
+          assert:
+            that:
+              - uuid_filtered.ansible_facts.mount_points | length == 1
+              - (uuid_fstab_entry.stdout.split()[1]) in uuid_filtered.ansible_facts.mount_points
+      always:
+        - name: Remove the temporary fstab source
+          file:
+            path: "{{ remote_tmp_dir }}/mount_facts_uuid_fstab"
+            state: absent
+      when:
+        - ansible_system == "Linux"
+        - uuid_fstab_entry.stdout | trim
+        - uuid_fstab_device.rc | default(1) == 0
+
 - name: Test duplicate sources
   mount_facts:
     sources:

--- a/test/units/modules/test_mount_facts.py
+++ b/test/units/modules/test_mount_facts.py
@@ -212,6 +212,29 @@ def test_get_mount_facts(monkeypatch, set_file_content, get_mock_module):
     assert len(mount_facts.get_mount_facts(module)) == 7
 
 
+def test_get_device_by_uuid_strips_output(monkeypatch, get_mock_module):
+    module = get_mock_module({})
+    monkeypatch.setattr(module, "get_bin_path", mock_callable(return_value="/usr/bin/blkid"))
+    monkeypatch.setattr(mount_facts.subprocess, "check_output", mock_callable(return_value="/dev/sda1\n"))
+    mount_facts.get_device_by_uuid.cache_clear()
+
+    assert mount_facts.get_device_by_uuid(module, "abc") == "/dev/sda1"
+
+
+def test_get_mount_facts_filter_uuid_by_device(monkeypatch, set_file_content, get_mock_module):
+    set_file_content({"/etc/fstab": "UUID=abc /data ext4 defaults 0 0\n"})
+    monkeypatch.setattr(mount_facts, "get_mount_size", mock_callable(return_value=None))
+    monkeypatch.setattr(mount_facts.subprocess, "check_output", mock_callable(return_value="/dev/sda1\n"))
+    module = get_mock_module({"sources": ["/etc/fstab"], "devices": ["/dev/sda1"]})
+    monkeypatch.setattr(module, "get_bin_path", mock_callable(return_value="/usr/bin/blkid"))
+    mount_facts.get_device_by_uuid.cache_clear()
+
+    results = mount_facts.get_mount_facts(module)
+
+    assert len(results) == 1
+    assert results[0]["mount"] == "/data"
+
+
 @pytest.mark.parametrize("filter_name, filter_value, source, mount_info", [
     ("devices", "proc", rhel9_4.mtab_parsed[0][2], rhel9_4.mtab_parsed[0][-1]),
     ("fstypes", "proc", rhel9_4.mtab_parsed[0][2], rhel9_4.mtab_parsed[0][-1]),


### PR DESCRIPTION

##### SUMMARY

`blkid --uuid` writes the resolved device path with a trailing newline.

`get_device_by_uuid()` returned this output unchanged, causing exact `devices` filters to compare values such as `/dev/sda1\n` with  `/dev/sda1`.

For example, an `/etc/fstab` entry using:

```text
UUID=abc /data ext4 defaults 0 0
```

was excluded by:

```yaml
- ansible.builtin.mount_facts:
    sources:
      - /etc/fstab
    devices:
      - /dev/sda1
```

even when `blkid --uuid abc` resolved to `/dev/sda1`.

This change strips whitespace from the `blkid` output in `get_device_by_uuid()`. It also adds regression coverage for the helper and the static fstab UUID plus device-filter path.

Tests:

- `ansible-test units test/units/modules/test_mount_facts.py`
- `ansible-test sanity lib/ansible/modules/mount_facts.py test/units/modules/test_mount_facts.py changelogs/fragments/mount-facts-strip-blkid-output.yml`

##### ISSUE TYPE

- Bugfix Pull Request
