### PR TITLE
[stable-2.21] Update module_utils urls unit tests (#87483)

### DIFF
--- a/test/units/module_utils/urls/test_Request.py
+++ b/test/units/module_utils/urls/test_Request.py
@@ -192,7 +192,15 @@ def test_Request_open_username(urlopen_mock, install_opener_mock):
         if isinstance(handler, expected_handlers):
             found_handlers.append(handler)
     assert len(found_handlers) == 2
-    assert found_handlers[0].passwd.passwd[None] == {(('ansible.com', '/'),): ('user', None)}
+
+    expected = ('user', None)
+    result = found_handlers[0].passwd.passwd[None]
+
+    assert (
+        # see https://github.com/python/cpython/issues/155694
+        result == {(('ansible.com', '/'),): expected} or  # before fix
+        result == {((None, 'ansible.com', '/'),): expected}  # after fix
+    )
 
 
 @pytest.mark.parametrize('url, expected', (
@@ -215,7 +223,14 @@ def test_Request_open_username_in_url(url, expected, urlopen_mock, install_opene
     for handler in handlers:
         if isinstance(handler, expected_handlers):
             found_handlers.append(handler)
-    assert found_handlers[0].passwd.passwd[None] == {(('ansible.com', '/'),): expected}
+
+    result = found_handlers[0].passwd.passwd[None]
+
+    assert (
+        # see https://github.com/python/cpython/issues/155694
+        result == {(('ansible.com', '/'),): expected} or  # before fix
+        result == {((None, 'ansible.com', '/'),): expected}  # after fix
+    )
 
 
 def test_Request_open_username_force_basic(urlopen_mock, install_opener_mock):


### PR DESCRIPTION
##### SUMMARY

Backport of https://github.com/ansible/ansible/pull/87483

Update the tests to work on newer Python versions which contain fixes for https://github.com/python/cpython/issues/155694.

(cherry picked from commit 5ba4572)

##### ISSUE TYPE

Test Pull Request
