### PR TITLE
validation: filter out None values in count_terms

### DIFF
--- a/changelogs/fragments/82724-count_terms-ignore-null.yml
+++ b/changelogs/fragments/82724-count_terms-ignore-null.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - count_terms - do not count parameters whose values are ``None`` in validation functions such as ``check_required_one_of`` (https://github.com/ansible/ansible/issues/82724).

--- a/lib/ansible/module_utils/common/validation.py
+++ b/lib/ansible/module_utils/common/validation.py
@@ -24,13 +24,13 @@ def count_terms(terms, parameters):
     :arg parameters: Dictionary of parameters
 
     :returns: An integer that is the number of occurrences of the terms values
-        in the provided dictionary.
+        in the provided dictionary whose value is not None.
     """
 
     if not is_iterable(terms):
         terms = [terms]
 
-    return len(set(terms).intersection(parameters))
+    return len([term for term in set(terms).intersection(parameters) if parameters[term] is not None])
 
 
 def check_mutually_exclusive(terms, parameters, options_context=None):

--- a/test/units/module_utils/common/validation/test_check_required_one_of.py
+++ b/test/units/module_utils/common/validation/test_check_required_one_of.py
@@ -44,3 +44,13 @@ def test_check_required_one_of_context(arguments_terms):
         check_required_one_of(arguments_terms, params, option_context)
 
     assert to_native(e.value) == expected
+
+
+def test_check_required_one_of_none_values(arguments_terms):
+    params = {"state": "present", "path": None, "owner": None}
+    expected = "one of the following is required: path, owner"
+
+    with pytest.raises(TypeError) as e:
+        check_required_one_of(arguments_terms, params)
+
+    assert to_native(e.value) == expected

--- a/test/units/module_utils/common/validation/test_count_terms.py
+++ b/test/units/module_utils/common/validation/test_count_terms.py
@@ -37,3 +37,11 @@ def test_count_terms_tuple_input(params):
 def test_count_terms_list_input(params):
     check = ['name', 'dest']
     assert count_terms(check, params) == 2
+
+
+def test_count_terms_none_value():
+    params = {'name': 'bob', 'dest': None, 'other': None}
+    assert count_terms(['name', 'dest'], params) == 1
+    assert count_terms(['dest', 'other'], params) == 0
+    assert count_terms('dest', params) == 0
+


### PR DESCRIPTION
##### SUMMARY
Fixes #82724: Updates `count_terms` in `ansible.module_utils.common.validation` to only count keys whose values are not `None`.

When module authors or validation workflows pass parameter dictionaries containing explicit `None` entries (e.g. from `module.params` or optional subspec arguments), `count_terms` previously counted key presence rather than non-None values, causing functions like `check_required_one_of` to treat missing/unspecified parameters as fulfilled.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/module_utils/common/validation.py`

##### ADDITIONAL INFORMATION
- Includes changelog fragment under `changelogs/fragments/82724-count_terms-ignore-null.yml`.
- Adds unit tests in `test/units/module_utils/common/validation/test_check_required_one_of.py` and `test_count_terms.py`.

Signed-off-by: Sundeep <sundeep8967@gmail.com>