### PR TITLE
docs: clarify agnostic become prompt

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -231,6 +231,10 @@ AGNOSTIC_BECOME_PROMPT:
   name: Display an agnostic become prompt
   default: True
   type: boolean
+  deprecated:
+    why: This setting causes confusion and is no longer recommended.
+    version: "2.20"
+    alternative: None
   description: Display an agnostic become prompt instead of displaying a prompt containing the command line supplied become method.
   env: [{name: ANSIBLE_AGNOSTIC_BECOME_PROMPT}]
   ini:


### PR DESCRIPTION
##### SUMMARY

Extends the documentation for `AGNOSTIC_BECOME_PROMPT` to clarify its behavior. It explains that enabling this option hides the specific escalation method and provides a generic `BECOME password:` prompt, which is useful for third-party integrations.

Fixes #81501

##### ISSUE TYPE

- Docs Pull Request