### PR TITLE
template: restore failed_when support for missing src file

### DIFF
--- a/changelogs/fragments/87491-template-failed-when-missing-src.yml
+++ b/changelogs/fragments/87491-template-failed-when-missing-src.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - template action - restore ``failed_when`` support when the template source file
+    is not found on the controller (https://github.com/ansible/ansible/issues/87491).

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -20,7 +20,7 @@ from jinja2.defaults import (
 
 from ansible import constants as C
 from ansible.config.manager import ensure_type
-from ansible.errors import AnsibleError, AnsibleActionFail
+from ansible.errors import AnsibleError, AnsibleActionFail, AnsibleFileNotFound
 from ansible.module_utils.common.text.converters import to_bytes, to_text, to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
@@ -92,14 +92,17 @@ class ActionModule(ActionBase):
                 try:
                     source = self._find_needle('templates', source)
                 except AnsibleError as e:
-                    raise AnsibleActionFail(to_text(e))
+                    return {"failed": True, "msg": to_text(e), "changed": False}
 
             mode = self._task.args.get('mode', None)
             if mode == 'preserve':
                 mode = '0%03o' % stat.S_IMODE(os.stat(source).st_mode)
 
             # template the source data locally & get ready to transfer
-            template_data = trust_as_template(self._loader.get_text_file_contents(source))
+            try:
+                template_data = trust_as_template(self._loader.get_text_file_contents(source))
+            except AnsibleFileNotFound as e:
+                return {"failed": True, "msg": f"could not find src={source}: {e!r}", "changed": False}
 
             # set jinja2 internal search path for includes
             searchpath = task_vars.get('ansible_search_path', [])

--- a/test/integration/targets/template/missing_src_failed_when_87491.yml
+++ b/test/integration/targets/template/missing_src_failed_when_87491.yml
@@ -1,0 +1,27 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: missing src with failed_when false
+      template:
+        src: does-not-exist.j2
+        dest: /tmp/out-does-not-exist
+      failed_when: false
+      register: result
+
+    - assert:
+        that:
+          - result is not failed
+          - result.failed_when_result == false
+          - "'Could not find or access' in result.msg"
+
+    - name: missing src with conditional failed_when
+      template:
+        src: does-not-exist.j2
+        dest: /tmp/out-does-not-exist
+      failed_when: "'Could not find or access' not in result.msg"
+      register: result
+
+    - assert:
+        that:
+          - result is not failed
+          - result.failed_when_result == false

--- a/test/integration/targets/template/runme.sh
+++ b/test/integration/targets/template/runme.sh
@@ -56,5 +56,8 @@ do
 	ANSIBLE_CONFIG="./${badcfg}.cfg" ansible-config dump --only-changed
 done
 
-# ensure we picle hostvarscorrectly with native https://github.com/ansible/ansible/issues/83503
+# ensure we pickle hostvars correctly with native https://github.com/ansible/ansible/issues/83503
 ANSIBLE_JINJA2_NATIVE=1 ansible -m debug -a "msg={{ groups.all | map('extract', hostvars) }}" -i testhost, all -c local -v "$@"
+
+# https://github.com/ansible/ansible/issues/87491
+ansible-playbook missing_src_failed_when_87491.yml -v "$@"


### PR DESCRIPTION
  ##### SUMMARY

  Return a result dict instead of raising `AnsibleActionFail` when the template source file cannot be found.
  Exceptions raised from the action plugin's `run()` bypass `failed_when`/`changed_when` evaluation in
  `_execute_internal`, so raising made the failure unconditional.

  The previous `get_real_file()` call had an explicit `try/except` for `AnsibleFileNotFound` that was lost when
  it was replaced by an unguarded `get_text_file_contents()` in the data tagging overhaul (#84621). This restores
  an equivalent catch around `get_text_file_contents` and converts the `_find_needle` error path to return a
  result dict.

  Fixes #87491

  ##### ISSUE TYPE

  - Bugfix Pull Request

  ##### COMPONENT NAME

  template

  ##### ADDITIONAL INFORMATION

  Before this fix:
  ```yaml
  - name: Template a possibly-missing file
    ansible.builtin.template:
      src: "does-not-exist.j2"
      dest: /tmp/out
    failed_when: false
  fatal: [localhost]: FAILED! => {"changed": false, "msg": "Could not find or access 'does-not-exist.j2'..."}
  failed_when: false had no effect.

  After this fix, the same task returns:
  {
      "changed": false,
      "failed": false,
      "failed_when_result": false,
      "msg": "Could not find or access 'does-not-exist.j2'..."
  }
