### PR TITLE
jsonfile: add option to configure the cache format

### DIFF
--- a/changelogs/fragments/jsonfile-cache-persistent.yml
+++ b/changelogs/fragments/jsonfile-cache-persistent.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - jsonfile - add a ``persistent`` option to configure the cache format. Setting the option to ``False`` restores the filename and lossy cache format used before ansible-core 2.19.

--- a/changelogs/fragments/jsonfile-cache-persistent.yml
+++ b/changelogs/fragments/jsonfile-cache-persistent.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - jsonfile - add a ``persistent`` option to configure the cache format. Setting the option to ``False`` restores the filename and lossy cache format used before ansible-core 2.19.
+  - jsonfile cache plugin - add ``persistent`` option to configure whether or not to persist data tags. Setting the option to ``False`` restores the filename and format used prior to ansible-core 2.19.

--- a/changelogs/fragments/jsonfile-cache-persistent.yml
+++ b/changelogs/fragments/jsonfile-cache-persistent.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - jsonfile cache plugin - add ``persistent`` option to configure whether or not to persist data tags. Setting the option to ``False`` restores the filename and format used prior to ansible-core 2.19.
+  - jsonfile cache plugin - add ``persist_metadata`` option to configure whether or not to preserve metadata like deprecation notices. Setting the option to ``False`` restores the filename and format used prior to ansible-core 2.19.

--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -38,6 +38,16 @@ DOCUMENTATION = """
           - key: fact_caching_timeout
             section: defaults
         type: integer
+      persistent:
+        version_added: "2.22"
+        description: Set to False to use the cache filename and lossy format used prior to ansible-core 2.19.
+        default: True
+        type: bool
+        env:
+          - name: ANSIBLE_CACHE_JSONFILE_PERSISTENT
+        ini:
+          - key: fact_caching_jsonfile_persistent
+            section: defaults
 """
 
 import json
@@ -48,6 +58,11 @@ from ansible.plugins.cache import BaseFileCacheModule
 
 class CacheModule(BaseFileCacheModule):
     """A caching module backed by json files."""
+
+    @property
+    def _persistent(self):
+        # evaluate on request, since the plugin loader initializes defs before checking _persistent
+        return self.get_option("persistent")
 
     def _load(self, filepath: str) -> object:
         return json.loads(pathlib.Path(filepath).read_text())

--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -38,17 +38,17 @@ DOCUMENTATION = """
           - key: fact_caching_timeout
             section: defaults
         type: integer
-      persistent:
+      persist_metadata:
         version_added: "2.22"
         description:
-          - Whether or not to persist data tags, such as deprecation notices.
-          - Setting this option to False will use the cache filename and tagless format used prior to ansible-core 2.19.
+          - By default, the fact cache preserves internal metadata, including deprecation notices and variable origin.
+          - Setting this option to False will remove this information, and use the filename and format matching the behavior before ansible-core 2.19.
         default: True
         type: bool
         env:
-          - name: ANSIBLE_CACHE_JSONFILE_PERSISTENT
+          - name: ANSIBLE_CACHE_JSONFILE_PERSIST_METADATA
         ini:
-          - key: persistent
+          - key: persist_metadata
             section: jsonfile_cache
 """
 
@@ -64,7 +64,7 @@ class CacheModule(BaseFileCacheModule):
     # NOTE: This relies on core impl details about cache instantiation and the PluginLoader that can change at any time.
     @property
     def _persistent(self):
-        return self.get_option("persistent")
+        return self.get_option("persist_metadata")
 
     def _load(self, filepath: str) -> object:
         return json.loads(pathlib.Path(filepath).read_text())

