### PR TITLE
copy: return destination for predicted content changes

### DIFF
--- a/changelogs/fragments/81569-copy-check-mode-dest.yml
+++ b/changelogs/fragments/81569-copy-check-mode-dest.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - copy - return the resolved destination when check mode predicts a file content change (https://github.com/ansible/ansible/issues/81569).

--- a/changelogs/fragments/81569-copy-check-mode-dest.yml
+++ b/changelogs/fragments/81569-copy-check-mode-dest.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - copy - return the resolved destination when check mode predicts a file content change (https://github.com/ansible/ansible/issues/81569).
+  - copy - initialize common file-copy result fields and retain the resolved destination in check mode (https://github.com/ansible/ansible/issues/81569).

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -293,6 +293,7 @@ class ActionModule(ActionBase):
             if self._task.check_mode:
                 self._remove_tempfile_if_content_defined(content, content_tempfile)
                 result['changed'] = True
+                result['dest'] = dest_file
                 return result
 
             # Define a remote directory that we will copy the file to.

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -236,8 +236,7 @@ class ActionModule(ActionBase):
         force = boolean(self._task.args.get('force', 'yes'), strict=False)
         raw = boolean(self._task.args.get('raw', 'no'), strict=False)
 
-        result = {}
-        result['diff'] = []
+        result = {'failed': False, 'changed': False, 'dest': dest, 'diff': [], 'src': source_full}
 
         # If the local file does not exist, get_real_file() raises AnsibleFileNotFound
         try:
@@ -277,6 +276,8 @@ class ActionModule(ActionBase):
                 dest_file = self._connection._shell.join_path(dest, source_rel)
                 dest_status = self._execute_remote_stat(dest_file, all_vars=task_vars, follow=follow, checksum=force)
 
+        result['dest'] = dest_file
+
         if dest_status['exists'] and not force:
             # remote_file exists so continue to next iteration.
             return None
@@ -293,7 +294,6 @@ class ActionModule(ActionBase):
             if self._task.check_mode:
                 self._remove_tempfile_if_content_defined(content, content_tempfile)
                 result['changed'] = True
-                result['dest'] = dest_file
                 return result
 
             # Define a remote directory that we will copy the file to.
@@ -391,6 +391,8 @@ class ActionModule(ActionBase):
             module_return['checksum'] = local_checksum
 
         result.update(module_return)
+        if 'path' in module_return and 'dest' not in module_return:
+            result['dest'] = module_return['path']
         return result
 
     def _create_content_tempfile(self, content):

--- a/test/integration/targets/copy/tasks/check_mode.yml
+++ b/test/integration/targets/copy/tasks/check_mode.yml
@@ -161,3 +161,5 @@
         - real_file_attribute is changed
         - "check_mode_file_attribute_stat.stat.mode == '0444'"
         - "real_file_attribute_stat.stat.mode == '0666'"
+
+- import_tasks: check_mode_dest.yml

--- a/test/integration/targets/copy/tasks/check_mode_dest.yml
+++ b/test/integration/targets/copy/tasks/check_mode_dest.yml
@@ -1,0 +1,89 @@
+- name: Check destination results for single-file copies in check mode
+  vars:
+    check_mode_destinations:
+      - dest: "{{ remote_dir }}/check_mode_dest/file.txt"
+        expected: "{{ remote_dir }}/check_mode_dest/file.txt"
+      - dest: "{{ remote_dir }}/check_mode_dest/trailing/"
+        expected: "{{ remote_dir }}/check_mode_dest/trailing/foo.txt"
+      - dest: "{{ remote_dir }}/check_mode_dest/directory"
+        expected: "{{ remote_dir }}/check_mode_dest/directory/foo.txt"
+  block:
+    - name: Create destination directories
+      file:
+        path: "{{ item.expected | dirname }}"
+        state: directory
+      loop: "{{ check_mode_destinations }}"
+
+    - name: Predict copies to missing files
+      copy:
+        src: "{{ role_path }}/files/foo.txt"
+        dest: "{{ item.dest }}"
+      check_mode: true
+      loop: "{{ check_mode_destinations }}"
+      register: predicted_copies
+
+    - name: Check that predicted copies did not create files
+      stat:
+        path: "{{ item.expected }}"
+      loop: "{{ check_mode_destinations }}"
+      register: predicted_files
+
+    - name: Verify predicted destinations
+      assert:
+        that:
+          - predicted_copies.results[index] is changed
+          - predicted_copies.results[index].dest == item.expected
+          - not predicted_files.results[index].stat.exists
+      loop: "{{ check_mode_destinations }}"
+      loop_control:
+        index_var: index
+
+    - name: Perform the copies
+      copy:
+        src: "{{ role_path }}/files/foo.txt"
+        dest: "{{ item.dest }}"
+      loop: "{{ check_mode_destinations }}"
+      register: actual_copies
+
+    - name: Predict copies to identical files
+      copy:
+        src: "{{ role_path }}/files/foo.txt"
+        dest: "{{ item.dest }}"
+      check_mode: true
+      loop: "{{ check_mode_destinations }}"
+      register: unchanged_copies
+
+    - name: Verify destinations agree across changed and unchanged copies
+      assert:
+        that:
+          - actual_copies.results[index] is changed
+          - unchanged_copies.results[index] is not changed
+          - predicted_copies.results[index].dest == actual_copies.results[index].dest
+          - unchanged_copies.results[index].dest == actual_copies.results[index].dest
+      loop: "{{ check_mode_destinations }}"
+      loop_control:
+        index_var: index
+
+    - name: Predict replacing the existing files with different content
+      copy:
+        content: replacement
+        dest: "{{ item.expected }}"
+      check_mode: true
+      loop: "{{ check_mode_destinations }}"
+      register: replacement_copies
+
+    - name: Check that predicted replacements did not modify the files
+      stat:
+        path: "{{ item.expected }}"
+      loop: "{{ check_mode_destinations }}"
+      register: original_files
+
+    - name: Verify replacement destinations and unchanged file contents
+      assert:
+        that:
+          - replacement_copies.results[index] is changed
+          - replacement_copies.results[index].dest == item.expected
+          - original_files.results[index].stat.checksum == actual_copies.results[index].checksum
+      loop: "{{ check_mode_destinations }}"
+      loop_control:
+        index_var: index

--- a/test/integration/targets/copy/tasks/check_mode_dest.yml
+++ b/test/integration/targets/copy/tasks/check_mode_dest.yml
@@ -33,6 +33,7 @@
         that:
           - predicted_copies.results[index] is changed
           - predicted_copies.results[index].dest == item.expected
+          - predicted_copies.results[index].src == role_path ~ '/files/foo.txt'
           - not predicted_files.results[index].stat.exists
       loop: "{{ check_mode_destinations }}"
       loop_control:
@@ -60,9 +61,56 @@
           - unchanged_copies.results[index] is not changed
           - predicted_copies.results[index].dest == actual_copies.results[index].dest
           - unchanged_copies.results[index].dest == actual_copies.results[index].dest
+          - unchanged_copies.results[index].src == role_path ~ '/files/foo.txt'
       loop: "{{ check_mode_destinations }}"
       loop_control:
         index_var: index
+
+    - name: Create a symlink to a file with identical content
+      file:
+        src: "{{ check_mode_destinations[0].expected }}"
+        dest: "{{ remote_dir }}/check_mode_dest/link.txt"
+        state: link
+
+    - name: Follow the symlink when predicting an unchanged copy
+      copy:
+        src: "{{ role_path }}/files/foo.txt"
+        dest: "{{ remote_dir }}/check_mode_dest/link.txt"
+        follow: true
+      check_mode: true
+      register: unchanged_link
+
+    - name: Follow the symlink when performing an unchanged copy
+      copy:
+        src: "{{ role_path }}/files/foo.txt"
+        dest: "{{ remote_dir }}/check_mode_dest/link.txt"
+        follow: true
+      register: actual_link
+
+    - name: Verify the followed file module path remains authoritative
+      assert:
+        that:
+          - unchanged_link is not changed
+          - actual_link is not changed
+          - unchanged_link.dest == check_mode_destinations[0].expected
+          - actual_link.dest == check_mode_destinations[0].expected
+
+    - name: Reject content copied to an existing directory without a trailing slash
+      copy:
+        content: replacement
+        dest: "{{ remote_dir }}/check_mode_dest/directory"
+      check_mode: true
+      register: directory_failure
+      ignore_errors: true
+
+    - name: Verify an early failure retains the common result fields
+      assert:
+        that:
+          - directory_failure is failed
+          - directory_failure is not changed
+          - directory_failure.dest == remote_dir ~ '/check_mode_dest/directory'
+          - directory_failure.src is string
+          - directory_failure.msg == 'can not use content with a dir as dest'
 
     - name: Predict replacing the existing files with different content
       copy:


### PR DESCRIPTION
##### SUMMARY

When `copy` predicts a content change in check mode, its early result can omit fields used by subsequent tasks, including `dest` and `src`.

Initialize the common file-copy result fields (`failed`, `changed`, `dest`, `diff`, and `src`) before the early-return branches. Update the destination after directory resolution, and preserve the destination or resolved path returned by the underlying module. In particular, unchanged copies that follow a symlink continue to report the target file's path.

Fixes #81569.

##### ISSUE TYPE

- Bugfix Pull Request

##### TESTING

- Integration coverage for file destinations, directories with a trailing slash, and directories detected by stat; predicted changes, actual copies, unchanged files, replacement content, symlink following, and an early content-to-directory failure.
- The tests verify that check mode does not create or modify files, and that common source/destination fields remain available.
- Ran the same integration task file through the real local action/module path on macOS with Python 3.13.5: 18 successful tasks, zero failures. One deliberately invalid content-to-directory task is ignored and its failure result is then asserted.
- The original implementation fails all three destination cases because `dest` is absent. Regression tests also catch missing `src` and loss of the file module's resolved symlink target when only default fields are added.
- `ansible-test sanity --local --python 3.13 --base-branch origin/devel` passed for all four PR files. The default-disabled `package-data` check was not enabled.
- `git diff --check` passed.

The full `copy` integration target was not run locally: it creates system users and sudoers entries. The focused tasks were executed separately against temporary localhost files, using the repository's `ansible-playbook` and the same task file imported by the target.

AI assistance: OpenAI Codex assisted with implementation, regression tests, and validation.
