### PR TITLE
Avoid starting a helper process for existing persistent connections

### DIFF
--- a/changelogs/fragments/task-executor-persistent-connection-reuse.yml
+++ b/changelogs/fragments/task-executor-persistent-connection-reuse.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - task executor - avoid starting a Python helper process when synchronizing task state with an existing persistent connection

--- a/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
+++ b/lib/ansible/cli/scripts/ansible_connection_cli_stub.py
@@ -2,7 +2,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import annotations
 
-import fcntl
 import io
 import os
 import pickle
@@ -11,10 +10,9 @@ import socket
 import sys
 import time
 import traceback
+import typing as t
 import errno
 import json
-
-from contextlib import contextmanager
 
 from ansible import constants as C
 from ansible.cli.arguments import option_helpers as opt_help
@@ -23,12 +21,63 @@ from ansible.module_utils.connection import Connection, ConnectionError, send_da
 from ansible.module_utils.service import fork_process
 from ansible.module_utils._internal._json._profiles import _tagless
 from ansible.playbook.play_context import PlayContext
+from ansible.plugins.connection import (
+    _get_persistent_connection_lock_path,
+    _get_persistent_connection_socket_path,
+    _persistent_connection_lock,
+)
 from ansible.plugins.loader import connection_loader, init_plugin_loader
 from ansible.utils.path import unfrackpath, makedirs_safe
 from ansible.utils.display import Display
 from ansible.utils.jsonrpc import JsonRpcServer
 
 display = Display()
+
+
+class _ConnectionProcessRpc:
+    """Expose controller-owned operations on a persistent connection."""
+
+    def __init__(self, connection: t.Any, socket_path: str) -> None:
+        self.connection = connection
+        self.socket_path = socket_path
+
+    def set_options_ansible_connection_cli_stub(
+        self,
+        options: dict[str, t.Any],
+        play_context_data: str,
+        task_uuid: str,
+    ) -> dict[str, t.Any]:
+        """Synchronize task-specific connection state in a single RPC."""
+        messages = [('vvvv', 'found existing local domain socket, using it!')]
+        result: dict[str, t.Any] = {}
+        set_options_failed = False
+
+        try:
+            try:
+                self.connection.set_options(direct=options)
+            except Exception:
+                set_options_failed = True
+                raise ConnectionError('Unable to decode JSON from response set_options. See the debug log for more information.') from None
+
+            if update_play_context := getattr(self.connection, 'update_play_context', None):
+                update_play_context(play_context_data)
+            if set_check_prompt := getattr(self.connection, 'set_check_prompt', None):
+                set_check_prompt(task_uuid)
+        except Exception as exc:
+            result.update({
+                'error': to_text(exc),
+                'exception': traceback.format_exc(),
+            })
+
+        connection_messages = self.connection.pop_messages()
+        if not set_options_failed:
+            messages.extend(connection_messages)
+        result.update({
+            'messages': messages,
+            'socket_path': self.socket_path,
+        })
+
+        return result
 
 
 def read_stream(byte_stream):
@@ -39,21 +88,6 @@ def read_stream(byte_stream):
         raise Exception("EOF found before data was complete")
 
     return data
-
-
-@contextmanager
-def file_lock(lock_path):
-    """
-    Uses contextmanager to create and release a file lock based on the
-    given path. This allows us to create locks using `with file_lock()`
-    to prevent deadlocks related to failure to unlock properly.
-    """
-
-    lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
-    fcntl.lockf(lock_fd, fcntl.LOCK_EX)
-    yield
-    fcntl.lockf(lock_fd, fcntl.LOCK_UN)
-    os.close(lock_fd)
 
 
 class ConnectionProcess(object):
@@ -98,6 +132,7 @@ class ConnectionProcess(object):
 
             self.connection._socket_path = self.socket_path
             self.srv.register(self.connection)
+            self.srv.register(_ConnectionProcessRpc(self.connection, self.socket_path))
             messages.extend([('vvvv', msg) for msg in sys.stdout.getvalue().splitlines()])
 
             self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -184,7 +219,7 @@ class ConnectionProcess(object):
     def shutdown(self):
         """ Shuts down the local domain socket
         """
-        lock_path = unfrackpath("%s/.ansible_pc_lock_%s" % os.path.split(self.socket_path))
+        lock_path = _get_persistent_connection_lock_path(self.socket_path)
         if os.path.exists(self.socket_path):
             try:
                 if self.sock:
@@ -253,19 +288,17 @@ def main(args=None):
         })
 
     if rc == 0:
-        ssh = connection_loader.get('ssh', class_only=True)
         ansible_playbook_pid = args.playbook_pid
         task_uuid = args.task_uuid
-        cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user, play_context.connection, ansible_playbook_pid)
         # create the persistent connection dir if need be and create the paths
         # which we will be using later
         tmp_path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
         makedirs_safe(tmp_path)
 
-        socket_path = unfrackpath(cp % dict(directory=tmp_path))
-        lock_path = unfrackpath("%s/.ansible_pc_lock_%s" % os.path.split(socket_path))
+        socket_path = _get_persistent_connection_socket_path(play_context, ansible_playbook_pid)
+        lock_path = _get_persistent_connection_lock_path(socket_path)
 
-        with file_lock(lock_path):
+        with _persistent_connection_lock(lock_path):
             if not os.path.exists(socket_path):
                 messages.append(('vvvv', 'local domain socket does not exist, starting it'))
                 original_path = os.getcwd()

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import itertools
 import os
+import pickle
 import time
 import json
 import pathlib
