### PR TITLE
setup_cron: run busybox crond in the foreground on Alpine

### DIFF
--- a/test/integration/targets/setup_cron/tasks/main.yml
+++ b/test/integration/targets/setup_cron/tasks/main.yml
@@ -90,8 +90,12 @@
     state: restarted
   when: ansible_distribution != 'Alpine'
 
+# Run busybox crond in the foreground: self-daemonizing closes all inherited fds,
+# including the one libfaketime (>= 0.9.13) holds for its flock-based stat lock, so
+# the next faked fstat() fails with EBADF and libfaketime aborts crond before it
+# schedules anything.
 - name: enable cron service - Alpine
-  command: nohup crond
+  shell: crond -f &
   environment:
     FAKETIME: "+0y x10"
     LD_PRELOAD: "{{ libfaketime_path }}"


### PR DESCRIPTION
##### SUMMARY
The cron integration test began failing on Alpine 3.24 with a 20s timeout waiting for the canary file, because crond never scheduled the job.

Root cause is a crash, not a timing problem. The test accelerates time with libfaketime via LD_PRELOAD. As of libfaketime 0.9.13 the default stat-lock backend switched from a POSIX semaphore (shared memory) to flock() on a marker file in /dev/shm, so the lock is now held through an open file descriptor cached in the library. busybox crond, started with `nohup crond`, self-daemonizes and runs bb_daemonize_or_rexec(DAEMON_CLOSE_EXTRA_FDS), whose close-all-fds loop (`while (fd > 2) close(fd--)`) closes every inherited descriptor - including libfaketime's lock fd, which crond knows nothing about. The next faked fstat() then calls flock() on the closed fd, gets EBADF, and libfaketime aborts crond via exit(1). No job ever runs.

Running crond in the foreground (`crond -f`, backgrounded by the shell) skips the daemonize ritual entirely, so the lock fd survives and stats are faked normally.

Confirmed three ways: pinning libfaketime <0.9.13 (POSIX semaphore backend) passes; setting NO_FAKE_STAT=1 (which disables the faked stat path that takes the lock) passes; and upstream commit b687b16 "Replace POSIX semaphore with flock() for cross-arch safety" is the change that introduced the fd-backed lock.

Why now: libfaketime-0.9.13-r0 landed in the Alpine community repo on 2026-08-31 - the first flock-backend build the test ever pulled.

Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>
<!--- Describe the change below, including rationale and design decisions -->

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->
- Test Pull Request
