### PR TITLE
Redact syslog secrets regardless of length

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1289,37 +1289,64 @@ class AnsibleModule(object):
                 msg_to_log=msg,
             )
 
-    def _log_invocation(self):
-        """ log that ansible ran the module """
-        # TODO: generalize a separate log function and make log_invocation use it
-        # Sanitize possible password argument when logging.
-        log_args = dict()
+    def _redact_no_log_params(
+        self,
+        argument_spec: Mapping[str, Mapping[str, t.Any]],
+        params: Mapping[str, t.Any],
+        prefix: str = '',
+    ) -> dict[str, t.Any]:
+        """Return a copy of ``params`` suitable for logging with ``no_log`` values replaced by a placeholder.
 
-        for param in self.params:
-            canon = self.aliases.get(param, param)
-            arg_opts = self.argument_spec.get(canon, {})
+        Values are redacted by their position in ``argument_spec`` rather than by matching their content, so
+        ``no_log`` values that are too short or not a string to be registered as a secret are still hidden.
+        Sub options are processed recursively using the same rules as the top level parameters.
+        """
+        aliases = {alias: name for name, opts in argument_spec.items() for alias in opts.get('aliases') or ()}
+        redacted: dict[str, t.Any] = {}
+
+        for param, value in params.items():
+            arg_opts = argument_spec.get(aliases.get(param, param), {})
             no_log = arg_opts.get('no_log', None)
 
             # try to proactively capture password/passphrase fields
             if no_log is None and PASSWORD_MATCH.search(param):
-                log_args[param] = '$REDACTED$'
-                self.warn('Module did not set no_log for %s' % param)
+                value = '$REDACTED$'
+                self.warn(f'Module did not set no_log for {prefix}{param}')
             elif self.boolean(no_log):
                 # We don't rely on the secret masker here because the value
                 # may have been set to anything (non-string/too short, etc) and
                 # historically we've always just blocked it out.
-                log_args[param] = '$REDACTED$'
-            else:
-                param_val = self.params[param]
-                if not isinstance(param_val, (str, bytes)):
-                    param_val = str(param_val)
-                elif isinstance(param_val, bytes):
-                    param_val = param_val.decode('utf-8')
+                value = '$REDACTED$'
+            elif (sub_spec := arg_opts.get('options')) and value is not None:
+                wanted_type = arg_opts.get('type')
 
-                # These log args will be masked in log() if they contain any secrets.
-                log_args[param] = param_val
+                if wanted_type == 'dict' and isinstance(value, Mapping):
+                    value = self._redact_no_log_params(
+                        argument_spec=sub_spec,
+                        params=value,
+                        prefix=f'{prefix}{param}.',
+                    )
+                elif wanted_type == 'list' and arg_opts.get('elements') == 'dict' and isinstance(value, list):
+                    value = [
+                        self._redact_no_log_params(
+                            argument_spec=sub_spec,
+                            params=elem,
+                            prefix=f'{prefix}{param}[{idx}].'
+                        ) if isinstance(elem, Mapping) else elem
+                        for idx, elem in enumerate(value)
+                    ]
 
-        msg = ['%s=%s' % (to_native(arg), to_native(val)) for arg, val in log_args.items()]
+            redacted[param] = value
+
+        return redacted
+
+    def _log_invocation(self) -> None:
+        """ log that ansible ran the module """
+        # TODO: generalize a separate log function and make log_invocation use it
+        # These log args will be masked in log() if they contain any secrets.
+        log_args = {key: to_text(value) for key, value in self._redact_no_log_params(self.argument_spec, self.params).items()}
+
+        msg = [f'{k}={v}' for k, v in log_args.items()]
         if msg:
             msg = 'Invoked with %s' % ' '.join(msg)
         else:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1346,9 +1346,8 @@ class AnsibleModule(object):
         # These log args will be masked in log() if they contain any secrets.
         log_args = {key: to_text(value) for key, value in self._redact_no_log_params(self.argument_spec, self.params).items()}
 
-        msg = [f'{k}={v}' for k, v in log_args.items()]
-        if msg:
-            msg = 'Invoked with %s' % ' '.join(msg)
+        if log_args:
+            msg = f"Invoked with {' '.join([f'{k}={v}' for k, v in log_args.items()])}"
         else:
             msg = 'Invoked'
 

--- a/test/integration/targets/module_no_log/library/module_with_no_log_suboptions.py
+++ b/test/integration/targets/module_no_log/library/module_with_no_log_suboptions.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+from __future__ import annotations
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(argument_spec=dict(
+        marker=dict(type='str'),
+        secret=dict(type='str', no_log=True),
+        opts=dict(
+            type='dict',
+            options=dict(
+                secret=dict(type='str', no_log=True),
+                plain=dict(type='str'),
+            ),
+        ),
+        entries=dict(
+            type='list',
+            elements='dict',
+            options=dict(
+                secret=dict(type='str', no_log=True),
+                plain=dict(type='str'),
+            ),
+        ),
+    ))
+
+    module.exit_json()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/targets/module_no_log/test_syslog.yml
+++ b/test/integration/targets/module_no_log/test_syslog.yml
@@ -62,3 +62,35 @@
           # 2) the AnsibleModule.log method is not working
           - good_message in grep.stdout
           - bad_message not in grep.stdout
+
+    - name: Generate a unique marker for the sub option log entry
+      set_fact:
+        suboption_marker: "marker{{ 999999999999 | random }}"
+
+    - name: Run a module with no_log sub options too short to be registered as secrets
+      module_with_no_log_suboptions:
+        marker: "{{ suboption_marker }}"
+        secret: r7t
+        opts:
+          secret: q7z
+          plain: visible
+        entries:
+          - secret: z7q
+            plain: alsovisible
+
+    - name: Search for the sub option log entry
+      shell: "(grep -e '{{ suboption_marker }}' /var/log/syslog) || (journalctl | grep -e '{{ suboption_marker }}')"
+      changed_when: no
+      register: suboption_grep
+
+    - name: Verify no_log sub options were redacted from the log entry
+      assert:
+        that:
+          - "'Invoked with' in suboption_grep.stdout"
+          - "'r7t' not in suboption_grep.stdout"
+          - "'q7z' not in suboption_grep.stdout"
+          - "'z7q' not in suboption_grep.stdout"
+          - "\"'plain': 'visible'\" in suboption_grep.stdout"
+          - "\"'plain': 'alsovisible'\" in suboption_grep.stdout"
+          - "' secret=$REDACTED$' in suboption_grep.stdout"
+          - "\"'secret': '$REDACTED$'\" in suboption_grep.stdout"


### PR DESCRIPTION
##### SUMMARY
The move to secret masking only does redaction of secrets if they are 4 characters or longer. We still want to redact all values regardless of length and type if they are marked as `no_log=True` even in nested sub options. The raw return values are still handled as normal, this only applies to module logging.

No changelog is needed as the bug is only present in devel.

##### ISSUE TYPE
- Bugfix Pull Request