@@ -28,11 +29,16 @@ from ansible.module_utils.datatag import native_type_name
 from ansible._internal._datatag._tags import TrustedAsTemplate
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.common.text.converters import to_text, to_native
-from ansible.module_utils.connection import write_to_stream
+from ansible.module_utils.connection import Connection, ConnectionError, write_to_stream
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins import get_plugin_class
 from ansible.plugins.action import ActionBase
-from ansible.plugins.connection import ConnectionBase
+from ansible.plugins.connection import (
+    ConnectionBase,
+    _get_persistent_connection_lock_path,
+    _get_persistent_connection_socket_path,
+    _persistent_connection_lock,
+)
 from ansible.plugins.loader import become_loader, cliconf_loader, connection_loader, httpapi_loader, netconf_loader, terminal_loader, PluginLoadContext
 from ansible._internal._templating._jinja_plugins import _invoke_lookup, _DirectCall
 from ansible._internal._templating._engine import TemplateEngine
@@ -1008,10 +1014,47 @@ class TaskExecutor:
 CLI_STUB_NAME = 'ansible_connection_cli_stub.py'
 
 
-def start_connection(play_context, options, task_uuid):
+def start_connection(
+    play_context: PlayContext,
+    options: dict[str, t.Any],
+    task_uuid: t.Any,
+) -> str:
     """
     Starts the persistent connection
     """
