### PR TITLE
Fix `getaddrinfo` patch detection on QNX Neutrino

### DIFF
--- a/changelogs/fragments/87498-fix-getaddrinfo-patch-detection.yml
+++ b/changelogs/fragments/87498-fix-getaddrinfo-patch-detection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_utils - fix module initialization failures on QNX Neutrino 6.5.0 by specifying IPv4 stream socket hints in the ``socket.getaddrinfo`` integer-subclass compatibility probe (https://github.com/ansible/ansible/issues/87496).

--- a/lib/ansible/module_utils/_internal/_patches/_socket_patch.py
+++ b/lib/ansible/module_utils/_internal/_patches/_socket_patch.py
@@ -22,7 +22,12 @@ class GetAddrInfoPatch(CallablePatch):
     @classmethod
     def is_patch_needed(cls) -> bool:
         with contextlib.suppress(OSError):
-            socket.getaddrinfo('127.0.0.1', _CustomInt(22))
+            socket.getaddrinfo(
+                '127.0.0.1',
+                _CustomInt(22),
+                family=socket.AF_INET,
+                type=socket.SOCK_STREAM,
+            )
             return False
 
         return True


### PR DESCRIPTION
##### SUMMARY

<!--- Describe the change below, including rationale and design decisions -->
Fact gathering on QNX Neutrino 6.5.0 with Python 3.9.0 fails during module initialization:
```text
RuntimeError: Validation of 'socket.getaddrinfo' failed after patching.
```
`GetAddrInfoPatch.is_patch_needed()` tests integer-subclass support using a numeric port without specifying a socket type or protocol. QNX explicitly documents this combination as invalid under "Incomplete specifications" in its [`getaddrinfo()` documentation](https://www.qnx.com/developers/docs/6.5.0SP1.update/com.qnx.doc.neutrino_lib_ref/g/getaddrinfo.html).

The probe consequently mistakes a socket-hint restriction for an integer-subclass incompatibility. Converting the port to a plain integer cannot resolve that restriction, so post-patch validation fails.

This change specifies `AF_INET` and `SOCK_STREAM` in the probe while retaining `_CustomInt(22)`. The family matches the existing IPv4 loopback address, and the socket type makes the numeric-port lookup valid on QNX.

<!--- Add "Fixes #1234" or steps to reproduce the problem if there is no corresponding issue -->
Fixes #87496

##### ISSUE TYPE

<!--- Pick one below and delete the rest -->

- Bugfix Pull Request

##### TESTING
Verified successfully on the affected QNX Neutrino 6.5.0 target running Python 3.9.0.
