### PR TITLE
user: preserve the existing password on BusyBox systems

### DIFF
--- a/changelogs/fragments/user-busybox-password-lock.yml
+++ b/changelogs/fragments/user-busybox-password-lock.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - user - On BusyBox systems, preserve the existing password lock marker when ``password_lock`` is omitted.

--- a/changelogs/fragments/user-busybox-password-lock.yml
+++ b/changelogs/fragments/user-busybox-password-lock.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - user - On BusyBox systems, preserve the existing password lock marker when ``password_lock`` is omitted.
+  - user module - On BusyBox systems, preserve the existing password lock marker when ``password_lock`` is omitted.

--- a/lib/ansible/modules/user.py
+++ b/lib/ansible/modules/user.py
@@ -3156,7 +3156,7 @@ class BusyBox(User):
         if self.shell not in shells:
             self.module.warn(f"'{self.shell}' is not listed as a valid shell on the remote host.")
 
-    def _build_password_string(self, current_password=None):
+    def _build_password_string(self, current_password: str | None = None) -> str:
         """
         Build the appropriate password string based on the current password and
         module parameters.
@@ -3164,27 +3164,29 @@ class BusyBox(User):
         This method will return '*' at a minimum to avoid creating an enabled
         account with no password.
         """
-        lock = LOCK_INDICATOR if self.password_lock else ''
+        if self.password is None and self.password_lock is None and current_password is not None:
+            return current_password
 
-        # Order of precedence when choosing the password:
-        #   1. password from module parameters
-        #   2. current password
-        #   3. string to enable the account but without a password
-        password = '*'
         if self.password is not None:
             password = self.password
         elif current_password:
             password = current_password
-            if current_password == LOCK_INDICATOR:
-                # Special handling when the password is only a '!' to avoid
-                # unnecessary changes to the password to values like '!!' or '!*'.
-                lock = ''
-            elif current_password.startswith(LOCK_INDICATOR):
-                # Preserve the existing password but unlock the account even if
-                # no password hash was provided in the module parameters.
-                password = current_password.lstrip(LOCK_INDICATOR)
+        else:
+            password = '*'
 
-        return f'{lock}{password}'
+        currently_locked = bool(current_password) and current_password.startswith(LOCK_INDICATOR)
+
+        if self.password_lock is True:
+            if not password.startswith(LOCK_INDICATOR):
+                password = f'{LOCK_INDICATOR}{password}'
+        elif self.password_lock is False:
+            # Leave a lone '!' as-is so unlocking does not produce an empty field.
+            if password.startswith(LOCK_INDICATOR) and password != LOCK_INDICATOR:
+                password = password.removeprefix(LOCK_INDICATOR)
+        elif currently_locked and not password.startswith(LOCK_INDICATOR):
+            password = f'{LOCK_INDICATOR}{password}'
+
+        return password
 
     def create_user(self):
         cmd = [self.module.get_bin_path('adduser', True)]
@@ -3322,13 +3324,11 @@ class BusyBox(User):
                         if rc is not None and rc != 0:
                             self.module.fail_json(name=self.name, msg=err, rc=rc)
 
-        # Manage password
+        # Manage password.
         current_password = to_native(user_info[1])
-        new_password = self._build_password_string(current_password)
-        if self.update_password == 'always':
-            lock_status_mismatch = self.password_lock and not current_password.startswith('!')
-            password_changed = new_password != current_password
-            if lock_status_mismatch or password_changed:
+        if self.password is not None or self.password_lock is not None:
+            new_password = self._build_password_string(current_password)
+            if self.update_password == 'always' and new_password != current_password:
                 cmd = [self.module.get_bin_path('chpasswd', True), '--encrypted']
                 data = f'{self.name}:{new_password}'
                 rc, out, err = self.execute_command(cmd, data=data)

--- a/test/integration/targets/user/tasks/test_password_lock.yml
+++ b/test/integration/targets/user/tasks/test_password_lock.yml
@@ -77,6 +77,74 @@
           - password_lock_7 is changed
           - password_lock_8 is not changed
 
+    - name: Lock account then omit password_lock
+      user:
+        name: ansibulluser
+        password_lock: yes
+
+    - name: Modify user with neither password nor password_lock
+      user:
+        name: ansibulluser
+      register: password_lock_omit_1
+
+    - name: Modify user with neither password nor password_lock again
+      user:
+        name: ansibulluser
+      register: password_lock_omit_2
+
+    - name: Ensure omitted password_lock does not change the account
+      assert:
+        that:
+          - password_lock_omit_1 is not changed
+          - password_lock_omit_2 is not changed
+
+    - name: LINUX | Get shadow after omitting password_lock
+      getent:
+        database: shadow
+        key: ansibulluser
+      when: ansible_facts.system == 'Linux'
+
+    - name: LINUX | Ensure lock is preserved when password_lock is omitted
+      assert:
+        that:
+          - getent_shadow['ansibulluser'][0].startswith('!')
+      when: ansible_facts.system == 'Linux'
+
+    - name: Change password without password_lock on BusyBox
+      when: ansible_distribution == 'Alpine'
+      block:
+        - name: Set new password and lock account
+          user:
+            name: ansibulluser
+            password: "$y$jCT$ZiF3ZV39/maUl9Lzt2Hk80$Ih6bI4OXU52OnWWqt3T1BAmVn8eH.4qlcP.8/NOjGN5"  #gitleaks:allow
+            password_lock: yes
+          register: password_lock_9
+
+        - name: Ensure lock marker is preserved on password change
+          assert:
+            that:
+              - password_lock_9.changed
+
+        - name: Modify user without password_lock
+          user:
+            name: ansibulluser
+          register: password_lock_10
+
+        - name: Ensure lock marker is preserved on password change
+          assert:
+            that:
+              - not password_lock_10.changed
+
+        - name: Get shadow after password change
+          getent:
+            database: shadow
+            key: ansibulluser
+
+        - name: Ensure lock marker is preserved when user is modified without password_lock
+          assert:
+            that:
+              - getent_shadow['ansibulluser'][0].startswith('!')
+
     - name: Lock account
       user:
         name: ansibulluser


### PR DESCRIPTION
##### SUMMARY

* On BusyBox systems, preserve the existing password lock marker
  when ``password_lock`` is omitted.

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/user-busybox-password-lock.yml
lib/ansible/modules/user.py
test/integration/targets/user/tasks/test_password_lock.yml


