### PR TITLE
cron: do not require user for env variables with cron_file

### DIFF
--- a/changelogs/fragments/83682-cron-env-cron_file-user.yml
+++ b/changelogs/fragments/83682-cron-env-cron_file-user.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - cron - do not require ``user`` parameter when adding an environment variable (``env=true``) with ``cron_file`` specified (https://github.com/ansible/ansible/issues/83682).

--- a/lib/ansible/modules/cron.py
+++ b/lib/ansible/modules/cron.py
@@ -60,7 +60,7 @@ options:
       - If this is a relative path, it is interpreted with respect to C(/etc/cron.d).
       - Many Linux distros expect (and some require) the filename portion to consist solely
         of upper- and lower-case letters, digits, underscores, and hyphens.
-      - Using this parameter requires you to specify the O(user) as well, unless O(state=absent).
+      - Using this parameter requires you to specify the O(user) as well, unless O(state=absent) or O(env=true).
       - Either this parameter or O(name) is required.
     type: path
   backup:
@@ -651,7 +651,7 @@ def main():
         module.fail_json(msg="Solaris does not support special_time=... or @reboot")
 
     if do_install:
-        if cron_file and not user:
+        if cron_file and not user and not env:
             module.fail_json(msg="To use cron_file=... parameter you must specify user=... as well")
 
         if job is None:

--- a/test/units/modules/test_cron.py
+++ b/test/units/modules/test_cron.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026 Ansible Project
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.modules import cron
+
+
+def test_cron_env_with_cron_file_does_not_require_user(set_module_args, capfd):
+    """Verify that adding an environment variable with cron_file does not require user."""
+    set_module_args({
+        'name': 'PATH',
+        'job': '/usr/local/bin:$PATH',
+        'state': 'present',
+        'cron_file': 'ansible-pull',
+        'env': True,
+    })
+
+    fake_crontab = MagicMock()
+    fake_crontab.cron_file = '/etc/cron.d/ansible-pull'
+    fake_crontab.find_env.return_value = []
+    fake_crontab.n_existing = ''
+    fake_crontab.get_jobnames.return_value = []
+    fake_crontab.get_envnames.return_value = ['PATH']
+
+    with patch.object(cron, 'CronTab', return_value=fake_crontab):
+        with pytest.raises(SystemExit) as exc:
+            cron.main()
+
+    assert exc.value.code == 0
+    out, err = capfd.readouterr()
+    res = json.loads(out)
+    assert res['changed'] is True
+    fake_crontab.add_env.assert_called_once_with('PATH="/usr/local/bin:$PATH"', None, None)
+    fake_crontab.write.assert_called_once()
+
+
+def test_cron_job_with_cron_file_requires_user(set_module_args, capfd):
+    """Verify that adding a normal cron job with cron_file still requires user."""
+    set_module_args({
+        'name': 'check job',
+        'job': 'ls -la',
+        'state': 'present',
+        'cron_file': 'my-cron',
+        'env': False,
+    })
+
+    fake_crontab = MagicMock()
+
+    with patch.object(cron, 'CronTab', return_value=fake_crontab):
+        with pytest.raises(SystemExit) as exc:
+            cron.main()
+
+    assert exc.value.code != 0
+    out, err = capfd.readouterr()
+    res = json.loads(out)
+    assert res['failed'] is True
+    assert "To use cron_file=... parameter you must specify user=... as well" in res['msg']


### PR DESCRIPTION
##### SUMMARY
Fixes #83682: When managing environment variables with `env=true` and `cron_file` in `ansible.builtin.cron`, do not require the `user` parameter.

Environment variable lines in crontab files do not contain a username field (unlike job lines in `/etc/cron.d/`), so requiring `user` when installing or updating environment variables was unnecessary.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/cron.py`

##### ADDITIONAL INFORMATION
- Includes changelog fragment under `changelogs/fragments/83682-cron-env-cron_file-user.yml`.
- Adds unit tests in `test/units/modules/test_cron.py`.

Signed-off-by: Sundeep <sundeep8967@gmail.com>