### PR TITLE
Backport secrets keyword for plugin schema

### DIFF
--- a/changelogs/fragments/ansible-test-validate-modules-secret.yml
+++ b/changelogs/fragments/ansible-test-validate-modules-secret.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - >-
+    ansible-test - Do not fail the ``validate-modules`` sanity test when a plugin documents an option with the
+    ``secret`` key. The key is only honored by ansible-core 2.22 and later, where it masks the option value in
+    output. It is ignored by earlier versions, but is now accepted by the sanity test so a collection can document
+    it while still testing against those versions.

--- a/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
+++ b/test/lib/ansible_test/_util/controller/sanity/validate-modules/validate_modules/schema.py
@@ -670,6 +670,10 @@ def list_dict_option_schema(for_collection, plugin_type):
             'cli': [cli_schema],
             'keyword': [keyword_schema],
             'deprecated': deprecated_schema,
+            # Only honored by ansible-core 2.22 and later. It is accepted here
+            # so a collection documenting it can still pass this sanity test
+            # when run under older ansible-core versions.
+            'secret': bool,
         })
 
     suboption_schema = dict(basic_option_schema)


### PR DESCRIPTION
##### SUMMARY
Backports the `secrets` keyword used in `validate-modules` sanity tests. While the keyword is still a no-op on older Ansible versions this will ensure collection authors can use the new option on 2.22 without having to ignore the sanity check for older Ansible versions.

Selective backport of the new keyword introduced in https://github.com/ansible/ansible/pull/87457.

##### ISSUE TYPE
- Bugfix Pull Request