+
+    result = None
+    socket_path = _get_persistent_connection_socket_path(play_context, os.getppid())
+    lock_path = _get_persistent_connection_lock_path(socket_path)
+
+    # The helper creates the lock before binding the socket, and bind() exposes the path before listen() makes it ready.
+    # Wait for either indication of connection creation, then recheck the socket while holding the shared lock.
+    if os.path.exists(socket_path) or os.path.exists(lock_path):
+        with _persistent_connection_lock(lock_path):
+            if os.path.exists(socket_path):
+                try:
+                    result = Connection(socket_path).set_options_ansible_connection_cli_stub(
+                        options=options,
+                        play_context_data=to_text(pickle.dumps(play_context.dump_attrs())),
+                        task_uuid=to_text(task_uuid),
+                    )
+                except ConnectionError as exc:
+                    if getattr(exc, 'code', None) == -32601 or not os.path.exists(socket_path):
+                        result = None
+                    else:
+                        result = {
+                            'error': to_text(exc),
+                            'exception': traceback.format_exc(),
+                        }
+
+    if result is None:
+        result = _start_connection_cli_stub(play_context, options, task_uuid)
+
+    return _handle_connection_result(play_context, result)
+
+
+def _start_connection_cli_stub(play_context: PlayContext, options: dict[str, t.Any], task_uuid: t.Any) -> dict[str, t.Any]:
+    """Start the connection helper and return its result."""
 
     env = os.environ.copy()
     env.update({
@@ -1052,6 +1095,11 @@ def start_connection(play_context, options, task_uuid):
         except json.decoder.JSONDecodeError:
             result = {'error': to_text(stderr, errors='surrogate_then_replace')}
 
+    return result
+
+
+def _handle_connection_result(play_context: PlayContext, result: dict[str, t.Any]) -> str:
+    """Dispatch connection messages and return the socket path or raise an error."""
     if 'messages' in result:
         for level, message in result['messages']:
             if level == 'log':

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -11,6 +11,7 @@ import shlex
 import typing as t
 
 from abc import abstractmethod
+from contextlib import contextmanager
 from functools import wraps
 
 from ansible import constants as C
@@ -36,6 +37,40 @@ class ConnectionKwargs(t.TypedDict):
     task_uuid: str
     ansible_playbook_pid: str
     shell: t.NotRequired[ShellBase]
+
+
+def _get_persistent_connection_socket_path(play_context: PlayContext, ansible_playbook_pid: str | int | None) -> str:
+    """Return the canonical persistent connection socket path for the supplied task context."""
+    ssh = connection_loader.get('ssh', class_only=True)
+    control_path = ssh._create_control_path(
+        play_context.remote_addr,
+        play_context.port,
+        play_context.remote_user,
+        play_context.connection,
+        ansible_playbook_pid,
+    )
+
+    tmp_path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
+    return unfrackpath(control_path % dict(directory=tmp_path))
+
+
+def _get_persistent_connection_lock_path(socket_path: str) -> str:
+    """Return the lock path used to serialize persistent connection setup."""
+    return unfrackpath("%s/.ansible_pc_lock_%s" % os.path.split(socket_path))
+
+
+@contextmanager
+def _persistent_connection_lock(lock_path: str) -> c.Iterator[None]:
+    """Acquire and release a persistent connection setup lock."""
+    lock_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.lockf(lock_fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.lockf(lock_fd, fcntl.LOCK_UN)
+    finally:
+        os.close(lock_fd)
 
 
 def ensure_connect[T, **P](
@@ -437,15 +472,7 @@ class NetworkConnectionBase(ConnectionBase):
         to True.  If the socket path doesn't exist, leave the socket path
         value to None and the _connected value to False
         """
-        ssh = connection_loader.get('ssh', class_only=True)
-        control_path = ssh._create_control_path(
-            self._play_context.remote_addr, self._play_context.port,
-            self._play_context.remote_user, self._play_context.connection,
-            self._ansible_playbook_pid
-        )
-
-        tmp_path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
-        socket_path = unfrackpath(control_path % dict(directory=tmp_path))
+        socket_path = _get_persistent_connection_socket_path(self._play_context, self._ansible_playbook_pid)
 
         if os.path.exists(socket_path):
             self._connected = True

--- a/test/integration/targets/connection_persistent/action_plugins/persistent_state.py
+++ b/test/integration/targets/connection_persistent/action_plugins/persistent_state.py
@@ -1,0 +1,18 @@
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+import json
+import typing as t
+
+from ansible.module_utils.connection import Connection
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+    """Return state from the active persistent daemon without executing a module."""
+
+    def run(self, tmp: str | None = None, task_vars: dict[str, t.Any] | None = None) -> dict[str, t.Any]:
+        result = super().run(tmp, task_vars)
+        result.update(json.loads(Connection(self._connection.socket_path).get_capabilities()))
+        return result

--- a/test/integration/targets/connection_persistent/aliases.yml
+++ b/test/integration/targets/connection_persistent/aliases.yml
@@ -1,0 +1,75 @@
+- name: Initialize one daemon concurrently through two inventory aliases
+  hosts: persistent_aliases
+  gather_facts: false
+  tasks:
+    - persistent:
+      vars:
+        ansible_command_timeout: 51
+      register: alias_initial
+
+    - assert:
+        that:
+          - alias_initial.pid == hostvars['persistent_alias_a'].alias_initial.pid
+          - alias_initial.pid == hostvars['persistent_alias_b'].alias_initial.pid
+          - alias_initial.timeout == 51
+          - alias_initial.command_timeout == 51
+          - alias_initial.remote_addr == 'shared-connection-target'
+          - alias_initial.remote_user == 'shared-user'
+          - alias_initial.port == 2222
+          - alias_initial.connection == 'persistent'
+          - lookup('file', alias_helper_counter_path).splitlines() | length == 2
+      run_once: true
+
+    - name: Refresh shared daemon state through the first alias
+      persistent_state:
+      vars:
+        ansible_command_timeout: 52
+        ansible_become: true
+      register: alias_a_refreshed
+      when: inventory_hostname == 'persistent_alias_a'
+
+    - assert:
+        that:
+          - hostvars['persistent_alias_a'].alias_a_refreshed.pid == hostvars['persistent_alias_a'].alias_initial.pid
+          - hostvars['persistent_alias_a'].alias_a_refreshed.timeout == 52
+          - hostvars['persistent_alias_a'].alias_a_refreshed.command_timeout == 52
+          - hostvars['persistent_alias_a'].alias_a_refreshed.become is true
+          - hostvars['persistent_alias_a'].alias_a_refreshed.check_prompt is truthy
+          - lookup('file', alias_helper_counter_path).splitlines() | length == 2
+      run_once: true
+
+    - name: Refresh the same daemon state through the second alias
+      persistent_state:
+      vars:
+        ansible_command_timeout: 53
+        ansible_become: false
+      register: alias_b_refreshed
+      when: inventory_hostname == 'persistent_alias_b'
+
+    - assert:
+        that:
+          - hostvars['persistent_alias_b'].alias_b_refreshed.pid == hostvars['persistent_alias_b'].alias_initial.pid
+          - hostvars['persistent_alias_b'].alias_b_refreshed.pid == hostvars['persistent_alias_a'].alias_a_refreshed.pid
+          - hostvars['persistent_alias_b'].alias_b_refreshed.timeout == 53
+          - hostvars['persistent_alias_b'].alias_b_refreshed.command_timeout == 53
+          - hostvars['persistent_alias_b'].alias_b_refreshed.become is false
+          - hostvars['persistent_alias_b'].alias_b_refreshed.check_prompt is truthy
+          - hostvars['persistent_alias_b'].alias_b_refreshed.check_prompt != hostvars['persistent_alias_a'].alias_a_refreshed.check_prompt
+          - lookup('file', alias_helper_counter_path).splitlines() | length == 2
+      run_once: true
+
+    - name: Reuse the shared daemon concurrently without more helpers
+      persistent:
+      vars:
+        ansible_command_timeout: 54
+      register: alias_reused
+
+    - assert:
+        that:
+          - alias_reused.pid == alias_initial.pid
+          - alias_reused.pid == hostvars['persistent_alias_a'].alias_reused.pid
+          - alias_reused.pid == hostvars['persistent_alias_b'].alias_reused.pid
+          - alias_reused.timeout == 54
+          - alias_reused.command_timeout == 54
+          - lookup('file', alias_helper_counter_path).splitlines() | length == 2
+      run_once: true

--- a/test/integration/targets/connection_persistent/connection_helper_wrapper.py
+++ b/test/integration/targets/connection_persistent/connection_helper_wrapper.py
@@ -1,0 +1,28 @@
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import time
+
+from ansible.cli import scripts
+
+
+counter_path = pathlib.Path(os.environ['ANSIBLE_TEST_CONNECTION_HELPER_COUNTER'])
+with counter_path.open('a', encoding='utf-8') as counter:
+    counter.write(f'{os.getpid()}\n')
+
+if barrier_size := int(os.environ.get('ANSIBLE_TEST_CONNECTION_HELPER_BARRIER_SIZE', '0')):
+    deadline = time.monotonic() + 10
+    while len(counter_path.read_text(encoding='utf-8').splitlines()) < barrier_size:
+        if time.monotonic() >= deadline:
+            raise RuntimeError(f'timed out waiting for {barrier_size} connection helpers')
+        time.sleep(0.01)
+
+helper_path = os.environ.get('ANSIBLE_TEST_CONNECTION_HELPER_TARGET') or os.environ.get('ANSIBLE_TEST_REAL_CONNECTION_PATH')
+if not helper_path:
+    helper_path = str(pathlib.Path(scripts.__file__).parent / 'ansible_connection_cli_stub.py')
+
+os.execv(sys.executable, [sys.executable, helper_path, *sys.argv[1:]])

--- a/test/integration/targets/connection_persistent/connection_plugins/persistent.py
+++ b/test/integration/targets/connection_persistent/connection_plugins/persistent.py
@@ -64,9 +64,14 @@ class Connection(NetworkConnectionBase):
             )
         )
 
+    def set_check_prompt(self, task_uuid):
+        self._check_prompt = task_uuid
+
     def get_capabilities(self, *args, **kwargs):
         return json.dumps({
             'pid': os.getpid(),
             'ppid': os.getppid(),
+            'command_timeout': self.get_option('persistent_command_timeout'),
+            'check_prompt': getattr(self, '_check_prompt', None),
             **self._play_context.dump_attrs()
         })

--- a/test/integration/targets/connection_persistent/inventory
+++ b/test/integration/targets/connection_persistent/inventory
@@ -1,1 +1,6 @@
+[persistent_default]
 localhost0 ansible_connection=persistent ansible_python_interpreter={{ansible_playbook_python}}
+
+[persistent_aliases]
+persistent_alias_a ansible_host=shared-connection-target ansible_connection=persistent ansible_user=shared-user ansible_port=2222 ansible_python_interpreter={{ansible_playbook_python}}
+persistent_alias_b ansible_host=shared-connection-target ansible_connection=persistent ansible_user=shared-user ansible_port=2222 ansible_python_interpreter={{ansible_playbook_python}}

--- a/test/integration/targets/connection_persistent/legacy_connection_helper.py
+++ b/test/integration/targets/connection_persistent/legacy_connection_helper.py
@@ -1,0 +1,23 @@
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+from ansible.cli.scripts import ansible_connection_cli_stub as connection_helper
+from ansible.utils.jsonrpc import JsonRpcServer
+
+
+class LegacyJsonRpcServer(JsonRpcServer):
+    """Simulate a daemon created before the compound synchronization RPC existed."""
+
+    def register(self, obj: object) -> None:
+        if isinstance(obj, connection_helper._ConnectionProcessRpc):
+            return
+
+        super().register(obj)
+
+
+connection_helper.JsonRpcServer = LegacyJsonRpcServer
+
+
+if __name__ == '__main__':
+    connection_helper.main()

--- a/test/integration/targets/connection_persistent/legacy_fallback.yml
+++ b/test/integration/targets/connection_persistent/legacy_fallback.yml
@@ -1,0 +1,33 @@
+- hosts: persistent_default
+  gather_facts: false
+  tasks:
+    - persistent:
+      vars:
+        ansible_command_timeout: 41
+      register: first
+
+    - persistent:
+      vars:
+        ansible_command_timeout: 42
+      register: second
+
+    - persistent:
+      vars:
+        ansible_command_timeout: 43
+      register: third
+
+    - assert:
+        that:
+          - first.pid == second.pid
+          - first.pid == third.pid
+          - first.timeout == 41
+          - second.timeout == 42
+          - third.timeout == 43
+          - first.command_timeout == 41
+          - second.command_timeout == 42
+          - third.command_timeout == 43
+          - first.check_prompt is none
+          - second.check_prompt is truthy
+          - third.check_prompt is truthy
+          - second.check_prompt != third.check_prompt
+          - lookup('file', legacy_helper_counter_path).splitlines() | length == 3

--- a/test/integration/targets/connection_persistent/playbook.yml
+++ b/test/integration/targets/connection_persistent/playbook.yml
@@ -1,5 +1,95 @@
-- hosts: all
+- hosts: persistent_default
   gather_facts: false
   tasks:
     - persistent:
+      vars:
+        ansible_command_timeout: 31
+      register: first
+
     - persistent:
+      vars:
+        ansible_command_timeout: 32
+      register: second
+
+    - persistent:
+      vars:
+        ansible_command_timeout: 33
+      register: third
+
+    - name: Enable become on the existing daemon
+      persistent_state:
+      vars:
+        ansible_become: true
+      register: become_enabled
+
+    - name: Disable become on the existing daemon
+      persistent_state:
+      vars:
+        ansible_become: false
+      register: become_disabled
+
+    - assert:
+        that:
+          - first.pid == second.pid
+          - first.pid == third.pid
+          - first.pid == become_enabled.pid
+          - first.pid == become_disabled.pid
+          - first.timeout == 31
+          - second.timeout == 32
+          - third.timeout == 33
+          - first.command_timeout == 31
+          - second.command_timeout == 32
+          - third.command_timeout == 33
+          - first.check_prompt is none
+          - second.check_prompt is truthy
+          - third.check_prompt is truthy
+          - second.check_prompt != third.check_prompt
+          - become_enabled.become is true
+          - become_disabled.become is false
+          - lookup('file', helper_counter_path).splitlines() | length == 1
+
+    - name: Reset the active persistent connection
+      meta: reset_connection
+
+    - name: Create a new daemon after reset
+      persistent:
+      vars:
+        ansible_command_timeout: 34
+      register: after_reset
+
+    - assert:
+        that:
+          - after_reset.pid != first.pid
+          - after_reset.timeout == 34
+          - after_reset.command_timeout == 34
+          - lookup('file', helper_counter_path).splitlines() | length == 2
+
+    - name: Reuse the daemon matching each final connection identity
+      persistent:
+      vars:
+        ansible_user: "{{ item.user }}"
+        ansible_port: "{{ item.port }}"
+      loop:
+        - {user: alice, port: 2201}
+        - {user: alice, port: 2202}
+        - {user: bob, port: 2201}
+        - {user: alice, port: 2201}
+        - {user: alice, port: 2202}
+        - {user: bob, port: 2201}
+      register: identities
+
+    - assert:
+        that:
+          - identities.results[0].pid != identities.results[1].pid
+          - identities.results[0].pid != identities.results[2].pid
+          - identities.results[1].pid != identities.results[2].pid
+          - identities.results[0].pid == identities.results[3].pid
+          - identities.results[1].pid == identities.results[4].pid
+          - identities.results[2].pid == identities.results[5].pid
+          - identities.results[0].check_prompt is none
+          - identities.results[1].check_prompt is none
+          - identities.results[2].check_prompt is none
+          - identities.results[3].check_prompt is truthy
+          - identities.results[3].check_prompt == identities.results[4].check_prompt
+          - identities.results[3].check_prompt == identities.results[5].check_prompt
+          - lookup('file', helper_counter_path).splitlines() | length == 5

--- a/test/integration/targets/connection_persistent/runme.sh
+++ b/test/integration/targets/connection_persistent/runme.sh
@@ -2,4 +2,25 @@
 
 set -eux
 
-ansible-playbook -i inventory playbook.yml -v "$@"
+helper_counter_path="$(mktemp)"
+alias_helper_counter_path="$(mktemp)"
+legacy_helper_counter_path="$(mktemp)"
+trap 'rm -f "${helper_counter_path}" "${alias_helper_counter_path}" "${legacy_helper_counter_path}"' EXIT
+
+export ANSIBLE_TEST_CONNECTION_HELPER_COUNTER="${helper_counter_path}"
+export ANSIBLE_TEST_REAL_CONNECTION_PATH="${_ANSIBLE_CONNECTION_PATH:-}"
+export _ANSIBLE_CONNECTION_PATH="${PWD}/connection_helper_wrapper.py"
+unset ANSIBLE_TEST_CONNECTION_HELPER_TARGET
+
+ansible-playbook -i inventory playbook.yml -v -e "helper_counter_path=${helper_counter_path}" "$@"
+
+export ANSIBLE_TEST_CONNECTION_HELPER_COUNTER="${alias_helper_counter_path}"
+export ANSIBLE_TEST_CONNECTION_HELPER_BARRIER_SIZE=2
+
+ansible-playbook -i inventory aliases.yml -v -e "alias_helper_counter_path=${alias_helper_counter_path}" "$@"
+
+export ANSIBLE_TEST_CONNECTION_HELPER_COUNTER="${legacy_helper_counter_path}"
+export ANSIBLE_TEST_CONNECTION_HELPER_TARGET="${PWD}/legacy_connection_helper.py"
+unset ANSIBLE_TEST_CONNECTION_HELPER_BARRIER_SIZE
+
+ansible-playbook -i inventory legacy_fallback.yml -v -e "legacy_helper_counter_path=${legacy_helper_counter_path}" "$@"

--- a/test/units/cli/scripts/test_ansible_connection_cli_stub.py
+++ b/test/units/cli/scripts/test_ansible_connection_cli_stub.py
@@ -1,0 +1,148 @@
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call
+
+from ansible.cli.scripts.ansible_connection_cli_stub import _ConnectionProcessRpc
+from ansible.module_utils.connection import ConnectionError
+
+
+def test_connection_process_rpc_synchronizes_connection_state_in_order():
+    connection = MagicMock()
+    connection.pop_messages.return_value = [('warning', 'queued warning')]
+    rpc = _ConnectionProcessRpc(connection, '/path/to/socket')
+
+    result = rpc.set_options_ansible_connection_cli_stub(
+        options={'persistent_command_timeout': 42},
+        play_context_data='serialized play context',
+        task_uuid='task uuid',
+    )
+
+    assert connection.method_calls == [
+        call.set_options(direct={'persistent_command_timeout': 42}),
+        call.update_play_context('serialized play context'),
+        call.set_check_prompt('task uuid'),
+        call.pop_messages(),
+    ]
+    assert result == {
+        'messages': [
+            ('vvvv', 'found existing local domain socket, using it!'),
+            ('warning', 'queued warning'),
+        ],
+        'socket_path': '/path/to/socket',
+    }
+
+
+def test_connection_process_rpc_skips_optional_connection_methods():
+    class MinimalConnection:
+        def __init__(self):
+            self.options = None
+
+        def set_options(self, *, direct):
+            self.options = direct
+
+        def pop_messages(self):
+            return []
+
+    connection = MinimalConnection()
+    rpc = _ConnectionProcessRpc(connection, '/path/to/socket')
+
+    result = rpc.set_options_ansible_connection_cli_stub({}, 'serialized play context', 'task uuid')
+
+    assert connection.options == {}
+    assert 'error' not in result
+
+
+def test_connection_process_rpc_updates_context_without_check_prompt():
+    class ContextOnlyConnection:
+        def __init__(self):
+            self.calls = []
+
+        def set_options(self, *, direct):
+            self.calls.append(('set_options', direct))
+
+        def update_play_context(self, play_context_data):
+            self.calls.append(('update_play_context', play_context_data))
+
+        def pop_messages(self):
+            self.calls.append(('pop_messages',))
+            return [('warning', 'context-only warning')]
+
+    connection = ContextOnlyConnection()
+    rpc = _ConnectionProcessRpc(connection, '/path/to/socket')
+
+    result = rpc.set_options_ansible_connection_cli_stub(
+        options={'persistent_command_timeout': 42},
+        play_context_data='serialized play context',
+        task_uuid='task uuid',
+    )
+
+    assert connection.calls == [
+        ('set_options', {'persistent_command_timeout': 42}),
+        ('update_play_context', 'serialized play context'),
+        ('pop_messages',),
+    ]
+    assert result == {
+        'messages': [
+            ('vvvv', 'found existing local domain socket, using it!'),
+            ('warning', 'context-only warning'),
+        ],
+        'socket_path': '/path/to/socket',
+    }
+
+
+def test_connection_process_rpc_marshals_connection_errors_without_options():
+    connection = MagicMock()
+    connection.set_options.side_effect = ConnectionError('invalid response')
+    connection.pop_messages.return_value = [('debug', 'potentially sensitive detail')]
+    rpc = _ConnectionProcessRpc(connection, '/path/to/socket')
+
+    result = rpc.set_options_ansible_connection_cli_stub(
+        options={'password': 'secret'},
+        play_context_data='serialized play context',
+        task_uuid='task uuid',
+    )
+
+    assert result['error'] == 'Unable to decode JSON from response set_options. See the debug log for more information.'
+    assert 'secret' not in result['exception']
+    assert result['messages'] == [('vvvv', 'found existing local domain socket, using it!')]
+    connection.update_play_context.assert_not_called()
+    connection.set_check_prompt.assert_not_called()
+    connection.pop_messages.assert_called_once_with()
+
+
+def test_connection_process_rpc_redacts_non_connection_set_options_errors():
+    secret = 'sentinel set_options secret'
+    connection = MagicMock()
+    connection.set_options.side_effect = ValueError(f'invalid password: {secret}')
+    connection.pop_messages.return_value = [('debug', f'option processing failed: {secret}')]
+    rpc = _ConnectionProcessRpc(connection, '/path/to/socket')
+
+    result = rpc.set_options_ansible_connection_cli_stub(
+        options={'password': secret},
+        play_context_data='serialized play context',
+        task_uuid='task uuid',
+    )
+
+    assert result['error'] == 'Unable to decode JSON from response set_options. See the debug log for more information.'
+    assert secret not in repr(result)
+    assert result['messages'] == [('vvvv', 'found existing local domain socket, using it!')]
+    connection.update_play_context.assert_not_called()
+    connection.set_check_prompt.assert_not_called()
+    connection.pop_messages.assert_called_once_with()
+
+
+def test_connection_process_rpc_marshals_context_update_errors():
+    connection = MagicMock()
+    connection.update_play_context.side_effect = RuntimeError('context update failed')
+    connection.pop_messages.return_value = [('debug', 'queued message')]
+    rpc = _ConnectionProcessRpc(connection, '/path/to/socket')
+
+    result = rpc.set_options_ansible_connection_cli_stub({}, 'serialized play context', 'task uuid')
+
+    assert result['error'] == 'context update failed'
+    assert 'RuntimeError: context update failed' in result['exception']
+    assert result['messages'][-1] == ('debug', 'queued message')
+    connection.set_check_prompt.assert_not_called()
+    connection.pop_messages.assert_called_once_with()

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -1,0 +1,220 @@
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import annotations
+
+import json
+import pickle
+import subprocess
+import sys
+from contextlib import contextmanager, nullcontext
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from ansible.errors import AnsibleError
+from ansible.executor import task_executor
+from ansible.module_utils.common.text.converters import to_text
+from ansible.module_utils.connection import ConnectionError
+
+
+@pytest.fixture
+def play_context():
+    value = MagicMock()
+    value.remote_addr = 'example.invalid'
+    value.dump_attrs.return_value = {'remote_addr': 'example.invalid', 'password': 'surrogate\udcff'}
+    return value
+
+
+@pytest.fixture(autouse=True)
+def connection_lock(mocker):
+    return mocker.patch.object(task_executor, '_persistent_connection_lock', side_effect=lambda lock_path: nullcontext())
+
+
+def test_start_connection_uses_existing_socket_without_subprocess(mocker, play_context, connection_lock):
+    options = {'persistent_command_timeout': 42}
+    connection = mocker.patch.object(task_executor, 'Connection').return_value
+    connection.set_options_ansible_connection_cli_stub.return_value = {
+        'messages': [],
+        'socket_path': '/path/to/socket',
+    }
+    get_socket_path = mocker.patch.object(task_executor, '_get_persistent_connection_socket_path', return_value='/path/to/socket')
+    mocker.patch.object(task_executor.os.path, 'exists', return_value=True)
+    cli_stub = mocker.patch.object(task_executor, '_start_connection_cli_stub')
+
+    result = task_executor.start_connection(play_context, options, 'task uuid')
+
+    assert result == '/path/to/socket'
+    get_socket_path.assert_called_once_with(play_context, task_executor.os.getppid())
+    connection_lock.assert_called_once_with('/path/to/.ansible_pc_lock_socket')
+    connection.set_options_ansible_connection_cli_stub.assert_called_once_with(
+        options=options,
+        play_context_data=to_text(pickle.dumps(play_context.dump_attrs())),
+        task_uuid='task uuid',
+    )
+    cli_stub.assert_not_called()
+
+
+def test_start_connection_uses_subprocess_without_existing_socket(mocker, play_context):
+    mocker.patch.object(task_executor, '_get_persistent_connection_socket_path', return_value='/missing/socket')
+    mocker.patch.object(task_executor.os.path, 'exists', return_value=False)
+    cli_stub = mocker.patch.object(
+        task_executor,
+        '_start_connection_cli_stub',
+        return_value={'messages': [], 'socket_path': '/new/socket'},
+    )
+
+    result = task_executor.start_connection(play_context, {}, 'task uuid')
+
+    assert result == '/new/socket'
+    cli_stub.assert_called_once_with(play_context, {}, 'task uuid')
+
+
+@pytest.mark.parametrize(
+    ('error', 'socket_exists'),
+    [
+        (ConnectionError('method not found', code=-32601), [True, True]),
+        (ConnectionError('socket disappeared'), [True, True, False]),
+    ],
+)
+def test_start_connection_falls_back_for_unsupported_or_disappeared_socket(mocker, play_context, error, socket_exists):
+    connection = mocker.patch.object(task_executor, 'Connection').return_value
+    connection.set_options_ansible_connection_cli_stub.side_effect = error
+    mocker.patch.object(task_executor, '_get_persistent_connection_socket_path', return_value='/old/socket')
+    mocker.patch.object(task_executor.os.path, 'exists', side_effect=socket_exists)
+    cli_stub = mocker.patch.object(
+        task_executor,
+        '_start_connection_cli_stub',
+        return_value={'messages': [], 'socket_path': '/new/socket'},
+    )
+
+    result = task_executor.start_connection(play_context, {}, 'task uuid')
+
+    assert result == '/new/socket'
+    cli_stub.assert_called_once_with(play_context, {}, 'task uuid')
+
+
+def test_start_connection_does_not_retry_other_existing_socket_errors(mocker, play_context):
+    connection = mocker.patch.object(task_executor, 'Connection').return_value
+    connection.set_options_ansible_connection_cli_stub.side_effect = ConnectionError('connection refused')
+    mocker.patch.object(task_executor, '_get_persistent_connection_socket_path', return_value='/stale/socket')
+    mocker.patch.object(task_executor.os.path, 'exists', return_value=True)
+    cli_stub = mocker.patch.object(task_executor, '_start_connection_cli_stub')
+
+    with pytest.raises(AnsibleError, match='connection refused'):
+        task_executor.start_connection(play_context, {}, 'task uuid')
+
+    cli_stub.assert_not_called()
+
+
+def test_start_connection_does_not_retry_daemon_operation_errors(mocker, play_context):
+    connection = mocker.patch.object(task_executor, 'Connection').return_value
+    connection.set_options_ansible_connection_cli_stub.return_value = {
+        'error': 'context update failed',
+        'exception': 'daemon traceback',
+        'messages': [],
+        'socket_path': '/path/to/socket',
+    }
+    mocker.patch.object(task_executor, '_get_persistent_connection_socket_path', return_value='/path/to/socket')
+    mocker.patch.object(task_executor.os.path, 'exists', return_value=True)
+    cli_stub = mocker.patch.object(task_executor, '_start_connection_cli_stub')
+
+    with pytest.raises(AnsibleError, match='context update failed'):
+        task_executor.start_connection(play_context, {}, 'task uuid')
+
+    cli_stub.assert_not_called()
+
+
+def test_start_connection_waits_for_creation_lock_before_using_socket(mocker, play_context, connection_lock):
+    events = []
+    socket_checks = iter([False, True])
+
+    def exists(path):
+        if path == '/path/to/socket':
+            events.append('socket-exists')
+            return next(socket_checks)
+        if path == '/path/to/lock':
+            events.append('lock-exists')
+            return True
+        raise AssertionError(f'unexpected path: {path}')
+
+    @contextmanager
+    def acquire_lock(lock_path):
+        assert lock_path == '/path/to/lock'
+        events.append('lock-enter')
+        try:
+            yield
+        finally:
+            events.append('lock-exit')
+
+    connection_lock.side_effect = acquire_lock
+    mocker.patch.object(task_executor, '_get_persistent_connection_socket_path', return_value='/path/to/socket')
+    mocker.patch.object(task_executor, '_get_persistent_connection_lock_path', return_value='/path/to/lock')
+    mocker.patch.object(task_executor.os.path, 'exists', side_effect=exists)
+    connection = mocker.patch.object(task_executor, 'Connection').return_value
+
+    def synchronize(**kwargs):
+        events.append('rpc')
+        return {'messages': [], 'socket_path': '/path/to/socket'}
+
+    connection.set_options_ansible_connection_cli_stub.side_effect = synchronize
+    cli_stub = mocker.patch.object(task_executor, '_start_connection_cli_stub')
+
+    result = task_executor.start_connection(play_context, {}, 'task uuid')
+
+    assert result == '/path/to/socket'
+    assert events == ['socket-exists', 'lock-exists', 'lock-enter', 'socket-exists', 'rpc', 'lock-exit']
+    cli_stub.assert_not_called()
+
+
+def test_start_connection_cli_stub_uses_configured_path(mocker, play_context, collection_loader):
+    process = MagicMock()
+    process.returncode = 0
+    process.communicate.return_value = (json.dumps({'messages': [], 'socket_path': '/new/socket'}).encode(), b'')
+    popen = mocker.patch.object(task_executor.subprocess, 'Popen', return_value=process)
+    write_to_stream = mocker.patch.object(task_executor, 'write_to_stream')
+    mocker.patch.object(task_executor.C.config, 'get_config_value', return_value='/custom/connection-helper')
+
+    result = task_executor._start_connection_cli_stub(play_context, {'timeout': 42}, 'task uuid')
+
+    assert result == {'messages': [], 'socket_path': '/new/socket'}
+    assert popen.call_args.args[0] == [sys.executable, '/custom/connection-helper', to_text(task_executor.os.getppid()), 'task uuid']
+    assert popen.call_args.kwargs['stdin'] is subprocess.PIPE
+    assert popen.call_args.kwargs['stdout'] is subprocess.PIPE
+    assert popen.call_args.kwargs['stderr'] is subprocess.PIPE
+    assert write_to_stream.call_args_list == [
+        call(process.stdin, {'timeout': 42}),
+        call(process.stdin, play_context.dump_attrs()),
+    ]
+
+
+@pytest.mark.parametrize('level', ['debug', 'v', 'vv', 'vvv', 'vvvv', 'vvvvv', 'vvvvvv'])
+def test_handle_connection_result_dispatches_host_messages(mocker, play_context, level):
+    display = mocker.patch.object(task_executor, 'display')
+
+    result = task_executor._handle_connection_result(
+        play_context,
+        {'messages': [(level, 'message')], 'socket_path': '/path/to/socket'},
+    )
+
+    assert result == '/path/to/socket'
+    getattr(display, level).assert_called_once_with('message', host='example.invalid')
+
+
+def test_handle_connection_result_dispatches_other_messages(mocker, play_context):
+    display = mocker.patch.object(task_executor, 'display', autospec=True)
+
+    task_executor._handle_connection_result(
+        play_context,
+        {
+            'messages': [
+                ('log', 'log message'),
+                ('warning', 'warning message'),
+                ('unknown', 'unknown message'),
+            ],
+            'socket_path': '/path/to/socket',
+        },
+    )
+
+    display.display.assert_called_once_with('log message', log_only=True)
+    display.warning.assert_called_once_with('warning message')
+    display.vvvv.assert_called_once_with('unknown message', host='example.invalid')

--- a/test/units/module_utils/test_connection.py
+++ b/test/units/module_utils/test_connection.py
@@ -9,13 +9,14 @@ from ansible.module_utils import connection
 import pytest
 
 
-def test_set_options_credential_exposure():
+@pytest.mark.parametrize('method_name', ['set_options', 'set_options_ansible_connection_cli_stub'])
+def test_set_options_credential_exposure(method_name):
     def send(data):
         return '{'
 
     c = connection.Connection(connection.__file__)
     c.send = send
     with pytest.raises(connection.ConnectionError) as excinfo:
-        c._exec_jsonrpc('set_options', become_pass='password')
+        c._exec_jsonrpc(method_name, become_pass='password')
 
     assert 'password' not in str(excinfo.value)

--- a/test/units/plugins/connection/test_connection.py
+++ b/test/units/plugins/connection/test_connection.py
@@ -18,9 +18,11 @@
 from __future__ import annotations
 
 from io import StringIO
+from unittest import mock
 
 import unittest
 from ansible.playbook.play_context import PlayContext
+from ansible.plugins import connection as connection_plugin
 from ansible.plugins.connection import ConnectionBase
 from ansible.plugins.loader import become_loader
 
@@ -67,6 +69,26 @@ class TestConnectionBaseClass(unittest.TestCase):
 
     def test_subclass_success(self):
         self.assertIsInstance(NoOpConnection(self.play_context, self.in_stream), NoOpConnection)
+
+    def test_persistent_connection_lock_releases_after_error(self):
+        with (
+            mock.patch.object(connection_plugin.os, 'open', return_value=42) as open_mock,
+            mock.patch.object(connection_plugin.fcntl, 'lockf') as lock_mock,
+            mock.patch.object(connection_plugin.os, 'close') as close_mock,
+            self.assertRaisesRegex(RuntimeError, 'operation failed'),
+        ):
+            with connection_plugin._persistent_connection_lock('/path/to/lock'):
+                raise RuntimeError('operation failed')
+
+        open_mock.assert_called_once_with('/path/to/lock', connection_plugin.os.O_RDWR | connection_plugin.os.O_CREAT, 0o600)
+        self.assertEqual(
+            lock_mock.call_args_list,
+            [
+                mock.call(42, connection_plugin.fcntl.LOCK_EX),
+                mock.call(42, connection_plugin.fcntl.LOCK_UN),
+            ],
+        )
+        close_mock.assert_called_once_with(42)
 
     def test_check_password_prompt(self):
         local = (


### PR DESCRIPTION
##### SUMMARY

Persistent connection tasks currently start `ansible_connection_cli_stub.py` for every action.
The helper is needed when creating the connection daemon, but once the daemon is running it only updates the task-specific connection state and returns the existing socket path.

This change sends that update directly to an existing daemon over its Unix socket.
The daemon provides a private RPC which applies the connection options, play context, and prompt-check state, then returns any queued connection messages.
The helper remains responsible for creating new daemons.

The task executor derives the socket path from the current play context rather than reusing the connection object's cached path.
This is required when connection variables such as the remote user or port change between loop items.
It also uses the helper's existing per-socket lock and rechecks the socket after acquiring the lock, so it cannot connect in the interval between `bind()` and `listen()`.

If the socket disappears, or the daemon does not implement the new RPC, execution falls back to the helper.
Other RPC failures are returned without retrying because the daemon may already have applied part of the state update.
Errors raised while applying connection options retain the existing generic error and do not expose exception details or queued messages which may contain credentials.

On the `connection_persistent` test connection, updating an existing daemon took a median of 420.5 ms through the helper and 0.90 ms through the new RPC.
Local testing/benchmarking showed savings of approximately 0.4 seconds for each action that reused an existing connection, for both loop items and separate tasks.
These results measure controller overhead; they are not timings from a live network device.

This is narrower than #76430.
It does not defer connection creation or move persistent-connection detection; it only avoids the helper process after a matching daemon already exists.
Related historical issue: #75813.

Tests were added for the direct RPC path, daemon creation and fallback, socket readiness, connection changes between loop items, shared sockets, connection reset, message handling, and credential-safe errors.
The focused unit tests, the `connection_persistent` integration target, and the applicable sanity tests pass.

##### ISSUE TYPE

- Feature Pull Request