--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -40,7 +40,9 @@ DOCUMENTATION = """
         type: integer
       persistent:
         version_added: "2.22"
-        description: Set to False to use the cache filename and lossy format used prior to ansible-core 2.19.
+        description:
+          - Whether or not to persist data tags, such as deprecation notices.
+          - Setting this option to False will use the cache filename and tagless format used prior to ansible-core 2.19.
         default: True
         type: bool
         env:
@@ -59,9 +61,9 @@ from ansible.plugins.cache import BaseFileCacheModule
 class CacheModule(BaseFileCacheModule):
     """A caching module backed by json files."""
 
+    # NOTE: This relies on core impl details about cache instantiation and the PluginLoader that can change at any time.
     @property
     def _persistent(self):
-        # evaluate on request, since the plugin loader initializes defs before checking _persistent
         return self.get_option("persistent")
 
     def _load(self, filepath: str) -> object:

--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -48,8 +48,8 @@ DOCUMENTATION = """
         env:
           - name: ANSIBLE_CACHE_JSONFILE_PERSISTENT
         ini:
-          - key: fact_caching_jsonfile_persistent
-            section: defaults
+          - key: persistent
+            section: jsonfile_cache
 """
 
 import json

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -1293,6 +1293,7 @@ class _CacheLoader(PluginLoader):
         if not plugin:
             raise AnsibleError(f'Unable to load the cache plugin {name!r}.')
 
+        # NOTE: jsonfile relies on the internal impl detail that the instance of the cache class is initialized at this point
         if plugin._persistent:
             return _cache.PluginInterposer(plugin)
 

--- a/test/integration/targets/cache-plugins/runme.sh
+++ b/test/integration/targets/cache-plugins/runme.sh
@@ -44,3 +44,11 @@ export ANSIBLE_CACHE_PLUGIN_PREFIX="YOLO"
 ansible-playbook -i chroot_inventory_config.yml invalid_hostname_file_caches.yml "$@"
 
 ANSIBLE_CACHE_PLUGIN=dummy_file_cache_persistent ansible-playbook -i chroot_inventory_config.yml invalid_hostname_file_caches.yml "$@"
+
+# test using the legacy cache filename and format
+echo '{"TEST_FACT": "DEFINED"}' > "$OUTPUT_DIR/legacy_localhost"
+ANSIBLE_CACHE_PLUGIN=ansible.builtin.jsonfile \
+    ANSIBLE_CACHE_PLUGIN_CONNECTION="${OUTPUT_DIR}" \
+    ANSIBLE_CACHE_PLUGIN_PREFIX=legacy_ \
+    ANSIBLE_CACHE_JSONFILE_PERSISTENT=false \
+    ansible localhost -m assert -a "that='TEST_FACT is defined'"

--- a/test/integration/targets/cache-plugins/runme.sh
+++ b/test/integration/targets/cache-plugins/runme.sh
@@ -49,7 +49,7 @@ ANSIBLE_CACHE_PLUGIN=dummy_file_cache_persistent ansible-playbook -i chroot_inve
 export ANSIBLE_CACHE_PLUGIN=ansible.builtin.jsonfile \
     ANSIBLE_CACHE_PLUGIN_CONNECTION="${OUTPUT_DIR}" \
     ANSIBLE_CACHE_PLUGIN_PREFIX=legacy_ \
-    ANSIBLE_CACHE_JSONFILE_PERSISTENT=false
+    ANSIBLE_CACHE_JSONFILE_PERSIST_METADATA=false
 
 ansible localhost -m assert -a "that='TEST_FACT is undefined'"
 ansible localhost -m set_fact -a "cacheable='True' TEST_FACT='DEFINED'"

--- a/test/integration/targets/cache-plugins/runme.sh
+++ b/test/integration/targets/cache-plugins/runme.sh
@@ -45,10 +45,20 @@ ansible-playbook -i chroot_inventory_config.yml invalid_hostname_file_caches.yml
 
 ANSIBLE_CACHE_PLUGIN=dummy_file_cache_persistent ansible-playbook -i chroot_inventory_config.yml invalid_hostname_file_caches.yml "$@"
 
-# test using the legacy cache filename and format
-echo '{"TEST_FACT": "DEFINED"}' > "$OUTPUT_DIR/legacy_localhost"
-ANSIBLE_CACHE_PLUGIN=ansible.builtin.jsonfile \
+# test user-facing jsonfile 'persistent' route specifically, which relies on internal implementation details
+export ANSIBLE_CACHE_PLUGIN=ansible.builtin.jsonfile \
     ANSIBLE_CACHE_PLUGIN_CONNECTION="${OUTPUT_DIR}" \
     ANSIBLE_CACHE_PLUGIN_PREFIX=legacy_ \
-    ANSIBLE_CACHE_JSONFILE_PERSISTENT=false \
-    ansible localhost -m assert -a "that='TEST_FACT is defined'"
+    ANSIBLE_CACHE_JSONFILE_PERSISTENT=false
+
+ansible localhost -m assert -a "that='TEST_FACT is undefined'"
+ansible localhost -m set_fact -a "cacheable='True' TEST_FACT='DEFINED'"
+ansible localhost -m assert -a "that='TEST_FACT is defined'"
+
+if [[ ! -f "$OUTPUT_DIR/legacy_localhost" ]]; then
+    echo "Missing expected cache filename"
+    exit 1
+elif ! grep -q "${OUTPUT_DIR}/legacy_localhost" -e '{"TEST_FACT": "DEFINED"}'; then
+    echo "Missing expected cache format"
+    exit 1
+fi

--- a/test/integration/targets/set_fact/runme.sh
+++ b/test/integration/targets/set_fact/runme.sh
@@ -27,6 +27,21 @@ fi
 
 ansible-playbook -i inventory --flush-cache "$@" set_fact_no_cache.yml
 
+# repeat cache tests using non-persistent jsonfile format
+export ANSIBLE_CACHE_JSONFILE_PERSISTENT=false
+
+ansible-playbook -i inventory "$@" set_fact_cached_1.yml
+ansible-playbook -i inventory "$@" set_fact_cached_2.yml
+
+# check contents of the fact cache before flushing it
+if [[ ! -f "$MYTMPDIR/prefix_localhost" ]]; then
+    echo "Missing expected cache file"
+    exit 1
+fi
+
+ansible-playbook -i inventory --flush-cache "$@" set_fact_no_cache.yml
+unset ANSIBLE_CACHE_JSONFILE_PERSISTENT
+
 # Test boolean conversions in set_fact
 ansible-playbook -v set_fact_bool_conv_jinja2_native.yml
 

--- a/test/integration/targets/set_fact/runme.sh
+++ b/test/integration/targets/set_fact/runme.sh
@@ -27,21 +27,6 @@ fi
 
 ansible-playbook -i inventory --flush-cache "$@" set_fact_no_cache.yml
 
-# repeat cache tests using non-persistent jsonfile format
-export ANSIBLE_CACHE_JSONFILE_PERSISTENT=false
-
-ansible-playbook -i inventory "$@" set_fact_cached_1.yml
-ansible-playbook -i inventory "$@" set_fact_cached_2.yml
-
-# check contents of the fact cache before flushing it
-if [[ ! -f "$MYTMPDIR/prefix_localhost" ]]; then
-    echo "Missing expected cache file"
-    exit 1
-fi
-
-ansible-playbook -i inventory --flush-cache "$@" set_fact_no_cache.yml
-unset ANSIBLE_CACHE_JSONFILE_PERSISTENT
-
 # Test boolean conversions in set_fact
 ansible-playbook -v set_fact_bool_conv_jinja2_native.yml
 


### PR DESCRIPTION
##### SUMMARY

Add an option to configure the `_persistent` attribute, preserving the default behavior. Setting the option to false restores the filename and format used before 2.19.

AWX fact caching can use this toggle to restore compatibility with current versions of ansible-core.

##### ISSUE TYPE

- Feature Pull Request
