### PR TITLE
user: add password_last_change_day parameter

### DIFF
--- a/changelogs/fragments/86828-user-password-last-change-day.yml
+++ b/changelogs/fragments/86828-user-password-last-change-day.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - user - add ``password_last_change_day`` parameter to manage the shadow last password change date on Linux (https://github.com/ansible/ansible/issues/86828).

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -272,6 +272,12 @@ options:
             - Supported on Linux only.
         type: int
         version_added: "2.16"
+    password_last_change_day:
+        description:
+            - The date of the last password change, expressed as the number of days since Jan 1, 1970 (or V(0) to force password change on next login).
+            - Supported on Linux only.
+        type: int
+        version_added: "2.21"
     umask:
         description:
             - Sets the umask of the user.
@@ -635,6 +641,7 @@ class User(object):
         self.password_expire_max = module.params['password_expire_max']
         self.password_expire_min = module.params['password_expire_min']
         self.password_expire_warn = module.params['password_expire_warn']
+        self.password_last_change_day = module.params['password_last_change_day']
         self.umask = module.params['umask']
         self.inactive = module.params['password_expire_account_disable']
         self.uid_min = module.params['uid_min']
@@ -1172,6 +1179,7 @@ class User(object):
         min_needs_change = self.password_expire_min is not None
         max_needs_change = self.password_expire_max is not None
         warn_needs_change = self.password_expire_warn is not None
+        last_change_needs_change = self.password_last_change_day is not None
 
         if HAVE_SPWD:
             try:
@@ -1182,18 +1190,21 @@ class User(object):
             min_needs_change &= self.password_expire_min != shadow_info.sp_min
             max_needs_change &= self.password_expire_max != shadow_info.sp_max
             warn_needs_change &= self.password_expire_warn != shadow_info.sp_warn
+            last_change_needs_change &= self.password_last_change_day != shadow_info.sp_lstchg
 
-        if not (min_needs_change or max_needs_change or warn_needs_change):
+        if not (min_needs_change or max_needs_change or warn_needs_change or last_change_needs_change):
             return (None, '', '')  # target state already reached
 
         command_name = 'chage'
         cmd = [self.module.get_bin_path(command_name, True)]
         if min_needs_change:
-            cmd.extend(["-m", self.password_expire_min])
+            cmd.extend(["-m", str(self.password_expire_min)])
         if max_needs_change:
-            cmd.extend(["-M", self.password_expire_max])
+            cmd.extend(["-M", str(self.password_expire_max)])
         if warn_needs_change:
-            cmd.extend(["-W", self.password_expire_warn])
+            cmd.extend(["-W", str(self.password_expire_warn)])
+        if last_change_needs_change:
+            cmd.extend(["-d", str(self.password_last_change_day)])
         cmd.append(self.name)
 
         return self.execute_command(cmd)
@@ -3427,6 +3438,7 @@ def main():
             password_expire_max=dict(type='int', no_log=False),
             password_expire_min=dict(type='int', no_log=False),
             password_expire_warn=dict(type='int', no_log=False),
+            password_last_change_day=dict(type='int', no_log=False),
             # following options are specific to macOS
             hidden=dict(type='bool'),
             # following options are specific to selinux

--- a/test/units/modules/test_user.py
+++ b/test/units/modules/test_user.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026 Ansible Project
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from collections import defaultdict, namedtuple
+
+from ansible.modules import user
+
+
+SpwdStruct = namedtuple('spwd', ['sp_nam', 'sp_pwdp', 'sp_lstchg', 'sp_min', 'sp_max', 'sp_warn', 'sp_inact', 'sp_expire', 'sp_flag'])
+
+
+def get_default_params(overrides=None):
+    params = defaultdict(lambda: None, {
+        'name': 'testuser',
+        'state': 'present',
+        'non_unique': False,
+        'force': False,
+        'remove': False,
+        'create_home': True,
+        'move_home': False,
+        'system': False,
+        'append': False,
+        'local': False,
+        'update_password': 'always',
+    })
+    if overrides:
+        params.update(overrides)
+    return params
+
+
+def test_set_password_expire_last_change_day():
+    module = MagicMock()
+    module.params = get_default_params({'password_last_change_day': 0})
+    module.get_bin_path.return_value = '/usr/bin/chage'
+
+    with patch('platform.system', return_value='Linux'):
+        u = user.User(module)
+    u.execute_command = MagicMock(return_value=(0, '', ''))
+
+    # Mock shadow info where sp_lstchg is currently 19000 (different from 0)
+    fake_spwd = SpwdStruct(
+        sp_nam='testuser',
+        sp_pwdp='*',
+        sp_lstchg=19000,
+        sp_min=0,
+        sp_max=99999,
+        sp_warn=7,
+        sp_inact=-1,
+        sp_expire=-1,
+        sp_flag=0,
+    )
+
+    with patch.object(user, 'HAVE_SPWD', True), patch.object(user, 'getspnam', return_value=fake_spwd):
+        rc, out, err = u.set_password_expire()
+
+    assert rc == 0
+    u.execute_command.assert_called_once_with(['/usr/bin/chage', '-d', '0', 'testuser'])
+
+
+def test_set_password_expire_no_change_needed():
+    module = MagicMock()
+    module.params = get_default_params({'password_last_change_day': 19000})
+
+    with patch('platform.system', return_value='Linux'):
+        u = user.User(module)
+    u.execute_command = MagicMock()
+
+    # Mock shadow info where sp_lstchg already matches 19000
+    fake_spwd = SpwdStruct(
+        sp_nam='testuser',
+        sp_pwdp='*',
+        sp_lstchg=19000,
+        sp_min=0,
+        sp_max=99999,
+        sp_warn=7,
+        sp_inact=-1,
+        sp_expire=-1,
+        sp_flag=0,
+    )
+
+    with patch.object(user, 'HAVE_SPWD', True), patch.object(user, 'getspnam', return_value=fake_spwd):
+        rc, out, err = u.set_password_expire()
+
+    assert rc is None
+    assert u.execute_command.call_count == 0


### PR DESCRIPTION
##### SUMMARY
Fixes #86828: Adds `password_last_change_day` parameter to `ansible.builtin.user` on Linux hosts, allowing users to configure the shadow last password change date (via `chage -d`).

This allows setting the last change date in days since Jan 1, 1970 (or `0` to force a password change upon next login).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`lib/ansible/modules/user.py`

##### ADDITIONAL INFORMATION
- Includes changelog fragment under `changelogs/fragments/86828-user-password-last-change-day.yml`.
- Adds unit tests in `test/units/modules/test_user.py`.

Signed-off-by: Sundeep <sundeep8967@gmail.com>